### PR TITLE
Integrate weighted hitter sample blending into lineup offense profiles

### DIFF
--- a/mlb_app/offense_profile_aggregation.py
+++ b/mlb_app/offense_profile_aggregation.py
@@ -2,17 +2,20 @@
 Offense profile aggregation utilities for matchup previews.
 
 This module builds projected-lineup-aware offense profiles by:
-- fetching player-level splits vs pitcher handedness
-- converting those player split rows into hitter profiles
-- aggregating those hitter profiles into one lineup offense profile
+- retrieving player-level split rows across multiple sample windows
+- converting those rows into hitter profiles
+- blending windowed hitter metrics
+- aggregating blended hitter profiles into one lineup offense profile
 """
 
 from __future__ import annotations
 
+import datetime
 from typing import Any, Dict, List, Optional
 
 from .hitter_profile import compute_hitter_profile
-from .player_splits import fetch_player_splits
+from .hitter_windows import fetch_player_splits_for_window
+from .sample_blending import HITTER_BLEND_WEIGHTS, blend_metric_dict
 
 
 def _average(values: List[Optional[float]]) -> Optional[float]:
@@ -24,6 +27,84 @@ def _average(values: List[Optional[float]]) -> Optional[float]:
 
 def _extract_metric(profile: Dict[str, Any], section: str, field: str) -> Optional[float]:
     return (profile.get(section) or {}).get(field)
+
+
+def _blend_hitter_profile_windows(window_profiles: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Blend multiple hitter profile windows into one player-level hitter profile.
+    """
+    return {
+        "metadata": {
+            "source_type": "player_split_blended",
+            "source_fields_used": ["last_30_days", "last_90_days", "current_season"],
+            "data_confidence": "medium" if window_profiles else "low",
+            "generated_from": "_blend_hitter_profile_windows",
+            "profile_granularity": "player",
+            "is_projected_lineup_derived": True,
+            "sample_window": "blended",
+            "sample_family": "blended",
+            "sample_description": "Weighted blend across hitter windows",
+            "sample_days": None,
+            "sample_size": None,
+            "sample_blend_policy": "hitter_v1_weighted_blend",
+            "stabilizer_window": "current_season",
+        },
+        "contact_skill": blend_metric_dict(
+            {
+                window_name: {
+                    "k_rate": _extract_metric(profile, "contact_skill", "k_rate"),
+                    "whiff_rate": _extract_metric(profile, "contact_skill", "whiff_rate"),
+                    "contact_rate": _extract_metric(profile, "contact_skill", "contact_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "plate_discipline": blend_metric_dict(
+            {
+                window_name: {
+                    "bb_rate": _extract_metric(profile, "plate_discipline", "bb_rate"),
+                    "chase_rate": _extract_metric(profile, "plate_discipline", "chase_rate"),
+                    "swing_rate": _extract_metric(profile, "plate_discipline", "swing_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "power": blend_metric_dict(
+            {
+                window_name: {
+                    "iso": _extract_metric(profile, "power", "iso"),
+                    "barrel_rate": _extract_metric(profile, "power", "barrel_rate"),
+                    "hard_hit_rate": _extract_metric(profile, "power", "hard_hit_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "batted_ball_quality": blend_metric_dict(
+            {
+                window_name: {
+                    "avg_exit_velocity": _extract_metric(profile, "batted_ball_quality", "avg_exit_velocity"),
+                    "avg_launch_angle": _extract_metric(profile, "batted_ball_quality", "avg_launch_angle"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "platoon_profile": blend_metric_dict(
+            {
+                window_name: {
+                    "vs_lhp_woba": _extract_metric(profile, "platoon_profile", "vs_lhp_woba"),
+                    "vs_rhp_woba": _extract_metric(profile, "platoon_profile", "vs_rhp_woba"),
+                    "vs_lhp_iso": _extract_metric(profile, "platoon_profile", "vs_lhp_iso"),
+                    "vs_rhp_iso": _extract_metric(profile, "platoon_profile", "vs_rhp_iso"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+    }
 
 
 def aggregate_hitter_profiles(
@@ -38,7 +119,7 @@ def aggregate_hitter_profiles(
     return {
         "metadata": {
             "source_type": "projected_lineup_profile",
-            "source_fields_used": ["player_splits", "compute_hitter_profile"],
+            "source_fields_used": ["player_splits", "compute_hitter_profile", "sample_blending"],
             "data_confidence": "medium" if hitter_profiles else "low",
             "generated_from": "aggregate_hitter_profiles",
             "profile_granularity": "lineup_candidate_group",
@@ -46,6 +127,13 @@ def aggregate_hitter_profiles(
             "lineup_source": lineup_source,
             "opposing_pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
             "player_count_used": player_count_used,
+            "sample_window": "blended",
+            "sample_family": "blended",
+            "sample_description": "Weighted blend across hitter windows",
+            "sample_days": None,
+            "sample_size": player_count_used,
+            "sample_blend_policy": "hitter_v1_weighted_blend",
+            "stabilizer_window": "current_season",
         },
         "contact_skill": {
             "k_rate": _average([_extract_metric(p, "contact_skill", "k_rate") for p in hitter_profiles]),
@@ -84,26 +172,14 @@ def build_projected_lineup_offense_profile(
     season: int,
     pitcher_hand: Optional[str],
     lineup_source: str,
+    target_date: Optional[datetime.date] = None,
 ) -> Dict[str, Any]:
     """
-    Build a projected-lineup offense profile from player split data.
-
-    Parameters
-    ----------
-    lineup : list of dict
-        List of lineup player records containing at least `id`.
-    season : int
-        Season year.
-    pitcher_hand : str or None
-        Opposing pitcher throwing hand. Expected 'L', 'R', or None.
-    lineup_source : str
-        Source label such as 'official', 'roster', or 'missing'.
-
-    Returns
-    -------
-    dict
-        Aggregated offense profile with stable contract and explicit metadata.
+    Build a projected-lineup offense profile from blended player split data.
     """
+    if target_date is None:
+        target_date = datetime.date.today()
+
     player_ids = [p.get("id") for p in lineup if p.get("id")]
     if not player_ids:
         return aggregate_hitter_profiles(
@@ -114,26 +190,55 @@ def build_projected_lineup_offense_profile(
         )
 
     split_code = "vr" if pitcher_hand == "R" else "vl" if pitcher_hand == "L" else None
-    all_splits = fetch_player_splits(player_ids, season)
+    if not split_code:
+        return aggregate_hitter_profiles(
+            hitter_profiles=[],
+            lineup_source=lineup_source,
+            pitcher_hand=pitcher_hand,
+            player_count_used=len(player_ids),
+        )
 
-    selected_rows = []
-    if split_code:
-        selected_rows = [row for row in all_splits if row.get("split") == split_code]
-    else:
-        selected_rows = []
+    windows = ["last_30_days", "last_90_days", "current_season"]
+    window_rows = {
+        window_name: fetch_player_splits_for_window(
+            player_ids=player_ids,
+            season=season,
+            window_name=window_name,
+            target_date=target_date,
+        )
+        for window_name in windows
+    }
 
     hitter_profiles = []
-    for row in selected_rows:
-        enriched_row = {
-            **row,
-            "source_type": "player_split",
-            "source_fields_used": sorted(list(row.keys())),
-            "data_confidence": "medium",
-            "generated_from": "fetch_player_splits",
-            "profile_granularity": "player",
-            "is_projected_lineup_derived": lineup_source == "official",
-        }
-        hitter_profiles.append(compute_hitter_profile(enriched_row))
+    for player_id in player_ids:
+        per_window_profiles: Dict[str, Dict[str, Any]] = {}
+        for window_name, rows in window_rows.items():
+            selected_row = next(
+                (
+                    row for row in rows
+                    if row.get("player_id") == player_id and row.get("split") == split_code
+                ),
+                None,
+            )
+            if not selected_row:
+                continue
+
+            enriched_row = {
+                **selected_row,
+                "source_type": "player_split",
+                "source_fields_used": sorted(list(selected_row.keys())),
+                "data_confidence": "medium",
+                "generated_from": "fetch_player_splits_for_window",
+                "profile_granularity": "player",
+                "is_projected_lineup_derived": lineup_source == "official",
+                "sample_window": window_name,
+                "sample_blend_policy": "hitter_v1_weighted_blend",
+                "stabilizer_window": "current_season",
+            }
+            per_window_profiles[window_name] = compute_hitter_profile(enriched_row)
+
+        if per_window_profiles:
+            hitter_profiles.append(_blend_hitter_profile_windows(per_window_profiles))
 
     return aggregate_hitter_profiles(
         hitter_profiles=hitter_profiles,

--- a/tests/test_hitter_blending_integration.py
+++ b/tests/test_hitter_blending_integration.py
@@ -1,0 +1,41 @@
+import datetime
+
+from mlb_app.offense_profile_aggregation import build_projected_lineup_offense_profile
+
+
+def test_build_projected_lineup_offense_profile_returns_stable_contract_when_no_lineup():
+    result = build_projected_lineup_offense_profile(
+        lineup=[],
+        season=2026,
+        pitcher_hand="R",
+        lineup_source="missing",
+        target_date=datetime.date(2026, 4, 22),
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["sample_window"] == "blended"
+    assert metadata["sample_blend_policy"] == "hitter_v1_weighted_blend"
+    assert metadata["player_count_used"] == 0
+
+
+def test_build_projected_lineup_offense_profile_marks_blended_metadata():
+    result = build_projected_lineup_offense_profile(
+        lineup=[{"id": 1, "fullName": "Test Batter", "batting_order": 1}],
+        season=2026,
+        pitcher_hand=None,
+        lineup_source="roster",
+        target_date=datetime.date(2026, 4, 22),
+    )
+
+    metadata = result["metadata"]
+    assert metadata["sample_window"] == "blended"
+    assert metadata["sample_family"] == "blended"
+    assert metadata["sample_blend_policy"] == "hitter_v1_weighted_blend"
+    assert metadata["stabilizer_window"] == "current_season"


### PR DESCRIPTION
Adds the first real hitter blending integration step for sandbox lineup-aware offense profiles.

This update:
- upgrades `offense_profile_aggregation.py` to retrieve hitter windows across `last_30_days`, `last_90_days`, and `current_season`
- blends player-level hitter metrics using the weighted sample blending engine
- rolls those blended player profiles up into the projected lineup offense profile
- preserves explicit blended-sample metadata and stabilizer labeling
- adds a focused contract test for blended projected-lineup offense profiles

This is the first integration point where the sample-window framework and weighted blending engine start affecting a real matchup output path.