### PR TITLE
Integrate full-game simulation into matchup detail

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -72,6 +72,7 @@ from .matchup_analysis import build_matchup_analysis
 from .pitcher_advanced_metrics import derive_pitcher_advanced_metrics
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
 from .simulation.inning_simulator import simulate_half_innings
+from .simulation.game_simulator import simulate_game
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -1381,6 +1382,33 @@ def create_app():
                 }
                 return result
 
+            def _build_game_simulation(away_pa_model, home_pa_model):
+                away_probabilities = (away_pa_model or {}).get("lineup_average_probabilities") or {}
+                home_probabilities = (home_pa_model or {}).get("lineup_average_probabilities") or {}
+
+                if not away_probabilities or not home_probabilities:
+                    return {
+                        "model_version": "full_game_sim_v1",
+                        "status": "missing_pa_probabilities",
+                    }
+
+                result = simulate_game(
+                    away_probabilities=away_probabilities,
+                    home_probabilities=home_probabilities,
+                    simulations=5000,
+                    seed=42,
+                    innings=9,
+                )
+                result["metadata"] = {
+                    **(result.get("metadata") or {}),
+                    "generated_from": "matchup_detail.full_game_simulation",
+                    "away_pa_model_version": (away_pa_model or {}).get("model_version"),
+                    "home_pa_model_version": (home_pa_model or {}).get("model_version"),
+                    "simulation_seed": 42,
+                    "simulation_count": 5000,
+                }
+                return result
+
             def _profile_has_useful_offense_metrics(profile):
                 for section in ["contact_skill", "plate_discipline", "power", "platoon_profile"]:
                     values = (profile.get(section) or {}).values()
@@ -1534,6 +1562,11 @@ def create_app():
                 side_label="away_offense",
             )
 
+            game_simulation = _build_game_simulation(
+                away_pa_model=away_pa_outcome_model,
+                home_pa_model=home_pa_outcome_model,
+            )
+
             return {
                 "game_pk": game_pk,
                 "game_date": game_date_iso,
@@ -1554,6 +1587,7 @@ def create_app():
                 "awayPAOutcomeModel": away_pa_outcome_model,
                 "homeHalfInningSimulation": home_half_inning_simulation,
                 "awayHalfInningSimulation": away_half_inning_simulation,
+                "gameSimulation": game_simulation,
                 "home_team": {
                     "id": home_team_id,
                     "name": home.get("team", {}).get("name"),


### PR DESCRIPTION
Integrates the full-game simulation engine into the matchup detail endpoint.

This update:
- imports `simulate_game` into matchup detail
- builds a `gameSimulation` object from home and away lineup-average PA probabilities
- returns expected runs, win probabilities, total run probabilities, team-total probabilities, and run/margin distributions
- includes metadata for PA model versions, simulation seed, and simulation count

This exposes game-level probability outputs in `/matchup/{game_pk}` and completes the PA → inning → game simulation pipeline needed before UI display and market edge comparison.