### PR TITLE
Add lineup-aware offense profiles to matchup output

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -33,6 +33,8 @@ from .hitter_profile import compute_hitter_profile
 from .pitcher_profile import compute_pitcher_profile
 from .environment_profile import compute_environment_profile
 from .environment_data import build_environment_context
+from .lineup_data import resolve_team_lineup
+from .offense_profile_aggregation import build_projected_lineup_offense_profile
 
 
 def _determine_hand(player_id: int) -> str | None:
@@ -133,6 +135,32 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             away_vs_pitcher_hand = {}
             away_split_source = "unknown"
 
+        home_lineup, home_lineup_source = resolve_team_lineup(
+            game=game,
+            team_id=home_team_id,
+            side="home",
+            season=season,
+        )
+        away_lineup, away_lineup_source = resolve_team_lineup(
+            game=game,
+            team_id=away_team_id,
+            side="away",
+            season=season,
+        )
+
+        home_projected_lineup_offense_profile = build_projected_lineup_offense_profile(
+            lineup=home_lineup,
+            season=season,
+            pitcher_hand=away_hand,
+            lineup_source=home_lineup_source,
+        )
+        away_projected_lineup_offense_profile = build_projected_lineup_offense_profile(
+            lineup=away_lineup,
+            season=season,
+            pitcher_hand=home_hand,
+            lineup_source=away_lineup_source,
+        )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
@@ -223,6 +251,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "awayPitcherProfile": away_pitcher_profile,
                 "homeTeamOffenseProfile": home_team_offense_profile,
                 "awayTeamOffenseProfile": away_team_offense_profile,
+                "homeProjectedLineupOffenseProfile": home_projected_lineup_offense_profile,
+                "awayProjectedLineupOffenseProfile": away_projected_lineup_offense_profile,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/lineup_data.py
+++ b/mlb_app/lineup_data.py
@@ -1,0 +1,89 @@
+"""
+Lineup data utilities for matchup previews.
+
+This module provides reusable helpers for retrieving official lineups from
+the MLB Stats API and falling back to active non-pitcher roster candidates
+when an official lineup has not yet been posted.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List, Tuple
+
+import requests
+
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+
+
+def fetch_roster_as_lineup(team_id: int, season: int) -> List[Dict[str, Any]]:
+    """
+    Return active non-pitcher roster entries when an official lineup is unavailable.
+    """
+    try:
+        resp = requests.get(
+            f"{MLB_STATS_BASE}/teams/{team_id}/roster",
+            params={"rosterType": "active", "season": season},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return [
+            {
+                "id": r["person"]["id"],
+                "fullName": r["person"]["fullName"],
+            }
+            for r in resp.json().get("roster", [])
+            if (r.get("position") or {}).get("type", "").lower() != "pitcher"
+            and r.get("person", {}).get("id")
+        ]
+    except requests.RequestException:
+        return []
+
+
+def resolve_team_lineup(
+    game: Dict[str, Any],
+    team_id: int,
+    side: str,
+    season: int,
+) -> Tuple[List[Dict[str, Any]], str]:
+    """
+    Resolve a team lineup from hydrated schedule data, falling back to active roster.
+
+    Returns
+    -------
+    tuple
+        (lineup_list, lineup_source) where lineup_source is one of:
+        - "official"
+        - "roster"
+        - "missing"
+    """
+    lineups = game.get("lineups", {}) or {}
+    lineup_raw = lineups.get(f"{side}Players", []) or []
+
+    if lineup_raw:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(lineup_raw)
+            if p.get("id")
+        ]
+        return lineup, "official"
+
+    roster_fallback = fetch_roster_as_lineup(team_id, season)
+    if roster_fallback:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(roster_fallback)
+            if p.get("id")
+        ]
+        return lineup, "roster"
+
+    return [], "missing"

--- a/mlb_app/offense_profile_aggregation.py
+++ b/mlb_app/offense_profile_aggregation.py
@@ -1,0 +1,143 @@
+"""
+Offense profile aggregation utilities for matchup previews.
+
+This module builds projected-lineup-aware offense profiles by:
+- fetching player-level splits vs pitcher handedness
+- converting those player split rows into hitter profiles
+- aggregating those hitter profiles into one lineup offense profile
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .hitter_profile import compute_hitter_profile
+from .player_splits import fetch_player_splits
+
+
+def _average(values: List[Optional[float]]) -> Optional[float]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _extract_metric(profile: Dict[str, Any], section: str, field: str) -> Optional[float]:
+    return (profile.get(section) or {}).get(field)
+
+
+def aggregate_hitter_profiles(
+    hitter_profiles: List[Dict[str, Any]],
+    lineup_source: str,
+    pitcher_hand: Optional[str],
+    player_count_used: int,
+) -> Dict[str, Any]:
+    """
+    Aggregate player-level hitter profiles into one projected-lineup offense profile.
+    """
+    return {
+        "metadata": {
+            "source_type": "projected_lineup_profile",
+            "source_fields_used": ["player_splits", "compute_hitter_profile"],
+            "data_confidence": "medium" if hitter_profiles else "low",
+            "generated_from": "aggregate_hitter_profiles",
+            "profile_granularity": "lineup_candidate_group",
+            "is_projected_lineup_derived": lineup_source == "official",
+            "lineup_source": lineup_source,
+            "opposing_pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "player_count_used": player_count_used,
+        },
+        "contact_skill": {
+            "k_rate": _average([_extract_metric(p, "contact_skill", "k_rate") for p in hitter_profiles]),
+            "whiff_rate": _average([_extract_metric(p, "contact_skill", "whiff_rate") for p in hitter_profiles]),
+            "contact_rate": _average([_extract_metric(p, "contact_skill", "contact_rate") for p in hitter_profiles]),
+        },
+        "plate_discipline": {
+            "bb_rate": _average([_extract_metric(p, "plate_discipline", "bb_rate") for p in hitter_profiles]),
+            "chase_rate": _average([_extract_metric(p, "plate_discipline", "chase_rate") for p in hitter_profiles]),
+            "swing_rate": _average([_extract_metric(p, "plate_discipline", "swing_rate") for p in hitter_profiles]),
+        },
+        "power": {
+            "iso": _average([_extract_metric(p, "power", "iso") for p in hitter_profiles]),
+            "barrel_rate": _average([_extract_metric(p, "power", "barrel_rate") for p in hitter_profiles]),
+            "hard_hit_rate": _average([_extract_metric(p, "power", "hard_hit_rate") for p in hitter_profiles]),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_exit_velocity") for p in hitter_profiles]
+            ),
+            "avg_launch_angle": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_launch_angle") for p in hitter_profiles]
+            ),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_lhp_woba") for p in hitter_profiles]),
+            "vs_rhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_rhp_woba") for p in hitter_profiles]),
+            "vs_lhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_lhp_iso") for p in hitter_profiles]),
+            "vs_rhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_rhp_iso") for p in hitter_profiles]),
+        },
+    }
+
+
+def build_projected_lineup_offense_profile(
+    lineup: List[Dict[str, Any]],
+    season: int,
+    pitcher_hand: Optional[str],
+    lineup_source: str,
+) -> Dict[str, Any]:
+    """
+    Build a projected-lineup offense profile from player split data.
+
+    Parameters
+    ----------
+    lineup : list of dict
+        List of lineup player records containing at least `id`.
+    season : int
+        Season year.
+    pitcher_hand : str or None
+        Opposing pitcher throwing hand. Expected 'L', 'R', or None.
+    lineup_source : str
+        Source label such as 'official', 'roster', or 'missing'.
+
+    Returns
+    -------
+    dict
+        Aggregated offense profile with stable contract and explicit metadata.
+    """
+    player_ids = [p.get("id") for p in lineup if p.get("id")]
+    if not player_ids:
+        return aggregate_hitter_profiles(
+            hitter_profiles=[],
+            lineup_source="missing",
+            pitcher_hand=pitcher_hand,
+            player_count_used=0,
+        )
+
+    split_code = "vr" if pitcher_hand == "R" else "vl" if pitcher_hand == "L" else None
+    all_splits = fetch_player_splits(player_ids, season)
+
+    selected_rows = []
+    if split_code:
+        selected_rows = [row for row in all_splits if row.get("split") == split_code]
+    else:
+        selected_rows = []
+
+    hitter_profiles = []
+    for row in selected_rows:
+        enriched_row = {
+            **row,
+            "source_type": "player_split",
+            "source_fields_used": sorted(list(row.keys())),
+            "data_confidence": "medium",
+            "generated_from": "fetch_player_splits",
+            "profile_granularity": "player",
+            "is_projected_lineup_derived": lineup_source == "official",
+        }
+        hitter_profiles.append(compute_hitter_profile(enriched_row))
+
+    return aggregate_hitter_profiles(
+        hitter_profiles=hitter_profiles,
+        lineup_source=lineup_source,
+        pitcher_hand=pitcher_hand,
+        player_count_used=len(player_ids),
+    )

