### PR TITLE
Add derived summary to PA outcome model

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -1304,6 +1304,22 @@ def create_app():
                     return {}
                 return {key: round(value / count, 4) for key, value in sorted(totals.items())}
 
+            def _average_summary_dict(models):
+                totals = {}
+                count = 0
+                for model in models or []:
+                    summary = model.get("summary") or {}
+                    if not summary:
+                        continue
+                    count += 1
+                    for key, value in summary.items():
+                        if value is None:
+                            continue
+                        totals[key] = totals.get(key, 0.0) + float(value)
+                if not count:
+                    return {}
+                return {key: round(value / count, 4) for key, value in sorted(totals.items())}
+
             def _build_lineup_pa_outcome_model(lineup, lineup_profile, opposing_pitcher_profile, environment_profile, side_label):
                 candidates = lineup or []
                 player_models = []
@@ -1321,14 +1337,17 @@ def create_app():
                         "player_id": player.get("id"),
                         "player_name": player.get("name"),
                         "probabilities": model.get("probabilities"),
+                        "summary": model.get("summary"),
                     })
 
                 lineup_average = _average_probability_dict(player_models)
+                lineup_summary = _average_summary_dict(player_models)
                 return {
                     "model_version": "lineup_pa_outcome_v1",
                     "side": side_label,
                     "player_count_used": len(player_models),
                     "lineup_average_probabilities": lineup_average,
+                    "lineup_average_summary": lineup_summary,
                     "player_outcomes": player_models,
                     "metadata": {
                         "generated_from": "matchup_detail.pa_outcome_integration",

--- a/mlb_app/simulation/pa_outcome_model.py
+++ b/mlb_app/simulation/pa_outcome_model.py
@@ -180,9 +180,30 @@ def build_pa_outcome_probabilities(
         "out": out_rate,
     })
 
+    summary = {
+        "hit_probability": round(
+            probabilities["single"] + probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            4,
+        ),
+        "on_base_probability": round(
+            probabilities["bb"] + probabilities["single"] + probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            4,
+        ),
+        "extra_base_hit_probability": round(
+            probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            4,
+        ),
+        "total_out_probability": round(
+            probabilities["k"] + probabilities["out"],
+            4,
+        ),
+        "contact_out_probability": probabilities["out"],
+    }
+
     return {
         "model_version": "pa_outcome_v1",
         "probabilities": probabilities,
+        "summary": summary,
         "inputs_used": {
             "batter_k_rate": batter_k,
             "batter_bb_rate": batter_bb,


### PR DESCRIPTION
Adds derived summary fields to the PA outcome probability model and exposes lineup-level averages in matchup detail.

This update:
- adds PA summary metrics: hit probability, on-base probability, extra-base-hit probability, total out probability, and contact out probability
- includes player-level PA summaries alongside probabilities
- aggregates lineup-average summary values in `homePAOutcomeModel` and `awayPAOutcomeModel`
- keeps the existing normalized K/BB/1B/2B/3B/HR/OUT probability distribution intact

This makes validation much easier before moving into half-inning simulation, because strikeouts and contact outs can now be viewed both separately and as total out probability.