### PR TITLE
Sprint 5: rolling stats, matchup detail, standings, historical fallback

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
 import HomePage from './pages/HomePage'
+import MatchupDetailPage from './pages/MatchupDetailPage'
 import PitcherPage from './pages/PitcherPage'
+import RollingPitcherPage from './pages/RollingPitcherPage'
 import BatterPage from './pages/BatterPage'
+import RollingBatterPage from './pages/RollingBatterPage'
 import TeamPage from './pages/TeamPage'
+import StandingsPage from './pages/StandingsPage'
 
 const styles = {
   nav: {
@@ -12,8 +16,9 @@ const styles = {
     padding: '0 24px',
     display: 'flex',
     alignItems: 'center',
-    gap: '32px',
+    gap: '28px',
     height: '56px',
+    flexWrap: 'wrap',
   },
   brand: {
     fontSize: '18px',
@@ -21,6 +26,7 @@ const styles = {
     color: '#58a6ff',
     textDecoration: 'none',
     letterSpacing: '-0.5px',
+    marginRight: '4px',
   },
   link: {
     color: '#8b949e',
@@ -36,38 +42,38 @@ const styles = {
     borderBottomColor: '#58a6ff',
   },
   main: {
-    maxWidth: '1100px',
+    maxWidth: '1200px',
     margin: '0 auto',
     padding: '32px 24px',
   },
 }
+
+const link = ({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })
 
 export default function App() {
   return (
     <BrowserRouter>
       <nav style={styles.nav}>
         <NavLink to="/" style={styles.brand}>⚾ MLB Predict</NavLink>
-        <NavLink to="/" style={({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })}>
-          Matchups
-        </NavLink>
-        <NavLink to="/pitcher" style={({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })}>
-          Pitcher
-        </NavLink>
-        <NavLink to="/batter" style={({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })}>
-          Batter
-        </NavLink>
-        <NavLink to="/team" style={({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })}>
-          Team
-        </NavLink>
+        <NavLink to="/" end style={link}>Matchups</NavLink>
+        <NavLink to="/standings" style={link}>Standings</NavLink>
+        <NavLink to="/pitcher" style={link}>Pitcher</NavLink>
+        <NavLink to="/batter" style={link}>Batter</NavLink>
+        <NavLink to="/team" style={link}>Team</NavLink>
       </nav>
       <main style={styles.main}>
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
+          <Route path="/standings" element={<StandingsPage />} />
           <Route path="/pitcher" element={<PitcherPage />} />
           <Route path="/pitcher/:id" element={<PitcherPage />} />
+          <Route path="/pitcher/:id/rolling" element={<RollingPitcherPage />} />
           <Route path="/batter" element={<BatterPage />} />
           <Route path="/batter/:id" element={<BatterPage />} />
+          <Route path="/batter/:id/rolling" element={<RollingBatterPage />} />
           <Route path="/team" element={<TeamPage />} />
+          <Route path="/team/:id" element={<TeamPage />} />
         </Routes>
       </main>
     </BrowserRouter>

--- a/frontend/src/pages/BatterPage.jsx
+++ b/frontend/src/pages/BatterPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 
 const API = '/api'
 
@@ -13,12 +13,25 @@ const s = {
     background: '#238636', color: '#fff', border: 'none', borderRadius: '6px',
     padding: '10px 20px', fontSize: '14px', fontWeight: '600', cursor: 'pointer',
   },
+  rollingLink: {
+    display: 'inline-block', background: '#21262d', border: '1px solid #30363d',
+    color: '#58a6ff', textDecoration: 'none', borderRadius: '6px',
+    padding: '7px 16px', fontSize: '13px', fontWeight: '500', marginBottom: '24px',
+  },
   section: { marginBottom: '28px' },
   sectionTitle: { fontSize: '16px', fontWeight: '600', color: '#e6edf3', marginBottom: '14px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
   statsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: '12px' },
   statCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px 16px' },
   statLabel: { fontSize: '12px', color: '#8b949e', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.5px' },
   statVal: { fontSize: '22px', fontWeight: '700', color: '#e6edf3' },
+  tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px' },
+  th: { padding: '10px 14px', textAlign: 'left', color: '#8b949e', fontWeight: '500', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
+  thRight: { textAlign: 'right' },
+  td: { padding: '10px 14px', borderBottom: '1px solid #0d1117', color: '#e6edf3', whiteSpace: 'nowrap' },
+  tdRight: { textAlign: 'right' },
+  tdMuted: { color: '#8b949e' },
+  sourceBadge: { display: 'inline-block', fontSize: '11px', padding: '2px 7px', borderRadius: '3px', background: '#21262d', color: '#8b949e', marginLeft: '10px', verticalAlign: 'middle', fontWeight: '400' },
   splitGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' },
   splitCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '16px' },
   splitTitle: { fontSize: '14px', fontWeight: '600', color: '#58a6ff', marginBottom: '12px' },
@@ -100,10 +113,10 @@ export default function BatterPage() {
   function handleSearch(e) {
     e.preventDefault()
     navigate(`/batter/${inputId}`)
-    load(inputId)
   }
 
   const agg = data?.aggregate
+  const multiSeason = data?.multi_season || []
 
   return (
     <div>
@@ -125,9 +138,18 @@ export default function BatterPage() {
 
       {data && (
         <>
+          {id && (
+            <Link to={`/batter/${id}/rolling`} style={s.rollingLink}>
+              View Rolling Stats (L10–L1000 ABs) →
+            </Link>
+          )}
+
           {agg && (
             <div style={s.section}>
-              <div style={s.sectionTitle}>90-Day Rolling Metrics</div>
+              <div style={s.sectionTitle}>
+                Current Metrics
+                {data.data_source && <span style={s.sourceBadge}>{data.data_source}</span>}
+              </div>
               <div style={s.statsGrid}>
                 <StatCard label="Exit Velocity" value={`${fmt(agg.avg_exit_velocity)} mph`} />
                 <StatCard label="Launch Angle" value={`${fmt(agg.avg_launch_angle)}°`} />
@@ -136,6 +158,42 @@ export default function BatterPage() {
                 <StatCard label="K%" value={pct(agg.k_pct)} />
                 <StatCard label="BB%" value={pct(agg.bb_pct)} />
                 <StatCard label="AVG" value={fmt(agg.batting_avg, 3)} />
+              </div>
+            </div>
+          )}
+
+          {multiSeason.some(r => r.avg_exit_velocity != null || r.k_pct != null) && (
+            <div style={s.section}>
+              <div style={s.sectionTitle}>Season-by-Season</div>
+              <div style={s.tableWrap}>
+                <table style={s.table}>
+                  <thead>
+                    <tr>
+                      <th style={s.th}>Season</th>
+                      <th style={{ ...s.th, ...s.thRight }}>EV</th>
+                      <th style={{ ...s.th, ...s.thRight }}>LA</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Hard Hit%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Barrel%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>K%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>BB%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>AVG</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {multiSeason.map((row, i) => (
+                      <tr key={i}>
+                        <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{row.label}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_exit_velocity)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_launch_angle)}°</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.hard_hit_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.barrel_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.k_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.bb_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.batting_avg, 3)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           )}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,56 +1,68 @@
 import React, { useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 const API = '/api'
 
 const s = {
-  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px' },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px', flexWrap: 'wrap', gap: '12px' },
   title: { fontSize: '24px', fontWeight: '700', color: '#e6edf3' },
   datePicker: {
     background: '#161b22', border: '1px solid #30363d', color: '#e6edf3',
     borderRadius: '6px', padding: '8px 12px', fontSize: '14px', cursor: 'pointer',
   },
-  grid: { display: 'grid', gap: '16px' },
+  grid: { display: 'grid', gap: '12px' },
   card: {
     background: '#161b22', border: '1px solid #30363d', borderRadius: '10px',
-    padding: '20px 24px', display: 'grid',
-    gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: '16px',
+    padding: '16px 20px', cursor: 'pointer', transition: 'border-color 0.15s',
   },
-  team: { display: 'flex', flexDirection: 'column', gap: '4px' },
-  teamName: { fontSize: '18px', fontWeight: '600', color: '#e6edf3' },
-  pitcher: { fontSize: '13px', color: '#8b949e' },
-  prob: { fontSize: '28px', fontWeight: '700' },
-  probWin: { color: '#3fb950' },
-  probLose: { color: '#8b949e' },
-  vs: { textAlign: 'center' },
-  vsText: { fontSize: '13px', color: '#8b949e', fontWeight: '600', letterSpacing: '1px' },
-  badge: {
-    display: 'inline-block', background: '#1f3a1f', color: '#3fb950',
-    borderRadius: '4px', padding: '2px 8px', fontSize: '12px', fontWeight: '600',
-    marginTop: '4px',
+  cardHover: { borderColor: '#58a6ff' },
+  meta: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px', fontSize: '12px', color: '#8b949e' },
+  venue: { display: 'flex', gap: '8px', alignItems: 'center' },
+  statusBadge: (status) => ({
+    display: 'inline-block', borderRadius: '4px', padding: '2px 7px',
+    fontSize: '11px', fontWeight: '600',
+    background: status === 'Final' ? '#21262d' : status?.includes('Progress') ? '#1f3a1f' : '#21262d',
+    color: status === 'Final' ? '#8b949e' : status?.includes('Progress') ? '#3fb950' : '#58a6ff',
+  }),
+  matchupRow: {
+    display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: '12px',
   },
+  team: { display: 'flex', flexDirection: 'column', gap: '3px' },
+  teamName: { fontSize: '16px', fontWeight: '600', color: '#e6edf3' },
+  record: { fontSize: '12px', color: '#8b949e' },
+  pitcher: { fontSize: '12px', color: '#58a6ff' },
+  prob: { fontSize: '26px', fontWeight: '700' },
+  vs: { textAlign: 'center', fontSize: '13px', color: '#8b949e', fontWeight: '600', letterSpacing: '1px' },
   noData: { color: '#8b949e', fontSize: '14px', textAlign: 'center', padding: '48px' },
   loader: { color: '#8b949e', textAlign: 'center', padding: '48px' },
   error: { color: '#f85149', textAlign: 'center', padding: '24px', background: '#1f1116', borderRadius: '8px' },
 }
 
 function probColor(p) {
-  if (p === null || p === undefined) return '#8b949e'
-  if (p >= 0.6) return '#3fb950'
-  if (p >= 0.5) return '#d29922'
+  if (p == null) return '#8b949e'
+  if (p >= 0.62) return '#3fb950'
+  if (p >= 0.50) return '#d29922'
   return '#f85149'
+}
+
+function formatTime(iso) {
+  if (!iso) return null
+  try {
+    const d = new Date(iso)
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET'
+  } catch { return null }
 }
 
 function ProbBar({ homeProb, awayProb }) {
   const hp = homeProb != null ? Math.round(homeProb * 100) : 50
   const ap = 100 - hp
   return (
-    <div style={{ margin: '12px 0 0', gridColumn: '1/-1' }}>
-      <div style={{ display: 'flex', height: '6px', borderRadius: '3px', overflow: 'hidden', background: '#21262d' }}>
+    <div style={{ marginTop: '12px' }}>
+      <div style={{ display: 'flex', height: '5px', borderRadius: '3px', overflow: 'hidden', background: '#21262d' }}>
         <div style={{ width: `${ap}%`, background: '#58a6ff', transition: 'width 0.4s' }} />
         <div style={{ width: `${hp}%`, background: '#3fb950', transition: 'width 0.4s' }} />
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: '#8b949e', marginTop: '4px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: '#8b949e', marginTop: '3px' }}>
         <span>{ap}% away</span>
         <span>{hp}% home</span>
       </div>
@@ -64,6 +76,8 @@ export default function HomePage() {
   const [matchups, setMatchups] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [hovered, setHovered] = useState(null)
+  const navigate = useNavigate()
 
   useEffect(() => {
     setLoading(true)
@@ -77,57 +91,68 @@ export default function HomePage() {
   return (
     <div>
       <div style={s.header}>
-        <h1 style={s.title}>Today's Matchups</h1>
-        <input
-          type="date"
-          value={date}
-          onChange={e => setDate(e.target.value)}
-          style={s.datePicker}
-        />
+        <h1 style={s.title}>Daily Matchups</h1>
+        <input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.datePicker} />
       </div>
 
       {loading && <div style={s.loader}>Loading matchups…</div>}
       {error && <div style={s.error}>Error: {error}</div>}
-
       {!loading && !error && matchups.length === 0 && (
         <div style={s.noData}>No games scheduled for {date}.</div>
       )}
 
       <div style={s.grid}>
         {matchups.map((m, i) => (
-          <div key={i} style={s.card}>
-            {/* Away team */}
-            <div style={s.team}>
-              <div style={s.teamName}>{m.away_team_name || `Team ${m.away_team_id}`}</div>
-              <div style={s.pitcher}>
-                {m.away_pitcher_name
-                  ? <Link to={`/pitcher/${m.away_pitcher_id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
-                      {m.away_pitcher_name}
-                    </Link>
-                  : 'TBD'}
+          <div
+            key={i}
+            style={{ ...s.card, ...(hovered === i ? s.cardHover : {}) }}
+            onMouseEnter={() => setHovered(i)}
+            onMouseLeave={() => setHovered(null)}
+            onClick={() => m.game_pk && navigate(`/matchup/${m.game_pk}`)}
+          >
+            {/* Meta row: venue + time + status */}
+            <div style={s.meta}>
+              <div style={s.venue}>
+                <span>{m.venue || '—'}</span>
+                {m.game_time && <span>· {formatTime(m.game_time)}</span>}
               </div>
-              <div style={{ ...s.prob, color: probColor(m.away_win_prob) }}>
-                {m.away_win_prob != null ? `${Math.round(m.away_win_prob * 100)}%` : '—'}
-              </div>
+              {m.status && <span style={s.statusBadge(m.status)}>{m.status}</span>}
             </div>
 
-            {/* VS */}
-            <div style={s.vs}>
-              <div style={s.vsText}>@</div>
-            </div>
-
-            {/* Home team */}
-            <div style={{ ...s.team, textAlign: 'right' }}>
-              <div style={s.teamName}>{m.home_team_name || `Team ${m.home_team_id}`}</div>
-              <div style={s.pitcher}>
-                {m.home_pitcher_name
-                  ? <Link to={`/pitcher/${m.home_pitcher_id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
-                      {m.home_pitcher_name}
-                    </Link>
-                  : 'TBD'}
+            {/* Main matchup row */}
+            <div style={s.matchupRow}>
+              {/* Away team */}
+              <div style={s.team}>
+                <div style={s.teamName}>{m.away_team_name || `Team ${m.away_team_id}`}</div>
+                <div style={s.record}>{m.away_team_record || ''}</div>
+                <div style={s.pitcher}>
+                  {m.away_pitcher_name
+                    ? <Link to={`/pitcher/${m.away_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                        {m.away_pitcher_name}
+                      </Link>
+                    : <span style={{ color: '#8b949e' }}>TBD</span>}
+                </div>
+                <div style={{ ...s.prob, color: probColor(m.away_win_prob) }}>
+                  {m.away_win_prob != null ? `${Math.round(m.away_win_prob * 100)}%` : '—'}
+                </div>
               </div>
-              <div style={{ ...s.prob, color: probColor(m.home_win_prob) }}>
-                {m.home_win_prob != null ? `${Math.round(m.home_win_prob * 100)}%` : '—'}
+
+              <div style={s.vs}>@</div>
+
+              {/* Home team */}
+              <div style={{ ...s.team, textAlign: 'right' }}>
+                <div style={s.teamName}>{m.home_team_name || `Team ${m.home_team_id}`}</div>
+                <div style={s.record}>{m.home_team_record || ''}</div>
+                <div style={{ ...s.pitcher, textAlign: 'right' }}>
+                  {m.home_pitcher_name
+                    ? <Link to={`/pitcher/${m.home_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                        {m.home_pitcher_name}
+                      </Link>
+                    : <span style={{ color: '#8b949e' }}>TBD</span>}
+                </div>
+                <div style={{ ...s.prob, color: probColor(m.home_win_prob), textAlign: 'right' }}>
+                  {m.home_win_prob != null ? `${Math.round(m.home_win_prob * 100)}%` : '—'}
+                </div>
               </div>
             </div>
 

--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -1,0 +1,361 @@
+import React, { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+
+const API = '/api'
+
+const PITCH_NAMES = {
+  FF: '4-Seam', SI: 'Sinker', FC: 'Cutter', FS: 'Splitter',
+  CH: 'Changeup', CU: 'Curveball', SL: 'Slider', ST: 'Sweeper',
+  KC: 'Knuckle-Curve', SV: 'Slurve', KN: 'Knuckleball', PO: 'Pitchout', UN: 'Unknown',
+}
+
+const t = {
+  page: {},
+  back: { color: '#58a6ff', textDecoration: 'none', fontSize: '13px', display: 'inline-block', marginBottom: '20px' },
+  // Header
+  header: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', padding: '20px 24px', marginBottom: '20px' },
+  headerTop: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: '12px' },
+  teamsRow: { display: 'flex', alignItems: 'center', gap: '16px', flexWrap: 'wrap' },
+  teamBlock: { textAlign: 'center' },
+  teamName: { fontSize: '20px', fontWeight: '700', color: '#e6edf3' },
+  teamRecord: { fontSize: '13px', color: '#8b949e', marginTop: '2px' },
+  at: { fontSize: '20px', color: '#8b949e', fontWeight: '600', padding: '0 4px' },
+  metaText: { fontSize: '13px', color: '#8b949e' },
+  statusBadge: { display: 'inline-block', background: '#1f3a1f', color: '#3fb950', borderRadius: '4px', padding: '3px 8px', fontSize: '12px', fontWeight: '600' },
+  parkBadge: { display: 'inline-block', background: '#21262d', color: '#8b949e', borderRadius: '4px', padding: '3px 8px', fontSize: '12px' },
+  // Win prob
+  probSection: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', padding: '20px 24px', marginBottom: '20px' },
+  probRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' },
+  probTeam: { fontSize: '15px', fontWeight: '600', color: '#e6edf3' },
+  probPct: { fontSize: '32px', fontWeight: '800' },
+  probBar: { height: '10px', borderRadius: '5px', overflow: 'hidden', background: '#21262d', display: 'flex' },
+  // Section
+  section: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', padding: '20px 24px', marginBottom: '20px' },
+  sectionTitle: { fontSize: '15px', fontWeight: '600', color: '#e6edf3', marginBottom: '16px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
+  // Pitcher comparison
+  pitcherGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' },
+  pitcherCard: { background: '#0d1117', border: '1px solid #21262d', borderRadius: '8px', padding: '16px' },
+  pitcherName: { fontSize: '16px', fontWeight: '700', color: '#e6edf3', marginBottom: '4px' },
+  dataSource: { fontSize: '11px', color: '#8b949e', marginBottom: '12px' },
+  statRow: { display: 'flex', justifyContent: 'space-between', padding: '5px 0', borderBottom: '1px solid #161b22', fontSize: '13px' },
+  statKey: { color: '#8b949e' },
+  statVal: { color: '#e6edf3', fontWeight: '500' },
+  // Arsenal
+  arsenalTable: { width: '100%', borderCollapse: 'collapse', fontSize: '12px', marginTop: '12px' },
+  th: { padding: '6px 8px', textAlign: 'left', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', borderBottom: '1px solid #21262d' },
+  td: { padding: '6px 8px', borderBottom: '1px solid #0d1117', color: '#e6edf3' },
+  // Team splits
+  splitsGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' },
+  splitCard: { background: '#0d1117', border: '1px solid #21262d', borderRadius: '8px', padding: '16px' },
+  splitTitle: { fontSize: '14px', fontWeight: '600', color: '#58a6ff', marginBottom: '10px' },
+  splitSubtitle: { fontSize: '12px', color: '#8b949e', marginBottom: '8px' },
+  // Game log
+  logTable: { width: '100%', borderCollapse: 'collapse', fontSize: '13px' },
+  // Lineup
+  lineupGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' },
+  lineupItem: { display: 'flex', gap: '10px', padding: '5px 0', borderBottom: '1px solid #0d1117', fontSize: '13px', color: '#e6edf3' },
+  orderNum: { color: '#8b949e', width: '20px', flexShrink: 0 },
+  loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
+  error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
+}
+
+const pct = (v, d = 1) => v != null ? `${(v * 100).toFixed(d)}%` : '—'
+const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
+const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
+
+function probColor(p) {
+  if (p == null) return '#8b949e'
+  if (p >= 0.62) return '#3fb950'
+  if (p >= 0.50) return '#d29922'
+  return '#f85149'
+}
+
+function parkLabel(factor) {
+  if (factor >= 1.10) return `Park +${Math.round((factor - 1) * 100)}% (Hitter-friendly)`
+  if (factor >= 1.03) return `Park +${Math.round((factor - 1) * 100)}% (Slight hitter-friendly)`
+  if (factor <= 0.92) return `Park ${Math.round((factor - 1) * 100)}% (Pitcher-friendly)`
+  if (factor <= 0.97) return `Park ${Math.round((factor - 1) * 100)}% (Slight pitcher-friendly)`
+  return 'Neutral park'
+}
+
+function formatTime(iso) {
+  if (!iso) return null
+  try {
+    return new Date(iso).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET'
+  } catch { return null }
+}
+
+function PitcherCard({ side, teamName, pitcherName, pitcherId, detail }) {
+  const agg = detail?.aggregate || {}
+  const arsenal = detail?.arsenal || []
+  const gameLog = detail?.game_log || []
+
+  return (
+    <div style={t.pitcherCard}>
+      <div style={{ fontSize: '12px', color: '#8b949e', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>{side}</div>
+      <div style={t.pitcherName}>
+        {pitcherId
+          ? <Link to={`/pitcher/${pitcherId}`} style={{ color: '#e6edf3', textDecoration: 'none' }}>{pitcherName || `ID ${pitcherId}`}</Link>
+          : <span style={{ color: '#8b949e' }}>TBD</span>}
+      </div>
+      <div style={t.dataSource}>{agg.data_source || 'No data'}</div>
+
+      {[
+        ['K%', pct(agg.k_pct)],
+        ['BB%', pct(agg.bb_pct)],
+        ['xwOBA', dec(agg.xwoba)],
+        ['Hard Hit%', pct(agg.hard_hit_pct)],
+        ['Velocity', mph(agg.avg_velocity) + (agg.avg_velocity ? ' mph' : '')],
+        ['Spin Rate', agg.avg_spin_rate ? `${Math.round(agg.avg_spin_rate)} rpm` : '—'],
+        ['Horiz Break', agg.avg_horiz_break != null ? `${Number(agg.avg_horiz_break).toFixed(2)}"` : '—'],
+        ['Vert Break', agg.avg_vert_break != null ? `${Number(agg.avg_vert_break).toFixed(2)}"` : '—'],
+      ].map(([k, v]) => (
+        <div key={k} style={t.statRow}>
+          <span style={t.statKey}>{k}</span>
+          <span style={t.statVal}>{v}</span>
+        </div>
+      ))}
+
+      {arsenal.length > 0 && (
+        <>
+          <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '14px', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Arsenal</div>
+          <table style={t.arsenalTable}>
+            <thead>
+              <tr>
+                {['Pitch', 'Use%', 'Whiff%', 'K%', 'xwOBA'].map(h => <th key={h} style={t.th}>{h}</th>)}
+              </tr>
+            </thead>
+            <tbody>
+              {arsenal.map((p, i) => (
+                <tr key={i}>
+                  <td style={t.td}>{PITCH_NAMES[p.pitch_type] || p.pitch_type}</td>
+                  <td style={t.td}>{pct(p.usage_pct)}</td>
+                  <td style={t.td}>{pct(p.whiff_pct)}</td>
+                  <td style={t.td}>{pct(p.strikeout_pct)}</td>
+                  <td style={t.td}>{dec(p.xwoba)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {gameLog.length > 0 && (
+        <>
+          <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '14px', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>Recent Outings</div>
+          <table style={t.logTable}>
+            <thead>
+              <tr>
+                {['Date', 'P', 'PA', 'K', 'BB', 'HR', 'HH%'].map(h => <th key={h} style={t.th}>{h}</th>)}
+              </tr>
+            </thead>
+            <tbody>
+              {gameLog.map((g, i) => (
+                <tr key={i}>
+                  <td style={t.td}>{g.game_date?.slice(5)}</td>
+                  <td style={t.td}>{g.pitch_count}</td>
+                  <td style={t.td}>{g.plate_appearances}</td>
+                  <td style={t.td}>{g.strikeouts}</td>
+                  <td style={t.td}>{g.walks}</td>
+                  <td style={t.td}>{g.home_runs}</td>
+                  <td style={t.td}>{pct(g.hard_hit_pct)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {pitcherId && (
+        <div style={{ marginTop: '14px' }}>
+          <Link to={`/pitcher/${pitcherId}/rolling`} style={{ color: '#58a6ff', fontSize: '12px', textDecoration: 'none' }}>
+            View Rolling Stats →
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SplitTable({ title, split }) {
+  return (
+    <div style={t.splitCard}>
+      <div style={t.splitTitle}>{title}</div>
+      {!split
+        ? <div style={{ color: '#8b949e', fontSize: '13px' }}>No data</div>
+        : [
+            ['PA', split.pa],
+            ['AVG', dec(split.batting_avg)],
+            ['OBP', dec(split.on_base_pct)],
+            ['SLG', dec(split.slugging_pct)],
+            ['HR', split.home_runs],
+            ['K%', pct(split.k_pct)],
+            ['BB%', pct(split.bb_pct)],
+          ].map(([k, v]) => (
+            <div key={k} style={t.statRow}>
+              <span style={t.statKey}>{k}</span>
+              <span style={t.statVal}>{v ?? '—'}</span>
+            </div>
+          ))}
+    </div>
+  )
+}
+
+export default function MatchupDetailPage() {
+  const { game_pk } = useParams()
+  const [matchup, setMatchup] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetch(`${API}/matchup/${game_pk}`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setMatchup(d); setLoading(false) })
+      .catch(e => { setError(String(e)); setLoading(false) })
+  }, [game_pk])
+
+  if (loading) return <div style={t.loader}>Loading matchup…</div>
+  if (error) return <div style={t.error}>{error}</div>
+  if (!matchup) return null
+
+  const home = matchup.home_team || {}
+  const away = matchup.away_team || {}
+  const hp = matchup.home_win_prob
+  const ap = matchup.away_win_prob
+  const hPct = hp != null ? Math.round(hp * 100) : 50
+  const aPct = 100 - hPct
+
+  const awayPitcherHand = away.pitcher_name?.includes('(L)') ? 'L' : 'R'
+  const homePitcherHand = home.pitcher_name?.includes('(L)') ? 'L' : 'R'
+
+  return (
+    <div>
+      <Link to="/" style={t.back}>← Back to Matchups</Link>
+
+      {/* Game Header */}
+      <div style={t.header}>
+        <div style={t.headerTop}>
+          <div style={t.teamsRow}>
+            <div style={t.teamBlock}>
+              <div style={t.teamName}>{away.name || 'Away'}</div>
+              <div style={t.teamRecord}>{away.record || ''}</div>
+            </div>
+            <div style={t.at}>@</div>
+            <div style={t.teamBlock}>
+              <div style={t.teamName}>{home.name || 'Home'}</div>
+              <div style={t.teamRecord}>{home.record || ''}</div>
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', alignItems: 'flex-end' }}>
+            {matchup.status && <span style={t.statusBadge}>{matchup.status}</span>}
+            {matchup.park_factor && <span style={t.parkBadge}>{parkLabel(matchup.park_factor)}</span>}
+          </div>
+        </div>
+        <div style={{ marginTop: '8px', display: 'flex', gap: '16px', flexWrap: 'wrap' }}>
+          {matchup.venue && <span style={t.metaText}>📍 {matchup.venue}</span>}
+          {matchup.game_date && <span style={t.metaText}>🕐 {formatTime(matchup.game_date)}</span>}
+        </div>
+      </div>
+
+      {/* Win Probability */}
+      {(hp != null || ap != null) && (
+        <div style={t.probSection}>
+          <div style={t.sectionTitle}>Win Probability</div>
+          <div style={t.probRow}>
+            <div>
+              <div style={{ fontSize: '13px', color: '#8b949e' }}>{away.name}</div>
+              <div style={{ ...t.probPct, color: probColor(ap) }}>{ap != null ? `${aPct}%` : '—'}</div>
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: '13px', color: '#8b949e' }}>{home.name}</div>
+              <div style={{ ...t.probPct, color: probColor(hp) }}>{hp != null ? `${hPct}%` : '—'}</div>
+            </div>
+          </div>
+          <div style={t.probBar}>
+            <div style={{ width: `${aPct}%`, background: '#58a6ff', transition: 'width 0.5s' }} />
+            <div style={{ width: `${hPct}%`, background: '#3fb950', transition: 'width 0.5s' }} />
+          </div>
+        </div>
+      )}
+
+      {/* Starting Pitchers */}
+      <div style={t.section}>
+        <div style={t.sectionTitle}>Starting Pitchers</div>
+        <div style={t.pitcherGrid}>
+          <PitcherCard
+            side="Away"
+            teamName={away.name}
+            pitcherName={away.pitcher_name}
+            pitcherId={away.pitcher_id}
+            detail={away}
+          />
+          <PitcherCard
+            side="Home"
+            teamName={home.name}
+            pitcherName={home.pitcher_name}
+            pitcherId={home.pitcher_id}
+            detail={home}
+          />
+        </div>
+      </div>
+
+      {/* Lineups (if posted) */}
+      {(away.lineup?.length > 0 || home.lineup?.length > 0) && (
+        <div style={t.section}>
+          <div style={t.sectionTitle}>Starting Lineups</div>
+          <div style={t.lineupGrid}>
+            <div>
+              <div style={{ fontSize: '13px', color: '#58a6ff', fontWeight: '600', marginBottom: '10px' }}>{away.name}</div>
+              {away.lineup.map((p, i) => (
+                <div key={i} style={t.lineupItem}>
+                  <span style={t.orderNum}>{i + 1}</span>
+                  <Link to={`/batter/${p.id}`} style={{ color: '#e6edf3', textDecoration: 'none', flex: 1 }}>
+                    {p.name}
+                  </Link>
+                  {p.position && <span style={{ color: '#8b949e', fontSize: '12px' }}>{p.position}</span>}
+                </div>
+              ))}
+            </div>
+            <div>
+              <div style={{ fontSize: '13px', color: '#3fb950', fontWeight: '600', marginBottom: '10px' }}>{home.name}</div>
+              {home.lineup.map((p, i) => (
+                <div key={i} style={t.lineupItem}>
+                  <span style={t.orderNum}>{i + 1}</span>
+                  <Link to={`/batter/${p.id}`} style={{ color: '#e6edf3', textDecoration: 'none', flex: 1 }}>
+                    {p.name}
+                  </Link>
+                  {p.position && <span style={{ color: '#8b949e', fontSize: '12px' }}>{p.position}</span>}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Team Splits */}
+      <div style={t.section}>
+        <div style={t.sectionTitle}>Team Hitting Splits</div>
+        <div style={{ marginBottom: '16px' }}>
+          <div style={{ fontSize: '13px', color: '#58a6ff', fontWeight: '600', marginBottom: '10px' }}>
+            {away.name} — vs {homePitcherHand}HP
+          </div>
+          <div style={t.splitsGrid}>
+            <SplitTable title="vs LHP" split={away.splits?.vsL} />
+            <SplitTable title="vs RHP" split={away.splits?.vsR} />
+          </div>
+        </div>
+        <div>
+          <div style={{ fontSize: '13px', color: '#3fb950', fontWeight: '600', marginBottom: '10px' }}>
+            {home.name} — vs {awayPitcherHand}HP
+          </div>
+          <div style={t.splitsGrid}>
+            <SplitTable title="vs LHP" split={home.splits?.vsL} />
+            <SplitTable title="vs RHP" split={home.splits?.vsR} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/PitcherPage.jsx
+++ b/frontend/src/pages/PitcherPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 
 const API = '/api'
 
@@ -13,15 +13,25 @@ const s = {
     background: '#238636', color: '#fff', border: 'none', borderRadius: '6px',
     padding: '10px 20px', fontSize: '14px', fontWeight: '600', cursor: 'pointer',
   },
+  rollingLink: {
+    display: 'inline-block', background: '#21262d', border: '1px solid #30363d',
+    color: '#58a6ff', textDecoration: 'none', borderRadius: '6px',
+    padding: '7px 16px', fontSize: '13px', fontWeight: '500', marginBottom: '24px',
+  },
   section: { marginBottom: '28px' },
   sectionTitle: { fontSize: '16px', fontWeight: '600', color: '#e6edf3', marginBottom: '14px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
   statsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: '12px' },
   statCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px 16px' },
   statLabel: { fontSize: '12px', color: '#8b949e', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.5px' },
   statVal: { fontSize: '22px', fontWeight: '700', color: '#e6edf3' },
-  table: { width: '100%', borderCollapse: 'collapse', fontSize: '14px' },
-  th: { padding: '10px 14px', textAlign: 'left', color: '#8b949e', fontWeight: '500', fontSize: '12px', textTransform: 'uppercase', borderBottom: '1px solid #21262d' },
-  td: { padding: '10px 14px', borderBottom: '1px solid #161b22', color: '#e6edf3' },
+  tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px' },
+  th: { padding: '10px 14px', textAlign: 'left', color: '#8b949e', fontWeight: '500', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
+  thRight: { textAlign: 'right' },
+  td: { padding: '10px 14px', borderBottom: '1px solid #0d1117', color: '#e6edf3', whiteSpace: 'nowrap' },
+  tdRight: { textAlign: 'right' },
+  tdMuted: { color: '#8b949e' },
+  sourceBadge: { display: 'inline-block', fontSize: '11px', padding: '2px 7px', borderRadius: '3px', background: '#21262d', color: '#8b949e', marginLeft: '10px', verticalAlign: 'middle', fontWeight: '400' },
   loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
   error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
   hint: { color: '#8b949e', textAlign: 'center', padding: '48px' },
@@ -31,7 +41,6 @@ function fmt(val, decimals = 1) {
   if (val == null) return '—'
   return typeof val === 'number' ? val.toFixed(decimals) : val
 }
-
 function pct(val) {
   if (val == null) return '—'
   return `${(val * 100).toFixed(1)}%`
@@ -69,11 +78,12 @@ export default function PitcherPage() {
   function handleSearch(e) {
     e.preventDefault()
     navigate(`/pitcher/${inputId}`)
-    load(inputId)
   }
 
   const agg = data?.aggregate
   const arsenal = data?.arsenal || []
+  const multiSeason = data?.multi_season || []
+  const gameLog = data?.game_log || []
 
   return (
     <div>
@@ -95,12 +105,21 @@ export default function PitcherPage() {
 
       {data && (
         <>
+          {id && (
+            <Link to={`/pitcher/${id}/rolling`} style={s.rollingLink}>
+              View Rolling Stats (L15–L150 Games) →
+            </Link>
+          )}
+
           {agg && (
             <div style={s.section}>
-              <div style={s.sectionTitle}>90-Day Rolling Metrics</div>
+              <div style={s.sectionTitle}>
+                Current Metrics
+                {data.data_source && <span style={s.sourceBadge}>{data.data_source}</span>}
+              </div>
               <div style={s.statsGrid}>
                 <StatCard label="Avg Velocity" value={`${fmt(agg.avg_velocity)} mph`} />
-                <StatCard label="Avg Spin Rate" value={`${fmt(agg.avg_spin_rate, 0)} rpm`} />
+                <StatCard label="Spin Rate" value={`${fmt(agg.avg_spin_rate, 0)} rpm`} />
                 <StatCard label="K%" value={pct(agg.k_pct)} />
                 <StatCard label="BB%" value={pct(agg.bb_pct)} />
                 <StatCard label="Hard Hit%" value={pct(agg.hard_hit_pct)} />
@@ -112,33 +131,110 @@ export default function PitcherPage() {
             </div>
           )}
 
+          {multiSeason.some(r => r.avg_velocity != null || r.k_pct != null) && (
+            <div style={s.section}>
+              <div style={s.sectionTitle}>Season-by-Season</div>
+              <div style={s.tableWrap}>
+                <table style={s.table}>
+                  <thead>
+                    <tr>
+                      <th style={s.th}>Season</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Velo</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Spin</th>
+                      <th style={{ ...s.th, ...s.thRight }}>K%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>BB%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Hard Hit%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>xwOBA</th>
+                      <th style={{ ...s.th, ...s.thRight }}>xBA</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {multiSeason.map((row, i) => (
+                      <tr key={i}>
+                        <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{row.label}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_velocity)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_spin_rate, 0)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.k_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.bb_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.hard_hit_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.xwoba, 3)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.xba, 3)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {gameLog.length > 0 && (
+            <div style={s.section}>
+              <div style={s.sectionTitle}>Recent Outings</div>
+              <div style={s.tableWrap}>
+                <table style={s.table}>
+                  <thead>
+                    <tr>
+                      <th style={s.th}>Date</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Pitches</th>
+                      <th style={{ ...s.th, ...s.thRight }}>PA</th>
+                      <th style={{ ...s.th, ...s.thRight }}>K</th>
+                      <th style={{ ...s.th, ...s.thRight }}>BB</th>
+                      <th style={{ ...s.th, ...s.thRight }}>HR</th>
+                      <th style={{ ...s.th, ...s.thRight }}>HH%</th>
+                      <th style={{ ...s.th, ...s.thRight }}>Velo</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {gameLog.map((g, i) => (
+                      <tr key={i}>
+                        <td style={{ ...s.td, ...s.tdMuted, fontSize: '12px' }}>{g.game_date}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{g.pitch_count ?? '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{g.plate_appearances ?? '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight, color: '#3fb950' }}>{g.strikeouts ?? '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight, color: '#d29922' }}>{g.walks ?? '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight, color: g.home_runs > 0 ? '#f85149' : '#e6edf3' }}>{g.home_runs ?? '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{g.hard_hit_pct != null ? pct(g.hard_hit_pct) : '—'}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{g.avg_velocity != null ? `${g.avg_velocity.toFixed(1)}` : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
           {arsenal.length > 0 && (
             <div style={s.section}>
-              <div style={s.sectionTitle}>Pitch Arsenal</div>
-              <table style={s.table}>
-                <thead>
-                  <tr>
-                    {['Pitch', 'Usage%', 'Whiff%', 'K%', 'RV/100', 'xwOBA', 'Hard Hit%'].map(h => (
-                      <th key={h} style={s.th}>{h}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {arsenal.map((p, i) => (
-                    <tr key={i}>
-                      <td style={s.td}>{p.pitch_name || p.pitch_type}</td>
-                      <td style={s.td}>{pct(p.usage_pct)}</td>
-                      <td style={s.td}>{pct(p.whiff_pct)}</td>
-                      <td style={s.td}>{pct(p.strikeout_pct)}</td>
-                      <td style={{ ...s.td, color: (p.rv_per_100 || 0) < 0 ? '#3fb950' : '#f85149' }}>
-                        {fmt(p.rv_per_100, 1)}
-                      </td>
-                      <td style={s.td}>{fmt(p.xwoba, 3)}</td>
-                      <td style={s.td}>{pct(p.hard_hit_pct)}</td>
+              <div style={s.sectionTitle}>
+                Pitch Arsenal
+                {data.arsenal_season && <span style={s.sourceBadge}>{data.arsenal_season}</span>}
+              </div>
+              <div style={s.tableWrap}>
+                <table style={s.table}>
+                  <thead>
+                    <tr>
+                      {['Pitch', 'Usage%', 'Whiff%', 'K%', 'RV/100', 'xwOBA', 'Hard Hit%'].map(h => (
+                        <th key={h} style={h === 'Pitch' ? s.th : { ...s.th, ...s.thRight }}>{h}</th>
+                      ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {arsenal.map((p, i) => (
+                      <tr key={i}>
+                        <td style={s.td}>{p.pitch_name || p.pitch_type}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.usage_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.whiff_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.strikeout_pct)}</td>
+                        <td style={{ ...s.td, ...s.tdRight, color: (p.rv_per_100 || 0) < 0 ? '#3fb950' : '#f85149' }}>
+                          {fmt(p.rv_per_100, 1)}
+                        </td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(p.xwoba, 3)}</td>
+                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.hard_hit_pct)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
         </>

--- a/frontend/src/pages/RollingBatterPage.jsx
+++ b/frontend/src/pages/RollingBatterPage.jsx
@@ -1,0 +1,249 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { useParams, Link } from 'react-router-dom'
+
+const API = '/api'
+
+const RESULT_COLORS = {
+  single: '#3fb950', double: '#3fb950', triple: '#3fb950', home_run: '#58a6ff',
+  walk: '#d29922', intent_walk: '#d29922', hit_by_pitch: '#d29922',
+  strikeout: '#f85149', strikeout_double_play: '#f85149',
+  field_out: '#8b949e', grounded_into_double_play: '#8b949e', double_play: '#8b949e',
+  force_out: '#8b949e', fielders_choice: '#8b949e', fielders_choice_out: '#8b949e',
+  sac_fly: '#8b949e', sac_bunt: '#8b949e',
+}
+
+const RESULT_LABELS = {
+  single: '1B', double: '2B', triple: '3B', home_run: 'HR',
+  walk: 'BB', intent_walk: 'IBB', hit_by_pitch: 'HBP',
+  strikeout: 'K', strikeout_double_play: 'KDP',
+  field_out: 'FO', grounded_into_double_play: 'GDP', double_play: 'DP',
+  force_out: 'FO', fielders_choice: 'FC', fielders_choice_out: 'FCO',
+  sac_fly: 'SF', sac_bunt: 'SB',
+}
+
+const s = {
+  back: { color: '#58a6ff', textDecoration: 'none', fontSize: '13px', display: 'inline-block', marginBottom: '20px' },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px', flexWrap: 'wrap', gap: '12px' },
+  title: { fontSize: '22px', fontWeight: '700', color: '#e6edf3' },
+  subtitle: { fontSize: '13px', color: '#8b949e', marginTop: '4px' },
+  tabs: { display: 'flex', gap: '0', marginBottom: '20px', background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', overflow: 'hidden', width: 'fit-content' },
+  tab: (active) => ({
+    padding: '8px 18px', fontSize: '13px', fontWeight: '500', cursor: 'pointer',
+    background: active ? '#58a6ff' : 'transparent',
+    color: active ? '#0d1117' : '#8b949e',
+    border: 'none', outline: 'none',
+  }),
+  tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto', marginBottom: '20px' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px', minWidth: '600px' },
+  th: { padding: '12px 14px', textAlign: 'left', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
+  thRight: { textAlign: 'right' },
+  td: { padding: '10px 14px', borderBottom: '1px solid #0d1117', color: '#e6edf3', whiteSpace: 'nowrap' },
+  tdRight: { textAlign: 'right' },
+  tdMuted: { color: '#8b949e' },
+  sectionTitle: { fontSize: '15px', fontWeight: '600', color: '#e6edf3', marginBottom: '12px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
+  abRow: { display: 'grid', gridTemplateColumns: '90px 28px 70px auto 60px 60px 40px', gap: '4px', padding: '7px 14px', borderBottom: '1px solid #0d1117', fontSize: '13px', alignItems: 'center' },
+  abHeader: { display: 'grid', gridTemplateColumns: '90px 28px 70px auto 60px 60px 40px', gap: '4px', padding: '9px 14px', borderBottom: '1px solid #21262d', fontSize: '11px', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.5px' },
+  pagination: { display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'center', padding: '16px', fontSize: '13px', color: '#8b949e' },
+  pageBtn: (disabled) => ({
+    background: disabled ? '#21262d' : '#30363d', border: 'none', color: disabled ? '#555' : '#e6edf3',
+    borderRadius: '6px', padding: '6px 14px', cursor: disabled ? 'default' : 'pointer', fontSize: '13px',
+  }),
+  loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
+  error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
+}
+
+const pct = (v) => v != null ? `${(v * 100).toFixed(1)}%` : '—'
+const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
+const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
+const deg = v => v != null ? `${Number(v).toFixed(1)}°` : '—'
+
+function avgColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v >= 0.280) return '#3fb950'
+  if (v >= 0.240) return '#d29922'
+  return '#f85149'
+}
+function kColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v <= 0.18) return '#3fb950'
+  if (v <= 0.25) return '#d29922'
+  return '#f85149'
+}
+function evColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v >= 92) return '#3fb950'
+  if (v >= 88) return '#d29922'
+  return '#f85149'
+}
+
+export default function RollingBatterPage() {
+  const { id } = useParams()
+  const [view, setView] = useState('abs')     // 'abs' | 'games'
+  const [rolling, setRolling] = useState(null)
+  const [abData, setAbData] = useState(null)
+  const [abPage, setAbPage] = useState(0)
+  const [abWindow, setAbWindow] = useState(50)
+  const [loading, setLoading] = useState(true)
+  const [abLoading, setAbLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const AB_PAGE_SIZE = 50
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    const windows = view === 'abs' ? '10,25,50,100,200,400,1000' : '15,30,60,90,120,150'
+    fetch(`${API}/batter/${id}/rolling?windows=${windows}&type=${view}`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setRolling(d); setLoading(false) })
+      .catch(e => { setError(String(e)); setLoading(false) })
+  }, [id, view])
+
+  const loadAbs = useCallback((page) => {
+    if (!id) return
+    setAbLoading(true)
+    fetch(`${API}/batter/${id}/at-bats?n=${AB_PAGE_SIZE}&offset=${page * AB_PAGE_SIZE}`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setAbData(d); setAbLoading(false) })
+      .catch(() => setAbLoading(false))
+  }, [id])
+
+  useEffect(() => { loadAbs(0) }, [loadAbs])
+
+  const totalPages = abData ? Math.ceil(abData.total_abs / AB_PAGE_SIZE) : 0
+
+  function goPage(p) {
+    setAbPage(p)
+    loadAbs(p)
+  }
+
+  if (error) return <div style={s.error}>{error}</div>
+
+  const windows = rolling?.windows || []
+
+  return (
+    <div>
+      <Link to={`/batter/${id}`} style={s.back}>← Back to Batter Profile</Link>
+
+      <div style={s.header}>
+        <div>
+          <div style={s.title}>Rolling Stats — Batter #{id}</div>
+          <div style={s.subtitle}>Green = elite · Yellow = average · Red = below average</div>
+        </div>
+      </div>
+
+      {/* Toggle */}
+      <div style={s.tabs}>
+        <button style={s.tab(view === 'abs')} onClick={() => setView('abs')}>Last N At-Bats</button>
+        <button style={s.tab(view === 'games')} onClick={() => setView('games')}>Last N Games</button>
+      </div>
+
+      {/* Rolling stats table */}
+      {loading ? <div style={s.loader}>Loading…</div> : (
+        <div style={s.tableWrap}>
+          <table style={s.table}>
+            <thead>
+              <tr>
+                <th style={s.th}>Window</th>
+                <th style={s.th}>{view === 'abs' ? 'ABs' : 'Games'}</th>
+                <th style={s.th}>Range</th>
+                <th style={{ ...s.th, ...s.thRight }}>AVG</th>
+                <th style={{ ...s.th, ...s.thRight }}>OBP</th>
+                <th style={{ ...s.th, ...s.thRight }}>SLG</th>
+                <th style={{ ...s.th, ...s.thRight }}>HR</th>
+                <th style={{ ...s.th, ...s.thRight }}>K%</th>
+                <th style={{ ...s.th, ...s.thRight }}>BB%</th>
+                <th style={{ ...s.th, ...s.thRight }}>EV</th>
+                <th style={{ ...s.th, ...s.thRight }}>LA</th>
+                <th style={{ ...s.th, ...s.thRight }}>HH%</th>
+                <th style={{ ...s.th, ...s.thRight }}>Barrel%</th>
+              </tr>
+            </thead>
+            <tbody>
+              {windows.map((w, i) => {
+                const st = w.stats
+                if (!st) {
+                  return (
+                    <tr key={i}>
+                      <td style={{ ...s.td, fontWeight: '600' }}>{w.window}</td>
+                      <td colSpan={12} style={{ ...s.td, ...s.tdMuted }}>Insufficient data</td>
+                    </tr>
+                  )
+                }
+                const count = st.actual_abs ?? st.actual_games ?? '—'
+                const dateRange = st.start_date && st.end_date
+                  ? `${st.start_date.slice(5)} – ${st.end_date.slice(5)}`
+                  : '—'
+                return (
+                  <tr key={i}>
+                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{w.window}</td>
+                    <td style={s.td}>{count}</td>
+                    <td style={{ ...s.td, ...s.tdMuted, fontSize: '12px' }}>{dateRange}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: avgColor(st.batting_avg), fontWeight: '600' }}>{dec(st.batting_avg)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{dec(st.on_base_pct ?? null)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{dec(st.slugging_pct ?? null)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{st.home_runs ?? '—'}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: kColor(st.k_pct), fontWeight: '600' }}>{pct(st.k_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.bb_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: evColor(st.avg_exit_velocity) }}>{mph(st.avg_exit_velocity)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{deg(st.avg_launch_angle)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.hard_hit_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.barrel_pct)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Chronological At-Bat Session */}
+      <div style={{ marginTop: '28px' }}>
+        <div style={s.sectionTitle}>Chronological At-Bat Session</div>
+        <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '14px' }}>
+          {abData ? `${abData.total_abs.toLocaleString()} total plate appearances on record · showing ${AB_PAGE_SIZE} per page` : ''}
+        </div>
+
+        {abLoading ? <div style={s.loader}>Loading at-bats…</div> : abData && (
+          <div style={s.tableWrap}>
+            <div style={s.abHeader}>
+              <span>Date</span>
+              <span>Hand</span>
+              <span>Pitch</span>
+              <span>Result</span>
+              <span style={{ textAlign: 'right' }}>EV</span>
+              <span style={{ textAlign: 'right' }}>LA</span>
+              <span>Stand</span>
+            </div>
+            {abData.at_bats.map((ab, i) => {
+              const resultLabel = RESULT_LABELS[ab.result] || ab.result?.replace(/_/g, ' ') || '?'
+              const resultColor = RESULT_COLORS[ab.result] || '#8b949e'
+              return (
+                <div key={i} style={s.abRow}>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.game_date}</span>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.pitcher_hand || '?'}</span>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.pitch_type || '—'}</span>
+                  <span style={{ color: resultColor, fontWeight: '600' }}>{resultLabel}</span>
+                  <span style={{ color: ab.exit_velocity ? '#e6edf3' : '#8b949e', textAlign: 'right' }}>
+                    {ab.exit_velocity ? `${ab.exit_velocity.toFixed(1)}` : '—'}
+                  </span>
+                  <span style={{ color: '#8b949e', textAlign: 'right', fontSize: '12px' }}>
+                    {ab.launch_angle != null ? `${ab.launch_angle.toFixed(0)}°` : '—'}
+                  </span>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.batter_stand || '?'}</span>
+                </div>
+              )
+            })}
+
+            {/* Pagination */}
+            <div style={s.pagination}>
+              <button style={s.pageBtn(abPage === 0)} disabled={abPage === 0} onClick={() => goPage(abPage - 1)}>← Prev</button>
+              <span>Page {abPage + 1} of {totalPages || 1}</span>
+              <button style={s.pageBtn(abPage >= totalPages - 1)} disabled={abPage >= totalPages - 1} onClick={() => goPage(abPage + 1)}>Next →</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/RollingPitcherPage.jsx
+++ b/frontend/src/pages/RollingPitcherPage.jsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+
+const API = '/api'
+
+const s = {
+  back: { color: '#58a6ff', textDecoration: 'none', fontSize: '13px', display: 'inline-block', marginBottom: '20px' },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px', flexWrap: 'wrap', gap: '12px' },
+  title: { fontSize: '22px', fontWeight: '700', color: '#e6edf3' },
+  subtitle: { fontSize: '13px', color: '#8b949e', marginTop: '4px' },
+  tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto', marginBottom: '20px' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px', minWidth: '700px' },
+  th: { padding: '12px 14px', textAlign: 'left', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
+  thRight: { textAlign: 'right' },
+  td: { padding: '11px 14px', borderBottom: '1px solid #0d1117', color: '#e6edf3', whiteSpace: 'nowrap' },
+  tdRight: { textAlign: 'right' },
+  tdMuted: { color: '#8b949e' },
+  noData: { color: '#8b949e', padding: '12px 14px', fontSize: '13px' },
+  loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
+  error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
+  note: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px 18px', fontSize: '13px', color: '#8b949e', marginBottom: '16px' },
+}
+
+const pct = (v, d = 1) => v != null ? `${(v * 100).toFixed(d)}%` : '—'
+const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
+const rpm = v => v != null ? `${Math.round(v)}` : '—'
+const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
+
+function kColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v >= 0.28) return '#3fb950'
+  if (v >= 0.22) return '#d29922'
+  return '#f85149'
+}
+function bbColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v <= 0.07) return '#3fb950'
+  if (v <= 0.09) return '#d29922'
+  return '#f85149'
+}
+function hhColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v <= 0.30) return '#3fb950'
+  if (v <= 0.37) return '#d29922'
+  return '#f85149'
+}
+function xwobaColor(v) {
+  if (v == null) return '#e6edf3'
+  if (v <= 0.28) return '#3fb950'
+  if (v <= 0.32) return '#d29922'
+  return '#f85149'
+}
+
+export default function RollingPitcherPage() {
+  const { id } = useParams()
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    fetch(`${API}/pitcher/${id}/rolling?windows=15,30,60,90,120,150`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setData(d); setLoading(false) })
+      .catch(e => { setError(String(e)); setLoading(false) })
+  }, [id])
+
+  if (loading) return <div style={s.loader}>Loading rolling stats…</div>
+  if (error) return <div style={s.error}>{error}</div>
+
+  const windows = data?.windows || []
+  const hasAny = windows.some(w => w.stats)
+
+  return (
+    <div>
+      <Link to={`/pitcher/${id}`} style={s.back}>← Back to Pitcher Profile</Link>
+
+      <div style={s.header}>
+        <div>
+          <div style={s.title}>Rolling Performance — Pitcher #{id}</div>
+          <div style={s.subtitle}>Last N game appearances. Green = elite · Yellow = average · Red = below average</div>
+        </div>
+      </div>
+
+      <div style={s.note}>
+        Stats computed from stored Statcast events. xwOBA and release metrics require full Statcast data (available on 90-day aggregate). Rolling windows show K%, BB%, Hard Hit%, and velocity from event-level data.
+      </div>
+
+      {!hasAny && (
+        <div style={{ color: '#8b949e', textAlign: 'center', padding: '48px' }}>
+          No event-level data available for pitcher #{id}. Run the ETL to populate Statcast events.
+        </div>
+      )}
+
+      {hasAny && (
+        <div style={s.tableWrap}>
+          <table style={s.table}>
+            <thead>
+              <tr>
+                <th style={s.th}>Window</th>
+                <th style={s.th}>Games</th>
+                <th style={s.th}>Date Range</th>
+                <th style={{ ...s.th, ...s.thRight }}>K%</th>
+                <th style={{ ...s.th, ...s.thRight }}>BB%</th>
+                <th style={{ ...s.th, ...s.thRight }}>Hard Hit%</th>
+                <th style={{ ...s.th, ...s.thRight }}>xwOBA</th>
+                <th style={{ ...s.th, ...s.thRight }}>Velo</th>
+                <th style={{ ...s.th, ...s.thRight }}>Spin</th>
+                <th style={{ ...s.th, ...s.thRight }}>HBreak</th>
+                <th style={{ ...s.th, ...s.thRight }}>VBreak</th>
+              </tr>
+            </thead>
+            <tbody>
+              {windows.map((w, i) => {
+                const st = w.stats
+                if (!st) {
+                  return (
+                    <tr key={i}>
+                      <td style={{ ...s.td, fontWeight: '600' }}>{w.window}</td>
+                      <td colSpan={10} style={{ ...s.td, ...s.tdMuted }}>Insufficient data</td>
+                    </tr>
+                  )
+                }
+                const dateRange = st.start_date && st.end_date
+                  ? `${st.start_date.slice(5)} – ${st.end_date.slice(5)}`
+                  : '—'
+                return (
+                  <tr key={i}>
+                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{w.window}</td>
+                    <td style={s.td}>{st.actual_games ?? '—'}</td>
+                    <td style={{ ...s.td, ...s.tdMuted, fontSize: '12px' }}>{dateRange}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: kColor(st.k_pct), fontWeight: '600' }}>{pct(st.k_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: bbColor(st.bb_pct), fontWeight: '600' }}>{pct(st.bb_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: hhColor(st.hard_hit_pct), fontWeight: '600' }}>{pct(st.hard_hit_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight, color: xwobaColor(st.xwoba) }}>{dec(st.xwoba)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{mph(st.avg_velocity)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{rpm(st.avg_spin_rate)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{st.avg_horiz_break != null ? Number(st.avg_horiz_break).toFixed(2) : '—'}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{st.avg_vert_break != null ? Number(st.avg_vert_break).toFixed(2) : '—'}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '8px' }}>
+        Window = last N distinct game dates. A pitcher appearing 3 times in a doubleheader counts as 1 game.
+        Seasons cross if N exceeds current-season appearances.
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StandingsPage.jsx
+++ b/frontend/src/pages/StandingsPage.jsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+
+const API = '/api'
+
+const DIVISIONS = {
+  201: 'AL East', 202: 'AL Central', 200: 'AL West',
+  204: 'NL East', 205: 'NL Central', 203: 'NL West',
+}
+const DIVISION_ORDER = [201, 202, 200, 204, 205, 203]
+
+const s = {
+  title: { fontSize: '24px', fontWeight: '700', color: '#e6edf3', marginBottom: '24px' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '20px' },
+  divCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'hidden' },
+  divHeader: { padding: '12px 16px', borderBottom: '1px solid #21262d', fontSize: '13px', fontWeight: '700', color: '#58a6ff', textTransform: 'uppercase', letterSpacing: '0.5px' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px' },
+  th: { padding: '8px 12px', textAlign: 'right', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', borderBottom: '1px solid #21262d' },
+  thLeft: { textAlign: 'left' },
+  td: { padding: '9px 12px', borderBottom: '1px solid #0d1117', color: '#e6edf3', textAlign: 'right', whiteSpace: 'nowrap' },
+  tdLeft: { textAlign: 'left' },
+  tdTeam: { display: 'flex', alignItems: 'center', gap: '8px' },
+  rank: { color: '#8b949e', width: '18px', flexShrink: 0, fontSize: '12px' },
+  teamLink: { color: '#e6edf3', textDecoration: 'none' },
+  streak: (s) => ({
+    fontSize: '11px', fontWeight: '600', padding: '1px 5px', borderRadius: '3px',
+    background: s?.startsWith('W') ? '#1f3a1f' : '#3a1f1f',
+    color: s?.startsWith('W') ? '#3fb950' : '#f85149',
+  }),
+  loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
+  error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
+  seasonRow: { display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '20px' },
+  select: {
+    background: '#161b22', border: '1px solid #30363d', color: '#e6edf3',
+    borderRadius: '6px', padding: '8px 12px', fontSize: '14px',
+  },
+}
+
+function pct(wins, losses) {
+  const total = wins + losses
+  if (total === 0) return '.000'
+  return (wins / total).toFixed(3).replace(/^0/, '')
+}
+
+function parseStreak(teamRecord) {
+  const streak = teamRecord?.streak?.streakCode
+  return streak || null
+}
+
+function parseLast10(teamRecord) {
+  const last10 = teamRecord?.records?.splitRecords?.find(r => r.type === 'lastTen')
+  if (!last10) return null
+  return `${last10.wins}-${last10.losses}`
+}
+
+export default function StandingsPage() {
+  const currentYear = new Date().getFullYear()
+  const [season, setSeason] = useState(currentYear)
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetch(`${API}/standings?season=${season}`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setData(d); setLoading(false) })
+      .catch(e => { setError(String(e)); setLoading(false) })
+  }, [season])
+
+  if (loading) return <div style={s.loader}>Loading standings…</div>
+  if (error) return <div style={s.error}>Error: {error}</div>
+
+  // Build division map
+  const divMap = {}
+  ;(data || []).forEach(record => {
+    const divId = record.division?.id
+    if (!divMap[divId]) divMap[divId] = []
+    ;(record.teamRecords || []).forEach(tr => divMap[divId].push(tr))
+  })
+
+  return (
+    <div>
+      <div style={s.title}>MLB Standings</div>
+
+      <div style={s.seasonRow}>
+        <select style={s.select} value={season} onChange={e => setSeason(Number(e.target.value))}>
+          {[currentYear, currentYear - 1, currentYear - 2, currentYear - 3].map(y => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+      </div>
+
+      <div style={s.grid}>
+        {DIVISION_ORDER.map(divId => {
+          const teams = divMap[divId] || []
+          const divName = DIVISIONS[divId] || `Division ${divId}`
+          if (teams.length === 0) return null
+
+          return (
+            <div key={divId} style={s.divCard}>
+              <div style={s.divHeader}>{divName}</div>
+              <table style={s.table}>
+                <thead>
+                  <tr>
+                    <th style={{ ...s.th, ...s.thLeft }}>Team</th>
+                    <th style={s.th}>W</th>
+                    <th style={s.th}>L</th>
+                    <th style={s.th}>PCT</th>
+                    <th style={s.th}>GB</th>
+                    <th style={s.th}>L10</th>
+                    <th style={s.th}>Str</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {teams.map((tr, i) => {
+                    const team = tr.team || {}
+                    const wins = tr.wins || 0
+                    const losses = tr.losses || 0
+                    const gb = tr.gamesBack === '0' ? '—' : tr.gamesBack
+                    const streak = parseStreak(tr)
+                    const last10 = parseLast10(tr)
+
+                    return (
+                      <tr key={i}>
+                        <td style={{ ...s.td, ...s.tdLeft }}>
+                          <div style={s.tdTeam}>
+                            <span style={s.rank}>{i + 1}</span>
+                            <Link to={`/team/${team.id}`} style={s.teamLink}>
+                              {team.name || `Team ${team.id}`}
+                            </Link>
+                          </div>
+                        </td>
+                        <td style={s.td}>{wins}</td>
+                        <td style={s.td}>{losses}</td>
+                        <td style={{ ...s.td, fontWeight: '600' }}>{pct(wins, losses)}</td>
+                        <td style={{ ...s.td, color: '#8b949e' }}>{gb}</td>
+                        <td style={{ ...s.td, color: '#8b949e' }}>{last10 || '—'}</td>
+                        <td style={s.td}>
+                          {streak ? <span style={s.streak(streak)}>{streak}</span> : '—'}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/TeamPage.jsx
+++ b/frontend/src/pages/TeamPage.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
 
 const API = '/api'
 
@@ -36,6 +37,7 @@ const TEAMS = [
 ]
 
 const s = {
+  back: { color: '#58a6ff', textDecoration: 'none', fontSize: '13px', display: 'inline-block', marginBottom: '20px' },
   row: { display: 'flex', gap: '12px', marginBottom: '28px', alignItems: 'center' },
   select: {
     flex: 1, background: '#161b22', border: '1px solid #30363d', color: '#e6edf3',
@@ -45,12 +47,26 @@ const s = {
     background: '#238636', color: '#fff', border: 'none', borderRadius: '6px',
     padding: '10px 20px', fontSize: '14px', fontWeight: '600', cursor: 'pointer',
   },
+  teamHeader: { marginBottom: '24px' },
+  teamName: { fontSize: '26px', fontWeight: '700', color: '#e6edf3', marginBottom: '6px' },
+  recordRow: { display: 'flex', gap: '20px', alignItems: 'center', flexWrap: 'wrap' },
+  recordBig: { fontSize: '28px', fontWeight: '700', color: '#3fb950' },
+  metaItem: { fontSize: '13px', color: '#8b949e' },
+  metaVal: { color: '#e6edf3', fontWeight: '600' },
+  streakBadge: (code) => ({
+    display: 'inline-block', fontSize: '12px', fontWeight: '700', padding: '3px 8px', borderRadius: '4px',
+    background: code?.startsWith('W') ? '#1f3a1f' : '#3a1f1f',
+    color: code?.startsWith('W') ? '#3fb950' : '#f85149',
+  }),
+  section: { marginBottom: '28px' },
+  sectionTitle: { fontSize: '16px', fontWeight: '600', color: '#e6edf3', marginBottom: '14px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
   splitGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' },
   splitCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '16px' },
   splitTitle: { fontSize: '14px', fontWeight: '600', color: '#58a6ff', marginBottom: '12px' },
   splitRow: { display: 'flex', justifyContent: 'space-between', padding: '6px 0', borderBottom: '1px solid #21262d', fontSize: '13px' },
   splitKey: { color: '#8b949e' },
   splitVal: { color: '#e6edf3', fontWeight: '500' },
+  standingsLink: { color: '#58a6ff', textDecoration: 'none', fontSize: '13px' },
   loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
   error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
   hint: { color: '#8b949e', textAlign: 'center', padding: '48px' },
@@ -69,7 +85,7 @@ function SplitCard({ title, split }) {
   if (!split) return (
     <div style={s.splitCard}>
       <div style={s.splitTitle}>{title}</div>
-      <div style={{ color: '#8b949e', fontSize: '13px' }}>No data in database yet. Run the ETL to populate.</div>
+      <div style={{ color: '#8b949e', fontSize: '13px' }}>No data — run ETL to populate team splits.</div>
     </div>
   )
   const rows = [
@@ -95,65 +111,92 @@ function SplitCard({ title, split }) {
 }
 
 export default function TeamPage() {
-  const currentYear = new Date().getFullYear()
-  const [teamId, setTeamId] = useState(147)
+  const { id: urlId } = useParams()
+  const [teamId, setTeamId] = useState(urlId ? Number(urlId) : 147)
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
-  function load() {
+  function load(tid) {
     setLoading(true)
     setError(null)
-    // Team splits live in /matchups context — we fetch directly from the MLB Stats API
-    // via our backend. For now fetch today's matchups and find the team.
-    const today = new Date().toISOString().slice(0, 10)
-    fetch(`${API}/matchups?date=${today}`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(matchups => {
-        // Find a game that has this team and surface its split data
-        const game = matchups.find(m => m.home_team_id === teamId || m.away_team_id === teamId)
-        setData(game || null)
-        setLoading(false)
-      })
+    fetch(`${API}/team/${tid}`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => { setData(d); setLoading(false) })
       .catch(e => { setError(String(e)); setLoading(false) })
   }
 
-  const teamName = TEAMS.find(t => t.id === teamId)?.name || `Team ${teamId}`
+  useEffect(() => {
+    if (urlId) load(Number(urlId))
+  }, [urlId])
+
+  const teamName = data?.standing?.team_name || TEAMS.find(t => t.id === teamId)?.name || `Team ${teamId}`
+  const standing = data?.standing
 
   return (
     <div>
-      <h1 style={{ fontSize: '24px', fontWeight: '700', marginBottom: '20px' }}>Team Splits</h1>
+      <Link to="/standings" style={s.back}>← Standings</Link>
 
-      <div style={s.row}>
-        <select style={s.select} value={teamId} onChange={e => setTeamId(Number(e.target.value))}>
-          {TEAMS.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
-        </select>
-        <button style={s.btn} onClick={load}>Load</button>
-      </div>
+      <div style={{ fontSize: '24px', fontWeight: '700', marginBottom: '20px' }}>Team Profile</div>
+
+      {!urlId && (
+        <div style={s.row}>
+          <select style={s.select} value={teamId} onChange={e => setTeamId(Number(e.target.value))}>
+            {TEAMS.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
+          </select>
+          <button style={s.btn} onClick={() => load(teamId)}>Load</button>
+        </div>
+      )}
 
       {loading && <div style={s.loader}>Loading…</div>}
       {error && <div style={s.error}>{error}</div>}
 
-      {!loading && !error && data && (
-        <div>
-          <h2 style={{ fontSize: '18px', fontWeight: '600', marginBottom: '16px', color: '#8b949e' }}>
-            {teamName} — Today's Game Context
-          </h2>
-          <div style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '16px', marginBottom: '16px', fontSize: '14px', color: '#8b949e' }}>
-            Team splits are populated via the ETL pipeline. Run <code style={{ background: '#21262d', padding: '2px 6px', borderRadius: '4px', color: '#e6edf3' }}>python seed_db.py</code> to load this season's data.
-          </div>
-          <div style={s.splitGrid}>
-            <SplitCard title="vs Left-Handed Pitchers" split={null} />
-            <SplitCard title="vs Right-Handed Pitchers" split={null} />
-          </div>
-        </div>
+      {!loading && !error && !data && !urlId && (
+        <div style={s.hint}>Select a team and click Load to view their stats.</div>
       )}
 
-      {!loading && !error && !data && (
-        <div style={s.hint}>
-          Select a team and click Load to view their splits.<br />
-          <span style={{ fontSize: '13px' }}>Data requires the ETL pipeline to have run for this season.</span>
-        </div>
+      {data && (
+        <>
+          <div style={s.teamHeader}>
+            <div style={s.teamName}>{teamName}</div>
+            {standing ? (
+              <div style={s.recordRow}>
+                <div style={s.recordBig}>
+                  {standing.wins ?? '—'} – {standing.losses ?? '—'}
+                </div>
+                {standing.pct && (
+                  <div style={s.metaItem}>
+                    <span style={s.metaVal}>{standing.pct}</span> PCT
+                  </div>
+                )}
+                {standing.division && (
+                  <div style={s.metaItem}>
+                    <span style={s.metaVal}>{standing.division}</span>
+                    {standing.games_back && standing.games_back !== '0' && (
+                      <span> · {standing.games_back} GB</span>
+                    )}
+                    {standing.games_back === '0' && <span> · Division Leader</span>}
+                  </div>
+                )}
+                {standing.streak && (
+                  <span style={s.streakBadge(standing.streak)}>{standing.streak}</span>
+                )}
+              </div>
+            ) : (
+              <div style={{ color: '#8b949e', fontSize: '13px', marginTop: '6px' }}>
+                Standings data unavailable.
+              </div>
+            )}
+          </div>
+
+          <div style={s.section}>
+            <div style={s.sectionTitle}>Team Splits — {data.season}</div>
+            <div style={s.splitGrid}>
+              <SplitCard title="vs Left-Handed Pitchers" split={data.splits?.vsL} />
+              <SplitCard title="vs Right-Handed Pitchers" split={data.splits?.vsR} />
+            </div>
+          </div>
+        </>
       )}
     </div>
   )

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -2,13 +2,18 @@
 FastAPI application for the MLB prediction engine.
 
 Endpoints:
-    GET  /matchups?date=YYYY-MM-DD       Daily matchups with win probabilities
-    GET  /pitcher/{player_id}            Pitcher aggregate + pitch arsenal
-    GET  /batter/{player_id}             Batter aggregate + platoon splits
+    GET  /health
+    GET  /matchups?date=YYYY-MM-DD
+    GET  /matchup/{game_pk}              Full detail: pitchers, lineup, splits, game log
+    GET  /pitcher/{id}                   Aggregate + arsenal
+    GET  /pitcher/{id}/rolling           L15G–L150G rolling stats
+    GET  /pitcher/{id}/game-log          Recent game-by-game appearances
+    GET  /batter/{id}                    Aggregate + platoon splits
+    GET  /batter/{id}/rolling            L10–L1000 AB rolling stats
+    GET  /batter/{id}/at-bats            Chronological at-bat session
+    GET  /standings                      MLB AL/NL standings
+    GET  /lineup/{team_id}               Day-of lineup from MLB Stats API
     POST /predict                        Score a specific pitcher vs batter
-
-Run:
-    uvicorn mlb_app.app:app --reload
 """
 
 from __future__ import annotations
@@ -17,8 +22,10 @@ import datetime
 import os
 from typing import Any, Dict, List, Optional
 
+import requests as _req
+
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, Query
     from fastapi.middleware.cors import CORSMiddleware
     from pydantic import BaseModel
     _FASTAPI = True
@@ -33,11 +40,24 @@ from .database import get_engine, create_tables, get_session
 from .matchup_generator import generate_matchups_for_date
 from .db_utils import (
     get_pitcher_aggregate,
+    get_pitcher_aggregate_with_fallback,
     get_batter_aggregate,
+    get_batter_aggregate_with_fallback,
     get_pitch_arsenal,
+    get_pitch_arsenal_with_fallback,
     get_player_split,
+    get_team_split,
+    get_pitcher_rolling_by_games,
+    get_batter_rolling_by_games,
+    get_batter_rolling_by_abs,
+    get_batter_at_bats,
+    get_pitcher_game_log,
+    get_pitcher_multi_season,
+    get_batter_multi_season,
 )
-from .scoring import score_individual_matchup
+from .scoring import compute_win_probability, score_individual_matchup, get_park_factor
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 
 
 def _get_session():
@@ -60,7 +80,7 @@ def create_app():
 
     app = FastAPI(
         title="MLB Prediction API",
-        version="0.4.0",
+        version="0.5.0",
         description="Statcast-powered daily matchup predictions",
     )
 
@@ -71,9 +91,17 @@ def create_app():
         allow_headers=["*"],
     )
 
+    # -------------------------------------------------------------------------
+    # Health
+    # -------------------------------------------------------------------------
+
     @app.get("/health")
     def health():
-        return {"status": "ok", "version": "0.4.0"}
+        return {"status": "ok", "version": "0.5.0"}
+
+    # -------------------------------------------------------------------------
+    # Matchups
+    # -------------------------------------------------------------------------
 
     @app.get("/matchups")
     def list_matchups(date: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -86,24 +114,165 @@ def create_app():
             except Exception as exc:
                 raise HTTPException(status_code=500, detail=str(exc))
 
-    @app.get("/pitcher/{player_id}")
-    def get_pitcher(player_id: int) -> Dict[str, Any]:
+    @app.get("/matchup/{game_pk}")
+    def get_matchup_detail(game_pk: int) -> Dict[str, Any]:
+        """Full matchup detail: probable pitchers, lineup, team splits, recent outings."""
+        url = f"{MLB_STATS_BASE}/schedule"
+        params = {
+            "gamePk": game_pk,
+            "hydrate": "probablePitcher,team,linescore,lineups,decisions",
+        }
+        try:
+            resp = _req.get(url, params=params, timeout=20)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"MLB API error: {exc}")
+
+        dates = resp.json().get("dates", [])
+        if not dates or not dates[0].get("games"):
+            raise HTTPException(status_code=404, detail=f"Game {game_pk} not found")
+
+        game = dates[0]["games"][0]
+        teams = game.get("teams", {})
+        home = teams.get("home", {})
+        away = teams.get("away", {})
+
+        home_team_id = home.get("team", {}).get("id")
+        away_team_id = away.get("team", {}).get("id")
+        home_pitcher_id = home.get("probablePitcher", {}).get("id")
+        away_pitcher_id = away.get("probablePitcher", {}).get("id")
+        game_date_iso = game.get("gameDate", "")
+        venue_name = game.get("venue", {}).get("name")
+        season = int(game_date_iso[:4]) if game_date_iso else datetime.date.today().year
+
+        home_record = home.get("leagueRecord", {})
+        away_record = away.get("leagueRecord", {})
+
+        lineups = game.get("lineups", {})
+        home_lineup_raw = lineups.get("homePlayers", [])
+        away_lineup_raw = lineups.get("awayPlayers", [])
+
         Session = _get_session()
         with Session() as session:
-            agg = get_pitcher_aggregate(session, player_id, "90d")
-            season = datetime.date.today().year
-            arsenal = get_pitch_arsenal(session, player_id, season)
-            if not agg and not arsenal:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No data found for pitcher {player_id}",
+
+            def pitcher_detail(pid):
+                if not pid:
+                    return {"aggregate": None, "arsenal": [], "game_log": []}
+                agg, data_source = get_pitcher_aggregate_with_fallback(session, pid, season)
+                arsenal, arsenal_season = get_pitch_arsenal_with_fallback(session, pid, season)
+                game_log = get_pitcher_game_log(session, pid, 5)
+                return {
+                    "aggregate": {
+                        "data_source": data_source,
+                        "avg_velocity": agg.avg_velocity if agg else None,
+                        "avg_spin_rate": agg.avg_spin_rate if agg else None,
+                        "hard_hit_pct": agg.hard_hit_pct if agg else None,
+                        "k_pct": agg.k_pct if agg else None,
+                        "bb_pct": agg.bb_pct if agg else None,
+                        "xwoba": agg.xwoba if agg else None,
+                        "xba": agg.xba if agg else None,
+                        "avg_horiz_break": agg.avg_horiz_break if agg else None,
+                        "avg_vert_break": agg.avg_vert_break if agg else None,
+                    },
+                    "arsenal": [
+                        {
+                            "pitch_type": r.pitch_type,
+                            "pitch_name": r.pitch_name,
+                            "usage_pct": r.usage_pct,
+                            "whiff_pct": r.whiff_pct,
+                            "strikeout_pct": r.strikeout_pct,
+                            "rv_per_100": r.rv_per_100,
+                            "xwoba": r.xwoba,
+                            "hard_hit_pct": r.hard_hit_pct,
+                        }
+                        for r in arsenal
+                    ],
+                    "arsenal_season": arsenal_season,
+                    "game_log": game_log,
+                }
+
+            def team_splits(tid):
+                vsL = get_team_split(session, tid, season, "vsL")
+                vsR = get_team_split(session, tid, season, "vsR")
+
+                def sd(s):
+                    if not s:
+                        return None
+                    return {
+                        "pa": s.pa, "batting_avg": s.batting_avg,
+                        "on_base_pct": s.on_base_pct, "slugging_pct": s.slugging_pct,
+                        "k_pct": s.k_pct, "bb_pct": s.bb_pct, "home_runs": s.home_runs,
+                    }
+                return {"vsL": sd(vsL), "vsR": sd(vsR)}
+
+            home_win_prob, away_win_prob = None, None
+            if home_pitcher_id and away_pitcher_id and home_team_id and away_team_id:
+                home_win_prob, away_win_prob = compute_win_probability(
+                    session,
+                    home_pitcher_id=home_pitcher_id,
+                    away_pitcher_id=away_pitcher_id,
+                    home_team_id=home_team_id,
+                    away_team_id=away_team_id,
+                    season=season,
                 )
+
+            return {
+                "game_pk": game_pk,
+                "game_date": game_date_iso,
+                "venue": venue_name,
+                "status": game.get("status", {}).get("detailedState"),
+                "park_factor": get_park_factor(venue_name),
+                "home_win_prob": home_win_prob,
+                "away_win_prob": away_win_prob,
+                "home_team": {
+                    "id": home_team_id,
+                    "name": home.get("team", {}).get("name"),
+                    "record": f"{home_record.get('wins',0)}-{home_record.get('losses',0)}" if home_record else None,
+                    "pitcher_id": home_pitcher_id,
+                    "pitcher_name": home.get("probablePitcher", {}).get("fullName"),
+                    **pitcher_detail(home_pitcher_id),
+                    "splits": team_splits(home_team_id),
+                    "lineup": [
+                        {"id": p.get("id"), "name": p.get("fullName"), "position": p.get("primaryPosition", {}).get("abbreviation")}
+                        for p in home_lineup_raw
+                    ],
+                },
+                "away_team": {
+                    "id": away_team_id,
+                    "name": away.get("team", {}).get("name"),
+                    "record": f"{away_record.get('wins',0)}-{away_record.get('losses',0)}" if away_record else None,
+                    "pitcher_id": away_pitcher_id,
+                    "pitcher_name": away.get("probablePitcher", {}).get("fullName"),
+                    **pitcher_detail(away_pitcher_id),
+                    "splits": team_splits(away_team_id),
+                    "lineup": [
+                        {"id": p.get("id"), "name": p.get("fullName"), "position": p.get("primaryPosition", {}).get("abbreviation")}
+                        for p in away_lineup_raw
+                    ],
+                },
+            }
+
+    # -------------------------------------------------------------------------
+    # Pitcher endpoints
+    # -------------------------------------------------------------------------
+
+    @app.get("/pitcher/{player_id}")
+    def get_pitcher(player_id: int) -> Dict[str, Any]:
+        season = datetime.date.today().year
+        Session = _get_session()
+        with Session() as session:
+            agg, data_source = get_pitcher_aggregate_with_fallback(session, player_id, season)
+            arsenal, arsenal_season = get_pitch_arsenal_with_fallback(session, player_id, season)
+            multi = get_pitcher_multi_season(session, player_id, [season, season - 1, season - 2, season - 3])
+            game_log = get_pitcher_game_log(session, player_id, 10)
+            if not agg and not arsenal:
+                raise HTTPException(status_code=404, detail=f"No data for pitcher {player_id}")
             return {
                 "player_id": player_id,
+                "data_source": data_source,
                 "aggregate": {
                     c.name: getattr(agg, c.name)
                     for c in agg.__table__.columns
-                    if c.name != "_sa_instance_state"
                 } if agg else None,
                 "arsenal": [
                     {
@@ -118,23 +287,52 @@ def create_app():
                     }
                     for r in arsenal
                 ],
+                "arsenal_season": arsenal_season,
+                "multi_season": multi,
+                "game_log": game_log,
             }
+
+    @app.get("/pitcher/{player_id}/rolling")
+    def pitcher_rolling(
+        player_id: int,
+        windows: str = Query("15,30,60,90,120,150"),
+    ) -> Dict[str, Any]:
+        sizes = [int(w) for w in windows.split(",") if w.strip().isdigit()]
+        Session = _get_session()
+        with Session() as session:
+            result = []
+            for n in sizes:
+                stats = get_pitcher_rolling_by_games(session, player_id, n)
+                result.append({
+                    "window": f"L{n}G",
+                    "n_requested": n,
+                    "stats": stats,
+                })
+            return {"player_id": player_id, "windows": result}
+
+    @app.get("/pitcher/{player_id}/game-log")
+    def pitcher_game_log(player_id: int, n: int = 10) -> Dict[str, Any]:
+        Session = _get_session()
+        with Session() as session:
+            return {"player_id": player_id, "game_log": get_pitcher_game_log(session, player_id, n)}
+
+    # -------------------------------------------------------------------------
+    # Batter endpoints
+    # -------------------------------------------------------------------------
 
     @app.get("/batter/{player_id}")
     def get_batter(player_id: int) -> Dict[str, Any]:
+        season = datetime.date.today().year
         Session = _get_session()
         with Session() as session:
-            agg = get_batter_aggregate(session, player_id, "90d")
-            season = datetime.date.today().year
+            agg, data_source = get_batter_aggregate_with_fallback(session, player_id, season)
             split_L = get_player_split(session, player_id, season, "vsL")
             split_R = get_player_split(session, player_id, season, "vsR")
+            multi = get_batter_multi_season(session, player_id, [season, season - 1, season - 2, season - 3])
             if not agg and not split_L and not split_R:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No data found for batter {player_id}",
-                )
+                raise HTTPException(status_code=404, detail=f"No data for batter {player_id}")
 
-            def _split_dict(s):
+            def _sd(s):
                 if not s:
                     return None
                 return {
@@ -146,13 +344,179 @@ def create_app():
 
             return {
                 "player_id": player_id,
+                "data_source": data_source,
                 "aggregate": {
                     c.name: getattr(agg, c.name)
                     for c in agg.__table__.columns
-                    if c.name != "_sa_instance_state"
                 } if agg else None,
-                "splits": {"vsL": _split_dict(split_L), "vsR": _split_dict(split_R)},
+                "splits": {"vsL": _sd(split_L), "vsR": _sd(split_R)},
+                "multi_season": multi,
             }
+
+    @app.get("/batter/{player_id}/rolling")
+    def batter_rolling(
+        player_id: int,
+        windows: str = Query("10,25,50,100,200,400,1000"),
+        type: str = Query("abs"),
+    ) -> Dict[str, Any]:
+        sizes = [int(w) for w in windows.split(",") if w.strip().isdigit()]
+        Session = _get_session()
+        with Session() as session:
+            result = []
+            for n in sizes:
+                if type == "games":
+                    stats = get_batter_rolling_by_games(session, player_id, n)
+                    label = f"L{n}G"
+                else:
+                    stats = get_batter_rolling_by_abs(session, player_id, n)
+                    label = f"L{n}"
+                result.append({"window": label, "n_requested": n, "stats": stats})
+            return {"player_id": player_id, "type": type, "windows": result}
+
+    @app.get("/batter/{player_id}/at-bats")
+    def batter_at_bats(
+        player_id: int,
+        n: int = Query(50, le=500),
+        offset: int = Query(0, ge=0),
+    ) -> Dict[str, Any]:
+        Session = _get_session()
+        with Session() as session:
+            total, rows = get_batter_at_bats(session, player_id, n, offset)
+            return {
+                "player_id": player_id,
+                "total_abs": total,
+                "n": n,
+                "offset": offset,
+                "at_bats": rows,
+            }
+
+    # -------------------------------------------------------------------------
+    # Standings
+    # -------------------------------------------------------------------------
+
+    @app.get("/standings")
+    def get_standings(season: Optional[int] = None) -> List[Dict[str, Any]]:
+        if not season:
+            season = datetime.date.today().year
+        url = f"{MLB_STATS_BASE}/standings"
+        params = {
+            "leagueId": "103,104",
+            "season": season,
+            "standingsTypes": "regularSeason",
+            "hydrate": "team,division,league,record",
+        }
+        try:
+            resp = _req.get(url, params=params, timeout=20)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"MLB API error: {exc}")
+        return resp.json().get("records", [])
+
+    # -------------------------------------------------------------------------
+    # Lineup
+    # -------------------------------------------------------------------------
+
+    @app.get("/lineup/{team_id}")
+    def get_team_lineup(team_id: int, date: Optional[str] = None) -> Dict[str, Any]:
+        if not date:
+            date = datetime.date.today().isoformat()
+        url = f"{MLB_STATS_BASE}/schedule"
+        params = {
+            "sportId": 1,
+            "date": date,
+            "teamId": team_id,
+            "hydrate": "lineups,probablePitcher,team",
+        }
+        try:
+            resp = _req.get(url, params=params, timeout=20)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"MLB API error: {exc}")
+
+        dates = resp.json().get("dates", [])
+        if not dates or not dates[0].get("games"):
+            return {"team_id": team_id, "date": date, "lineup": [], "probable_pitcher": None}
+
+        game = dates[0]["games"][0]
+        teams = game.get("teams", {})
+        side = "home" if teams.get("home", {}).get("team", {}).get("id") == team_id else "away"
+        lineup_raw = game.get("lineups", {}).get(f"{side}Players", [])
+        pitcher = teams.get(side, {}).get("probablePitcher", {})
+
+        return {
+            "team_id": team_id,
+            "date": date,
+            "game_pk": game.get("gamePk"),
+            "probable_pitcher": {
+                "id": pitcher.get("id"),
+                "name": pitcher.get("fullName"),
+            } if pitcher else None,
+            "lineup": [
+                {"batting_order": i + 1, "id": p.get("id"), "name": p.get("fullName")}
+                for i, p in enumerate(lineup_raw)
+            ],
+        }
+
+    # -------------------------------------------------------------------------
+    # Team
+    # -------------------------------------------------------------------------
+
+    @app.get("/team/{team_id}")
+    def get_team(team_id: int, season: Optional[int] = None) -> Dict[str, Any]:
+        if not season:
+            season = datetime.date.today().year
+        Session = _get_session()
+        with Session() as session:
+            vsL = get_team_split(session, team_id, season, "vsL")
+            vsR = get_team_split(session, team_id, season, "vsR")
+
+            def _sd(sp):
+                if not sp:
+                    return None
+                return {
+                    c.name: getattr(sp, c.name)
+                    for c in sp.__table__.columns
+                }
+
+        standings_url = f"{MLB_STATS_BASE}/standings"
+        standings_params = {
+            "leagueId": "103,104",
+            "season": season,
+            "standingsTypes": "regularSeason",
+            "hydrate": "team,division,record",
+        }
+        team_standing = None
+        try:
+            s_resp = _req.get(standings_url, params=standings_params, timeout=15)
+            s_resp.raise_for_status()
+            for div_record in s_resp.json().get("records", []):
+                for tr in div_record.get("teamRecords", []):
+                    if tr.get("team", {}).get("id") == team_id:
+                        team_standing = {
+                            "team_name": tr["team"].get("name"),
+                            "wins": tr.get("wins"),
+                            "losses": tr.get("losses"),
+                            "pct": tr.get("winningPercentage"),
+                            "games_back": tr.get("gamesBack"),
+                            "division": div_record.get("division", {}).get("nameShort"),
+                            "streak": tr.get("streak", {}).get("streakCode"),
+                        }
+                        break
+                if team_standing:
+                    break
+        except Exception:
+            pass
+
+        return {
+            "team_id": team_id,
+            "season": season,
+            "standing": team_standing,
+            "splits": {"vsL": _sd(vsL), "vsR": _sd(vsR)},
+        }
+
+    # -------------------------------------------------------------------------
+    # Predict
+    # -------------------------------------------------------------------------
 
     @app.post("/predict")
     def predict_matchup(req: PredictRequest) -> Dict[str, Any]:
@@ -166,11 +530,7 @@ def create_app():
                 season=season,
                 pitcher_throws=req.pitcher_throws,
             )
-        return {
-            "pitcher_id": req.pitcher_id,
-            "batter_id": req.batter_id,
-            **result,
-        }
+        return {"pitcher_id": req.pitcher_id, "batter_id": req.batter_id, **result}
 
     return app
 

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -1,176 +1,441 @@
 """
-Database helper functions for retrieving aggregated metrics.
-
-This module provides convenience functions to query pitcher and batter
-aggregates, pitch‑arsenal statistics and hitting splits from the
-database using SQLAlchemy sessions.  It encapsulates common query
-patterns so that the rest of the application can remain agnostic of the
-underlying ORM models.
-
-Functions defined here accept a ``Session`` object bound to the
-application's database engine and return instances of the ORM models
-defined in ``database.py`` or ``None`` if no matching record exists.
-
-Example usage::
-
-    from mlb_app.database import get_engine, create_tables, get_session
-    from mlb_app.db_utils import (
-        get_pitcher_aggregate,
-        get_batter_aggregate,
-        get_pitch_arsenal,
-        get_player_split,
-        get_team_split,
-    )
-
-    engine = get_engine("postgresql+psycopg2://user:pass@host/db")
-    create_tables(engine)
-    SessionLocal = get_session(engine)
-
-    with SessionLocal() as session:
-        agg = get_pitcher_aggregate(session, pitcher_id=123, window="90d")
-        arsenal = get_pitch_arsenal(session, pitcher_id=123, season=2026)
-        hitter_vs_rhp = get_player_split(session, player_id=456, season=2026, split="vsR")
-
+Database helper functions — aggregates, rolling windows, game logs.
 """
 
 from __future__ import annotations
 
-from typing import List, Optional
+import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
+import pandas as pd
 from sqlalchemy.orm import Session
 
 from .database import (
-    PitcherAggregate,
     BatterAggregate,
     PitchArsenal,
+    PitcherAggregate,
     PlayerSplit,
+    StatcastEvent,
     TeamSplit,
 )
 
 
+# ---------------------------------------------------------------------------
+# Standard aggregate lookups
+# ---------------------------------------------------------------------------
+
 def get_pitcher_aggregate(
     session: Session, pitcher_id: int, window: str
 ) -> Optional[PitcherAggregate]:
-    """Return a pitcher aggregate for a given pitcher and window.
-
-    :param session: Active database session.
-    :param pitcher_id: MLBAM identifier for the pitcher.
-    :param window: Rolling window or season label (e.g., ``"90d"``,
-        ``"2025"``) used when aggregating metrics.
-    :returns: A :class:`PitcherAggregate` instance if found, otherwise
-        ``None``.
-    """
     return (
         session.query(PitcherAggregate)
-        .filter(
-            PitcherAggregate.pitcher_id == pitcher_id,
-            PitcherAggregate.window == window,
-        )
+        .filter(PitcherAggregate.pitcher_id == pitcher_id,
+                PitcherAggregate.window == window)
         .order_by(PitcherAggregate.end_date.desc())
         .first()
     )
 
 
+def get_pitcher_aggregate_with_fallback(
+    session: Session, pitcher_id: int, current_season: Optional[int] = None
+) -> Tuple[Optional[PitcherAggregate], Optional[str]]:
+    """Return best available pitcher aggregate and a human-readable source label.
+
+    Priority: 90-day rolling → current season → 3 prior seasons.
+    """
+    if current_season is None:
+        current_season = datetime.date.today().year
+
+    agg = get_pitcher_aggregate(session, pitcher_id, "90d")
+    if agg:
+        return agg, "Last 90 Days"
+
+    agg = get_pitcher_aggregate(session, pitcher_id, str(current_season))
+    if agg:
+        return agg, f"{current_season} Season"
+
+    for year in range(current_season - 1, current_season - 4, -1):
+        agg = get_pitcher_aggregate(session, pitcher_id, str(year))
+        if agg:
+            return agg, f"{year} Season"
+
+    return None, None
+
 
 def get_batter_aggregate(
     session: Session, batter_id: int, window: str
 ) -> Optional[BatterAggregate]:
-    """Return a batter aggregate for a given batter and window.
-
-    :param session: Active database session.
-    :param batter_id: MLBAM identifier for the batter.
-    :param window: Rolling window or season label.
-    :returns: A :class:`BatterAggregate` instance if found, otherwise
-        ``None``.
-    """
     return (
         session.query(BatterAggregate)
-        .filter(
-            BatterAggregate.batter_id == batter_id,
-            BatterAggregate.window == window,
-        )
+        .filter(BatterAggregate.batter_id == batter_id,
+                BatterAggregate.window == window)
         .order_by(BatterAggregate.end_date.desc())
         .first()
     )
 
 
+def get_batter_aggregate_with_fallback(
+    session: Session, batter_id: int, current_season: Optional[int] = None
+) -> Tuple[Optional[BatterAggregate], Optional[str]]:
+    if current_season is None:
+        current_season = datetime.date.today().year
+
+    agg = get_batter_aggregate(session, batter_id, "90d")
+    if agg:
+        return agg, "Last 90 Days"
+
+    agg = get_batter_aggregate(session, batter_id, str(current_season))
+    if agg:
+        return agg, f"{current_season} Season"
+
+    for year in range(current_season - 1, current_season - 4, -1):
+        agg = get_batter_aggregate(session, batter_id, str(year))
+        if agg:
+            return agg, f"{year} Season"
+
+    return None, None
+
 
 def get_pitch_arsenal(
     session: Session, pitcher_id: int, season: int
 ) -> List[PitchArsenal]:
-    """Return all pitch‑arsenal records for a pitcher in a given season.
-
-    :param session: Active database session.
-    :param pitcher_id: MLBAM identifier for the pitcher.
-    :param season: Numeric year (e.g., 2026) for which to retrieve
-        pitch‑arsenal stats.
-    :returns: A list of :class:`PitchArsenal` records (possibly empty).
-    """
     return (
         session.query(PitchArsenal)
-        .filter(
-            PitchArsenal.pitcher_id == pitcher_id,
-            PitchArsenal.season == season,
-        )
-        .order_by(PitchArsenal.pitch_type)
+        .filter(PitchArsenal.pitcher_id == pitcher_id,
+                PitchArsenal.season == season)
+        .order_by(PitchArsenal.usage_pct.desc())
         .all()
     )
 
+
+def get_pitch_arsenal_with_fallback(
+    session: Session, pitcher_id: int, current_season: Optional[int] = None
+) -> Tuple[List[PitchArsenal], Optional[int]]:
+    if current_season is None:
+        current_season = datetime.date.today().year
+
+    for season in [current_season, current_season - 1, current_season - 2]:
+        arsenal = get_pitch_arsenal(session, pitcher_id, season)
+        if arsenal:
+            return arsenal, season
+
+    return [], None
 
 
 def get_player_split(
     session: Session, player_id: int, season: int, split: str
 ) -> Optional[PlayerSplit]:
-    """Return a player's hitting split for a given season and split code.
-
-    :param session: Active database session.
-    :param player_id: MLBAM identifier for the batter.
-    :param season: Year to query.
-    :param split: ``"vsL"`` or ``"vsR"`` indicating the pitcher
-        handedness.
-    :returns: A :class:`PlayerSplit` instance if found, otherwise
-        ``None``.
-    """
     return (
         session.query(PlayerSplit)
-        .filter(
-            PlayerSplit.player_id == player_id,
-            PlayerSplit.season == season,
-            PlayerSplit.split == split,
-        )
+        .filter(PlayerSplit.player_id == player_id,
+                PlayerSplit.season == season,
+                PlayerSplit.split == split)
         .first()
     )
-
 
 
 def get_team_split(
     session: Session, team_id: int, season: int, split: str
 ) -> Optional[TeamSplit]:
-    """Return a team's hitting split for a given season and split code.
-
-    :param session: Active database session.
-    :param team_id: MLBAM identifier for the team.
-    :param season: Year to query.
-    :param split: ``"vsL"`` or ``"vsR"`` indicating pitcher
-        handedness.
-    :returns: A :class:`TeamSplit` instance if found, otherwise
-        ``None``.
-    """
     return (
         session.query(TeamSplit)
-        .filter(
-            TeamSplit.team_id == team_id,
-            TeamSplit.season == season,
-            TeamSplit.split == split,
-        )
+        .filter(TeamSplit.team_id == team_id,
+                TeamSplit.season == season,
+                TeamSplit.split == split)
         .first()
     )
 
 
+# ---------------------------------------------------------------------------
+# DataFrame converters for rolling window computation
+# ---------------------------------------------------------------------------
+
+def _events_to_pitcher_df(events: List[StatcastEvent]) -> pd.DataFrame:
+    """StatcastEvent ORM rows → DataFrame usable by calculate_pitcher_aggregates."""
+    rows = []
+    for e in events:
+        rows.append({
+            "release_speed": e.release_speed,
+            "release_spin_rate": e.release_spin_rate,
+            "launch_speed": e.launch_speed,
+            "events": e.events or "",
+            "description": "",          # not stored; whiff_pct will be None
+            "pfx_x": e.pfx_x,
+            "pfx_z": e.pfx_z,
+            "release_pos_x": None,
+            "release_pos_z": None,
+            "release_extension": None,
+            "estimated_woba_using_speedangle": None,
+            "estimated_ba_using_speedangle": None,
+        })
+    return pd.DataFrame(rows)
+
+
+def _events_to_batter_df(events: List[StatcastEvent]) -> pd.DataFrame:
+    """StatcastEvent ORM rows → DataFrame usable by calculate_batter_aggregates."""
+    rows = []
+    for e in events:
+        rows.append({
+            "launch_speed": e.launch_speed,
+            "launch_angle": e.launch_angle,
+            "events": e.events or "",
+        })
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Rolling windows — computed on-the-fly from StatcastEvent
+# ---------------------------------------------------------------------------
+
+def get_pitcher_rolling_by_games(
+    session: Session, pitcher_id: int, n_games: int
+) -> Optional[Dict[str, Any]]:
+    """Pitcher stats from last n distinct game appearances."""
+    date_rows = (
+        session.query(StatcastEvent.game_date)
+        .filter(StatcastEvent.pitcher_id == pitcher_id)
+        .distinct()
+        .order_by(StatcastEvent.game_date.desc())
+        .limit(n_games)
+        .all()
+    )
+    if not date_rows:
+        return None
+
+    date_list = [r[0] for r in date_rows]
+    events = (
+        session.query(StatcastEvent)
+        .filter(StatcastEvent.pitcher_id == pitcher_id,
+                StatcastEvent.game_date.in_(date_list))
+        .all()
+    )
+    if not events:
+        return None
+
+    from .statcast_utils import calculate_pitcher_aggregates
+    stats = calculate_pitcher_aggregates(_events_to_pitcher_df(events))
+    stats["actual_games"] = len(date_list)
+    stats["start_date"] = min(date_list).isoformat()
+    stats["end_date"] = max(date_list).isoformat()
+    return stats
+
+
+def get_batter_rolling_by_games(
+    session: Session, batter_id: int, n_games: int
+) -> Optional[Dict[str, Any]]:
+    """Batter stats from last n distinct game appearances."""
+    date_rows = (
+        session.query(StatcastEvent.game_date)
+        .filter(StatcastEvent.batter_id == batter_id)
+        .distinct()
+        .order_by(StatcastEvent.game_date.desc())
+        .limit(n_games)
+        .all()
+    )
+    if not date_rows:
+        return None
+
+    date_list = [r[0] for r in date_rows]
+    events = (
+        session.query(StatcastEvent)
+        .filter(StatcastEvent.batter_id == batter_id,
+                StatcastEvent.game_date.in_(date_list),
+                StatcastEvent.events.isnot(None),
+                StatcastEvent.events != "")
+        .all()
+    )
+    if not events:
+        return None
+
+    from .statcast_utils import calculate_batter_aggregates
+    stats = calculate_batter_aggregates(_events_to_batter_df(events))
+    stats["actual_games"] = len(date_list)
+    stats["start_date"] = min(date_list).isoformat()
+    stats["end_date"] = max(date_list).isoformat()
+    return stats
+
+
+def get_batter_rolling_by_abs(
+    session: Session, batter_id: int, n_abs: int
+) -> Optional[Dict[str, Any]]:
+    """Batter stats from last n plate appearances regardless of date."""
+    events = (
+        session.query(StatcastEvent)
+        .filter(StatcastEvent.batter_id == batter_id,
+                StatcastEvent.events.isnot(None),
+                StatcastEvent.events != "")
+        .order_by(StatcastEvent.game_date.desc())
+        .limit(n_abs)
+        .all()
+    )
+    if not events:
+        return None
+
+    from .statcast_utils import calculate_batter_aggregates
+    stats = calculate_batter_aggregates(_events_to_batter_df(events))
+    stats["actual_abs"] = len(events)
+    dates = [e.game_date for e in events if e.game_date]
+    stats["start_date"] = min(dates).isoformat() if dates else None
+    stats["end_date"] = max(dates).isoformat() if dates else None
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# At-bat session (chronological PA log)
+# ---------------------------------------------------------------------------
+
+def get_batter_at_bats(
+    session: Session, batter_id: int, n: int = 50, offset: int = 0
+) -> Tuple[int, List[Dict[str, Any]]]:
+    """Paginated chronological at-bat log for a batter."""
+    base = (
+        session.query(StatcastEvent)
+        .filter(StatcastEvent.batter_id == batter_id,
+                StatcastEvent.events.isnot(None),
+                StatcastEvent.events != "")
+    )
+    total = base.count()
+    events = (
+        base.order_by(StatcastEvent.game_date.desc())
+        .offset(offset)
+        .limit(n)
+        .all()
+    )
+    rows = [
+        {
+            "game_date": e.game_date.isoformat() if e.game_date else None,
+            "pitcher_id": e.pitcher_id,
+            "pitcher_hand": e.p_throws,
+            "batter_stand": e.stand,
+            "result": e.events,
+            "exit_velocity": e.launch_speed,
+            "launch_angle": e.launch_angle,
+            "pitch_type": e.pitch_type,
+        }
+        for e in events
+    ]
+    return total, rows
+
+
+# ---------------------------------------------------------------------------
+# Pitcher game log
+# ---------------------------------------------------------------------------
+
+def get_pitcher_game_log(
+    session: Session, pitcher_id: int, n: int = 10
+) -> List[Dict[str, Any]]:
+    """Per-game appearance summary for a pitcher."""
+    date_rows = (
+        session.query(StatcastEvent.game_date)
+        .filter(StatcastEvent.pitcher_id == pitcher_id)
+        .distinct()
+        .order_by(StatcastEvent.game_date.desc())
+        .limit(n)
+        .all()
+    )
+    if not date_rows:
+        return []
+
+    date_list = [r[0] for r in date_rows]
+    events = (
+        session.query(StatcastEvent)
+        .filter(StatcastEvent.pitcher_id == pitcher_id,
+                StatcastEvent.game_date.in_(date_list))
+        .all()
+    )
+
+    by_date: Dict[str, List[StatcastEvent]] = {}
+    for e in events:
+        key = e.game_date.isoformat() if e.game_date else "unknown"
+        by_date.setdefault(key, []).append(e)
+
+    log = []
+    for d in sorted(by_date, reverse=True):
+        evs = by_date[d]
+        outcomes = [e.events for e in evs if e.events and e.events != ""]
+        ev_vals = [e.launch_speed for e in evs if e.launch_speed is not None]
+        speeds = [e.release_speed for e in evs if e.release_speed is not None]
+        hard_hits = sum(1 for v in ev_vals if v >= 95)
+
+        log.append({
+            "game_date": d,
+            "pitch_count": len(evs),
+            "plate_appearances": len(outcomes),
+            "strikeouts": outcomes.count("strikeout"),
+            "walks": outcomes.count("walk"),
+            "home_runs": outcomes.count("home_run"),
+            "hard_hit_pct": round(hard_hits / len(ev_vals), 3) if ev_vals else None,
+            "avg_velocity": round(sum(speeds) / len(speeds), 1) if speeds else None,
+        })
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Multi-season table
+# ---------------------------------------------------------------------------
+
+def get_pitcher_multi_season(
+    session: Session, pitcher_id: int, seasons: List[int]
+) -> List[Dict[str, Any]]:
+    """One row per season for the multi-season stats table on pitcher profiles."""
+    today_year = datetime.date.today().year
+    result = []
+    for season in seasons:
+        window = "90d" if season == today_year else str(season)
+        agg = get_pitcher_aggregate(session, pitcher_id, window)
+        label = "YTD (90d)" if season == today_year else str(season)
+        result.append({
+            "season": season,
+            "label": label,
+            "avg_velocity": agg.avg_velocity if agg else None,
+            "avg_spin_rate": agg.avg_spin_rate if agg else None,
+            "k_pct": agg.k_pct if agg else None,
+            "bb_pct": agg.bb_pct if agg else None,
+            "hard_hit_pct": agg.hard_hit_pct if agg else None,
+            "xwoba": agg.xwoba if agg else None,
+            "xba": agg.xba if agg else None,
+        })
+    return result
+
+
+def get_batter_multi_season(
+    session: Session, batter_id: int, seasons: List[int]
+) -> List[Dict[str, Any]]:
+    """One row per season for the multi-season stats table on batter profiles."""
+    today_year = datetime.date.today().year
+    result = []
+    for season in seasons:
+        window = "90d" if season == today_year else str(season)
+        agg = get_batter_aggregate(session, batter_id, window)
+        label = "YTD (90d)" if season == today_year else str(season)
+        result.append({
+            "season": season,
+            "label": label,
+            "avg_exit_velocity": agg.avg_exit_velocity if agg else None,
+            "avg_launch_angle": agg.avg_launch_angle if agg else None,
+            "hard_hit_pct": agg.hard_hit_pct if agg else None,
+            "barrel_pct": agg.barrel_pct if agg else None,
+            "k_pct": agg.k_pct if agg else None,
+            "bb_pct": agg.bb_pct if agg else None,
+            "batting_avg": agg.batting_avg if agg else None,
+        })
+    return result
+
+
 __all__ = [
     "get_pitcher_aggregate",
+    "get_pitcher_aggregate_with_fallback",
     "get_batter_aggregate",
+    "get_batter_aggregate_with_fallback",
     "get_pitch_arsenal",
+    "get_pitch_arsenal_with_fallback",
     "get_player_split",
     "get_team_split",
+    "get_pitcher_rolling_by_games",
+    "get_batter_rolling_by_games",
+    "get_batter_rolling_by_abs",
+    "get_batter_at_bats",
+    "get_pitcher_game_log",
+    "get_pitcher_multi_season",
+    "get_batter_multi_season",
 ]

--- a/mlb_app/etl.py
+++ b/mlb_app/etl.py
@@ -312,8 +312,44 @@ def run_etl_for_date(date_str: str) -> None:
             _load_pitcher_aggregate(session, pitcher_id, df, end_dt)
             if not arsenal_loaded:
                 _load_pitch_arsenal_from_df(session, pitcher_id, df, season)
+            if df.empty:
+                _ensure_historical_aggregate(session, pitcher_id, season)
 
         log.info("ETL complete for %s", date_str)
+
+
+def _ensure_historical_aggregate(session, pitcher_id: int, current_season: int) -> None:
+    """Pull prior-season Statcast for pitchers with no data in the current window."""
+    existing = session.query(PitcherAggregate).filter(
+        PitcherAggregate.pitcher_id == pitcher_id
+    ).first()
+    if existing:
+        return
+
+    for year in [current_season - 1, current_season - 2]:
+        start = f"{year}-03-15"
+        end = f"{year}-11-01"
+        try:
+            df = fetch_statcast_pitcher_data(pitcher_id, start, end)
+        except Exception as e:
+            log.warning("Historical backfill failed pitcher=%s year=%s: %s", pitcher_id, year, e)
+            continue
+        if df is None or df.empty:
+            continue
+        metrics = calculate_pitcher_aggregates(df)
+        if not metrics:
+            continue
+        record = PitcherAggregate(
+            pitcher_id=pitcher_id,
+            window=str(year),
+            end_date=datetime.date(year, 11, 1),
+            **{k: v for k, v in metrics.items() if hasattr(PitcherAggregate, k)},
+        )
+        session.add(record)
+        session.commit()
+        _load_pitch_arsenal_from_df(session, pitcher_id, df, year)
+        log.info("Backfilled %s season data for pitcher=%s", year, pitcher_id)
+        return
 
 
 def run_backfill(days: int = 30) -> None:

--- a/mlb_app/matchup_generator.py
+++ b/mlb_app/matchup_generator.py
@@ -101,6 +101,7 @@ def generate_matchups_for_date(session: Session, date_str: str) -> List[Dict]:
             # Still include games without probable pitchers — just no win probs
             matchup = {
                 "game_date": date_str,
+                "game_pk": game.get("_game_pk"),
                 "game_time": game.get("_game_date"),
                 "venue": game.get("_venue"),
                 "status": game.get("_status"),
@@ -135,6 +136,7 @@ def generate_matchups_for_date(session: Session, date_str: str) -> List[Dict]:
 
         matchup = {
             "game_date": date_str,
+            "game_pk": game.get("_game_pk"),
             "game_time": game.get("_game_date"),
             "venue": game.get("_venue"),
             "status": game.get("_status"),

--- a/mlb_app/scoring.py
+++ b/mlb_app/scoring.py
@@ -5,9 +5,6 @@ Core concept: for each pitch type in the pitcher's arsenal, weight their
 effectiveness (whiff%, K%, RV/100, xwOBA) against the batter's performance
 vs that handedness split. Combine into a composite advantage score and
 convert to win probability using a logistic transform.
-
-The formula is intentionally transparent so you can tune weights as more
-data accumulates.
 """
 
 from __future__ import annotations
@@ -27,19 +24,17 @@ from .db_utils import (
 
 
 # ---------------------------------------------------------------------------
-# Weight configuration (tune these)
+# Weight configuration
 # ---------------------------------------------------------------------------
 
-# Pitcher aggregate weights (higher = better pitcher performance)
 PITCHER_WEIGHTS = {
     "k_pct": 2.0,
-    "bb_pct": -1.5,       # walks hurt
+    "bb_pct": -1.5,
     "hard_hit_pct": -1.5,
-    "xwoba": -2.0,         # lower xwOBA against = better
-    "avg_velocity": 0.05,  # small bonus for velo
+    "xwoba": -2.0,
+    "avg_velocity": 0.05,
 }
 
-# Batter aggregate weights (higher = better batter performance vs pitcher)
 BATTER_WEIGHTS = {
     "avg_exit_velocity": 0.03,
     "hard_hit_pct": 1.5,
@@ -49,20 +44,18 @@ BATTER_WEIGHTS = {
     "batting_avg": 2.0,
 }
 
-# Arsenal matchup weights
 ARSENAL_WEIGHTS = {
     "whiff_pct": 1.5,
     "strikeout_pct": 1.5,
-    "rv_per_100": -1.0,   # negative RV/100 = good for pitcher
+    "rv_per_100": -1.0,
     "xwoba": -2.0,
 }
 
-# Home-field advantage logit bump
 HOME_FIELD_LOGIT = 0.12
 
 
 # ---------------------------------------------------------------------------
-# Stat normalization baselines (league average 2025 approximations)
+# League-average baselines (2025 approximations)
 # ---------------------------------------------------------------------------
 
 PITCHER_BASELINE = {
@@ -91,23 +84,64 @@ ARSENAL_BASELINE = {
 
 
 # ---------------------------------------------------------------------------
+# Ballpark run-factor lookup (neutral = 1.0)
+# ---------------------------------------------------------------------------
+
+PARK_FACTORS: Dict[str, float] = {
+    "Coors Field": 1.30,
+    "Great American Ball Park": 1.15,
+    "Yankee Stadium": 1.10,
+    "Citizens Bank Park": 1.04,
+    "Fenway Park": 1.05,
+    "Rogers Centre": 1.03,
+    "Globe Life Field": 1.03,
+    "American Family Field": 1.01,
+    "Guaranteed Rate Field": 1.01,
+    "Minute Maid Park": 1.01,
+    "Busch Stadium": 0.99,
+    "Wrigley Field": 0.99,
+    "Truist Park": 0.99,
+    "Camden Yards": 0.99,
+    "Chase Field": 0.98,
+    "Citi Field": 0.98,
+    "Nationals Park": 0.98,
+    "Progressive Field": 0.97,
+    "PNC Park": 0.97,
+    "Target Field": 0.97,
+    "Angel Stadium": 0.97,
+    "Dodger Stadium": 0.96,
+    "Comerica Park": 0.95,
+    "Oracle Park": 0.95,
+    "loanDepot park": 0.94,
+    "Oakland Coliseum": 0.93,
+    "Kauffman Stadium": 0.92,
+    "Petco Park": 0.90,
+    "Tropicana Field": 0.88,
+    "T-Mobile Park": 0.88,
+}
+
+
+def get_park_factor(venue_name: Optional[str]) -> float:
+    if not venue_name:
+        return 1.0
+    return PARK_FACTORS.get(venue_name, 1.0)
+
+
+# ---------------------------------------------------------------------------
 # Core math
 # ---------------------------------------------------------------------------
 
-def _normalize(value: Optional[float], baseline: float, scale: float = 1.0) -> float:
-    """Return (value - baseline) / scale, or 0 if value is None."""
+def _normalize(value: Optional[float], baseline: float) -> float:
     if value is None:
         return 0.0
-    return (value - baseline) / scale
+    return value - baseline
 
 
 def _logistic(x: float) -> float:
-    """Sigmoid function mapping any real to (0, 1)."""
     return 1.0 / (1.0 + math.exp(-x))
 
 
 def _pitcher_advantage(agg) -> float:
-    """Compute pitcher quality score vs league average."""
     if agg is None:
         return 0.0
     score = 0.0
@@ -119,7 +153,6 @@ def _pitcher_advantage(agg) -> float:
 
 
 def _batter_advantage(agg) -> float:
-    """Compute batter quality score vs league average."""
     if agg is None:
         return 0.0
     score = 0.0
@@ -131,14 +164,9 @@ def _batter_advantage(agg) -> float:
 
 
 def _arsenal_vs_batter(arsenal: List, batter_split) -> float:
-    """
-    For each pitch in arsenal, score pitcher effectiveness weighted by usage%.
-    batter_split is a PlayerSplit or TeamSplit ORM object (or None).
-    """
     if not arsenal:
         return 0.0
 
-    # If we have batter split, use their OBP as a proxy for vulnerability
     batter_obp = None
     if batter_split:
         batter_obp = getattr(batter_split, "on_base_pct", None)
@@ -153,11 +181,34 @@ def _arsenal_vs_batter(arsenal: List, batter_split) -> float:
             pitch_score += weight * _normalize(val, baseline)
         score += usage * pitch_score
 
-    # Adjust by batter OBP vs baseline (.320 league avg OBP)
     if batter_obp is not None:
         score -= (batter_obp - 0.320) * 2.0
 
     return score
+
+
+def _best_pitcher_agg(session: Session, pitcher_id: int, season: int):
+    """Return best available aggregate, trying 90d then prior seasons."""
+    agg = get_pitcher_aggregate(session, pitcher_id, "90d")
+    if agg:
+        return agg
+    for window in [str(season)] + [str(y) for y in range(season - 1, season - 4, -1)]:
+        agg = get_pitcher_aggregate(session, pitcher_id, window)
+        if agg:
+            return agg
+    return None
+
+
+def _best_arsenal(session: Session, pitcher_id: int, season: int):
+    """Return best available arsenal, trying current then prior seasons."""
+    arsenal = get_pitch_arsenal(session, pitcher_id, season)
+    if arsenal:
+        return arsenal
+    for yr in range(season - 1, season - 3, -1):
+        arsenal = get_pitch_arsenal(session, pitcher_id, yr)
+        if arsenal:
+            return arsenal
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -171,21 +222,13 @@ def score_pitcher_vs_lineup(
     season: int,
     pitcher_throws: str = "R",
 ) -> float:
-    """
-    Compute a raw advantage score for a pitcher facing an opposing lineup.
-    Positive = pitcher advantage, negative = batter advantage.
-    """
-    agg = get_pitcher_aggregate(session, pitcher_id, "90d")
-    arsenal = get_pitch_arsenal(session, pitcher_id, season)
+    agg = _best_pitcher_agg(session, pitcher_id, season)
+    arsenal = _best_arsenal(session, pitcher_id, season)
 
-    # Determine relevant split for opposing batters
     split_key = "vsR" if pitcher_throws == "R" else "vsL"
     team_split = get_team_split(session, opposing_team_id, season, split_key)
 
-    pitcher_score = _pitcher_advantage(agg)
-    arsenal_score = _arsenal_vs_batter(arsenal, team_split)
-
-    return pitcher_score + arsenal_score
+    return _pitcher_advantage(agg) + _arsenal_vs_batter(arsenal, team_split)
 
 
 def compute_win_probability(
@@ -198,26 +241,16 @@ def compute_win_probability(
     home_pitcher_throws: str = "R",
     away_pitcher_throws: str = "R",
 ) -> Tuple[float, float]:
-    """
-    Return (home_win_prob, away_win_prob) for a game matchup.
-
-    Uses pitcher quality, arsenal effectiveness vs opposing lineup, and
-    home field advantage.
-    """
-    home_pitcher_score = score_pitcher_vs_lineup(
+    home_score = score_pitcher_vs_lineup(
         session, home_pitcher_id, away_team_id, season, home_pitcher_throws
     )
-    away_pitcher_score = score_pitcher_vs_lineup(
+    away_score = score_pitcher_vs_lineup(
         session, away_pitcher_id, home_team_id, season, away_pitcher_throws
     )
 
-    # Net advantage: home pitcher better = positive logit
-    net_logit = (home_pitcher_score - away_pitcher_score) + HOME_FIELD_LOGIT
-
+    net_logit = (home_score - away_score) + HOME_FIELD_LOGIT
     home_win_prob = _logistic(net_logit)
-    away_win_prob = 1.0 - home_win_prob
-
-    return round(home_win_prob, 4), round(away_win_prob, 4)
+    return round(home_win_prob, 4), round(1.0 - home_win_prob, 4)
 
 
 def score_individual_matchup(
@@ -227,13 +260,9 @@ def score_individual_matchup(
     season: int,
     pitcher_throws: str = "R",
 ) -> Dict[str, float]:
-    """
-    Score a specific pitcher vs batter matchup.
-    Returns a dict with pitcher_advantage, batter_advantage, and net_score.
-    """
-    pitcher_agg = get_pitcher_aggregate(session, pitcher_id, "90d")
+    pitcher_agg = _best_pitcher_agg(session, pitcher_id, season)
     batter_agg = get_batter_aggregate(session, batter_id, "90d")
-    arsenal = get_pitch_arsenal(session, pitcher_id, season)
+    arsenal = _best_arsenal(session, pitcher_id, season)
 
     split_key = "vsR" if pitcher_throws == "R" else "vsL"
     batter_split = get_player_split(session, batter_id, season, split_key)
@@ -241,7 +270,6 @@ def score_individual_matchup(
     p_score = _pitcher_advantage(pitcher_agg)
     b_score = _batter_advantage(batter_agg)
     a_score = _arsenal_vs_batter(arsenal, batter_split)
-
     net = (p_score + a_score) - b_score
 
     return {


### PR DESCRIPTION
Backend:
- db_utils: rolling window functions (game-based + AB-based), game log, multi-season tables, batter at-bat log with pagination
- scoring: park factors dict (30 parks), historical aggregate fallback chain
- etl: _ensure_historical_aggregate backfill for prior 2 seasons
- matchup_generator: add game_pk field to all matchup responses
- app: 8 new endpoints — /matchup/{pk}, /pitcher/{id}/rolling, /pitcher/{id}/game-log, /batter/{id}/rolling, /batter/{id}/at-bats, /standings, /lineup/{team_id}, /team/{team_id}

Frontend:
- App.jsx: 4 new routes + Standings nav link
- HomePage: venue, game time, team records, status badge, clickable cards
- MatchupDetailPage: 4-section matchup page (header, win prob, pitchers, lineups)
- RollingPitcherPage: L15G–L150G rolling stats table
- RollingBatterPage: L10–L1000 AB rolling + chronological at-bat session
- StandingsPage: AL/NL division cards with streak badges + season selector
- PitcherPage: multi-season table + recent outings game log + rolling link
- BatterPage: multi-season table + rolling link
- TeamPage: real standing + vsL/vsR splits via /team/{id} endpoint

https://claude.ai/code/session_01KjhgakAZZsKqrr9HRonohE