### PR TITLE
Add dynamic starter exit to bullpen-adjusted simulation

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -1006,6 +1006,8 @@ function GameSimulationPanel({ simulation, homeName, awayName }) {
     [`${awayName} Win Probability`, simulation.away_win_probability],
     [`${homeName} Win Probability`, simulation.home_win_probability],
     ['Tie After Regulation', simulation.tie_after_regulation_probability],
+    ['Away Starter Quality', simulation.away_starter_quality],
+    ['Home Starter Quality', simulation.home_starter_quality],
   ]
 
   const totalRows = [
@@ -1045,9 +1047,11 @@ function GameSimulationPanel({ simulation, homeName, awayName }) {
             <div key={label} style={t.statRow}>
               <span style={t.statKey}>{label}</span>
               <span style={t.statVal}>
-                {String(label).includes('Probability') || String(label).includes('Tie')
-                  ? pct(value)
-                  : metricValue(value)}
+                {typeof value === 'string'
+                  ? value.replace(/_/g, ' ')
+                  : String(label).includes('Probability') || String(label).includes('Tie')
+                    ? pct(value)
+                    : metricValue(value)}
               </span>
             </div>
           ))}

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -73,7 +73,7 @@ from .matchup_analysis import build_matchup_analysis
 from .pitcher_advanced_metrics import derive_pitcher_advanced_metrics
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
 from .simulation.inning_simulator import simulate_half_innings
-from .simulation.game_simulator import simulate_game, simulate_game_with_bullpen
+from .simulation.game_simulator import simulate_game, simulate_game_with_bullpen, classify_starter_quality
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 MATCHUP_SNAPSHOT_CACHE: Dict[str, List[Dict[str, Any]]] = {}
@@ -1429,7 +1429,7 @@ def create_app():
                 }
                 return result
 
-            def _build_bullpen_adjusted_game_simulation(away_starter_pa_model, home_starter_pa_model, away_bullpen_pa_model, home_bullpen_pa_model):
+            def _build_bullpen_adjusted_game_simulation(away_starter_pa_model, home_starter_pa_model, away_bullpen_pa_model, home_bullpen_pa_model, away_pitcher_profile, home_pitcher_profile):
                 away_starter_probabilities = (away_starter_pa_model or {}).get("lineup_average_probabilities") or {}
                 home_starter_probabilities = (home_starter_pa_model or {}).get("lineup_average_probabilities") or {}
                 away_bullpen_probabilities = (away_bullpen_pa_model or {}).get("lineup_average_probabilities") or {}
@@ -1441,6 +1441,9 @@ def create_app():
                         "status": "missing_pa_probabilities",
                     }
 
+                away_starter_quality = classify_starter_quality(away_pitcher_profile)
+                home_starter_quality = classify_starter_quality(home_pitcher_profile)
+
                 result = simulate_game_with_bullpen(
                     away_starter_probabilities=away_starter_probabilities,
                     home_starter_probabilities=home_starter_probabilities,
@@ -1450,6 +1453,9 @@ def create_app():
                     seed=42,
                     innings=9,
                     starter_innings=5,
+                    away_starter_quality=away_starter_quality,
+                    home_starter_quality=home_starter_quality,
+                    dynamic_starter_exit=True,
                 )
                 result["metadata"] = {
                     **(result.get("metadata") or {}),
@@ -1458,6 +1464,8 @@ def create_app():
                     "home_starter_pa_model_version": (home_starter_pa_model or {}).get("model_version"),
                     "away_bullpen_pa_model_version": (away_bullpen_pa_model or {}).get("model_version"),
                     "home_bullpen_pa_model_version": (home_bullpen_pa_model or {}).get("model_version"),
+                    "away_starter_quality": away_starter_quality,
+                    "home_starter_quality": home_starter_quality,
                 }
                 return result
 
@@ -1645,6 +1653,8 @@ def create_app():
                 home_starter_pa_model=home_pa_outcome_model,
                 away_bullpen_pa_model=away_vs_home_bullpen_pa_outcome_model,
                 home_bullpen_pa_model=home_vs_away_bullpen_pa_outcome_model,
+                away_pitcher_profile=away_pitcher_profile,
+                home_pitcher_profile=home_pitcher_profile,
             )
 
             return {

--- a/mlb_app/simulation/game_simulator.py
+++ b/mlb_app/simulation/game_simulator.py
@@ -174,6 +174,77 @@ def simulate_game(
         },
     }
 
