### PR TITLE
Fix batter rolling metrics and profile QA

### DIFF
--- a/frontend/src/pages/BatterPage.jsx
+++ b/frontend/src/pages/BatterPage.jsx
@@ -21,6 +21,8 @@ const s = {
     color: '#58a6ff', textDecoration: 'none', borderRadius: '6px',
     padding: '7px 16px', fontSize: '13px', fontWeight: '500', marginBottom: '24px',
   },
+  qaBox: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '12px 14px', marginBottom: '20px', fontSize: '13px', color: '#8b949e' },
+  qaWarn: { color: '#d29922', marginTop: '6px' },
   section: { marginBottom: '28px' },
   sectionTitle: { fontSize: '16px', fontWeight: '600', color: '#e6edf3', marginBottom: '14px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
   statsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))', gap: '12px' },
@@ -70,6 +72,18 @@ function StatCard({ label, value }) {
   )
 }
 
+function DataQualityBox({ quality }) {
+  if (!quality) return null
+  const warnings = quality.warnings || []
+  return (
+    <div style={s.qaBox}>
+      <div>Data Quality: <strong style={{ color: '#e6edf3' }}>{quality.ordering_quality || 'unknown'}</strong></div>
+      <div>Latest Statcast Event: <strong style={{ color: '#e6edf3' }}>{quality.latest_event_date || '—'}</strong></div>
+      {warnings.map((w, i) => <div key={i} style={s.qaWarn}>⚠ {w}</div>)}
+    </div>
+  )
+}
+
 function SplitCard({ title, split }) {
   if (!split) return (
     <div style={s.splitCard}>
@@ -115,7 +129,7 @@ export default function BatterPage() {
   function load(pid) {
     if (!pid) return
     setLoading(true); setError(null); setResults([])
-    fetch(`${API}/batter/${pid}`)
+    fetch(`${API}/batter/${pid}/profile`)
       .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
       .then(d => { setData(d); setLoading(false) })
       .catch(e => { setError(String(e)); setLoading(false); setData(null) })
@@ -148,6 +162,7 @@ export default function BatterPage() {
   const splits = data?.splits || {}
   const yby = data?.year_by_year || []
   const agg = data?.aggregate
+  const dq = data?.data_quality
 
   return (
     <div>
@@ -184,7 +199,6 @@ export default function BatterPage() {
 
       {data && (
         <>
-          {/* Player header */}
           {info && (
             <div style={s.playerHeader}>
               <div style={s.playerName}>{info.name}</div>
@@ -198,13 +212,14 @@ export default function BatterPage() {
             </div>
           )}
 
+          <DataQualityBox quality={dq} />
+
           {id && (
             <Link to={`/batter/${id}/rolling`} style={s.rollingLink}>
-              View Rolling Stats (L10–L1000 ABs) →
+              View Rolling Stats (PA / AB / Games) →
             </Link>
           )}
 
-          {/* Live season stats */}
           {ss && (
             <div style={s.section}>
               <div style={s.sectionTitle}>
@@ -232,7 +247,6 @@ export default function BatterPage() {
             </div>
           )}
 
-          {/* Statcast metrics from DB events */}
           {sc && (
             <div style={s.section}>
               <div style={s.sectionTitle}>
@@ -252,12 +266,11 @@ export default function BatterPage() {
             </div>
           )}
 
-          {/* DB aggregate if available */}
           {agg && (
             <div style={s.section}>
               <div style={s.sectionTitle}>
                 Aggregate (DB)
-                {data.data_source && <span style={s.sourceBadge}>{data.data_source}</span>}
+                {data.aggregate_label && <span style={s.sourceBadge}>{data.aggregate_label}</span>}
               </div>
               <div style={s.statsGrid}>
                 <StatCard label="Exit Velocity" value={`${fmt(agg.avg_exit_velocity)} mph`} />
@@ -271,7 +284,6 @@ export default function BatterPage() {
             </div>
           )}
 
-          {/* Current splits */}
           {(splits.vsL || splits.vsR) && (
             <div style={s.section}>
               <div style={s.sectionTitle}>Platoon Splits — Current Season</div>
@@ -282,7 +294,6 @@ export default function BatterPage() {
             </div>
           )}
 
-          {/* Year-by-year from MLB API */}
           {yby.length > 0 && (
             <div style={s.section}>
               <div style={s.sectionTitle}>

--- a/frontend/src/pages/RollingBatterPage.jsx
+++ b/frontend/src/pages/RollingBatterPage.jsx
@@ -29,10 +29,10 @@ const s = {
   tabs: { display: 'flex', gap: '0', marginBottom: '20px', background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', overflow: 'hidden', width: 'fit-content' },
   tab: (active) => ({
     padding: '8px 18px', fontSize: '13px', fontWeight: '500', cursor: 'pointer',
-    background: active ? '#58a6ff' : 'transparent',
-    color: active ? '#0d1117' : '#8b949e',
-    border: 'none', outline: 'none',
+    background: active ? '#58a6ff' : 'transparent', color: active ? '#0d1117' : '#8b949e', border: 'none', outline: 'none',
   }),
+  qaBox: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '12px 14px', marginBottom: '20px', fontSize: '13px', color: '#8b949e' },
+  qaWarn: { color: '#d29922', marginTop: '6px' },
   tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto', marginBottom: '20px' },
   table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px', minWidth: '600px' },
   th: { padding: '12px 14px', textAlign: 'left', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
@@ -41,13 +41,10 @@ const s = {
   tdRight: { textAlign: 'right' },
   tdMuted: { color: '#8b949e' },
   sectionTitle: { fontSize: '15px', fontWeight: '600', color: '#e6edf3', marginBottom: '12px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
-  abRow: { display: 'grid', gridTemplateColumns: '90px 28px 70px auto 60px 60px 40px', gap: '4px', padding: '7px 14px', borderBottom: '1px solid #0d1117', fontSize: '13px', alignItems: 'center' },
-  abHeader: { display: 'grid', gridTemplateColumns: '90px 28px 70px auto 60px 60px 40px', gap: '4px', padding: '9px 14px', borderBottom: '1px solid #21262d', fontSize: '11px', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.5px' },
+  abRow: { display: 'grid', gridTemplateColumns: '90px 56px 56px 70px auto 60px 60px 40px', gap: '4px', padding: '7px 14px', borderBottom: '1px solid #0d1117', fontSize: '13px', alignItems: 'center' },
+  abHeader: { display: 'grid', gridTemplateColumns: '90px 56px 56px 70px auto 60px 60px 40px', gap: '4px', padding: '9px 14px', borderBottom: '1px solid #21262d', fontSize: '11px', color: '#8b949e', textTransform: 'uppercase', letterSpacing: '0.5px' },
   pagination: { display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'center', padding: '16px', fontSize: '13px', color: '#8b949e' },
-  pageBtn: (disabled) => ({
-    background: disabled ? '#21262d' : '#30363d', border: 'none', color: disabled ? '#555' : '#e6edf3',
-    borderRadius: '6px', padding: '6px 14px', cursor: disabled ? 'default' : 'pointer', fontSize: '13px',
-  }),
+  pageBtn: (disabled) => ({ background: disabled ? '#21262d' : '#30363d', border: 'none', color: disabled ? '#555' : '#e6edf3', borderRadius: '6px', padding: '6px 14px', cursor: disabled ? 'default' : 'pointer', fontSize: '13px' }),
   loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
   error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
 }
@@ -57,28 +54,25 @@ const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
 const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
 const deg = v => v != null ? `${Number(v).toFixed(1)}°` : '—'
 
-function avgColor(v) {
-  if (v == null) return '#e6edf3'
-  if (v >= 0.280) return '#3fb950'
-  if (v >= 0.240) return '#d29922'
-  return '#f85149'
-}
-function kColor(v) {
-  if (v == null) return '#e6edf3'
-  if (v <= 0.18) return '#3fb950'
-  if (v <= 0.25) return '#d29922'
-  return '#f85149'
-}
-function evColor(v) {
-  if (v == null) return '#e6edf3'
-  if (v >= 92) return '#3fb950'
-  if (v >= 88) return '#d29922'
-  return '#f85149'
+function avgColor(v) { if (v == null) return '#e6edf3'; if (v >= 0.280) return '#3fb950'; if (v >= 0.240) return '#d29922'; return '#f85149' }
+function kColor(v) { if (v == null) return '#e6edf3'; if (v <= 0.18) return '#3fb950'; if (v <= 0.25) return '#d29922'; return '#f85149' }
+function evColor(v) { if (v == null) return '#e6edf3'; if (v >= 92) return '#3fb950'; if (v >= 88) return '#d29922'; return '#f85149' }
+
+function DataQualityBox({ quality }) {
+  if (!quality) return null
+  const warnings = quality.warnings || []
+  return (
+    <div style={s.qaBox}>
+      <div>Data Quality: <strong style={{ color: '#e6edf3' }}>{quality.ordering_quality || 'unknown'}</strong></div>
+      <div>Latest Event: <strong style={{ color: '#e6edf3' }}>{quality.latest_event_date || '—'}</strong></div>
+      {warnings.map((w, i) => <div key={i} style={s.qaWarn}>⚠ {w}</div>)}
+    </div>
+  )
 }
 
 export default function RollingBatterPage() {
   const { id } = useParams()
-  const [view, setView] = useState('abs')
+  const [view, setView] = useState('pa')
   const [rolling, setRolling] = useState(null)
   const [splits, setSplits] = useState(null)
   const [abData, setAbData] = useState(null)
@@ -91,17 +85,21 @@ export default function RollingBatterPage() {
 
   useEffect(() => {
     if (!id) return
-    fetch(`${API}/batter/${id}/splits`)
+    fetch(`${API}/batter/${id}/rolling/splits?pa=200`)
       .then(r => r.ok ? r.json() : null)
-      .then(d => { if (d) setSplits(d.seasons || {}) })
+      .then(d => { if (d) setSplits(d.splits || {}) })
       .catch(() => {})
   }, [id])
 
   useEffect(() => {
     if (!id) return
-    setLoading(true)
-    const windows = view === 'abs' ? '10,25,50,100,200,400,1000' : '15,30,60,90,120,150'
-    fetch(`${API}/batter/${id}/rolling?windows=${windows}&type=${view}`)
+    setLoading(true); setError(null)
+    const endpoint = view === 'games'
+      ? `${API}/batter/${id}/rolling/games?windows=5,10,15,30`
+      : view === 'ab'
+        ? `${API}/batter/${id}/rolling/ab?windows=10,25,50,100`
+        : `${API}/batter/${id}/rolling/pa?windows=10,25,50,100,200,400,1000`
+    fetch(endpoint)
       .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
       .then(d => { setRolling(d); setLoading(false) })
       .catch(e => { setError(String(e)); setLoading(false) })
@@ -110,7 +108,7 @@ export default function RollingBatterPage() {
   const loadAbs = useCallback((page) => {
     if (!id) return
     setAbLoading(true)
-    fetch(`${API}/batter/${id}/at-bats?n=${AB_PAGE_SIZE}&offset=${page * AB_PAGE_SIZE}`)
+    fetch(`${API}/batter/${id}/at-bats/ordered?limit=${AB_PAGE_SIZE}&offset=${page * AB_PAGE_SIZE}`)
       .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
       .then(d => { setAbData(d); setAbLoading(false) })
       .catch(() => setAbLoading(false))
@@ -118,30 +116,30 @@ export default function RollingBatterPage() {
 
   useEffect(() => { loadAbs(0) }, [loadAbs])
 
-  const totalPages = abData ? Math.ceil(abData.total_abs / AB_PAGE_SIZE) : 0
+  const totalEvents = abData?.total || 0
+  const totalPages = Math.ceil(totalEvents / AB_PAGE_SIZE)
+  const rows = rolling?.windows
+    ? Object.entries(rolling.windows).map(([window, stats]) => ({ window, stats }))
+    : []
 
-  function goPage(p) {
-    setAbPage(p)
-    loadAbs(p)
-  }
-
+  function goPage(p) { setAbPage(p); loadAbs(p) }
   if (error) return <div style={s.error}>{error}</div>
-
-  const windows = rolling?.windows || []
 
   return (
     <div>
       <Link to={`/batter/${id}`} style={s.back}>← Back to Batter Profile</Link>
-
       <div style={s.header}>
         <div>
           <div style={s.title}>Rolling Stats — Batter #{id}</div>
-          <div style={s.subtitle}>Green = elite · Yellow = average · Red = below average</div>
+          <div style={s.subtitle}>Rolling PA is default. AB mode uses strict official AB filtering.</div>
         </div>
       </div>
 
+      <DataQualityBox quality={rolling?.data_quality} />
+
       <div style={s.tabs}>
-        <button style={s.tab(view === 'abs')} onClick={() => setView('abs')}>Last N At-Bats</button>
+        <button style={s.tab(view === 'pa')} onClick={() => setView('pa')}>Last N PA</button>
+        <button style={s.tab(view === 'ab')} onClick={() => setView('ab')}>Last N AB</button>
         <button style={s.tab(view === 'games')} onClick={() => setView('games')}>Last N Games</button>
       </div>
 
@@ -151,7 +149,7 @@ export default function RollingBatterPage() {
             <thead>
               <tr>
                 <th style={s.th}>Window</th>
-                <th style={s.th}>{view === 'abs' ? 'ABs' : 'Games'}</th>
+                <th style={s.th}>{view === 'games' ? 'Games' : view === 'ab' ? 'AB' : 'PA'}</th>
                 <th style={s.th}>Range</th>
                 <th style={{ ...s.th, ...s.thRight }}>AVG</th>
                 <th style={{ ...s.th, ...s.thRight }}>OBP</th>
@@ -166,20 +164,13 @@ export default function RollingBatterPage() {
               </tr>
             </thead>
             <tbody>
-              {windows.map((w, i) => {
+              {rows.map((w, i) => {
                 const st = w.stats
                 if (!st) {
-                  return (
-                    <tr key={i}>
-                      <td style={{ ...s.td, fontWeight: '600' }}>{w.window}</td>
-                      <td colSpan={12} style={{ ...s.td, ...s.tdMuted }}>Insufficient data</td>
-                    </tr>
-                  )
+                  return <tr key={i}><td style={{ ...s.td, fontWeight: '600' }}>{w.window}</td><td colSpan={12} style={{ ...s.td, ...s.tdMuted }}>Insufficient data</td></tr>
                 }
-                const count = st.actual_abs ?? st.actual_games ?? '—'
-                const dateRange = st.start_date && st.end_date
-                  ? `${st.start_date.slice(5)} – ${st.end_date.slice(5)}`
-                  : '—'
+                const count = st.actual_pa ?? st.actual_ab ?? st.actual_games ?? '—'
+                const dateRange = st.start_date && st.end_date ? `${st.start_date.slice(5)} – ${st.end_date.slice(5)}` : '—'
                 return (
                   <tr key={i}>
                     <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{w.window}</td>
@@ -205,42 +196,22 @@ export default function RollingBatterPage() {
 
       {splits && Object.keys(splits).length > 0 && (
         <div style={{ marginBottom: '24px' }}>
-          <div style={s.sectionTitle}>Historical Platoon Splits</div>
+          <div style={s.sectionTitle}>Rolling Platoon Splits</div>
           <div style={s.tableWrap}>
             <table style={s.table}>
-              <thead>
-                <tr>
-                  <th style={s.th}>Season</th>
-                  <th style={{ ...s.th, ...s.thRight }}>Split</th>
-                  <th style={{ ...s.th, ...s.thRight }}>PA</th>
-                  <th style={{ ...s.th, ...s.thRight }}>AVG</th>
-                  <th style={{ ...s.th, ...s.thRight }}>OBP</th>
-                  <th style={{ ...s.th, ...s.thRight }}>SLG</th>
-                  <th style={{ ...s.th, ...s.thRight }}>K%</th>
-                  <th style={{ ...s.th, ...s.thRight }}>BB%</th>
-                  <th style={{ ...s.th, ...s.thRight }}>HR</th>
-                </tr>
-              </thead>
+              <thead><tr><th style={s.th}>Split</th><th style={{ ...s.th, ...s.thRight }}>PA</th><th style={{ ...s.th, ...s.thRight }}>AVG</th><th style={{ ...s.th, ...s.thRight }}>K%</th><th style={{ ...s.th, ...s.thRight }}>BB%</th><th style={{ ...s.th, ...s.thRight }}>EV</th><th style={{ ...s.th, ...s.thRight }}>HH%</th></tr></thead>
               <tbody>
-                {Object.entries(splits)
-                  .sort((a, b) => Number(b[0]) - Number(a[0]))
-                  .flatMap(([season, sp]) => [
-                    { season, name: 'vsL', data: sp.vsL },
-                    { season, name: 'vsR', data: sp.vsR },
-                  ])
-                  .map((row, i) => (
-                    <tr key={`${row.season}-${row.name}-${i}`}>
-                      <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{row.season}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.name}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.pa ?? '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.batting_avg != null ? dec(row.data.batting_avg) : '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.on_base_pct != null ? dec(row.data.on_base_pct) : '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.slugging_pct != null ? dec(row.data.slugging_pct) : '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.k_pct != null ? pct(row.data.k_pct) : '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.bb_pct != null ? pct(row.data.bb_pct) : '—'}</td>
-                      <td style={{ ...s.td, ...s.tdRight }}>{row.data?.home_runs ?? '—'}</td>
-                    </tr>
-                  ))}
+                {Object.entries(splits).map(([name, st]) => st && (
+                  <tr key={name}>
+                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{name}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{st.actual_pa ?? '—'}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{dec(st.batting_avg)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.k_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.bb_pct)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{mph(st.avg_exit_velocity)}</td>
+                    <td style={{ ...s.td, ...s.tdRight }}>{pct(st.hard_hit_pct)}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -248,42 +219,27 @@ export default function RollingBatterPage() {
       )}
 
       <div style={{ marginTop: '28px' }}>
-        <div style={s.sectionTitle}>Chronological At-Bat Session</div>
-        <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '14px' }}>
-          {abData ? `${abData.total_abs.toLocaleString()} total plate appearances on record · showing ${AB_PAGE_SIZE} per page` : ''}
-        </div>
-
-        {abLoading ? <div style={s.loader}>Loading at-bats…</div> : abData && (
+        <div style={s.sectionTitle}>Chronological Plate Appearance Session</div>
+        <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '14px' }}>{abData ? `${totalEvents.toLocaleString()} total terminal PA outcomes on record · showing ${AB_PAGE_SIZE} per page` : ''}</div>
+        {abLoading ? <div style={s.loader}>Loading events…</div> : abData && (
           <div style={s.tableWrap}>
-            <div style={s.abHeader}>
-              <span>Date</span>
-              <span>Hand</span>
-              <span>Pitch</span>
-              <span>Result</span>
-              <span style={{ textAlign: 'right' }}>EV</span>
-              <span style={{ textAlign: 'right' }}>LA</span>
-              <span>Stand</span>
-            </div>
-            {abData.at_bats.map((ab, i) => {
+            <div style={s.abHeader}><span>Date</span><span>AB #</span><span>Pitch #</span><span>Pitch</span><span>Result</span><span style={{ textAlign: 'right' }}>EV</span><span style={{ textAlign: 'right' }}>LA</span><span>Stand</span></div>
+            {(abData.events || []).map((ab, i) => {
               const resultLabel = RESULT_LABELS[ab.result] || ab.result?.replace(/_/g, ' ') || '?'
               const resultColor = RESULT_COLORS[ab.result] || '#8b949e'
               return (
                 <div key={i} style={s.abRow}>
                   <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.game_date}</span>
-                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.pitcher_hand || '?'}</span>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.at_bat_number ?? '—'}</span>
+                  <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.pitch_number ?? '—'}</span>
                   <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.pitch_type || '—'}</span>
                   <span style={{ color: resultColor, fontWeight: '600' }}>{resultLabel}</span>
-                  <span style={{ color: ab.exit_velocity ? '#e6edf3' : '#8b949e', textAlign: 'right' }}>
-                    {ab.exit_velocity ? `${ab.exit_velocity.toFixed(1)}` : '—'}
-                  </span>
-                  <span style={{ color: '#8b949e', textAlign: 'right', fontSize: '12px' }}>
-                    {ab.launch_angle != null ? `${ab.launch_angle.toFixed(0)}°` : '—'}
-                  </span>
+                  <span style={{ color: ab.exit_velocity ? '#e6edf3' : '#8b949e', textAlign: 'right' }}>{ab.exit_velocity ? `${ab.exit_velocity.toFixed(1)}` : '—'}</span>
+                  <span style={{ color: '#8b949e', textAlign: 'right', fontSize: '12px' }}>{ab.launch_angle != null ? `${ab.launch_angle.toFixed(0)}°` : '—'}</span>
                   <span style={{ color: '#8b949e', fontSize: '12px' }}>{ab.batter_stand || '?'}</span>
                 </div>
               )
             })}
-
             <div style={s.pagination}>
               <button style={s.pageBtn(abPage === 0)} disabled={abPage === 0} onClick={() => goPage(abPage - 1)}>← Prev</button>
               <span>Page {abPage + 1} of {totalPages || 1}</span>

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -77,6 +77,8 @@ from .odds_provider import (
     fetch_draftkings_events,
 )
 
+from .batter_routes import router as batter_router
+
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
 LIVE_CACHE: Dict[str, Dict[str, Any]] = {}
@@ -643,6 +645,8 @@ def create_app():
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    app.include_router(batter_router)
 
     @app.get("/health")
     def health():

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, Optional
+
+import requests as _req
+from fastapi import APIRouter, Query
+
+from .database import get_engine, create_tables, get_session
+from .db_utils import (
+    get_batter_aggregate_with_fallback,
+    get_batter_at_bats,
+    get_batter_data_quality,
+    get_batter_multi_season,
+    get_batter_rolling_by_ab,
+    get_batter_rolling_by_abs,
+    get_batter_rolling_by_games,
+    get_batter_rolling_by_pa,
+    get_batter_rolling_pitch_types,
+    get_batter_rolling_splits,
+    get_player_splits_multi_season,
+)
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+router = APIRouter()
+
+
+def _get_session():
+    import os
+    db_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(db_url)
+    create_tables(engine)
+    return get_session(engine)
+
+
+def _safe_float(val) -> Optional[float]:
+    try:
+        return float(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
+    out: Dict[str, Any] = {
+        "player_info": None,
+        "season_stats": None,
+        "splits": {"vsL": None, "vsR": None},
+        "year_by_year": [],
+    }
+
+    try:
+        r = _req.get(
+            f"{MLB_STATS_BASE}/people/{player_id}",
+            params={"hydrate": "currentTeam"},
+            timeout=10,
+        )
+        if r.ok:
+            p = (r.json().get("people") or [{}])[0]
+            out["player_info"] = {
+                "name": p.get("fullName"),
+                "position": (p.get("primaryPosition") or {}).get("abbreviation"),
+                "team": (p.get("currentTeam") or {}).get("name"),
+                "bats": (p.get("batSide") or {}).get("code"),
+                "throws": (p.get("pitchHand") or {}).get("code"),
+                "birth_date": p.get("birthDate"),
+                "mlb_debut": p.get("mlbDebutDate"),
+            }
+    except Exception:
+        pass
+
+    def _parse_stat(s: dict) -> Dict[str, Any]:
+        pa = s.get("plateAppearances") or 0
+        k = s.get("strikeOuts") or 0
+        bb = s.get("baseOnBalls") or 0
+        return {
+            "g": s.get("gamesPlayed"),
+            "ab": s.get("atBats"),
+            "pa": pa,
+            "r": s.get("runs"),
+            "h": s.get("hits"),
+            "doubles": s.get("doubles"),
+            "triples": s.get("triples"),
+            "hr": s.get("homeRuns"),
+            "rbi": s.get("rbi"),
+            "sb": s.get("stolenBases"),
+            "bb": bb,
+            "k": k,
+            "batting_avg": _safe_float(s.get("avg")),
+            "on_base_pct": _safe_float(s.get("obp")),
+            "slugging_pct": _safe_float(s.get("slg")),
+            "ops": _safe_float(s.get("ops")),
+            "k_pct": round(k / pa, 3) if pa > 0 else None,
+            "bb_pct": round(bb / pa, 3) if pa > 0 else None,
+            "home_runs": s.get("homeRuns"),
+        }
+
+    try:
+        r = _req.get(
+            f"{MLB_STATS_BASE}/people/{player_id}/stats",
+            params={"stats": "season", "group": "hitting", "season": season},
+            timeout=10,
+        )
+        if r.ok:
+            splits = (r.json().get("stats") or [{}])[0].get("splits", [])
+            if splits:
+                out["season_stats"] = _parse_stat(splits[0].get("stat", {}))
+    except Exception:
+        pass
+
+    for sit, key in [("vl", "vsL"), ("vr", "vsR")]:
+        try:
+            r = _req.get(
+                f"{MLB_STATS_BASE}/people/{player_id}/stats",
+                params={"stats": "statSplits", "group": "hitting", "season": season, "sitCodes": sit},
+                timeout=10,
+            )
+            if r.ok:
+                splits = (r.json().get("stats") or [{}])[0].get("splits", [])
+                if splits:
+                    out["splits"][key] = _parse_stat(splits[0].get("stat", {}))
+        except Exception:
+            pass
+
+    try:
+        r = _req.get(
+            f"{MLB_STATS_BASE}/people/{player_id}/stats",
+            params={"stats": "yearByYear", "group": "hitting"},
+            timeout=15,
+        )
+        if r.ok:
+            for sp in (r.json().get("stats") or [{}])[0].get("splits", []):
+                yr = sp.get("season")
+                if yr:
+                    row = _parse_stat(sp.get("stat", {}))
+                    row["season"] = yr
+                    out["year_by_year"].append(row)
+            out["year_by_year"].sort(key=lambda x: x["season"], reverse=True)
+    except Exception:
+        pass
+
+    return out
+
+
+def _aggregate_to_dict(agg) -> Optional[Dict[str, Any]]:
+    if not agg:
+        return None
+    return {
+        "avg_exit_velocity": agg.avg_exit_velocity,
+        "avg_launch_angle": agg.avg_launch_angle,
+        "hard_hit_pct": agg.hard_hit_pct,
+        "barrel_pct": agg.barrel_pct,
+        "k_pct": agg.k_pct,
+        "bb_pct": agg.bb_pct,
+        "batting_avg": agg.batting_avg,
+        "end_date": agg.end_date.isoformat() if agg.end_date else None,
+        "window": agg.window,
+    }
+
+
+@router.get("/batter/{id}/profile")
+def batter_profile(id: int, season: Optional[int] = None) -> Dict[str, Any]:
+    if season is None:
+        season = datetime.date.today().year
+    Session = _get_session()
+    with Session() as session:
+        agg, agg_label = get_batter_aggregate_with_fallback(session, id, season)
+        seasons = [season, season - 1, season - 2]
+        live = _fetch_batter_live_data(id, season)
+        return {
+            "batter_id": id,
+            "season": season,
+            "player_info": live.get("player_info"),
+            "season_stats": live.get("season_stats"),
+            "aggregate_label": agg_label,
+            "aggregate": _aggregate_to_dict(agg),
+            "multi_season": get_batter_multi_season(session, id, seasons),
+            "splits": get_player_splits_multi_season(session, id, seasons) or live.get("splits"),
+            "year_by_year": live.get("year_by_year", []),
+            "data_quality": get_batter_data_quality(session, id),
+        }
+
+
+@router.get("/batter/{id}/rolling/pa")
+def batter_rolling_pa(id: int, windows: str = Query("10,25,50,100")) -> Dict[str, Any]:
+    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
+    parsed = parsed or [10, 25, 50, 100]
+    Session = _get_session()
+    with Session() as session:
+        return {
+            "batter_id": id,
+            "window_type": "PA",
+            "windows": {str(w): get_batter_rolling_by_pa(session, id, w) for w in parsed},
+            "data_quality": get_batter_data_quality(session, id),
+        }
+
+
+@router.get("/batter/{id}/rolling/ab")
+def batter_rolling_ab(id: int, windows: str = Query("10,25,50,100")) -> Dict[str, Any]:
+    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
+    parsed = parsed or [10, 25, 50, 100]
+    Session = _get_session()
+    with Session() as session:
+        return {
+            "batter_id": id,
+            "window_type": "AB",
+            "windows": {str(w): get_batter_rolling_by_ab(session, id, w) for w in parsed},
+            "data_quality": get_batter_data_quality(session, id),
+        }
+
+
+@router.get("/batter/{id}/rolling/games")
+def batter_rolling_games(id: int, windows: str = Query("5,10,15,30")) -> Dict[str, Any]:
+    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
+    parsed = parsed or [5, 10, 15, 30]
+    Session = _get_session()
+    with Session() as session:
+        return {
+            "batter_id": id,
+            "window_type": "games",
+            "windows": {str(w): get_batter_rolling_by_games(session, id, w) for w in parsed},
+            "data_quality": get_batter_data_quality(session, id),
+        }
+
+
+@router.get("/batter/{id}/rolling/splits")
+def batter_rolling_splits(id: int, pa: int = 100) -> Dict[str, Any]:
+    Session = _get_session()
+    with Session() as session:
+        return {"batter_id": id, **get_batter_rolling_splits(session, id, pa)}
+
+
+@router.get("/batter/{id}/rolling/pitch-types")
+def batter_rolling_pitch_types(id: int, pa: int = 100) -> Dict[str, Any]:
+    Session = _get_session()
+    with Session() as session:
+        return {"batter_id": id, **get_batter_rolling_pitch_types(session, id, pa)}
+
+
+@router.get("/batter/{id}/rolling/legacy")
+def batter_rolling_legacy(id: int) -> Dict[str, Any]:
+    windows = [10, 25, 50, 100, 200, 400, 1000]
+    Session = _get_session()
+    with Session() as session:
+        return {
+            "batter_id": id,
+            "window_type": "PA",
+            "legacy_note": "Legacy rolling abs endpoint uses PA-style terminal outcomes. Use /rolling/ab for strict AB windows.",
+            "windows": {str(w): get_batter_rolling_by_abs(session, id, w) for w in windows},
+            "data_quality": get_batter_data_quality(session, id),
+        }
+
+
+@router.get("/batter/{id}/qa")
+def batter_data_quality(id: int) -> Dict[str, Any]:
+    Session = _get_session()
+    with Session() as session:
+        return {"batter_id": id, "data_quality": get_batter_data_quality(session, id)}
+
+
+@router.get("/batter/{id}/at-bats/ordered")
+def batter_ordered_at_bats(id: int, limit: int = 50, offset: int = 0) -> Dict[str, Any]:
+    Session = _get_session()
+    with Session() as session:
+        total, rows = get_batter_at_bats(session, id, n=limit, offset=offset)
+        return {
+            "batter_id": id,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "events": rows,
+            "data_quality": get_batter_data_quality(session, id),
+        }

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -68,6 +68,14 @@ class StatcastEvent(Base):
 
     id: int = Column(Integer, primary_key=True, autoincrement=True)
     game_date: date = Column(Date, nullable=False, index=True)
+    game_pk: Optional[int] = Column(Integer, nullable=True, index=True)
+    at_bat_number: Optional[int] = Column(Integer, nullable=True)
+    pitch_number: Optional[int] = Column(Integer, nullable=True)
+    inning: Optional[int] = Column(Integer, nullable=True)
+    inning_topbot: Optional[str] = Column(String(10), nullable=True)
+    outs_when_up: Optional[int] = Column(Integer, nullable=True)
+    home_team: Optional[str] = Column(String(10), nullable=True)
+    away_team: Optional[str] = Column(String(10), nullable=True)
     pitcher_id: int = Column(Integer, nullable=False, index=True)
     batter_id: int = Column(Integer, nullable=False, index=True)
     pitch_type: Optional[str] = Column(String(5), nullable=True)
@@ -89,6 +97,7 @@ class StatcastEvent(Base):
     __table_args__ = (
         Index("ix_statcast_events_date_pitcher", "game_date", "pitcher_id"),
         Index("ix_statcast_events_date_batter", "game_date", "batter_id"),
+        Index("ix_statcast_events_batter_order", "batter_id", "game_date", "game_pk", "at_bat_number", "pitch_number"),
     )
 
 
@@ -292,7 +301,7 @@ def create_tables(engine) -> None:
     Call this function once during initialization to ensure the schema
     exists.  It will emit CREATE TABLE statements for any missing tables.
 
-    :param engine: A SQLAlchemy Engine connected to the target database.
+    :param engine: SQLAlchemy Engine connected to the target database.
     """
     Base.metadata.create_all(engine)
 

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -4,9 +4,21 @@ import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from .database import BatterAggregate, PitchArsenal, PitcherAggregate, PlayerSplit, StatcastEvent, TeamSplit
+
+HIT_EVENTS = {"single", "double", "triple", "home_run"}
+NON_AB_EVENTS = {"walk", "intent_walk", "hit_by_pitch", "sac_bunt", "sac_fly", "catcher_interf", "catcher_interference"}
+TERMINAL_EVENTS = {
+    "single", "double", "triple", "home_run",
+    "strikeout", "strikeout_double_play",
+    "walk", "intent_walk", "hit_by_pitch",
+    "field_out", "force_out", "double_play", "grounded_into_double_play",
+    "fielders_choice", "fielders_choice_out", "sac_fly", "sac_bunt",
+    "catcher_interf", "catcher_interference",
+}
 
 
 def get_pitcher_aggregate(session: Session, pitcher_id: int, window: str) -> Optional[PitcherAggregate]:
@@ -115,6 +127,78 @@ def _events_to_batter_df(events: List[StatcastEvent]) -> pd.DataFrame:
     ])
 
 
+def _calculate_batter_stats(events: List[StatcastEvent]) -> Dict[str, Any]:
+    from .statcast_utils import calculate_batter_aggregates
+    stats = calculate_batter_aggregates(_events_to_batter_df(events)) if events else {}
+    dates = [e.game_date for e in events if e.game_date]
+    stats["start_date"] = min(dates).isoformat() if dates else None
+    stats["end_date"] = max(dates).isoformat() if dates else None
+    return stats
+
+
+def _has_full_event_order(session: Session, batter_id: int) -> bool:
+    return session.query(StatcastEvent.id).filter(
+        StatcastEvent.batter_id == batter_id,
+        StatcastEvent.game_pk.isnot(None),
+        StatcastEvent.at_bat_number.isnot(None),
+        StatcastEvent.pitch_number.isnot(None),
+    ).first() is not None
+
+
+def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
+    total = session.query(func.count(StatcastEvent.id)).filter(StatcastEvent.batter_id == batter_id).scalar() or 0
+    latest = (
+        session.query(func.max(StatcastEvent.game_date))
+        .filter(StatcastEvent.batter_id == batter_id)
+        .scalar()
+    )
+    terminal_count = session.query(func.count(StatcastEvent.id)).filter(
+        StatcastEvent.batter_id == batter_id,
+        StatcastEvent.events.isnot(None),
+        StatcastEvent.events != "",
+    ).scalar() or 0
+    full_order = _has_full_event_order(session, batter_id)
+    warnings: List[str] = []
+    if total == 0:
+        ordering_quality = "unavailable"
+        warnings.append("No Statcast events found for this batter.")
+    elif full_order:
+        ordering_quality = "full_event_order"
+    else:
+        ordering_quality = "date_only"
+        warnings.append("Rolling PA order is date-level only; intra-game PA order unavailable.")
+    return {
+        "has_statcast": total > 0,
+        "latest_event_date": latest.isoformat() if latest else None,
+        "rolling_pa_available": terminal_count > 0,
+        "rolling_game_available": total > 0,
+        "ordering_quality": ordering_quality,
+        "warnings": warnings,
+    }
+
+
+def _ordered_batter_terminal_query(session: Session, batter_id: int):
+    query = session.query(StatcastEvent).filter(
+        StatcastEvent.batter_id == batter_id,
+        StatcastEvent.events.isnot(None),
+        StatcastEvent.events != "",
+    )
+    if _has_full_event_order(session, batter_id):
+        return query.order_by(
+            StatcastEvent.game_date.desc(),
+            StatcastEvent.game_pk.desc(),
+            StatcastEvent.at_bat_number.desc(),
+            StatcastEvent.pitch_number.desc(),
+        )
+    return query.order_by(StatcastEvent.game_date.desc(), StatcastEvent.id.desc())
+
+
+def _is_true_ab_event(event_name: Optional[str]) -> bool:
+    if not event_name:
+        return False
+    return event_name not in NON_AB_EVENTS
+
+
 def get_pitcher_rolling_by_games(session: Session, pitcher_id: int, n_games: int) -> Optional[Dict[str, Any]]:
     date_rows = (
         session.query(StatcastEvent.game_date)
@@ -143,58 +227,133 @@ def get_pitcher_rolling_by_games(session: Session, pitcher_id: int, n_games: int
 
 
 def get_batter_rolling_by_games(session: Session, batter_id: int, n_games: int) -> Optional[Dict[str, Any]]:
-    date_rows = (
-        session.query(StatcastEvent.game_date)
-        .filter(StatcastEvent.batter_id == batter_id)
-        .distinct()
-        .order_by(StatcastEvent.game_date.desc())
-        .limit(n_games)
-        .all()
-    )
-    if not date_rows:
-        return None
-    date_list = [r[0] for r in date_rows]
-    events = (
-        session.query(StatcastEvent)
-        .filter(StatcastEvent.batter_id == batter_id, StatcastEvent.game_date.in_(date_list), StatcastEvent.events.isnot(None), StatcastEvent.events != "")
-        .all()
-    )
+    quality = get_batter_data_quality(session, batter_id)
+    if quality["ordering_quality"] == "full_event_order":
+        game_rows = (
+            session.query(StatcastEvent.game_pk, func.max(StatcastEvent.game_date).label("game_date"))
+            .filter(StatcastEvent.batter_id == batter_id, StatcastEvent.game_pk.isnot(None))
+            .group_by(StatcastEvent.game_pk)
+            .order_by(func.max(StatcastEvent.game_date).desc(), StatcastEvent.game_pk.desc())
+            .limit(n_games)
+            .all()
+        )
+        if not game_rows:
+            return None
+        game_pks = [r[0] for r in game_rows]
+        events = session.query(StatcastEvent).filter(
+            StatcastEvent.batter_id == batter_id,
+            StatcastEvent.game_pk.in_(game_pks),
+            StatcastEvent.events.isnot(None),
+            StatcastEvent.events != "",
+        ).all()
+        actual_games = len(game_pks)
+    else:
+        date_rows = (
+            session.query(StatcastEvent.game_date)
+            .filter(StatcastEvent.batter_id == batter_id)
+            .distinct()
+            .order_by(StatcastEvent.game_date.desc())
+            .limit(n_games)
+            .all()
+        )
+        if not date_rows:
+            return None
+        date_list = [r[0] for r in date_rows]
+        events = session.query(StatcastEvent).filter(
+            StatcastEvent.batter_id == batter_id,
+            StatcastEvent.game_date.in_(date_list),
+            StatcastEvent.events.isnot(None),
+            StatcastEvent.events != "",
+        ).all()
+        actual_games = len(date_list)
+        quality["warnings"] = list(quality.get("warnings", [])) + ["Rolling game windows are date-based because game_pk is unavailable."]
     if not events:
         return None
-    from .statcast_utils import calculate_batter_aggregates
-    stats = calculate_batter_aggregates(_events_to_batter_df(events))
-    stats["actual_games"] = len(date_list)
-    stats["start_date"] = min(date_list).isoformat()
-    stats["end_date"] = max(date_list).isoformat()
+    stats = _calculate_batter_stats(events)
+    stats["actual_games"] = actual_games
+    stats["window_type"] = "games"
+    stats["data_quality"] = quality
+    return stats
+
+
+def get_batter_rolling_by_pa(session: Session, batter_id: int, n_pa: int) -> Optional[Dict[str, Any]]:
+    events = _ordered_batter_terminal_query(session, batter_id).limit(n_pa).all()
+    if not events:
+        return None
+    stats = _calculate_batter_stats(events)
+    stats["actual_pa"] = len(events)
+    stats["window_type"] = "PA"
+    stats["label"] = f"Last {n_pa} PA"
+    stats["data_quality"] = get_batter_data_quality(session, batter_id)
+    return stats
+
+
+def get_batter_rolling_by_ab(session: Session, batter_id: int, n_ab: int) -> Optional[Dict[str, Any]]:
+    candidates = _ordered_batter_terminal_query(session, batter_id).limit(max(n_ab * 3, n_ab)).all()
+    events = [e for e in candidates if _is_true_ab_event(e.events)][:n_ab]
+    if not events:
+        return None
+    stats = _calculate_batter_stats(events)
+    stats["actual_ab"] = len(events)
+    stats["window_type"] = "AB"
+    stats["label"] = f"Last {n_ab} AB"
+    stats["data_quality"] = get_batter_data_quality(session, batter_id)
     return stats
 
 
 def get_batter_rolling_by_abs(session: Session, batter_id: int, n_abs: int) -> Optional[Dict[str, Any]]:
-    events = (
-        session.query(StatcastEvent)
-        .filter(StatcastEvent.batter_id == batter_id, StatcastEvent.events.isnot(None), StatcastEvent.events != "")
-        .order_by(StatcastEvent.game_date.desc())
-        .limit(n_abs)
-        .all()
-    )
-    if not events:
-        return None
-    from .statcast_utils import calculate_batter_aggregates
-    stats = calculate_batter_aggregates(_events_to_batter_df(events))
-    stats["actual_abs"] = len(events)
-    dates = [e.game_date for e in events if e.game_date]
-    stats["start_date"] = min(dates).isoformat() if dates else None
-    stats["end_date"] = max(dates).isoformat() if dates else None
-    return stats
+    result = get_batter_rolling_by_pa(session, batter_id, n_abs)
+    if result:
+        result["actual_abs"] = result.get("actual_pa")
+        result["legacy_alias"] = "get_batter_rolling_by_abs"
+        result["label_warning"] = "Legacy abs rolling returns PA-style terminal outcomes, not strict official AB."
+    return result
+
+
+def get_batter_rolling_splits(session: Session, batter_id: int, n_pa: int = 100) -> Dict[str, Any]:
+    events = _ordered_batter_terminal_query(session, batter_id).limit(n_pa).all()
+    grouped = {"vsL": [], "vsR": [], "unknown": []}
+    for event in events:
+        key = "vsL" if event.p_throws == "L" else "vsR" if event.p_throws == "R" else "unknown"
+        grouped[key].append(event)
+    return {
+        "window_type": "PA",
+        "requested_pa": n_pa,
+        "splits": {k: ({**_calculate_batter_stats(v), "actual_pa": len(v)} if v else None) for k, v in grouped.items()},
+        "data_quality": get_batter_data_quality(session, batter_id),
+    }
+
+
+def get_batter_rolling_pitch_types(session: Session, batter_id: int, n_pa: int = 100) -> Dict[str, Any]:
+    events = _ordered_batter_terminal_query(session, batter_id).limit(n_pa).all()
+    grouped: Dict[str, List[StatcastEvent]] = {}
+    for event in events:
+        key = event.pitch_type or "unknown"
+        grouped.setdefault(key, []).append(event)
+    return {
+        "window_type": "PA",
+        "requested_pa": n_pa,
+        "pitch_types": {
+            k: {**_calculate_batter_stats(v), "actual_pa": len(v)}
+            for k, v in sorted(grouped.items(), key=lambda item: len(item[1]), reverse=True)
+        },
+        "data_quality": get_batter_data_quality(session, batter_id),
+    }
 
 
 def get_batter_at_bats(session: Session, batter_id: int, n: int = 50, offset: int = 0) -> Tuple[int, List[Dict[str, Any]]]:
     base = session.query(StatcastEvent).filter(StatcastEvent.batter_id == batter_id, StatcastEvent.events.isnot(None), StatcastEvent.events != "")
     total = base.count()
-    events = base.order_by(StatcastEvent.game_date.desc()).offset(offset).limit(n).all()
+    events = _ordered_batter_terminal_query(session, batter_id).offset(offset).limit(n).all()
     rows = [
         {
             "game_date": e.game_date.isoformat() if e.game_date else None,
+            "game_pk": e.game_pk,
+            "at_bat_number": e.at_bat_number,
+            "pitch_number": e.pitch_number,
+            "inning": e.inning,
+            "inning_topbot": e.inning_topbot,
+            "outs_when_up": e.outs_when_up,
             "pitcher_id": e.pitcher_id,
             "pitcher_hand": e.p_throws,
             "batter_stand": e.stand,
@@ -212,7 +371,7 @@ def _dedupe_events(events: List[StatcastEvent]) -> List[StatcastEvent]:
     seen = set()
     out: List[StatcastEvent] = []
     for e in events:
-        key = (e.game_date, e.pitcher_id, e.batter_id, e.pitch_type, e.release_speed, e.release_spin_rate, e.launch_speed, e.launch_angle, e.balls, e.strikes, e.events, e.stand, e.p_throws, e.pfx_x, e.pfx_z, e.plate_x, e.plate_z)
+        key = (e.game_date, e.game_pk, e.at_bat_number, e.pitch_number, e.pitcher_id, e.batter_id, e.pitch_type, e.release_speed, e.release_spin_rate, e.launch_speed, e.launch_angle, e.balls, e.strikes, e.events, e.stand, e.p_throws, e.pfx_x, e.pfx_z, e.plate_x, e.plate_z)
         if key in seen:
             continue
         seen.add(key)
@@ -336,8 +495,13 @@ __all__ = [
     "get_player_splits_multi_season",
     "get_team_split",
     "get_pitcher_rolling_by_games",
+    "get_batter_data_quality",
     "get_batter_rolling_by_games",
+    "get_batter_rolling_by_pa",
+    "get_batter_rolling_by_ab",
     "get_batter_rolling_by_abs",
+    "get_batter_rolling_splits",
+    "get_batter_rolling_pitch_types",
     "get_batter_at_bats",
     "get_pitcher_game_log",
     "get_pitcher_multi_season",

--- a/mlb_app/etl.py
+++ b/mlb_app/etl.py
@@ -150,6 +150,22 @@ def _load_team_splits(session, team_ids: List[int], season: int) -> None:
 # Statcast + aggregates
 # ---------------------------------------------------------------------------
 
+def _safe_int(val) -> Optional[int]:
+    try:
+        if pd.isna(val):
+            return None
+        return int(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_str(val, max_len: int) -> Optional[str]:
+    if val is None or pd.isna(val):
+        return None
+    text = str(val).strip()
+    return text[:max_len] if text else None
+
+
 def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -> pd.DataFrame:
     try:
         df = fetch_statcast_pitcher_data(pitcher_id, start, end)
@@ -159,11 +175,20 @@ def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -
     if df is None or df.empty:
         return pd.DataFrame()
 
-    # Persist raw events (deduplicate by game_date + pitcher + batter + description)
+    # Persist raw events. Ordering fields are nullable so older or partial
+    # Statcast pulls remain compatible while newer pulls support true PA order.
     for _, row in df.iterrows():
         try:
             ev = StatcastEvent(
                 game_date=pd.to_datetime(row.get("game_date")).date() if row.get("game_date") else None,
+                game_pk=_safe_int(row.get("game_pk")),
+                at_bat_number=_safe_int(row.get("at_bat_number")),
+                pitch_number=_safe_int(row.get("pitch_number")),
+                inning=_safe_int(row.get("inning")),
+                inning_topbot=_safe_str(row.get("inning_topbot"), 10),
+                outs_when_up=_safe_int(row.get("outs_when_up")),
+                home_team=_safe_str(row.get("home_team"), 10),
+                away_team=_safe_str(row.get("away_team"), 10),
                 pitcher_id=pitcher_id,
                 batter_id=int(row["batter"]) if pd.notna(row.get("batter")) else 0,
                 pitch_type=str(row.get("pitch_type", "") or "")[:5] or None,


### PR DESCRIPTION
## Summary

This PR fixes the batter profile and rolling metrics workflow so frontend pages use the corrected batter data endpoints and no longer silently label PA-style outcomes as ABs.

## Changes

- Adds Statcast ordering/context fields to `StatcastEvent`:
  - `game_pk`
  - `at_bat_number`
  - `pitch_number`
  - `inning`
  - `inning_topbot`
  - `outs_when_up`
  - `home_team`
  - `away_team`
- Populates those fields during ETL when Statcast provides them.
- Refactors batter rolling logic to separate PA, AB, games, splits, and pitch-type windows.
- Preserves legacy `get_batter_rolling_by_abs()` as a compatibility wrapper.
- Adds batter profile/rolling QA API routes.
- Wires the new batter router into `app.py`.
- Updates frontend batter profile to call `/batter/{id}/profile`.
- Updates rolling batter page to call:
  - `/batter/{id}/rolling/pa`
  - `/batter/{id}/rolling/ab`
  - `/batter/{id}/rolling/games`
  - `/batter/{id}/at-bats/ordered`
- Displays data quality warnings in the UI.
- Renames misleading AB labels to PA unless strict AB mode is selected.

## Validation Notes

The branch is current with `main` and is 7 commits ahead, 0 behind. It preserves existing routes while adding new cleaner endpoints.