### PR TITLE
Harden sandbox matchup profile contract

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -40,6 +40,9 @@ def _determine_hand(player_id: int) -> str:
     # TODO: implement call to statsapi to fetch pitcher throwing hand.
     return "R"
 
+from .hitter_profile import compute_hitter_profile
+from .pitcher_profile import compute_pitcher_profile
+from .environment_profile import compute_environment_profile
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:
     """Compute feature dictionaries for each game scheduled on a date.
@@ -52,20 +55,18 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
     Returns
     -------
     list of dict
-        Each dictionary contains basic matchup metadata (teams,
-        probable pitchers, game time) along with aggregated statistics
-        such as team win/loss records, platoon splits and pitcher metrics.
-        If Statcast retrieval functions are unimplemented, pitcher/batter
-        metrics will be empty dicts.
+        Each dictionary contains matchup metadata, team records, platoon splits,
+        pitcher metrics, and structured hitter/pitcher/environment profiles.
+        If Statcast retrieval functions are unimplemented, some metric/profile
+        fields will remain empty or default to None.
     """
-    # Parse date
     target_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
     schedule = fetch_schedule(date_str)
-    # Get season year for standings and splits
     season = target_date.year
-    # Load team records (wins, losses, run differential)
     team_records = {rec["team"]["id"]: rec for rec in fetch_team_records(season)}
+
     matchups = []
+
     for game in schedule:
         game_info = {
             "gamePk": game.get("gamePk"),
@@ -73,16 +74,21 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             "homeTeam": game.get("teams", {}).get("home", {}).get("team", {}).get("name"),
             "awayTeam": game.get("teams", {}).get("away", {}).get("team", {}).get("name"),
         }
-        home_team_id = game.get("teams", {}).get("home", {}).get("team", {}).get("id")
-        away_team_id = game.get("teams", {}).get("away", {}).get("team", {}).get("id")
-        # Probable pitchers (if available)
+
+        home_team = game.get("teams", {}).get("home", {}).get("team", {}) or {}
+        away_team = game.get("teams", {}).get("away", {}).get("team", {}) or {}
+        home_team_id = home_team.get("id")
+        away_team_id = away_team.get("id")
+
         home_pitcher = game.get("teams", {}).get("home", {}).get("probablePitcher")
         away_pitcher = game.get("teams", {}).get("away", {}).get("probablePitcher")
+
         home_pitcher_id = home_pitcher.get("id") if isinstance(home_pitcher, dict) else None
         away_pitcher_id = away_pitcher.get("id") if isinstance(away_pitcher, dict) else None
-        # Attach team records
+
         home_record = team_records.get(home_team_id, {})
         away_record = team_records.get(away_team_id, {})
+
         matchup_features: Dict[str, object] = game_info.copy()
         matchup_features.update(
             {
@@ -98,10 +104,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 },
             }
         )
-        # Determine pitcher throwing hands for platoon splits (placeholder)
+
         home_hand = _determine_hand(home_pitcher_id) if home_pitcher_id else None
         away_hand = _determine_hand(away_pitcher_id) if away_pitcher_id else None
-        # Fetch team hitting splits vs LHP/RHP for the current season
+
         home_vs_pitcher_hand = (
             fetch_team_splits(home_team_id, season, "vsRHP") if away_hand == "R" else
             fetch_team_splits(home_team_id, season, "vsLHP") if away_hand == "L" else {}
@@ -110,35 +116,87 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             fetch_team_splits(away_team_id, season, "vsRHP") if home_hand == "R" else
             fetch_team_splits(away_team_id, season, "vsLHP") if home_hand == "L" else {}
         )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
                 "awayTeamSplit": away_vs_pitcher_hand,
             }
         )
-        # Compute pitcher metrics for probable pitchers
+
+        home_pitcher_metrics: Dict[str, object] = {}
+        away_pitcher_metrics: Dict[str, object] = {}
+
         if home_pitcher_id:
             try:
