### PR TITLE
Make pitcher advanced metric averages NaN-safe

### DIFF
--- a/mlb_app/pitcher_advanced_metrics.py
+++ b/mlb_app/pitcher_advanced_metrics.py
@@ -8,6 +8,7 @@ CSW rate from pitch description, remain None until those fields are stored.
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, Iterable, Optional
 
 
@@ -15,9 +16,12 @@ def _safe_float(value: Any) -> Optional[float]:
     if value is None:
         return None
     try:
-        return float(value)
+        numeric = float(value)
     except (TypeError, ValueError):
         return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
 
 
 def _average(values: Iterable[Optional[float]]) -> Optional[float]:


### PR DESCRIPTION
Fixes NaN handling in derived pitcher advanced metrics so live Statcast fallback averages can survive into the pitcher profile response.

After the live Statcast fallback started populating Zone Rate, First Pitch Strike Rate, and Barrel Allowed, debug metadata showed Avg EV Allowed and Avg LA Allowed were marked available but still rendered as null. The likely cause was pandas NaN values being treated as floats by `_safe_float`.

This update:
- imports `math`
- updates `_safe_float` to return `None` for NaN or infinite values
- keeps existing live Statcast fallback and DB fallback behavior unchanged

This should allow Avg EV Allowed and Avg LA Allowed to populate when live Statcast rows include valid launch speed / launch angle values.