### PR TITLE
Fix InsightCards closing brace

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -406,6 +406,8 @@ function InsightCards({ items }) {
       ))}
     </div>
   )
+}
+
 function displayKey(key) {
   if (!key) return '—'
   const map = {


### PR DESCRIPTION
Repairs the remaining frontend build syntax error in `frontend/src/pages/MatchupDetailPage.jsx`.

Railway was failing during `npm --prefix frontend run build` with:

`Unexpected "export"` at `MatchupDetailPage.jsx:637`

Cause:
- `InsightCards` was missing its closing brace after the previous merge-marker cleanup
- the parser reached `export default` while still inside the function scope

This minimal fix:
- adds the missing closing brace after `InsightCards`
- keeps the existing analysis tab and insight-card code intact
- should unblock the next Railway frontend build step