### PR TITLE
Use bullpen-adjusted game simulation in UI

### DIFF
--- a/frontend/src/pages/MatchupDetailPage.jsx
+++ b/frontend/src/pages/MatchupDetailPage.jsx
@@ -1045,6 +1045,7 @@ function GameSimulationPanel({ simulation, homeName, awayName }) {
       <div style={t.pitcherName}>{awayName} vs {homeName}</div>
       <div style={{ color: '#8b949e', fontSize: '12px', marginBottom: '12px' }}>
         {simulation.model_version || 'Full-game simulation'} · Sims: {simulation.simulations ?? simulation.metadata?.simulation_count ?? '—'}
+        {simulation.dynamic_starter_exit ? ' · Dynamic starter exit' : ''}
       </div>
 
       <div style={t.splitsGrid}>
@@ -1394,7 +1395,11 @@ export default function MatchupDetailPage() {
           </div>
 
           <div style={{ ...t.sectionTitle, marginTop: '22px' }}>Full Game Simulation</div>
-          <GameSimulationPanel simulation={matchup.gameSimulation} awayName={away.name} homeName={home.name} />
+          <GameSimulationPanel
+            simulation={matchup.bullpenAdjustedGameSimulation || matchup.gameSimulation}
+            awayName={away.name}
+            homeName={home.name}
+          />
         </div>
       )}
 


### PR DESCRIPTION
Updates the Full Game Simulation UI panel to prefer the richer bullpen-adjusted simulation output.

This update:
- renders `matchup.bullpenAdjustedGameSimulation` when available, falling back to `matchup.gameSimulation`
- adds a subtitle indicator when dynamic starter exit is active
- ensures the UI displays bullpen-adjusted totals, starter quality labels, and dynamic starter-exit simulation metadata instead of the older base full-game simulation object

This fixes the issue where the backend had richer bullpen-adjusted simulation data but the frontend was still showing `full_game_sim_v1` outputs.