### PR TITLE
Add debug metadata for pitcher advanced metrics

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -824,6 +824,7 @@ def create_app():
                         aggregate[key] = value
 
                 advanced_metrics = _pitcher_advanced_metric_input(pitcher_id)
+                advanced_debug = advanced_metrics.pop("_debug", {})
                 for key, value in advanced_metrics.items():
                     if aggregate.get(key) is None and value is not None:
                         aggregate[key] = value
@@ -859,6 +860,7 @@ def create_app():
                         "source_fields_used": fields_used,
                         "data_confidence": "medium" if has_aggregate_values else "low",
                         "generated_from": "matchup_detail.pitcher_detail",
+                        **advanced_debug,
                         "sample_window": "blended",
                         "sample_blend_policy": (
                             "pitcher_v1_weighted_blend_with_advanced_derived_metrics"

--- a/mlb_app/pitcher_advanced_metrics.py
+++ b/mlb_app/pitcher_advanced_metrics.py
@@ -77,6 +77,13 @@ def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional
             "barrel_rate_allowed": None,
             "avg_exit_velocity_allowed": None,
             "avg_launch_angle_allowed": None,
+            "_debug": {
+                "advanced_event_rows_used": 0,
+                "advanced_zone_rows_used": 0,
+                "advanced_first_pitch_rows_used": 0,
+                "advanced_batted_ball_rows_used": 0,
+                "advanced_metrics_available": [],
+            },
         }
 
     zone_known = [
@@ -104,7 +111,7 @@ def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional
         if batted_ball_rows else None
     )
 
-    return {
+    metrics = {
         # Requires Statcast description; not persisted yet.
         "csw_rate": None,
         "zone_rate": zone_rate,
@@ -117,3 +124,15 @@ def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional
             _safe_float(getattr(row, "launch_angle", None)) for row in batted_ball_rows
         ),
     }
+
+    metrics["_debug"] = {
+        "advanced_event_rows_used": len(rows),
+        "advanced_zone_rows_used": len(zone_known),
+        "advanced_first_pitch_rows_used": len(first_pitch_rows),
+        "advanced_batted_ball_rows_used": len(batted_ball_rows),
+        "advanced_metrics_available": sorted(
+            [key for key, value in metrics.items() if not key.startswith("_") and value is not None]
+        ),
+    }
+
+    return metrics


### PR DESCRIPTION
Adds diagnostic metadata for derived pitcher advanced metrics so we can tell whether missing values are caused by no StatcastEvent rows, missing zone fields, missing first-pitch rows, or missing batted-ball fields.

This update:
- returns `_debug` counts from `derive_pitcher_advanced_metrics`
- exposes those counts in pitcher profile metadata instead of metric sections
- tracks event rows, zone rows, first-pitch rows, batted-ball rows, and available derived metric keys
- keeps existing metric calculations and frontend behavior unchanged

This should help diagnose why Zone Rate, First Pitch Strike Rate, Barrel Allowed, Avg EV Allowed, and Avg LA Allowed are still empty in sandbox after the derived-metrics foundation landed.