### PR TITLE
Fix remaining InsightCards conflict markers

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -406,12 +406,8 @@ function InsightCards({ items }) {
       ))}
     </div>
   )
-<<<<<<< HEAD
 }
 
-=======
-  }
->>>>>>> upstream/sandbox/contributor-analysis
 function displayKey(key) {
   if (!key) return '—'
   const map = {


### PR DESCRIPTION
Removes the remaining Git conflict marker block inside `InsightCards` in `frontend/src/pages/MatchupDetailPage.jsx`.

Railway is currently failing during `npm --prefix frontend run build` with:

`Unexpected "<<"` at `MatchupDetailPage.jsx:409`

This minimal repair:
- removes the leftover `<<<<<<<`, `=======`, and `>>>>>>>` lines
- leaves a single clean closing brace for `InsightCards`
- keeps the existing analysis tab and insight-card code intact

Local verification after the patch showed no conflict markers and the expected ordering of `InsightCards`, `displayKey`, and `export default`.