### PR TITLE
Resolve pitcher handedness from MLB Stats API

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -19,6 +19,7 @@ combine available data sources.
 from __future__ import annotations
 
 import datetime
+import requests
 from typing import Dict, List
 
 from .data_ingestion import (
@@ -38,14 +39,25 @@ from .offense_profile_aggregation import build_projected_lineup_offense_profile
 
 
 def _determine_hand(player_id: int) -> str | None:
-    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
+    """Determine a pitcher's throwing hand ('L' or 'R') from MLB Stats API.
 
-    This is intentionally unresolved until a real MLB Stats API or roster lookup
-    is implemented. Returning None is safer than silently defaulting to 'R',
-    because split selection should not pretend certainty when hand is unknown.
+    If the API request fails or the hand is unavailable, return None so the
+    pipeline can preserve honest fallback behavior rather than assume certainty.
     """
-    # TODO: implement real pitcher hand lookup.
-    return None
+    if not player_id:
+        return None
+
+    url = f"https://statsapi.mlb.com/api/v1/people/{player_id}"
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        people = response.json().get("people", [])
+        if not people:
+            return None
+        hand = (people[0].get("pitchHand") or {}).get("code")
+        return hand if hand in {"L", "R"} else None
+    except requests.RequestException:
+        return None
 
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:

--- a/tests/test_pitcher_handedness_resolution.py
+++ b/tests/test_pitcher_handedness_resolution.py
@@ -1,0 +1,35 @@
+from mlb_app.analysis_pipeline import _determine_hand
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_determine_hand_returns_pitch_hand_code(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.requests.get",
+        lambda url, timeout=10: DummyResponse(
+            {"people": [{"pitchHand": {"code": "R"}}]}
+        ),
+    )
+
+    assert _determine_hand(12345) == "R"
+
+
+def test_determine_hand_returns_none_on_request_failure(monkeypatch):
+    class DummyException(Exception):
+        pass
+
+    def raise_error(url, timeout=10):
+        raise DummyException("network error")
+
+    monkeypatch.setattr("mlb_app.analysis_pipeline.requests.get", raise_error)
+
+    assert _determine_hand(12345) is None


### PR DESCRIPTION
Adds real pitcher handedness lookup to sandbox matchup generation using MLB Stats API player data.

This update:
- replaces placeholder handedness logic with live pitcher hand resolution
- uses `pitchHand.code` from MLB Stats API when available
- preserves honest fallback behavior when handedness cannot be determined
- improves split selection for both team offense proxies and projected-lineup offense profiles
- adds a small test for handedness resolution behavior

This makes split-backed matchup context more accurate without sacrificing the contract-safe fallback behavior already established in sandbox.