### PR TITLE
Add team offense prior fallback for PA models

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -868,6 +868,7 @@ function PAOutcomePanel({ sideLabel, teamName, model }) {
       <div style={t.pitcherName}>{teamName}</div>
       <div style={{ color: '#8b949e', fontSize: '12px', marginBottom: '12px' }}>
         {model.model_version || 'PA outcome model'} · Players used: {model.player_count_used ?? '—'}
+        {model.fallback_used ? ` · Fallback: ${String(model.offense_profile_source || model.fallback_reason || 'team prior').replace(/_/g, ' ')}` : ''}
       </div>
 
       <div style={t.splitsGrid}>

--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -69,6 +69,7 @@ from .pitcher_profile import compute_pitcher_profile
 from .offense_profile_aggregation import build_projected_lineup_offense_profile
 from .environment_profile import compute_environment_profile
 from .bullpen_profile import build_bullpen_profile
+from .team_offense_prior import build_team_offense_prior
 from .matchup_analysis import build_matchup_analysis
 from .pitcher_advanced_metrics import derive_pitcher_advanced_metrics
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
@@ -1323,7 +1324,7 @@ def create_app():
                     return {}
                 return {key: round(value / count, 4) for key, value in sorted(totals.items())}
 
-            def _build_lineup_pa_outcome_model(lineup, lineup_profile, opposing_pitcher_profile, environment_profile, side_label):
+            def _build_lineup_pa_outcome_model(lineup, lineup_profile, opposing_pitcher_profile, environment_profile, side_label, team=None):
                 candidates = lineup or []
                 player_models = []
 
@@ -1336,27 +1337,61 @@ def create_app():
                         pitcher_profile=opposing_pitcher_profile,
                         environment_profile=environment_profile,
                     )
+                    probabilities = model.get("probabilities") or {}
+                    if not probabilities:
+                        continue
                     player_models.append({
                         "player_id": player.get("id"),
                         "player_name": player.get("name"),
-                        "probabilities": model.get("probabilities"),
+                        "probabilities": probabilities,
                         "summary": model.get("summary"),
                     })
+
+                fallback_used = False
+                fallback_reason = None
+                offense_profile_source = "lineup_aggregate"
+
+                if not player_models:
+                    fallback_used = True
+                    fallback_reason = "no_lineup_player_models"
+                    offense_profile_source = "team_offense_prior"
+                    team_profile = build_team_offense_prior(
+                        team_id=(team or {}).get("id"),
+                        team_name=(team or {}).get("name"),
+                    )
+                    model = build_pa_outcome_probabilities(
+                        batter_profile=team_profile,
+                        pitcher_profile=opposing_pitcher_profile,
+                        environment_profile=environment_profile,
+                    )
+                    probabilities = model.get("probabilities") or {}
+                    if probabilities:
+                        player_models.append({
+                            "player_id": None,
+                            "player_name": "Team offense prior",
+                            "probabilities": probabilities,
+                            "summary": model.get("summary"),
+                        })
 
                 lineup_average = _average_probability_dict(player_models)
                 lineup_summary = _average_summary_dict(player_models)
                 return {
                     "model_version": "lineup_pa_outcome_v1",
                     "side": side_label,
-                    "player_count_used": len(player_models),
+                    "player_count_used": len([m for m in player_models if m.get("player_id") is not None]),
+                    "model_count_used": len(player_models),
+                    "fallback_used": fallback_used,
+                    "fallback_reason": fallback_reason,
+                    "offense_profile_source": offense_profile_source,
                     "lineup_average_probabilities": lineup_average,
                     "lineup_average_summary": lineup_summary,
                     "player_outcomes": player_models,
                     "metadata": {
-                        "generated_from": "matchup_detail.pa_outcome_integration",
-                        "batter_profile_granularity": "lineup_aggregate",
+                        "generated_from": "matchup_detail.pa_outcome_model",
+                        "batter_profile_granularity": offense_profile_source,
                         "pitcher_profile_granularity": "starter_profile",
                         "environment_profile_used": bool(environment_profile),
+                        "team_offense_prior_used": fallback_used,
                     },
                 }
 
@@ -1604,6 +1639,7 @@ def create_app():
                 opposing_pitcher_profile=away_pitcher_profile,
                 environment_profile=environment_profile,
                 side_label="home_offense",
