### PR TITLE
Fix wind text parser regex escaping

### DIFF
--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -41,12 +41,12 @@ def compute_environment_profile(raw_context: dict) -> dict:
             return None, None
 
         speed = None
-        speed_match = re.search(r"(\\d+(?:\\.\\d+)?)\\s*mph", text, re.IGNORECASE)
+        speed_match = re.search(r"(\d+(?:\.\d+)?)\s*mph", text, re.IGNORECASE)
         if speed_match:
             speed = _safe_float(speed_match.group(1))
 
         direction = text
-        direction = re.sub(r"^\\s*\\d+(?:\\.\\d+)?\\s*mph\\s*,?\\s*", "", direction, flags=re.IGNORECASE)
+        direction = re.sub(r"^\s*\d+(?:\.\d+)?\s*mph\s*,?\s*", "", direction, flags=re.IGNORECASE)
         direction = direction.strip(" ,") or None
 
         return speed, direction


### PR DESCRIPTION
Fixes the wind text parser regex so numeric wind speed is correctly extracted from raw strings such as `0 mph, None`, `2 mph, Out To RF`, and `9 mph, R To L`.

The previous regex was over-escaped, causing `wind_parsed_from_text` to show true while `wind_speed_mph` remained null. This update:
- correctly parses numeric wind speed from raw wind text
- correctly strips the speed prefix from wind direction
- allows downstream wind tier, direction type, and adjustment logic to receive normalized values

Verified locally with `compute_environment_profile` using `0 mph, None`, producing `wind_speed_mph: 0.0`, `wind_direction: None`, and `wind_speed_tier: calm`.