### PR TITLE
Add HBP and reached-on-error PA outcomes

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -844,10 +844,12 @@ function PAOutcomePanel({ sideLabel, teamName, model }) {
   const outcomeRows = [
     ['K', probs.k],
     ['BB', probs.bb],
+    ['HBP', probs.hbp],
     ['1B', probs.single],
     ['2B', probs.double],
     ['3B', probs.triple],
     ['HR', probs.hr],
+    ['ROE', probs.reached_on_error],
     ['Contact Out', probs.out],
   ]
 
@@ -856,6 +858,7 @@ function PAOutcomePanel({ sideLabel, teamName, model }) {
     ['On-Base Probability', summary.on_base_probability],
     ['Extra-Base Hit Probability', summary.extra_base_hit_probability],
     ['Total Out Probability', summary.total_out_probability],
+    ['Non-Hit On-Base Probability', summary.non_hit_on_base_probability],
     ['Contact Out Probability', summary.contact_out_probability],
   ]
 

--- a/mlb_app/simulation/inning_simulator.py
+++ b/mlb_app/simulation/inning_simulator.py
@@ -19,7 +19,7 @@ from collections import Counter
 from typing import Dict, Optional, Any
 
 
-OUTCOMES = ["k", "bb", "single", "double", "triple", "hr", "out"]
+OUTCOMES = ["k", "bb", "hbp", "single", "double", "triple", "hr", "reached_on_error", "out"]
 
 
 def _normalize_probabilities(probabilities: Dict[str, float]) -> Dict[str, float]:
@@ -29,11 +29,13 @@ def _normalize_probabilities(probabilities: Dict[str, float]) -> Dict[str, float
         return {
             "k": 0.225,
             "bb": 0.085,
+            "hbp": 0.011,
             "single": 0.145,
             "double": 0.045,
             "triple": 0.004,
             "hr": 0.030,
-            "out": 0.466,
+            "reached_on_error": 0.007,
+            "out": 0.459,
         }
     return {key: value / total for key, value in cleaned.items()}
 
@@ -66,7 +68,7 @@ def advance_runners(
     if outcome in {"k", "out"}:
         return bases, 0
 
-    if outcome == "bb":
+    if outcome in {"bb", "hbp"}:
         # Force runners only as needed.
         if first and second and third:
             runs += 1
@@ -75,7 +77,7 @@ def advance_runners(
         new_first = True
         return (new_first, new_second, new_third), runs
 
-    if outcome == "single":
+    if outcome in {"single", "reached_on_error"}:
         # Conservative: runner on third scores; runner on second scores;
         # runner on first advances to second.
         runs += int(third) + int(second)

--- a/mlb_app/simulation/pa_outcome_model.py
+++ b/mlb_app/simulation/pa_outcome_model.py
@@ -19,30 +19,36 @@ from typing import Any, Dict, Optional
 BASE_PA_OUTCOMES = {
     "k": 0.225,
     "bb": 0.085,
+    "hbp": 0.011,
     "single": 0.145,
     "double": 0.045,
     "triple": 0.004,
     "hr": 0.030,
-    "out": 0.466,
+    "reached_on_error": 0.007,
+    "out": 0.459,
 }
 
 MIN_OUTCOME = {
     "k": 0.08,
     "bb": 0.03,
+    "hbp": 0.002,
     "single": 0.06,
     "double": 0.015,
     "triple": 0.0005,
     "hr": 0.005,
+    "reached_on_error": 0.001,
     "out": 0.25,
 }
 
 MAX_OUTCOME = {
     "k": 0.42,
     "bb": 0.18,
+    "hbp": 0.025,
     "single": 0.24,
     "double": 0.09,
     "triple": 0.018,
     "hr": 0.085,
+    "reached_on_error": 0.018,
     "out": 0.68,
 }
 
@@ -125,6 +131,11 @@ def build_pa_outcome_probabilities(
     k_rate = _blend([batter_k, pitcher_k], BASE_PA_OUTCOMES["k"])
     bb_rate = _blend([batter_bb, pitcher_bb], BASE_PA_OUTCOMES["bb"])
 
+    # HBP and reached-on-error are included as conservative baseline events in v1.
+    # They can be upgraded later with player/team/defense-specific features.
+    hbp_rate = BASE_PA_OUTCOMES["hbp"]
+    reached_on_error_rate = BASE_PA_OUTCOMES["reached_on_error"]
+
     contact_quality = _blend(
         [
             batter_hard_hit,
@@ -168,15 +179,26 @@ def build_pa_outcome_probabilities(
     double_rate *= env_run_multiplier
     triple_rate *= env_run_multiplier
 
-    out_rate = 1.0 - (k_rate + bb_rate + single_rate + double_rate + triple_rate + hr_rate)
+    out_rate = 1.0 - (
+        k_rate
+        + bb_rate
+        + hbp_rate
+        + single_rate
+        + double_rate
+        + triple_rate
+        + hr_rate
+        + reached_on_error_rate
+    )
 
     probabilities = _normalize({
         "k": k_rate,
         "bb": bb_rate,
+        "hbp": hbp_rate,
         "single": single_rate,
         "double": double_rate,
         "triple": triple_rate,
         "hr": hr_rate,
+        "reached_on_error": reached_on_error_rate,
         "out": out_rate,
     })
 
@@ -186,7 +208,13 @@ def build_pa_outcome_probabilities(
             4,
         ),
         "on_base_probability": round(
-            probabilities["bb"] + probabilities["single"] + probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            probabilities["bb"]
+            + probabilities["hbp"]
+            + probabilities["single"]
+            + probabilities["double"]
+            + probabilities["triple"]
+            + probabilities["hr"]
+            + probabilities["reached_on_error"],
             4,
         ),
         "extra_base_hit_probability": round(
@@ -195,6 +223,10 @@ def build_pa_outcome_probabilities(
         ),
         "total_out_probability": round(
             probabilities["k"] + probabilities["out"],
+            4,
+        ),
+        "non_hit_on_base_probability": round(
+            probabilities["bb"] + probabilities["hbp"] + probabilities["reached_on_error"],
             4,
         ),
         "contact_out_probability": probabilities["out"],


### PR DESCRIPTION
Adds additional on-base events to the PA outcome model and half-inning simulator.

This update:
- adds `hbp` and `reached_on_error` to the PA outcome probability distribution
- treats HBP as walk-like base advancement in the inning simulator
- treats reached-on-error as conservative single-like advancement
- updates PA summary metrics to include non-hit on-base probability
- updates the PA Outcome frontend panel to show HBP, ROE, and non-hit on-base probability
- keeps intentional walks and catcher interference out of v1 because they are rare/state-dependent and better handled in future context-aware simulation logic

Smoke test result:
- probabilities sum to ~1.0
- on-base + total-out summary sums to ~1.0
- expected half-inning runs remained realistic at ~0.565 with no max-PA guardrail trips

This makes the PA and inning simulation layers more realistic before endpoint/game simulation integration.