### PR TITLE
Add weighted sample blending engine

### DIFF
--- a/mlb_app/sample_blending.py
+++ b/mlb_app/sample_blending.py
@@ -1,0 +1,77 @@
+"""
+Weighted sample blending helpers for matchup analysis.
+
+This module provides reusable helpers for blending metric dictionaries
+across multiple sample windows such as last 30 days, last 90 days,
+current season, and last 365 days.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+
+HITTER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.50,
+    "last_90_days": 0.30,
+    "current_season": 0.20,
+}
+
+PITCHER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.35,
+    "last_90_days": 0.35,
+    "last_365_days": 0.30,
+}
+
+
+def weighted_average(values: Dict[str, Optional[float]], weights: Dict[str, float]) -> Optional[float]:
+    """
+    Compute a weighted average using only non-null values.
+    """
+    numerator = 0.0
+    denominator = 0.0
+
+    for key, weight in weights.items():
+        value = values.get(key)
+        if value is None:
+            continue
+        numerator += value * weight
+        denominator += weight
+
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def blend_metric_dict(
+    metric_windows: Dict[str, Dict[str, Optional[float]]],
+    weights: Dict[str, float],
+) -> Dict[str, Optional[float]]:
+    """
+    Blend metric dictionaries across multiple windows.
+
+    Parameters
+    ----------
+    metric_windows : dict
+        Mapping of window_name -> metric dict
+    weights : dict
+        Mapping of window_name -> weight
+
+    Returns
+    -------
+    dict
+        Blended metric dictionary using weighted averages for shared keys.
+    """
+    all_keys = set()
+    for window_metrics in metric_windows.values():
+        all_keys.update(window_metrics.keys())
+
+    blended: Dict[str, Optional[float]] = {}
+    for metric_key in all_keys:
+        values = {
+            window_name: metrics.get(metric_key)
+            for window_name, metrics in metric_windows.items()
+        }
+        blended[metric_key] = weighted_average(values, weights)
+
+    return blended

--- a/tests/test_sample_blending.py
+++ b/tests/test_sample_blending.py
@@ -1,0 +1,44 @@
+from mlb_app.sample_blending import (
+    HITTER_BLEND_WEIGHTS,
+    PITCHER_BLEND_WEIGHTS,
+    blend_metric_dict,
+    weighted_average,
+)
+
+
+def test_weighted_average_ignores_none_values():
+    values = {
+        "last_30_days": 0.300,
+        "last_90_days": None,
+        "current_season": 0.250,
+    }
+    weights = {
+        "last_30_days": 0.50,
+        "last_90_days": 0.30,
+        "current_season": 0.20,
+    }
+
+    result = weighted_average(values, weights)
+    expected = (0.300 * 0.50 + 0.250 * 0.20) / (0.50 + 0.20)
+    assert round(result, 6) == round(expected, 6)
+
+
+def test_blend_metric_dict_blends_shared_keys():
+    metric_windows = {
+        "last_30_days": {"k_rate": 0.22, "bb_rate": 0.08},
+        "last_90_days": {"k_rate": 0.24, "bb_rate": 0.09},
+        "current_season": {"k_rate": 0.23, "bb_rate": 0.10},
+    }
+
+    result = blend_metric_dict(metric_windows, HITTER_BLEND_WEIGHTS)
+
+    assert "k_rate" in result
+    assert "bb_rate" in result
+    assert result["k_rate"] is not None
+    assert result["bb_rate"] is not None
+
+
+def test_pitcher_blend_weights_exist_for_expected_windows():
+    assert PITCHER_BLEND_WEIGHTS["last_30_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_90_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_365_days"] == 0.30


### PR DESCRIPTION
Adds a reusable weighted sample blending engine for sandbox analytical modeling.

This update:
- introduces `sample_blending.py` with v1 hitter and pitcher blend weights
- adds a weighted average helper that ignores missing values safely
- adds a metric-dictionary blending helper for multi-window inputs
- adds tests for weighted average behavior, metric blending, and expected pitcher blend weights

This is a backend capability layer only. It does not yet wire the blended windows into all hitter, pitcher, or matchup-analysis calculations, but it establishes the reusable engine needed for that next step.