### PR TITLE
Add pitcher multi-window retrieval framework

### DIFF
--- a/mlb_app/pitcher_windows.py
+++ b/mlb_app/pitcher_windows.py
@@ -1,0 +1,54 @@
+"""
+Pitcher multi-window retrieval utilities.
+
+This module provides a first-pass framework for retrieving pitcher metric
+data across named sample windows such as last 30 days, last 90 days,
+and last 365 days.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Optional
+
+from .pitcher_analysis import get_pitcher_metrics
+from .sample_windows import get_window_start_date
+
+
+def fetch_pitcher_metrics_for_window(
+    pitcher_id: int,
+    target_date: datetime.date,
+    window_name: str,
+) -> Dict[str, Optional[float]]:
+    """
+    Retrieve pitcher metrics for a named sample window.
+
+    This v1 implementation supports:
+    - last_365_days: real rolling retrieval using the existing pitcher metrics path
+    - rolling shorter windows: contract-safe scaffold that still uses the current
+      retrieval path shape while explicitly labeling the sample window
+
+    Future work can improve the shorter windows with more exact bounded retrieval.
+    """
+    if not pitcher_id:
+        return {}
+
+    end_date = target_date.isoformat()
+
+    if window_name == "last_365_days":
+        start_date = get_window_start_date(target_date, "last_365_days")
+        metrics = get_pitcher_metrics(pitcher_id, start_date, end_date)
+        metrics["sample_window"] = "last_365_days"
+        metrics["sample_target_date"] = end_date
+        metrics["sample_is_scaffold"] = False
+        return metrics
+
+    if window_name in {"last_30_days", "last_90_days"}:
+        start_date = get_window_start_date(target_date, window_name)
+        metrics = get_pitcher_metrics(pitcher_id, start_date, end_date)
+        metrics["sample_window"] = window_name
+        metrics["sample_target_date"] = end_date
+        metrics["sample_is_scaffold"] = True
+        return metrics
+
+    return {}

--- a/tests/test_pitcher_windows.py
+++ b/tests/test_pitcher_windows.py
@@ -1,0 +1,21 @@
+import datetime
+
+from mlb_app.pitcher_windows import fetch_pitcher_metrics_for_window
+
+
+def test_returns_empty_for_missing_pitcher_id():
+    result = fetch_pitcher_metrics_for_window(
+        pitcher_id=0,
+        target_date=datetime.date(2026, 4, 22),
+        window_name="last_365_days",
+    )
+    assert result == {}
+
+
+def test_unknown_window_returns_empty():
+    result = fetch_pitcher_metrics_for_window(
+        pitcher_id=123,
+        target_date=datetime.date(2026, 4, 22),
+        window_name="unknown_window",
+    )
+    assert result == {}


### PR DESCRIPTION
Adds a first-pass pitcher multi-window retrieval framework for sandbox analytical modeling.

This update:
- introduces `pitcher_windows.py` with named window retrieval for `last_30_days`, `last_90_days`, and `last_365_days`
- uses the existing pitcher metrics retrieval path for the supported 365-day window
- preserves a stable contract for shorter rolling windows while explicitly marking them as scaffolded for now
- adds tests for missing-pitcher handling and unknown-window behavior

This is a retrieval framework layer only. It does not yet implement full pitcher blending integration, but it creates the windowed retrieval contract needed for that next step.