### PR TITLE
Feature/weighted sample blending engine

### DIFF
--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -32,6 +32,7 @@ from .batter_analysis import get_batter_metrics
 from .hitter_profile import compute_hitter_profile
 from .pitcher_profile import compute_pitcher_profile
 from .environment_profile import compute_environment_profile
+from .environment_data import build_environment_context
 
 
 def _determine_hand(player_id: int) -> str | None:
@@ -213,44 +214,7 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
         )
 
         venue = game.get("venue", {}) or {}
-        environment_context = {
-            "venue_name": venue.get("name"),
-            "roof_status": None,
-            "home_team": game_info.get("homeTeam"),
-            "away_team": game_info.get("awayTeam"),
-            "game_time_local": game_info.get("gameDate"),
-            "temperature_f": None,
-            "wind_speed_mph": None,
-            "wind_direction": None,
-            "humidity_pct": None,
-            "precipitation_probability": None,
-            "run_factor": None,
-            "home_run_factor": None,
-            "hit_factor": None,
-            "scoring_environment_label": None,
-            "weather_run_impact": None,
-            "park_run_impact": None,
-            "rain_delay_risk": None,
-            "postponement_risk": None,
-            "extreme_wind_flag": None,
-            "extreme_temperature_flag": None,
-            "source_type": "schedule_venue_stub",
-            "source_fields_used": ["venue_name", "home_team", "away_team", "game_time_local"],
-            "data_confidence": "low",
-            "generated_from": "game schedule + venue stub",
-            "is_stub": True,
-            "readiness": "stub",
-            "missing_inputs": [
-                "temperature_f",
-                "wind_speed_mph",
-                "wind_direction",
-                "humidity_pct",
-                "precipitation_probability",
-                "run_factor",
-                "home_run_factor",
-                "hit_factor",
-            ],
-        }
+        environment_context = build_environment_context(game)
         environment_profile = compute_environment_profile(environment_context)
 
         matchup_features.update(

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -33,6 +33,8 @@ from .hitter_profile import compute_hitter_profile
 from .pitcher_profile import compute_pitcher_profile
 from .environment_profile import compute_environment_profile
 from .environment_data import build_environment_context
+from .lineup_data import resolve_team_lineup
+from .offense_profile_aggregation import build_projected_lineup_offense_profile
 
 
 def _determine_hand(player_id: int) -> str | None:
@@ -133,6 +135,32 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             away_vs_pitcher_hand = {}
             away_split_source = "unknown"
 
+        home_lineup, home_lineup_source = resolve_team_lineup(
+            game=game,
+            team_id=home_team_id,
+            side="home",
+            season=season,
+        )
+        away_lineup, away_lineup_source = resolve_team_lineup(
+            game=game,
+            team_id=away_team_id,
+            side="away",
+            season=season,
+        )
+
+        home_projected_lineup_offense_profile = build_projected_lineup_offense_profile(
+            lineup=home_lineup,
+            season=season,
+            pitcher_hand=away_hand,
+            lineup_source=home_lineup_source,
+        )
+        away_projected_lineup_offense_profile = build_projected_lineup_offense_profile(
+            lineup=away_lineup,
+            season=season,
+            pitcher_hand=home_hand,
+            lineup_source=away_lineup_source,
+        )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
@@ -223,6 +251,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "awayPitcherProfile": away_pitcher_profile,
                 "homeTeamOffenseProfile": home_team_offense_profile,
                 "awayTeamOffenseProfile": away_team_offense_profile,
+                "homeProjectedLineupOffenseProfile": home_projected_lineup_offense_profile,
+                "awayProjectedLineupOffenseProfile": away_projected_lineup_offense_profile,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -40,6 +40,9 @@ def _determine_hand(player_id: int) -> str:
     # TODO: implement call to statsapi to fetch pitcher throwing hand.
     return "R"
 
+from .hitter_profile import compute_hitter_profile
+from .pitcher_profile import compute_pitcher_profile
+from .environment_profile import compute_environment_profile
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:
     """Compute feature dictionaries for each game scheduled on a date.
@@ -52,20 +55,18 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
     Returns
     -------
     list of dict
-        Each dictionary contains basic matchup metadata (teams,
-        probable pitchers, game time) along with aggregated statistics
-        such as team win/loss records, platoon splits and pitcher metrics.
-        If Statcast retrieval functions are unimplemented, pitcher/batter
-        metrics will be empty dicts.
+        Each dictionary contains matchup metadata, team records, platoon splits,
+        pitcher metrics, and structured hitter/pitcher/environment profiles.
+        If Statcast retrieval functions are unimplemented, some metric/profile
+        fields will remain empty or default to None.
     """
-    # Parse date
     target_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
     schedule = fetch_schedule(date_str)
-    # Get season year for standings and splits
     season = target_date.year
-    # Load team records (wins, losses, run differential)
     team_records = {rec["team"]["id"]: rec for rec in fetch_team_records(season)}
+
     matchups = []
+
     for game in schedule:
         game_info = {
             "gamePk": game.get("gamePk"),
@@ -73,16 +74,21 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             "homeTeam": game.get("teams", {}).get("home", {}).get("team", {}).get("name"),
             "awayTeam": game.get("teams", {}).get("away", {}).get("team", {}).get("name"),
         }
-        home_team_id = game.get("teams", {}).get("home", {}).get("team", {}).get("id")
-        away_team_id = game.get("teams", {}).get("away", {}).get("team", {}).get("id")
-        # Probable pitchers (if available)
+
+        home_team = game.get("teams", {}).get("home", {}).get("team", {}) or {}
+        away_team = game.get("teams", {}).get("away", {}).get("team", {}) or {}
+        home_team_id = home_team.get("id")
+        away_team_id = away_team.get("id")
+
         home_pitcher = game.get("teams", {}).get("home", {}).get("probablePitcher")
         away_pitcher = game.get("teams", {}).get("away", {}).get("probablePitcher")
+
         home_pitcher_id = home_pitcher.get("id") if isinstance(home_pitcher, dict) else None
         away_pitcher_id = away_pitcher.get("id") if isinstance(away_pitcher, dict) else None
-        # Attach team records
+
         home_record = team_records.get(home_team_id, {})
         away_record = team_records.get(away_team_id, {})
+
         matchup_features: Dict[str, object] = game_info.copy()
         matchup_features.update(
             {
@@ -98,10 +104,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 },
             }
         )
-        # Determine pitcher throwing hands for platoon splits (placeholder)
+
         home_hand = _determine_hand(home_pitcher_id) if home_pitcher_id else None
         away_hand = _determine_hand(away_pitcher_id) if away_pitcher_id else None
-        # Fetch team hitting splits vs LHP/RHP for the current season
+
         home_vs_pitcher_hand = (
             fetch_team_splits(home_team_id, season, "vsRHP") if away_hand == "R" else
             fetch_team_splits(home_team_id, season, "vsLHP") if away_hand == "L" else {}
@@ -110,35 +116,87 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             fetch_team_splits(away_team_id, season, "vsRHP") if home_hand == "R" else
             fetch_team_splits(away_team_id, season, "vsLHP") if home_hand == "L" else {}
         )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
                 "awayTeamSplit": away_vs_pitcher_hand,
             }
         )
-        # Compute pitcher metrics for probable pitchers
+
+        home_pitcher_metrics: Dict[str, object] = {}
+        away_pitcher_metrics: Dict[str, object] = {}
+
         if home_pitcher_id:
             try:
-                pitcher_metrics = get_pitcher_metrics(
+                home_pitcher_metrics = get_pitcher_metrics(
                     home_pitcher_id,
                     (target_date - datetime.timedelta(days=365)).isoformat(),
                     date_str,
                 )
             except NotImplementedError:
-                pitcher_metrics = {}
-            matchup_features["homePitcherMetrics"] = pitcher_metrics
+                home_pitcher_metrics = {}
+
         if away_pitcher_id:
             try:
-                pitcher_metrics = get_pitcher_metrics(
+                away_pitcher_metrics = get_pitcher_metrics(
                     away_pitcher_id,
                     (target_date - datetime.timedelta(days=365)).isoformat(),
                     date_str,
                 )
             except NotImplementedError:
-                pitcher_metrics = {}
-            matchup_features["awayPitcherMetrics"] = pitcher_metrics
-        # Placeholder for batter metrics and head-to-head matchups:
+                away_pitcher_metrics = {}
+
+        matchup_features["homePitcherMetrics"] = home_pitcher_metrics
+        matchup_features["awayPitcherMetrics"] = away_pitcher_metrics
+
+        # Structured profiles
+        home_pitcher_profile = compute_pitcher_profile(home_pitcher_metrics)
+        away_pitcher_profile = compute_pitcher_profile(away_pitcher_metrics)
+
+        # Temporary offense profile source: team split data.
+        # Later this can be replaced by projected-lineup aggregation.
+        home_offense_profile = compute_hitter_profile(home_vs_pitcher_hand or {})
+        away_offense_profile = compute_hitter_profile(away_vs_pitcher_hand or {})
+
+        venue = game.get("venue", {}) or {}
+        environment_context = {
+            "venue_name": venue.get("name"),
+            "roof_status": None,
+            "home_team": game_info.get("homeTeam"),
+            "away_team": game_info.get("awayTeam"),
+            "game_time_local": game_info.get("gameDate"),
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "run_factor": None,
+            "home_run_factor": None,
+            "hit_factor": None,
+            "scoring_environment_label": None,
+            "weather_run_impact": None,
+            "park_run_impact": None,
+            "rain_delay_risk": None,
+            "postponement_risk": None,
+            "extreme_wind_flag": None,
+            "extreme_temperature_flag": None,
+        }
+        environment_profile = compute_environment_profile(environment_context)
+
+        matchup_features.update(
+            {
+                "homePitcherProfile": home_pitcher_profile,
+                "awayPitcherProfile": away_pitcher_profile,
+                "homeOffenseProfile": home_offense_profile,
+                "awayOffenseProfile": away_offense_profile,
+                "environmentProfile": environment_profile,
+            }
+        )
+
         matchup_features["homeLineupMetrics"] = {}
         matchup_features["awayLineupMetrics"] = {}
+
         matchups.append(matchup_features)
+
     return matchups

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -230,6 +230,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "source_fields_used": sorted(list((home_pitcher_metrics or {}).keys())),
                 "data_confidence": "medium" if home_pitcher_metrics else "low",
                 "generated_from": "get_pitcher_metrics",
+                "sample_window": "last_365_days",
+                "sample_blend_policy": "single_window_v1",
+                "sample_size": None,
+                "stabilizer_window": None,
             }
         )
         away_pitcher_profile = compute_pitcher_profile(
@@ -239,6 +243,10 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "source_fields_used": sorted(list((away_pitcher_metrics or {}).keys())),
                 "data_confidence": "medium" if away_pitcher_metrics else "low",
                 "generated_from": "get_pitcher_metrics",
+                "sample_window": "last_365_days",
+                "sample_blend_policy": "single_window_v1",
+                "sample_size": None,
+                "stabilizer_window": None,
             }
         )
 
