### PR TITLE
Fix sandbox Railway start command to expand PORT via shell

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "DOCKERFILE"
   },
   "deploy": {
-    "startCommand": "uvicorn mlb_app.app:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "sh -c 'uvicorn mlb_app.app:app --host 0.0.0.0 --port ${PORT:-8080}'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
Closing this housekeeping PR because the sandbox Railway start-command fix has already been applied directly on `sandbox/contributor-analysis` and does not need to remain as a separate active review item.