### PR TITLE
Skip completed hitter Statcast backfills

### DIFF
--- a/scripts/backfill_hitter_statcast.py
+++ b/scripts/backfill_hitter_statcast.py
@@ -13,7 +13,7 @@ new swing/xwOBA fields required by the UI.
 
 Default controls:
     HITTER_STATCAST_START_DATE=2023-03-01
-    HITTER_STATCAST_MAX_PLAYERS=150
+    HITTER_STATCAST_MAX_PLAYERS=1000
     HITTER_STATCAST_OUTPUT_PATH=hitter_statcast_backfill.json
     HITTER_STATCAST_SKIP_COMPLETED=1
     HITTER_STATCAST_FORCE_REFRESH=0
@@ -44,22 +44,11 @@ from mlb_app.statcast_utils import fetch_statcast_batter_data
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
 DEFAULT_START_DATE = os.getenv("HITTER_STATCAST_START_DATE", "2023-03-01")
-DEFAULT_MAX_PLAYERS = int(os.getenv("HITTER_STATCAST_MAX_PLAYERS", "150"))
+DEFAULT_MAX_PLAYERS = int(os.getenv("HITTER_STATCAST_MAX_PLAYERS", "1000"))
 OUTPUT_PATH = os.getenv("HITTER_STATCAST_OUTPUT_PATH", "hitter_statcast_backfill.json")
 REQUEST_TIMEOUT_SECONDS = int(os.getenv("HITTER_STATCAST_TIMEOUT_SECONDS", "30"))
 SKIP_COMPLETED = os.getenv("HITTER_STATCAST_SKIP_COMPLETED", "1") == "1"
 FORCE_REFRESH = os.getenv("HITTER_STATCAST_FORCE_REFRESH", "0") == "1"
-
-
-IDENTITY_COLUMNS = (
-    "game_pk",
-    "at_bat_number",
-    "pitch_number",
-    "pitcher_id",
-    "batter_id",
-    "pitch_type",
-)
-
 CHECKPOINT_TABLE = "hitter_statcast_backfill_checkpoints"
 
 
@@ -115,11 +104,7 @@ def _target_dates() -> List[str]:
 def _fetch_schedule(date_str: str) -> List[Dict[str, Any]]:
     data = _request_json(
         f"{MLB_STATS_BASE}/schedule",
-        params={
-            "sportId": 1,
-            "date": date_str,
-            "hydrate": "probablePitcher,team,lineups",
-        },
+        params={"sportId": 1, "date": date_str, "hydrate": "probablePitcher,team,lineups"},
     )
     games: List[Dict[str, Any]] = []
     for day in data.get("dates", []) or []:
@@ -138,7 +123,6 @@ def _game_date_candidates(game_date_iso: str) -> List[str]:
                     candidates.append(candidate)
         except Exception:
             pass
-
     today = dt.date.today().isoformat()
     if today not in candidates:
         candidates.append(today)
@@ -160,16 +144,12 @@ def _fetch_previous_completed_game_lineup(team_id: int, game_date_iso: str) -> L
                     "sportId": 1,
                 },
             )
-
             completed_games: List[Dict[str, Any]] = []
             for date_row in data.get("dates", []) or []:
                 for game in date_row.get("games", []) or []:
-                    status = (game.get("status") or {}).get("codedGameState")
-                    if status == "F":
+                    if (game.get("status") or {}).get("codedGameState") == "F":
                         completed_games.append(game)
-
             completed_games.sort(key=lambda game: game.get("gameDate") or "", reverse=True)
-
             for game in completed_games:
                 teams = game.get("teams") or {}
                 for side in ("home", "away"):
@@ -182,7 +162,6 @@ def _fetch_previous_completed_game_lineup(team_id: int, game_date_iso: str) -> L
                         return players[:9]
         except Exception as exc:
             _log(f"Previous lineup fetch failed team={team_id} candidate={candidate_date}: {exc}")
-            continue
     return []
 
 
