### PR TITLE
Apply Issue 115 supporting data changes

### DIFF
--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -58,8 +58,11 @@ class StatcastEvent(Base):
     balls: Optional[int] = Column(Integer, nullable=True)
     strikes: Optional[int] = Column(Integer, nullable=True)
     events: Optional[str] = Column(String(50), nullable=True)
+    description: Optional[str] = Column(String(60), nullable=True)
     launch_speed: Optional[float] = Column(Float, nullable=True)
     launch_angle: Optional[float] = Column(Float, nullable=True)
+    estimated_woba_using_speedangle: Optional[float] = Column(Float, nullable=True)
+    estimated_ba_using_speedangle: Optional[float] = Column(Float, nullable=True)
     stand: Optional[str] = Column(String(1), nullable=True)
     p_throws: Optional[str] = Column(String(1), nullable=True)
 
@@ -263,11 +266,14 @@ STATCAST_EVENT_SAFE_COLUMNS = {
     "outs_when_up": "INTEGER",
     "home_team": "VARCHAR(10)",
     "away_team": "VARCHAR(10)",
+    "description": "VARCHAR(60)",
+    "estimated_woba_using_speedangle": "FLOAT",
+    "estimated_ba_using_speedangle": "FLOAT",
 }
 
 
 def _ensure_statcast_event_columns(engine) -> None:
-    """Add missing nullable Statcast ordering columns without touching existing data.
+    """Add missing nullable Statcast ordering and hitter-quality columns without touching existing data.
 
     This is intentionally additive only. It never drops tables, deletes rows,
     rewrites existing values, or changes cron/refresh behavior.

--- a/mlb_app/etl.py
+++ b/mlb_app/etl.py
@@ -98,7 +98,6 @@ def _extract_team_ids(games: List[dict]) -> List[int]:
 
 def _fetch_team_split(team_id: int, season: int, split_code: str) -> Optional[dict]:
     url = f"{MLB_STATS_BASE}/teams/{team_id}/stats"
-    # statSplits returns proper vsLHP/vsRHP breakdowns; "season" returns overall only
     params = {"stats": "statSplits", "group": "hitting", "season": season, "sitCodes": split_code}
     try:
         resp = requests.get(url, params=params, timeout=20)
@@ -120,7 +119,6 @@ def _load_team_splits(session, team_ids: List[int], season: int) -> None:
             existing = session.query(TeamSplit).filter_by(
                 team_id=team_id, season=season, split=split_label
             ).first()
-            # Update existing record so stale identical data gets corrected
             if existing:
                 target = existing
             else:
@@ -175,8 +173,6 @@ def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -
     if df is None or df.empty:
         return pd.DataFrame()
 
-    # Persist raw events. Ordering fields are nullable so older or partial
-    # Statcast pulls remain compatible while newer pulls support true PA order.
     for _, row in df.iterrows():
         try:
             ev = StatcastEvent(
@@ -201,8 +197,11 @@ def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -
                 balls=int(row["balls"]) if pd.notna(row.get("balls")) else None,
                 strikes=int(row["strikes"]) if pd.notna(row.get("strikes")) else None,
                 events=str(row.get("events", "") or "")[:50] or None,
+                description=_safe_str(row.get("description"), 60),
                 launch_speed=_safe_float(row.get("launch_speed")),
                 launch_angle=_safe_float(row.get("launch_angle")),
+                estimated_woba_using_speedangle=_safe_float(row.get("estimated_woba_using_speedangle")),
+                estimated_ba_using_speedangle=_safe_float(row.get("estimated_ba_using_speedangle")),
                 stand=str(row.get("stand", "") or "")[:1] or None,
                 p_throws=str(row.get("p_throws", "") or "")[:1] or None,
             )
@@ -329,10 +328,8 @@ def run_etl_for_date(date_str: str) -> None:
 
         log.info("Found %d pitchers, %d teams", len(pitcher_ids), len(team_ids))
 
-        # Team splits
         _load_team_splits(session, team_ids, season)
 
-        # Try leaderboard arsenal first; fall back to per-pitcher Statcast
         arsenal_loaded = _try_load_arsenal_leaderboard(session, season)
 
         for pitcher_id in pitcher_ids:
