### PR TITLE
Map existing pitcher aggregate metrics into profile output

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -452,6 +452,8 @@ function displayKey(key) {
     barrel_rate_allowed: 'Barrel Allowed',
     avg_exit_velocity_allowed: 'Avg EV Allowed',
     avg_launch_angle_allowed: 'Avg LA Allowed',
+    xwoba_allowed: 'xwOBA Allowed',
+    xba_allowed: 'xBA Allowed',
     vs_lhb_woba_allowed: 'vs LHB wOBA Allowed',
     vs_rhb_woba_allowed: 'vs RHB wOBA Allowed',
     vs_lhb_k_rate: 'vs LHB K Rate',

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -60,8 +60,14 @@ def compute_pitcher_profile(raw_stats: dict) -> dict:
             "barrel_rate_allowed": raw_stats.get(
                 "barrel_rate_allowed", raw_stats.get("barrel_pct_allowed")
             ),
-            "avg_exit_velocity_allowed": raw_stats.get("avg_exit_velocity_allowed"),
-            "avg_launch_angle_allowed": raw_stats.get("avg_launch_angle_allowed"),
+            "avg_exit_velocity_allowed": raw_stats.get(
+                "avg_exit_velocity_allowed", raw_stats.get("avg_exit_velocity")
+            ),
+            "avg_launch_angle_allowed": raw_stats.get(
+                "avg_launch_angle_allowed", raw_stats.get("avg_launch_angle")
+            ),
+            "xwoba_allowed": raw_stats.get("xwoba_allowed", raw_stats.get("xwoba")),
+            "xba_allowed": raw_stats.get("xba_allowed", raw_stats.get("xba")),
         },
         "platoon_profile": {
             "vs_lhb_woba_allowed": raw_stats.get("vs_lhb_woba_allowed"),


### PR DESCRIPTION
Maps existing pitcher aggregate metrics into the structured pitcher profile output so the new Pitcher tab can show more real values instead of blanks.

This update:
- exposes existing `xwoba` and `xba` values as `xwoba_allowed` and `xba_allowed` in the pitcher profile contact-management section
- adds fallbacks for average exit velocity and launch angle allowed when those source fields are available
- adds frontend display labels for the newly exposed pitcher profile fields
- does not introduce new derived metrics or fake unavailable data

This is a focused data-mapping improvement using values already available in the existing pitcher aggregate path.