+def _sample_from_distribution(distribution: Dict[int, float], rng: random.Random) -> int:
+    draw = rng.random()
+    cumulative = 0.0
+    for value, probability in sorted(distribution.items()):
+        cumulative += probability
+        if draw <= cumulative:
+            return value
+    return max(distribution.keys())
+
+
+def _starter_exit_distribution(starter_quality: str) -> Dict[int, float]:
+    if starter_quality == "strong":
+        return {4: 0.05, 5: 0.20, 6: 0.45, 7: 0.25, 8: 0.05}
+    if starter_quality == "weak":
+        return {3: 0.08, 4: 0.27, 5: 0.40, 6: 0.20, 7: 0.05}
+    return {4: 0.12, 5: 0.38, 6: 0.35, 7: 0.13, 8: 0.02}
+
+
+def classify_starter_quality(pitcher_profile: Optional[Dict[str, Any]]) -> str:
+    if not pitcher_profile:
+        return "average"
+
+    bat_missing = pitcher_profile.get("bat_missing") or {}
+    command = pitcher_profile.get("command_control") or {}
+    contact = pitcher_profile.get("contact_management") or {}
+
+    k_rate = bat_missing.get("k_rate")
+    bb_rate = command.get("bb_rate")
+    xwoba = contact.get("xwoba_allowed")
+    hard_hit = contact.get("hard_hit_rate_allowed")
+    barrel = contact.get("barrel_rate_allowed")
+
+    score = 0
+
+    if isinstance(k_rate, (int, float)):
+        if k_rate >= 0.27:
+            score += 1
+        elif k_rate <= 0.19:
+            score -= 1
+
+    if isinstance(bb_rate, (int, float)):
+        if bb_rate <= 0.07:
+            score += 1
+        elif bb_rate >= 0.105:
+            score -= 1
+
+    if isinstance(xwoba, (int, float)):
+        if xwoba <= 0.300:
+            score += 1
+        elif xwoba >= 0.345:
+            score -= 1
+
+    if isinstance(hard_hit, (int, float)):
+        if hard_hit <= 0.36:
+            score += 1
+        elif hard_hit >= 0.43:
+            score -= 1
+
+    if isinstance(barrel, (int, float)):
+        if barrel <= 0.065:
+            score += 1
+        elif barrel >= 0.095:
+            score -= 1
+
+    if score >= 2:
+        return "strong"
+    if score <= -2:
+        return "weak"
+    return "average"
+
+
 def simulate_game_with_bullpen(
     away_starter_probabilities: Dict[str, float],
     home_starter_probabilities: Dict[str, float],
@@ -183,6 +254,9 @@ def simulate_game_with_bullpen(
     seed: Optional[int] = None,
     innings: int = 9,
     starter_innings: int = 5,
+    away_starter_quality: str = "average",
+    home_starter_quality: str = "average",
+    dynamic_starter_exit: bool = True,
 ) -> Dict[str, Any]:
     """
     Simulate a game with separate early-inning starter probabilities and
@@ -203,19 +277,38 @@ def simulate_game_with_bullpen(
     home_wins = 0
     ties_after_regulation = 0
 
+    away_exit_distribution = _starter_exit_distribution(away_starter_quality)
+    home_exit_distribution = _starter_exit_distribution(home_starter_quality)
+    away_starter_innings_counter = Counter()
+    home_starter_innings_counter = Counter()
+
     for _ in range(simulations):
         away_runs = 0
         home_runs = 0
 
+        away_starter_innings = (
+            _sample_from_distribution(away_exit_distribution, rng)
+            if dynamic_starter_exit
+            else starter_innings
+        )
+        home_starter_innings = (
+            _sample_from_distribution(home_exit_distribution, rng)
+            if dynamic_starter_exit
+            else starter_innings
+        )
+
+        away_starter_innings_counter[away_starter_innings] += 1
+        home_starter_innings_counter[home_starter_innings] += 1
+
         for inning_index in range(1, innings + 1):
             away_probs = (
                 away_starter_probabilities
-                if inning_index <= starter_innings
+                if inning_index <= home_starter_innings
                 else away_bullpen_probabilities
             )
             home_probs = (
                 home_starter_probabilities
-                if inning_index <= starter_innings
+                if inning_index <= away_starter_innings
                 else home_bullpen_probabilities
             )
 
@@ -265,6 +358,11 @@ def simulate_game_with_bullpen(
         "simulations": simulations,
         "innings": innings,
         "starter_innings": starter_innings,
+        "dynamic_starter_exit": dynamic_starter_exit,
+        "away_starter_quality": away_starter_quality,
+        "home_starter_quality": home_starter_quality,
+        "away_starter_innings_distribution": _distribution(away_starter_innings_counter, simulations),
+        "home_starter_innings_distribution": _distribution(home_starter_innings_counter, simulations),
         "bullpen_innings": max(0, innings - starter_innings),
         "away_expected_runs": away_expected_runs,
         "home_expected_runs": home_expected_runs,
@@ -293,6 +391,11 @@ def simulate_game_with_bullpen(
             "seed": seed,
             "simulation_count": simulations,
             "starter_innings": starter_innings,
+            "dynamic_starter_exit": dynamic_starter_exit,
+            "away_starter_quality": away_starter_quality,
+            "home_starter_quality": home_starter_quality,
+            "away_starter_innings_distribution": _distribution(away_starter_innings_counter, simulations),
+            "home_starter_innings_distribution": _distribution(home_starter_innings_counter, simulations),
             "bullpen_innings": max(0, innings - starter_innings),
             **GAME_SIM_CALIBRATION,
             "calibration_applied_to": ["expected_runs"],


### PR DESCRIPTION
Adds dynamic starter-exit modeling to the bullpen-adjusted full-game simulation.

This update:
- classifies starter quality from available pitcher profile K/BB/contact signals
- samples starter innings from a quality-based distribution instead of using a fixed 5-inning starter window
- applies sampled home starter length to away offense PA probabilities and sampled away starter length to home offense PA probabilities
- returns starter quality labels and starter-innings distributions in the game simulation output and metadata
- updates the Full Game Simulation UI panel to display starter quality labels

Smoke testing showed stable dynamic exit distributions: strong starters produced more 6–7 inning outcomes, weak starters more 3–5 inning outcomes, with expected runs remaining in realistic ranges.