@@ -193,41 +172,28 @@ def _lineup_players_for_game(game: Dict[str, Any], side: str) -> Tuple[List[Dict
     lineups = game.get("lineups") or {}
     lineup_key = "homePlayers" if side == "home" else "awayPlayers"
     players = (lineups.get(lineup_key) or [])[:9]
-
     if players:
         return players, "official_lineup"
-
     if team_id:
         previous = _fetch_previous_completed_game_lineup(int(team_id), game.get("gameDate") or "")
         if previous:
             return previous[:9], "projected_previous_completed_game"
-
     return [], "missing_lineup"
 
 
 def collect_daily_lineup_hitters(max_players: int) -> List[Dict[str, Any]]:
-    """Collect up to max_players lineup hitters from today and tomorrow.
-
-    With 15 games, this targets 30 teams x 9 hitters = 270 possible hitters.
-    The default cap of 150 covers a normal full slate without pulling every
-    projected bench/roster player.
-    """
+    """Collect up to max_players lineup hitters from today and tomorrow."""
     players: List[Dict[str, Any]] = []
     seen_ids: Set[int] = set()
-
     for date_str in _target_dates():
         games = _fetch_schedule(date_str)
         _log(f"Loaded {len(games)} games for hitter Statcast date={date_str}")
-
         for game in games:
             game_pk = game.get("gamePk")
             teams = game.get("teams") or {}
             for side in ("away", "home"):
                 team = (((teams.get(side) or {}).get("team")) or {})
-                team_id = team.get("id")
-                team_name = team.get("name")
                 lineup, source = _lineup_players_for_game(game, side)
-
                 for order, player in enumerate(lineup[:9], start=1):
                     player_id = player.get("id")
                     if not player_id:
@@ -240,8 +206,8 @@ def collect_daily_lineup_hitters(max_players: int) -> List[Dict[str, Any]]:
                         {
                             "player_id": player_id,
                             "player_name": player.get("fullName"),
-                            "team_id": team_id,
-                            "team_name": team_name,
+                            "team_id": team.get("id"),
+                            "team_name": team.get("name"),
                             "game_pk": game_pk,
                             "target_date": date_str,
                             "side": side,
@@ -251,48 +217,28 @@ def collect_daily_lineup_hitters(max_players: int) -> List[Dict[str, Any]]:
                     )
                     if len(players) >= max_players:
                         return players
-
     return players
 
 
 def _ensure_checkpoint_table(engine) -> None:
     with engine.begin() as conn:
-        if engine.dialect.name == "postgresql":
-            conn.execute(
-                text(
-                    f"""
-                    CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
-                        batter_id INTEGER NOT NULL,
-                        start_date DATE NOT NULL,
-                        end_date DATE NOT NULL,
-                        player_name VARCHAR(120),
-                        fetched_rows INTEGER DEFAULT 0,
-                        inserted_rows INTEGER DEFAULT 0,
-                        updated_rows INTEGER DEFAULT 0,
-                        completed_at TIMESTAMP NOT NULL,
-                        PRIMARY KEY (batter_id, start_date, end_date)
-                    )
-                    """
+        conn.execute(
+            text(
+                f"""
+                CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
+                    batter_id INTEGER NOT NULL,
+                    start_date DATE NOT NULL,
+                    end_date DATE NOT NULL,
+                    player_name VARCHAR(120),
+                    fetched_rows INTEGER DEFAULT 0,
+                    inserted_rows INTEGER DEFAULT 0,
+                    updated_rows INTEGER DEFAULT 0,
+                    completed_at TIMESTAMP NOT NULL,
+                    PRIMARY KEY (batter_id, start_date, end_date)
                 )
+                """
             )
-        else:
-            conn.execute(
-                text(
-                    f"""
-                    CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
-                        batter_id INTEGER NOT NULL,
-                        start_date DATE NOT NULL,
-                        end_date DATE NOT NULL,
-                        player_name VARCHAR(120),
-                        fetched_rows INTEGER DEFAULT 0,
-                        inserted_rows INTEGER DEFAULT 0,
-                        updated_rows INTEGER DEFAULT 0,
-                        completed_at TIMESTAMP NOT NULL,
-                        PRIMARY KEY (batter_id, start_date, end_date)
-                    )
-                    """
-                )
-            )
+        )
 
 
 def _is_completed(session, batter_id: int, start_date: str, end_date: str) -> bool:
@@ -466,25 +412,19 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
             f"Skipping completed hitter Statcast batter={batter_id} "
             f"name={batter.get('player_name')} start_date={start_date} end_date={end_date}"
         )
-        return {
-            **batter,
-            "fetched_rows": 0,
-            "inserted_rows": 0,
-            "updated_rows": 0,
-            "skipped_completed": True,
-        }
+        return {**batter, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0, "skipped_completed": True}
 
     try:
         df = fetch_statcast_batter_data(batter_id, start_date, end_date)
     except Exception as exc:
         _log(f"Batter Statcast fetch failed batter={batter_id} name={batter.get('player_name')}: {exc}")
-        return {"player_id": batter_id, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0, "error": str(exc)}
+        return {**batter, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0, "error": str(exc)}
 
     if df is None or df.empty:
         _log(f"No hitter Statcast rows batter={batter_id} name={batter.get('player_name')}")
         _mark_completed(session, batter_id, batter.get("player_name"), start_date, end_date, 0, 0, 0)
         session.commit()
-        return {"player_id": batter_id, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0}
+        return {**batter, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0, "skipped_completed": False}
 
     existing = _existing_event_map(session, batter_id, start, end)
     inserted = 0
@@ -517,11 +457,7 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
             before_xwoba = event.estimated_woba_using_speedangle
             before_xba = event.estimated_ba_using_speedangle
             _assign_event_fields(event, row, batter_id)
-            if (
-                before_description != event.description
-                or before_xwoba != event.estimated_woba_using_speedangle
-                or before_xba != event.estimated_ba_using_speedangle
-            ):
+            if before_description != event.description or before_xwoba != event.estimated_woba_using_speedangle or before_xba != event.estimated_ba_using_speedangle:
                 updated += 1
 
     _mark_completed(
@@ -540,7 +476,6 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
         f"Backfilled hitter Statcast batter={batter_id} name={batter.get('player_name')} "
         f"fetched={len(df)} inserted={inserted} updated={updated} skipped_no_identity={skipped_no_identity}"
     )
-
     return {
         **batter,
         "fetched_rows": int(len(df)),
@@ -551,11 +486,7 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
     }
 
 
-def run(
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    max_players: Optional[int] = None,
-) -> Dict[str, Any]:
+def run(start_date: Optional[str] = None, end_date: Optional[str] = None, max_players: Optional[int] = None) -> Dict[str, Any]:
     start_date = start_date or DEFAULT_START_DATE
     end_date = end_date or dt.date.today().isoformat()
     max_players = max_players or DEFAULT_MAX_PLAYERS
@@ -599,14 +530,12 @@ def run(
     if output_path.parent != Path("."):
         output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(output, indent=2, sort_keys=True), encoding="utf-8")
-
     _log(
         f"Hitter Statcast backfill completed: targets={output['target_count']}, "
         f"skipped_completed_players={output['skipped_completed_players']}, "
         f"fetched_rows={output['fetched_rows']}, inserted_rows={output['inserted_rows']}, "
         f"updated_rows={output['updated_rows']}; artifact={output_path}"
     )
-
     return output
 
 

--- a/scripts/backfill_hitter_statcast.py
+++ b/scripts/backfill_hitter_statcast.py
@@ -15,6 +15,8 @@ Default controls:
     HITTER_STATCAST_START_DATE=2023-03-01
     HITTER_STATCAST_MAX_PLAYERS=150
     HITTER_STATCAST_OUTPUT_PATH=hitter_statcast_backfill.json
+    HITTER_STATCAST_SKIP_COMPLETED=1
+    HITTER_STATCAST_FORCE_REFRESH=0
 """
 
 from __future__ import annotations
@@ -29,6 +31,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 import requests
+from sqlalchemy import text
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -44,6 +47,8 @@ DEFAULT_START_DATE = os.getenv("HITTER_STATCAST_START_DATE", "2023-03-01")
 DEFAULT_MAX_PLAYERS = int(os.getenv("HITTER_STATCAST_MAX_PLAYERS", "150"))
 OUTPUT_PATH = os.getenv("HITTER_STATCAST_OUTPUT_PATH", "hitter_statcast_backfill.json")
 REQUEST_TIMEOUT_SECONDS = int(os.getenv("HITTER_STATCAST_TIMEOUT_SECONDS", "30"))
+SKIP_COMPLETED = os.getenv("HITTER_STATCAST_SKIP_COMPLETED", "1") == "1"
+FORCE_REFRESH = os.getenv("HITTER_STATCAST_FORCE_REFRESH", "0") == "1"
 
 
 IDENTITY_COLUMNS = (
@@ -54,6 +59,8 @@ IDENTITY_COLUMNS = (
     "batter_id",
     "pitch_type",
 )
+
+CHECKPOINT_TABLE = "hitter_statcast_backfill_checkpoints"
 
 
 def _log(message: str) -> None:
@@ -248,6 +255,116 @@ def collect_daily_lineup_hitters(max_players: int) -> List[Dict[str, Any]]:
     return players
 
 
+def _ensure_checkpoint_table(engine) -> None:
+    with engine.begin() as conn:
+        if engine.dialect.name == "postgresql":
+            conn.execute(
+                text(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
+                        batter_id INTEGER NOT NULL,
+                        start_date DATE NOT NULL,
+                        end_date DATE NOT NULL,
+                        player_name VARCHAR(120),
+                        fetched_rows INTEGER DEFAULT 0,
+                        inserted_rows INTEGER DEFAULT 0,
+                        updated_rows INTEGER DEFAULT 0,
+                        completed_at TIMESTAMP NOT NULL,
+                        PRIMARY KEY (batter_id, start_date, end_date)
+                    )
+                    """
+                )
+            )
+        else:
+            conn.execute(
+                text(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {CHECKPOINT_TABLE} (
+                        batter_id INTEGER NOT NULL,
+                        start_date DATE NOT NULL,
+                        end_date DATE NOT NULL,
+                        player_name VARCHAR(120),
+                        fetched_rows INTEGER DEFAULT 0,
+                        inserted_rows INTEGER DEFAULT 0,
+                        updated_rows INTEGER DEFAULT 0,
+                        completed_at TIMESTAMP NOT NULL,
+                        PRIMARY KEY (batter_id, start_date, end_date)
+                    )
+                    """
+                )
+            )
+
+
+def _is_completed(session, batter_id: int, start_date: str, end_date: str) -> bool:
+    if FORCE_REFRESH or not SKIP_COMPLETED:
+        return False
+    row = session.execute(
+        text(
+            f"""
+            SELECT batter_id
+            FROM {CHECKPOINT_TABLE}
+            WHERE batter_id = :batter_id
+              AND start_date = :start_date
+              AND end_date = :end_date
+            LIMIT 1
+            """
+        ),
+        {"batter_id": batter_id, "start_date": start_date, "end_date": end_date},
+    ).first()
+    return row is not None
+
+
+def _mark_completed(
+    session,
+    batter_id: int,
+    player_name: Optional[str],
+    start_date: str,
+    end_date: str,
+    fetched_rows: int,
+    inserted_rows: int,
+    updated_rows: int,
+) -> None:
+    completed_at = dt.datetime.utcnow()
+    if session.bind and session.bind.dialect.name == "postgresql":
+        stmt = text(
+            f"""
+            INSERT INTO {CHECKPOINT_TABLE}
+                (batter_id, start_date, end_date, player_name, fetched_rows, inserted_rows, updated_rows, completed_at)
+            VALUES
+                (:batter_id, :start_date, :end_date, :player_name, :fetched_rows, :inserted_rows, :updated_rows, :completed_at)
+            ON CONFLICT (batter_id, start_date, end_date)
+            DO UPDATE SET
+                player_name = EXCLUDED.player_name,
+                fetched_rows = EXCLUDED.fetched_rows,
+                inserted_rows = EXCLUDED.inserted_rows,
+                updated_rows = EXCLUDED.updated_rows,
+                completed_at = EXCLUDED.completed_at
+            """
+        )
+    else:
+        stmt = text(
+            f"""
+            INSERT OR REPLACE INTO {CHECKPOINT_TABLE}
+                (batter_id, start_date, end_date, player_name, fetched_rows, inserted_rows, updated_rows, completed_at)
+            VALUES
+                (:batter_id, :start_date, :end_date, :player_name, :fetched_rows, :inserted_rows, :updated_rows, :completed_at)
+            """
+        )
+    session.execute(
+        stmt,
+        {
+            "batter_id": batter_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "player_name": player_name,
+            "fetched_rows": fetched_rows,
+            "inserted_rows": inserted_rows,
+            "updated_rows": updated_rows,
+            "completed_at": completed_at,
+        },
+    )
+
+
 def _pitch_identity_from_values(
     game_pk: Optional[int],
     at_bat_number: Optional[int],
@@ -344,6 +461,19 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
     start = dt.date.fromisoformat(start_date)
     end = dt.date.fromisoformat(end_date)
 
+    if _is_completed(session, batter_id, start_date, end_date):
+        _log(
+            f"Skipping completed hitter Statcast batter={batter_id} "
+            f"name={batter.get('player_name')} start_date={start_date} end_date={end_date}"
+        )
+        return {
+            **batter,
+            "fetched_rows": 0,
+            "inserted_rows": 0,
+            "updated_rows": 0,
+            "skipped_completed": True,
+        }
+
     try:
         df = fetch_statcast_batter_data(batter_id, start_date, end_date)
     except Exception as exc:
@@ -352,6 +482,8 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
 
     if df is None or df.empty:
         _log(f"No hitter Statcast rows batter={batter_id} name={batter.get('player_name')}")
+        _mark_completed(session, batter_id, batter.get("player_name"), start_date, end_date, 0, 0, 0)
+        session.commit()
         return {"player_id": batter_id, "fetched_rows": 0, "inserted_rows": 0, "updated_rows": 0}
 
     existing = _existing_event_map(session, batter_id, start, end)
@@ -392,6 +524,16 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
             ):
                 updated += 1
 
+    _mark_completed(
+        session,
+        batter_id=batter_id,
+        player_name=batter.get("player_name"),
+        start_date=start_date,
+        end_date=end_date,
+        fetched_rows=int(len(df)),
+        inserted_rows=inserted,
+        updated_rows=updated,
+    )
     session.commit()
 
     _log(
@@ -405,6 +547,7 @@ def _insert_or_update_batter_statcast(session, batter: Dict[str, Any], start_dat
         "inserted_rows": inserted,
         "updated_rows": updated,
         "skipped_no_identity": skipped_no_identity,
+        "skipped_completed": False,
     }
 
 
@@ -419,12 +562,14 @@ def run(
 
     engine = get_engine(DATABASE_URL)
     create_tables(engine)
+    _ensure_checkpoint_table(engine)
     Session = get_session(engine)
 
     hitters = collect_daily_lineup_hitters(max_players=max_players)
     _log(
         f"Collected {len(hitters)} lineup hitters for Statcast backfill, "
-        f"max_players={max_players}, start_date={start_date}, end_date={end_date}"
+        f"max_players={max_players}, start_date={start_date}, end_date={end_date}, "
+        f"skip_completed={int(SKIP_COMPLETED)}, force_refresh={int(FORCE_REFRESH)}"
     )
 
     output: Dict[str, Any] = {
@@ -436,6 +581,7 @@ def run(
         "fetched_rows": 0,
         "inserted_rows": 0,
         "updated_rows": 0,
+        "skipped_completed_players": 0,
         "players": [],
     }
 
@@ -446,6 +592,8 @@ def run(
             output["fetched_rows"] += int(result.get("fetched_rows") or 0)
             output["inserted_rows"] += int(result.get("inserted_rows") or 0)
             output["updated_rows"] += int(result.get("updated_rows") or 0)
+            if result.get("skipped_completed"):
+                output["skipped_completed_players"] += 1
 
     output_path = Path(OUTPUT_PATH)
     if output_path.parent != Path("."):
@@ -454,6 +602,7 @@ def run(
 
     _log(
         f"Hitter Statcast backfill completed: targets={output['target_count']}, "
+        f"skipped_completed_players={output['skipped_completed_players']}, "
         f"fetched_rows={output['fetched_rows']}, inserted_rows={output['inserted_rows']}, "
         f"updated_rows={output['updated_rows']}; artifact={output_path}"
     )

--- a/scripts/run_refresh_job.py
+++ b/scripts/run_refresh_job.py
@@ -42,7 +42,7 @@ os.environ.setdefault("STATCAST_LOOKBACK_DAYS", "365")
 os.environ.setdefault("HITTING_MATCHUPS_DAYS_BACK", "365")
 os.environ.setdefault("HITTING_MATCHUPS_MAX_BATTERS", "240")
 os.environ.setdefault("HITTER_STATCAST_START_DATE", "2023-03-01")
-os.environ.setdefault("HITTER_STATCAST_MAX_PLAYERS", "150")
+os.environ.setdefault("HITTER_STATCAST_MAX_PLAYERS", "1000")
 
 
 def _log(message: str) -> None:
@@ -122,14 +122,14 @@ def _run_hitter_statcast_backfill() -> None:
     _log(
         "Starting hitter Statcast backfill: "
         f"start_date={os.environ.get('HITTER_STATCAST_START_DATE', '2023-03-01')}, "
-        f"max_players={os.environ.get('HITTER_STATCAST_MAX_PLAYERS', '150')}"
+        f"max_players={os.environ.get('HITTER_STATCAST_MAX_PLAYERS', '1000')}"
     )
     from scripts.backfill_hitter_statcast import run
 
     result = run(
         start_date=os.environ.get("HITTER_STATCAST_START_DATE", "2023-03-01"),
         end_date=dt.date.today().isoformat(),
-        max_players=int(os.environ.get("HITTER_STATCAST_MAX_PLAYERS", "150")),
+        max_players=int(os.environ.get("HITTER_STATCAST_MAX_PLAYERS", "1000")),
     )
     _log(
         "Hitter Statcast backfill completed: "


### PR DESCRIPTION
## Summary

Adds a lightweight checkpoint table to `scripts/backfill_hitter_statcast.py` so increasing `HITTER_STATCAST_MAX_PLAYERS` after an initial run does not refetch/reprocess already completed hitters.

## Why

The first hitter Statcast backfill can be long. After the initial 150 hitter run finishes, we want to safely raise `HITTER_STATCAST_MAX_PLAYERS` to 1000 without spending the night redoing the same first 150 hitters.

## Changes

- Creates a small DB checkpoint table from inside the script:
  - `hitter_statcast_backfill_checkpoints`
- Marks a hitter as completed by:
  - `batter_id`
  - `start_date`
  - `end_date`
- Skips completed hitters by default on later runs.
- Adds env controls:
  - `HITTER_STATCAST_SKIP_COMPLETED=1` default
  - `HITTER_STATCAST_FORCE_REFRESH=0` default
- Logs skipped completed players in the final summary.

## Next run after merge

After the active 150-player run finishes, set:

```text
RUN_STATCAST_ETL=0
HITTER_STATCAST_MAX_PLAYERS=1000
HITTER_STATCAST_SKIP_COMPLETED=1
HITTER_STATCAST_FORCE_REFRESH=0
```

Then manually run the cron again. It should skip already completed hitters and continue filling additional lineup hitters instead of duplicating/reprocessing the first batch.