+                team=home,
             )
             away_pa_outcome_model = _build_lineup_pa_outcome_model(
                 lineup=away_lineup,
@@ -1611,6 +1647,7 @@ def create_app():
                 opposing_pitcher_profile=home_pitcher_profile,
                 environment_profile=environment_profile,
                 side_label="away_offense",
+                team=away,
             )
 
             home_half_inning_simulation = _build_half_inning_simulation(
@@ -1620,6 +1657,15 @@ def create_app():
             away_half_inning_simulation = _build_half_inning_simulation(
                 away_pa_outcome_model,
                 side_label="away_offense",
+            )
+
+            home_team_offense_prior = build_team_offense_prior(
+                team_id=home.get("id"),
+                team_name=home.get("name"),
+            )
+            away_team_offense_prior = build_team_offense_prior(
+                team_id=away.get("id"),
+                team_name=away.get("name"),
             )
 
             home_bullpen_profile = build_bullpen_profile(
@@ -1683,6 +1729,8 @@ def create_app():
                 "homeVsAwayBullpenPAOutcomeModel": home_vs_away_bullpen_pa_outcome_model,
                 "homeBullpenProfile": home_bullpen_profile,
                 "awayBullpenProfile": away_bullpen_profile,
+                "homeTeamOffensePrior": home_team_offense_prior,
+                "awayTeamOffensePrior": away_team_offense_prior,
                 "home_team": {
                     "id": home_team_id,
                     "name": home.get("team", {}).get("name"),

--- a/mlb_app/team_offense_prior.py
+++ b/mlb_app/team_offense_prior.py
@@ -1,0 +1,144 @@
+"""
+Team offense prior profile.
+
+Used when official/projected lineups are unavailable or do not produce enough
+usable hitter data. V1 provides a stable conservative profile so PA/game
+simulation can still run for future games before lineups are posted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+TEAM_OFFENSE_PRIOR_V1 = {
+    "contact_skill": {
+        "k_rate": 0.225,
+        "whiff_rate": 0.235,
+        "contact_rate": 0.765,
+    },
+    "plate_discipline": {
+        "bb_rate": 0.085,
+        "chase_rate": 0.300,
+        "swing_rate": 0.470,
+    },
+    "power": {
+        "iso": 0.165,
+        "barrel_rate": 0.075,
+        "hard_hit_rate": 0.395,
+    },
+    "batted_ball_quality": {
+        "avg_exit_velocity": 88.5,
+        "avg_launch_angle": 12.5,
+    },
+    "platoon_profile": {
+        "vs_lhp_woba": 0.315,
+        "vs_rhp_woba": 0.315,
+        "vs_lhp_iso": 0.160,
+        "vs_rhp_iso": 0.160,
+    },
+}
+
+
+# Conservative team offense quality layer.
+# Positive score = stronger than prior offense.
+# Negative score = weaker than prior offense.
+# This should later be replaced by live/team aggregate batting data.
+TEAM_OFFENSE_QUALITY_V1 = {
+    119: {"quality_score": 0.08, "label": "strong_offense"},       # Dodgers
+    147: {"quality_score": 0.07, "label": "strong_offense"},       # Yankees
+    141: {"quality_score": 0.06, "label": "above_average_offense"},# Blue Jays
+    140: {"quality_score": 0.05, "label": "above_average_offense"},# Rangers
+    108: {"quality_score": 0.05, "label": "above_average_offense"},# Angels
+    116: {"quality_score": 0.04, "label": "above_average_offense"},# Tigers
+
+    115: {"quality_score": -0.04, "label": "below_average_offense"},# Rockies
+    146: {"quality_score": -0.04, "label": "below_average_offense"},# Marlins
+    120: {"quality_score": -0.04, "label": "below_average_offense"},# Nationals
+    133: {"quality_score": -0.03, "label": "slightly_below_average_offense"},# Athletics
+}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deepcopy_profile(profile: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {
+        section: dict(values)
+        for section, values in profile.items()
+    }
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _apply_team_quality(profile: Dict[str, Dict[str, Any]], quality_score: float) -> None:
+    q = _clamp(quality_score, -0.12, 0.12)
+
+    profile["contact_skill"]["k_rate"] = round(_clamp(profile["contact_skill"]["k_rate"] - (q * 0.16), 0.17, 0.30), 3)
+    profile["contact_skill"]["whiff_rate"] = round(_clamp(profile["contact_skill"]["whiff_rate"] - (q * 0.14), 0.18, 0.30), 3)
+    profile["contact_skill"]["contact_rate"] = round(_clamp(profile["contact_skill"]["contact_rate"] + (q * 0.14), 0.70, 0.82), 3)
+
+    profile["plate_discipline"]["bb_rate"] = round(_clamp(profile["plate_discipline"]["bb_rate"] + (q * 0.08), 0.055, 0.125), 3)
+    profile["plate_discipline"]["chase_rate"] = round(_clamp(profile["plate_discipline"]["chase_rate"] - (q * 0.10), 0.24, 0.36), 3)
+    profile["plate_discipline"]["swing_rate"] = round(_clamp(profile["plate_discipline"]["swing_rate"] + (q * 0.04), 0.42, 0.52), 3)
+
+    profile["power"]["iso"] = round(_clamp(profile["power"]["iso"] + (q * 0.22), 0.115, 0.230), 3)
+    profile["power"]["barrel_rate"] = round(_clamp(profile["power"]["barrel_rate"] + (q * 0.08), 0.045, 0.115), 3)
+    profile["power"]["hard_hit_rate"] = round(_clamp(profile["power"]["hard_hit_rate"] + (q * 0.16), 0.32, 0.48), 3)
+
+    profile["batted_ball_quality"]["avg_exit_velocity"] = round(_clamp(profile["batted_ball_quality"]["avg_exit_velocity"] + (q * 5.0), 86.0, 91.5), 1)
+    profile["batted_ball_quality"]["avg_launch_angle"] = round(_clamp(profile["batted_ball_quality"]["avg_launch_angle"] + (q * 3.0), 8.0, 17.0), 1)
+
+    profile["platoon_profile"]["vs_lhp_woba"] = round(_clamp(profile["platoon_profile"]["vs_lhp_woba"] + (q * 0.14), 0.275, 0.365), 3)
+    profile["platoon_profile"]["vs_rhp_woba"] = round(_clamp(profile["platoon_profile"]["vs_rhp_woba"] + (q * 0.14), 0.275, 0.365), 3)
+    profile["platoon_profile"]["vs_lhp_iso"] = round(_clamp(profile["platoon_profile"]["vs_lhp_iso"] + (q * 0.12), 0.115, 0.220), 3)
+    profile["platoon_profile"]["vs_rhp_iso"] = round(_clamp(profile["platoon_profile"]["vs_rhp_iso"] + (q * 0.12), 0.115, 0.220), 3)
+
+
+def build_team_offense_prior(
+    team_id: Optional[int] = None,
+    team_name: Optional[str] = None,
+    raw_context: Optional[dict] = None,
+) -> Dict[str, Any]:
+    raw_context = raw_context or {}
+    profile = _deepcopy_profile(TEAM_OFFENSE_PRIOR_V1)
+
+    team_quality = TEAM_OFFENSE_QUALITY_V1.get(team_id, {})
+    quality_score = _safe_float(raw_context.get("quality_score", team_quality.get("quality_score")))
+    quality_label = raw_context.get("quality_label", team_quality.get("label", "league_average_offense"))
+
+    if quality_score is not None:
+        _apply_team_quality(profile, quality_score)
+    else:
+        quality_score = 0.0
+
+    profile["metadata"] = {
+        "source_type": raw_context.get("source_type", "team_offense_prior_v1"),
+        "team_id": team_id,
+        "team_name": team_name,
+        "data_confidence": raw_context.get("data_confidence", "low"),
+        "generated_from": "build_team_offense_prior",
+        "profile_granularity": "team_offense_prior",
+        "sample_window": raw_context.get("sample_window", "prior"),
+        "sample_size": raw_context.get("sample_size"),
+        "team_offense_prior_version": "team_offense_prior_v1",
+        "team_offense_quality_version": "team_offense_quality_v1",
+        "team_offense_quality_score": quality_score,
+        "team_offense_quality_label": quality_label,
+        "team_quality_adjustment_applied": quality_score != 0.0,
+        "notes": [
+            "V1 uses conservative team offense priors when lineup data is unavailable.",
+            "Future versions should aggregate projected/active hitters and recent team offense data.",
+            "Use this profile only as a low-confidence fallback for pre-lineup games.",
+        ],
+    }
+
+    return profile


### PR DESCRIPTION
Adds a low-confidence team offense prior fallback so PA/game simulation outputs can populate before official lineups are posted.

This update:
- creates `mlb_app/team_offense_prior.py`
- defines conservative team offense priors for contact, discipline, power, batted-ball quality, and platoon profile
- adds a small team offense quality layer for modest team-specific separation
- updates PA outcome model construction to fall back to a team offense prior when no usable lineup/player models are available
- exposes fallback metadata including source, reason, model counts, and whether the team prior was used
- exposes `homeTeamOffensePrior` and `awayTeamOffensePrior` in matchup detail
- updates the PA Outcome UI subtitle to show when fallback is being used

This fixes pre-lineup matchups where PA outcome, half-inning, and game simulation panels were rendering structurally but showing blank values due to zero usable hitters.