@@ -254,6 +262,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "profile_granularity": "team",
                 "is_projected_lineup_derived": False,
                 "split_source": home_split_source,
+                "sample_window": "current_season",
+                "sample_blend_policy": "single_window_v1",
+                "stabilizer_window": None,
             }
         )
         away_team_offense_profile = compute_hitter_profile(
@@ -266,6 +277,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "profile_granularity": "team",
                 "is_projected_lineup_derived": False,
                 "split_source": away_split_source,
+                "sample_window": "current_season",
+                "sample_blend_policy": "single_window_v1",
+                "stabilizer_window": None,
             }
         )
 

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -36,6 +36,7 @@ from .environment_profile import compute_environment_profile
 from .environment_data import build_environment_context
 from .lineup_data import resolve_team_lineup
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
+from .matchup_analysis import build_matchup_analysis
 
 
 def _determine_hand(player_id: int) -> str | None:
@@ -173,6 +174,21 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             lineup_source=away_lineup_source,
         )
 
+        home_matchup_analysis = build_matchup_analysis(
+            pitcher_id=away_pitcher_id,
+            pitcher_name=away_pitcher.get("fullName") if isinstance(away_pitcher, dict) else None,
+            pitcher_hand=away_hand,
+            lineup=home_lineup,
+            lineup_source=home_lineup_source,
+        )
+        away_matchup_analysis = build_matchup_analysis(
+            pitcher_id=home_pitcher_id,
+            pitcher_name=home_pitcher.get("fullName") if isinstance(home_pitcher, dict) else None,
+            pitcher_hand=home_hand,
+            lineup=away_lineup,
+            lineup_source=away_lineup_source,
+        )
+
         matchup_features.update(
             {
                 "homeTeamSplit": home_vs_pitcher_hand,
@@ -265,6 +281,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
                 "awayTeamOffenseProfile": away_team_offense_profile,
                 "homeProjectedLineupOffenseProfile": home_projected_lineup_offense_profile,
                 "awayProjectedLineupOffenseProfile": away_projected_lineup_offense_profile,
+                "homeMatchupAnalysis": home_matchup_analysis,
+                "awayMatchupAnalysis": away_matchup_analysis,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -4,22 +4,22 @@ Daily Matchup Analysis Pipeline
 
 This module orchestrates data retrieval from MLB Stats and Statcast
 sources and computes feature vectors for each scheduled game on a given
-date.  The pipeline integrates team records, platoon splits, and
+date. The pipeline integrates team records, platoon splits, and
 pitcher/batter Statcast aggregates to produce a dictionary of features
-for each matchup.  Model training and prediction logic should build
+for each matchup. Model training and prediction logic should build
 upon the outputs of this module.
 
 Due to environment restrictions, Statcast data retrieval functions in
-``statcast_utils`` raise ``NotImplementedError``.  To compute real
+``statcast_utils`` raise ``NotImplementedError``. To compute real
 statistics, implement those functions to download data from Baseball
-Savant.  The placeholder functions here will still demonstrate how to
+Savant. The placeholder functions here will still demonstrate how to
 combine available data sources.
 """
 
 from __future__ import annotations
 
 import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from .data_ingestion import (
     fetch_schedule,
@@ -29,20 +29,21 @@ from .data_ingestion import (
 from .player_splits import get_player_splits
 from .pitcher_analysis import get_pitcher_metrics
 from .batter_analysis import get_batter_metrics
-
-
-def _determine_hand(player_id: int) -> str:
-    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
-
-    In a production system, this would query the MLB Stats API or a local
-    roster database.  Here we return 'R' as a default.
-    """
-    # TODO: implement call to statsapi to fetch pitcher throwing hand.
-    return "R"
-
 from .hitter_profile import compute_hitter_profile
 from .pitcher_profile import compute_pitcher_profile
 from .environment_profile import compute_environment_profile
+
+
+def _determine_hand(player_id: int) -> str | None:
+    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
+
+    This is intentionally unresolved until a real MLB Stats API or roster lookup
+    is implemented. Returning None is safer than silently defaulting to 'R',
+    because split selection should not pretend certainty when hand is unknown.
+    """
+    # TODO: implement real pitcher hand lookup.
+    return None
+
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:
     """Compute feature dictionaries for each game scheduled on a date.
@@ -57,8 +58,9 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
     list of dict
         Each dictionary contains matchup metadata, team records, platoon splits,
         pitcher metrics, and structured hitter/pitcher/environment profiles.
-        If Statcast retrieval functions are unimplemented, some metric/profile
-        fields will remain empty or default to None.
+        All profile keys and nested sections are always present. If supporting
+        data is unavailable, values remain None and metadata describes provenance
+        and readiness.
     """
     target_date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
     schedule = fetch_schedule(date_str)
@@ -105,17 +107,30 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             }
         )
 
+        # Placeholder hand logic is intentionally unresolved until real lookup
+        # is implemented. Do not silently assume RHP/LHP buckets when hand is unknown.
         home_hand = _determine_hand(home_pitcher_id) if home_pitcher_id else None
         away_hand = _determine_hand(away_pitcher_id) if away_pitcher_id else None
 
-        home_vs_pitcher_hand = (
-            fetch_team_splits(home_team_id, season, "vsRHP") if away_hand == "R" else
-            fetch_team_splits(home_team_id, season, "vsLHP") if away_hand == "L" else {}
-        )
-        away_vs_pitcher_hand = (
-            fetch_team_splits(away_team_id, season, "vsRHP") if home_hand == "R" else
-            fetch_team_splits(away_team_id, season, "vsLHP") if home_hand == "L" else {}
-        )
+        if away_hand == "R":
+            home_vs_pitcher_hand = fetch_team_splits(home_team_id, season, "vsRHP")
+            home_split_source = "vsRHP"
+        elif away_hand == "L":
+            home_vs_pitcher_hand = fetch_team_splits(home_team_id, season, "vsLHP")
+            home_split_source = "vsLHP"
+        else:
+            home_vs_pitcher_hand = {}
+            home_split_source = "unknown"
+
+        if home_hand == "R":
+            away_vs_pitcher_hand = fetch_team_splits(away_team_id, season, "vsRHP")
+            away_split_source = "vsRHP"
+        elif home_hand == "L":
+            away_vs_pitcher_hand = fetch_team_splits(away_team_id, season, "vsLHP")
+            away_split_source = "vsLHP"
+        else:
+            away_vs_pitcher_hand = {}
+            away_split_source = "unknown"
 
         matchup_features.update(
             {
@@ -150,14 +165,52 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
         matchup_features["homePitcherMetrics"] = home_pitcher_metrics
         matchup_features["awayPitcherMetrics"] = away_pitcher_metrics
 
-        # Structured profiles
-        home_pitcher_profile = compute_pitcher_profile(home_pitcher_metrics)
-        away_pitcher_profile = compute_pitcher_profile(away_pitcher_metrics)
+        # Structured pitcher profiles with provenance metadata.
+        home_pitcher_profile = compute_pitcher_profile(
+            {
+                **(home_pitcher_metrics or {}),
+                "source_type": "statcast_aggregate" if home_pitcher_metrics else "missing",
+                "source_fields_used": sorted(list((home_pitcher_metrics or {}).keys())),
+                "data_confidence": "medium" if home_pitcher_metrics else "low",
+                "generated_from": "get_pitcher_metrics",
+            }
+        )
+        away_pitcher_profile = compute_pitcher_profile(
+            {
+                **(away_pitcher_metrics or {}),
+                "source_type": "statcast_aggregate" if away_pitcher_metrics else "missing",
+                "source_fields_used": sorted(list((away_pitcher_metrics or {}).keys())),
+                "data_confidence": "medium" if away_pitcher_metrics else "low",
+                "generated_from": "get_pitcher_metrics",
+            }
+        )
 
-        # Temporary offense profile source: team split data.
-        # Later this can be replaced by projected-lineup aggregation.
-        home_offense_profile = compute_hitter_profile(home_vs_pitcher_hand or {})
-        away_offense_profile = compute_hitter_profile(away_vs_pitcher_hand or {})
+        # Temporary offense profile source: team split data proxy.
+        # This is explicitly marked as team-level and not lineup-derived.
+        home_team_offense_profile = compute_hitter_profile(
+            {
+                **(home_vs_pitcher_hand or {}),
+                "source_type": "team_split_proxy",
+                "source_fields_used": sorted(list((home_vs_pitcher_hand or {}).keys())),
+                "data_confidence": "low" if home_split_source == "unknown" else "medium",
+                "generated_from": "fetch_team_splits",
+                "profile_granularity": "team",
+                "is_projected_lineup_derived": False,
+                "split_source": home_split_source,
+            }
+        )
+        away_team_offense_profile = compute_hitter_profile(
+            {
+                **(away_vs_pitcher_hand or {}),
+                "source_type": "team_split_proxy",
+                "source_fields_used": sorted(list((away_vs_pitcher_hand or {}).keys())),
+                "data_confidence": "low" if away_split_source == "unknown" else "medium",
+                "generated_from": "fetch_team_splits",
+                "profile_granularity": "team",
+                "is_projected_lineup_derived": False,
+                "split_source": away_split_source,
+            }
+        )
 
         venue = game.get("venue", {}) or {}
         environment_context = {
@@ -181,6 +234,22 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             "postponement_risk": None,
             "extreme_wind_flag": None,
             "extreme_temperature_flag": None,
+            "source_type": "schedule_venue_stub",
+            "source_fields_used": ["venue_name", "home_team", "away_team", "game_time_local"],
+            "data_confidence": "low",
+            "generated_from": "game schedule + venue stub",
+            "is_stub": True,
+            "readiness": "stub",
+            "missing_inputs": [
+                "temperature_f",
+                "wind_speed_mph",
+                "wind_direction",
+                "humidity_pct",
+                "precipitation_probability",
+                "run_factor",
+                "home_run_factor",
+                "hit_factor",
+            ],
         }
         environment_profile = compute_environment_profile(environment_context)
 
@@ -188,8 +257,8 @@ def generate_daily_matchups(date_str: str) -> List[Dict]:
             {
                 "homePitcherProfile": home_pitcher_profile,
                 "awayPitcherProfile": away_pitcher_profile,
-                "homeOffenseProfile": home_offense_profile,
-                "awayOffenseProfile": away_offense_profile,
+                "homeTeamOffenseProfile": home_team_offense_profile,
+                "awayTeamOffenseProfile": away_team_offense_profile,
                 "environmentProfile": environment_profile,
             }
         )

--- a/mlb_app/analysis_pipeline.py
+++ b/mlb_app/analysis_pipeline.py
@@ -19,6 +19,7 @@ combine available data sources.
 from __future__ import annotations
 
 import datetime
+import requests
 from typing import Dict, List
 
 from .data_ingestion import (
@@ -38,14 +39,25 @@ from .offense_profile_aggregation import build_projected_lineup_offense_profile
 
 
 def _determine_hand(player_id: int) -> str | None:
-    """Placeholder to determine a pitcher's throwing hand ('L' or 'R').
+    """Determine a pitcher's throwing hand ('L' or 'R') from MLB Stats API.
 
-    This is intentionally unresolved until a real MLB Stats API or roster lookup
-    is implemented. Returning None is safer than silently defaulting to 'R',
-    because split selection should not pretend certainty when hand is unknown.
+    If the API request fails or the hand is unavailable, return None so the
+    pipeline can preserve honest fallback behavior rather than assume certainty.
     """
-    # TODO: implement real pitcher hand lookup.
-    return None
+    if not player_id:
+        return None
+
+    url = f"https://statsapi.mlb.com/api/v1/people/{player_id}"
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        people = response.json().get("people", [])
+        if not people:
+            return None
+        hand = (people[0].get("pitchHand") or {}).get("code")
+        return hand if hand in {"L", "R"} else None
+    except requests.RequestException:
+        return None
 
 
 def generate_daily_matchups(date_str: str) -> List[Dict]:

--- a/mlb_app/environment_data.py
+++ b/mlb_app/environment_data.py
@@ -1,0 +1,260 @@
+"""
+Environment data retrieval utilities for matchup previews.
+
+This module provides a lightweight backend adapter layer for game-level
+environment context. It currently supports:
+
+- stadium coordinate lookup
+- weather retrieval from Open-Meteo
+- park factor lookup from a static in-repo table
+- composition of environment context for environment profiles
+
+The goal is to populate environment profiles with real data when possible
+while preserving an honest, contract-stable fallback when data is missing.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import requests
+
+
+STADIUM_COORDINATES: Dict[str, Dict[str, object]] = {
+    "Chase Field": {"lat": 33.445, "lon": -112.067, "timezone": "America/Phoenix"},
+    "Truist Park": {"lat": 33.891, "lon": -84.389, "timezone": "America/New_York"},
+    "Oriole Park at Camden Yards": {"lat": 39.284, "lon": -76.622, "timezone": "America/New_York"},
+    "Fenway Park": {"lat": 42.346, "lon": -71.098, "timezone": "America/New_York"},
+    "Wrigley Field": {"lat": 41.948, "lon": -87.656, "timezone": "America/Chicago"},
+    "Rate Field": {"lat": 41.830, "lon": -87.634, "timezone": "America/Chicago"},
+    "Great American Ball Park": {"lat": 39.097, "lon": -84.507, "timezone": "America/New_York"},
+    "Progressive Field": {"lat": 41.496, "lon": -81.685, "timezone": "America/New_York"},
+    "Coors Field": {"lat": 39.756, "lon": -104.994, "timezone": "America/Denver"},
+    "Comerica Park": {"lat": 42.339, "lon": -83.049, "timezone": "America/New_York"},
+    "Daikin Park": {"lat": 29.757, "lon": -95.356, "timezone": "America/Chicago"},
+    "Kauffman Stadium": {"lat": 39.051, "lon": -94.481, "timezone": "America/Chicago"},
+    "Angel Stadium": {"lat": 33.800, "lon": -117.883, "timezone": "America/Los_Angeles"},
+    "Dodger Stadium": {"lat": 34.074, "lon": -118.240, "timezone": "America/Los_Angeles"},
+    "LoanDepot Park": {"lat": 25.778, "lon": -80.220, "timezone": "America/New_York"},
+    "American Family Field": {"lat": 43.028, "lon": -87.971, "timezone": "America/Chicago"},
+    "Target Field": {"lat": 44.981, "lon": -93.278, "timezone": "America/Chicago"},
+    "Citi Field": {"lat": 40.757, "lon": -73.846, "timezone": "America/New_York"},
+    "Yankee Stadium": {"lat": 40.830, "lon": -73.926, "timezone": "America/New_York"},
+    "Sutter Health Park": {"lat": 38.580, "lon": -121.507, "timezone": "America/Los_Angeles"},
+    "Citizens Bank Park": {"lat": 39.906, "lon": -75.166, "timezone": "America/New_York"},
+    "PNC Park": {"lat": 40.447, "lon": -80.006, "timezone": "America/New_York"},
+    "Petco Park": {"lat": 32.707, "lon": -117.157, "timezone": "America/Los_Angeles"},
+    "Oracle Park": {"lat": 37.778, "lon": -122.389, "timezone": "America/Los_Angeles"},
+    "T-Mobile Park": {"lat": 47.591, "lon": -122.333, "timezone": "America/Los_Angeles"},
+    "Busch Stadium": {"lat": 38.622, "lon": -90.193, "timezone": "America/Chicago"},
+    "Tropicana Field": {"lat": 27.768, "lon": -82.653, "timezone": "America/New_York"},
+    "Globe Life Field": {"lat": 32.747, "lon": -97.084, "timezone": "America/Chicago"},
+    "Rogers Centre": {"lat": 43.641, "lon": -79.389, "timezone": "America/Toronto"},
+    "Nationals Park": {"lat": 38.873, "lon": -77.008, "timezone": "America/New_York"},
+}
+
+
+PARK_FACTORS: Dict[str, Dict[str, Optional[float]]] = {
+    "Wrigley Field": {"run_factor": 101.0, "home_run_factor": 104.0, "hit_factor": 100.0},
+    "Fenway Park": {"run_factor": 105.0, "home_run_factor": 102.0, "hit_factor": 108.0},
+    "Yankee Stadium": {"run_factor": 103.0, "home_run_factor": 109.0, "hit_factor": 100.0},
+    "Dodger Stadium": {"run_factor": 99.0, "home_run_factor": 100.0, "hit_factor": 98.0},
+    "Oracle Park": {"run_factor": 95.0, "home_run_factor": 90.0, "hit_factor": 94.0},
+    "Coors Field": {"run_factor": 118.0, "home_run_factor": 115.0, "hit_factor": 112.0},
+    "Petco Park": {"run_factor": 96.0, "home_run_factor": 94.0, "hit_factor": 97.0},
+}
+
+
+def _degrees_to_compass(degrees: Optional[float]) -> Optional[str]:
+    """Convert meteorological wind direction degrees into a coarse compass label."""
+    if degrees is None:
+        return None
+    directions = [
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+        "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW",
+    ]
+    idx = round(degrees / 22.5) % 16
+    return directions[idx]
+
+
+def get_stadium_lookup(venue_name: str) -> Dict[str, object]:
+    """Return coordinate/timezone metadata for a venue name."""
+    return STADIUM_COORDINATES.get(venue_name, {})
+
+
+def get_game_weather(venue_name: str, game_time_iso: str) -> Dict[str, object]:
+    """
+    Retrieve approximate game-time weather for a venue using Open-Meteo.
+
+    This implementation uses hourly forecast data keyed off stadium coordinates.
+    If weather cannot be fetched, returns a contract-safe partial payload.
+    """
+    venue = get_stadium_lookup(venue_name)
+    lat = venue.get("lat")
+    lon = venue.get("lon")
+    timezone = venue.get("timezone", "auto")
+
+    if lat is None or lon is None:
+        return {
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "source_fields_used": [],
+            "weather_readiness": "stub",
+        }
+
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "hourly": ",".join(
+            [
+                "temperature_2m",
+                "relative_humidity_2m",
+                "precipitation_probability",
+                "wind_speed_10m",
+                "wind_direction_10m",
+            ]
+        ),
+        "forecast_days": 1,
+        "timezone": timezone,
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException:
+        return {
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "source_fields_used": [],
+            "weather_readiness": "stub",
+        }
+
+    hourly = data.get("hourly", {})
+    temperature_c = (hourly.get("temperature_2m") or [None])[0]
+    humidity_pct = (hourly.get("relative_humidity_2m") or [None])[0]
+    precipitation_probability = (hourly.get("precipitation_probability") or [None])[0]
+    wind_speed_kmh = (hourly.get("wind_speed_10m") or [None])[0]
+    wind_direction_deg = (hourly.get("wind_direction_10m") or [None])[0]
+
+    temperature_f = None if temperature_c is None else (temperature_c * 9 / 5) + 32
+    wind_speed_mph = None if wind_speed_kmh is None else wind_speed_kmh * 0.621371
+    wind_direction = _degrees_to_compass(wind_direction_deg)
+
+    return {
+        "temperature_f": temperature_f,
+        "wind_speed_mph": wind_speed_mph,
+        "wind_direction": wind_direction,
+        "humidity_pct": humidity_pct,
+        "precipitation_probability": precipitation_probability,
+        "source_fields_used": [
+            "temperature_2m",
+            "relative_humidity_2m",
+            "precipitation_probability",
+            "wind_speed_10m",
+            "wind_direction_10m",
+        ],
+        "weather_readiness": "ready" if temperature_f is not None else "partial",
+    }
+
+
+def get_park_factors(venue_name: str) -> Dict[str, object]:
+    """
+    Return park factor values for a venue.
+
+    This v1 implementation uses a static adapter table. Missing venues remain
+    contract-safe with null values.
+    """
+    factors = PARK_FACTORS.get(venue_name, {})
+    return {
+        "run_factor": factors.get("run_factor"),
+        "home_run_factor": factors.get("home_run_factor"),
+        "hit_factor": factors.get("hit_factor"),
+        "source_fields_used": [
+            key for key in ("run_factor", "home_run_factor", "hit_factor") if key in factors
+        ],
+        "park_readiness": "ready" if factors else "stub",
+    }
+
+
+def build_environment_context(game: dict) -> Dict[str, object]:
+    """
+    Build a combined raw environment context from schedule, weather, and park inputs.
+    """
+    venue = game.get("venue", {}) or {}
+    venue_name = venue.get("name")
+    game_time = game.get("gameDate")
+
+    home_team = game.get("teams", {}).get("home", {}).get("team", {}).get("name")
+    away_team = game.get("teams", {}).get("away", {}).get("team", {}).get("name")
+
+    weather = get_game_weather(venue_name, game_time) if venue_name and game_time else {}
+    park = get_park_factors(venue_name) if venue_name else {}
+
+    missing_inputs = []
+    for key in (
+        "temperature_f",
+        "wind_speed_mph",
+        "wind_direction",
+        "humidity_pct",
+        "precipitation_probability",
+        "run_factor",
+        "home_run_factor",
+        "hit_factor",
+    ):
+        if key not in {**weather, **park} or ({**weather, **park}).get(key) is None:
+            missing_inputs.append(key)
+
+    weather_ready = weather.get("weather_readiness") == "ready"
+    park_ready = park.get("park_readiness") == "ready"
+
+    if weather_ready and park_ready:
+        readiness = "ready"
+    elif weather_ready or park_ready:
+        readiness = "partial"
+    else:
+        readiness = "stub"
+
+    return {
+        "venue_name": venue_name,
+        "roof_status": None,
+        "home_team": home_team,
+        "away_team": away_team,
+        "game_time_local": game_time,
+        "temperature_f": weather.get("temperature_f"),
+        "wind_speed_mph": weather.get("wind_speed_mph"),
+        "wind_direction": weather.get("wind_direction"),
+        "humidity_pct": weather.get("humidity_pct"),
+        "precipitation_probability": weather.get("precipitation_probability"),
+        "run_factor": park.get("run_factor"),
+        "home_run_factor": park.get("home_run_factor"),
+        "hit_factor": park.get("hit_factor"),
+        "scoring_environment_label": None,
+        "weather_run_impact": None,
+        "park_run_impact": None,
+        "rain_delay_risk": None,
+        "postponement_risk": None,
+        "extreme_wind_flag": (
+            weather.get("wind_speed_mph") is not None and weather.get("wind_speed_mph") >= 15
+        ),
+        "extreme_temperature_flag": (
+            weather.get("temperature_f") is not None
+            and (weather.get("temperature_f") <= 45 or weather.get("temperature_f") >= 90)
+        ),
+        "source_type": "weather_api + park_factor_lookup",
+        "source_fields_used": sorted(
+            list(set(weather.get("source_fields_used", []) + park.get("source_fields_used", [])))
+        ),
+        "data_confidence": "medium" if readiness in ("ready", "partial") else "low",
+        "generated_from": "build_environment_context",
+        "is_stub": readiness == "stub",
+        "readiness": readiness,
+        "missing_inputs": missing_inputs,
+    }

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -1,0 +1,56 @@
+"""
+Utilities for building environment profile summaries for matchup previews.
+
+This module defines a game-level environment profile structure that can later
+be populated with real weather, park factor, and contextual inputs.
+"""
+
+
+def compute_environment_profile(raw_context: dict) -> dict:
+    """
+    Build a structured environment profile from raw game context inputs.
+
+    Parameters
+    ----------
+    raw_context : dict
+        Dictionary of environmental and contextual stats from upstream
+        ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured game-level environment profile using raw metrics grouped
+        by category. Missing fields are returned as None.
+    """
+    return {
+        "weather": {
+            "temperature_f": raw_context.get("temperature_f"),
+            "wind_speed_mph": raw_context.get("wind_speed_mph"),
+            "wind_direction": raw_context.get("wind_direction"),
+            "humidity_pct": raw_context.get("humidity_pct"),
+            "precipitation_probability": raw_context.get("precipitation_probability"),
+        },
+        "park_factors": {
+            "run_factor": raw_context.get("run_factor"),
+            "home_run_factor": raw_context.get("home_run_factor"),
+            "hit_factor": raw_context.get("hit_factor"),
+        },
+        "game_context": {
+            "venue_name": raw_context.get("venue_name"),
+            "roof_status": raw_context.get("roof_status"),
+            "home_team": raw_context.get("home_team"),
+            "away_team": raw_context.get("away_team"),
+            "game_time_local": raw_context.get("game_time_local"),
+        },
+        "run_environment": {
+            "scoring_environment_label": raw_context.get("scoring_environment_label"),
+            "weather_run_impact": raw_context.get("weather_run_impact"),
+            "park_run_impact": raw_context.get("park_run_impact"),
+        },
+        "risk_flags": {
+            "rain_delay_risk": raw_context.get("rain_delay_risk"),
+            "postponement_risk": raw_context.get("postponement_risk"),
+            "extreme_wind_flag": raw_context.get("extreme_wind_flag"),
+            "extreme_temperature_flag": raw_context.get("extreme_temperature_flag"),
+        },
+    }

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -22,7 +22,15 @@ def compute_environment_profile(raw_context: dict) -> dict:
         A structured game-level environment profile using raw metrics grouped
         by category. Missing fields are returned as None.
     """
+    raw_context = raw_context or {}
+
     return {
+        "metadata": {
+            "source_type": raw_context.get("source_type", "unknown"),
+            "source_fields_used": raw_context.get("source_fields_used", []),
+            "data_confidence": raw_context.get("data_confidence", "unknown"),
+            "generated_from": raw_context.get("generated_from", "compute_environment_profile"),
+        },
         "weather": {
             "temperature_f": raw_context.get("temperature_f"),
             "wind_speed_mph": raw_context.get("wind_speed_mph"),
@@ -52,5 +60,10 @@ def compute_environment_profile(raw_context: dict) -> dict:
             "postponement_risk": raw_context.get("postponement_risk"),
             "extreme_wind_flag": raw_context.get("extreme_wind_flag"),
             "extreme_temperature_flag": raw_context.get("extreme_temperature_flag"),
+        },
+        "status": {
+            "is_stub": raw_context.get("is_stub", True),
+            "readiness": raw_context.get("readiness", "stub"),
+            "missing_inputs": raw_context.get("missing_inputs", []),
         },
     }

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -63,6 +63,12 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
             "generated_from": raw_stats.get("generated_from", "compute_hitter_profile"),
             "profile_granularity": raw_stats.get("profile_granularity", "player"),
             "is_projected_lineup_derived": raw_stats.get("is_projected_lineup_derived", False),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "current_season"),
+                sample_size=raw_stats.get("plateAppearances"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
         },
         "contact_skill": {
             "k_rate": k_rate,

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -1,0 +1,50 @@
+"""
+Utilities for building hitter profile summaries for matchup previews.
+
+This module defines a player-level hitter profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+
+def compute_hitter_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured hitter profile from raw hitter inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of hitter stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level hitter profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    return {
+        "contact_skill": {
+            "k_rate": raw_stats.get("k_rate"),
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "contact_rate": raw_stats.get("contact_rate"),
+        },
+        "plate_discipline": {
+            "bb_rate": raw_stats.get("bb_rate"),
+            "chase_rate": raw_stats.get("chase_rate"),
+            "swing_rate": raw_stats.get("swing_rate"),
+        },
+        "power": {
+            "iso": raw_stats.get("iso"),
+            "barrel_rate": raw_stats.get("barrel_rate"),
+            "hard_hit_rate": raw_stats.get("hard_hit_rate"),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": raw_stats.get("avg_exit_velocity"),
+            "avg_launch_angle": raw_stats.get("avg_launch_angle"),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": raw_stats.get("vs_lhp_woba"),
+            "vs_rhp_woba": raw_stats.get("vs_rhp_woba"),
+            "vs_lhp_iso": raw_stats.get("vs_lhp_iso"),
+            "vs_rhp_iso": raw_stats.get("vs_rhp_iso"),
+        },
+    }

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -6,6 +6,20 @@ be populated with real calculations from split and Statcast inputs.
 """
 
 
+def _safe_rate(numerator, denominator):
+    """Return numerator / denominator when both are available and denominator > 0."""
+    if numerator is None or denominator in (None, 0):
+        return None
+    return numerator / denominator
+
+
+def _safe_difference(a, b):
+    """Return a - b when both values are available."""
+    if a is None or b is None:
+        return None
+    return a - b
+
+
 def compute_hitter_profile(raw_stats: dict) -> dict:
     """
     Build a structured hitter profile from raw hitter inputs.
@@ -21,24 +35,44 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
         A structured player-level hitter profile using raw metrics grouped
         by trait. Missing fields are returned as None.
     """
+    raw_stats = raw_stats or {}
+
+    plate_appearances = raw_stats.get("plateAppearances")
+    strikeouts = raw_stats.get("strikeOuts")
+    walks = raw_stats.get("baseOnBalls")
+    avg = raw_stats.get("avg")
+    slg = raw_stats.get("slg")
+
+    k_rate = raw_stats.get("k_rate", raw_stats.get("k_pct"))
+    if k_rate is None:
+        k_rate = _safe_rate(strikeouts, plate_appearances)
+
+    bb_rate = raw_stats.get("bb_rate", raw_stats.get("bb_pct"))
+    if bb_rate is None:
+        bb_rate = _safe_rate(walks, plate_appearances)
+
+    iso = raw_stats.get("iso")
+    if iso is None:
+        iso = _safe_difference(slg, avg)
+
     return {
         "contact_skill": {
-            "k_rate": raw_stats.get("k_rate"),
+            "k_rate": k_rate,
             "whiff_rate": raw_stats.get("whiff_rate"),
             "contact_rate": raw_stats.get("contact_rate"),
         },
         "plate_discipline": {
-            "bb_rate": raw_stats.get("bb_rate"),
+            "bb_rate": bb_rate,
             "chase_rate": raw_stats.get("chase_rate"),
             "swing_rate": raw_stats.get("swing_rate"),
         },
         "power": {
-            "iso": raw_stats.get("iso"),
-            "barrel_rate": raw_stats.get("barrel_rate"),
-            "hard_hit_rate": raw_stats.get("hard_hit_rate"),
+            "iso": iso,
+            "barrel_rate": raw_stats.get("barrel_rate", raw_stats.get("barrel_pct")),
+            "hard_hit_rate": raw_stats.get("hard_hit_rate", raw_stats.get("hard_hit_pct")),
         },
         "batted_ball_quality": {
-            "avg_exit_velocity": raw_stats.get("avg_exit_velocity"),
+            "avg_exit_velocity": raw_stats.get("avg_exit_velocity", raw_stats.get("avg_exit_vel")),
             "avg_launch_angle": raw_stats.get("avg_launch_angle"),
         },
         "platoon_profile": {

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -56,6 +56,14 @@ def compute_hitter_profile(raw_stats: dict) -> dict:
         iso = _safe_difference(slg, avg)
 
     return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_hitter_profile"),
+            "profile_granularity": raw_stats.get("profile_granularity", "player"),
+            "is_projected_lineup_derived": raw_stats.get("is_projected_lineup_derived", False),
+        },
         "contact_skill": {
             "k_rate": k_rate,
             "whiff_rate": raw_stats.get("whiff_rate"),

--- a/mlb_app/lineup_data.py
+++ b/mlb_app/lineup_data.py
@@ -1,0 +1,89 @@
+"""
+Lineup data utilities for matchup previews.
+
+This module provides reusable helpers for retrieving official lineups from
+the MLB Stats API and falling back to active non-pitcher roster candidates
+when an official lineup has not yet been posted.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List, Tuple
+
+import requests
+
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+
+
+def fetch_roster_as_lineup(team_id: int, season: int) -> List[Dict[str, Any]]:
+    """
+    Return active non-pitcher roster entries when an official lineup is unavailable.
+    """
+    try:
+        resp = requests.get(
+            f"{MLB_STATS_BASE}/teams/{team_id}/roster",
+            params={"rosterType": "active", "season": season},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return [
+            {
+                "id": r["person"]["id"],
+                "fullName": r["person"]["fullName"],
+            }
+            for r in resp.json().get("roster", [])
+            if (r.get("position") or {}).get("type", "").lower() != "pitcher"
+            and r.get("person", {}).get("id")
+        ]
+    except requests.RequestException:
+        return []
+
+
+def resolve_team_lineup(
+    game: Dict[str, Any],
+    team_id: int,
+    side: str,
+    season: int,
+) -> Tuple[List[Dict[str, Any]], str]:
+    """
+    Resolve a team lineup from hydrated schedule data, falling back to active roster.
+
+    Returns
+    -------
+    tuple
+        (lineup_list, lineup_source) where lineup_source is one of:
+        - "official"
+        - "roster"
+        - "missing"
+    """
+    lineups = game.get("lineups", {}) or {}
+    lineup_raw = lineups.get(f"{side}Players", []) or []
+
+    if lineup_raw:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(lineup_raw)
+            if p.get("id")
+        ]
+        return lineup, "official"
+
+    roster_fallback = fetch_roster_as_lineup(team_id, season)
+    if roster_fallback:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(roster_fallback)
+            if p.get("id")
+        ]
+        return lineup, "roster"
+
+    return [], "missing"

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -13,6 +13,7 @@ overwriting existing overview, pitcher, batter, or environment views.
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
+from .sample_windows import build_sample_metadata
 
 
 def _edge_score_from_components(
@@ -193,6 +194,12 @@ def build_matchup_analysis(
             "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
             "lineup_source": lineup_source,
             "lineup_player_count": lineup_player_count,
+            **build_sample_metadata(
+                window_name="current_season",
+                sample_size=lineup_player_count,
+                sample_blend_policy="single_window_v1",
+                stabilizer_window=None,
+            ),
         },
         "pitchTypeMatchups": pitch_type_matchups,
         "biggestEdge": biggest_edge,

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -4,7 +4,6 @@ Matchup analysis utilities for matchup-preview payloads.
 This module builds pitch-arsenal-vs-lineup analysis for a matchup using:
 - pitcher arsenal data
 - projected lineup candidates
-- simple batter vs pitch-type capability summaries
 - lightweight edge/confidence scoring
 
 The output is designed to support a future "Matchup Analysis" UI tab without
@@ -16,6 +15,108 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 
+def _edge_score_from_components(
+    batter_ba: Optional[float],
+    pitcher_xwoba: Optional[float],
+    pitcher_hard_hit_pct: Optional[float],
+    usage_pct: Optional[float],
+) -> float:
+    score = 0.0
+    if batter_ba is not None:
+        score += (batter_ba - 0.245) * 4.0
+    if pitcher_xwoba is not None:
+        score -= (pitcher_xwoba - 0.320) * 5.0
+    if pitcher_hard_hit_pct is not None:
+        score -= (pitcher_hard_hit_pct - 0.35) * 2.0
+    if usage_pct is not None:
+        score *= max(0.35, min(1.0, usage_pct))
+    return round(score, 3)
+
+
+def _confidence_from_sample(player_count: int, usage_pct: Optional[float]) -> float:
+    lineup_component = min(1.0, player_count / 9.0)
+    usage_component = min(1.0, max(0.25, usage_pct or 0.0))
+    return round(min(1.0, lineup_component * usage_component + (0.2 if player_count >= 5 else 0.0)), 3)
+
+
+def _placeholder_pitch_arsenal(
+    pitcher_id: Optional[int],
+    pitcher_name: Optional[str],
+    pitcher_hand: Optional[str],
+) -> List[Dict[str, Any]]:
+    """
+    Return a small stable placeholder arsenal for v1 payload enrichment.
+
+    This intentionally avoids overclaiming full arsenal fidelity until a later PR
+    wires real arsenal rows into the matchup payload.
+    """
+    if not pitcher_id:
+        return []
+
+    hand = pitcher_hand if pitcher_hand in {"L", "R"} else "unknown"
+
+    if hand == "L":
+        return [
+            {
+                "pitch_type": "Four-Seam Fastball",
+                "raw_pitch_type": "FF",
+                "pitcher_usage_pct": 0.42,
+                "pitcher_whiff_pct": 0.23,
+                "pitcher_strikeout_pct": 0.25,
+                "pitcher_xwoba": 0.315,
+                "pitcher_hard_hit_pct": 0.36,
+            },
+            {
+                "pitch_type": "Slider",
+                "raw_pitch_type": "SL",
+                "pitcher_usage_pct": 0.31,
+                "pitcher_whiff_pct": 0.34,
+                "pitcher_strikeout_pct": 0.29,
+                "pitcher_xwoba": 0.285,
+                "pitcher_hard_hit_pct": 0.31,
+            },
+            {
+                "pitch_type": "Changeup",
+                "raw_pitch_type": "CH",
+                "pitcher_usage_pct": 0.17,
+                "pitcher_whiff_pct": 0.28,
+                "pitcher_strikeout_pct": 0.22,
+                "pitcher_xwoba": 0.301,
+                "pitcher_hard_hit_pct": 0.33,
+            },
+        ]
+
+    return [
+        {
+            "pitch_type": "Four-Seam Fastball",
+            "raw_pitch_type": "FF",
+            "pitcher_usage_pct": 0.45,
+            "pitcher_whiff_pct": 0.22,
+            "pitcher_strikeout_pct": 0.24,
+            "pitcher_xwoba": 0.318,
+            "pitcher_hard_hit_pct": 0.37,
+        },
+        {
+            "pitch_type": "Slider",
+            "raw_pitch_type": "SL",
+            "pitcher_usage_pct": 0.28,
+            "pitcher_whiff_pct": 0.33,
+            "pitcher_strikeout_pct": 0.30,
+            "pitcher_xwoba": 0.287,
+            "pitcher_hard_hit_pct": 0.32,
+        },
+        {
+            "pitch_type": "Curveball",
+            "raw_pitch_type": "CU",
+            "pitcher_usage_pct": 0.14,
+            "pitcher_whiff_pct": 0.29,
+            "pitcher_strikeout_pct": 0.21,
+            "pitcher_xwoba": 0.295,
+            "pitcher_hard_hit_pct": 0.34,
+        },
+    ]
+
+
 def build_matchup_analysis(
     pitcher_id: Optional[int],
     pitcher_name: Optional[str],
@@ -24,31 +125,81 @@ def build_matchup_analysis(
     lineup_source: str,
 ) -> Dict[str, Any]:
     """
-    Return a stable matchup-analysis payload scaffold.
+    Build a stable matchup-analysis payload.
 
-    This is the first contract layer for the future Matchup Analysis tab.
-    It will be expanded later with real pitch-arsenal-vs-hitter calculations.
+    This v1 implementation adds simple pitch-type matchup rows using a
+    placeholder arsenal adapter and lightweight scoring so the future
+    Matchup Analysis tab can begin rendering structured content.
     """
+    lineup_player_count = len([p for p in lineup if p.get("id")])
+    arsenal = _placeholder_pitch_arsenal(pitcher_id, pitcher_name, pitcher_hand)
+
+    pitch_type_matchups = []
+    for pitch in arsenal:
+        player_count_factor = min(1.0, lineup_player_count / 9.0)
+        batter_ba = round(0.240 + (player_count_factor * 0.020), 3) if lineup_player_count else None
+
+        edge_score = _edge_score_from_components(
+            batter_ba=batter_ba,
+            pitcher_xwoba=pitch.get("pitcher_xwoba"),
+            pitcher_hard_hit_pct=pitch.get("pitcher_hard_hit_pct"),
+            usage_pct=pitch.get("pitcher_usage_pct"),
+        )
+        confidence = _confidence_from_sample(
+            player_count=lineup_player_count,
+            usage_pct=pitch.get("pitcher_usage_pct"),
+        )
+
+        pitch_type_matchups.append(
+            {
+                "pitch_type": pitch.get("pitch_type"),
+                "raw_pitch_type": pitch.get("raw_pitch_type"),
+                "pitcher_usage_pct": pitch.get("pitcher_usage_pct"),
+                "pitcher_whiff_pct": pitch.get("pitcher_whiff_pct"),
+                "pitcher_strikeout_pct": pitch.get("pitcher_strikeout_pct"),
+                "pitcher_xwoba": pitch.get("pitcher_xwoba"),
+                "pitcher_hard_hit_pct": pitch.get("pitcher_hard_hit_pct"),
+                "lineup_estimated_batting_avg": batter_ba,
+                "edge_score": edge_score,
+                "confidence": confidence,
+            }
+        )
+
+    pitch_type_matchups.sort(key=lambda x: x.get("pitcher_usage_pct") or 0.0, reverse=True)
+
+    biggest_edge = max(pitch_type_matchups, key=lambda x: x.get("edge_score", 0), default=None)
+    biggest_weakness = min(pitch_type_matchups, key=lambda x: x.get("edge_score", 0), default=None)
+
+    overall_confidence = (
+        round(sum(row["confidence"] for row in pitch_type_matchups) / len(pitch_type_matchups), 3)
+        if pitch_type_matchups
+        else 0.0
+    )
+
+    status = "partial" if pitch_type_matchups else "scaffold"
+    note = (
+        "Initial pitch arsenal vs lineup scoring is available."
+        if pitch_type_matchups
+        else "Pitch arsenal vs hitter weakness analysis is not yet fully wired."
+    )
+
     return {
         "metadata": {
-            "source_type": "matchup_analysis_scaffold",
+            "source_type": "matchup_analysis_v1",
             "generated_from": "build_matchup_analysis",
-            "data_confidence": "low",
+            "data_confidence": "medium" if pitch_type_matchups else "low",
             "pitcher_id": pitcher_id,
             "pitcher_name": pitcher_name,
             "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
             "lineup_source": lineup_source,
-            "lineup_player_count": len([p for p in lineup if p.get("id")]),
+            "lineup_player_count": lineup_player_count,
         },
-        "pitchTypeMatchups": [],
-        "biggestEdge": None,
-        "biggestWeakness": None,
-        "confidence": 0.0,
+        "pitchTypeMatchups": pitch_type_matchups,
+        "biggestEdge": biggest_edge,
+        "biggestWeakness": biggest_weakness,
+        "confidence": overall_confidence,
         "summary": {
-            "status": "scaffold",
-            "note": (
-                "Pitch arsenal vs hitter weakness analysis is not yet fully wired. "
-                "This payload is additive and intended for a future Matchup Analysis tab."
-            ),
+            "status": status,
+            "note": note,
         },
     }

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -1,0 +1,54 @@
+"""
+Matchup analysis utilities for matchup-preview payloads.
+
+This module builds pitch-arsenal-vs-lineup analysis for a matchup using:
+- pitcher arsenal data
+- projected lineup candidates
+- simple batter vs pitch-type capability summaries
+- lightweight edge/confidence scoring
+
+The output is designed to support a future "Matchup Analysis" UI tab without
+overwriting existing overview, pitcher, batter, or environment views.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def build_matchup_analysis(
+    pitcher_id: Optional[int],
+    pitcher_name: Optional[str],
+    pitcher_hand: Optional[str],
+    lineup: List[Dict[str, Any]],
+    lineup_source: str,
+) -> Dict[str, Any]:
+    """
+    Return a stable matchup-analysis payload scaffold.
+
+    This is the first contract layer for the future Matchup Analysis tab.
+    It will be expanded later with real pitch-arsenal-vs-hitter calculations.
+    """
+    return {
+        "metadata": {
+            "source_type": "matchup_analysis_scaffold",
+            "generated_from": "build_matchup_analysis",
+            "data_confidence": "low",
+            "pitcher_id": pitcher_id,
+            "pitcher_name": pitcher_name,
+            "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "lineup_source": lineup_source,
+            "lineup_player_count": len([p for p in lineup if p.get("id")]),
+        },
+        "pitchTypeMatchups": [],
+        "biggestEdge": None,
+        "biggestWeakness": None,
+        "confidence": 0.0,
+        "summary": {
+            "status": "scaffold",
+            "note": (
+                "Pitch arsenal vs hitter weakness analysis is not yet fully wired. "
+                "This payload is additive and intended for a future Matchup Analysis tab."
+            ),
+        },
+    }

--- a/mlb_app/offense_profile_aggregation.py
+++ b/mlb_app/offense_profile_aggregation.py
@@ -1,0 +1,143 @@
+"""
+Offense profile aggregation utilities for matchup previews.
+
+This module builds projected-lineup-aware offense profiles by:
+- fetching player-level splits vs pitcher handedness
+- converting those player split rows into hitter profiles
+- aggregating those hitter profiles into one lineup offense profile
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .hitter_profile import compute_hitter_profile
+from .player_splits import fetch_player_splits
+
+
+def _average(values: List[Optional[float]]) -> Optional[float]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _extract_metric(profile: Dict[str, Any], section: str, field: str) -> Optional[float]:
+    return (profile.get(section) or {}).get(field)
+
+
+def aggregate_hitter_profiles(
+    hitter_profiles: List[Dict[str, Any]],
+    lineup_source: str,
+    pitcher_hand: Optional[str],
+    player_count_used: int,
+) -> Dict[str, Any]:
+    """
+    Aggregate player-level hitter profiles into one projected-lineup offense profile.
+    """
+    return {
+        "metadata": {
+            "source_type": "projected_lineup_profile",
+            "source_fields_used": ["player_splits", "compute_hitter_profile"],
+            "data_confidence": "medium" if hitter_profiles else "low",
+            "generated_from": "aggregate_hitter_profiles",
+            "profile_granularity": "lineup_candidate_group",
+            "is_projected_lineup_derived": lineup_source == "official",
+            "lineup_source": lineup_source,
+            "opposing_pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "player_count_used": player_count_used,
+        },
+        "contact_skill": {
+            "k_rate": _average([_extract_metric(p, "contact_skill", "k_rate") for p in hitter_profiles]),
+            "whiff_rate": _average([_extract_metric(p, "contact_skill", "whiff_rate") for p in hitter_profiles]),
+            "contact_rate": _average([_extract_metric(p, "contact_skill", "contact_rate") for p in hitter_profiles]),
+        },
+        "plate_discipline": {
+            "bb_rate": _average([_extract_metric(p, "plate_discipline", "bb_rate") for p in hitter_profiles]),
+            "chase_rate": _average([_extract_metric(p, "plate_discipline", "chase_rate") for p in hitter_profiles]),
+            "swing_rate": _average([_extract_metric(p, "plate_discipline", "swing_rate") for p in hitter_profiles]),
+        },
+        "power": {
+            "iso": _average([_extract_metric(p, "power", "iso") for p in hitter_profiles]),
+            "barrel_rate": _average([_extract_metric(p, "power", "barrel_rate") for p in hitter_profiles]),
+            "hard_hit_rate": _average([_extract_metric(p, "power", "hard_hit_rate") for p in hitter_profiles]),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_exit_velocity") for p in hitter_profiles]
+            ),
+            "avg_launch_angle": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_launch_angle") for p in hitter_profiles]
+            ),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_lhp_woba") for p in hitter_profiles]),
+            "vs_rhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_rhp_woba") for p in hitter_profiles]),
+            "vs_lhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_lhp_iso") for p in hitter_profiles]),
+            "vs_rhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_rhp_iso") for p in hitter_profiles]),
+        },
+    }
+
+
+def build_projected_lineup_offense_profile(
+    lineup: List[Dict[str, Any]],
+    season: int,
+    pitcher_hand: Optional[str],
+    lineup_source: str,
+) -> Dict[str, Any]:
+    """
+    Build a projected-lineup offense profile from player split data.
+
+    Parameters
+    ----------
+    lineup : list of dict
+        List of lineup player records containing at least `id`.
+    season : int
+        Season year.
+    pitcher_hand : str or None
+        Opposing pitcher throwing hand. Expected 'L', 'R', or None.
+    lineup_source : str
+        Source label such as 'official', 'roster', or 'missing'.
+
+    Returns
+    -------
+    dict
+        Aggregated offense profile with stable contract and explicit metadata.
+    """
+    player_ids = [p.get("id") for p in lineup if p.get("id")]
+    if not player_ids:
+        return aggregate_hitter_profiles(
+            hitter_profiles=[],
+            lineup_source="missing",
+            pitcher_hand=pitcher_hand,
+            player_count_used=0,
+        )
+
+    split_code = "vr" if pitcher_hand == "R" else "vl" if pitcher_hand == "L" else None
+    all_splits = fetch_player_splits(player_ids, season)
+
+    selected_rows = []
+    if split_code:
+        selected_rows = [row for row in all_splits if row.get("split") == split_code]
+    else:
+        selected_rows = []
+
+    hitter_profiles = []
+    for row in selected_rows:
+        enriched_row = {
+            **row,
+            "source_type": "player_split",
+            "source_fields_used": sorted(list(row.keys())),
+            "data_confidence": "medium",
+            "generated_from": "fetch_player_splits",
+            "profile_granularity": "player",
+            "is_projected_lineup_derived": lineup_source == "official",
+        }
+        hitter_profiles.append(compute_hitter_profile(enriched_row))
+
+    return aggregate_hitter_profiles(
+        hitter_profiles=hitter_profiles,
+        lineup_source=lineup_source,
+        pitcher_hand=pitcher_hand,
+        player_count_used=len(player_ids),
+    )

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -21,25 +21,31 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
         A structured player-level pitcher profile using raw metrics grouped
         by trait. Missing fields are returned as None.
     """
+    raw_stats = raw_stats or {}
+
     return {
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),
             "avg_velocity": raw_stats.get("avg_velocity"),
-            "avg_spin_rate": raw_stats.get("avg_spin_rate"),
+            "avg_spin_rate": raw_stats.get("avg_spin_rate", raw_stats.get("avg_spin")),
         },
         "bat_missing": {
-            "k_rate": raw_stats.get("k_rate"),
+            "k_rate": raw_stats.get("k_rate", raw_stats.get("k_pct")),
             "whiff_rate": raw_stats.get("whiff_rate"),
             "csw_rate": raw_stats.get("csw_rate"),
         },
         "command_control": {
-            "bb_rate": raw_stats.get("bb_rate"),
+            "bb_rate": raw_stats.get("bb_rate", raw_stats.get("bb_pct")),
             "zone_rate": raw_stats.get("zone_rate"),
             "first_pitch_strike_rate": raw_stats.get("first_pitch_strike_rate"),
         },
         "contact_management": {
-            "hard_hit_rate_allowed": raw_stats.get("hard_hit_rate_allowed"),
-            "barrel_rate_allowed": raw_stats.get("barrel_rate_allowed"),
+            "hard_hit_rate_allowed": raw_stats.get(
+                "hard_hit_rate_allowed", raw_stats.get("hard_hit_pct")
+            ),
+            "barrel_rate_allowed": raw_stats.get(
+                "barrel_rate_allowed", raw_stats.get("barrel_pct_allowed")
+            ),
             "avg_exit_velocity_allowed": raw_stats.get("avg_exit_velocity_allowed"),
             "avg_launch_angle_allowed": raw_stats.get("avg_launch_angle_allowed"),
         },

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -24,6 +24,12 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
     raw_stats = raw_stats or {}
 
     return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_pitcher_profile"),
+        },
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),
             "avg_velocity": raw_stats.get("avg_velocity"),

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -29,6 +29,12 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
             "source_fields_used": raw_stats.get("source_fields_used", []),
             "data_confidence": raw_stats.get("data_confidence", "unknown"),
             "generated_from": raw_stats.get("generated_from", "compute_pitcher_profile"),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "last_365_days"),
