### PR TITLE
Fix DB-backed batter rolling stats and UI metadata

### DIFF
--- a/frontend/src/pages/RollingBatterPage.jsx
+++ b/frontend/src/pages/RollingBatterPage.jsx
@@ -33,6 +33,8 @@ const s = {
   }),
   qaBox: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '12px 14px', marginBottom: '20px', fontSize: '13px', color: '#8b949e' },
   qaWarn: { color: '#d29922', marginTop: '6px' },
+  metaGrid: { display: 'flex', flexWrap: 'wrap', gap: '8px', marginTop: '10px' },
+  metaChip: { background: '#21262d', border: '1px solid #30363d', borderRadius: '999px', padding: '3px 9px', fontSize: '12px', color: '#8b949e' },
   tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto', marginBottom: '20px' },
   table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px', minWidth: '600px' },
   th: { padding: '12px 14px', textAlign: 'left', color: '#8b949e', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
@@ -53,6 +55,7 @@ const pct = (v) => v != null ? `${(v * 100).toFixed(1)}%` : '—'
 const dec = (v, d = 3) => v != null ? Number(v).toFixed(d) : '—'
 const mph = v => v != null ? `${Number(v).toFixed(1)}` : '—'
 const deg = v => v != null ? `${Number(v).toFixed(1)}°` : '—'
+const num = v => v != null ? Number(v).toLocaleString() : '—'
 
 function avgColor(v) { if (v == null) return '#e6edf3'; if (v >= 0.280) return '#3fb950'; if (v >= 0.240) return '#d29922'; return '#f85149' }
 function kColor(v) { if (v == null) return '#e6edf3'; if (v <= 0.18) return '#3fb950'; if (v <= 0.25) return '#d29922'; return '#f85149' }
@@ -64,8 +67,25 @@ function DataQualityBox({ quality }) {
   return (
     <div style={s.qaBox}>
       <div>Data Quality: <strong style={{ color: '#e6edf3' }}>{quality.ordering_quality || 'unknown'}</strong></div>
-      <div>Latest Event: <strong style={{ color: '#e6edf3' }}>{quality.latest_event_date || '—'}</strong></div>
+      <div>Latest Event: <strong style={{ color: quality.is_stale ? '#d29922' : '#e6edf3' }}>{quality.latest_event_date || '—'}</strong></div>
+      <div style={s.metaGrid}>
+        <span style={s.metaChip}>Source: {quality.source || 'postgres_statcast_events'}</span>
+        <span style={s.metaChip}>As of: {quality.as_of_date || '—'}</span>
+        <span style={s.metaChip}>Days stale: {quality.days_stale ?? '—'}</span>
+        <span style={s.metaChip}>Terminal rows: {num(quality.terminal_event_rows)}</span>
+        <span style={s.metaChip}>Total rows: {num(quality.total_event_rows)}</span>
+      </div>
       {warnings.map((w, i) => <div key={i} style={s.qaWarn}>⚠ {w}</div>)}
+    </div>
+  )
+}
+
+function WindowMeta({ stats }) {
+  if (!stats) return null
+  return (
+    <div style={{ color: '#8b949e', fontSize: '11px', marginTop: '3px' }}>
+      PA {num(stats.actual_pa)} · AB {num(stats.actual_ab)} · BBE {num(stats.batted_ball_count)} · HH {num(stats.hard_hit_count)} · Barrel {num(stats.barrel_count)}
+      {stats.invalid_event_count ? ` · Invalid ${num(stats.invalid_event_count)}` : ''}
     </div>
   )
 }
@@ -169,11 +189,14 @@ export default function RollingBatterPage() {
                 if (!st) {
                   return <tr key={i}><td style={{ ...s.td, fontWeight: '600' }}>{w.window}</td><td colSpan={12} style={{ ...s.td, ...s.tdMuted }}>Insufficient data</td></tr>
                 }
-                const count = st.actual_pa ?? st.actual_ab ?? st.actual_games ?? '—'
+                const count = view === 'games' ? (st.actual_games ?? '—') : view === 'ab' ? (st.actual_ab ?? '—') : (st.actual_pa ?? '—')
                 const dateRange = st.start_date && st.end_date ? `${st.start_date.slice(5)} – ${st.end_date.slice(5)}` : '—'
                 return (
                   <tr key={i}>
-                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{w.window}</td>
+                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>
+                      {w.window}
+                      <WindowMeta stats={st} />
+                    </td>
                     <td style={s.td}>{count}</td>
                     <td style={{ ...s.td, ...s.tdMuted, fontSize: '12px' }}>{dateRange}</td>
                     <td style={{ ...s.td, ...s.tdRight, color: avgColor(st.batting_avg), fontWeight: '600' }}>{dec(st.batting_avg)}</td>
@@ -203,7 +226,10 @@ export default function RollingBatterPage() {
               <tbody>
                 {Object.entries(splits).map(([name, st]) => st && (
                   <tr key={name}>
-                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{name}</td>
+                    <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>
+                      {name}
+                      <WindowMeta stats={st} />
+                    </td>
                     <td style={{ ...s.td, ...s.tdRight }}>{st.actual_pa ?? '—'}</td>
                     <td style={{ ...s.td, ...s.tdRight }}>{dec(st.batting_avg)}</td>
                     <td style={{ ...s.td, ...s.tdRight }}>{pct(st.k_pct)}</td>
@@ -221,6 +247,7 @@ export default function RollingBatterPage() {
       <div style={{ marginTop: '28px' }}>
         <div style={s.sectionTitle}>Chronological Plate Appearance Session</div>
         <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '14px' }}>{abData ? `${totalEvents.toLocaleString()} total terminal PA outcomes on record · showing ${AB_PAGE_SIZE} per page` : ''}</div>
+        <DataQualityBox quality={abData?.data_quality} />
         {abLoading ? <div style={s.loader}>Loading events…</div> : abData && (
           <div style={s.tableWrap}>
             <div style={s.abHeader}><span>Date</span><span>AB #</span><span>Pitch #</span><span>Pitch</span><span>Result</span><span style={{ textAlign: 'right' }}>EV</span><span style={{ textAlign: 'right' }}>LA</span><span>Stand</span></div>

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -10,6 +10,9 @@ from sqlalchemy.orm import Session
 from .database import BatterAggregate, PitchArsenal, PitcherAggregate, PlayerSplit, StatcastEvent, TeamSplit
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
+WALK_EVENTS = {"walk", "intent_walk"}
+HBP_EVENTS = {"hit_by_pitch"}
+STRIKEOUT_EVENTS = {"strikeout", "strikeout_double_play"}
 NON_AB_EVENTS = {"walk", "intent_walk", "hit_by_pitch", "sac_bunt", "sac_fly", "catcher_interf", "catcher_interference"}
 TERMINAL_EVENTS = {
     "single", "double", "triple", "home_run",
@@ -19,6 +22,26 @@ TERMINAL_EVENTS = {
     "fielders_choice", "fielders_choice_out", "sac_fly", "sac_bunt",
     "catcher_interf", "catcher_interference",
 }
+TOTAL_BASES = {"single": 1, "double": 2, "triple": 3, "home_run": 4}
+
+
+def _clean_event_name(event_name: Optional[Any]) -> Optional[str]:
+    if event_name is None:
+        return None
+    text = str(event_name).strip().lower()
+    if text in {"", "nan", "none", "null", "na", "n/a"}:
+        return None
+    return text
+
+
+def _is_terminal_event(event_name: Optional[Any]) -> bool:
+    cleaned = _clean_event_name(event_name)
+    return cleaned in TERMINAL_EVENTS
+
+
+def _is_true_ab_event(event_name: Optional[Any]) -> bool:
+    cleaned = _clean_event_name(event_name)
+    return bool(cleaned and cleaned in TERMINAL_EVENTS and cleaned not in NON_AB_EVENTS)
 
 
 def get_pitcher_aggregate(session: Session, pitcher_id: int, window: str) -> Optional[PitcherAggregate]:
@@ -106,7 +129,7 @@ def _events_to_pitcher_df(events: List[StatcastEvent]) -> pd.DataFrame:
             "release_speed": e.release_speed,
             "release_spin_rate": e.release_spin_rate,
             "launch_speed": e.launch_speed,
-            "events": e.events or "",
+            "events": _clean_event_name(e.events) or "",
             "description": "",
             "pfx_x": e.pfx_x,
             "pfx_z": e.pfx_z,
@@ -122,17 +145,60 @@ def _events_to_pitcher_df(events: List[StatcastEvent]) -> pd.DataFrame:
 
 def _events_to_batter_df(events: List[StatcastEvent]) -> pd.DataFrame:
     return pd.DataFrame([
-        {"launch_speed": e.launch_speed, "launch_angle": e.launch_angle, "events": e.events or ""}
+        {"launch_speed": e.launch_speed, "launch_angle": e.launch_angle, "events": _clean_event_name(e.events) or ""}
         for e in events
     ])
 
 
-def _calculate_batter_stats(events: List[StatcastEvent]) -> Dict[str, Any]:
-    from .statcast_utils import calculate_batter_aggregates
-    stats = calculate_batter_aggregates(_events_to_batter_df(events)) if events else {}
-    dates = [e.game_date for e in events if e.game_date]
-    stats["start_date"] = min(dates).isoformat() if dates else None
-    stats["end_date"] = max(dates).isoformat() if dates else None
+def _calculate_batter_stats(events: List[StatcastEvent], raw_event_count: Optional[int] = None) -> Dict[str, Any]:
+    terminal = [e for e in events if _is_terminal_event(e.events)]
+    raw_count = len(events) if raw_event_count is None else raw_event_count
+    dates = [e.game_date for e in terminal if e.game_date]
+    pa = len(terminal)
+    ab_events = [e for e in terminal if _is_true_ab_event(e.events)]
+    ab = len(ab_events)
+    outcomes = [_clean_event_name(e.events) for e in terminal]
+    hits = sum(1 for event in outcomes if event in HIT_EVENTS)
+    walks = sum(1 for event in outcomes if event in WALK_EVENTS)
+    hbp = sum(1 for event in outcomes if event in HBP_EVENTS)
+    strikeouts = sum(1 for event in outcomes if event in STRIKEOUT_EVENTS)
+    home_runs = sum(1 for event in outcomes if event == "home_run")
+    sacrifice_flies = sum(1 for event in outcomes if event == "sac_fly")
+    total_bases = sum(TOTAL_BASES.get(event or "", 0) for event in outcomes)
+    batted_balls = [e for e in terminal if e.launch_speed is not None]
+    launch_angles = [e.launch_angle for e in terminal if e.launch_angle is not None]
+    hard_hit_count = sum(1 for e in batted_balls if e.launch_speed is not None and e.launch_speed >= 95)
+    barrel_count = sum(1 for e in batted_balls if e.launch_speed is not None and e.launch_angle is not None and e.launch_speed >= 98 and 8 <= e.launch_angle <= 50)
+    obp_denominator = ab + walks + hbp + sacrifice_flies
+    obp = round((hits + walks + hbp) / obp_denominator, 3) if obp_denominator else None
+    slg = round(total_bases / ab, 3) if ab else None
+    stats = {
+        "actual_pa": pa,
+        "actual_ab": ab,
+        "event_count": raw_count,
+        "terminal_event_count": pa,
+        "invalid_event_count": max(raw_count - pa, 0),
+        "batted_ball_count": len(batted_balls),
+        "hard_hit_count": hard_hit_count,
+        "barrel_count": barrel_count,
+        "hits": hits,
+        "walks": walks,
+        "strikeouts": strikeouts,
+        "home_runs": home_runs,
+        "batting_avg": round(hits / ab, 3) if ab else None,
+        "on_base_pct": obp,
+        "slugging_pct": slg,
+        "ops": round(obp + slg, 3) if obp is not None and slg is not None else None,
+        "k_pct": round(strikeouts / pa, 3) if pa else None,
+        "bb_pct": round(walks / pa, 3) if pa else None,
+        "avg_exit_velocity": round(sum(e.launch_speed for e in batted_balls if e.launch_speed is not None) / len(batted_balls), 1) if batted_balls else None,
+        "avg_launch_angle": round(sum(launch_angles) / len(launch_angles), 1) if launch_angles else None,
+        "hard_hit_pct": round(hard_hit_count / len(batted_balls), 3) if batted_balls else None,
+        "barrel_pct": round(barrel_count / len(batted_balls), 3) if batted_balls else None,
+        "start_date": min(dates).isoformat() if dates else None,
+        "end_date": max(dates).isoformat() if dates else None,
+        "source": "postgres_statcast_events",
+    }
     return stats
 
 
@@ -145,6 +211,17 @@ def _has_full_event_order(session: Session, batter_id: int) -> bool:
     ).first() is not None
 
 
+def _freshness_from_latest(latest: Optional[datetime.date]) -> Dict[str, Any]:
+    today = datetime.date.today()
+    days_stale = (today - latest).days if latest else None
+    return {
+        "as_of_date": today.isoformat(),
+        "latest_event_date": latest.isoformat() if latest else None,
+        "days_stale": days_stale,
+        "is_stale": days_stale is None or days_stale > 1,
+    }
+
+
 def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
     total = session.query(func.count(StatcastEvent.id)).filter(StatcastEvent.batter_id == batter_id).scalar() or 0
     latest = (
@@ -154,11 +231,16 @@ def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
     )
     terminal_count = session.query(func.count(StatcastEvent.id)).filter(
         StatcastEvent.batter_id == batter_id,
-        StatcastEvent.events.isnot(None),
-        StatcastEvent.events != "",
+        StatcastEvent.events.in_(TERMINAL_EVENTS),
     ).scalar() or 0
     full_order = _has_full_event_order(session, batter_id)
+    freshness = _freshness_from_latest(latest)
     warnings: List[str] = []
+    if freshness["is_stale"]:
+        warnings.append(
+            f"Statcast data is stale: latest event is {freshness['latest_event_date'] or 'unavailable'}, "
+            f"as-of date is {freshness['as_of_date']}."
+        )
     if total == 0:
         ordering_quality = "unavailable"
         warnings.append("No Statcast events found for this batter.")
@@ -169,19 +251,24 @@ def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
         warnings.append("Rolling PA order is date-level only; intra-game PA order unavailable.")
     return {
         "has_statcast": total > 0,
-        "latest_event_date": latest.isoformat() if latest else None,
+        "total_event_rows": total,
+        "terminal_event_rows": terminal_count,
+        "latest_event_date": freshness["latest_event_date"],
+        "as_of_date": freshness["as_of_date"],
+        "days_stale": freshness["days_stale"],
+        "is_stale": freshness["is_stale"],
         "rolling_pa_available": terminal_count > 0,
         "rolling_game_available": total > 0,
         "ordering_quality": ordering_quality,
         "warnings": warnings,
+        "source": "postgres_statcast_events",
     }
 
 
 def _ordered_batter_terminal_query(session: Session, batter_id: int):
     query = session.query(StatcastEvent).filter(
         StatcastEvent.batter_id == batter_id,
-        StatcastEvent.events.isnot(None),
-        StatcastEvent.events != "",
+        StatcastEvent.events.in_(TERMINAL_EVENTS),
     )
     if _has_full_event_order(session, batter_id):
         return query.order_by(
@@ -191,12 +278,6 @@ def _ordered_batter_terminal_query(session: Session, batter_id: int):
             StatcastEvent.pitch_number.desc(),
         )
     return query.order_by(StatcastEvent.game_date.desc(), StatcastEvent.id.desc())
-
-
-def _is_true_ab_event(event_name: Optional[str]) -> bool:
-    if not event_name:
-        return False
-    return event_name not in NON_AB_EVENTS
 
 
 def get_pitcher_rolling_by_games(session: Session, pitcher_id: int, n_games: int) -> Optional[Dict[str, Any]]:
@@ -231,7 +312,11 @@ def get_batter_rolling_by_games(session: Session, batter_id: int, n_games: int) 
     if quality["ordering_quality"] == "full_event_order":
         game_rows = (
             session.query(StatcastEvent.game_pk, func.max(StatcastEvent.game_date).label("game_date"))
-            .filter(StatcastEvent.batter_id == batter_id, StatcastEvent.game_pk.isnot(None))
+            .filter(
+                StatcastEvent.batter_id == batter_id,
+                StatcastEvent.game_pk.isnot(None),
+                StatcastEvent.events.in_(TERMINAL_EVENTS),
+            )
             .group_by(StatcastEvent.game_pk)
             .order_by(func.max(StatcastEvent.game_date).desc(), StatcastEvent.game_pk.desc())
             .limit(n_games)
@@ -243,14 +328,13 @@ def get_batter_rolling_by_games(session: Session, batter_id: int, n_games: int) 
         events = session.query(StatcastEvent).filter(
             StatcastEvent.batter_id == batter_id,
             StatcastEvent.game_pk.in_(game_pks),
-            StatcastEvent.events.isnot(None),
-            StatcastEvent.events != "",
+            StatcastEvent.events.in_(TERMINAL_EVENTS),
         ).all()
         actual_games = len(game_pks)
     else:
         date_rows = (
             session.query(StatcastEvent.game_date)
-            .filter(StatcastEvent.batter_id == batter_id)
+            .filter(StatcastEvent.batter_id == batter_id, StatcastEvent.events.in_(TERMINAL_EVENTS))
             .distinct()
             .order_by(StatcastEvent.game_date.desc())
             .limit(n_games)
@@ -262,14 +346,13 @@ def get_batter_rolling_by_games(session: Session, batter_id: int, n_games: int) 
         events = session.query(StatcastEvent).filter(
             StatcastEvent.batter_id == batter_id,
             StatcastEvent.game_date.in_(date_list),
-            StatcastEvent.events.isnot(None),
-            StatcastEvent.events != "",
+            StatcastEvent.events.in_(TERMINAL_EVENTS),
         ).all()
         actual_games = len(date_list)
         quality["warnings"] = list(quality.get("warnings", [])) + ["Rolling game windows are date-based because game_pk is unavailable."]
     if not events:
         return None
-    stats = _calculate_batter_stats(events)
+    stats = _calculate_batter_stats(events, raw_event_count=len(events))
     stats["actual_games"] = actual_games
     stats["window_type"] = "games"
     stats["data_quality"] = quality
@@ -280,7 +363,7 @@ def get_batter_rolling_by_pa(session: Session, batter_id: int, n_pa: int) -> Opt
     events = _ordered_batter_terminal_query(session, batter_id).limit(n_pa).all()
     if not events:
         return None
-    stats = _calculate_batter_stats(events)
+    stats = _calculate_batter_stats(events, raw_event_count=len(events))
     stats["actual_pa"] = len(events)
     stats["window_type"] = "PA"
     stats["label"] = f"Last {n_pa} PA"
@@ -289,11 +372,11 @@ def get_batter_rolling_by_pa(session: Session, batter_id: int, n_pa: int) -> Opt
 
 
 def get_batter_rolling_by_ab(session: Session, batter_id: int, n_ab: int) -> Optional[Dict[str, Any]]:
-    candidates = _ordered_batter_terminal_query(session, batter_id).limit(max(n_ab * 3, n_ab)).all()
+    candidates = _ordered_batter_terminal_query(session, batter_id).limit(max(n_ab * 5, n_ab)).all()
     events = [e for e in candidates if _is_true_ab_event(e.events)][:n_ab]
     if not events:
         return None
-    stats = _calculate_batter_stats(events)
+    stats = _calculate_batter_stats(events, raw_event_count=len(candidates))
     stats["actual_ab"] = len(events)
     stats["window_type"] = "AB"
     stats["label"] = f"Last {n_ab} AB"
@@ -319,6 +402,7 @@ def get_batter_rolling_splits(session: Session, batter_id: int, n_pa: int = 100)
     return {
         "window_type": "PA",
         "requested_pa": n_pa,
+        "actual_pa": len(events),
         "splits": {k: ({**_calculate_batter_stats(v), "actual_pa": len(v)} if v else None) for k, v in grouped.items()},
         "data_quality": get_batter_data_quality(session, batter_id),
     }
@@ -333,6 +417,7 @@ def get_batter_rolling_pitch_types(session: Session, batter_id: int, n_pa: int =
     return {
         "window_type": "PA",
         "requested_pa": n_pa,
+        "actual_pa": len(events),
         "pitch_types": {
             k: {**_calculate_batter_stats(v), "actual_pa": len(v)}
             for k, v in sorted(grouped.items(), key=lambda item: len(item[1]), reverse=True)
@@ -342,7 +427,7 @@ def get_batter_rolling_pitch_types(session: Session, batter_id: int, n_pa: int =
 
 
 def get_batter_at_bats(session: Session, batter_id: int, n: int = 50, offset: int = 0) -> Tuple[int, List[Dict[str, Any]]]:
-    base = session.query(StatcastEvent).filter(StatcastEvent.batter_id == batter_id, StatcastEvent.events.isnot(None), StatcastEvent.events != "")
+    base = session.query(StatcastEvent).filter(StatcastEvent.batter_id == batter_id, StatcastEvent.events.in_(TERMINAL_EVENTS))
     total = base.count()
     events = _ordered_batter_terminal_query(session, batter_id).offset(offset).limit(n).all()
     rows = [
@@ -357,7 +442,7 @@ def get_batter_at_bats(session: Session, batter_id: int, n: int = 50, offset: in
             "pitcher_id": e.pitcher_id,
             "pitcher_hand": e.p_throws,
             "batter_stand": e.stand,
-            "result": e.events,
+            "result": _clean_event_name(e.events),
             "exit_velocity": e.launch_speed,
             "launch_angle": e.launch_angle,
             "pitch_type": e.pitch_type,
@@ -403,8 +488,8 @@ def get_pitcher_game_log(session: Session, pitcher_id: int, n: int = 10) -> List
     log = []
     for d in sorted(by_date, reverse=True):
         evs = by_date[d]
-        terminal = [e for e in evs if e.events and e.events != ""]
-        outcomes = [e.events for e in terminal]
+        terminal = [e for e in evs if _is_terminal_event(e.events)]
+        outcomes = [_clean_event_name(e.events) for e in terminal]
         ev_vals = [e.launch_speed for e in terminal if e.launch_speed is not None]
         speeds = [e.release_speed for e in evs if e.release_speed is not None]
         hard_hits = sum(1 for v in ev_vals if v >= 95)


### PR DESCRIPTION
## Summary

This PR keeps the existing rolling batter UI/routes intact and makes targeted fixes so rolling pages read trustworthy values from the persisted `statcast_events` Postgres store.

## Changes

- Preserve existing `/batter/{id}/rolling/*` routes and React page structure.
- Keep rolling calculations sourced from stored Postgres `statcast_events` rows.
- Filter malformed/invalid Statcast event values such as `nan`, `null`, empty, and non-terminal pitch rows.
- Enforce correct rolling definitions:
  - PA windows use terminal plate appearance outcomes.
  - AB windows use strict official AB outcomes.
  - Games windows group from stored game/date history.
- Add backend freshness/source/denominator metadata:
  - `latest_event_date`
  - `as_of_date`
  - `days_stale`
  - `is_stale`
  - `source`
  - `total_event_rows`
  - `terminal_event_rows`
  - `event_count`
  - `terminal_event_count`
  - `invalid_event_count`
  - `batted_ball_count`
  - `hard_hit_count`
  - `barrel_count`
- Update `RollingBatterPage.jsx` to render freshness/source/denominator metadata.
- Does not change cron behavior or mix live matchup refreshes with heavy Statcast backfill.

## Files changed

- `mlb_app/db_utils.py`
- `frontend/src/pages/RollingBatterPage.jsx`

## Validation focus

After merge/deploy, check:

- `/batter/{id}/rolling/pa?windows=10,25,50,100,200,400,1000`
- `/batter/{id}/rolling/ab?windows=10,25,50,100`
- `/batter/{id}/rolling/games?windows=5,10,15,30`
- `/batter/{id}/at-bats/ordered`

Expected behavior:

- No `result = nan` rows in chronological PA table.
- UI displays freshness metadata and stale-data warnings.
- Rolling windows show denominator counts for PA, AB, BBE, hard-hit, barrel, and invalid events.
- Values are sourced from `postgres_statcast_events`.

Closes #75.