### PR TITLE
Add sample window framework metadata

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -230,6 +230,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "source_fields_used": sorted(list((home_pitcher_metrics or {}).keys())),
                 "data_confidence": "medium" if home_pitcher_metrics else "low",
                 "generated_from": "get_pitcher_metrics",
+                "sample_window": "last_365_days",
+                "sample_blend_policy": "single_window_v1",
+                "sample_size": None,
+                "stabilizer_window": None,
             }
         )
         away_pitcher_profile = compute_pitcher_profile(
@@ -239,6 +243,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "source_fields_used": sorted(list((away_pitcher_metrics or {}).keys())),
                 "data_confidence": "medium" if away_pitcher_metrics else "low",
                 "generated_from": "get_pitcher_metrics",
+                "sample_window": "last_365_days",
+                "sample_blend_policy": "single_window_v1",
+                "sample_size": None,
+                "stabilizer_window": None,
             }
         )
 
@@ -254,6 +262,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "profile_granularity": "team",
                 "is_projected_lineup_derived": False,
                 "split_source": home_split_source,
+                "sample_window": "current_season",
+                "sample_blend_policy": "single_window_v1",
+                "stabilizer_window": None,
             }
         )
         away_team_offense_profile = compute_hitter_profile(
@@ -266,6 +277,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "profile_granularity": "team",
                 "is_projected_lineup_derived": False,
                 "split_source": away_split_source,
+                "sample_window": "current_season",
+                "sample_blend_policy": "single_window_v1",
+                "stabilizer_window": None,
             }
         )
 

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -63,6 +63,12 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
             "generated_from": raw_stats.get("generated_from", "compute_hitter_profile"),
             "profile_granularity": raw_stats.get("profile_granularity", "player"),
             "is_projected_lineup_derived": raw_stats.get("is_projected_lineup_derived", False),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "current_season"),
+                sample_size=raw_stats.get("plateAppearances"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
         },
         "contact_skill": {
             "k_rate": k_rate,

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -13,6 +13,7 @@ overwriting existing overview, pitcher, batter, or environment views.
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+from .sample_windows import build_sample_metadata
 
 
 def _edge_score_from_components(
@@ -193,6 +194,12 @@ def build_matchup_analysis(
             "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
             "lineup_source": lineup_source,
             "lineup_player_count": lineup_player_count,
+            **build_sample_metadata(
+                window_name="current_season",
+                sample_size=lineup_player_count,
+                sample_blend_policy="single_window_v1",
+                stabilizer_window=None,
+            ),
         },
         "pitchTypeMatchups": pitch_type_matchups,
         "biggestEdge": biggest_edge,

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -29,6 +29,12 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
             "source_fields_used": raw_stats.get("source_fields_used", []),
             "data_confidence": raw_stats.get("data_confidence", "unknown"),
             "generated_from": raw_stats.get("generated_from", "compute_pitcher_profile"),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "last_365_days"),
+                sample_size=raw_stats.get("sample_size"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
         },
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),

--- a/mlb_app/sample_windows.py
+++ b/mlb_app/sample_windows.py
@@ -1,0 +1,89 @@
+"""
+Sample window definitions for matchup analysis.
+
+This module provides a stable framework for naming, describing, and
+eventually blending time windows used across hitter, pitcher, and
+matchup-analysis calculations.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Optional
+
+
+SAMPLE_WINDOWS: Dict[str, Dict[str, object]] = {
+    "last_30_days": {
+        "window_type": "rolling",
+        "days": 30,
+        "description": "Rolling last 30 days",
+    },
+    "last_90_days": {
+        "window_type": "rolling",
+        "days": 90,
+        "description": "Rolling last 90 days",
+    },
+    "last_365_days": {
+        "window_type": "rolling",
+        "days": 365,
+        "description": "Rolling last 365 days",
+    },
+    "current_season": {
+        "window_type": "season",
+        "days": None,
+        "description": "Current season to date",
+    },
+    "career": {
+        "window_type": "career",
+        "days": None,
+        "description": "Career baseline",
+    },
+}
+
+
+def get_window_definition(window_name: str) -> Dict[str, object]:
+    """Return metadata for a named sample window."""
+    return SAMPLE_WINDOWS.get(
+        window_name,
+        {
+            "window_type": "unknown",
+            "days": None,
+            "description": "Unknown sample window",
+        },
+    )
+
+
+def get_window_start_date(
+    target_date: datetime.date,
+    window_name: str,
+) -> Optional[str]:
+    """
+    Return an ISO start date for rolling windows.
+
+    Non-rolling windows return None because they are not anchored only by
+    a backwards-looking day count.
+    """
+    definition = get_window_definition(window_name)
+    days = definition.get("days")
+    if not days:
+        return None
+    return (target_date - datetime.timedelta(days=int(days))).isoformat()
+
+
+def build_sample_metadata(
+    window_name: str,
+    sample_size: Optional[int] = None,
+    sample_blend_policy: str = "single_window_v1",
+    stabilizer_window: Optional[str] = None,
+) -> Dict[str, object]:
+    """Build a reusable sample metadata block."""
+    definition = get_window_definition(window_name)
+    return {
+        "sample_window": window_name,
+        "sample_family": definition.get("window_type"),
+        "sample_description": definition.get("description"),
+        "sample_days": definition.get("days"),
+        "sample_size": sample_size,
+        "sample_blend_policy": sample_blend_policy,
+        "stabilizer_window": stabilizer_window,
+    }

--- a/tests/test_sample_windows.py
+++ b/tests/test_sample_windows.py
@@ -1,0 +1,37 @@
+import datetime
+
+from mlb_app.sample_windows import (
+    build_sample_metadata,
+    get_window_definition,
+    get_window_start_date,
+)
+
+
+def test_get_window_definition_known_window():
+    result = get_window_definition("last_30_days")
+    assert result["window_type"] == "rolling"
+    assert result["days"] == 30
+    assert result["description"] == "Rolling last 30 days"
+
+
+def test_get_window_start_date_for_rolling_window():
+    target_date = datetime.date(2026, 4, 22)
+    result = get_window_start_date(target_date, "last_90_days")
+    assert result == "2026-01-22"
+
+
+def test_build_sample_metadata_contract():
+    result = build_sample_metadata(
+        window_name="current_season",
+        sample_size=120,
+        sample_blend_policy="single_window_v1",
+        stabilizer_window=None,
+    )
+
+    assert result["sample_window"] == "current_season"
+    assert result["sample_family"] == "season"
+    assert result["sample_description"] == "Current season to date"
+    assert result["sample_days"] is None
+    assert result["sample_size"] == 120
+    assert result["sample_blend_policy"] == "single_window_v1"
+    assert result["stabilizer_window"] is None


### PR DESCRIPTION
Adds a first-pass sample window framework for sandbox analytical payloads.

This update:
- introduces `sample_windows.py` with named windows such as `last_30_days`, `last_90_days`, `last_365_days`, `current_season`, and `career`
- adds reusable sample metadata helpers for payloads and profiles
- wires explicit sample window metadata into hitter, pitcher, and matchup analysis objects
- updates the pipeline to pass the current real sample choices intentionally
- adds tests for sample window definition, date range calculation, and metadata contract

This is a framework layer only. It does not yet implement multi-window weighted blending, but it makes the current sample choices explicit and prepares the sandbox for future blended-window modeling.