### PR TITLE
Add live stats and scoring: 5 backend endpoints + 2 frontend pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ import StandingsPage from './pages/StandingsPage'
 import CompetitiveAnalysisPage from './pages/CompetitiveAnalysisPage'
 import YesterdayTodayPage from './pages/YesterdayTodayPage'
 import AIPage from './pages/AIPage'
+import LiveScoreboardPage from './pages/LiveScoreboardPage'
+import LiveGamePage from './pages/LiveGamePage'
 
 const styles = {
   nav: {
@@ -65,6 +67,7 @@ export default function App() {
         <NavLink to="/team" style={link}>Team</NavLink>
         <NavLink to="/calendar" style={link}>Calendar</NavLink>
         <NavLink to="/ai" style={link}>AI</NavLink>
+        <NavLink to="/live" style={link}>Live</NavLink>
       </nav>
       <main style={styles.main}>
         <Routes>
@@ -82,6 +85,8 @@ export default function App() {
           <Route path="/team/:id" element={<TeamPage />} />
           <Route path="/calendar" element={<YesterdayTodayPage />} />
           <Route path="/ai" element={<AIPage />} />
+          <Route path="/live" element={<LiveScoreboardPage />} />
+          <Route path="/live/:game_pk" element={<LiveGamePage />} />
         </Routes>
       </main>
     </BrowserRouter>

--- a/frontend/src/pages/LiveGamePage.jsx
+++ b/frontend/src/pages/LiveGamePage.jsx
@@ -1,0 +1,601 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { API_BASE } from '../lib/api'
+
+const REFRESH_LIVE_MS = 15_000
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function val(v, suffix = '') {
+  return v != null ? `${v}${suffix}` : '—'
+}
+
+function fmtAvg(v) {
+  if (v == null) return '—'
+  const n = parseFloat(v)
+  return isNaN(n) ? v : n.toFixed(3)
+}
+
+function CountBall({ filled }) {
+  return (
+    <span style={{
+      display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%',
+      background: filled ? '#3fb950' : '#21262d',
+      border: '1px solid #30363d', marginRight: '3px',
+    }} />
+  )
+}
+
+function CountStrike({ filled }) {
+  return (
+    <span style={{
+      display: 'inline-block', width: '10px', height: '10px', borderRadius: '50%',
+      background: filled ? '#f85149' : '#21262d',
+      border: '1px solid #30363d', marginRight: '3px',
+    }} />
+  )
+}
+
+function RunnerDiamond({ runners }) {
+  const on1 = Boolean(runners?.first)
+  const on2 = Boolean(runners?.second)
+  const on3 = Boolean(runners?.third)
+  const base = (filled, label) => (
+    <div title={label || ''} style={{
+      width: '16px', height: '16px',
+      background: filled ? '#d29922' : '#21262d',
+      border: `1px solid ${filled ? '#d29922' : '#30363d'}`,
+      transform: 'rotate(45deg)',
+    }} />
+  )
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '20px 20px 20px', gridTemplateRows: '20px 20px', gap: '2px', alignItems: 'center' }}>
+      <div />
+      {base(on2, runners?.second)}
+      <div />
+      {base(on3, runners?.third)}
+      <div />
+      {base(on1, runners?.first)}
+    </div>
+  )
+}
+
+function SectionHeader({ children }) {
+  return (
+    <div style={{ fontSize: '11px', fontWeight: '600', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '10px' }}>
+      {children}
+    </div>
+  )
+}
+
+function Card({ children, style }) {
+  return (
+    <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: '8px', padding: '16px', ...style }}>
+      {children}
+    </div>
+  )
+}
+
+// ─── Tab: Live (current play state) ─────────────────────────────────────────
+
+function LiveTab({ state }) {
+  if (!state) return <div style={{ color: '#8b949e' }}>No live state data.</div>
+
+  const { current_batter, current_pitcher, count, runners, pitch_sequence, status, status_detail } = state
+  const isLive = status === 'Live'
+
+  return (
+    <div>
+      {/* Score banner */}
+      <Card style={{ marginBottom: '16px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-around', alignItems: 'center' }}>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: '13px', color: '#8b949e' }}>{state.away?.abbreviation}</div>
+            <div style={{ fontSize: '36px', fontWeight: '700', color: '#e6edf3' }}>{val(state.away?.score)}</div>
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            {isLive ? (
+              <>
+                <div style={{ fontSize: '13px', fontWeight: '600', color: '#3fb950' }}>
+                  {state.inning_state} {state.inning}
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: '3px', marginTop: '4px' }}>
+                  {[0, 1, 2].map(i => (
+                    <span key={i} style={{
+                      width: '8px', height: '8px', borderRadius: '50%',
+                      background: i < (state.outs ?? 0) ? '#d29922' : '#21262d',
+                      border: '1px solid #30363d',
+                      display: 'inline-block',
+                    }} />
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div style={{ fontSize: '13px', color: '#8b949e' }}>{status_detail || status}</div>
+            )}
+          </div>
+          <div style={{ textAlign: 'center' }}>
+            <div style={{ fontSize: '13px', color: '#8b949e' }}>{state.home?.abbreviation}</div>
+            <div style={{ fontSize: '36px', fontWeight: '700', color: '#e6edf3' }}>{val(state.home?.score)}</div>
+          </div>
+        </div>
+      </Card>
+
+      {isLive && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '16px' }}>
+          {/* Current batter */}
+          <Card>
+            <SectionHeader>At Bat</SectionHeader>
+            {current_batter?.id ? (
+              <Link to={`/batter/${current_batter.id}`} style={{ textDecoration: 'none' }}>
+                <div style={{ fontSize: '16px', fontWeight: '600', color: '#58a6ff' }}>{current_batter.name}</div>
+              </Link>
+            ) : (
+              <div style={{ color: '#8b949e' }}>—</div>
+            )}
+            {current_batter?.bat_side && (
+              <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '3px' }}>Bats {current_batter.bat_side}</div>
+            )}
+
+            {/* Count */}
+            <div style={{ marginTop: '12px' }}>
+              <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '4px' }}>COUNT</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <div>
+                  {[0,1,2,3].map(i => <CountBall key={i} filled={i < (count?.balls ?? 0)} />)}
+                  <span style={{ fontSize: '11px', color: '#8b949e', marginLeft: '2px' }}>B</span>
+                </div>
+                <div>
+                  {[0,1].map(i => <CountStrike key={i} filled={i < (count?.strikes ?? 0)} />)}
+                  <span style={{ fontSize: '11px', color: '#8b949e', marginLeft: '2px' }}>S</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Runners */}
+            <div style={{ marginTop: '12px' }}>
+              <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '6px' }}>RUNNERS</div>
+              <RunnerDiamond runners={runners} />
+              <div style={{ fontSize: '11px', color: '#8b949e', marginTop: '4px' }}>
+                {runners?.first ? `1B: ${runners.first}` : ''}
+                {runners?.second ? ` · 2B: ${runners.second}` : ''}
+                {runners?.third ? ` · 3B: ${runners.third}` : ''}
+              </div>
+            </div>
+          </Card>
+
+          {/* Current pitcher */}
+          <Card>
+            <SectionHeader>Pitching</SectionHeader>
+            {current_pitcher?.id ? (
+              <Link to={`/pitcher/${current_pitcher.id}`} style={{ textDecoration: 'none' }}>
+                <div style={{ fontSize: '16px', fontWeight: '600', color: '#58a6ff' }}>{current_pitcher.name}</div>
+              </Link>
+            ) : (
+              <div style={{ color: '#8b949e' }}>—</div>
+            )}
+            {current_pitcher?.pitch_hand && (
+              <div style={{ fontSize: '12px', color: '#8b949e', marginTop: '3px' }}>Throws {current_pitcher.pitch_hand}</div>
+            )}
+
+            {/* Pitch sequence */}
+            {pitch_sequence?.length > 0 && (
+              <div style={{ marginTop: '12px' }}>
+                <div style={{ fontSize: '11px', color: '#8b949e', marginBottom: '6px' }}>PITCH SEQUENCE ({pitch_sequence.length} pitches)</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                  {pitch_sequence.map((p, i) => (
+                    <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', color: '#c9d1d9', background: '#161b22', borderRadius: '4px', padding: '4px 8px' }}>
+                      <span style={{ color: '#8b949e' }}>#{i + 1}</span>
+                      <span>{p.pitch_type || '—'}</span>
+                      <span style={{ color: '#58a6ff' }}>{p.speed_mph != null ? `${Number(p.speed_mph).toFixed(1)} mph` : '—'}</span>
+                      <span style={{ color: p.call?.includes('Strike') || p.call?.includes('Foul') ? '#f85149' : p.call?.includes('Ball') ? '#3fb950' : '#8b949e' }}>
+                        {p.call || '—'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Tab: Box Score ──────────────────────────────────────────────────────────
+
+function BoxScoreTab({ boxscore }) {
+  if (!boxscore) return <div style={{ color: '#8b949e' }}>No box score data.</div>
+
+  function PitcherTable({ pitchers, title }) {
+    return (
+      <div style={{ marginBottom: '20px' }}>
+        <SectionHeader>{title} Pitchers</SectionHeader>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+            <thead>
+              <tr style={{ color: '#8b949e', borderBottom: '1px solid #30363d' }}>
+                <th style={{ textAlign: 'left', padding: '6px 8px', fontWeight: '500' }}>Pitcher</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>IP</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>H</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>R</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>ER</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>BB</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>K</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>HR</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>PC-ST</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>ERA</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pitchers.map(p => (
+                <tr key={p.id} style={{ borderBottom: '1px solid #21262d', background: p.is_current_pitcher ? '#161b22' : 'transparent' }}>
+                  <td style={{ padding: '6px 8px', color: '#e6edf3' }}>
+                    <Link to={`/pitcher/${p.id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                      {p.name}
+                    </Link>
+                    {p.is_current_pitcher && <span style={{ color: '#3fb950', fontSize: '10px', marginLeft: '6px' }}>●</span>}
+                  </td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(p.innings_pitched)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(p.hits)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(p.runs)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: p.earned_runs > 2 ? '#f85149' : '#c9d1d9' }}>{val(p.earned_runs)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(p.walks)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#3fb950' }}>{val(p.strikeouts)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: p.home_runs > 0 ? '#f85149' : '#c9d1d9' }}>{val(p.home_runs)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#8b949e', fontSize: '12px' }}>
+                    {p.pitch_count != null ? `${p.pitch_count}-${p.strikes_thrown ?? '?'}` : '—'}
+                  </td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(p.era)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
+  function BatterTable({ batters, title }) {
+    return (
+      <div style={{ marginBottom: '20px' }}>
+        <SectionHeader>{title} Batters</SectionHeader>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+            <thead>
+              <tr style={{ color: '#8b949e', borderBottom: '1px solid #30363d' }}>
+                <th style={{ textAlign: 'left', padding: '6px 8px', fontWeight: '500' }}>#</th>
+                <th style={{ textAlign: 'left', padding: '6px 8px', fontWeight: '500' }}>Batter</th>
+                <th style={{ textAlign: 'center', padding: '6px 8px', fontWeight: '500' }}>POS</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>AB</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>R</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>H</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>RBI</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>HR</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>BB</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>K</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>AVG</th>
+                <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: '500' }}>OPS</th>
+              </tr>
+            </thead>
+            <tbody>
+              {batters.map(b => (
+                <tr key={b.id} style={{ borderBottom: '1px solid #21262d' }}>
+                  <td style={{ padding: '6px 8px', color: '#484f58', fontSize: '11px' }}>
+                    {b.batting_order ? Math.floor(b.batting_order / 100) : ''}
+                  </td>
+                  <td style={{ padding: '6px 8px', color: '#e6edf3' }}>
+                    <Link to={`/batter/${b.id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                      {b.name}
+                    </Link>
+                  </td>
+                  <td style={{ textAlign: 'center', padding: '6px 8px', color: '#8b949e', fontSize: '11px' }}>{val(b.position)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(b.at_bats)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(b.runs)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: b.hits > 0 ? '#e6edf3' : '#c9d1d9', fontWeight: b.hits > 0 ? '600' : '400' }}>{val(b.hits)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: b.rbi > 0 ? '#3fb950' : '#c9d1d9' }}>{val(b.rbi)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: b.home_runs > 0 ? '#f85149' : '#c9d1d9' }}>{val(b.home_runs)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(b.walks)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#c9d1d9' }}>{val(b.strikeouts)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#8b949e' }}>{fmtAvg(b.season_avg)}</td>
+                  <td style={{ textAlign: 'right', padding: '6px 8px', color: '#8b949e' }}>{val(b.season_ops)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <PitcherTable pitchers={boxscore.away?.pitchers || []} title="Away" />
+      <BatterTable batters={boxscore.away?.batters || []} title="Away" />
+      <PitcherTable pitchers={boxscore.home?.pitchers || []} title="Home" />
+      <BatterTable batters={boxscore.home?.batters || []} title="Home" />
+    </div>
+  )
+}
+
+// ─── Tab: Play-by-Play ───────────────────────────────────────────────────────
+
+function PlaysTab({ plays }) {
+  if (!plays) return <div style={{ color: '#8b949e' }}>No play data.</div>
+  const list = plays.plays || []
+  if (!list.length) return <div style={{ color: '#8b949e' }}>No plays recorded yet.</div>
+
+  return (
+    <div>
+      <div style={{ marginBottom: '8px', fontSize: '12px', color: '#8b949e' }}>
+        Showing {list.length} of {plays.total_plays} plays (most recent first)
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+        {list.map((play, i) => (
+          <div key={i} style={{
+            background: play.is_scoring_play ? '#161b22' : '#0d1117',
+            border: `1px solid ${play.is_scoring_play ? '#3fb950' : '#21262d'}`,
+            borderRadius: '6px',
+            padding: '10px 14px',
+          }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px' }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '3px' }}>
+                  <span style={{ fontSize: '11px', color: '#8b949e' }}>
+                    {play.half_inning === 'top' ? '▲' : '▼'}{play.inning}
+                  </span>
+                  <span style={{
+                    fontSize: '12px', fontWeight: '600',
+                    color: play.event_type === 'home_run' ? '#f85149' : play.is_scoring_play ? '#3fb950' : '#e6edf3',
+                  }}>
+                    {play.event || '—'}
+                  </span>
+                  {play.rbi > 0 && (
+                    <span style={{ fontSize: '11px', background: '#3fb95022', border: '1px solid #3fb95044', borderRadius: '3px', padding: '1px 5px', color: '#3fb950' }}>
+                      {play.rbi} RBI
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: '12px', color: '#8b949e' }}>{play.description}</div>
+              </div>
+              <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                <div style={{ fontSize: '13px', fontWeight: '600', color: '#e6edf3' }}>
+                  {play.away_score}–{play.home_score}
+                </div>
+                {play.hit_data && (
+                  <div style={{ fontSize: '11px', color: '#58a6ff', marginTop: '3px' }}>
+                    {play.hit_data.exit_velocity != null && `${Number(play.hit_data.exit_velocity).toFixed(1)} mph`}
+                    {play.hit_data.distance != null && ` · ${Math.round(play.hit_data.distance)} ft`}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div style={{ marginTop: '6px', fontSize: '12px', color: '#484f58', display: 'flex', gap: '12px' }}>
+              {play.batter?.name && (
+                <Link to={`/batter/${play.batter.id}`} style={{ color: '#484f58', textDecoration: 'none' }}>
+                  {play.batter.name}
+                </Link>
+              )}
+              {play.pitcher?.name && (
+                <span>vs <Link to={`/pitcher/${play.pitcher.id}`} style={{ color: '#484f58', textDecoration: 'none' }}>{play.pitcher.name}</Link></span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ─── Tab: Linescore ──────────────────────────────────────────────────────────
+
+function LinescoreTab({ linescore }) {
+  if (!linescore) return <div style={{ color: '#8b949e' }}>No linescore data.</div>
+  const innings = linescore.innings || []
+
+  return (
+    <div>
+      <Card>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
+            <thead>
+              <tr style={{ color: '#8b949e', borderBottom: '1px solid #30363d' }}>
+                <th style={{ textAlign: 'left', padding: '6px 10px', fontWeight: '500' }}>Team</th>
+                {innings.map(inn => (
+                  <th key={inn.num} style={{ textAlign: 'center', padding: '6px 8px', fontWeight: '500', minWidth: '28px' }}>{inn.num}</th>
+                ))}
+                <th style={{ textAlign: 'right', padding: '6px 10px', fontWeight: '600', color: '#e6edf3', borderLeft: '1px solid #30363d' }}>R</th>
+                <th style={{ textAlign: 'right', padding: '6px 10px', fontWeight: '500' }}>H</th>
+                <th style={{ textAlign: 'right', padding: '6px 10px', fontWeight: '500' }}>E</th>
+                <th style={{ textAlign: 'right', padding: '6px 10px', fontWeight: '500' }}>LOB</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                { key: 'away', label: linescore.away_team || 'Away', runsKey: 'away_runs', hitsKey: 'away_hits', errKey: 'away_errors' },
+                { key: 'home', label: linescore.home_team || 'Home', runsKey: 'home_runs', hitsKey: 'home_hits', errKey: 'home_errors' },
+              ].map(row => (
+                <tr key={row.key} style={{ borderBottom: '1px solid #21262d' }}>
+                  <td style={{ padding: '8px 10px', fontWeight: '600', color: '#e6edf3' }}>{row.label}</td>
+                  {innings.map(inn => (
+                    <td key={inn.num} style={{ textAlign: 'center', padding: '8px 8px', color: inn[row.runsKey] > 0 ? '#e6edf3' : '#484f58' }}>
+                      {inn[row.runsKey] != null ? inn[row.runsKey] : '—'}
+                    </td>
+                  ))}
+                  <td style={{ textAlign: 'right', padding: '8px 10px', fontWeight: '700', fontSize: '15px', color: '#e6edf3', borderLeft: '1px solid #30363d' }}>
+                    {val(linescore.totals?.[row.key]?.runs)}
+                  </td>
+                  <td style={{ textAlign: 'right', padding: '8px 10px', color: '#c9d1d9' }}>{val(linescore.totals?.[row.key]?.hits)}</td>
+                  <td style={{ textAlign: 'right', padding: '8px 10px', color: linescore.totals?.[row.key]?.errors > 0 ? '#f85149' : '#c9d1d9' }}>
+                    {val(linescore.totals?.[row.key]?.errors)}
+                  </td>
+                  <td style={{ textAlign: 'right', padding: '8px 10px', color: '#8b949e' }}>{val(linescore.totals?.[row.key]?.left_on_base)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Decisions */}
+        {linescore.decisions && (linescore.decisions.winner || linescore.decisions.loser) && (
+          <div style={{ marginTop: '16px', paddingTop: '12px', borderTop: '1px solid #21262d', display: 'flex', gap: '20px', fontSize: '13px' }}>
+            {linescore.decisions.winner && (
+              <span>
+                <span style={{ color: '#8b949e' }}>W: </span>
+                <Link to={`/pitcher/${linescore.decisions.winner.id}`} style={{ color: '#3fb950', textDecoration: 'none' }}>
+                  {linescore.decisions.winner.name}
+                </Link>
+              </span>
+            )}
+            {linescore.decisions.loser && (
+              <span>
+                <span style={{ color: '#8b949e' }}>L: </span>
+                <Link to={`/pitcher/${linescore.decisions.loser.id}`} style={{ color: '#f85149', textDecoration: 'none' }}>
+                  {linescore.decisions.loser.name}
+                </Link>
+              </span>
+            )}
+            {linescore.decisions.save && (
+              <span>
+                <span style={{ color: '#8b949e' }}>S: </span>
+                <Link to={`/pitcher/${linescore.decisions.save.id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                  {linescore.decisions.save.name}
+                </Link>
+              </span>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+
+const TABS = [
+  { id: 'live', label: 'Live' },
+  { id: 'boxscore', label: 'Box Score' },
+  { id: 'plays', label: 'Play-by-Play' },
+  { id: 'linescore', label: 'Linescore' },
+]
+
+export default function LiveGamePage() {
+  const { game_pk } = useParams()
+  const [activeTab, setActiveTab] = useState('live')
+  const [state, setState] = useState(null)
+  const [boxscore, setBoxscore] = useState(null)
+  const [plays, setPlays] = useState(null)
+  const [linescore, setLinescore] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [lastRefresh, setLastRefresh] = useState(null)
+  const timerRef = useRef(null)
+
+  function fetchAll() {
+    Promise.all([
+      fetch(`${API_BASE}/live/game/${game_pk}`).then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText))),
+      fetch(`${API_BASE}/live/game/${game_pk}/boxscore`).then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch(`${API_BASE}/live/game/${game_pk}/plays`).then(r => r.ok ? r.json() : null).catch(() => null),
+      fetch(`${API_BASE}/live/game/${game_pk}/linescore`).then(r => r.ok ? r.json() : null).catch(() => null),
+    ])
+      .then(([s, b, p, l]) => {
+        setState(s)
+        setBoxscore(b)
+        setPlays(p)
+        setLinescore(l)
+        setLastRefresh(new Date())
+        setLoading(false)
+        setError(null)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    fetchAll()
+  }, [game_pk])
+
+  useEffect(() => {
+    if (state?.status === 'Live') {
+      timerRef.current = setInterval(fetchAll, REFRESH_LIVE_MS)
+    }
+    return () => clearInterval(timerRef.current)
+  }, [state?.status, game_pk])
+
+  if (loading) return <div style={{ color: '#8b949e', padding: '40px' }}>Loading game data…</div>
+  if (error) return (
+    <div style={{ padding: '40px' }}>
+      <Link to="/live" style={{ color: '#58a6ff', textDecoration: 'none', fontSize: '13px' }}>← Scoreboard</Link>
+      <div style={{ color: '#f85149', marginTop: '12px' }}>Error: {error}</div>
+    </div>
+  )
+
+  const away = state?.away
+  const home = state?.home
+  const isLive = state?.status === 'Live'
+
+  return (
+    <div>
+      {/* Header */}
+      <div style={{ marginBottom: '20px' }}>
+        <Link to="/live" style={{ color: '#58a6ff', textDecoration: 'none', fontSize: '13px' }}>← Scoreboard</Link>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '10px' }}>
+          <h1 style={{ margin: 0, fontSize: '20px', fontWeight: '700', color: '#e6edf3' }}>
+            {away?.abbreviation || away?.name} @ {home?.abbreviation || home?.name}
+          </h1>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            {isLive && (
+              <span style={{ fontSize: '12px', color: '#3fb950', background: '#3fb95022', border: '1px solid #3fb95044', borderRadius: '4px', padding: '2px 8px' }}>
+                ● LIVE · {state?.inning_state} {state?.inning}
+              </span>
+            )}
+            {lastRefresh && (
+              <span style={{ fontSize: '11px', color: '#8b949e' }}>{lastRefresh.toLocaleTimeString()}</span>
+            )}
+            <button
+              onClick={fetchAll}
+              style={{ background: '#21262d', border: '1px solid #30363d', color: '#e6edf3', borderRadius: '6px', padding: '5px 12px', cursor: 'pointer', fontSize: '12px' }}
+            >
+              ↻
+            </button>
+          </div>
+        </div>
+        {state?.status && !isLive && (
+          <div style={{ fontSize: '13px', color: '#8b949e', marginTop: '4px' }}>{state.status_detail || state.status}</div>
+        )}
+      </div>
+
+      {/* Tabs */}
+      <div style={{ display: 'flex', gap: '4px', marginBottom: '20px', borderBottom: '1px solid #30363d', paddingBottom: '0' }}>
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              borderBottom: activeTab === tab.id ? '2px solid #58a6ff' : '2px solid transparent',
+              color: activeTab === tab.id ? '#e6edf3' : '#8b949e',
+              fontSize: '14px',
+              fontWeight: activeTab === tab.id ? '600' : '400',
+              padding: '8px 16px',
+              cursor: 'pointer',
+              marginBottom: '-1px',
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'live' && <LiveTab state={state} />}
+      {activeTab === 'boxscore' && <BoxScoreTab boxscore={boxscore} />}
+      {activeTab === 'plays' && <PlaysTab plays={plays} />}
+      {activeTab === 'linescore' && <LinescoreTab linescore={linescore} />}
+    </div>
+  )
+}

--- a/frontend/src/pages/LiveScoreboardPage.jsx
+++ b/frontend/src/pages/LiveScoreboardPage.jsx
@@ -1,0 +1,265 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { API_BASE } from '../lib/api'
+
+const REFRESH_INTERVAL_MS = 30_000
+
+const STATUS_COLORS = {
+  Live: '#3fb950',
+  Final: '#8b949e',
+  Preview: '#58a6ff',
+  'Pre-Game': '#58a6ff',
+  Warmup: '#d29922',
+  Delayed: '#d29922',
+  Postponed: '#f85149',
+  Suspended: '#f85149',
+}
+
+function statusColor(abstract, detail) {
+  if (abstract === 'Live') return STATUS_COLORS.Live
+  if (abstract === 'Final') return STATUS_COLORS.Final
+  return STATUS_COLORS[detail] || STATUS_COLORS[abstract] || '#8b949e'
+}
+
+function statusLabel(abstract, detail, inning, inningState) {
+  if (abstract === 'Live' && inning) return `${inningState || ''} ${inning}`.trim()
+  return detail || abstract || '—'
+}
+
+function WeatherBadge({ weather }) {
+  if (!weather) return null
+  const parts = [weather.condition, weather.temp_f ? `${weather.temp_f}°F` : null, weather.wind].filter(Boolean)
+  if (!parts.length) return null
+  return (
+    <span style={{ fontSize: '11px', color: '#8b949e' }}>{parts.join(' · ')}</span>
+  )
+}
+
+function ProbablePitcher({ label, pitcher }) {
+  if (!pitcher) return <span style={{ color: '#8b949e', fontSize: '12px' }}>{label}: TBD</span>
+  return (
+    <span style={{ fontSize: '12px', color: '#c9d1d9' }}>
+      <span style={{ color: '#8b949e' }}>{label}: </span>
+      <Link to={`/pitcher/${pitcher.id}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+        {pitcher.name}
+      </Link>
+    </span>
+  )
+}
+
+function DecisionLine({ decisions }) {
+  if (!decisions) return null
+  const parts = []
+  if (decisions.winner) parts.push(`W: ${decisions.winner.name}`)
+  if (decisions.loser) parts.push(`L: ${decisions.loser.name}`)
+  if (decisions.save) parts.push(`S: ${decisions.save.name}`)
+  if (!parts.length) return null
+  return (
+    <div style={{ fontSize: '11px', color: '#8b949e', marginTop: '4px' }}>
+      {parts.join('  ·  ')}
+    </div>
+  )
+}
+
+function GameCard({ game }) {
+  const color = statusColor(game.status_abstract, game.status_detail)
+  const label = statusLabel(game.status_abstract, game.status_detail, game.inning, game.inning_state)
+  const isLive = game.status_abstract === 'Live'
+  const isFinal = game.status_abstract === 'Final'
+
+  return (
+    <Link to={`/live/${game.game_pk}`} style={{ textDecoration: 'none' }}>
+      <div style={{
+        background: '#0d1117',
+        border: `1px solid ${isLive ? '#3fb950' : '#30363d'}`,
+        borderRadius: '8px',
+        padding: '16px',
+        cursor: 'pointer',
+        transition: 'border-color 0.15s',
+      }}>
+        {/* Status badge */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+          <span style={{
+            fontSize: '11px',
+            fontWeight: '600',
+            color: color,
+            background: `${color}22`,
+            border: `1px solid ${color}44`,
+            borderRadius: '4px',
+            padding: '2px 7px',
+          }}>
+            {isLive && <span style={{ marginRight: '4px' }}>●</span>}
+            {label}
+          </span>
+          <span style={{ fontSize: '11px', color: '#8b949e' }}>{game.venue || ''}</span>
+        </div>
+
+        {/* Score row */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          {[
+            { side: game.away, label: 'Away' },
+            { side: game.home, label: 'Home' },
+          ].map(({ side }) => (
+            <div key={side.team_id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span style={{ fontSize: '15px', fontWeight: '600', color: '#e6edf3' }}>
+                {side.abbreviation || side.name}
+              </span>
+              <span style={{
+                fontSize: '22px',
+                fontWeight: '700',
+                color: (isFinal || isLive) ? '#e6edf3' : '#484f58',
+                minWidth: '28px',
+                textAlign: 'right',
+              }}>
+                {side.score != null ? side.score : '—'}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Outs indicator for live games */}
+        {isLive && game.outs != null && (
+          <div style={{ marginTop: '8px', display: 'flex', gap: '4px', alignItems: 'center' }}>
+            <span style={{ fontSize: '11px', color: '#8b949e', marginRight: '4px' }}>Outs:</span>
+            {[0, 1, 2].map(i => (
+              <span key={i} style={{
+                width: '8px', height: '8px', borderRadius: '50%',
+                background: i < game.outs ? '#d29922' : '#21262d',
+                border: '1px solid #30363d',
+                display: 'inline-block',
+              }} />
+            ))}
+          </div>
+        )}
+
+        {/* Probable pitchers for preview games */}
+        {!isFinal && (
+          <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column', gap: '3px' }}>
+            <ProbablePitcher label={game.away.abbreviation} pitcher={game.away.probable_pitcher} />
+            <ProbablePitcher label={game.home.abbreviation} pitcher={game.home.probable_pitcher} />
+          </div>
+        )}
+
+        {/* Decisions for final games */}
+        {isFinal && <DecisionLine decisions={game.decisions} />}
+
+        {/* Weather */}
+        {game.weather && (
+          <div style={{ marginTop: '8px' }}>
+            <WeatherBadge weather={game.weather} />
+          </div>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+export default function LiveScoreboardPage() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [lastRefresh, setLastRefresh] = useState(null)
+  const timerRef = useRef(null)
+
+  function fetchScoreboard() {
+    fetch(`${API_BASE}/live/scoreboard`)
+      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
+      .then(d => {
+        setData(d)
+        setLastRefresh(new Date())
+        setLoading(false)
+        setError(null)
+      })
+      .catch(e => {
+        setError(String(e))
+        setLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    fetchScoreboard()
+    timerRef.current = setInterval(fetchScoreboard, REFRESH_INTERVAL_MS)
+    return () => clearInterval(timerRef.current)
+  }, [])
+
+  if (loading) return <div style={{ color: '#8b949e', padding: '40px' }}>Loading scoreboard…</div>
+  if (error) return <div style={{ color: '#f85149', padding: '40px' }}>Error: {error}</div>
+
+  const games = data?.games || []
+  const liveGames = games.filter(g => g.status_abstract === 'Live')
+  const previewGames = games.filter(g => g.status_abstract === 'Preview')
+  const finalGames = games.filter(g => g.status_abstract === 'Final')
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
+        <div>
+          <h1 style={{ margin: 0, fontSize: '22px', fontWeight: '700', color: '#e6edf3' }}>
+            Live Scoreboard
+          </h1>
+          <div style={{ fontSize: '13px', color: '#8b949e', marginTop: '4px' }}>
+            {data?.date} · {games.length} games
+            {liveGames.length > 0 && (
+              <span style={{ color: '#3fb950', marginLeft: '8px' }}>● {liveGames.length} live</span>
+            )}
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          {lastRefresh && (
+            <span style={{ fontSize: '11px', color: '#8b949e' }}>
+              Updated {lastRefresh.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            onClick={fetchScoreboard}
+            style={{
+              background: '#21262d', border: '1px solid #30363d', color: '#e6edf3',
+              borderRadius: '6px', padding: '6px 14px', cursor: 'pointer', fontSize: '13px',
+            }}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {games.length === 0 && (
+        <div style={{ color: '#8b949e', textAlign: 'center', padding: '60px 0' }}>
+          No games scheduled for {data?.date}.
+        </div>
+      )}
+
+      {liveGames.length > 0 && (
+        <section style={{ marginBottom: '32px' }}>
+          <h2 style={{ fontSize: '13px', fontWeight: '600', color: '#3fb950', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '12px' }}>
+            ● In Progress
+          </h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '12px' }}>
+            {liveGames.map(g => <GameCard key={g.game_pk} game={g} />)}
+          </div>
+        </section>
+      )}
+
+      {previewGames.length > 0 && (
+        <section style={{ marginBottom: '32px' }}>
+          <h2 style={{ fontSize: '13px', fontWeight: '600', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '12px' }}>
+            Upcoming
+          </h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '12px' }}>
+            {previewGames.map(g => <GameCard key={g.game_pk} game={g} />)}
+          </div>
+        </section>
+      )}
+
+      {finalGames.length > 0 && (
+        <section>
+          <h2 style={{ fontSize: '13px', fontWeight: '600', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '12px' }}>
+            Final
+          </h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', gap: '12px' }}>
+            {finalGames.map(g => <GameCard key={g.game_pk} game={g} />)}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -19,6 +19,11 @@ Endpoints:
     GET  /players/all                    All active MLB players for a season
     GET  /team/{team_id}/roster          Full roster for a team
     POST /predict                        Score a specific pitcher vs batter
+    GET  /live/scoreboard                Today's games: scores, status, weather, probable pitchers
+    GET  /live/game/{pk}                 Current play state: batter, pitcher, count, runners, pitch sequence
+    GET  /live/game/{pk}/boxscore        In-game pitcher lines + batter lines (AB/H/R/RBI/K)
+    GET  /live/game/{pk}/plays           Recent play-by-play with hit data (exit velo, distance)
+    GET  /live/game/{pk}/linescore       Inning-by-inning runs/hits/errors + game decisions
 """
 
 from __future__ import annotations
@@ -26,6 +31,7 @@ from __future__ import annotations
 import datetime
 import os
 import re
+import time
 from typing import Any, Dict, List, Optional
 
 import requests as _req
@@ -68,6 +74,7 @@ from .statcast_utils import fetch_pitch_arsenal_leaderboard
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
+LIVE_CACHE: Dict[str, Dict[str, Any]] = {}
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
 OUTCOME_EVENTS = {
@@ -575,6 +582,36 @@ def _fetch_previous_completed_game_lineup(team_id: int, game_date_iso: str) -> L
         except Exception:
             continue
     return []
+
+
+def _live_cache_get(key: str) -> Optional[Any]:
+    entry = LIVE_CACHE.get(key)
+    if entry and time.time() < entry["expires_at"]:
+        return entry["data"]
+    return None
+
+
+def _live_cache_set(key: str, data: Any, ttl: int = 30) -> None:
+    LIVE_CACHE[key] = {"data": data, "expires_at": time.time() + ttl}
+
+
+def _fetch_live_feed(game_pk: int) -> Optional[Dict[str, Any]]:
+    """Fetch and TTL-cache the full MLB live feed for a single game."""
+    cache_key = f"feed:{game_pk}"
+    cached = _live_cache_get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        resp = _req.get(
+            f"https://statsapi.mlb.com/api/v1.1/game/{game_pk}/feed/live",
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        _live_cache_set(cache_key, data, ttl=20)
+        return data
+    except Exception:
+        return None
 
 
 class PredictRequest(BaseModel):
@@ -1366,6 +1403,335 @@ def create_app():
                 pitcher_throws=req.pitcher_throws,
             )
         return {"pitcher_id": req.pitcher_id, "batter_id": req.batter_id, **result}
+
+    # ------------------------------------------------------------------
+    # LIVE DATA — 5 endpoints, all backed by MLB Stats API + TTL cache
+    # ------------------------------------------------------------------
+
+    @app.get("/live/scoreboard")
+    def live_scoreboard(date: Optional[str] = None) -> Dict[str, Any]:
+        """Today's games: scores, status, inning, weather, probable pitchers, decisions."""
+        target_date = date or datetime.date.today().isoformat()
+        cache_key = f"scoreboard:{target_date}"
+        cached = _live_cache_get(cache_key)
+        if cached is not None:
+            return cached
+        try:
+            resp = _req.get(
+                f"{MLB_STATS_BASE}/schedule",
+                params={
+                    "sportId": 1,
+                    "date": target_date,
+                    "hydrate": "linescore,decisions,probablePitcher,weather,flags",
+                },
+                timeout=15,
+            )
+            resp.raise_for_status()
+            raw = resp.json()
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail=f"MLB API error: {exc}")
+
+        games = []
+        for date_entry in raw.get("dates", []):
+            for g in date_entry.get("games", []):
+                status = g.get("status", {})
+                teams = g.get("teams", {})
+                away = teams.get("away", {})
+                home = teams.get("home", {})
+                away_team = away.get("team", {})
+                home_team = home.get("team", {})
+                linescore = g.get("linescore", {})
+                away_prob = away.get("probablePitcher") or {}
+                home_prob = home.get("probablePitcher") or {}
+                decisions = g.get("decisions") or {}
+                winner = decisions.get("winner") or {}
+                loser = decisions.get("loser") or {}
+                save = decisions.get("save") or {}
+                games.append({
+                    "game_pk": g.get("gamePk"),
+                    "game_datetime": g.get("gameDate"),
+                    "venue": (g.get("venue") or {}).get("name"),
+                    "status_code": status.get("statusCode"),
+                    "status_abstract": status.get("abstractGameState"),
+                    "status_detail": status.get("detailedState"),
+                    "inning": linescore.get("currentInning"),
+                    "inning_state": linescore.get("inningState"),
+                    "outs": linescore.get("outs"),
+                    "away": {
+                        "team_id": away_team.get("id"),
+                        "name": away_team.get("name"),
+                        "abbreviation": away_team.get("abbreviation"),
+                        "score": away.get("score"),
+                        "probable_pitcher": {"id": away_prob.get("id"), "name": away_prob.get("fullName")} if away_prob.get("id") else None,
+                    },
+                    "home": {
+                        "team_id": home_team.get("id"),
+                        "name": home_team.get("name"),
+                        "abbreviation": home_team.get("abbreviation"),
+                        "score": home.get("score"),
+                        "probable_pitcher": {"id": home_prob.get("id"), "name": home_prob.get("fullName")} if home_prob.get("id") else None,
+                    },
+                    "weather": _extract_weather(g),
+                    "decisions": {
+                        "winner": {"id": winner.get("id"), "name": winner.get("fullName")} if winner.get("id") else None,
+                        "loser": {"id": loser.get("id"), "name": loser.get("fullName")} if loser.get("id") else None,
+                        "save": {"id": save.get("id"), "name": save.get("fullName")} if save.get("id") else None,
+                    },
+                })
+        result = {"date": target_date, "game_count": len(games), "games": games}
+        is_live = any(g["status_abstract"] == "Live" for g in games)
+        _live_cache_set(cache_key, result, ttl=20 if is_live else 60)
+        return result
+
+    @app.get("/live/game/{game_pk}")
+    def live_game_state(game_pk: int) -> Dict[str, Any]:
+        """Current play: batter, pitcher, count, outs, runners on base, pitch sequence."""
+        feed = _fetch_live_feed(game_pk)
+        if feed is None:
+            raise HTTPException(status_code=502, detail="Could not fetch live game feed")
+        game_data = feed.get("gameData", {})
+        live_data = feed.get("liveData", {})
+        status = game_data.get("status", {})
+        teams = game_data.get("teams", {})
+        linescore = live_data.get("linescore", {})
+        current_play = live_data.get("plays", {}).get("currentPlay") or {}
+        matchup = current_play.get("matchup", {})
+        batter = matchup.get("batter") or {}
+        pitcher = matchup.get("pitcher") or {}
+        count = current_play.get("count") or {}
+        offense = linescore.get("offense") or {}
+        ls_teams = linescore.get("teams") or {}
+
+        pitch_sequence = []
+        for event in current_play.get("playEvents", []):
+            if not event.get("isPitch"):
+                continue
+            pd = event.get("pitchData") or {}
+            details = event.get("details") or {}
+            pitch_sequence.append({
+                "pitch_type": (details.get("type") or {}).get("description"),
+                "call": (details.get("call") or {}).get("description"),
+                "speed_mph": pd.get("startSpeed"),
+                "zone": pd.get("zone"),
+                "spin_rate": (pd.get("breaks") or {}).get("spinRate"),
+                "induced_vert_break": (pd.get("breaks") or {}).get("breakVerticalInduced"),
+                "horiz_break": (pd.get("breaks") or {}).get("breakHorizontal"),
+            })
+
+        return {
+            "game_pk": game_pk,
+            "status": status.get("abstractGameState"),
+            "status_detail": status.get("detailedState"),
+            "inning": linescore.get("currentInning"),
+            "inning_state": linescore.get("inningState"),
+            "outs": linescore.get("outs"),
+            "away": {
+                "team_id": (teams.get("away") or {}).get("id"),
+                "name": (teams.get("away") or {}).get("name"),
+                "abbreviation": (teams.get("away") or {}).get("abbreviation"),
+                "score": ls_teams.get("away", {}).get("runs"),
+            },
+            "home": {
+                "team_id": (teams.get("home") or {}).get("id"),
+                "name": (teams.get("home") or {}).get("name"),
+                "abbreviation": (teams.get("home") or {}).get("abbreviation"),
+                "score": ls_teams.get("home", {}).get("runs"),
+            },
+            "current_batter": {
+                "id": batter.get("id"),
+                "name": batter.get("fullName"),
+                "bat_side": (matchup.get("batSide") or {}).get("code"),
+            },
+            "current_pitcher": {
+                "id": pitcher.get("id"),
+                "name": pitcher.get("fullName"),
+                "pitch_hand": (matchup.get("pitchHand") or {}).get("code"),
+            },
+            "count": {
+                "balls": count.get("balls"),
+                "strikes": count.get("strikes"),
+                "outs": count.get("outs"),
+            },
+            "runners": {
+                "first": (offense.get("first") or {}).get("fullName"),
+                "second": (offense.get("second") or {}).get("fullName"),
+                "third": (offense.get("third") or {}).get("fullName"),
+            },
+            "pitch_sequence": pitch_sequence,
+        }
+
+    @app.get("/live/game/{game_pk}/boxscore")
+    def live_boxscore(game_pk: int) -> Dict[str, Any]:
+        """All pitcher lines (IP/H/ER/BB/K/ERA) and batter lines (AB/H/R/RBI/HR/OPS) for the game."""
+        feed = _fetch_live_feed(game_pk)
+        if feed is None:
+            raise HTTPException(status_code=502, detail="Could not fetch live game feed")
+        boxscore = feed.get("liveData", {}).get("boxscore", {})
+        bs_teams = boxscore.get("teams", {})
+
+        def parse_pitchers(side: Dict) -> List[Dict]:
+            players = side.get("players") or {}
+            result = []
+            for pid in side.get("pitchers", []):
+                p = players.get(f"ID{pid}") or {}
+                gs = p.get("gameStatus") or {}
+                stats = (p.get("stats") or {}).get("pitching") or {}
+                season = (p.get("seasonStats") or {}).get("pitching") or {}
+                result.append({
+                    "id": pid,
+                    "name": (p.get("person") or {}).get("fullName"),
+                    "innings_pitched": stats.get("inningsPitched"),
+                    "hits": stats.get("hits"),
+                    "runs": stats.get("runs"),
+                    "earned_runs": stats.get("earnedRuns"),
+                    "walks": stats.get("baseOnBalls"),
+                    "strikeouts": stats.get("strikeOuts"),
+                    "home_runs": stats.get("homeRuns"),
+                    "pitch_count": stats.get("pitchesThrown"),
+                    "strikes_thrown": stats.get("strikes"),
+                    "era": season.get("era"),
+                    "is_current_pitcher": gs.get("isCurrentPitcher", False),
+                })
+            return result
+
+        def parse_batters(side: Dict) -> List[Dict]:
+            players = side.get("players") or {}
+            result = []
+            for bid in side.get("batters", []):
+                p = players.get(f"ID{bid}") or {}
+                stats = (p.get("stats") or {}).get("batting") or {}
+                season = (p.get("seasonStats") or {}).get("batting") or {}
+                pos = (p.get("position") or {}).get("abbreviation")
+                result.append({
+                    "id": bid,
+                    "name": (p.get("person") or {}).get("fullName"),
+                    "position": pos,
+                    "batting_order": p.get("battingOrder"),
+                    "at_bats": stats.get("atBats"),
+                    "runs": stats.get("runs"),
+                    "hits": stats.get("hits"),
+                    "rbi": stats.get("rbi"),
+                    "home_runs": stats.get("homeRuns"),
+                    "walks": stats.get("baseOnBalls"),
+                    "strikeouts": stats.get("strikeOuts"),
+                    "left_on_base": stats.get("leftOnBase"),
+                    "season_avg": season.get("avg"),
+                    "season_ops": season.get("ops"),
+                })
+            return result
+
+        return {
+            "game_pk": game_pk,
+            "away": {
+                "pitchers": parse_pitchers(bs_teams.get("away") or {}),
+                "batters": parse_batters(bs_teams.get("away") or {}),
+            },
+            "home": {
+                "pitchers": parse_pitchers(bs_teams.get("home") or {}),
+                "batters": parse_batters(bs_teams.get("home") or {}),
+            },
+        }
+
+    @app.get("/live/game/{game_pk}/plays")
+    def live_plays(game_pk: int, limit: int = Query(default=25, le=100)) -> Dict[str, Any]:
+        """Recent play-by-play: event, description, RBI, score change, hit data (exit velo/distance)."""
+        feed = _fetch_live_feed(game_pk)
+        if feed is None:
+            raise HTTPException(status_code=502, detail="Could not fetch live game feed")
+        plays_data = feed.get("liveData", {}).get("plays", {})
+        all_plays = plays_data.get("allPlays") or []
+        completed = [p for p in all_plays if (p.get("about") or {}).get("isComplete")]
+        recent = list(reversed(completed[-limit:]))
+
+        result = []
+        for play in recent:
+            about = play.get("about") or {}
+            res = play.get("result") or {}
+            matchup = play.get("matchup") or {}
+            hit_data = None
+            for event in reversed(play.get("playEvents") or []):
+                hd = event.get("hitData")
+                if hd:
+                    hit_data = {
+                        "exit_velocity": hd.get("launchSpeed"),
+                        "launch_angle": hd.get("launchAngle"),
+                        "distance": hd.get("totalDistance"),
+                        "hardness": hd.get("hardness"),
+                    }
+                    break
+            result.append({
+                "play_index": about.get("atBatIndex"),
+                "inning": about.get("inning"),
+                "half_inning": about.get("halfInning"),
+                "is_scoring_play": about.get("isScoringPlay", False),
+                "batter": {"id": (matchup.get("batter") or {}).get("id"), "name": (matchup.get("batter") or {}).get("fullName")},
+                "pitcher": {"id": (matchup.get("pitcher") or {}).get("id"), "name": (matchup.get("pitcher") or {}).get("fullName")},
+                "event": res.get("event"),
+                "event_type": res.get("eventType"),
+                "description": res.get("description"),
+                "rbi": res.get("rbi"),
+                "away_score": res.get("awayScore"),
+                "home_score": res.get("homeScore"),
+                "hit_data": hit_data,
+            })
+        return {"game_pk": game_pk, "total_plays": len(all_plays), "plays": result}
+
+    @app.get("/live/game/{game_pk}/linescore")
+    def live_linescore(game_pk: int) -> Dict[str, Any]:
+        """Inning-by-inning runs/hits/errors, totals, outs, and game decisions (W/L/S pitcher)."""
+        feed = _fetch_live_feed(game_pk)
+        if feed is None:
+            raise HTTPException(status_code=502, detail="Could not fetch live game feed")
+        live_data = feed.get("liveData", {})
+        game_data = feed.get("gameData", {})
+        linescore = live_data.get("linescore", {})
+        ls_teams = linescore.get("teams") or {}
+        gd_teams = game_data.get("teams") or {}
+        decisions = live_data.get("decisions") or {}
+        winner = decisions.get("winner") or {}
+        loser = decisions.get("loser") or {}
+        save = decisions.get("save") or {}
+
+        innings = []
+        for inn in linescore.get("innings", []):
+            innings.append({
+                "num": inn.get("num"),
+                "away_runs": (inn.get("away") or {}).get("runs"),
+                "away_hits": (inn.get("away") or {}).get("hits"),
+                "away_errors": (inn.get("away") or {}).get("errors"),
+                "home_runs": (inn.get("home") or {}).get("runs"),
+                "home_hits": (inn.get("home") or {}).get("hits"),
+                "home_errors": (inn.get("home") or {}).get("errors"),
+            })
+
+        return {
+            "game_pk": game_pk,
+            "away_team": (gd_teams.get("away") or {}).get("abbreviation"),
+            "home_team": (gd_teams.get("home") or {}).get("abbreviation"),
+            "innings": innings,
+            "totals": {
+                "away": {
+                    "runs": ls_teams.get("away", {}).get("runs"),
+                    "hits": ls_teams.get("away", {}).get("hits"),
+                    "errors": ls_teams.get("away", {}).get("errors"),
+                    "left_on_base": ls_teams.get("away", {}).get("leftOnBase"),
+                },
+                "home": {
+                    "runs": ls_teams.get("home", {}).get("runs"),
+                    "hits": ls_teams.get("home", {}).get("hits"),
+                    "errors": ls_teams.get("home", {}).get("errors"),
+                    "left_on_base": ls_teams.get("home", {}).get("leftOnBase"),
+                },
+            },
+            "current_inning": linescore.get("currentInning"),
+            "inning_state": linescore.get("inningState"),
+            "outs": linescore.get("outs"),
+            "decisions": {
+                "winner": {"id": winner.get("id"), "name": winner.get("fullName")} if winner.get("id") else None,
+                "loser": {"id": loser.get("id"), "name": loser.get("fullName")} if loser.get("id") else None,
+                "save": {"id": save.get("id"), "name": save.get("fullName")} if save.get("id") else None,
+            },
+        }
 
     _dist = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'frontend', 'dist')
     if os.path.isdir(_dist):


### PR DESCRIPTION
Backend (mlb_app/app.py):
- TTL in-memory cache (LIVE_CACHE) with _live_cache_get/_live_cache_set helpers
- _fetch_live_feed(): fetches/caches MLB feed/live endpoint per game (20s TTL)
- GET /live/scoreboard: today's games with score, status, inning, weather, probable pitchers, decisions
- GET /live/game/{pk}: current play state — batter, pitcher, count, outs, runners, pitch sequence with speed/break
- GET /live/game/{pk}/boxscore: all pitcher lines (IP/H/ER/BB/K/ERA/PC) and batter lines (AB/H/R/RBI/HR/OPS)
- GET /live/game/{pk}/plays: recent play-by-play with hit data (exit velo, launch angle, distance)
- GET /live/game/{pk}/linescore: inning-by-inning R/H/E, totals, LOB, W/L/S decisions

Frontend:
- LiveScoreboardPage: auto-refresh 30s, game cards grouped by Live/Upcoming/Final, status badges, weather, outs indicator
- LiveGamePage: auto-refresh 15s for live games, 4 tabs (Live/Box Score/Play-by-Play/Linescore), links to pitcher/batter profiles
- App.jsx: /live and /live/:game_pk routes, Live nav link

All endpoints use existing _extract_weather helper, zero DB changes, zero ETL changes.

https://claude.ai/code/session_01Uv4Zsp6vDoMM5grzSuskbq