### PR TITLE
Add hitter multi-window retrieval framework

### DIFF
--- a/mlb_app/hitter_windows.py
+++ b/mlb_app/hitter_windows.py
@@ -1,0 +1,60 @@
+"""
+Hitter multi-window retrieval utilities.
+
+This module provides a first-pass framework for retrieving hitter split
+data across named sample windows such as current season, last 30 days,
+and last 90 days.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, List
+
+from .player_splits import fetch_player_splits
+from .sample_windows import get_window_definition
+
+
+def fetch_player_splits_for_window(
+    player_ids: List[int],
+    season: int,
+    window_name: str,
+    target_date: datetime.date,
+) -> List[Dict[str, float]]:
+    """
+    Retrieve hitter split rows for a named sample window.
+
+    This v1 implementation supports:
+    - current_season: real season split retrieval
+    - rolling windows: contract-safe scaffold using the same output shape
+
+    Future work can replace rolling-window scaffolds with true date-bounded
+    Statcast or API-backed calculations.
+    """
+    if not player_ids:
+        return []
+
+    window_def = get_window_definition(window_name)
+    window_type = window_def.get("window_type")
+
+    # Current season: use the existing real split retrieval path.
+    if window_name == "current_season":
+        rows = fetch_player_splits(player_ids, season)
+        for row in rows:
+            row["sample_window"] = "current_season"
+            row["sample_window_type"] = window_type
+            row["sample_target_date"] = target_date.isoformat()
+        return rows
+
+    # Rolling windows: v1 scaffold preserves contract but does not yet claim
+    # true date-bounded split calculations.
+    if window_name in {"last_30_days", "last_90_days"}:
+        rows = fetch_player_splits(player_ids, season)
+        for row in rows:
+            row["sample_window"] = window_name
+            row["sample_window_type"] = window_type
+            row["sample_target_date"] = target_date.isoformat()
+            row["sample_is_scaffold"] = True
+        return rows
+
+    return []

--- a/tests/test_hitter_windows.py
+++ b/tests/test_hitter_windows.py
@@ -1,0 +1,23 @@
+import datetime
+
+from mlb_app.hitter_windows import fetch_player_splits_for_window
+
+
+def test_returns_empty_for_no_players():
+    result = fetch_player_splits_for_window(
+        player_ids=[],
+        season=2026,
+        window_name="current_season",
+        target_date=datetime.date(2026, 4, 22),
+    )
+    assert result == []
+
+
+def test_unknown_window_returns_empty():
+    result = fetch_player_splits_for_window(
+        player_ids=[1],
+        season=2026,
+        window_name="unknown_window",
+        target_date=datetime.date(2026, 4, 22),
+    )
+    assert result == []


### PR DESCRIPTION
Adds a first-pass hitter multi-window retrieval framework for sandbox analytical modeling.

This update:
- introduces `hitter_windows.py` with named window retrieval for `current_season`, `last_30_days`, and `last_90_days`
- uses the existing player split retrieval path for current season windows
- preserves a stable contract for rolling windows while explicitly marking rolling-window results as scaffolds for now
- adds tests for empty-player handling and unknown-window behavior

This is a retrieval framework layer only. It does not yet implement true date-bounded rolling hitter calculations, but it creates the windowed retrieval contract needed for upcoming hitter blending integration.