@@ -370,7 +367,7 @@ def _ensure_historical_aggregate(session, pitcher_id: int, current_season: int) 
         record = PitcherAggregate(
             pitcher_id=pitcher_id,
             window=str(year),
-            end_date=datetime.date(year, 11, 1),
+            end_date=date(year, 11, 1),
             **{k: v for k, v in metrics.items() if hasattr(PitcherAggregate, k)},
         )
         session.add(record)

--- a/scripts/run_hitting_matchups_refresh.py
+++ b/scripts/run_hitting_matchups_refresh.py
@@ -12,7 +12,7 @@ This script is intentionally additive and safe:
 
 Environment controls:
     HITTING_MATCHUPS_DAYS_BACK=365
-    HITTING_MATCHUPS_MAX_BATTERS=40
+    HITTING_MATCHUPS_MAX_BATTERS=240
     HITTING_MATCHUPS_OUTPUT_PATH=hitting_matchups_refresh.json
 """
 
@@ -39,7 +39,7 @@ from mlb_app.hitting_matchups import build_batter_pitch_type_summary
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
 DAYS_BACK = int(os.getenv("HITTING_MATCHUPS_DAYS_BACK", "365"))
-MAX_BATTERS = int(os.getenv("HITTING_MATCHUPS_MAX_BATTERS", "40"))
+MAX_BATTERS = int(os.getenv("HITTING_MATCHUPS_MAX_BATTERS", "240"))
 OUTPUT_PATH = os.getenv("HITTING_MATCHUPS_OUTPUT_PATH", "hitting_matchups_refresh.json")
 REQUEST_TIMEOUT_SECONDS = int(os.getenv("HITTING_MATCHUPS_TIMEOUT_SECONDS", "30"))
 

--- a/scripts/run_refresh_job.py
+++ b/scripts/run_refresh_job.py
@@ -38,7 +38,7 @@ RUN_HITTING_MATCHUPS_REFRESH = os.environ.get("RUN_HITTING_MATCHUPS_REFRESH", "1
 REFRESH_ETL_BACKFILL_DAYS = int(os.environ.get("REFRESH_ETL_BACKFILL_DAYS", "7"))
 os.environ.setdefault("STATCAST_LOOKBACK_DAYS", "365")
 os.environ.setdefault("HITTING_MATCHUPS_DAYS_BACK", "365")
-os.environ.setdefault("HITTING_MATCHUPS_MAX_BATTERS", "40")
+os.environ.setdefault("HITTING_MATCHUPS_MAX_BATTERS", "240")
 
 
 def _log(message: str) -> None:
@@ -118,7 +118,7 @@ def _run_hitting_matchups_refresh() -> None:
     _log(
         "Starting hittingMatchups refresh: "
         f"days_back={os.environ.get('HITTING_MATCHUPS_DAYS_BACK', '365')}, "
-        f"max_batters={os.environ.get('HITTING_MATCHUPS_MAX_BATTERS', '40')}"
+        f"max_batters={os.environ.get('HITTING_MATCHUPS_MAX_BATTERS', '240')}"
     )
     from scripts.run_hitting_matchups_refresh import run
 


### PR DESCRIPTION
## Summary

This PR applies the Issue 115 supporting data changes to the actual source files. The prior PR merged the intended supporting file changes as a patch artifact, so the Batter vs Arsenal UI could still fall back because the data-generation side was not fully active.

## Changes

- Adds `description`, `estimated_woba_using_speedangle`, and `estimated_ba_using_speedangle` to `StatcastEvent`.
- Adds the same fields to the additive `STATCAST_EVENT_SAFE_COLUMNS` schema guard so production can add them safely.
- Populates those fields during Statcast ETL ingestion.
- Raises `HITTING_MATCHUPS_MAX_BATTERS` default from `40` to `240` in both the cron entrypoint and the hitter matchup refresh runner.

## Expected impact

After deploy and one cron run, `batter_pitch_type_matchups` should populate for more of the daily slate and provide swings, whiffs, xwOBA, xBA, EV, LA, Whiff%, K%, PutAway%, and HardHit% to the Batter vs Arsenal cards instead of falling back to low-sample live Statcast summaries.

## Verification after deploy

Check cron logs for:

```text
Starting hittingMatchups refresh: days_back=365, max_batters=240
hittingMatchups refresh completed: targets=..., upserted_rows=...
```

Then verify the API response includes stored rows:

```bash
curl "https://YOUR_BACKEND/matchup/824445/competitive" | jq '.. | objects | select(.source? == "batter_pitch_type_matchups")'
```
