### PR TITLE
Add matchup analysis payload scaffold

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -36,6 +36,7 @@ from .environment_profile import compute_environment_profile
 from .environment_data import build_environment_context
 from .lineup_data import resolve_team_lineup
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
+from .matchup_analysis import build_matchup_analysis
 
 
 def _determine_hand(player_id: int) -> str | None:
@@ -173,6 +174,21 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             lineup_source=away_lineup_source,
         )
 
+        home_matchup_analysis = build_matchup_analysis(
+            pitcher_id=away_pitcher_id,
+            pitcher_name=away_pitcher.get("fullName") if isinstance(away_pitcher, dict) else None,
+            pitcher_hand=away_hand,
+            lineup=home_lineup,
+            lineup_source=home_lineup_source,
+        )
+        away_matchup_analysis = build_matchup_analysis(
+            pitcher_id=home_pitcher_id,
+            pitcher_name=home_pitcher.get("fullName") if isinstance(home_pitcher, dict) else None,
+            pitcher_hand=home_hand,
+            lineup=away_lineup,
+            lineup_source=away_lineup_source,
+        )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
@@ -265,6 +281,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "awayTeamOffenseProfile": away_team_offense_profile,
                 "homeProjectedLineupOffenseProfile": home_projected_lineup_offense_profile,
                 "awayProjectedLineupOffenseProfile": away_projected_lineup_offense_profile,
+                "homeMatchupAnalysis": home_matchup_analysis,
+                "awayMatchupAnalysis": away_matchup_analysis,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -1,0 +1,54 @@
+"""
+Matchup analysis utilities for matchup-preview payloads.
+
+This module builds pitch-arsenal-vs-lineup analysis for a matchup using:
+- pitcher arsenal data
+- projected lineup candidates
+- simple batter vs pitch-type capability summaries
+- lightweight edge/confidence scoring
+
+The output is designed to support a future "Matchup Analysis" UI tab without
+overwriting existing overview, pitcher, batter, or environment views.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def build_matchup_analysis(
+    pitcher_id: Optional[int],
+    pitcher_name: Optional[str],
+    pitcher_hand: Optional[str],
+    lineup: List[Dict[str, Any]],
+    lineup_source: str,
+) -> Dict[str, Any]:
+    """
+    Return a stable matchup-analysis payload scaffold.
+
+    This is the first contract layer for the future Matchup Analysis tab.
+    It will be expanded later with real pitch-arsenal-vs-hitter calculations.
+    """
+    return {
+        "metadata": {
+            "source_type": "matchup_analysis_scaffold",
+            "generated_from": "build_matchup_analysis",
+            "data_confidence": "low",
+            "pitcher_id": pitcher_id,
+            "pitcher_name": pitcher_name,
+            "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "lineup_source": lineup_source,
+            "lineup_player_count": len([p for p in lineup if p.get("id")]),
+        },
+        "pitchTypeMatchups": [],
+        "biggestEdge": None,
+        "biggestWeakness": None,
+        "confidence": 0.0,
+        "summary": {
+            "status": "scaffold",
+            "note": (
+                "Pitch arsenal vs hitter weakness analysis is not yet fully wired. "
+                "This payload is additive and intended for a future Matchup Analysis tab."
+            ),
+        },
+    }

--- a/tests/test_matchup_analysis_contract.py
+++ b/tests/test_matchup_analysis_contract.py
@@ -1,0 +1,50 @@
+from mlb_app.matchup_analysis import build_matchup_analysis
+
+
+def test_matchup_analysis_contract_with_missing_lineup():
+    result = build_matchup_analysis(
+        pitcher_id=None,
+        pitcher_name=None,
+        pitcher_hand=None,
+        lineup=[],
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "pitchTypeMatchups" in result
+    assert "biggestEdge" in result
+    assert "biggestWeakness" in result
+    assert "confidence" in result
+    assert "summary" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "matchup_analysis_scaffold"
+    assert metadata["pitcher_hand"] == "unknown"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["lineup_player_count"] == 0
+
+    assert result["pitchTypeMatchups"] == []
+    assert result["biggestEdge"] is None
+    assert result["biggestWeakness"] is None
+    assert result["confidence"] == 0.0
+    assert result["summary"]["status"] == "scaffold"
+
+
+def test_matchup_analysis_contract_with_lineup_players():
+    result = build_matchup_analysis(
+        pitcher_id=123,
+        pitcher_name="Pitcher Example",
+        pitcher_hand="R",
+        lineup=[
+            {"id": 1, "fullName": "Batter One", "batting_order": 1},
+            {"id": 2, "fullName": "Batter Two", "batting_order": 2},
+        ],
+        lineup_source="official",
+    )
+
+    metadata = result["metadata"]
+    assert metadata["pitcher_id"] == 123
+    assert metadata["pitcher_name"] == "Pitcher Example"
+    assert metadata["pitcher_hand"] == "R"
+    assert metadata["lineup_source"] == "official"
+    assert metadata["lineup_player_count"] == 2


### PR DESCRIPTION
Adds an additive backend payload scaffold for a future Matchup Analysis tab in the sandbox branch.

This update:
- introduces `matchup_analysis.py` as the initial backend contract for matchup analysis
- adds `homeMatchupAnalysis` and `awayMatchupAnalysis` to the matchup payload
- preserves the existing overview, pitcher, batter, and environment payloads
- adds a contract test to ensure the new payload shape is stable

This is intentionally a scaffold layer so the frontend can add a new Matchup Analysis tab without overwriting the current site behavior.