### PR TITLE
Add bullpen profile foundation

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -951,6 +951,44 @@ function HalfInningSimulationPanel({ sideLabel, teamName, simulation }) {
   )
 }
 
+function BullpenProfilePanel({ sideLabel, teamName, profile }) {
+  if (!profile) return <div style={t.noData}>No bullpen profile available yet.</div>
+
+  const sections = [
+    ['Bat Missing', profile.bat_missing],
+    ['Command / Control', profile.command_control],
+    ['Contact Management', profile.contact_management],
+    ['Platoon Profile', profile.platoon_profile],
+    ['Arsenal', profile.arsenal],
+  ]
+
+  return (
+    <div style={t.pitcherCard}>
+      <div style={{ fontSize: '12px', color: '#8b949e', marginBottom: '4px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>{sideLabel}</div>
+      <div style={t.pitcherName}>{teamName}</div>
+      <div style={{ color: '#8b949e', fontSize: '12px', marginBottom: '12px' }}>
+        {profile.metadata?.bullpen_profile_version || 'bullpen profile'} · Confidence: {profile.metadata?.data_confidence || 'unknown'}
+      </div>
+
+      <div style={t.splitsGrid}>
+        {sections.map(([title, values]) => (
+          <div key={title} style={t.splitCard}>
+            <div style={t.splitTitle}>{title}</div>
+            {values ? Object.entries(values).map(([key, value]) => (
+              <div key={key} style={t.statRow}>
+                <span style={t.statKey}>{displayKey(key)}</span>
+                <span style={t.statVal}>
+                  {typeof value === 'number' && value <= 1 ? pct(value) : metricValue(value)}
+                </span>
+              </div>
+            )) : <div style={t.noData}>No data available.</div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function GameSimulationPanel({ simulation, homeName, awayName }) {
   if (!simulation) return <div style={t.noData}>No game simulation available yet.</div>
 
@@ -1335,6 +1373,12 @@ export default function MatchupDetailPage() {
           <div style={t.pitcherGrid}>
             <HalfInningSimulationPanel sideLabel="Away Offense" teamName={away.name} simulation={matchup.awayHalfInningSimulation} />
             <HalfInningSimulationPanel sideLabel="Home Offense" teamName={home.name} simulation={matchup.homeHalfInningSimulation} />
+          </div>
+
+          <div style={{ ...t.sectionTitle, marginTop: '22px' }}>Bullpen Profiles</div>
+          <div style={t.pitcherGrid}>
+            <BullpenProfilePanel sideLabel="Away Bullpen" teamName={away.name} profile={matchup.awayBullpenProfile} />
+            <BullpenProfilePanel sideLabel="Home Bullpen" teamName={home.name} profile={matchup.homeBullpenProfile} />
           </div>
 
           <div style={{ ...t.sectionTitle, marginTop: '22px' }}>Full Game Simulation</div>

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -68,6 +68,7 @@ from .statcast_utils import fetch_pitch_arsenal_leaderboard, fetch_statcast_pitc
 from .pitcher_profile import compute_pitcher_profile
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
 from .environment_profile import compute_environment_profile
+from .bullpen_profile import build_bullpen_profile
 from .matchup_analysis import build_matchup_analysis
 from .pitcher_advanced_metrics import derive_pitcher_advanced_metrics
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
@@ -1567,6 +1568,15 @@ def create_app():
                 home_pa_model=home_pa_outcome_model,
             )
 
+            home_bullpen_profile = build_bullpen_profile(
+                team_id=home.get("id"),
+                team_name=home.get("name"),
+            )
+            away_bullpen_profile = build_bullpen_profile(
+                team_id=away.get("id"),
+                team_name=away.get("name"),
+            )
+
             return {
                 "game_pk": game_pk,
                 "game_date": game_date_iso,
@@ -1588,6 +1598,8 @@ def create_app():
                 "homeHalfInningSimulation": home_half_inning_simulation,
                 "awayHalfInningSimulation": away_half_inning_simulation,
                 "gameSimulation": game_simulation,
+                "homeBullpenProfile": home_bullpen_profile,
+                "awayBullpenProfile": away_bullpen_profile,
                 "home_team": {
                     "id": home_team_id,
                     "name": home.get("team", {}).get("name"),

--- a/mlb_app/bullpen_profile.py
+++ b/mlb_app/bullpen_profile.py
@@ -1,0 +1,106 @@
+"""
+Team bullpen profile foundation.
+
+V1 creates a stable bullpen profile contract that mirrors starter pitcher
+profile sections. Later branches can enrich these priors with actual reliever
+aggregates, recent workload, handedness mix, and leverage availability.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+BULLPEN_PRIOR_V1 = {
+    "bat_missing": {
+        "k_rate": 0.235,
+        "whiff_rate": 0.255,
+        "csw_rate": 0.285,
+    },
+    "command_control": {
+        "bb_rate": 0.090,
+        "zone_rate": 0.485,
+        "first_pitch_strike_rate": 0.600,
+    },
+    "contact_management": {
+        "hard_hit_rate_allowed": 0.390,
+        "barrel_rate_allowed": 0.075,
+        "avg_exit_velocity_allowed": 88.5,
+        "avg_launch_angle_allowed": 12.0,
+        "xwoba_allowed": 0.320,
+        "xba_allowed": 0.245,
+    },
+    "platoon_profile": {
+        "vs_lhb_woba_allowed": 0.320,
+        "vs_rhb_woba_allowed": 0.320,
+        "vs_lhb_iso_allowed": 0.155,
+        "vs_rhb_iso_allowed": 0.155,
+    },
+    "arsenal": {
+        "pitch_mix": "Bullpen prior mix",
+        "avg_velocity": 94.0,
+        "avg_spin_rate": 2350.0,
+    },
+}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deepcopy_profile(profile: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {
+        section: dict(values)
+        for section, values in profile.items()
+    }
+
+
+def build_bullpen_profile(
+    team_id: Optional[int] = None,
+    team_name: Optional[str] = None,
+    raw_context: Optional[dict] = None,
+) -> Dict[str, Any]:
+    """
+    Build a team bullpen profile.
+
+    V1 intentionally returns conservative priors with metadata so downstream
+    simulation can rely on a stable shape before real reliever aggregation is
+    added.
+    """
+    raw_context = raw_context or {}
+    profile = _deepcopy_profile(BULLPEN_PRIOR_V1)
+
+    # Allow explicit overrides when future callers have already-computed team
+    # bullpen values. This keeps v1 extensible without changing the response
+    # contract later.
+    overrides = raw_context.get("bullpen_profile_overrides") or {}
+    for section, values in overrides.items():
+        if section not in profile or not isinstance(values, dict):
+            continue
+        for key, value in values.items():
+            if key in profile[section] and value is not None:
+                profile[section][key] = value
+
+    profile["metadata"] = {
+        "source_type": raw_context.get("source_type", "bullpen_prior_v1"),
+        "team_id": team_id,
+        "team_name": team_name,
+        "data_confidence": raw_context.get("data_confidence", "low"),
+        "generated_from": "build_bullpen_profile",
+        "profile_granularity": "team_bullpen",
+        "sample_window": raw_context.get("sample_window", "prior"),
+        "sample_size": raw_context.get("sample_size"),
+        "bullpen_profile_version": "bullpen_profile_v1",
+        "notes": [
+            "V1 uses conservative league-average bullpen priors.",
+            "Future versions should aggregate active relievers by team and role.",
+            "Use this profile as a stable contract before bullpen simulation integration.",
+        ],
+    }
+
+    return profile


### PR DESCRIPTION
Adds the first team bullpen profile foundation.

This update:
- creates `mlb_app/bullpen_profile.py`
- defines a stable bullpen profile contract mirroring starter pitcher sections: bat-missing, command/control, contact management, platoon profile, and arsenal
- returns conservative league-average bullpen priors with low-confidence metadata in v1
- wires `homeBullpenProfile` and `awayBullpenProfile` into matchup detail
- adds a frontend Bullpen Profiles panel to the Analysis tab

This establishes the API/UI structure needed before enriching bullpen profiles with active reliever aggregates and integrating bullpen-adjusted PA/game simulation.