### PR TITLE
Matchup calendar snapshots, AI assistant endpoint, and percentage normalization

### DIFF
--- a/docs/DATA_AUDIT.md
+++ b/docs/DATA_AUDIT.md
@@ -1,0 +1,43 @@
+# Data Architecture Audit (Current State)
+
+## 1) Pull Layer (external APIs)
+- MLB schedule, lineups, probable pitchers, weather: `mlb_app/app.py` (`/matchups`, `/matchup/{game_pk}`, `/matchup/{game_pk}/competitive`).
+- MLB team/player endpoints for roster/search/standings: `mlb_app/app.py`.
+- Savant arsenal leaderboard fallback for pitchers missing DB arsenal: `_fetch_live_pitch_arsenal` in `mlb_app/app.py`.
+
+## 2) Storage Layer
+- SQLAlchemy models + tables: `mlb_app/database.py`.
+- Event-level source of truth for rolling pages and game logs: `StatcastEvent`.
+- Aggregate tables for pitcher/batter/team/splits: accessed through `mlb_app/db_utils.py`.
+
+## 3) Transform Layer
+- Aggregate + fallback resolution helpers in `mlb_app/db_utils.py`.
+- Matchup assembly + probabilities in `mlb_app/matchup_generator.py` and `mlb_app/scoring.py`.
+- Competitive matchup matrix generation in `_build_competitive_matchup` (`mlb_app/app.py`).
+
+## 4) Serve Layer
+- API surface in `mlb_app/app.py`.
+- Calendar/snapshot consistency endpoints:
+  - `GET /matchups/calendar`
+  - `POST /matchups/snapshot/{date_str}`
+- AI data assistant endpoint:
+  - `POST /ai/ask`
+
+## 5) UI Consumption Map
+- Daily matchups/date picker: `frontend/src/pages/HomePage.jsx`.
+- Yesterday/Today/Tomorrow snapshot view: `frontend/src/pages/YesterdayTodayPage.jsx`.
+- Matchup detail and batter-vs-arsenal matrix: `frontend/src/pages/MatchupDetailPage.jsx`.
+- Pitcher profile and arsenal tables: `frontend/src/pages/PitcherPage.jsx`.
+- Rolling pitcher diagnostics (event-level availability warnings): `frontend/src/pages/RollingPitcherPage.jsx`.
+- AI question page: `frontend/src/pages/AIPage.jsx`.
+
+## 6) Data Quality Risks Identified
+- Percentage scale mismatch (fraction vs whole-number %) can inflate output values (e.g. 2500%).
+- Missing pitcher arsenal rows reduce matchup matrix completeness.
+- Missing event-level rows show blank rolling pages even if aggregate rows exist.
+
+## 7) Fixes Implemented in this iteration
+- Percentage normalization introduced at API and UI layers.
+- Live arsenal fallback normalized and reused when DB is empty.
+- Calendar snapshot endpoints provide stable yesterday/today snapshots.
+- Rolling page error copy now explicitly explains data absence vs UI failure.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,8 @@ import RollingBatterPage from './pages/RollingBatterPage'
 import TeamPage from './pages/TeamPage'
 import StandingsPage from './pages/StandingsPage'
 import CompetitiveAnalysisPage from './pages/CompetitiveAnalysisPage'