+                sample_size=raw_stats.get("sample_size"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
         },
         "arsenal": {
             "pitch_mix": raw_stats.get("pitch_mix"),

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -1,0 +1,54 @@
+"""
+Utilities for building pitcher profile summaries for matchup previews.
+
+This module defines a player-level pitcher profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+
+def compute_pitcher_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured pitcher profile from raw pitcher inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of pitcher stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level pitcher profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    return {
+        "arsenal": {
+            "pitch_mix": raw_stats.get("pitch_mix"),
+            "avg_velocity": raw_stats.get("avg_velocity"),
+            "avg_spin_rate": raw_stats.get("avg_spin_rate"),
+        },
+        "bat_missing": {
+            "k_rate": raw_stats.get("k_rate"),
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "csw_rate": raw_stats.get("csw_rate"),
+        },
+        "command_control": {
+            "bb_rate": raw_stats.get("bb_rate"),
+            "zone_rate": raw_stats.get("zone_rate"),
+            "first_pitch_strike_rate": raw_stats.get("first_pitch_strike_rate"),
+        },
+        "contact_management": {
+            "hard_hit_rate_allowed": raw_stats.get("hard_hit_rate_allowed"),
+            "barrel_rate_allowed": raw_stats.get("barrel_rate_allowed"),
+            "avg_exit_velocity_allowed": raw_stats.get("avg_exit_velocity_allowed"),
+            "avg_launch_angle_allowed": raw_stats.get("avg_launch_angle_allowed"),
+        },
+        "platoon_profile": {
+            "vs_lhb_woba_allowed": raw_stats.get("vs_lhb_woba_allowed"),
+            "vs_rhb_woba_allowed": raw_stats.get("vs_rhb_woba_allowed"),
+            "vs_lhb_k_rate": raw_stats.get("vs_lhb_k_rate"),
+            "vs_rhb_k_rate": raw_stats.get("vs_rhb_k_rate"),
+            "vs_lhb_bb_rate": raw_stats.get("vs_lhb_bb_rate"),
+            "vs_rhb_bb_rate": raw_stats.get("vs_rhb_bb_rate"),
+        },
+    }

--- a/mlb_app/sample_blending.py
+++ b/mlb_app/sample_blending.py
@@ -1,0 +1,77 @@
+"""
+Weighted sample blending helpers for matchup analysis.
+
+This module provides reusable helpers for blending metric dictionaries
+across multiple sample windows such as last 30 days, last 90 days,
+current season, and last 365 days.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+
+HITTER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.50,
+    "last_90_days": 0.30,
+    "current_season": 0.20,
+}
+
+PITCHER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.35,
+    "last_90_days": 0.35,
+    "last_365_days": 0.30,
+}
+
+
+def weighted_average(values: Dict[str, Optional[float]], weights: Dict[str, float]) -> Optional[float]:
+    """
+    Compute a weighted average using only non-null values.
+    """
+    numerator = 0.0
+    denominator = 0.0
+
+    for key, weight in weights.items():
+        value = values.get(key)
+        if value is None:
+            continue
+        numerator += value * weight
+        denominator += weight
+
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def blend_metric_dict(
+    metric_windows: Dict[str, Dict[str, Optional[float]]],
+    weights: Dict[str, float],
+) -> Dict[str, Optional[float]]:
+    """
+    Blend metric dictionaries across multiple windows.
+
+    Parameters
+    ----------
+    metric_windows : dict
+        Mapping of window_name -> metric dict
+    weights : dict
+        Mapping of window_name -> weight
+
+    Returns
+    -------
+    dict
+        Blended metric dictionary using weighted averages for shared keys.
+    """
+    all_keys = set()
+    for window_metrics in metric_windows.values():
+        all_keys.update(window_metrics.keys())
+
+    blended: Dict[str, Optional[float]] = {}
+    for metric_key in all_keys:
+        values = {
+            window_name: metrics.get(metric_key)
+            for window_name, metrics in metric_windows.items()
+        }
+        blended[metric_key] = weighted_average(values, weights)
+
+    return blended