--- a/tests/test_lineup_offense_profile_contract.py
+++ b/tests/test_lineup_offense_profile_contract.py
@@ -1,0 +1,44 @@
+from mlb_app.offense_profile_aggregation import build_projected_lineup_offense_profile
+
+
+def test_projected_lineup_offense_profile_contract_when_lineup_missing():
+    result = build_projected_lineup_offense_profile(
+        lineup=[],
+        season=2026,
+        pitcher_hand=None,
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "projected_lineup_profile"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["opposing_pitcher_hand"] == "unknown"
+    assert metadata["player_count_used"] == 0
+
+
+def test_projected_lineup_offense_profile_contract_with_roster_source():
+    result = build_projected_lineup_offense_profile(
+        lineup=[{"id": 1, "fullName": "Test Batter", "batting_order": 1}],
+        season=2026,
+        pitcher_hand="R",
+        lineup_source="roster",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["lineup_source"] == "roster"
+    assert metadata["opposing_pitcher_hand"] == "R"
+    assert metadata["player_count_used"] == 1


### PR DESCRIPTION
Adds projected-lineup-aware offense profiles to sandbox matchup output.

This update:
- introduces `lineup_data.py` for official lineup resolution with active-roster fallback
- introduces `offense_profile_aggregation.py` for player-split-based lineup offense aggregation
- adds `homeProjectedLineupOffenseProfile` and `awayProjectedLineupOffenseProfile` to the matchup payload
- preserves the existing team-level offense proxy profiles for compatibility
- adds a contract test for projected-lineup offense profile shape and metadata

This moves the sandbox offense layer closer to true matchup context by using likely hitters against opposing pitcher handedness rather than only team-level split proxies.