### PR TITLE
Add initial hitter profile scaffold

### DIFF
--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -1,0 +1,30 @@
+"""
+Utilities for building hitter profile summaries for matchup previews.
+
+This module is currently a scaffold and will be expanded to incorporate
+contact skill, plate discipline, power, batted-ball quality, and platoon splits.
+"""
+
+
+def compute_hitter_profile(raw_stats: dict) -> dict:
+    """
+    Build a basic hitter profile from raw hitter inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of hitter stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A placeholder hitter profile structure that can later be populated
+        with real calculations.
+    """
+    return {
+        "contact_skill": None,
+        "plate_discipline": None,
+        "power": None,
+        "batted_ball_quality": None,
+        "platoon_split_strength": None,
+    }


### PR DESCRIPTION
Adds a small starter module for hitter profile construction.

This PR is intended as a scaffold for future matchup-preview work and introduces a placeholder `compute_hitter_profile` function that returns a basic hitter-profile structure.

No pipeline integration yet.