+import YesterdayTodayPage from './pages/YesterdayTodayPage'
+import AIPage from './pages/AIPage'
 
 const styles = {
   nav: {
@@ -61,6 +63,8 @@ export default function App() {
         <NavLink to="/pitcher" style={link}>Pitcher</NavLink>
         <NavLink to="/batter" style={link}>Batter</NavLink>
         <NavLink to="/team" style={link}>Team</NavLink>
+        <NavLink to="/calendar" style={link}>Calendar</NavLink>
+        <NavLink to="/ai" style={link}>AI</NavLink>
       </nav>
       <main style={styles.main}>
         <Routes>
@@ -76,6 +80,8 @@ export default function App() {
           <Route path="/batter/:id/rolling" element={<RollingBatterPage />} />
           <Route path="/team" element={<TeamPage />} />
           <Route path="/team/:id" element={<TeamPage />} />
+          <Route path="/calendar" element={<YesterdayTodayPage />} />
+          <Route path="/ai" element={<AIPage />} />
         </Routes>
       </main>
     </BrowserRouter>

--- a/frontend/src/pages/AIPage.jsx
+++ b/frontend/src/pages/AIPage.jsx
@@ -6,17 +6,35 @@ export default function AIPage() {
   const [question, setQuestion] = useState('How many matchups are there today?')
   const [response, setResponse] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
   async function ask() {
     setLoading(true)
-    const res = await fetch(`${API}/ai/ask`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ question }),
-    })
-    const json = await res.json()
-    setResponse(json)
-    setLoading(false)
+    setError(null)
+
+    try {
+      const res = await fetch(`${API}/ai/ask`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question }),
+      })
+
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(text || `Request failed (${res.status})`)
+      }
+
+      const json = await res.json()
+      setResponse(json)
+
+    } catch (err) {
+      console.error('AI request failed:', err)
+      setError(err.message || 'Request failed')
+      setResponse(null)
+
+    } finally {
+      setLoading(false)
+    }
   }
 
   return (
@@ -25,27 +43,76 @@ export default function AIPage() {
       <p style={{ color: '#8b949e', marginBottom: '12px' }}>
         Ask about matchups by day, weather, and team performance (e.g. "team 147").
       </p>
+
       <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
         <input
           value={question}
           onChange={e => setQuestion(e.target.value)}
-          style={{ flex: 1, background: '#161b22', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '6px', padding: '10px' }}
+          style={{
+            flex: 1,
+            background: '#161b22',
+            color: '#e6edf3',
+            border: '1px solid #30363d',
+            borderRadius: '6px',
+            padding: '10px'
+          }}
         />
-        <button onClick={ask} disabled={loading}>{loading ? 'Asking…' : 'Ask'}</button>
+
+        <button onClick={ask} disabled={loading}>
+          {loading ? 'Asking…' : 'Ask'}
+        </button>
       </div>
 
+      {error && (
+        <div style={{
+          background: '#2d1b1b',
+          border: '1px solid #a33',
+          borderRadius: '8px',
+          padding: '14px',
+          marginBottom: '12px'
+        }}>
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
       {response && (
-        <div style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px' }}>
-          <div style={{ fontWeight: 700, marginBottom: '8px' }}>Answer</div>
-          <div style={{ marginBottom: '10px' }}>{response.answer}</div>
-          {response.sources?.length > 0 && <div style={{ fontSize: '12px', color: '#8b949e' }}>Sources: {response.sources.join(', ')}</div>}
+        <div style={{
+          background: '#161b22',
+          border: '1px solid #30363d',
+          borderRadius: '8px',
+          padding: '14px'
+        }}>
+
+          <div style={{ fontWeight: 700, marginBottom: '8px' }}>
+            Answer
+          </div>
+
+          <div style={{ marginBottom: '10px' }}>
+            {response.answer}
+          </div>
+
+          {response.sources?.length > 0 && (
+            <div style={{ fontSize: '12px', color: '#8b949e' }}>
+              Sources: {response.sources.join(', ')}
+            </div>
+          )}
+
           {response.data && (
-            <pre style={{ marginTop: '12px', background: '#0d1117', borderRadius: '6px', padding: '10px', overflowX: 'auto', fontSize: '12px' }}>
+            <pre style={{
+              marginTop: '12px',
+              background: '#0d1117',
+              borderRadius: '6px',
+              padding: '10px',
+              overflowX: 'auto',
+              fontSize: '12px'
+            }}>
               {JSON.stringify(response.data, null, 2)}
             </pre>
           )}
+
         </div>
       )}
+
     </div>
   )
 }

--- a/frontend/src/pages/AIPage.jsx
+++ b/frontend/src/pages/AIPage.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react'
+
+const API = import.meta.env.VITE_API_BASE_URL || ''
+
+export default function AIPage() {
+  const [question, setQuestion] = useState('How many matchups are there today?')
+  const [response, setResponse] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  async function ask() {
+    setLoading(true)
+    const res = await fetch(`${API}/ai/ask`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question }),
+    })
+    const json = await res.json()
+    setResponse(json)
+    setLoading(false)
+  }
+
+  return (
+    <div>
+      <h1 style={{ fontSize: '24px', marginBottom: '12px' }}>AI Data Assistant</h1>
+      <p style={{ color: '#8b949e', marginBottom: '12px' }}>
+        Ask about matchups by day, weather, and team performance (e.g. "team 147").
+      </p>
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
+        <input
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          style={{ flex: 1, background: '#161b22', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '6px', padding: '10px' }}
+        />
+        <button onClick={ask} disabled={loading}>{loading ? 'Asking…' : 'Ask'}</button>
+      </div>
+
+      {response && (
+        <div style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px' }}>
+          <div style={{ fontWeight: 700, marginBottom: '8px' }}>Answer</div>
+          <div style={{ marginBottom: '10px' }}>{response.answer}</div>
+          {response.sources?.length > 0 && <div style={{ fontSize: '12px', color: '#8b949e' }}>Sources: {response.sources.join(', ')}</div>}
+          {response.data && (
+            <pre style={{ marginTop: '12px', background: '#0d1117', borderRadius: '6px', padding: '10px', overflowX: 'auto', fontSize: '12px' }}>
+              {JSON.stringify(response.data, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/CompetitiveAnalysisPage.jsx
+++ b/frontend/src/pages/CompetitiveAnalysisPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { fmtPct, fmtDec, normalizeRate } from '../utils/formatters'
 import { useParams, Link } from 'react-router-dom'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
@@ -131,11 +132,11 @@ export default function CompetitiveAnalysisPage() {
                 </div>
                 <div style={s.h2hRow}>
                   <span style={s.h2hLabel}>BA</span>
-                  <span style={s.h2hValue}>{matchup.head_to_head.batting_avg}</span>
+                  <span style={s.h2hValue}>{fmtDec(matchup.head_to_head.batting_avg, 3)}</span>
                 </div>
                 <div style={s.h2hRow}>
                   <span style={s.h2hLabel}>xwOBA</span>
-                  <span style={s.h2hValue}>{matchup.head_to_head.xwoba || '—'}</span>
+                  <span style={s.h2hValue}>{fmtDec(matchup.head_to_head.xwoba, 3)}</span>
                 </div>
               </div>
 
@@ -160,16 +161,16 @@ export default function CompetitiveAnalysisPage() {
                         <tr key={pt.pitch_type}>
                           <td style={s.td}>{pt.pitch_type}</td>
                           <td style={{ ...s.td, ...s.tdRight, ...s.tdMuted }}>
-                            {(pt.pitcher_usage_pct * 100).toFixed(0)}%
+                            {fmtPct(normalizeRate(pt.pitcher_usage_pct), 1)}
                           </td>
                           <td style={{ ...s.td, ...s.tdRight }}>
-                            {pt.batter_vs_type.batting_avg}
+                            {fmtDec(pt.batter_vs_type.batting_avg, 3)}
                           </td>
                           <td style={{ ...s.td, ...s.tdRight }}>
-                            {pt.batter_vs_type.xwoba || '—'}
+                            {fmtDec(pt.batter_vs_type.xwoba, 3)}
                           </td>
                           <td style={{ ...s.td, ...s.tdRight, ...s.edgeScore(pt.edge_score) }}>
-                            {pt.edge_score > 0 ? '+' : ''}{pt.edge_score}
+                            {pt.edge_score > 0 ? '+' : ''}{Number(pt.edge_score || 0).toFixed(2)}
                           </td>
                           <td style={{ ...s.td, ...s.tdRight }}>
                             <span style={s.confidenceBadge(pt.confidence)}>

--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { fmtPct, fmtDec } from '../utils/formatters'
 import { useParams, Link } from 'react-router-dom'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
@@ -65,8 +66,8 @@ const t = {
   noData: { color: '#8b949e', fontSize: '13px', textAlign: 'center', padding: '24px' },
 }
 
-const pct = (v, d = 1) => v != null ? `${(v * 100).toFixed(d)}%` : '—'
-const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
+const pct = (v, d = 1) => fmtPct(v, d)
+const dec = (v, d = 3) => fmtDec(v, d)
 const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
 
 function probColor(p) {

--- a/frontend/src/pages/PitcherPage.jsx
+++ b/frontend/src/pages/PitcherPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { fmtPct } from '../utils/formatters'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
@@ -53,8 +54,7 @@ function fmt(val, decimals = 1) {
   return typeof val === 'number' ? val.toFixed(decimals) : val
 }
 function pct(val) {
-  if (val == null) return '—'
-  return `${(val * 100).toFixed(1)}%`
+  return fmtPct(val, 1)
 }
 
 function StatCard({ label, value }) {

--- a/frontend/src/pages/RollingPitcherPage.jsx
+++ b/frontend/src/pages/RollingPitcherPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { fmtPct, fmtDec } from '../utils/formatters'
 import { useParams, Link } from 'react-router-dom'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
@@ -21,10 +22,10 @@ const s = {
   note: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px 18px', fontSize: '13px', color: '#8b949e', marginBottom: '16px' },
 }
 
-const pct = (v, d = 1) => v != null ? `${(v * 100).toFixed(d)}%` : '—'
+const pct = (v, d = 1) => fmtPct(v, d)
 const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
 const rpm = v => v != null ? `${Math.round(v)}` : '—'
-const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
+const dec = (v, d = 3) => fmtDec(v, d)
 
 function kColor(v) {
   if (v == null) return '#e6edf3'
@@ -90,6 +91,9 @@ export default function RollingPitcherPage() {
       {!hasAny && (
         <div style={{ color: '#8b949e', textAlign: 'center', padding: '48px' }}>
           No event-level data available for pitcher #{id}. Run the ETL to populate Statcast events.
+          <div style={{ fontSize: '12px', marginTop: '10px' }}>
+            This means the UI is healthy, but the database has no pitch-by-pitch rows for this pitcher yet.
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/YesterdayTodayPage.jsx
+++ b/frontend/src/pages/YesterdayTodayPage.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const API = import.meta.env.VITE_API_BASE_URL || ''
+
+const card = { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', padding: '16px', marginBottom: '16px' }
+
+export default function YesterdayTodayPage() {
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    fetch(`${API}/matchups/calendar`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(setData)
+      .catch(e => setError(String(e)))
+  }, [])
+
+  async function snapshot(date) {
+    await fetch(`${API}/matchups/snapshot/${date}`, { method: 'POST' })
+    const refreshed = await fetch(`${API}/matchups/calendar`).then(r => r.json())
+    setData(refreshed)
+  }
+
+  if (error) return <div style={{ color: '#f85149' }}>{error}</div>
+  if (!data) return <div style={{ color: '#8b949e' }}>Loading calendar snapshots…</div>
+
+  return (
+    <div>
+      <h1 style={{ fontSize: '24px', marginBottom: '16px' }}>Matchup Calendar (Yesterday / Today)</h1>
+      {['yesterday', 'today', 'tomorrow'].map((k) => (
+        <div key={k} style={card}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '10px' }}>
+            <strong style={{ textTransform: 'capitalize' }}>{k}: {data[k].date}</strong>
+            <button onClick={() => snapshot(data[k].date)}>Save latest copy</button>
+          </div>
+          <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '8px' }}>{data[k].count} games</div>
+          {data[k].games.slice(0, 8).map((g) => (
+            <div key={g.game_pk} style={{ marginBottom: '6px', fontSize: '14px' }}>
+              <Link to={`/matchup/${g.game_pk}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                {g.away_team_name} @ {g.home_team_name}
+              </Link>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,16 @@
+export function normalizeRate(value) {
+  if (value == null || Number.isNaN(Number(value))) return null
+  const n = Number(value)
+  return n > 1 ? n / 100 : n
+}
+
+export function fmtPct(value, digits = 1) {
+  const n = normalizeRate(value)
+  if (n == null) return '—'
+  return `${(n * 100).toFixed(digits)}%`
+}
+
+export function fmtDec(value, digits = 3) {
+  if (value == null || Number.isNaN(Number(value))) return '—'
+  return Number(value).toFixed(digits)
+}

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 import requests as _req
@@ -66,6 +67,7 @@ from .scoring import compute_win_probability, score_individual_matchup, get_park
 from .statcast_utils import fetch_pitch_arsenal_leaderboard
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
 OUTCOME_EVENTS = {
@@ -154,6 +156,23 @@ def _extract_weather(game: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return {"condition": condition, "temp_f": temp, "wind": wind}
 
 
+def _normalize_rate(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if value > 1:
+        return round(value / 100.0, 4)
+    return round(value, 4)
+
+
+def _build_date_window() -> Dict[str, str]:
+    today = datetime.date.today()
+    return {
+        "yesterday": (today - datetime.timedelta(days=1)).isoformat(),
+        "today": today.isoformat(),
+        "tomorrow": (today + datetime.timedelta(days=1)).isoformat(),
+    }
+
+
 def _fetch_live_pitch_arsenal(pitcher_id: int, current_season: int) -> tuple[list[dict], Optional[int]]:
     """Fallback arsenal from Savant leaderboard if DB does not yet have rows."""
     season_candidates = [current_season, current_season - 1, current_season - 2]
@@ -177,12 +196,12 @@ def _fetch_live_pitch_arsenal(pitcher_id: int, current_season: int) -> tuple[lis
                     {
                         "pitch_type": pitch_type,
                         "pitch_name": row.get("pitch_name"),
-                        "usage_pct": _safe_float(row.get("pitch_usage") or row.get("usage_pct")),
-                        "whiff_pct": _safe_float(row.get("whiff_percent") or row.get("whiff_pct")),
-                        "strikeout_pct": _safe_float(row.get("k_percent") or row.get("strikeout_pct")),
+                        "usage_pct": _normalize_rate(_safe_float(row.get("pitch_usage") or row.get("usage_pct"))),
+                        "whiff_pct": _normalize_rate(_safe_float(row.get("whiff_percent") or row.get("whiff_pct"))),
+                        "strikeout_pct": _normalize_rate(_safe_float(row.get("k_percent") or row.get("strikeout_pct"))),
                         "rv_per_100": _safe_float(row.get("run_value_per_100") or row.get("rv_per_100")),
                         "xwoba": _safe_float(row.get("est_woba") or row.get("xwoba")),
-                        "hard_hit_pct": _safe_float(row.get("hard_hit_percent") or row.get("hard_hit_pct")),
+                        "hard_hit_pct": _normalize_rate(_safe_float(row.get("hard_hit_percent") or row.get("hard_hit_pct"))),
                     }
                 )
             out = sorted(out, key=lambda r: r.get("usage_pct") or 0, reverse=True)
@@ -518,6 +537,82 @@ def create_app():
             except Exception as exc:
                 raise HTTPException(status_code=500, detail=str(exc))
 
+    @app.get("/matchups/calendar")
+    def matchup_calendar() -> Dict[str, Any]:
+        """Return yesterday/today/tomorrow with cached snapshots for consistency."""
+        dates = _build_date_window()
+        Session = _get_session()
+        with Session() as session:
+            payload = {}
+            for key, d in dates.items():
+                if d not in MATCHUP_SNAPSHOT_CACHE:
+                    MATCHUP_SNAPSHOT_CACHE[d] = generate_matchups_for_date(session, d)
+                payload[key] = {
+                    "date": d,
+                    "count": len(MATCHUP_SNAPSHOT_CACHE[d]),
+                    "games": MATCHUP_SNAPSHOT_CACHE[d],
+                }
+            return payload
+
+    @app.post("/matchups/snapshot/{date_str}")
+    def snapshot_matchups(date_str: str) -> Dict[str, Any]:
+        """Persist the latest schedule pull for a specific date into in-memory cache."""
+        Session = _get_session()
+        with Session() as session:
+            try:
+                MATCHUP_SNAPSHOT_CACHE[date_str] = generate_matchups_for_date(session, date_str)
+            except Exception as exc:
+                raise HTTPException(status_code=500, detail=str(exc))
+        return {"date": date_str, "games_cached": len(MATCHUP_SNAPSHOT_CACHE[date_str])}
+
+    @app.post("/ai/ask")
+    def ai_ask(payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Lightweight MLB data assistant powered by current API data."""
+        question = str(payload.get("question", "")).strip()
+        if not question:
+            raise HTTPException(status_code=400, detail="Question is required")
+        ql = question.lower()
+        dates = _build_date_window()
+        Session = _get_session()
+        with Session() as session:
+            if "today" in ql or "matchup" in ql:
+                games = generate_matchups_for_date(session, dates["today"])
+                return {
+                    "answer": f"There are {len(games)} scheduled games for {dates['today']}.",
+                    "sources": ["/matchups", f"/matchups?date={dates['today']}"],
+                    "data": {"date": dates["today"], "games": games[:8]},
+                }
+            if "yesterday" in ql:
+                games = MATCHUP_SNAPSHOT_CACHE.get(dates["yesterday"]) or generate_matchups_for_date(session, dates["yesterday"])
+                MATCHUP_SNAPSHOT_CACHE[dates["yesterday"]] = games
+                return {
+                    "answer": f"Loaded {len(games)} games for yesterday ({dates['yesterday']}).",
+                    "sources": ["/matchups/calendar", f"/matchups?date={dates['yesterday']}"],
+                    "data": {"date": dates["yesterday"], "games": games[:8]},
+                }
+            if "weather" in ql:
+                games = generate_matchups_for_date(session, dates["today"])
+                weather_games = [g for g in games if g.get("weather")]
+                return {
+                    "answer": f"Found weather data for {len(weather_games)} of {len(games)} games today.",
+                    "sources": [f"/matchups?date={dates['today']}"],
+                    "data": weather_games[:10],
+                }
+            team_match = re.search(r"team\s+(\d+)", ql)
+            if team_match:
+                team_id = int(team_match.group(1))
+                team = get_team(team_id)
+                return {
+                    "answer": f"Team {team_id} standing and split profile loaded.",
+                    "sources": [f"/team/{team_id}", "/standings"],
+                    "data": team,
+                }
+        return {
+            "answer": "I can currently answer questions about today/yesterday matchups, weather, and team IDs (e.g., 'team 147').",
+            "sources": ["/matchups", "/team/{team_id}", "/standings"],
+            "data": None,
+        }
+
     @app.get("/matchup/{game_pk}")
     def get_matchup_detail(game_pk: int) -> Dict[str, Any]:
         url = f"{MLB_STATS_BASE}/schedule"
@@ -567,12 +662,12 @@ def create_app():
                     {
                         "pitch_type": r.pitch_type,
                         "pitch_name": r.pitch_name,
-                        "usage_pct": r.usage_pct,
-                        "whiff_pct": r.whiff_pct,
-                        "strikeout_pct": r.strikeout_pct,
+                        "usage_pct": _normalize_rate(r.usage_pct),
+                        "whiff_pct": _normalize_rate(r.whiff_pct),
+                        "strikeout_pct": _normalize_rate(r.strikeout_pct),
                         "rv_per_100": r.rv_per_100,
                         "xwoba": r.xwoba,
-                        "hard_hit_pct": r.hard_hit_pct,
+                        "hard_hit_pct": _normalize_rate(r.hard_hit_pct),
                     }
                     for r in arsenal
                 ]
@@ -772,12 +867,12 @@ def create_app():
                 {
                     "pitch_type": r.pitch_type,
                     "pitch_name": r.pitch_name,
-                    "usage_pct": r.usage_pct,
-                    "whiff_pct": r.whiff_pct,
-                    "strikeout_pct": r.strikeout_pct,
+                    "usage_pct": _normalize_rate(r.usage_pct),
+                    "whiff_pct": _normalize_rate(r.whiff_pct),
+                    "strikeout_pct": _normalize_rate(r.strikeout_pct),
                     "rv_per_100": r.rv_per_100,
                     "xwoba": r.xwoba,
-                    "hard_hit_pct": r.hard_hit_pct,
+                    "hard_hit_pct": _normalize_rate(r.hard_hit_pct),
                 }
                 for r in arsenal
             ]

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -67,7 +67,7 @@ from .scoring import compute_win_probability, score_individual_matchup, get_park
 from .statcast_utils import fetch_pitch_arsenal_leaderboard
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
-MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
+MATCHUP_SNAPSHOT_CACHE: Dict[str, Dict[str, Any]] = {}
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
 OUTCOME_EVENTS = {
@@ -170,6 +170,36 @@ def _build_date_window() -> Dict[str, str]:
         "yesterday": (today - datetime.timedelta(days=1)).isoformat(),
         "today": today.isoformat(),
         "tomorrow": (today + datetime.timedelta(days=1)).isoformat(),
+    }
+
+
+def _get_snapshot_payload(session, date_str: str, force_refresh: bool = False) -> Dict[str, Any]:
+    cached = MATCHUP_SNAPSHOT_CACHE.get(date_str)
+    today_str = datetime.date.today().isoformat()
+
+    should_refresh = force_refresh
+    if cached is None:
+        should_refresh = True
+    elif date_str == today_str and cached.get("refreshed_on") != today_str:
+        should_refresh = True
+
+    if should_refresh:
+        games = generate_matchups_for_date(session, date_str)
+        cached = {
+            "date": date_str,
+            "games": games,
+            "count": len(games),
+            "refreshed_on": today_str,
+            "snapshot_type": "in_memory",
+        }
+        MATCHUP_SNAPSHOT_CACHE[date_str] = cached
+
+    return {
+        "date": cached["date"],
+        "games": cached["games"],
+        "count": cached["count"],
+        "snapshot_type": cached.get("snapshot_type", "in_memory"),
+        "refreshed_on": cached.get("refreshed_on"),
     }
 
 
@@ -498,7 +528,7 @@ def _fetch_roster_as_lineup(team_id: int, season: int) -> List[Dict[str, Any]]:
         return []
 
 
-
+class PredictRequest(BaseModel):
     pitcher_id: int
     batter_id: int
     season: Optional[int] = None
@@ -539,31 +569,27 @@ def create_app():
 
     @app.get("/matchups/calendar")
     def matchup_calendar() -> Dict[str, Any]:
-        """Return yesterday/today/tomorrow with cached snapshots for consistency."""
+        """Return yesterday/today/tomorrow with in-memory snapshots and daily refresh for today."""
         dates = _build_date_window()
         Session = _get_session()
         with Session() as session:
-            payload = {}
-            for key, d in dates.items():
-                if d not in MATCHUP_SNAPSHOT_CACHE:
-                    MATCHUP_SNAPSHOT_CACHE[d] = generate_matchups_for_date(session, d)
-                payload[key] = {
-                    "date": d,
-                    "count": len(MATCHUP_SNAPSHOT_CACHE[d]),
-                    "games": MATCHUP_SNAPSHOT_CACHE[d],
-                }
-            return payload
+            return {key: _get_snapshot_payload(session, date_str) for key, date_str in dates.items()}
 
     @app.post("/matchups/snapshot/{date_str}")
     def snapshot_matchups(date_str: str) -> Dict[str, Any]:
-        """Persist the latest schedule pull for a specific date into in-memory cache."""
+        """Refresh and store the latest schedule pull for a specific date in process memory."""
         Session = _get_session()
         with Session() as session:
             try:
-                MATCHUP_SNAPSHOT_CACHE[date_str] = generate_matchups_for_date(session, date_str)
+                snapshot = _get_snapshot_payload(session, date_str, force_refresh=True)
             except Exception as exc:
                 raise HTTPException(status_code=500, detail=str(exc))
-        return {"date": date_str, "games_cached": len(MATCHUP_SNAPSHOT_CACHE[date_str])}
+        return {
+            "date": snapshot["date"],
+            "games_cached": snapshot["count"],
+            "snapshot_type": snapshot["snapshot_type"],
+            "refreshed_on": snapshot["refreshed_on"],
+        }
 
     @app.post("/ai/ask")
     def ai_ask(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -575,20 +601,19 @@ def create_app():
         dates = _build_date_window()
         Session = _get_session()
         with Session() as session:
-            if "today" in ql or "matchup" in ql:
-                games = generate_matchups_for_date(session, dates["today"])
-                return {
-                    "answer": f"There are {len(games)} scheduled games for {dates['today']}.",
-                    "sources": ["/matchups", f"/matchups?date={dates['today']}"],
-                    "data": {"date": dates["today"], "games": games[:8]},
-                }
             if "yesterday" in ql:
-                games = MATCHUP_SNAPSHOT_CACHE.get(dates["yesterday"]) or generate_matchups_for_date(session, dates["yesterday"])
-                MATCHUP_SNAPSHOT_CACHE[dates["yesterday"]] = games
+                snapshot = _get_snapshot_payload(session, dates["yesterday"])
                 return {
-                    "answer": f"Loaded {len(games)} games for yesterday ({dates['yesterday']}).",
+                    "answer": f"Loaded {snapshot['count']} games for yesterday ({dates['yesterday']}).",
                     "sources": ["/matchups/calendar", f"/matchups?date={dates['yesterday']}"],
-                    "data": {"date": dates["yesterday"], "games": games[:8]},
+                    "data": {"date": dates["yesterday"], "games": snapshot["games"][:8]},
+                }
+            if "tomorrow" in ql:
+                snapshot = _get_snapshot_payload(session, dates["tomorrow"])
+                return {
+                    "answer": f"Loaded {snapshot['count']} scheduled games for tomorrow ({dates['tomorrow']}).",
+                    "sources": ["/matchups/calendar", f"/matchups?date={dates['tomorrow']}"],
+                    "data": {"date": dates['tomorrow'], "games": snapshot["games"][:8]},
                 }
             if "weather" in ql:
                 games = generate_matchups_for_date(session, dates["today"])
@@ -607,9 +632,16 @@ def create_app():
                     "sources": [f"/team/{team_id}", "/standings"],
                     "data": team,
                 }
+            if "today" in ql or "matchup" in ql or "games" in ql:
+                games = generate_matchups_for_date(session, dates["today"])
+                return {
+                    "answer": f"There are {len(games)} scheduled games for {dates['today']}.",
+                    "sources": ["/matchups", f"/matchups?date={dates['today']}"],
+                    "data": {"date": dates["today"], "games": games[:8]},
+                }
         return {
-            "answer": "I can currently answer questions about today/yesterday matchups, weather, and team IDs (e.g., 'team 147').",
-            "sources": ["/matchups", "/team/{team_id}", "/standings"],
+            "answer": "I can currently answer questions about today, yesterday, or tomorrow matchups, weather, and team IDs like 'team 147'. Calendar snapshots are stored in memory for the running app instance.",
+            "sources": ["/matchups", "/matchups/calendar", "/team/{team_id}", "/standings"],
             "data": None,
         }
 
@@ -709,7 +741,6 @@ def create_app():
                     }
 
                 db_result = {"vsL": sd(vsL), "vsR": sd(vsR)}
-                # If DB is missing both splits or both are identical, use live MLB API data
                 both_missing = not db_result["vsL"] and not db_result["vsR"]
                 identical = (
                     db_result["vsL"] and db_result["vsR"] and
@@ -805,8 +836,6 @@ def create_app():
         home_lineup_raw = lineups.get("homePlayers", []) or []
         away_lineup_raw = lineups.get("awayPlayers", []) or []
 
-        # Official lineups aren't posted until ~1-2 hrs before game time.
-        # Fall back to active non-pitcher roster so the matrix always renders.
         away_lineup_source = "official"
         home_lineup_source = "official"
         if not away_lineup_raw and away_team_id:
@@ -884,8 +913,6 @@ def create_app():
             multi = get_pitcher_multi_season(session, player_id, [season, season - 1, season - 2, season - 3])
             game_log = get_pitcher_game_log(session, player_id, 10)
             if not agg and not arsenal_rows:
-                # Fallback: fetch basic player info from MLB Stats API so the page
-                # can at least show the player's name rather than a hard 404
                 player_name = None
                 try:
                     p_resp = _req.get(
@@ -959,7 +986,6 @@ def create_app():
             split_seasons = get_player_splits_multi_season(session, player_id, [season, season - 1, season - 2, season - 3])
             statcast = _compute_batter_statcast(session, player_id, since_year=2024)
 
-        # Always fetch live MLB data regardless of DB state
         live = _fetch_batter_live_data(player_id, season)
 
         def _sd(s):
@@ -972,7 +998,6 @@ def create_app():
                 "home_runs": s.home_runs,
             }
 
-        # Prefer DB splits; fall back to live API splits
         db_vsL, db_vsR = _sd(split_L), _sd(split_R)
         if db_vsL or db_vsR:
             splits = {"vsL": db_vsL, "vsR": db_vsR}
@@ -1249,7 +1274,6 @@ def create_app():
             )
         return {"pitcher_id": req.pitcher_id, "batter_id": req.batter_id, **result}
 
-    # Serve the built React frontend — must be mounted last so API routes take priority
     _dist = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'frontend', 'dist')
     if os.path.isdir(_dist):
         app.mount("/", StaticFiles(directory=_dist, html=True), name="frontend")


### PR DESCRIPTION
### Motivation
- Stabilize daily matchup data (yesterday/today/tomorrow) so the UI does not drift to tomorrow while games are in progress.
- Fix data-quality issues where percent/rate fields were mis-scaled (e.g., values showing as 2500%).
- Provide a lightweight in-app data assistant so users can ask questions about matchups, weather, and team data without adding charts or new data sources.
- Produce a clear audit of the current data architecture and where data is pulled, stored, transformed, and consumed.

### Description
- Added in-memory snapshot support and APIs `GET /matchups/calendar` and `POST /matchups/snapshot/{date_str}` with a `MATCHUP_SNAPSHOT_CACHE` to serve consistent yesterday/today/tomorrow views and allow one-click snapshot saves (backend: `mlb_app/app.py`).
- Added a simple AI assistant endpoint `POST /ai/ask` that answers basic questions about matchups, weather, and team lookups using existing API data (backend: `mlb_app/app.py`).
- Normalized rate/percentage fields at the API and UI layers via `_normalize_rate` and normalized usage/whiff/strikeout/hard-hit fields when pulling from Savant or DB to avoid whole-number vs fraction mismatches (backend: `mlb_app/app.py`).
- Centralized frontend formatters in `frontend/src/utils/formatters.js` with `normalizeRate`, `fmtPct`, and `fmtDec`, and applied them across matchup/competitive/pitcher pages to ensure consistent decimal places and percent formatting (frontend pages updated under `frontend/src/pages/*`).
- Added a new Calendar page (`/calendar`) and AI page (`/ai`) in the frontend (`frontend/src/pages/YesterdayTodayPage.jsx`, `frontend/src/pages/AIPage.jsx`) and wired them into navigation and routing (`frontend/src/App.jsx`).
- Clarified the rolling-pitcher no-data message to explain when event-level data is missing vs a UI error (frontend: `frontend/src/pages/RollingPitcherPage.jsx`).
- Added a data architecture audit and structure map documenting pull → storage → transform → serve → UI in `docs/DATA_AUDIT.md`.

### Testing
- Ran Python compilation check via `python -m compileall mlb_app` and it completed successfully.
- Built the frontend with `npm run build` (inside `frontend/`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e574231540832db04f5f8956ed5c0d)