### PR TITLE
Add foundation for derived pitcher advanced metrics

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -69,6 +69,7 @@ from .pitcher_profile import compute_pitcher_profile
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
 from .environment_profile import compute_environment_profile
 from .matchup_analysis import build_matchup_analysis
+from .pitcher_advanced_metrics import derive_pitcher_advanced_metrics
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -792,7 +793,22 @@ def create_app():
                     return sum(simple_values) / len(simple_values)
                 return None
 
-            def _pitcher_profile_input(detail):
+            def _pitcher_advanced_metric_input(pitcher_id):
+                if not pitcher_id:
+                    return {}
+
+                start_date = datetime.date(season, 1, 1)
+                events = (
+                    session.query(StatcastEvent)
+                    .filter(
+                        StatcastEvent.pitcher_id == pitcher_id,
+                        StatcastEvent.game_date >= start_date,
+                    )
+                    .all()
+                )
+                return derive_pitcher_advanced_metrics(events)
+
+            def _pitcher_profile_input(detail, pitcher_id):
                 aggregate = dict(detail.get("aggregate") or {})
                 arsenal_rows = detail.get("arsenal") or {}
 
@@ -807,17 +823,34 @@ def create_app():
                     if aggregate.get(key) is None and value is not None:
                         aggregate[key] = value
 
+                advanced_metrics = _pitcher_advanced_metric_input(pitcher_id)
+                for key, value in advanced_metrics.items():
+                    if aggregate.get(key) is None and value is not None:
+                        aggregate[key] = value
+
                 fields_used = sorted([k for k, v in aggregate.items() if v is not None])
                 has_aggregate_values = bool(fields_used)
                 has_arsenal_fallbacks = any(
                     key in aggregate and aggregate.get(key) is not None
                     for key in ["k_pct", "whiff_rate", "hard_hit_pct", "xwoba"]
                 )