-                pitcher_metrics = get_pitcher_metrics(
+                home_pitcher_metrics = get_pitcher_metrics(
                     home_pitcher_id,
                     (target_date - datetime.timedelta(days=365)).isoformat(),
                     date_str,
                 )
             except NotImplementedError:
-                pitcher_metrics = {}
-            matchup_features["homePitcherMetrics"] = pitcher_metrics
+                home_pitcher_metrics = {}
+
         if away_pitcher_id:
             try:
-                pitcher_metrics = get_pitcher_metrics(
+                away_pitcher_metrics = get_pitcher_metrics(
                     away_pitcher_id,
                     (target_date - datetime.timedelta(days=365)).isoformat(),
                     date_str,
                 )
             except NotImplementedError:
-                pitcher_metrics = {}
-            matchup_features["awayPitcherMetrics"] = pitcher_metrics
-        # Placeholder for batter metrics and head-to-head matchups:
+                away_pitcher_metrics = {}
+
+        matchup_features["homePitcherMetrics"] = home_pitcher_metrics
+        matchup_features["awayPitcherMetrics"] = away_pitcher_metrics
+
+        # Structured profiles
+        home_pitcher_profile = compute_pitcher_profile(home_pitcher_metrics)
+        away_pitcher_profile = compute_pitcher_profile(away_pitcher_metrics)
+
+        # Temporary offense profile source: team split data.
+        # Later this can be replaced by projected-lineup aggregation.
+        home_offense_profile = compute_hitter_profile(home_vs_pitcher_hand or {})
+        away_offense_profile = compute_hitter_profile(away_vs_pitcher_hand or {})
+
+        venue = game.get("venue", {}) or {}
+        environment_context = {
+            "venue_name": venue.get("name"),
+            "roof_status": None,
+            "home_team": game_info.get("homeTeam"),
+            "away_team": game_info.get("awayTeam"),
+            "game_time_local": game_info.get("gameDate"),
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "run_factor": None,
+            "home_run_factor": None,
+            "hit_factor": None,
+            "scoring_environment_label": None,
+            "weather_run_impact": None,
+            "park_run_impact": None,
+            "rain_delay_risk": None,
+            "postponement_risk": None,
+            "extreme_wind_flag": None,
+            "extreme_temperature_flag": None,
+        }
+        environment_profile = compute_environment_profile(environment_context)
+
+        matchup_features.update(
+            {
+                "homePitcherProfile": home_pitcher_profile,
+                "awayPitcherProfile": away_pitcher_profile,
+                "homeOffenseProfile": home_offense_profile,
+                "awayOffenseProfile": away_offense_profile,
+                "environmentProfile": environment_profile,
+            }
+        )
+
         matchup_features["homeLineupMetrics"] = {}
         matchup_features["awayLineupMetrics"] = {}
+
         matchups.append(matchup_features)
+
     return matchups

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -4,22 +4,22 @@ Daily Matchup Analysis Pipeline
 
 This module orchestrates data retrieval from MLB Stats and Statcast
 sources and computes feature vectors for each scheduled game on a given
-date.  The pipeline integrates team records, platoon splits, and
+date. The pipeline integrates team records, platoon splits, and
 pitcher/batter Statcast aggregates to produce a dictionary of features
-for each matchup.  Model training and prediction logic should build
+for each matchup. Model training and prediction logic should build
 upon the outputs of this module.
 
 Due to environment restrictions, Statcast data retrieval functions in
-``statcast_utils`` raise ``NotImplementedError``.  To compute real
+``statcast_utils`` raise ``NotImplementedError``. To compute real
 statistics, implement those functions to download data from Baseball
-Savant.  The placeholder functions here will still demonstrate how to
+Savant. The placeholder functions here will still demonstrate how to
 combine available data sources.
 """
 
 from __future__ import annotations
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from .data_ingestion import (
     fetch_schedule,
@@ -29,20 +29,21 @@ from .data_ingestion import (
 from .player_splits import get_player_splits
 from .pitcher_analysis import get_pitcher_metrics
 from .batter_analysis import get_batter_metrics
-
-
-def _determine_hand(player_id: int) -> str:
-    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
-
-    In a production system, this would query the MLB Stats API or a local
-    roster database.  Here we return 'R' as a default.
-    """
-    # TODO: implement call to statsapi to fetch pitcher throwing hand.
-    return "R"
-
 from .hitter_profile import compute_hitter_profile
 from .pitcher_profile import compute_pitcher_profile
 from .environment_profile import compute_environment_profile
+
+
+def _determine_hand(player_id: int) -> str | None:
+    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
+
+    This is intentionally unresolved until a real MLB Stats API or roster lookup
+    is implemented. Returning None is safer than silently defaulting to 'R',
+    because split selection should not pretend certainty when hand is unknown.
+    """
+    # TODO: implement real pitcher hand lookup.
+    return None
+
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:
     """Compute feature dictionaries for each game scheduled on a date.
@@ -57,8 +58,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
     list of dict
         Each dictionary contains matchup metadata, team records, platoon splits,
         pitcher metrics, and structured hitter/pitcher/environment profiles.
-        If Statcast retrieval functions are unimplemented, some metric/profile
-        fields will remain empty or default to None.
+        All profile keys and nested sections are always present. If supporting
+        data is unavailable, values remain None and metadata describes provenance
+        and readiness.
     """
     target_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
     schedule = fetch_schedule(date_str)
@@ -105,17 +107,30 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             }
         )
 
+        # Placeholder hand logic is intentionally unresolved until real lookup
+        # is implemented. Do not silently assume RHP/LHP buckets when hand is unknown.
         home_hand = _determine_hand(home_pitcher_id) if home_pitcher_id else None
         away_hand = _determine_hand(away_pitcher_id) if away_pitcher_id else None
 
-        home_vs_pitcher_hand = (
-            fetch_team_splits(home_team_id, season, "vsRHP") if away_hand == "R" else
-            fetch_team_splits(home_team_id, season, "vsLHP") if away_hand == "L" else {}
-        )
-        away_vs_pitcher_hand = (
-            fetch_team_splits(away_team_id, season, "vsRHP") if home_hand == "R" else
-            fetch_team_splits(away_team_id, season, "vsLHP") if home_hand == "L" else {}
-        )
+        if away_hand == "R":
+            home_vs_pitcher_hand = fetch_team_splits(home_team_id, season, "vsRHP")
+            home_split_source = "vsRHP"
+        elif away_hand == "L":
+            home_vs_pitcher_hand = fetch_team_splits(home_team_id, season, "vsLHP")
+            home_split_source = "vsLHP"
+        else:
+            home_vs_pitcher_hand = {}
+            home_split_source = "unknown"
+
+        if home_hand == "R":
+            away_vs_pitcher_hand = fetch_team_splits(away_team_id, season, "vsRHP")
+            away_split_source = "vsRHP"
+        elif home_hand == "L":
+            away_vs_pitcher_hand = fetch_team_splits(away_team_id, season, "vsLHP")
+            away_split_source = "vsLHP"
+        else:
+            away_vs_pitcher_hand = {}
+            away_split_source = "unknown"
 
         matchup_features.update(
             {
@@ -150,14 +165,52 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
         matchup_features["homePitcherMetrics"] = home_pitcher_metrics
         matchup_features["awayPitcherMetrics"] = away_pitcher_metrics
 
-        # Structured profiles
-        home_pitcher_profile = compute_pitcher_profile(home_pitcher_metrics)
-        away_pitcher_profile = compute_pitcher_profile(away_pitcher_metrics)
+        # Structured pitcher profiles with provenance metadata.
+        home_pitcher_profile = compute_pitcher_profile(
+            {
+                **(home_pitcher_metrics or {}),
+                "source_type": "statcast_aggregate" if home_pitcher_metrics else "missing",
+                "source_fields_used": sorted(list((home_pitcher_metrics or {}).keys())),
+                "data_confidence": "medium" if home_pitcher_metrics else "low",
+                "generated_from": "get_pitcher_metrics",
+            }
+        )
+        away_pitcher_profile = compute_pitcher_profile(
+            {
+                **(away_pitcher_metrics or {}),
+                "source_type": "statcast_aggregate" if away_pitcher_metrics else "missing",
+                "source_fields_used": sorted(list((away_pitcher_metrics or {}).keys())),
+                "data_confidence": "medium" if away_pitcher_metrics else "low",
+                "generated_from": "get_pitcher_metrics",
+            }
+        )
 
-        # Temporary offense profile source: team split data.
-        # Later this can be replaced by projected-lineup aggregation.
-        home_offense_profile = compute_hitter_profile(home_vs_pitcher_hand or {})
-        away_offense_profile = compute_hitter_profile(away_vs_pitcher_hand or {})
+        # Temporary offense profile source: team split data proxy.
+        # This is explicitly marked as team-level and not lineup-derived.
+        home_team_offense_profile = compute_hitter_profile(
+            {
+                **(home_vs_pitcher_hand or {}),
+                "source_type": "team_split_proxy",
+                "source_fields_used": sorted(list((home_vs_pitcher_hand or {}).keys())),
+                "data_confidence": "low" if home_split_source == "unknown" else "medium",
+                "generated_from": "fetch_team_splits",
+                "profile_granularity": "team",
+                "is_projected_lineup_derived": False,
+                "split_source": home_split_source,
+            }
+        )
+        away_team_offense_profile = compute_hitter_profile(
+            {
+                **(away_vs_pitcher_hand or {}),
+                "source_type": "team_split_proxy",
+                "source_fields_used": sorted(list((away_vs_pitcher_hand or {}).keys())),
+                "data_confidence": "low" if away_split_source == "unknown" else "medium",
+                "generated_from": "fetch_team_splits",
+                "profile_granularity": "team",
+                "is_projected_lineup_derived": False,
+                "split_source": away_split_source,
+            }
+        )
 
         venue = game.get("venue", {}) or {}
         environment_context = {
@@ -181,6 +234,22 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             "postponement_risk": None,
             "extreme_wind_flag": None,
             "extreme_temperature_flag": None,
+            "source_type": "schedule_venue_stub",
+            "source_fields_used": ["venue_name", "home_team", "away_team", "game_time_local"],
+            "data_confidence": "low",
+            "generated_from": "game schedule + venue stub",
+            "is_stub": True,
+            "readiness": "stub",
+            "missing_inputs": [
+                "temperature_f",
+                "wind_speed_mph",
+                "wind_direction",
+                "humidity_pct",
+                "precipitation_probability",
+                "run_factor",
+                "home_run_factor",
+                "hit_factor",
+            ],
         }
         environment_profile = compute_environment_profile(environment_context)
 
@@ -188,8 +257,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             {
                 "homePitcherProfile": home_pitcher_profile,
                 "awayPitcherProfile": away_pitcher_profile,
-                "homeOffenseProfile": home_offense_profile,
-                "awayOffenseProfile": away_offense_profile,
+                "homeTeamOffenseProfile": home_team_offense_profile,
+                "awayTeamOffenseProfile": away_team_offense_profile,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -1,0 +1,56 @@
+"""
+Utilities for building environment profile summaries for matchup previews.
+
+This module defines a game-level environment profile structure that can later
+be populated with real weather, park factor, and contextual inputs.
+"""
+
+
+def compute_environment_profile(raw_context: dict) -> dict:
+    """
+    Build a structured environment profile from raw game context inputs.
+
+    Parameters
+    ----------
+    raw_context : dict
+        Dictionary of environmental and contextual stats from upstream
+        ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured game-level environment profile using raw metrics grouped
+        by category. Missing fields are returned as None.
+    """
+    return {
+        "weather": {
+            "temperature_f": raw_context.get("temperature_f"),
+            "wind_speed_mph": raw_context.get("wind_speed_mph"),
+            "wind_direction": raw_context.get("wind_direction"),
+            "humidity_pct": raw_context.get("humidity_pct"),
+            "precipitation_probability": raw_context.get("precipitation_probability"),
+        },
+        "park_factors": {
+            "run_factor": raw_context.get("run_factor"),
+            "home_run_factor": raw_context.get("home_run_factor"),
+            "hit_factor": raw_context.get("hit_factor"),
+        },
+        "game_context": {
+            "venue_name": raw_context.get("venue_name"),
+            "roof_status": raw_context.get("roof_status"),
+            "home_team": raw_context.get("home_team"),
+            "away_team": raw_context.get("away_team"),
+            "game_time_local": raw_context.get("game_time_local"),
+        },
+        "run_environment": {
+            "scoring_environment_label": raw_context.get("scoring_environment_label"),
+            "weather_run_impact": raw_context.get("weather_run_impact"),
+            "park_run_impact": raw_context.get("park_run_impact"),
+        },
+        "risk_flags": {
+            "rain_delay_risk": raw_context.get("rain_delay_risk"),
+            "postponement_risk": raw_context.get("postponement_risk"),
+            "extreme_wind_flag": raw_context.get("extreme_wind_flag"),
+            "extreme_temperature_flag": raw_context.get("extreme_temperature_flag"),
+        },
+    }

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -22,7 +22,15 @@ def compute_environment_profile(raw_context: dict) -> dict:
         A structured game-level environment profile using raw metrics grouped
         by category. Missing fields are returned as None.
     """
+    raw_context = raw_context or {}
+
     return {
+        "metadata": {
+            "source_type": raw_context.get("source_type", "unknown"),
+            "source_fields_used": raw_context.get("source_fields_used", []),
+            "data_confidence": raw_context.get("data_confidence", "unknown"),
+            "generated_from": raw_context.get("generated_from", "compute_environment_profile"),
+        },
         "weather": {
             "temperature_f": raw_context.get("temperature_f"),
             "wind_speed_mph": raw_context.get("wind_speed_mph"),
@@ -52,5 +60,10 @@ def compute_environment_profile(raw_context: dict) -> dict:
             "postponement_risk": raw_context.get("postponement_risk"),
             "extreme_wind_flag": raw_context.get("extreme_wind_flag"),
             "extreme_temperature_flag": raw_context.get("extreme_temperature_flag"),
+        },
+        "status": {
+            "is_stub": raw_context.get("is_stub", True),
+            "readiness": raw_context.get("readiness", "stub"),
+            "missing_inputs": raw_context.get("missing_inputs", []),
         },
     }

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -1,0 +1,50 @@
+"""
+Utilities for building hitter profile summaries for matchup previews.
+
+This module defines a player-level hitter profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+
+def compute_hitter_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured hitter profile from raw hitter inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of hitter stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level hitter profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    return {
+        "contact_skill": {
+            "k_rate": raw_stats.get("k_rate"),
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "contact_rate": raw_stats.get("contact_rate"),
+        },
+        "plate_discipline": {
+            "bb_rate": raw_stats.get("bb_rate"),
+            "chase_rate": raw_stats.get("chase_rate"),
+            "swing_rate": raw_stats.get("swing_rate"),
+        },
+        "power": {
+            "iso": raw_stats.get("iso"),
+            "barrel_rate": raw_stats.get("barrel_rate"),
+            "hard_hit_rate": raw_stats.get("hard_hit_rate"),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": raw_stats.get("avg_exit_velocity"),
+            "avg_launch_angle": raw_stats.get("avg_launch_angle"),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": raw_stats.get("vs_lhp_woba"),
+            "vs_rhp_woba": raw_stats.get("vs_rhp_woba"),
+            "vs_lhp_iso": raw_stats.get("vs_lhp_iso"),
+            "vs_rhp_iso": raw_stats.get("vs_rhp_iso"),
+        },
+    }

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -6,6 +6,20 @@ be populated with real calculations from split and Statcast inputs.
 """
 
 
+def _safe_rate(numerator, denominator):
+    """Return numerator / denominator when both are available and denominator > 0."""
+    if numerator is None or denominator in (None, 0):
+        return None
+    return numerator / denominator
+
+
+def _safe_difference(a, b):
+    """Return a - b when both values are available."""
+    if a is None or b is None:
+        return None
+    return a - b
+
+
 def compute_hitter_profile(raw_stats: dict) -> dict:
     """
     Build a structured hitter profile from raw hitter inputs.
@@ -21,24 +35,44 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
         A structured player-level hitter profile using raw metrics grouped
         by trait. Missing fields are returned as None.
     """
+    raw_stats = raw_stats or {}
+
+    plate_appearances = raw_stats.get("plateAppearances")
+    strikeouts = raw_stats.get("strikeOuts")
+    walks = raw_stats.get("baseOnBalls")
+    avg = raw_stats.get("avg")
+    slg = raw_stats.get("slg")
+
+    k_rate = raw_stats.get("k_rate", raw_stats.get("k_pct"))
+    if k_rate is None:
+        k_rate = _safe_rate(strikeouts, plate_appearances)
+
+    bb_rate = raw_stats.get("bb_rate", raw_stats.get("bb_pct"))
+    if bb_rate is None:
+        bb_rate = _safe_rate(walks, plate_appearances)
+
+    iso = raw_stats.get("iso")
+    if iso is None:
+        iso = _safe_difference(slg, avg)
+
     return {
         "contact_skill": {
-            "k_rate": raw_stats.get("k_rate"),
+            "k_rate": k_rate,
             "whiff_rate": raw_stats.get("whiff_rate"),
             "contact_rate": raw_stats.get("contact_rate"),
         },
         "plate_discipline": {
-            "bb_rate": raw_stats.get("bb_rate"),
+            "bb_rate": bb_rate,
             "chase_rate": raw_stats.get("chase_rate"),
             "swing_rate": raw_stats.get("swing_rate"),
         },
         "power": {
-            "iso": raw_stats.get("iso"),
-            "barrel_rate": raw_stats.get("barrel_rate"),
-            "hard_hit_rate": raw_stats.get("hard_hit_rate"),
+            "iso": iso,
+            "barrel_rate": raw_stats.get("barrel_rate", raw_stats.get("barrel_pct")),
+            "hard_hit_rate": raw_stats.get("hard_hit_rate", raw_stats.get("hard_hit_pct")),
         },
         "batted_ball_quality": {
-            "avg_exit_velocity": raw_stats.get("avg_exit_velocity"),
+            "avg_exit_velocity": raw_stats.get("avg_exit_velocity", raw_stats.get("avg_exit_vel")),
             "avg_launch_angle": raw_stats.get("avg_launch_angle"),
         },
         "platoon_profile": {

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -56,6 +56,14 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
         iso = _safe_difference(slg, avg)
 
     return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_hitter_profile"),
+            "profile_granularity": raw_stats.get("profile_granularity", "player"),
+            "is_projected_lineup_derived": raw_stats.get("is_projected_lineup_derived", False),
+        },
         "contact_skill": {
             "k_rate": k_rate,
             "whiff_rate": raw_stats.get("whiff_rate"),

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -21,25 +21,31 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
         A structured player-level pitcher profile using raw metrics grouped
         by trait. Missing fields are returned as None.
     """
+    raw_stats = raw_stats or {}
+
     return {
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),
             "avg_velocity": raw_stats.get("avg_velocity"),
-            "avg_spin_rate": raw_stats.get("avg_spin_rate"),
+            "avg_spin_rate": raw_stats.get("avg_spin_rate", raw_stats.get("avg_spin")),
         },
         "bat_missing": {
-            "k_rate": raw_stats.get("k_rate"),
+            "k_rate": raw_stats.get("k_rate", raw_stats.get("k_pct")),
             "whiff_rate": raw_stats.get("whiff_rate"),
             "csw_rate": raw_stats.get("csw_rate"),
         },
         "command_control": {
-            "bb_rate": raw_stats.get("bb_rate"),
+            "bb_rate": raw_stats.get("bb_rate", raw_stats.get("bb_pct")),
             "zone_rate": raw_stats.get("zone_rate"),
             "first_pitch_strike_rate": raw_stats.get("first_pitch_strike_rate"),
         },
         "contact_management": {
-            "hard_hit_rate_allowed": raw_stats.get("hard_hit_rate_allowed"),
-            "barrel_rate_allowed": raw_stats.get("barrel_rate_allowed"),
+            "hard_hit_rate_allowed": raw_stats.get(
+                "hard_hit_rate_allowed", raw_stats.get("hard_hit_pct")
+            ),
+            "barrel_rate_allowed": raw_stats.get(
+                "barrel_rate_allowed", raw_stats.get("barrel_pct_allowed")
+            ),
             "avg_exit_velocity_allowed": raw_stats.get("avg_exit_velocity_allowed"),
             "avg_launch_angle_allowed": raw_stats.get("avg_launch_angle_allowed"),
         },

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -24,6 +24,12 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
     raw_stats = raw_stats or {}
 
     return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_pitcher_profile"),
+        },
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),
             "avg_velocity": raw_stats.get("avg_velocity"),

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -1,0 +1,54 @@
+"""
+Utilities for building pitcher profile summaries for matchup previews.
+
+This module defines a player-level pitcher profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+
+def compute_pitcher_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured pitcher profile from raw pitcher inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of pitcher stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level pitcher profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    return {
+        "arsenal": {
+            "pitch_mix": raw_stats.get("pitch_mix"),
+            "avg_velocity": raw_stats.get("avg_velocity"),
+            "avg_spin_rate": raw_stats.get("avg_spin_rate"),
+        },
+        "bat_missing": {
+            "k_rate": raw_stats.get("k_rate"),
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "csw_rate": raw_stats.get("csw_rate"),
+        },
+        "command_control": {
+            "bb_rate": raw_stats.get("bb_rate"),
+            "zone_rate": raw_stats.get("zone_rate"),
+            "first_pitch_strike_rate": raw_stats.get("first_pitch_strike_rate"),
+        },
+        "contact_management": {
+            "hard_hit_rate_allowed": raw_stats.get("hard_hit_rate_allowed"),
+            "barrel_rate_allowed": raw_stats.get("barrel_rate_allowed"),
+            "avg_exit_velocity_allowed": raw_stats.get("avg_exit_velocity_allowed"),
+            "avg_launch_angle_allowed": raw_stats.get("avg_launch_angle_allowed"),
+        },
+        "platoon_profile": {
+            "vs_lhb_woba_allowed": raw_stats.get("vs_lhb_woba_allowed"),
+            "vs_rhb_woba_allowed": raw_stats.get("vs_rhb_woba_allowed"),
+            "vs_lhb_k_rate": raw_stats.get("vs_lhb_k_rate"),
+            "vs_rhb_k_rate": raw_stats.get("vs_rhb_k_rate"),
+            "vs_lhb_bb_rate": raw_stats.get("vs_lhb_bb_rate"),
+            "vs_rhb_bb_rate": raw_stats.get("vs_rhb_bb_rate"),
+        },
+    }

--- a/tests/test_matchup_profile_contract.py
+++ b/tests/test_matchup_profile_contract.py
@@ -1,0 +1,84 @@
+from mlb_app.analysis_pipeline import generate_daily_matchups
+
+
+def test_generate_daily_matchups_profile_contract(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_schedule",
+        lambda date_str: [
+            {
+                "gamePk": 123,
+                "gameDate": "2026-04-22T18:05:00Z",
+                "teams": {
+                    "home": {
+                        "team": {"id": 1, "name": "Home Team"},
+                        "probablePitcher": {"id": 1001},
+                    },
+                    "away": {
+                        "team": {"id": 2, "name": "Away Team"},
+                        "probablePitcher": {"id": 1002},
+                    },
+                },
+                "venue": {"name": "Sample Park"},
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_records",
+        lambda season: [
+            {"team": {"id": 1}, "wins": 10, "losses": 5, "runDifferential": 12},
+            {"team": {"id": 2}, "wins": 8, "losses": 7, "runDifferential": -3},
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_splits",
+        lambda team_id, season, split: {},
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.get_pitcher_metrics",
+        lambda player_id, start_date, end_date: {},
+    )
+
+    matchups = generate_daily_matchups("2026-04-22")
+    assert len(matchups) == 1
+
+    matchup = matchups[0]
+
+    # Top-level contract
+    assert "homePitcherProfile" in matchup
+    assert "awayPitcherProfile" in matchup
+    assert "homeTeamOffenseProfile" in matchup
+    assert "awayTeamOffenseProfile" in matchup
+    assert "environmentProfile" in matchup
+
+    # Pitcher profile nested sections
+    for key in ("homePitcherProfile", "awayPitcherProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "arsenal" in profile
+        assert "bat_missing" in profile
+        assert "command_control" in profile
+        assert "contact_management" in profile
+        assert "platoon_profile" in profile
+
+    # Offense profile nested sections
+    for key in ("homeTeamOffenseProfile", "awayTeamOffenseProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "contact_skill" in profile
+        assert "plate_discipline" in profile
+        assert "power" in profile
+        assert "batted_ball_quality" in profile
+        assert "platoon_profile" in profile
+
+    # Environment profile nested sections
+    environment = matchup["environmentProfile"]
+    assert "metadata" in environment
+    assert "weather" in environment
+    assert "park_factors" in environment
+    assert "game_context" in environment
+    assert "run_environment" in environment
+    assert "risk_flags" in environment
+    assert "status" in environment


### PR DESCRIPTION
Tightens the sandbox matchup profile contract so downstream automation can consume it safely.

This update:
- guarantees stable profile object presence and nested sections
- renames offense payloads to explicit team-level proxy profiles
- adds provenance metadata to hitter, pitcher, and environment profiles
- stops silently defaulting pitcher hand to R and marks unresolved split selection honestly
- marks environment profiles as stub/incomplete with readiness metadata
- adds a schema smoke test to guard payload contract stability

This is intended as a sandbox hardening pass before building additional automation and environment ingestion on top of the matchup-preview architecture.