--- a/mlb_app/sample_windows.py
+++ b/mlb_app/sample_windows.py
@@ -1,0 +1,89 @@
+"""
+Sample window definitions for matchup analysis.
+
+This module provides a stable framework for naming, describing, and
+eventually blending time windows used across hitter, pitcher, and
+matchup-analysis calculations.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Optional
+
+
+SAMPLE_WINDOWS: Dict[str, Dict[str, object]] = {
+    "last_30_days": {
+        "window_type": "rolling",
+        "days": 30,
+        "description": "Rolling last 30 days",
+    },
+    "last_90_days": {
+        "window_type": "rolling",
+        "days": 90,
+        "description": "Rolling last 90 days",
+    },
+    "last_365_days": {
+        "window_type": "rolling",
+        "days": 365,
+        "description": "Rolling last 365 days",
+    },
+    "current_season": {
+        "window_type": "season",
+        "days": None,
+        "description": "Current season to date",
+    },
+    "career": {
+        "window_type": "career",
+        "days": None,
+        "description": "Career baseline",
+    },
+}
+
+
+def get_window_definition(window_name: str) -> Dict[str, object]:
+    """Return metadata for a named sample window."""
+    return SAMPLE_WINDOWS.get(
+        window_name,
+        {
+            "window_type": "unknown",
+            "days": None,
+            "description": "Unknown sample window",
+        },
+    )
+
+
+def get_window_start_date(
+    target_date: datetime.date,
+    window_name: str,
+) -> Optional[str]:
+    """
+    Return an ISO start date for rolling windows.
+
+    Non-rolling windows return None because they are not anchored only by
+    a backwards-looking day count.
+    """
+    definition = get_window_definition(window_name)
+    days = definition.get("days")
+    if not days:
+        return None
+    return (target_date - datetime.timedelta(days=int(days))).isoformat()
+
+
+def build_sample_metadata(
+    window_name: str,
+    sample_size: Optional[int] = None,
+    sample_blend_policy: str = "single_window_v1",
+    stabilizer_window: Optional[str] = None,
+) -> Dict[str, object]:
+    """Build a reusable sample metadata block."""
+    definition = get_window_definition(window_name)
+    return {
+        "sample_window": window_name,
+        "sample_family": definition.get("window_type"),
+        "sample_description": definition.get("description"),
+        "sample_days": definition.get("days"),
+        "sample_size": sample_size,
+        "sample_blend_policy": sample_blend_policy,
+        "stabilizer_window": stabilizer_window,
+    }

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
     "builder": "DOCKERFILE"
   },
   "deploy": {
-    "startCommand": "uvicorn mlb_app.app:app --host 0.0.0.0 --port $PORT",
+    "startCommand": "sh -c 'uvicorn mlb_app.app:app --host 0.0.0.0 --port ${PORT:-8080}'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",

--- a/tests/test_environment_data.py
+++ b/tests/test_environment_data.py
@@ -1,0 +1,38 @@
+from mlb_app.environment_data import build_environment_context, get_park_factors
+
+
+def test_get_park_factors_returns_contract_for_unknown_venue():
+    result = get_park_factors("Unknown Park")
+    assert "run_factor" in result
+    assert "home_run_factor" in result
+    assert "hit_factor" in result
+    assert "source_fields_used" in result
+    assert "park_readiness" in result
+    assert result["park_readiness"] == "stub"
+
+
+def test_build_environment_context_returns_stable_contract_for_unknown_venue():
+    game = {
+        "gameDate": "2026-04-22T18:05:00Z",
+        "venue": {"name": "Unknown Park"},
+        "teams": {
+            "home": {"team": {"name": "Home Team"}},
+            "away": {"team": {"name": "Away Team"}},
+        },
+    }
+
+    result = build_environment_context(game)
+
+    assert "venue_name" in result
+    assert "temperature_f" in result
+    assert "wind_speed_mph" in result
+    assert "run_factor" in result
+    assert "home_run_factor" in result
+    assert "hit_factor" in result
+    assert "source_type" in result
+    assert "source_fields_used" in result
+    assert "data_confidence" in result
+    assert "generated_from" in result
+    assert "is_stub" in result
+    assert "readiness" in result
+    assert "missing_inputs" in result

--- a/tests/test_lineup_offense_profile_contract.py
+++ b/tests/test_lineup_offense_profile_contract.py
@@ -1,0 +1,44 @@
+from mlb_app.offense_profile_aggregation import build_projected_lineup_offense_profile
+
+
+def test_projected_lineup_offense_profile_contract_when_lineup_missing():
+    result = build_projected_lineup_offense_profile(
+        lineup=[],
+        season=2026,
+        pitcher_hand=None,
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "projected_lineup_profile"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["opposing_pitcher_hand"] == "unknown"
+    assert metadata["player_count_used"] == 0
+
+
+def test_projected_lineup_offense_profile_contract_with_roster_source():
+    result = build_projected_lineup_offense_profile(
+        lineup=[{"id": 1, "fullName": "Test Batter", "batting_order": 1}],
+        season=2026,
+        pitcher_hand="R",
+        lineup_source="roster",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["lineup_source"] == "roster"
+    assert metadata["opposing_pitcher_hand"] == "R"
+    assert metadata["player_count_used"] == 1

--- a/tests/test_matchup_analysis_contract.py
+++ b/tests/test_matchup_analysis_contract.py
@@ -1,0 +1,50 @@
+from mlb_app.matchup_analysis import build_matchup_analysis
+
+
+def test_matchup_analysis_contract_with_missing_lineup():
+    result = build_matchup_analysis(
+        pitcher_id=None,
+        pitcher_name=None,
+        pitcher_hand=None,
+        lineup=[],
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "pitchTypeMatchups" in result
+    assert "biggestEdge" in result
+    assert "biggestWeakness" in result
+    assert "confidence" in result
+    assert "summary" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "matchup_analysis_scaffold"
+    assert metadata["pitcher_hand"] == "unknown"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["lineup_player_count"] == 0
+
+    assert result["pitchTypeMatchups"] == []
+    assert result["biggestEdge"] is None
+    assert result["biggestWeakness"] is None
+    assert result["confidence"] == 0.0
+    assert result["summary"]["status"] == "scaffold"
+
+
+def test_matchup_analysis_contract_with_lineup_players():
+    result = build_matchup_analysis(
+        pitcher_id=123,
+        pitcher_name="Pitcher Example",
+        pitcher_hand="R",
+        lineup=[
+            {"id": 1, "fullName": "Batter One", "batting_order": 1},
+            {"id": 2, "fullName": "Batter Two", "batting_order": 2},
+        ],
+        lineup_source="official",
+    )
+
+    metadata = result["metadata"]
+    assert metadata["pitcher_id"] == 123
+    assert metadata["pitcher_name"] == "Pitcher Example"
+    assert metadata["pitcher_hand"] == "R"
+    assert metadata["lineup_source"] == "official"
+    assert metadata["lineup_player_count"] == 2

--- a/tests/test_matchup_analysis_contract.py
+++ b/tests/test_matchup_analysis_contract.py
@@ -18,7 +18,7 @@ def test_matchup_analysis_contract_with_missing_lineup():
     assert "summary" in result
 
     metadata = result["metadata"]
-    assert metadata["source_type"] == "matchup_analysis_scaffold"
+    assert metadata["source_type"] == "matchup_analysis_v1"
     assert metadata["pitcher_hand"] == "unknown"
     assert metadata["lineup_source"] == "missing"
     assert metadata["lineup_player_count"] == 0
@@ -43,8 +43,16 @@ def test_matchup_analysis_contract_with_lineup_players():
     )
 
     metadata = result["metadata"]
+    assert metadata["source_type"] == "matchup_analysis_v1"
     assert metadata["pitcher_id"] == 123
     assert metadata["pitcher_name"] == "Pitcher Example"
     assert metadata["pitcher_hand"] == "R"
     assert metadata["lineup_source"] == "official"
     assert metadata["lineup_player_count"] == 2
+
+    assert isinstance(result["pitchTypeMatchups"], list)
+    assert len(result["pitchTypeMatchups"]) > 0
+    assert result["biggestEdge"] is not None
+    assert result["biggestWeakness"] is not None
+    assert result["confidence"] > 0.0
+    assert result["summary"]["status"] == "partial"

--- a/tests/test_matchup_profile_contract.py
+++ b/tests/test_matchup_profile_contract.py
@@ -1,0 +1,84 @@
+from mlb_app.analysis_pipeline import generate_daily_matchups
+
+
+def test_generate_daily_matchups_profile_contract(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_schedule",
+        lambda date_str: [
+            {
+                "gamePk": 123,
+                "gameDate": "2026-04-22T18:05:00Z",
+                "teams": {
+                    "home": {
+                        "team": {"id": 1, "name": "Home Team"},
+                        "probablePitcher": {"id": 1001},
+                    },
+                    "away": {
+                        "team": {"id": 2, "name": "Away Team"},
+                        "probablePitcher": {"id": 1002},
+                    },
+                },
+                "venue": {"name": "Sample Park"},
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_records",
+        lambda season: [
+            {"team": {"id": 1}, "wins": 10, "losses": 5, "runDifferential": 12},
+            {"team": {"id": 2}, "wins": 8, "losses": 7, "runDifferential": -3},
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_splits",
+        lambda team_id, season, split: {},
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.get_pitcher_metrics",
+        lambda player_id, start_date, end_date: {},
+    )
+
+    matchups = generate_daily_matchups("2026-04-22")
+    assert len(matchups) == 1
+
+    matchup = matchups[0]
+
+    # Top-level contract
+    assert "homePitcherProfile" in matchup
+    assert "awayPitcherProfile" in matchup
+    assert "homeTeamOffenseProfile" in matchup
+    assert "awayTeamOffenseProfile" in matchup
+    assert "environmentProfile" in matchup
+
+    # Pitcher profile nested sections
+    for key in ("homePitcherProfile", "awayPitcherProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "arsenal" in profile
+        assert "bat_missing" in profile
+        assert "command_control" in profile
+        assert "contact_management" in profile
+        assert "platoon_profile" in profile
+
+    # Offense profile nested sections
+    for key in ("homeTeamOffenseProfile", "awayTeamOffenseProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "contact_skill" in profile
+        assert "plate_discipline" in profile
+        assert "power" in profile
+        assert "batted_ball_quality" in profile
+        assert "platoon_profile" in profile
+
+    # Environment profile nested sections
+    environment = matchup["environmentProfile"]
+    assert "metadata" in environment
+    assert "weather" in environment
+    assert "park_factors" in environment
+    assert "game_context" in environment
+    assert "run_environment" in environment
+    assert "risk_flags" in environment
+    assert "status" in environment

--- a/tests/test_pitcher_handedness_resolution.py
+++ b/tests/test_pitcher_handedness_resolution.py
@@ -1,0 +1,35 @@
+from mlb_app.analysis_pipeline import _determine_hand
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_determine_hand_returns_pitch_hand_code(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.requests.get",
+        lambda url, timeout=10: DummyResponse(
+            {"people": [{"pitchHand": {"code": "R"}}]}
+        ),
+    )
+
+    assert _determine_hand(12345) == "R"
+
+
+def test_determine_hand_returns_none_on_request_failure(monkeypatch):
+    class DummyException(Exception):
+        pass
+
+    def raise_error(url, timeout=10):
+        raise DummyException("network error")
+
+    monkeypatch.setattr("mlb_app.analysis_pipeline.requests.get", raise_error)
+
+    assert _determine_hand(12345) is None

--- a/tests/test_sample_blending.py
+++ b/tests/test_sample_blending.py
@@ -1,0 +1,44 @@
+from mlb_app.sample_blending import (
+    HITTER_BLEND_WEIGHTS,
+    PITCHER_BLEND_WEIGHTS,
+    blend_metric_dict,
+    weighted_average,
+)
+
+
+def test_weighted_average_ignores_none_values():
+    values = {
+        "last_30_days": 0.300,
+        "last_90_days": None,
+        "current_season": 0.250,
+    }
+    weights = {
+        "last_30_days": 0.50,
+        "last_90_days": 0.30,
+        "current_season": 0.20,
+    }
+
+    result = weighted_average(values, weights)
+    expected = (0.300 * 0.50 + 0.250 * 0.20) / (0.50 + 0.20)
+    assert round(result, 6) == round(expected, 6)
+
+
+def test_blend_metric_dict_blends_shared_keys():
+    metric_windows = {
+        "last_30_days": {"k_rate": 0.22, "bb_rate": 0.08},
+        "last_90_days": {"k_rate": 0.24, "bb_rate": 0.09},
+        "current_season": {"k_rate": 0.23, "bb_rate": 0.10},
+    }
+
+    result = blend_metric_dict(metric_windows, HITTER_BLEND_WEIGHTS)
+
+    assert "k_rate" in result
+    assert "bb_rate" in result
+    assert result["k_rate"] is not None
+    assert result["bb_rate"] is not None
+
+
+def test_pitcher_blend_weights_exist_for_expected_windows():
+    assert PITCHER_BLEND_WEIGHTS["last_30_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_90_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_365_days"] == 0.30

--- a/tests/test_sample_windows.py
+++ b/tests/test_sample_windows.py
@@ -1,0 +1,37 @@
+import datetime
+
+from mlb_app.sample_windows import (
+    build_sample_metadata,
+    get_window_definition,
+    get_window_start_date,
+)
+
+
+def test_get_window_definition_known_window():
+    result = get_window_definition("last_30_days")
+    assert result["window_type"] == "rolling"
+    assert result["days"] == 30
+    assert result["description"] == "Rolling last 30 days"
+
+
+def test_get_window_start_date_for_rolling_window():
+    target_date = datetime.date(2026, 4, 22)
+    result = get_window_start_date(target_date, "last_90_days")
+    assert result == "2026-01-22"
+
+
+def test_build_sample_metadata_contract():
+    result = build_sample_metadata(
+        window_name="current_season",
+        sample_size=120,
+        sample_blend_policy="single_window_v1",
+        stabilizer_window=None,
+    )
+
+    assert result["sample_window"] == "current_season"
+    assert result["sample_family"] == "season"
+    assert result["sample_description"] == "Current season to date"
+    assert result["sample_days"] is None
+    assert result["sample_size"] == 120
+    assert result["sample_blend_policy"] == "single_window_v1"
+    assert result["stabilizer_window"] is None


### PR DESCRIPTION
Adds a reusable weighted sample blending engine for sandbox analytical modeling.

This update:
- introduces `sample_blending.py` with v1 hitter and pitcher blend weights
- adds a weighted average helper that ignores missing values safely
- adds a metric-dictionary blending helper for multi-window inputs
- adds tests for weighted average behavior, metric blending, and expected pitcher blend weights

This is a backend capability layer only. It does not yet wire the blended windows into all hitter, pitcher, or matchup-analysis calculations, but it establishes the reusable engine needed for that next step.