+                has_advanced_derived_metrics = any(
+                    key in aggregate and aggregate.get(key) is not None
+                    for key in [
+                        "zone_rate",
+                        "first_pitch_strike_rate",
+                        "barrel_rate_allowed",
+                        "avg_exit_velocity_allowed",
+                        "avg_launch_angle_allowed",
+                    ]
+                )
 
                 aggregate.update(
                     {
                         "source_type": (
-                            "statcast_aggregate_with_arsenal_fallbacks"
+                            "statcast_aggregate_with_advanced_derived_metrics"
+                            if has_advanced_derived_metrics
+                            else "statcast_aggregate_with_arsenal_fallbacks"
                             if has_arsenal_fallbacks
                             else "statcast_aggregate_blended"
                             if has_aggregate_values
@@ -828,7 +861,9 @@ def create_app():
                         "generated_from": "matchup_detail.pitcher_detail",
                         "sample_window": "blended",
                         "sample_blend_policy": (
-                            "pitcher_v1_weighted_blend_with_arsenal_fallbacks"
+                            "pitcher_v1_weighted_blend_with_advanced_derived_metrics"
+                            if has_advanced_derived_metrics
+                            else "pitcher_v1_weighted_blend_with_arsenal_fallbacks"
                             if has_arsenal_fallbacks
                             else "pitcher_v1_weighted_blend"
                         ),
@@ -839,10 +874,10 @@ def create_app():
                 return aggregate
 
             home_pitcher_profile = compute_pitcher_profile(
-                _pitcher_profile_input(home_pitcher_detail)
+                _pitcher_profile_input(home_pitcher_detail, home_pitcher_id)
             )
             away_pitcher_profile = compute_pitcher_profile(
-                _pitcher_profile_input(away_pitcher_detail)
+                _pitcher_profile_input(away_pitcher_detail, away_pitcher_id)
             )
 
             home_projected_lineup_offense_profile = build_projected_lineup_offense_profile(

--- a/mlb_app/pitcher_advanced_metrics.py
+++ b/mlb_app/pitcher_advanced_metrics.py
@@ -1,0 +1,119 @@
+"""
+Derived pitcher metric helpers from stored StatcastEvent rows.
+
+These helpers intentionally use only fields currently persisted in the
+StatcastEvent model. Metrics that require unavailable raw fields, such as
+CSW rate from pitch description, remain None until those fields are stored.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _average(values: Iterable[Optional[float]]) -> Optional[float]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _is_in_approx_zone(event: Any) -> bool:
+    plate_x = _safe_float(getattr(event, "plate_x", None))
+    plate_z = _safe_float(getattr(event, "plate_z", None))
+    if plate_x is None or plate_z is None:
+        return False
+
+    # Approximate rulebook zone. This is intentionally conservative until
+    # batter-specific sz_top/sz_bot fields are available.
+    return abs(plate_x) <= 0.83 and 1.5 <= plate_z <= 3.5
+
+
+def _is_first_pitch(event: Any) -> bool:
+    return getattr(event, "balls", None) == 0 and getattr(event, "strikes", None) == 0
+
+
+def _is_first_pitch_strike(event: Any) -> bool:
+    if not _is_first_pitch(event):
+        return False
+
+    # Without Statcast description, use zone location as the safest persisted
+    # proxy for first-pitch strike. This excludes chase swings for now.
+    return _is_in_approx_zone(event)
+
+
+def _is_barrel_approx(event: Any) -> bool:
+    launch_speed = _safe_float(getattr(event, "launch_speed", None))
+    launch_angle = _safe_float(getattr(event, "launch_angle", None))
+    if launch_speed is None or launch_angle is None:
+        return False
+
+    # Lightweight barrel approximation. True Savant barrels use a variable
+    # launch-angle band by EV; this captures the high-value core region.
+    return launch_speed >= 98 and 26 <= launch_angle <= 30
+
+
+def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional[float]]:
+    """
+    Compute pitcher advanced metrics from stored StatcastEvent rows.
+
+    Returns rates as decimals, matching the existing profile schema.
+    """
+    rows = list(events or [])
+    if not rows:
+        return {
+            "csw_rate": None,
+            "zone_rate": None,
+            "first_pitch_strike_rate": None,
+            "barrel_rate_allowed": None,
+            "avg_exit_velocity_allowed": None,
+            "avg_launch_angle_allowed": None,
+        }
+
+    zone_known = [
+        row for row in rows
+        if _safe_float(getattr(row, "plate_x", None)) is not None
+        and _safe_float(getattr(row, "plate_z", None)) is not None
+    ]
+    first_pitch_rows = [row for row in rows if _is_first_pitch(row)]
+    batted_ball_rows = [
+        row for row in rows
+        if _safe_float(getattr(row, "launch_speed", None)) is not None
+        or _safe_float(getattr(row, "launch_angle", None)) is not None
+    ]
+
+    zone_rate = (
+        sum(1 for row in zone_known if _is_in_approx_zone(row)) / len(zone_known)
+        if zone_known else None
+    )
+    first_pitch_strike_rate = (
+        sum(1 for row in first_pitch_rows if _is_first_pitch_strike(row)) / len(first_pitch_rows)
+        if first_pitch_rows else None
+    )
+    barrel_rate_allowed = (
+        sum(1 for row in batted_ball_rows if _is_barrel_approx(row)) / len(batted_ball_rows)
+        if batted_ball_rows else None
+    )
+
+    return {
+        # Requires Statcast description; not persisted yet.
+        "csw_rate": None,
+        "zone_rate": zone_rate,
+        "first_pitch_strike_rate": first_pitch_strike_rate,
+        "barrel_rate_allowed": barrel_rate_allowed,
+        "avg_exit_velocity_allowed": _average(
+            _safe_float(getattr(row, "launch_speed", None)) for row in batted_ball_rows
+        ),
+        "avg_launch_angle_allowed": _average(
+            _safe_float(getattr(row, "launch_angle", None)) for row in batted_ball_rows
+        ),
+    }


### PR DESCRIPTION
Adds a backend foundation for deriving advanced pitcher metrics from stored StatcastEvent rows.

This update:
- introduces `pitcher_advanced_metrics.py` with reusable helpers for derived pitcher metrics
- computes zone rate from persisted plate location fields
- computes first-pitch strike rate using first-pitch count plus zone-location proxy
- computes barrel-rate allowed using a conservative launch-speed/launch-angle approximation
- computes average exit velocity allowed and average launch angle allowed from stored batted-ball rows
- wires derived metrics into matchup detail pitcher profile inputs when stored Statcast events are available
- keeps CSW rate as unavailable for now because Statcast `description` is not currently persisted

This is a foundation step that uses only fields already available in the current database model and avoids overclaiming unavailable pitch-description-based metrics.