### PR TITLE
Add Daily Odds real model engine and model panels

### DIFF
--- a/frontend/src/pages/DailyOddsPage.jsx
+++ b/frontend/src/pages/DailyOddsPage.jsx
@@ -12,6 +12,7 @@ const s = {
   subtitle: { color: '#8b949e', fontSize: '14px', marginTop: '8px', maxWidth: '640px' },
   controls: { display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap' },
   input: { background: '#0d1117', border: '1px solid #30363d', color: '#e6edf3', borderRadius: '10px', padding: '10px 12px', fontSize: '14px', outline: 'none' },
+  select: { background: '#0d1117', border: '1px solid #30363d', color: '#e6edf3', borderRadius: '10px', padding: '9px 11px', fontSize: '13px', outline: 'none', minWidth: '220px' },
   button: { background: '#238636', border: '1px solid #2ea043', color: '#fff', borderRadius: '10px', padding: '10px 14px', fontSize: '13px', fontWeight: '800', cursor: 'pointer' },
   mutedButton: { background: '#21262d', border: '1px solid #30363d', color: '#58a6ff', borderRadius: '9px', padding: '8px 11px', fontSize: '12px', fontWeight: '800', cursor: 'pointer' },
   stats: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(145px, 1fr))', gap: '10px', marginTop: '18px' },
@@ -32,7 +33,15 @@ const s = {
   marketTitle: { color: '#8b949e', fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.9px', fontWeight: '900', marginBottom: '9px' },
   oddsLine: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '10px', color: '#e6edf3', fontSize: '13px', marginTop: '6px', padding: '5px 0', borderTop: '1px solid rgba(48,54,61,0.55)' },
   price: { fontWeight: '900', color: '#e6edf3', whiteSpace: 'nowrap' },
+  modelPanel: { borderTop: '1px solid #30363d', padding: '14px 16px', background: '#0f151d' },
+  modelGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: '10px' },
+  modelCard: { border: '1px solid #30363d', borderRadius: '12px', padding: '12px', background: '#0d1117' },
+  modelTitle: { color: '#58a6ff', fontSize: '10px', fontWeight: '900', textTransform: 'uppercase', letterSpacing: '0.8px' },
+  modelPick: { color: '#e6edf3', fontSize: '15px', fontWeight: '900', marginTop: '7px' },
+  modelMeta: { color: '#8b949e', fontSize: '12px', marginTop: '4px' },
+  modelDriver: { color: '#8b949e', fontSize: '11px', marginTop: '8px' },
   props: { borderTop: '1px solid #30363d', padding: '13px 16px 16px', background: '#111820' },
+  propControls: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '10px', marginBottom: '10px' },
   propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(235px, 1fr))', gap: '9px' },
   propCard: { border: '1px solid #30363d', borderRadius: '10px', padding: '10px', background: '#0d1117' },
   propMarket: { color: '#d29922', fontSize: '10px', fontWeight: '900', textTransform: 'uppercase', letterSpacing: '0.6px', marginBottom: '6px' },
@@ -46,58 +55,32 @@ const s = {
 function normalizeTeamName(name) {
   return String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '').replace(/^the/, '')
 }
