### PR TITLE
Add live Statcast fallback for pitcher advanced metrics

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -64,7 +64,7 @@ from .db_utils import (
     get_batter_multi_season,
 )
 from .scoring import compute_win_probability, score_individual_matchup, get_park_factor
-from .statcast_utils import fetch_pitch_arsenal_leaderboard
+from .statcast_utils import fetch_pitch_arsenal_leaderboard, fetch_statcast_pitcher_data
 from .pitcher_profile import compute_pitcher_profile
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
 from .environment_profile import compute_environment_profile
@@ -798,6 +798,7 @@ def create_app():
                     return {}
 
                 start_date = datetime.date(season, 1, 1)
+                end_date = datetime.date.today()
                 events = (
                     session.query(StatcastEvent)
                     .filter(
@@ -806,7 +807,32 @@ def create_app():
                     )
                     .all()
                 )
-                return derive_pitcher_advanced_metrics(events)
+
+                if events:
+                    metrics = derive_pitcher_advanced_metrics(events)
+                    metrics.setdefault("_debug", {})["advanced_event_source"] = "db"
+                    return metrics
+
+                try:
+                    df = fetch_statcast_pitcher_data(
+                        pitcher_id,
+                        start_date.isoformat(),
+                        end_date.isoformat(),
+                    )
+                except Exception:
+                    metrics = derive_pitcher_advanced_metrics([])
+                    metrics.setdefault("_debug", {})["advanced_event_source"] = "live_statcast_failed"
+                    return metrics
+
+                if df is None or df.empty:
+                    metrics = derive_pitcher_advanced_metrics([])
+                    metrics.setdefault("_debug", {})["advanced_event_source"] = "live_statcast_empty"
+                    return metrics
+
+                live_rows = df.to_dict("records")
+                metrics = derive_pitcher_advanced_metrics(live_rows)
+                metrics.setdefault("_debug", {})["advanced_event_source"] = "live_statcast_fallback"
+                return metrics
 
             def _pitcher_profile_input(detail, pitcher_id):
                 aggregate = dict(detail.get("aggregate") or {})

--- a/mlb_app/pitcher_advanced_metrics.py
+++ b/mlb_app/pitcher_advanced_metrics.py
@@ -27,9 +27,15 @@ def _average(values: Iterable[Optional[float]]) -> Optional[float]:
     return sum(nums) / len(nums)
 
 
+def _get_field(event: Any, key: str) -> Any:
+    if isinstance(event, dict):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
 def _is_in_approx_zone(event: Any) -> bool:
-    plate_x = _safe_float(getattr(event, "plate_x", None))
-    plate_z = _safe_float(getattr(event, "plate_z", None))
+    plate_x = _safe_float(_get_field(event, "plate_x"))
+    plate_z = _safe_float(_get_field(event, "plate_z"))
     if plate_x is None or plate_z is None:
         return False
 
@@ -39,7 +45,7 @@ def _is_in_approx_zone(event: Any) -> bool:
 
 
 def _is_first_pitch(event: Any) -> bool:
-    return getattr(event, "balls", None) == 0 and getattr(event, "strikes", None) == 0
+    return _get_field(event, "balls") == 0 and _get_field(event, "strikes") == 0
 
 
 def _is_first_pitch_strike(event: Any) -> bool:
@@ -52,8 +58,8 @@ def _is_first_pitch_strike(event: Any) -> bool:
 
 
 def _is_barrel_approx(event: Any) -> bool:
-    launch_speed = _safe_float(getattr(event, "launch_speed", None))
-    launch_angle = _safe_float(getattr(event, "launch_angle", None))
+    launch_speed = _safe_float(_get_field(event, "launch_speed"))
+    launch_angle = _safe_float(_get_field(event, "launch_angle"))
     if launch_speed is None or launch_angle is None:
         return False
 
@@ -88,14 +94,14 @@ def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional
 
     zone_known = [
         row for row in rows
-        if _safe_float(getattr(row, "plate_x", None)) is not None
-        and _safe_float(getattr(row, "plate_z", None)) is not None
+        if _safe_float(_get_field(row, "plate_x")) is not None
+        and _safe_float(_get_field(row, "plate_z")) is not None
     ]
     first_pitch_rows = [row for row in rows if _is_first_pitch(row)]
     batted_ball_rows = [
         row for row in rows
-        if _safe_float(getattr(row, "launch_speed", None)) is not None
-        or _safe_float(getattr(row, "launch_angle", None)) is not None
+        if _safe_float(_get_field(row, "launch_speed")) is not None
+        or _safe_float(_get_field(row, "launch_angle")) is not None
     ]
 
     zone_rate = (
@@ -118,10 +124,10 @@ def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional
         "first_pitch_strike_rate": first_pitch_strike_rate,
         "barrel_rate_allowed": barrel_rate_allowed,
         "avg_exit_velocity_allowed": _average(
-            _safe_float(getattr(row, "launch_speed", None)) for row in batted_ball_rows
+            _safe_float(_get_field(row, "launch_speed")) for row in batted_ball_rows
         ),
         "avg_launch_angle_allowed": _average(
-            _safe_float(getattr(row, "launch_angle", None)) for row in batted_ball_rows
+            _safe_float(_get_field(row, "launch_angle")) for row in batted_ball_rows
         ),
     }
 


### PR DESCRIPTION
Adds a live Statcast fallback for derived pitcher advanced metrics when the sandbox database has no stored `StatcastEvent` rows for a pitcher.

This update:
- imports `fetch_statcast_pitcher_data` into the matchup detail backend path
- keeps the DB query as the preferred source when stored event rows exist
- falls back to live `pybaseball.statcast_pitcher` data when no DB rows are available
- allows `derive_pitcher_advanced_metrics` to work with both ORM event objects and dict rows from a DataFrame
- tags debug metadata with `advanced_event_source` values such as `db`, `live_statcast_fallback`, `live_statcast_empty`, or `live_statcast_failed`

This should help populate advanced pitcher fields such as Zone Rate, First Pitch Strike Rate, Barrel Allowed, Avg EV Allowed, and Avg LA Allowed even before the ETL/backfill has persisted StatcastEvent rows.