-
-function matchupKey(away, home) {
-  return `${normalizeTeamName(away)}@${normalizeTeamName(home)}`
-}
-
-function keyFromMatchup(m) {
-  return matchupKey(m.away_team_name || m.away_team || m.away_name, m.home_team_name || m.home_team || m.home_name)
-}
-
-function keyFromEvent(e) {
-  return matchupKey(e?.away_team?.name || e?.away_team || '', e?.home_team?.name || e?.home_team || '')
-}
-
-function american(v) {
-  if (v == null || v === '') return '—'
-  const n = Number(v)
-  if (Number.isNaN(n)) return String(v)
-  return n > 0 ? `+${n}` : `${n}`
-}
-
-function formatTime(iso) {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET'
-  } catch {
-    return '—'
-  }
-}
-
-function getMarkets(event) {
-  return Array.isArray(event?.markets) ? event.markets : []
-}
-
-function findMarket(event, keys) {
-  const wanted = Array.isArray(keys) ? keys : [keys]
-  return getMarkets(event).find(m => wanted.includes(m.market_key) || wanted.includes(m.market_type) || wanted.includes(m.market_name))
-}
+function matchupKey(away, home) { return `${normalizeTeamName(away)}@${normalizeTeamName(home)}` }
+function keyFromMatchup(m) { return matchupKey(m.away_team_name || m.away_team || m.away_name, m.home_team_name || m.home_team || m.home_name) }
+function keyFromEvent(e) { return matchupKey(e?.away_team?.name || e?.away_team || '', e?.home_team?.name || e?.home_team || '') }
+function american(v) { if (v == null || v === '') return '—'; const n = Number(v); if (Number.isNaN(n)) return String(v); return n > 0 ? `+${n}` : `${n}` }
+function pct(v) { if (v == null) return '—'; const n = Number(v); if (Number.isNaN(n)) return '—'; return `${Math.round(n * 1000) / 10}%` }
+function formatTime(iso) { if (!iso) return '—'; try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET' } catch { return '—' } }
+function cleanMarketName(name) { return String(name || 'Market').replaceAll('_', ' ') }
+function getMarkets(event) { return Array.isArray(event?.markets) ? event.markets : [] }
+function findMarket(event, keys) { const wanted = Array.isArray(keys) ? keys : [keys]; return getMarkets(event).find(m => wanted.includes(m.market_key) || wanted.includes(m.market_type) || wanted.includes(m.market_name)) }
+function selectionLabel(sel) { return `${sel?.name || sel?.description || '—'}${sel?.line != null ? ` ${sel.line}` : ''}` }
 
 function MarketBox({ label, market }) {
   const selections = market?.selections || []
-  return (
-    <div style={s.market}>
-      <div style={s.marketTitle}>{label}</div>
-      {selections.length === 0 && <div style={s.oddsLine}><span>Unavailable</span><strong style={s.price}>—</strong></div>}
-      {selections.slice(0, 3).map((sel, idx) => (
-        <div key={`${label}-${idx}`} style={s.oddsLine}>
-          <span>{sel.name || sel.description || '—'}{sel.line != null ? ` ${sel.line}` : ''}</span>
-          <strong style={s.price}>{american(sel.price)}</strong>
-        </div>
-      ))}
-    </div>
-  )
+  return <div style={s.market}><div style={s.marketTitle}>{label}</div>{selections.length === 0 && <div style={s.oddsLine}><span>Unavailable</span><strong style={s.price}>—</strong></div>}{selections.slice(0, 3).map((sel, idx) => <div key={`${label}-${idx}`} style={s.oddsLine}><span>{selectionLabel(sel)}</span><strong style={s.price}>{american(sel.price)}</strong></div>)}</div>
+}
+
+function ModelCard({ title, model }) {
+  if (!model) return <div style={s.modelCard}><div style={s.modelTitle}>{title}</div><div style={s.modelPick}>Unavailable</div><div style={s.modelMeta}>No model output returned.</div></div>
+  const missing = model.missing_inputs || []
+  const drivers = model.drivers || []
+  return <div style={s.modelCard}><div style={s.modelTitle}>{title}</div><div style={s.modelPick}>{model.pick || 'No pick'}</div><div style={s.modelMeta}>Confidence {pct(model.confidence)} · Edge {model.edge == null ? '—' : pct(model.edge)} · Market {pct(model.market_implied_probability)}</div><div style={s.modelMeta}>Score {model.score ?? '—'} · Model {pct(model.model_probability)}</div>{drivers.length > 0 && <div style={s.modelDriver}>Drivers: {drivers.slice(0, 3).join(', ')}</div>}{missing.length > 0 && <div style={s.modelDriver}>Missing: {missing.slice(0, 4).join(', ')}</div>}</div>
+}
+
+function GameModelPanel({ modelRow }) {
+  const models = modelRow?.models
+  return <div style={s.modelPanel}><div style={{ ...s.marketTitle, marginBottom: '10px' }}>BaseballGPT Model Engine</div><div style={s.modelGrid}><ModelCard title="Moneyline" model={models?.moneyline} /><ModelCard title="Run Line" model={models?.spread} /><ModelCard title="Total" model={models?.total} /></div>{!modelRow && <div style={{ ...s.modelMeta, marginTop: '10px' }}>Model endpoint did not return a matching row for this game.</div>}</div>
 }
 
 function PropsPanel({ eventId }) {
@@ -105,49 +88,26 @@ function PropsPanel({ eventId }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
+  const [selectedMarket, setSelectedMarket] = useState('all')
+  const [propModels, setPropModels] = useState(null)
 
   function toggle() {
-    if (open) {
-      setOpen(false)
-      return
-    }
+    if (open) { setOpen(false); return }
     setOpen(true)
     if (data || loading) return
-    setLoading(true)
-    setError(null)
-    fetch(`${API}/odds/draftkings/event/${eventId}/props`)
-      .then(async r => {
-        if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`)
-        return r.json()
-      })
-      .then(json => { setData(json); setLoading(false) })
-      .catch(err => { setError(String(err?.message || err)); setLoading(false) })
+    setLoading(true); setError(null)
+    Promise.all([
+      fetch(`${API}/odds/draftkings/event/${eventId}/props`).then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
+      fetch(`${API}/daily-odds/event/${eventId}/prop-models`).then(async r => r.ok ? r.json() : null).catch(() => null),
+    ]).then(([json, modelJson]) => { setData(json); setPropModels(modelJson); setLoading(false) }).catch(err => { setError(String(err?.message || err)); setLoading(false) })
   }
 
   const markets = data?.markets || data?.event?.markets || []
-  const props = markets.flatMap(market =>
-    (market.selections || []).map(sel => ({ market, sel }))
-  )
+  const filteredMarkets = selectedMarket === 'all' ? markets : markets.filter((_, idx) => String(idx) === selectedMarket)
+  const props = filteredMarkets.flatMap(market => (market.selections || []).map(sel => ({ market, sel })))
+  const topProps = propModels?.models?.top_candidates || []
 
-  return (
-    <div style={s.props}>
-      <button type="button" style={s.mutedButton} onClick={toggle}>{open ? 'Hide Player Props' : 'Show Player Props'}</button>
-      {open && loading && <div style={{ color: '#8b949e', fontSize: '12px', marginTop: '10px' }}>Loading props…</div>}
-      {open && error && <div style={{ color: '#f85149', fontSize: '12px', marginTop: '10px' }}>Props error: {error}</div>}
-      {open && !loading && !error && data && props.length === 0 && <div style={{ color: '#8b949e', fontSize: '12px', marginTop: '10px' }}>No props returned for this event.</div>}
-      {open && props.length > 0 && (
-        <div style={{ ...s.propsGrid, marginTop: '10px' }}>
-          {props.slice(0, 60).map(({ market, sel }, idx) => (
-            <div key={`${market.market_key || market.market_name}-${sel.description}-${sel.name}-${idx}`} style={s.propCard}>
-              <div style={s.propMarket}>{String(market.market_name || market.market_key || 'Market').replaceAll('_', ' ')}</div>
-              <div style={s.propName}>{sel.description || sel.name || '—'}</div>
-              <div style={s.propDetail}>{sel.name || '—'} {sel.line != null ? sel.line : ''} · <strong style={{ color: '#e6edf3' }}>{american(sel.price)}</strong></div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  )
+  return <div style={s.props}><div style={s.propControls}><button type="button" style={s.mutedButton} onClick={toggle}>{open ? 'Hide Player Props' : 'Show Player Props'}</button>{open && markets.length > 0 && <select value={selectedMarket} onChange={e => setSelectedMarket(e.target.value)} style={s.select}><option value="all">All prop markets</option>{markets.map((market, idx) => <option key={`${market.market_key || market.market_name}-${idx}`} value={String(idx)}>{cleanMarketName(market.market_name || market.market_key)}</option>)}</select>}</div>{open && loading && <div style={{ color: '#8b949e', fontSize: '12px', marginTop: '10px' }}>Loading props…</div>}{open && error && <div style={{ color: '#f85149', fontSize: '12px', marginTop: '10px' }}>Props error: {error}</div>}{open && topProps.length > 0 && <div style={{ marginBottom: '10px' }}><div style={{ ...s.marketTitle, marginBottom: '8px' }}>Top Prop Model Candidates</div><div style={s.modelGrid}>{topProps.map((p, idx) => <ModelCard key={`${p.market}-${p.pick}-${idx}`} title={`Prop ${idx + 1}`} model={p} />)}</div></div>}{open && !loading && !error && data && props.length === 0 && <div style={{ color: '#8b949e', fontSize: '12px', marginTop: '10px' }}>No props returned for this selection.</div>}{open && props.length > 0 && <div style={{ ...s.propsGrid, marginTop: '10px' }}>{props.slice(0, 80).map(({ market, sel }, idx) => <div key={`${market.market_key || market.market_name}-${sel.description}-${sel.name}-${idx}`} style={s.propCard}><div style={s.propMarket}>{cleanMarketName(market.market_name || market.market_key)}</div><div style={s.propName}>{sel.description || sel.name || '—'}</div><div style={s.propDetail}>{selectionLabel(sel)} · <strong style={{ color: '#e6edf3' }}>{american(sel.price)}</strong></div></div>)}</div>}</div>
 }
 
 export default function DailyOddsPage() {
@@ -155,120 +115,27 @@ export default function DailyOddsPage() {
   const [date, setDate] = useState(today)
   const [matchups, setMatchups] = useState([])
   const [events, setEvents] = useState([])
+  const [models, setModels] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [lastRefreshed, setLastRefreshed] = useState(null)
 
   function load() {
-    setLoading(true)
-    setError(null)
+    setLoading(true); setError(null)
     Promise.all([
-      fetch(`${API}/matchups?date=${date}`).then(async r => {
-        if (!r.ok) throw new Error(`/matchups failed: ${r.status} ${r.statusText}: ${await r.text()}`)
-        return r.json()
-      }),
-      fetch(`${API}/odds/draftkings/events?date=${date}`).then(async r => {
-        if (!r.ok) throw new Error(`/odds/draftkings/events failed: ${r.status} ${r.statusText}: ${await r.text()}`)
-        return r.json()
-      }),
-    ])
-      .then(([matchupData, oddsData]) => {
-        setMatchups(Array.isArray(matchupData) ? matchupData : [])
-        setEvents(Array.isArray(oddsData?.events) ? oddsData.events : [])
-        setLastRefreshed(new Date())
-        setLoading(false)
-      })
-      .catch(err => {
-        setError(String(err?.message || err))
-        setLoading(false)
-      })
+      fetch(`${API}/matchups?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/matchups failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
+      fetch(`${API}/odds/draftkings/events?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/odds/draftkings/events failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
+      fetch(`${API}/daily-odds/models?date=${date}`).then(async r => r.ok ? r.json() : null).catch(() => null),
+    ]).then(([matchupData, oddsData, modelData]) => { setMatchups(Array.isArray(matchupData) ? matchupData : []); setEvents(Array.isArray(oddsData?.events) ? oddsData.events : []); setModels(Array.isArray(modelData?.models) ? modelData.models : []); setLastRefreshed(new Date()); setLoading(false) }).catch(err => { setError(String(err?.message || err)); setLoading(false) })
   }
 
   useEffect(() => { load() }, [date])
 
-  const matchupByKey = useMemo(() => {
-    const map = new Map()
-    matchups.forEach(m => {
-      const key = keyFromMatchup(m)
-      if (key !== '@') map.set(key, m)
-    })
-    return map
-  }, [matchups])
-
-  const rows = useMemo(() => events.map(event => {
-    const key = keyFromEvent(event)
-    const matchup = matchupByKey.get(key)
-    return { event, matchup, matched: Boolean(matchup), key }
-  }), [events, matchupByKey])
-
+  const matchupByKey = useMemo(() => { const map = new Map(); matchups.forEach(m => { const key = keyFromMatchup(m); if (key !== '@') map.set(key, m) }); return map }, [matchups])
+  const modelByEventId = useMemo(() => { const map = new Map(); models.forEach(row => { if (row?.event_id) map.set(String(row.event_id), row) }); return map }, [models])
+  const rows = useMemo(() => events.map(event => { const key = keyFromEvent(event); const matchup = matchupByKey.get(key); return { event, matchup, matched: Boolean(matchup), key } }), [events, matchupByKey])
   const matchedCount = rows.filter(r => r.matched).length
   const unmatchedCount = rows.length - matchedCount
 
-  return (
-    <div style={s.page}>
-      <section style={s.hero}>
-        <div style={s.header}>
-          <div>
-            <div style={s.eyebrow}>DraftKings board</div>
-            <h1 style={s.title}>Daily Odds</h1>
-            <div style={s.subtitle}>Moneyline, run line, totals, props, event IDs, and MLB game matching in one clean board.</div>
-          </div>
-          <div style={s.controls}>
-            <input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} />
-            <button type="button" style={s.button} onClick={load} disabled={loading}>{loading ? 'Refreshing…' : 'Refresh Odds'}</button>
-          </div>
-        </div>
-
-        <div style={s.stats}>
-          <div style={s.statCard}><div style={s.statLabel}>MLB Games</div><div style={s.statValue}>{matchups.length}</div></div>
-          <div style={s.statCard}><div style={s.statLabel}>DK Events</div><div style={s.statValue}>{events.length}</div></div>
-          <div style={s.statCard}><div style={s.statLabel}>Matched</div><div style={s.statValue}>{matchedCount}</div></div>
-          <div style={s.statCard}><div style={s.statLabel}>Unmatched</div><div style={s.statValue}>{unmatchedCount}</div></div>
-          <div style={s.statCard}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: '15px' }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : '—'}</div></div>
-        </div>
-      </section>
-
-      <div style={s.toolbar}>
-        <div style={s.toolbarText}>{rows.length} sportsbook events loaded for {date}</div>
-        <div style={s.toolbarText}>Matched by normalized away/home team names</div>
-      </div>
-
-      {error && <div style={s.error}>{error}</div>}
-      {loading && <div style={s.loader}>Loading daily odds…</div>}
-      {!loading && !error && rows.length === 0 && <div style={s.empty}>No DraftKings events returned for {date}.</div>}
-
-      <div style={s.grid}>
-        {rows.map(({ event, matchup, matched, key }, idx) => {
-          const away = event?.away_team?.name || event?.away_team || matchup?.away_team_name || 'Away'
-          const home = event?.home_team?.name || event?.home_team || matchup?.home_team_name || 'Home'
-          const moneyline = findMarket(event, 'h2h')
-          const spread = findMarket(event, 'spreads')
-          const total = findMarket(event, 'totals')
-          return (
-            <article key={`${event.event_id || key || idx}`} style={s.card}>
-              <div style={s.cardTop}>
-                <div>
-                  <div style={s.matchup}>{away} @ {home}</div>
-                  <div style={s.metaRow}>
-                    <span style={s.chip}>Time: {formatTime(matchup?.game_time || event?.start_time || event?.commence_time)}</span>
-                    <span style={s.chip}>MLB: {matchup?.game_pk ? <Link to={`/matchup/${matchup.game_pk}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>{matchup.game_pk}</Link> : '—'}</span>
-                    <span style={s.chip}>DK: {event.event_id || '—'}</span>
-                  </div>
-                </div>
-                <span style={s.badge(matched)}>{matched ? 'MATCHED' : 'UNMATCHED'}</span>
-              </div>
-
-              <div style={s.markets}>
-                <MarketBox label="Moneyline" market={moneyline} />
-                <MarketBox label="Run Line" market={spread} />
-                <MarketBox label="Total" market={total} />
-              </div>
-
-              {event.event_id && <PropsPanel eventId={event.event_id} />}
-            </article>
-          )
-        })}
-      </div>
-    </div>
-  )
+  return <div style={s.page}><section style={s.hero}><div style={s.header}><div><div style={s.eyebrow}>DraftKings board</div><h1 style={s.title}>Daily Odds</h1><div style={s.subtitle}>Moneyline, run line, totals, prop market selectors, model outputs, event IDs, and MLB game matching in one clean board.</div></div><div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={s.button} onClick={load} disabled={loading}>{loading ? 'Refreshing…' : 'Refresh Odds'}</button></div></div><div style={s.stats}><div style={s.statCard}><div style={s.statLabel}>MLB Games</div><div style={s.statValue}>{matchups.length}</div></div><div style={s.statCard}><div style={s.statLabel}>DK Events</div><div style={s.statValue}>{events.length}</div></div><div style={s.statCard}><div style={s.statLabel}>Matched</div><div style={s.statValue}>{matchedCount}</div></div><div style={s.statCard}><div style={s.statLabel}>Unmatched</div><div style={s.statValue}>{unmatchedCount}</div></div><div style={s.statCard}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: '15px' }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : '—'}</div></div></div></section><div style={s.toolbar}><div style={s.toolbarText}>{rows.length} sportsbook events loaded for {date}</div><div style={s.toolbarText}>BaseballGPT model panels use available matchup and market data and expose missing inputs.</div></div>{error && <div style={s.error}>{error}</div>}{loading && <div style={s.loader}>Loading daily odds…</div>}{!loading && !error && rows.length === 0 && <div style={s.empty}>No DraftKings events returned for {date}.</div>}<div style={s.grid}>{rows.map(({ event, matchup, matched, key }, idx) => { const away = event?.away_team?.name || event?.away_team || matchup?.away_team_name || 'Away'; const home = event?.home_team?.name || event?.home_team || matchup?.home_team_name || 'Home'; const moneyline = findMarket(event, 'h2h'); const spread = findMarket(event, 'spreads'); const total = findMarket(event, 'totals'); const modelRow = modelByEventId.get(String(event.event_id)); return <article key={`${event.event_id || key || idx}`} style={s.card}><div style={s.cardTop}><div><div style={s.matchup}>{away} @ {home}</div><div style={s.metaRow}><span style={s.chip}>Time: {formatTime(matchup?.game_time || event?.start_time || event?.commence_time)}</span><span style={s.chip}>MLB: {matchup?.game_pk ? <Link to={`/matchup/${matchup.game_pk}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>{matchup.game_pk}</Link> : '—'}</span><span style={s.chip}>DK: {event.event_id || '—'}</span></div></div><span style={s.badge(matched)}>{matched ? 'MATCHED' : 'UNMATCHED'}</span></div><div style={s.markets}><MarketBox label="Moneyline" market={moneyline} /><MarketBox label="Run Line" market={spread} /><MarketBox label="Total" market={total} /></div><GameModelPanel modelRow={modelRow} />{event.event_id && <PropsPanel eventId={event.event_id} />}</article> })}</div></div>
 }

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -79,6 +79,8 @@ from .odds_provider import (
 
 from .batter_routes import router as batter_router
 
+from .daily_odds_routes import router as daily_odds_router
+
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
 LIVE_CACHE: Dict[str, Dict[str, Any]] = {}
@@ -647,6 +649,8 @@ def create_app():
     )
 
     app.include_router(batter_router)
+
+    app.include_router(daily_odds_router)
 
     @app.get("/health")
     def health():

--- a/mlb_app/daily_odds_models.py
+++ b/mlb_app/daily_odds_models.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def _norm(value: Optional[float], baseline: float, scale: float, invert: bool = False) -> Optional[float]:
+    if value is None or scale == 0:
+        return None
+    score = (value - baseline) / scale
+    if invert:
+        score *= -1
+    return _clamp(0.5 + score / 2.0)
+
+
+def _american_to_implied(price: Any) -> Optional[float]:
+    p = _safe_float(price)
+    if p is None or p == 0:
+        return None
+    if p > 0:
+        return round(100.0 / (p + 100.0), 4)
+    return round(abs(p) / (abs(p) + 100.0), 4)
+
+
+def _pct(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    if value > 1:
+        return value / 100.0
+    return value
+
+
+def _get(obj: Dict[str, Any], paths: List[str]) -> Tuple[Optional[Any], Optional[str]]:
+    for path in paths:
+        cur: Any = obj
+        ok = True
+        for part in path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                ok = False
+                break
+        if ok and cur is not None:
+            return cur, path
+    return None, None
+
+
+def _feature(features: List[Dict[str, Any]], name: str, value: Any, source: Optional[str], transform: str = "raw") -> Optional[float]:
+    numeric = _safe_float(value)
+    if numeric is not None:
+        features.append({"name": name, "value": numeric, "source": source or "unknown", "transform": transform})
+    return numeric
+
+
+def _score_from_features(values: List[Optional[float]]) -> Tuple[float, int]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return 0.5, 0
+    return round(sum(nums) / len(nums), 4), len(nums)
+
+
+def _confidence(used: int, expected: int, model_depth: float = 1.0) -> float:
+    if expected <= 0:
+        return 0.0
+    return round(_clamp((used / expected) * model_depth), 3)
+
+
+def _selection_label(sel: Dict[str, Any]) -> str:
+    base = sel.get("description") or sel.get("name") or "Selection"
+    line = sel.get("line")
+    return f"{base} {line}" if line is not None else str(base)
+
+
+def _find_market(event: Dict[str, Any], keys: List[str]) -> Optional[Dict[str, Any]]:
+    for market in event.get("markets", []) or []:
+        market_key = market.get("market_key") or market.get("market_type") or market.get("market_name")
+        if market_key in keys:
+            return market
+    return None
+
+
+def _pick_selection_by_team(market: Optional[Dict[str, Any]], team_name: str) -> Optional[Dict[str, Any]]:
+    if not market:
+        return None
+    target = str(team_name or "").lower()
+    for sel in market.get("selections", []) or []:
+        candidate = str(sel.get("name") or sel.get("team") or "").lower()
+        if target and (target in candidate or candidate in target):
+            return sel
+    return None
+
+
+def _best_price_selection(market: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not market:
+        return None
+    priced = []
+    for sel in market.get("selections", []) or []:
+        implied = _american_to_implied(sel.get("price"))
+        if implied is not None:
+            priced.append((implied, sel))
+    if not priced:
+        return None
+    priced.sort(key=lambda x: x[0])
+    return priced[0][1]
+
+
+def _market_hold(market: Optional[Dict[str, Any]]) -> Optional[float]:
+    if not market:
+        return None
+    probs = [_american_to_implied(sel.get("price")) for sel in market.get("selections", []) or []]
+    probs = [p for p in probs if p is not None]
+    if len(probs) < 2:
+        return None
+    return round(max(0.0, sum(probs) - 1.0), 4)
+
+
+def _model_output(model: str, market: str, pick: str, score: float, model_probability: Optional[float], market_probability: Optional[float], features: List[Dict[str, Any]], missing: List[str], drivers: List[str]) -> Dict[str, Any]:
+    used = len(features)
+    expected = used + len(missing)
+    edge = None
+    if model_probability is not None and market_probability is not None:
+        edge = round(model_probability - market_probability, 4)
+    return {
+        "model": model,
+        "market": market,
+        "pick": pick,
+        "score": round(score, 4),
+        "model_probability": round(model_probability, 4) if model_probability is not None else None,
+        "market_implied_probability": round(market_probability, 4) if market_probability is not None else None,
+        "edge": edge,
+        "confidence": _confidence(used, expected if expected else 1),
+        "features_used": features,
+        "missing_inputs": missing,
+        "drivers": drivers,
+        "available": used >= 3,
+    }
+
+
+def _game_context(matchup: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "away_team": matchup.get("away_team_name") or matchup.get("away_team") or matchup.get("away_name"),
+        "home_team": matchup.get("home_team_name") or matchup.get("home_team") or matchup.get("home_name"),
+        "game_pk": matchup.get("game_pk"),
+    }
+
+
+def build_game_models(matchup: Dict[str, Any], event: Dict[str, Any]) -> Dict[str, Any]:
+    ctx = _game_context(matchup)
+    moneyline = _find_market(event, ["h2h"])
+    spread = _find_market(event, ["spreads"])
+    total = _find_market(event, ["totals"])
+    return {
+        "game_pk": ctx.get("game_pk"),
+        "event_id": event.get("event_id"),
+        "moneyline": build_moneyline_model(matchup, moneyline, ctx),
+        "spread": build_spread_model(matchup, spread, ctx),
+        "total": build_total_model(matchup, total, ctx),
+    }
+
+
+def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Any]:
+    features: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    drivers: List[str] = []
+
+    home_prob_raw, home_prob_src = _get(matchup, ["home_win_probability", "home_win_prob", "probabilities.home", "prediction.home_win_probability"])
+    away_prob_raw, away_prob_src = _get(matchup, ["away_win_probability", "away_win_prob", "probabilities.away", "prediction.away_win_probability"])
+    home_prob = _feature(features, "home_internal_win_probability", home_prob_raw, home_prob_src)
+    away_prob = _feature(features, "away_internal_win_probability", away_prob_raw, away_prob_src)
+    if home_prob is None:
+        missing.append("home_internal_win_probability")
+    if away_prob is None:
+        missing.append("away_internal_win_probability")
+
+    home_pitch_raw, home_pitch_src = _get(matchup, ["home_pitcher_score", "home_pitcher_rating", "home_pitcher_xwoba", "home_pitcher_era", "home_pitcher_stats.xwoba"])
+    away_pitch_raw, away_pitch_src = _get(matchup, ["away_pitcher_score", "away_pitcher_rating", "away_pitcher_xwoba", "away_pitcher_era", "away_pitcher_stats.xwoba"])
+    home_pitch = _feature(features, "home_pitcher_quality", home_pitch_raw, home_pitch_src)
+    away_pitch = _feature(features, "away_pitcher_quality", away_pitch_raw, away_pitch_src)
+    if home_pitch is None:
+        missing.append("home_pitcher_quality")
+    if away_pitch is None:
+        missing.append("away_pitcher_quality")
+
+    home_off_raw, home_off_src = _get(matchup, ["home_offense_score", "home_team_strength", "home_hitting_score", "home_team_stats.ops"])
+    away_off_raw, away_off_src = _get(matchup, ["away_offense_score", "away_team_strength", "away_hitting_score", "away_team_stats.ops"])
+    home_off = _feature(features, "home_offense_strength", home_off_raw, home_off_src)
+    away_off = _feature(features, "away_offense_strength", away_off_raw, away_off_src)
+    if home_off is None:
+        missing.append("home_offense_strength")
+    if away_off is None:
+        missing.append("away_offense_strength")
+
+    home_sel = _pick_selection_by_team(market, ctx.get("home_team") or "")
+    away_sel = _pick_selection_by_team(market, ctx.get("away_team") or "")
+    home_market = _american_to_implied(home_sel.get("price") if home_sel else None)
+    away_market = _american_to_implied(away_sel.get("price") if away_sel else None)
+    if home_market is not None:
+        features.append({"name": "home_market_implied_probability", "value": home_market, "source": "draftkings.h2h.home", "transform": "american_to_implied"})
+    else:
+        missing.append("home_market_implied_probability")
+    if away_market is not None:
+        features.append({"name": "away_market_implied_probability", "value": away_market, "source": "draftkings.h2h.away", "transform": "american_to_implied"})
+    else:
+        missing.append("away_market_implied_probability")
+
+    signals = []
+    if home_prob is not None and away_prob is not None:
+        signals.append(_clamp(0.5 + (home_prob - away_prob) / 2.0))
+        drivers.append("internal win probability gap")
+    if home_off is not None and away_off is not None:
+        signals.append(_clamp(0.5 + (home_off - away_off) / 2.0))
+        drivers.append("team offense gap")
+    if home_pitch is not None and away_pitch is not None:
+        signals.append(_clamp(0.5 + (home_pitch - away_pitch) / 2.0))
+        drivers.append("starting pitcher gap")
+    model_home_prob, used_signal_count = _score_from_features(signals)
+    pick_home = model_home_prob >= 0.5
+    pick = ctx.get("home_team") if pick_home else ctx.get("away_team")
+    market_prob = home_market if pick_home else away_market
+    return _model_output("moneyline_real_v1", "moneyline", str(pick or "No pick"), model_home_prob, model_home_prob if pick_home else round(1 - model_home_prob, 4), market_prob, features, missing, drivers)
+
+
+def build_spread_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Any]:
+    features: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    drivers: List[str] = []
+    home_runs_raw, home_runs_src = _get(matchup, ["home_projected_runs", "home_runs_projected", "projection.home_runs", "home_score_projection"])
+    away_runs_raw, away_runs_src = _get(matchup, ["away_projected_runs", "away_runs_projected", "projection.away_runs", "away_score_projection"])
+    home_runs = _feature(features, "home_projected_runs", home_runs_raw, home_runs_src)
+    away_runs = _feature(features, "away_projected_runs", away_runs_raw, away_runs_src)
+    if home_runs is None:
+        missing.append("home_projected_runs")
+    if away_runs is None:
+        missing.append("away_projected_runs")
+
+    home_off_raw, home_off_src = _get(matchup, ["home_offense_score", "home_team_strength", "home_hitting_score", "home_team_stats.ops"])
+    away_off_raw, away_off_src = _get(matchup, ["away_offense_score", "away_team_strength", "away_hitting_score", "away_team_stats.ops"])
+    home_off = _feature(features, "home_offense_strength", home_off_raw, home_off_src)
+    away_off = _feature(features, "away_offense_strength", away_off_raw, away_off_src)
+    if home_off is None:
+        missing.append("home_offense_strength")
+    if away_off is None:
+        missing.append("away_offense_strength")
+
+    home_pitch_raw, home_pitch_src = _get(matchup, ["home_pitcher_volatility", "home_pitcher_xwoba", "home_pitcher_hard_hit_pct", "home_pitcher_stats.xwoba"])
+    away_pitch_raw, away_pitch_src = _get(matchup, ["away_pitcher_volatility", "away_pitcher_xwoba", "away_pitcher_hard_hit_pct", "away_pitcher_stats.xwoba"])
+    home_pitch_risk = _feature(features, "home_pitcher_run_risk", home_pitch_raw, home_pitch_src)
+    away_pitch_risk = _feature(features, "away_pitcher_run_risk", away_pitch_raw, away_pitch_src)
+    if home_pitch_risk is None:
+        missing.append("home_pitcher_run_risk")
+    if away_pitch_risk is None:
+        missing.append("away_pitcher_run_risk")
+
+    if home_runs is not None and away_runs is not None:
+        run_diff = home_runs - away_runs
+        drivers.append("projected run differential")
+    else:
+        pieces = []
+        if home_off is not None and away_off is not None:
+            pieces.append(home_off - away_off)
+            drivers.append("offense differential proxy")
+        if home_pitch_risk is not None and away_pitch_risk is not None:
+            pieces.append(away_pitch_risk - home_pitch_risk)
+            drivers.append("pitcher run-risk proxy")
+        run_diff = sum(pieces) if pieces else 0.0
+    home_sel = _pick_selection_by_team(market, ctx.get("home_team") or "")
+    away_sel = _pick_selection_by_team(market, ctx.get("away_team") or "")
+    home_line = _safe_float(home_sel.get("line") if home_sel else None)
+    away_line = _safe_float(away_sel.get("line") if away_sel else None)
+    home_market = _american_to_implied(home_sel.get("price") if home_sel else None)
+    away_market = _american_to_implied(away_sel.get("price") if away_sel else None)
+    if home_line is None:
+        missing.append("home_spread_line")
+    else:
+        features.append({"name": "home_spread_line", "value": home_line, "source": "draftkings.spreads.home", "transform": "raw"})
+    if away_line is None:
+        missing.append("away_spread_line")
+    else:
+        features.append({"name": "away_spread_line", "value": away_line, "source": "draftkings.spreads.away", "transform": "raw"})
+    if home_market is not None:
+        features.append({"name": "home_spread_implied_probability", "value": home_market, "source": "draftkings.spreads.home", "transform": "american_to_implied"})
+    if away_market is not None:
+        features.append({"name": "away_spread_implied_probability", "value": away_market, "source": "draftkings.spreads.away", "transform": "american_to_implied"})
+    pick_home = run_diff + (home_line or 0) > 0
+    pick = f"{ctx.get('home_team')} {home_line}" if pick_home else f"{ctx.get('away_team')} {away_line}"
+    model_prob = _clamp(0.5 + abs(run_diff) / 6.0)
+    market_prob = home_market if pick_home else away_market
+    return _model_output("spread_real_v1", "spread", pick, run_diff, model_prob, market_prob, features, missing, drivers)
+
+
+def build_total_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]], ctx: Dict[str, Any]) -> Dict[str, Any]:
+    features: List[Dict[str, Any]] = []
+    missing: List[str] = []
+    drivers: List[str] = []
+    temp_raw, temp_src = _get(matchup, ["weather.temp_f", "weather.temp", "temp_f"])
+    temp = _feature(features, "temperature_f", temp_raw, temp_src)
+    if temp is None:
+        missing.append("temperature_f")
+    wind_raw, wind_src = _get(matchup, ["weather.wind_speed", "wind_speed"])
+    wind = _feature(features, "wind_speed", wind_raw, wind_src)
+    if wind is None:
+        missing.append("wind_speed")
+    home_off_raw, home_off_src = _get(matchup, ["home_offense_score", "home_team_strength", "home_hitting_score", "home_team_stats.ops"])
+    away_off_raw, away_off_src = _get(matchup, ["away_offense_score", "away_team_strength", "away_hitting_score", "away_team_stats.ops"])
+    home_off = _feature(features, "home_offense_strength", home_off_raw, home_off_src)
+    away_off = _feature(features, "away_offense_strength", away_off_raw, away_off_src)
+    if home_off is None:
+        missing.append("home_offense_strength")
+    if away_off is None:
+        missing.append("away_offense_strength")
+    home_pitch_raw, home_pitch_src = _get(matchup, ["home_pitcher_run_prevention", "home_pitcher_xwoba", "home_pitcher_era", "home_pitcher_stats.xwoba"])
+    away_pitch_raw, away_pitch_src = _get(matchup, ["away_pitcher_run_prevention", "away_pitcher_xwoba", "away_pitcher_era", "away_pitcher_stats.xwoba"])
+    home_pitch = _feature(features, "home_pitcher_run_prevention", home_pitch_raw, home_pitch_src)
+    away_pitch = _feature(features, "away_pitcher_run_prevention", away_pitch_raw, away_pitch_src)
+    if home_pitch is None:
+        missing.append("home_pitcher_run_prevention")
+    if away_pitch is None:
+        missing.append("away_pitcher_run_prevention")
+
+    total_sel = None
+    over_sel = None
+    under_sel = None
+    if market:
+        for sel in market.get("selections", []) or []:
+            name = str(sel.get("name") or "").lower()
+            if "over" in name:
+                over_sel = sel
+            elif "under" in name:
+                under_sel = sel
+        total_sel = over_sel or under_sel or (market.get("selections") or [None])[0]
+    market_total = _safe_float(total_sel.get("line") if total_sel else None)
+    over_prob = _american_to_implied(over_sel.get("price") if over_sel else None)
+    under_prob = _american_to_implied(under_sel.get("price") if under_sel else None)
+    if market_total is not None:
+        features.append({"name": "market_total", "value": market_total, "source": "draftkings.totals.line", "transform": "raw"})
+    else:
+        missing.append("market_total")
+    if over_prob is not None:
+        features.append({"name": "over_implied_probability", "value": over_prob, "source": "draftkings.totals.over", "transform": "american_to_implied"})
+    else:
+        missing.append("over_implied_probability")
+    if under_prob is not None:
+        features.append({"name": "under_implied_probability", "value": under_prob, "source": "draftkings.totals.under", "transform": "american_to_implied"})
+    else:
+        missing.append("under_implied_probability")
+
+    env = 0.0
+    if temp is not None:
+        env += (temp - 70.0) / 25.0
+        drivers.append("temperature run environment")
+    if wind is not None:
+        env += wind / 30.0
+        drivers.append("wind run environment")
+    if home_off is not None and away_off is not None:
+        env += (home_off + away_off - 1.0)
+        drivers.append("combined offense")
+    if home_pitch is not None and away_pitch is not None:
+        env -= (home_pitch + away_pitch - 1.0)
+        drivers.append("starting pitcher suppression")
+    projected_total = (market_total if market_total is not None else 8.5) + env
+    pick_over = projected_total >= (market_total if market_total is not None else 8.5)
+    pick = f"Over {market_total}" if pick_over else f"Under {market_total}"
+    model_prob = _clamp(0.5 + abs(projected_total - (market_total or 8.5)) / 5.0)
+    market_prob = over_prob if pick_over else under_prob
+    return _model_output("total_real_v1", "total", pick, projected_total, model_prob, market_prob, features, missing, drivers)
+
+
+def build_prop_models(matchup: Dict[str, Any], prop_markets: List[Dict[str, Any]], market_filter: Optional[str] = None) -> Dict[str, Any]:
+    candidates: List[Dict[str, Any]] = []
+    for market in prop_markets or []:
+        market_name = str(market.get("market_name") or market.get("market_key") or "prop")
+        if market_filter and market_filter != "all" and market_filter != market_name:
+            continue
+        for sel in market.get("selections", []) or []:
+            implied = _american_to_implied(sel.get("price"))
+            line = _safe_float(sel.get("line"))
+            score = (1 - implied) if implied is not None else 0.0
+            if line is not None:
+                score += min(0.25, abs(line) / 20.0)
+            candidates.append({
+                "model": "prop_real_v1",
+                "market": market_name,
+                "pick": _selection_label(sel),
+                "score": round(score, 4),
+                "model_probability": None,
+                "market_implied_probability": implied,
+                "edge": None,
+                "confidence": 0.35 if implied is not None else 0.1,
+                "features_used": [
+                    {"name": "prop_price", "value": sel.get("price"), "source": "draftkings.props.price", "transform": "american"},
+                    {"name": "prop_line", "value": line, "source": "draftkings.props.line", "transform": "raw"},
+                ],
+                "missing_inputs": ["player_statcast_context", "opponent_matchup_context", "lineup_role_context"],
+                "drivers": ["market price", "prop line"],
+                "available": implied is not None,
+            })
+    candidates.sort(key=lambda row: row.get("score") or 0, reverse=True)
+    return {"top_candidates": candidates[:3], "candidate_count": len(candidates)}

--- a/mlb_app/daily_odds_routes.py
+++ b/mlb_app/daily_odds_routes.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter
+
+from .daily_odds_models import build_game_models
+from .matchup_generator import generate_matchups_for_date
+from .odds_provider import fetch_draftkings_events, fetch_draftkings_event_odds
+
+router = APIRouter()
+
+
+def _normalize_team_key(name: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(name or "").lower().replace("the", "", 1))
+
+
+def _matchup_key(away: Any, home: Any) -> str:
+    return f"{_normalize_team_key(away)}@{_normalize_team_key(home)}"
+
+
+def _key_from_matchup(matchup: Dict[str, Any]) -> str:
+    return _matchup_key(
+        matchup.get("away_team_name") or matchup.get("away_team") or matchup.get("away_name"),
+        matchup.get("home_team_name") or matchup.get("home_team") or matchup.get("home_name"),
+    )
+
+
+def _key_from_event(event: Dict[str, Any]) -> str:
+    away = event.get("away_team") or {}
+    home = event.get("home_team") or {}
+    away_name = away.get("name") if isinstance(away, dict) else away
+    home_name = home.get("name") if isinstance(home, dict) else home
+    return _matchup_key(away_name, home_name)
+
+
+def _build_matchup_index(matchups: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    index: Dict[str, Dict[str, Any]] = {}
+    for matchup in matchups or []:
+        key = _key_from_matchup(matchup)
+        if key != "@":
+            index[key] = matchup
+    return index
+
+
+@router.get("/daily-odds/models")
+def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
+    target_date = date or datetime.date.today().isoformat()
+    matchups = generate_matchups_for_date(target_date)
+    odds_payload = fetch_draftkings_events(date=target_date, raw=False)
+    events = odds_payload.get("events", []) if isinstance(odds_payload, dict) else []
+    matchup_index = _build_matchup_index(matchups)
+
+    outputs: List[Dict[str, Any]] = []
+    for event in events:
+        key = _key_from_event(event)
+        matchup = matchup_index.get(key)
+        if not matchup:
+            outputs.append({
+                "event_id": event.get("event_id"),
+                "matched": False,
+                "match_key": key,
+                "models": None,
+                "missing_inputs": ["matched_mlb_game"],
+            })
+            continue
+        outputs.append({
+            "game_pk": matchup.get("game_pk"),
+            "event_id": event.get("event_id"),
+            "matched": True,
+            "match_key": key,
+            "models": build_game_models(matchup, event),
+        })
+
+    return {
+        "date": target_date,
+        "count": len(outputs),
+        "matched_count": sum(1 for row in outputs if row.get("matched")),
+        "unmatched_count": sum(1 for row in outputs if not row.get("matched")),
+        "odds_status": odds_payload.get("status") if isinstance(odds_payload, dict) else None,
+        "last_updated": odds_payload.get("last_updated") if isinstance(odds_payload, dict) else None,
+        "models": outputs,
+    }
+
+
+@router.get("/daily-odds/event/{event_id}/prop-models")
+def daily_odds_prop_models(event_id: str, market: Optional[str] = None) -> Dict[str, Any]:
+    from .daily_odds_models import build_prop_models
+
+    payload = fetch_draftkings_event_odds(event_id, props_only=True, raw=False)
+    prop_markets = payload.get("markets", []) if isinstance(payload, dict) else []
+    return {
+        "event_id": event_id,
+        "market_filter": market or "all",
+        "models": build_prop_models({}, prop_markets, market_filter=market or "all"),
+        "odds_status": payload.get("status") if isinstance(payload, dict) else None,
+        "last_updated": payload.get("last_updated") if isinstance(payload, dict) else None,
+    }


### PR DESCRIPTION
## Summary

Adds the first real Daily Odds modeling layer across backend and frontend.

## What changed

- Adds `mlb_app/daily_odds_models.py`
  - Moneyline model output
  - Spread/run-line model output
  - Total model output
  - Prop candidate model output
  - Confidence calculation
  - Missing input tracking
  - Features-used reporting
  - Market implied probability calculations

- Adds `mlb_app/daily_odds_routes.py`
  - `GET /daily-odds/models?date=YYYY-MM-DD`
  - `GET /daily-odds/event/{event_id}/prop-models`
  - Matches DraftKings events to MLB games
  - Runs model engine per matched game

- Updates `frontend/src/pages/DailyOddsPage.jsx`
  - Calls `/daily-odds/models`
  - Renders BaseballGPT model panels under each game
  - Shows Moneyline, Run Line, and Total model cards
  - Shows confidence, edge, drivers, and missing inputs
  - Calls prop model endpoint when props are opened
  - Renders top prop model candidates

## Important note

This PR assumes `daily_odds_router` is registered in `mlb_app/app.py` with:

```python
from .daily_odds_routes import router as daily_odds_router
app.include_router(daily_odds_router)
```

The route module and frontend wiring are included here. If that registration is already committed on the branch, the endpoint should be live after deploy.

## Model behavior

These are V1 production model panels. They use available matchup and DraftKings market data, expose missing fields, and lower confidence when inputs are not present. They do not invent unavailable datapoints.

## Testing checklist

- Visit `/daily-odds`
- Confirm games and odds still load
- Confirm each game displays BaseballGPT model cards
- Confirm `/daily-odds/models?date=YYYY-MM-DD` returns model JSON
- Open player props and confirm top prop candidates render when available
- Confirm missing inputs display instead of fake values