### PR TITLE
Add simulation models to model projections

### DIFF
--- a/mlb_app/bullpen_profile.py
+++ b/mlb_app/bullpen_profile.py
@@ -1,0 +1,209 @@
+"""
+Team bullpen profile foundation.
+
+V1 creates a stable bullpen profile contract that mirrors starter pitcher
+profile sections. Later branches can enrich these priors with actual reliever
+aggregates, recent workload, handedness mix, and leverage availability.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+BULLPEN_PRIOR_V1 = {
+    "bat_missing": {
+        "k_rate": 0.235,
+        "whiff_rate": 0.255,
+        "csw_rate": 0.285,
+    },
+    "command_control": {
+        "bb_rate": 0.090,
+        "zone_rate": 0.485,
+        "first_pitch_strike_rate": 0.600,
+    },
+    "contact_management": {
+        "hard_hit_rate_allowed": 0.390,
+        "barrel_rate_allowed": 0.075,
+        "avg_exit_velocity_allowed": 88.5,
+        "avg_launch_angle_allowed": 12.0,
+        "xwoba_allowed": 0.320,
+        "xba_allowed": 0.245,
+    },
+    "platoon_profile": {
+        "vs_lhb_woba_allowed": 0.320,
+        "vs_rhb_woba_allowed": 0.320,
+        "vs_lhb_iso_allowed": 0.155,
+        "vs_rhb_iso_allowed": 0.155,
+    },
+    "arsenal": {
+        "pitch_mix": "Bullpen prior mix",
+        "avg_velocity": 94.0,
+        "avg_spin_rate": 2350.0,
+    },
+}
+
+# V1 team-quality layer.
+#
+# These are conservative profile adjustments, not final measured bullpen stats.
+# Positive quality_score means better-than-prior bullpen run prevention.
+# Negative quality_score means weaker-than-prior bullpen run prevention.
+#
+# Future versions should replace this with active-reliever aggregation.
+TEAM_BULLPEN_QUALITY_V1 = {
+    # Conservative v1 bullpen priors for all MLB teams.
+    # Positive quality_score means better-than-prior bullpen run prevention.
+    # Negative quality_score means weaker-than-prior bullpen run prevention.
+    #
+    # These are intentionally modest and should be replaced later with
+    # active-reliever aggregation, recent workload, and role availability.
+
+    # Strong / above-average bullpen priors
+    119: {"quality_score": 0.08, "label": "strong_bullpen"},          # Los Angeles Dodgers
+    147: {"quality_score": 0.07, "label": "strong_bullpen"},          # New York Yankees
+    139: {"quality_score": 0.06, "label": "above_average_bullpen"},   # Tampa Bay Rays
+    114: {"quality_score": 0.05, "label": "above_average_bullpen"},   # Cleveland Guardians
+    117: {"quality_score": 0.04, "label": "above_average_bullpen"},   # Houston Astros
+    121: {"quality_score": 0.04, "label": "above_average_bullpen"},   # New York Mets
+    138: {"quality_score": 0.04, "label": "above_average_bullpen"},   # St. Louis Cardinals
+    158: {"quality_score": 0.03, "label": "slightly_above_average_bullpen"}, # Milwaukee Brewers
+    135: {"quality_score": 0.03, "label": "slightly_above_average_bullpen"}, # San Diego Padres
+    142: {"quality_score": 0.03, "label": "slightly_above_average_bullpen"}, # Minnesota Twins
+    145: {"quality_score": 0.02, "label": "slightly_above_average_bullpen"}, # Chicago White Sox
+    143: {"quality_score": 0.02, "label": "slightly_above_average_bullpen"}, # Philadelphia Phillies
+    110: {"quality_score": 0.02, "label": "slightly_above_average_bullpen"}, # Baltimore Orioles
+
+    # Near-average bullpen priors
+    140: {"quality_score": 0.01, "label": "near_average_bullpen"},    # Texas Rangers
+    133: {"quality_score": 0.01, "label": "near_average_bullpen"},    # Athletics
+    116: {"quality_score": 0.00, "label": "league_average_bullpen"},  # Detroit Tigers
+    141: {"quality_score": 0.00, "label": "league_average_bullpen"},  # Toronto Blue Jays
+    108: {"quality_score": 0.00, "label": "league_average_bullpen"},  # Los Angeles Angels
+    144: {"quality_score": 0.00, "label": "league_average_bullpen"},  # Atlanta Braves
+    137: {"quality_score": -0.01, "label": "near_average_bullpen"},   # San Francisco Giants
+    112: {"quality_score": -0.01, "label": "near_average_bullpen"},   # Chicago Cubs
+
+    # Below-average bullpen priors
+    109: {"quality_score": -0.02, "label": "slightly_below_average_bullpen"}, # Arizona Diamondbacks
+    136: {"quality_score": -0.02, "label": "slightly_below_average_bullpen"}, # Seattle Mariners
+    118: {"quality_score": -0.03, "label": "slightly_below_average_bullpen"}, # Kansas City Royals
+    113: {"quality_score": -0.03, "label": "slightly_below_average_bullpen"}, # Cincinnati Reds
+    134: {"quality_score": -0.03, "label": "slightly_below_average_bullpen"}, # Pittsburgh Pirates
+    111: {"quality_score": -0.04, "label": "below_average_bullpen"},  # Boston Red Sox
+    120: {"quality_score": -0.04, "label": "below_average_bullpen"},  # Washington Nationals
+    146: {"quality_score": -0.04, "label": "below_average_bullpen"},  # Miami Marlins
+    115: {"quality_score": -0.05, "label": "below_average_bullpen"},  # Colorado Rockies
+}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deepcopy_profile(profile: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {
+        section: dict(values)
+        for section, values in profile.items()
+    }
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _apply_team_quality(profile: Dict[str, Dict[str, Any]], quality_score: float) -> None:
+    """
+    Apply conservative team bullpen quality adjustments in-place.
+
+    Better bullpens:
+    - increase K/whiff/CSW
+    - reduce BB
+    - improve zone/FPS
+    - reduce hard contact/xwOBA/xBA
+    """
+    q = _clamp(quality_score, -0.12, 0.12)
+
+    profile["bat_missing"]["k_rate"] = round(_clamp(profile["bat_missing"]["k_rate"] + (q * 0.20), 0.16, 0.32), 3)
+    profile["bat_missing"]["whiff_rate"] = round(_clamp(profile["bat_missing"]["whiff_rate"] + (q * 0.18), 0.18, 0.34), 3)
+    profile["bat_missing"]["csw_rate"] = round(_clamp(profile["bat_missing"]["csw_rate"] + (q * 0.12), 0.23, 0.34), 3)
+
+    profile["command_control"]["bb_rate"] = round(_clamp(profile["command_control"]["bb_rate"] - (q * 0.10), 0.055, 0.13), 3)
+    profile["command_control"]["zone_rate"] = round(_clamp(profile["command_control"]["zone_rate"] + (q * 0.08), 0.43, 0.53), 3)
+    profile["command_control"]["first_pitch_strike_rate"] = round(_clamp(profile["command_control"]["first_pitch_strike_rate"] + (q * 0.10), 0.54, 0.66), 3)
+
+    profile["contact_management"]["hard_hit_rate_allowed"] = round(_clamp(profile["contact_management"]["hard_hit_rate_allowed"] - (q * 0.18), 0.31, 0.47), 3)
+    profile["contact_management"]["barrel_rate_allowed"] = round(_clamp(profile["contact_management"]["barrel_rate_allowed"] - (q * 0.05), 0.045, 0.105), 3)
+    profile["contact_management"]["xwoba_allowed"] = round(_clamp(profile["contact_management"]["xwoba_allowed"] - (q * 0.15), 0.275, 0.365), 3)
+    profile["contact_management"]["xba_allowed"] = round(_clamp(profile["contact_management"]["xba_allowed"] - (q * 0.10), 0.215, 0.285), 3)
+
+    profile["platoon_profile"]["vs_lhb_woba_allowed"] = round(_clamp(profile["platoon_profile"]["vs_lhb_woba_allowed"] - (q * 0.13), 0.28, 0.36), 3)
+    profile["platoon_profile"]["vs_rhb_woba_allowed"] = round(_clamp(profile["platoon_profile"]["vs_rhb_woba_allowed"] - (q * 0.13), 0.28, 0.36), 3)
+    profile["platoon_profile"]["vs_lhb_iso_allowed"] = round(_clamp(profile["platoon_profile"]["vs_lhb_iso_allowed"] - (q * 0.08), 0.12, 0.20), 3)
+    profile["platoon_profile"]["vs_rhb_iso_allowed"] = round(_clamp(profile["platoon_profile"]["vs_rhb_iso_allowed"] - (q * 0.08), 0.12, 0.20), 3)
+
+    profile["arsenal"]["avg_velocity"] = round(_clamp(profile["arsenal"]["avg_velocity"] + (q * 6.0), 91.0, 97.5), 1)
+    profile["arsenal"]["avg_spin_rate"] = round(_clamp(profile["arsenal"]["avg_spin_rate"] + (q * 250.0), 2150.0, 2550.0), 0)
+
+
+def build_bullpen_profile(
+    team_id: Optional[int] = None,
+    team_name: Optional[str] = None,
+    raw_context: Optional[dict] = None,
+) -> Dict[str, Any]:
+    """
+    Build a team bullpen profile.
+
+    V1 intentionally returns conservative priors with metadata so downstream
+    simulation can rely on a stable shape before real reliever aggregation is
+    added.
+    """
+    raw_context = raw_context or {}
+    profile = _deepcopy_profile(BULLPEN_PRIOR_V1)
+
+    team_quality = TEAM_BULLPEN_QUALITY_V1.get(team_id, {})
+    quality_score = _safe_float(raw_context.get("quality_score", team_quality.get("quality_score")))
+    quality_label = raw_context.get("quality_label", team_quality.get("label", "league_average_bullpen"))
+
+    if quality_score is not None:
+        _apply_team_quality(profile, quality_score)
+    else:
+        quality_score = 0.0
+
+    # Allow explicit overrides when future callers have already-computed team
+    # bullpen values. This keeps v1 extensible without changing the response
+    # contract later.
+    overrides = raw_context.get("bullpen_profile_overrides") or {}
+    for section, values in overrides.items():
+        if section not in profile or not isinstance(values, dict):
+            continue
+        for key, value in values.items():
+            if key in profile[section] and value is not None:
+                profile[section][key] = value
+
+    profile["metadata"] = {
+        "source_type": raw_context.get("source_type", "bullpen_prior_v1"),
+        "team_id": team_id,
+        "team_name": team_name,
+        "data_confidence": raw_context.get("data_confidence", "low"),
+        "generated_from": "build_bullpen_profile",
+        "profile_granularity": "team_bullpen",
+        "sample_window": raw_context.get("sample_window", "prior"),
+        "sample_size": raw_context.get("sample_size"),
+        "bullpen_profile_version": "bullpen_profile_v1",
+        "bullpen_quality_version": "team_bullpen_quality_v1",
+        "bullpen_quality_score": quality_score,
+        "bullpen_quality_label": quality_label,
+        "team_quality_adjustment_applied": quality_score != 0.0,
+        "notes": [
+            "V1 uses conservative league-average bullpen priors.",
+            "Future versions should aggregate active relievers by team and role.",
+            "Use this profile as a stable contract before bullpen simulation integration.",
+        ],
+    }
+
+    return profile

--- a/mlb_app/environment_data.py
+++ b/mlb_app/environment_data.py
@@ -1,0 +1,260 @@
+"""
+Environment data retrieval utilities for matchup previews.
+
+This module provides a lightweight backend adapter layer for game-level
+environment context. It currently supports:
+
+- stadium coordinate lookup
+- weather retrieval from Open-Meteo
+- park factor lookup from a static in-repo table
+- composition of environment context for environment profiles
+
+The goal is to populate environment profiles with real data when possible
+while preserving an honest, contract-stable fallback when data is missing.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import requests
+
+
+STADIUM_COORDINATES: Dict[str, Dict[str, object]] = {
+    "Chase Field": {"lat": 33.445, "lon": -112.067, "timezone": "America/Phoenix"},
+    "Truist Park": {"lat": 33.891, "lon": -84.389, "timezone": "America/New_York"},
+    "Oriole Park at Camden Yards": {"lat": 39.284, "lon": -76.622, "timezone": "America/New_York"},
+    "Fenway Park": {"lat": 42.346, "lon": -71.098, "timezone": "America/New_York"},
+    "Wrigley Field": {"lat": 41.948, "lon": -87.656, "timezone": "America/Chicago"},
+    "Rate Field": {"lat": 41.830, "lon": -87.634, "timezone": "America/Chicago"},
+    "Great American Ball Park": {"lat": 39.097, "lon": -84.507, "timezone": "America/New_York"},
+    "Progressive Field": {"lat": 41.496, "lon": -81.685, "timezone": "America/New_York"},
+    "Coors Field": {"lat": 39.756, "lon": -104.994, "timezone": "America/Denver"},
+    "Comerica Park": {"lat": 42.339, "lon": -83.049, "timezone": "America/New_York"},
+    "Daikin Park": {"lat": 29.757, "lon": -95.356, "timezone": "America/Chicago"},
+    "Kauffman Stadium": {"lat": 39.051, "lon": -94.481, "timezone": "America/Chicago"},
+    "Angel Stadium": {"lat": 33.800, "lon": -117.883, "timezone": "America/Los_Angeles"},
+    "Dodger Stadium": {"lat": 34.074, "lon": -118.240, "timezone": "America/Los_Angeles"},
+    "LoanDepot Park": {"lat": 25.778, "lon": -80.220, "timezone": "America/New_York"},
+    "American Family Field": {"lat": 43.028, "lon": -87.971, "timezone": "America/Chicago"},
+    "Target Field": {"lat": 44.981, "lon": -93.278, "timezone": "America/Chicago"},
+    "Citi Field": {"lat": 40.757, "lon": -73.846, "timezone": "America/New_York"},
+    "Yankee Stadium": {"lat": 40.830, "lon": -73.926, "timezone": "America/New_York"},
+    "Sutter Health Park": {"lat": 38.580, "lon": -121.507, "timezone": "America/Los_Angeles"},
+    "Citizens Bank Park": {"lat": 39.906, "lon": -75.166, "timezone": "America/New_York"},
+    "PNC Park": {"lat": 40.447, "lon": -80.006, "timezone": "America/New_York"},
+    "Petco Park": {"lat": 32.707, "lon": -117.157, "timezone": "America/Los_Angeles"},
+    "Oracle Park": {"lat": 37.778, "lon": -122.389, "timezone": "America/Los_Angeles"},
+    "T-Mobile Park": {"lat": 47.591, "lon": -122.333, "timezone": "America/Los_Angeles"},
+    "Busch Stadium": {"lat": 38.622, "lon": -90.193, "timezone": "America/Chicago"},
+    "Tropicana Field": {"lat": 27.768, "lon": -82.653, "timezone": "America/New_York"},
+    "Globe Life Field": {"lat": 32.747, "lon": -97.084, "timezone": "America/Chicago"},
+    "Rogers Centre": {"lat": 43.641, "lon": -79.389, "timezone": "America/Toronto"},
+    "Nationals Park": {"lat": 38.873, "lon": -77.008, "timezone": "America/New_York"},
+}
+
+
+PARK_FACTORS: Dict[str, Dict[str, Optional[float]]] = {
+    "Wrigley Field": {"run_factor": 101.0, "home_run_factor": 104.0, "hit_factor": 100.0},
+    "Fenway Park": {"run_factor": 105.0, "home_run_factor": 102.0, "hit_factor": 108.0},
+    "Yankee Stadium": {"run_factor": 103.0, "home_run_factor": 109.0, "hit_factor": 100.0},
+    "Dodger Stadium": {"run_factor": 99.0, "home_run_factor": 100.0, "hit_factor": 98.0},
+    "Oracle Park": {"run_factor": 95.0, "home_run_factor": 90.0, "hit_factor": 94.0},
+    "Coors Field": {"run_factor": 118.0, "home_run_factor": 115.0, "hit_factor": 112.0},
+    "Petco Park": {"run_factor": 96.0, "home_run_factor": 94.0, "hit_factor": 97.0},
+}
+
+
+def _degrees_to_compass(degrees: Optional[float]) -> Optional[str]:
+    """Convert meteorological wind direction degrees into a coarse compass label."""
+    if degrees is None:
+        return None
+    directions = [
+        "N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE",
+        "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW",
+    ]
+    idx = round(degrees / 22.5) % 16
+    return directions[idx]
+
+
+def get_stadium_lookup(venue_name: str) -> Dict[str, object]:
+    """Return coordinate/timezone metadata for a venue name."""
+    return STADIUM_COORDINATES.get(venue_name, {})
+
+
+def get_game_weather(venue_name: str, game_time_iso: str) -> Dict[str, object]:
+    """
+    Retrieve approximate game-time weather for a venue using Open-Meteo.
+
+    This implementation uses hourly forecast data keyed off stadium coordinates.
+    If weather cannot be fetched, returns a contract-safe partial payload.
+    """
+    venue = get_stadium_lookup(venue_name)
+    lat = venue.get("lat")
+    lon = venue.get("lon")
+    timezone = venue.get("timezone", "auto")
+
+    if lat is None or lon is None:
+        return {
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "source_fields_used": [],
+            "weather_readiness": "stub",
+        }
+
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "hourly": ",".join(
+            [
+                "temperature_2m",
+                "relative_humidity_2m",
+                "precipitation_probability",
+                "wind_speed_10m",
+                "wind_direction_10m",
+            ]
+        ),
+        "forecast_days": 1,
+        "timezone": timezone,
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException:
+        return {
+            "temperature_f": None,
+            "wind_speed_mph": None,
+            "wind_direction": None,
+            "humidity_pct": None,
+            "precipitation_probability": None,
+            "source_fields_used": [],
+            "weather_readiness": "stub",
+        }
+
+    hourly = data.get("hourly", {})
+    temperature_c = (hourly.get("temperature_2m") or [None])[0]
+    humidity_pct = (hourly.get("relative_humidity_2m") or [None])[0]
+    precipitation_probability = (hourly.get("precipitation_probability") or [None])[0]
+    wind_speed_kmh = (hourly.get("wind_speed_10m") or [None])[0]
+    wind_direction_deg = (hourly.get("wind_direction_10m") or [None])[0]
+
+    temperature_f = None if temperature_c is None else (temperature_c * 9 / 5) + 32
+    wind_speed_mph = None if wind_speed_kmh is None else wind_speed_kmh * 0.621371
+    wind_direction = _degrees_to_compass(wind_direction_deg)
+
+    return {
+        "temperature_f": temperature_f,
+        "wind_speed_mph": wind_speed_mph,
+        "wind_direction": wind_direction,
+        "humidity_pct": humidity_pct,
+        "precipitation_probability": precipitation_probability,
+        "source_fields_used": [
+            "temperature_2m",
+            "relative_humidity_2m",
+            "precipitation_probability",
+            "wind_speed_10m",
+            "wind_direction_10m",
+        ],
+        "weather_readiness": "ready" if temperature_f is not None else "partial",
+    }
+
+
+def get_park_factors(venue_name: str) -> Dict[str, object]:
+    """
+    Return park factor values for a venue.
+
+    This v1 implementation uses a static adapter table. Missing venues remain
+    contract-safe with null values.
+    """
+    factors = PARK_FACTORS.get(venue_name, {})
+    return {
+        "run_factor": factors.get("run_factor"),
+        "home_run_factor": factors.get("home_run_factor"),
+        "hit_factor": factors.get("hit_factor"),
+        "source_fields_used": [
+            key for key in ("run_factor", "home_run_factor", "hit_factor") if key in factors
+        ],
+        "park_readiness": "ready" if factors else "stub",
+    }
+
+
+def build_environment_context(game: dict) -> Dict[str, object]:
+    """
+    Build a combined raw environment context from schedule, weather, and park inputs.
+    """
+    venue = game.get("venue", {}) or {}
+    venue_name = venue.get("name")
+    game_time = game.get("gameDate")
+
+    home_team = game.get("teams", {}).get("home", {}).get("team", {}).get("name")
+    away_team = game.get("teams", {}).get("away", {}).get("team", {}).get("name")
+
+    weather = get_game_weather(venue_name, game_time) if venue_name and game_time else {}
+    park = get_park_factors(venue_name) if venue_name else {}
+
+    missing_inputs = []
+    for key in (
+        "temperature_f",
+        "wind_speed_mph",
+        "wind_direction",
+        "humidity_pct",
+        "precipitation_probability",
+        "run_factor",
+        "home_run_factor",
+        "hit_factor",
+    ):
+        if key not in {**weather, **park} or ({**weather, **park}).get(key) is None:
+            missing_inputs.append(key)
+
+    weather_ready = weather.get("weather_readiness") == "ready"
+    park_ready = park.get("park_readiness") == "ready"
+
+    if weather_ready and park_ready:
+        readiness = "ready"
+    elif weather_ready or park_ready:
+        readiness = "partial"
+    else:
+        readiness = "stub"
+
+    return {
+        "venue_name": venue_name,
+        "roof_status": None,
+        "home_team": home_team,
+        "away_team": away_team,
+        "game_time_local": game_time,
+        "temperature_f": weather.get("temperature_f"),
+        "wind_speed_mph": weather.get("wind_speed_mph"),
+        "wind_direction": weather.get("wind_direction"),
+        "humidity_pct": weather.get("humidity_pct"),
+        "precipitation_probability": weather.get("precipitation_probability"),
+        "run_factor": park.get("run_factor"),
+        "home_run_factor": park.get("home_run_factor"),
+        "hit_factor": park.get("hit_factor"),
+        "scoring_environment_label": None,
+        "weather_run_impact": None,
+        "park_run_impact": None,
+        "rain_delay_risk": None,
+        "postponement_risk": None,
+        "extreme_wind_flag": (
+            weather.get("wind_speed_mph") is not None and weather.get("wind_speed_mph") >= 15
+        ),
+        "extreme_temperature_flag": (
+            weather.get("temperature_f") is not None
+            and (weather.get("temperature_f") <= 45 or weather.get("temperature_f") >= 90)
+        ),
+        "source_type": "weather_api + park_factor_lookup",
+        "source_fields_used": sorted(
+            list(set(weather.get("source_fields_used", []) + park.get("source_fields_used", [])))
+        ),
+        "data_confidence": "medium" if readiness in ("ready", "partial") else "low",
+        "generated_from": "build_environment_context",
+        "is_stub": readiness == "stub",
+        "readiness": readiness,
+        "missing_inputs": missing_inputs,
+    }

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -1,0 +1,412 @@
+"""
+Utilities for building environment profile summaries for matchup previews.
+
+This module defines a game-level environment profile structure that can later
+be populated with real weather, park factor, and contextual inputs.
+"""
+
+import re
+
+
+def compute_environment_profile(raw_context: dict) -> dict:
+    """
+    Build a structured environment profile from raw game context inputs.
+
+    Parameters
+    ----------
+    raw_context : dict
+        Dictionary of environmental and contextual stats from upstream
+        ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured game-level environment profile using raw metrics grouped
+        by category. Missing fields are returned as None.
+    """
+    raw_context = raw_context or {}
+    weather = raw_context.get("weather") or {}
+
+    def _safe_float(value):
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_wind_text(value):
+        text = str(value or "").strip()
+        if not text:
+            return None, None
+
+        speed = None
+        speed_match = re.search(r"(\d+(?:\.\d+)?)\s*mph", text, re.IGNORECASE)
+        if speed_match:
+            speed = _safe_float(speed_match.group(1))
+
+        direction = text
+        direction = re.sub(r"^\s*\d+(?:\.\d+)?\s*mph\s*,?\s*", "", direction, flags=re.IGNORECASE)
+        direction = direction.strip(" ,") or None
+
+        return speed, direction
+
+    calibration = {
+        "environment_calibration_version": "env_calibration_v1",
+        "park_weight": 1.00,
+        "temperature_weight": 1.00,
+        "wind_weight": 1.00,
+        "max_weather_adjustment": 0.075,
+        "max_total_adjustment": 0.150,
+        "neutral_index": 1.000,
+    }
+
+    def _clamp(value, lower, upper):
+        if value is None:
+            return None
+        return max(lower, min(upper, value))
+
+    def _calibrated_index(base_index, adjustment):
+        base = base_index if base_index is not None else calibration["neutral_index"]
+        max_total = calibration["max_total_adjustment"]
+        raw = base + adjustment
+        return round(_clamp(raw, calibration["neutral_index"] - max_total, calibration["neutral_index"] + max_total), 3)
+
+    def _park_label(run_factor):
+        if run_factor is None:
+            return None
+        if run_factor >= 1.10:
+            return "hitter_friendly"
+        if run_factor >= 1.03:
+            return "slight_hitter_friendly"
+        if run_factor <= 0.92:
+            return "pitcher_friendly"
+        if run_factor <= 0.97:
+            return "slight_pitcher_friendly"
+        return "neutral"
+
+    def _park_factor_proxy(run_factor, multiplier, lower, upper):
+        if run_factor is None:
+            return None
+        value = 1.0 + ((run_factor - 1.0) * multiplier)
+        return round(_clamp(value, lower, upper), 3)
+
+    def _wind_direction_type(wind_direction):
+        text = str(wind_direction or "").lower()
+        if not text:
+            return None
+        if "in from" in text or "blowing in" in text or text.startswith("in "):
+            return "in"
+        if "out to" in text or "blowing out" in text or text.startswith("out "):
+            return "out"
+        if "cross" in text or "r to l" in text or "l to r" in text or "right to left" in text or "left to right" in text:
+            return "cross"
+        return "unknown"
+
+    def _wind_speed_tier(wind_speed):
+        if wind_speed is None:
+            return None
+        if wind_speed >= 15:
+            return "strong"
+        if wind_speed >= 10:
+            return "moderate"
+        if wind_speed >= 6:
+            return "mild"
+        return "calm"
+
+    def _wind_adjustments(wind_speed, wind_direction):
+        direction_type = _wind_direction_type(wind_direction)
+        tier = _wind_speed_tier(wind_speed)
+
+        base = {
+            "calm": 0.0,
+            "mild": 0.01,
+            "moderate": 0.025,
+            "strong": 0.04,
+        }.get(tier, 0.0)
+
+        direction_multiplier = {
+            "out": 1.0,
+            "in": -1.0,
+            "cross": -0.25,
+            "unknown": 0.0,
+            None: 0.0,
+        }.get(direction_type, 0.0)
+
+        wind_weight = calibration["wind_weight"]
+        hr_adjustment = round(base * 1.50 * direction_multiplier * wind_weight, 3)
+        run_adjustment = round(base * 0.85 * direction_multiplier * wind_weight, 3)
+        hit_adjustment = round(base * 0.25 * direction_multiplier * wind_weight, 3)
+
+        return {
+            "wind_direction_type": direction_type,
+            "wind_speed_tier": tier,
+            "wind_hr_adjustment": hr_adjustment,
+            "wind_run_adjustment": run_adjustment,
+            "wind_hit_adjustment": hit_adjustment,
+        }
+
+    def _wind_impact(wind_speed, wind_direction):
+        direction_type = _wind_direction_type(wind_direction)
+        tier = _wind_speed_tier(wind_speed)
+        if wind_speed is None:
+            return None
+        if direction_type == "in" and tier in {"moderate", "strong"}:
+            return "wind_in_suppresses_carry"
+        if direction_type == "out" and tier in {"moderate", "strong"}:
+            return "wind_out_boosts_carry"
+        if direction_type == "cross" and tier in {"moderate", "strong"}:
+            return "crosswind_may_affect_carry"
+        if tier in {"moderate", "strong"}:
+            return "wind_may_affect_carry"
+        if tier == "mild" and direction_type == "in":
+            return "mild_wind_in_slight_suppression"
+        if tier == "mild" and direction_type == "out":
+            return "mild_wind_out_slight_boost"
+        return "limited_wind_impact"
+
+    def _temperature_impact(temp_f):
+        if temp_f is None:
+            return None
+        if temp_f >= 85:
+            return "hot_air_boosts_carry"
+        if temp_f >= 75:
+            return "warm_air_slight_boost"
+        if temp_f <= 45:
+            return "cold_air_strongly_suppresses_carry"
+        if temp_f <= 55:
+            return "cold_air_suppresses_carry"
+        return "neutral_temperature"
+
+    def _weather_impact(temp_f, wind_speed, wind_direction):
+        wind = _wind_impact(wind_speed, wind_direction)
+        temp = _temperature_impact(temp_f)
+
+        if wind in {"wind_in_suppresses_carry", "wind_out_boosts_carry"}:
+            return wind
+        if temp in {"hot_air_boosts_carry", "cold_air_strongly_suppresses_carry", "cold_air_suppresses_carry"}:
+            return temp
+        if wind:
+            return wind
+        return temp or "neutral_or_unknown"
+
+    def _temperature_adjustment(temp_f):
+        temp = _temperature_impact(temp_f)
+        temperature_weight = calibration["temperature_weight"]
+        if temp == "hot_air_boosts_carry":
+            return 0.03 * temperature_weight
+        if temp == "warm_air_slight_boost":
+            return 0.01 * temperature_weight
+        if temp == "cold_air_strongly_suppresses_carry":
+            return -0.04 * temperature_weight
+        if temp == "cold_air_suppresses_carry":
+            return -0.02 * temperature_weight
+        return 0.0
+
+    def _run_scoring_index(run_factor, temp_f, wind_speed, wind_direction):
+        base = run_factor if run_factor is not None else calibration["neutral_index"]
+        weather_adjustment = _temperature_adjustment(temp_f) + _wind_adjustments(wind_speed, wind_direction)["wind_run_adjustment"]
+        weather_adjustment = _clamp(
+            weather_adjustment,
+            -calibration["max_weather_adjustment"],
+            calibration["max_weather_adjustment"],
+        )
+        return _calibrated_index(base, weather_adjustment)
+
+    def _scoring_label(index):
+        if index is None:
+            return None
+        if index >= 1.08:
+            return "offense_boost"
+        if index >= 1.03:
+            return "slight_offense_boost"
+        if index <= 0.92:
+            return "run_suppression"
+        if index <= 0.97:
+            return "slight_run_suppression"
+        return "neutral"
+
+    temperature_f = raw_context.get("temperature_f", weather.get("temp_f"))
+    wind_raw = raw_context.get("wind_direction", weather.get("wind_direction") or weather.get("wind"))
+    wind_speed_mph = raw_context.get("wind_speed_mph", weather.get("wind_speed_mph"))
+    wind_direction = wind_raw
+    parsed_wind_speed, parsed_wind_direction = _parse_wind_text(wind_raw)
+    condition = raw_context.get("condition", weather.get("condition"))
+
+    temperature_f = _safe_float(temperature_f)
+    wind_speed_mph = _safe_float(wind_speed_mph)
+    if wind_speed_mph is None and parsed_wind_speed is not None:
+        wind_speed_mph = parsed_wind_speed
+    if parsed_wind_direction:
+        wind_direction = parsed_wind_direction
+
+    run_factor = raw_context.get("run_factor", raw_context.get("park_factor"))
+    run_factor = _safe_float(run_factor)
+
+    raw_home_run_factor = _safe_float(raw_context.get("home_run_factor"))
+    raw_hit_factor = _safe_float(raw_context.get("hit_factor"))
+
+    home_run_factor = raw_home_run_factor
+    hit_factor = raw_hit_factor
+    park_factor_fallback_used = False
+    park_factor_fallback_source = None
+
+    if home_run_factor is None and run_factor is not None:
+        home_run_factor = _park_factor_proxy(run_factor, multiplier=1.10, lower=0.85, upper=1.15)
+        park_factor_fallback_used = True
+        park_factor_fallback_source = "run_factor_proxy"
+    if hit_factor is None and run_factor is not None:
+        hit_factor = _park_factor_proxy(run_factor, multiplier=0.60, lower=0.90, upper=1.10)
+        park_factor_fallback_used = True
+        park_factor_fallback_source = "run_factor_proxy"
+
+    wind_adjustments = _wind_adjustments(wind_speed_mph, wind_direction)
+
+    run_scoring_index = raw_context.get(
+        "run_scoring_index",
+        _run_scoring_index(run_factor, temperature_f, wind_speed_mph, wind_direction),
+    )
+    base_index = run_factor if run_factor is not None else calibration["neutral_index"]
+    hr_boost_index = raw_context.get(
+        "hr_boost_index",
+        _calibrated_index(base_index, _temperature_adjustment(temperature_f) + wind_adjustments["wind_hr_adjustment"]),
+    )
+    hit_boost_index = raw_context.get(
+        "hit_boost_index",
+        _calibrated_index(base_index, (_temperature_adjustment(temperature_f) * 0.35) + wind_adjustments["wind_hit_adjustment"]),
+    )
+
+    missing_inputs = []
+    if temperature_f is None:
+        missing_inputs.append("temperature_f")
+    if wind_speed_mph is None and not wind_direction:
+        missing_inputs.append("wind")
+    if run_factor is None:
+        missing_inputs.append("run_factor")
+
+    source_fields_used = [
+        key for key in [
+            "game_pk",
+            "game_date",
+            "venue_name",
+            "weather",
+            "park_factor",
+            "home_team",
+            "away_team",
+        ]
+        if raw_context.get(key) is not None
+    ]
+
+    return {
+        "metadata": {
+            "source_type": raw_context.get("source_type", "matchup_detail_context"),
+            "source_fields_used": raw_context.get("source_fields_used", source_fields_used),
+            "data_confidence": raw_context.get(
+                "data_confidence",
+                "medium" if run_factor is not None or weather else "low",
+            ),
+            "generated_from": raw_context.get("generated_from", "compute_environment_profile"),
+            "environment_calibration_version": calibration["environment_calibration_version"],
+            "park_weight": calibration["park_weight"],
+            "temperature_weight": calibration["temperature_weight"],
+            "wind_weight": calibration["wind_weight"],
+            "max_weather_adjustment": calibration["max_weather_adjustment"],
+            "max_total_adjustment": calibration["max_total_adjustment"],
+            "wind_raw": wind_raw,
+            "wind_parsed_from_text": parsed_wind_speed is not None or bool(parsed_wind_direction),
+            "park_factor_fallback_used": park_factor_fallback_used,
+            "park_factor_fallback_source": park_factor_fallback_source,
+        },
+        "weather": {
+            "temperature_f": temperature_f,
+            "condition": condition,
+            "wind_speed_mph": wind_speed_mph,
+            "wind_direction": wind_direction,
+            "humidity_pct": raw_context.get("humidity_pct", weather.get("humidity_pct")),
+            "precipitation_probability": raw_context.get(
+                "precipitation_probability",
+                weather.get("precipitation_probability"),
+            ),
+        },
+        "park_factors": {
+            "run_factor": run_factor,
+            "home_run_factor": home_run_factor,
+            "hit_factor": hit_factor,
+        },
+        "game_context": {
+            "venue_name": raw_context.get("venue_name"),
+            "roof_status": raw_context.get("roof_status"),
+            "home_team": raw_context.get("home_team"),
+            "away_team": raw_context.get("away_team"),
+            "game_time_local": raw_context.get("game_time_local", raw_context.get("game_date")),
+            "game_status": raw_context.get("game_status", raw_context.get("status")),
+        },
+        "run_environment": {
+            "run_scoring_index": run_scoring_index,
+            "hr_boost_index": hr_boost_index,
+            "hit_boost_index": hit_boost_index,
+            "scoring_environment_label": raw_context.get(
+                "scoring_environment_label",
+                _scoring_label(run_scoring_index),
+            ),
+            "weather_run_impact": raw_context.get(
+                "weather_run_impact",
+                _weather_impact(temperature_f, wind_speed_mph, wind_direction),
+            ),
+            "park_run_impact": raw_context.get(
+                "park_run_impact",
+                _park_label(run_factor),
+            ),
+            "wind_run_impact": raw_context.get(
+                "wind_run_impact",
+                _wind_impact(wind_speed_mph, wind_direction),
+            ),
+            "wind_direction_type": raw_context.get(
+                "wind_direction_type",
+                wind_adjustments["wind_direction_type"],
+            ),
+            "wind_speed_tier": raw_context.get(
+                "wind_speed_tier",
+                wind_adjustments["wind_speed_tier"],
+            ),
+            "wind_run_adjustment": raw_context.get(
+                "wind_run_adjustment",
+                wind_adjustments["wind_run_adjustment"],
+            ),
+            "wind_hr_adjustment": raw_context.get(
+                "wind_hr_adjustment",
+                wind_adjustments["wind_hr_adjustment"],
+            ),
+            "wind_hit_adjustment": raw_context.get(
+                "wind_hit_adjustment",
+                wind_adjustments["wind_hit_adjustment"],
+            ),
+            "temperature_run_impact": raw_context.get(
+                "temperature_run_impact",
+                _temperature_impact(temperature_f),
+            ),
+        },
+        "risk_flags": {
+            "rain_delay_risk": raw_context.get(
+                "rain_delay_risk",
+                "rain" in str(condition or "").lower(),
+            ),
+            "postponement_risk": raw_context.get("postponement_risk", False),
+            "extreme_wind_flag": raw_context.get(
+                "extreme_wind_flag",
+                wind_speed_mph is not None and wind_speed_mph >= 15,
+            ),
+            "extreme_temperature_flag": raw_context.get(
+                "extreme_temperature_flag",
+                temperature_f is not None and (temperature_f <= 40 or temperature_f >= 95),
+            ),
+        },
+        "status": {
+            "is_stub": raw_context.get("is_stub", False),
+            "readiness": raw_context.get(
+                "readiness",
+                "partial" if missing_inputs else "ready",
+            ),
+            "missing_inputs": raw_context.get("missing_inputs", missing_inputs),
+        },
+    }

--- a/mlb_app/hitter_profile.py
+++ b/mlb_app/hitter_profile.py
@@ -1,0 +1,98 @@
+"""
+Utilities for building hitter profile summaries for matchup previews.
+
+This module defines a player-level hitter profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+
+def _safe_rate(numerator, denominator):
+    """Return numerator / denominator when both are available and denominator > 0."""
+    if numerator is None or denominator in (None, 0):
+        return None
+    return numerator / denominator
+
+
+def _safe_difference(a, b):
+    """Return a - b when both values are available."""
+    if a is None or b is None:
+        return None
+    return a - b
+
+
+def compute_hitter_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured hitter profile from raw hitter inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of hitter stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level hitter profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    raw_stats = raw_stats or {}
+
+    plate_appearances = raw_stats.get("plateAppearances")
+    strikeouts = raw_stats.get("strikeOuts")
+    walks = raw_stats.get("baseOnBalls")
+    avg = raw_stats.get("avg")
+    slg = raw_stats.get("slg")
+
+    k_rate = raw_stats.get("k_rate", raw_stats.get("k_pct"))
+    if k_rate is None:
+        k_rate = _safe_rate(strikeouts, plate_appearances)
+
+    bb_rate = raw_stats.get("bb_rate", raw_stats.get("bb_pct"))
+    if bb_rate is None:
+        bb_rate = _safe_rate(walks, plate_appearances)
+
+    iso = raw_stats.get("iso")
+    if iso is None:
+        iso = _safe_difference(slg, avg)
+
+    return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_hitter_profile"),
+            "profile_granularity": raw_stats.get("profile_granularity", "player"),
+            "is_projected_lineup_derived": raw_stats.get("is_projected_lineup_derived", False),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "current_season"),
+                sample_size=raw_stats.get("plateAppearances"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
+        },
+        "contact_skill": {
+            "k_rate": k_rate,
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "contact_rate": raw_stats.get("contact_rate"),
+        },
+        "plate_discipline": {
+            "bb_rate": bb_rate,
+            "chase_rate": raw_stats.get("chase_rate"),
+            "swing_rate": raw_stats.get("swing_rate"),
+        },
+        "power": {
+            "iso": iso,
+            "barrel_rate": raw_stats.get("barrel_rate", raw_stats.get("barrel_pct")),
+            "hard_hit_rate": raw_stats.get("hard_hit_rate", raw_stats.get("hard_hit_pct")),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": raw_stats.get("avg_exit_velocity", raw_stats.get("avg_exit_vel")),
+            "avg_launch_angle": raw_stats.get("avg_launch_angle"),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": raw_stats.get("vs_lhp_woba"),
+            "vs_rhp_woba": raw_stats.get("vs_rhp_woba"),
+            "vs_lhp_iso": raw_stats.get("vs_lhp_iso"),
+            "vs_rhp_iso": raw_stats.get("vs_rhp_iso"),
+        },
+    }

--- a/mlb_app/hitter_windows.py
+++ b/mlb_app/hitter_windows.py
@@ -1,0 +1,60 @@
+"""
+Hitter multi-window retrieval utilities.
+
+This module provides a first-pass framework for retrieving hitter split
+data across named sample windows such as current season, last 30 days,
+and last 90 days.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, List
+
+from .player_splits import fetch_player_splits
+from .sample_windows import get_window_definition
+
+
+def fetch_player_splits_for_window(
+    player_ids: List[int],
+    season: int,
+    window_name: str,
+    target_date: datetime.date,
+) -> List[Dict[str, float]]:
+    """
+    Retrieve hitter split rows for a named sample window.
+
+    This v1 implementation supports:
+    - current_season: real season split retrieval
+    - rolling windows: contract-safe scaffold using the same output shape
+
+    Future work can replace rolling-window scaffolds with true date-bounded
+    Statcast or API-backed calculations.
+    """
+    if not player_ids:
+        return []
+
+    window_def = get_window_definition(window_name)
+    window_type = window_def.get("window_type")
+
+    # Current season: use the existing real split retrieval path.
+    if window_name == "current_season":
+        rows = fetch_player_splits(player_ids, season)
+        for row in rows:
+            row["sample_window"] = "current_season"
+            row["sample_window_type"] = window_type
+            row["sample_target_date"] = target_date.isoformat()
+        return rows
+
+    # Rolling windows: v1 scaffold preserves contract but does not yet claim
+    # true date-bounded split calculations.
+    if window_name in {"last_30_days", "last_90_days"}:
+        rows = fetch_player_splits(player_ids, season)
+        for row in rows:
+            row["sample_window"] = window_name
+            row["sample_window_type"] = window_type
+            row["sample_target_date"] = target_date.isoformat()
+            row["sample_is_scaffold"] = True
+        return rows
+
+    return []

--- a/mlb_app/lineup_data.py
+++ b/mlb_app/lineup_data.py
@@ -1,0 +1,89 @@
+"""
+Lineup data utilities for matchup previews.
+
+This module provides reusable helpers for retrieving official lineups from
+the MLB Stats API and falling back to active non-pitcher roster candidates
+when an official lineup has not yet been posted.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List, Tuple
+
+import requests
+
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+
+
+def fetch_roster_as_lineup(team_id: int, season: int) -> List[Dict[str, Any]]:
+    """
+    Return active non-pitcher roster entries when an official lineup is unavailable.
+    """
+    try:
+        resp = requests.get(
+            f"{MLB_STATS_BASE}/teams/{team_id}/roster",
+            params={"rosterType": "active", "season": season},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return [
+            {
+                "id": r["person"]["id"],
+                "fullName": r["person"]["fullName"],
+            }
+            for r in resp.json().get("roster", [])
+            if (r.get("position") or {}).get("type", "").lower() != "pitcher"
+            and r.get("person", {}).get("id")
+        ]
+    except requests.RequestException:
+        return []
+
+
+def resolve_team_lineup(
+    game: Dict[str, Any],
+    team_id: int,
+    side: str,
+    season: int,
+) -> Tuple[List[Dict[str, Any]], str]:
+    """
+    Resolve a team lineup from hydrated schedule data, falling back to active roster.
+
+    Returns
+    -------
+    tuple
+        (lineup_list, lineup_source) where lineup_source is one of:
+        - "official"
+        - "roster"
+        - "missing"
+    """
+    lineups = game.get("lineups", {}) or {}
+    lineup_raw = lineups.get(f"{side}Players", []) or []
+
+    if lineup_raw:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(lineup_raw)
+            if p.get("id")
+        ]
+        return lineup, "official"
+
+    roster_fallback = fetch_roster_as_lineup(team_id, season)
+    if roster_fallback:
+        lineup = [
+            {
+                "id": p.get("id"),
+                "fullName": p.get("fullName"),
+                "batting_order": i + 1,
+            }
+            for i, p in enumerate(roster_fallback)
+            if p.get("id")
+        ]
+        return lineup, "roster"
+
+    return [], "missing"

--- a/mlb_app/matchup_analysis.py
+++ b/mlb_app/matchup_analysis.py
@@ -1,0 +1,267 @@
+"""
+Matchup analysis utilities for matchup-preview payloads.
+
+This module builds pitch-arsenal-vs-lineup analysis for a matchup using:
+- pitcher arsenal data
+- projected lineup candidates
+- lightweight edge/confidence scoring
+
+The output is designed to support a future "Matchup Analysis" UI tab without
+overwriting existing overview, pitcher, batter, or environment views.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from .sample_windows import build_sample_metadata
+
+
+def _edge_score_from_components(
+    batter_ba: Optional[float],
+    pitcher_xwoba: Optional[float],
+    pitcher_hard_hit_pct: Optional[float],
+    usage_pct: Optional[float],
+) -> float:
+    score = 0.0
+    if batter_ba is not None:
+        score += (batter_ba - 0.245) * 4.0
+    if pitcher_xwoba is not None:
+        score -= (pitcher_xwoba - 0.320) * 5.0
+    if pitcher_hard_hit_pct is not None:
+        score -= (pitcher_hard_hit_pct - 0.35) * 2.0
+    if usage_pct is not None:
+        score *= max(0.35, min(1.0, usage_pct))
+    return round(score, 3)
+
+
+def _confidence_from_sample(
+    player_count: int,
+    usage_pct: Optional[float],
+    arsenal_source: str = "placeholder_arsenal",
+) -> float:
+    """
+    Estimate confidence for a pitch-type matchup row.
+
+    Real arsenal rows should not collapse to 0.0 just because lineup-level
+    batter-vs-pitch samples are not available yet. Until hitter-vs-pitch-type
+    samples are wired in, confidence is primarily a usage/data-source signal.
+    """
+    usage = usage_pct or 0.0
+
+    if arsenal_source == "real_arsenal_rows":
+        if usage >= 0.30:
+            base = 0.78
+        elif usage >= 0.15:
+            base = 0.64
+        elif usage >= 0.05:
+            base = 0.50
+        else:
+            base = 0.38
+    else:
+        if usage >= 0.30:
+            base = 0.48
+        elif usage >= 0.15:
+            base = 0.38
+        else:
+            base = 0.28
+
+    lineup_bonus = 0.07 if player_count >= 9 else 0.04 if player_count >= 5 else 0.0
+    return round(min(0.9, base + lineup_bonus), 3)
+
+
+def _placeholder_pitch_arsenal(
+    pitcher_id: Optional[int],
+    pitcher_name: Optional[str],
+    pitcher_hand: Optional[str],
+) -> List[Dict[str, Any]]:
+    """
+    Return a small stable placeholder arsenal for v1 payload enrichment.
+
+    This intentionally avoids overclaiming full arsenal fidelity until a later PR
+    wires real arsenal rows into the matchup payload.
+    """
+    if not pitcher_id:
+        return []
+
+    hand = pitcher_hand if pitcher_hand in {"L", "R"} else "unknown"
+
+    if hand == "L":
+        return [
+            {
+                "pitch_type": "Four-Seam Fastball",
+                "raw_pitch_type": "FF",
+                "pitcher_usage_pct": 0.42,
+                "pitcher_whiff_pct": 0.23,
+                "pitcher_strikeout_pct": 0.25,
+                "pitcher_xwoba": 0.315,
+                "pitcher_hard_hit_pct": 0.36,
+            },
+            {
+                "pitch_type": "Slider",
+                "raw_pitch_type": "SL",
+                "pitcher_usage_pct": 0.31,
+                "pitcher_whiff_pct": 0.34,
+                "pitcher_strikeout_pct": 0.29,
+                "pitcher_xwoba": 0.285,
+                "pitcher_hard_hit_pct": 0.31,
+            },
+            {
+                "pitch_type": "Changeup",
+                "raw_pitch_type": "CH",
+                "pitcher_usage_pct": 0.17,
+                "pitcher_whiff_pct": 0.28,
+                "pitcher_strikeout_pct": 0.22,
+                "pitcher_xwoba": 0.301,
+                "pitcher_hard_hit_pct": 0.33,
+            },
+        ]
+
+    return [
+        {
+            "pitch_type": "Four-Seam Fastball",
+            "raw_pitch_type": "FF",
+            "pitcher_usage_pct": 0.45,
+            "pitcher_whiff_pct": 0.22,
+            "pitcher_strikeout_pct": 0.24,
+            "pitcher_xwoba": 0.318,
+            "pitcher_hard_hit_pct": 0.37,
+        },
+        {
+            "pitch_type": "Slider",
+            "raw_pitch_type": "SL",
+            "pitcher_usage_pct": 0.28,
+            "pitcher_whiff_pct": 0.33,
+            "pitcher_strikeout_pct": 0.30,
+            "pitcher_xwoba": 0.287,
+            "pitcher_hard_hit_pct": 0.32,
+        },
+        {
+            "pitch_type": "Curveball",
+            "raw_pitch_type": "CU",
+            "pitcher_usage_pct": 0.14,
+            "pitcher_whiff_pct": 0.29,
+            "pitcher_strikeout_pct": 0.21,
+            "pitcher_xwoba": 0.295,
+            "pitcher_hard_hit_pct": 0.34,
+        },
+    ]
+
+
+def _normalize_real_arsenal_rows(arsenal_rows: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    normalized = []
+    for row in arsenal_rows or []:
+        raw_pitch_type = row.get("pitch_type")
+        pitch_name = row.get("pitch_name") or raw_pitch_type
+        normalized.append(
+            {
+                "pitch_type": pitch_name,
+                "raw_pitch_type": raw_pitch_type,
+                "pitcher_usage_pct": row.get("usage_pct"),
+                "pitcher_whiff_pct": row.get("whiff_pct"),
+                "pitcher_strikeout_pct": row.get("strikeout_pct"),
+                "pitcher_xwoba": row.get("xwoba"),
+                "pitcher_hard_hit_pct": row.get("hard_hit_pct"),
+            }
+        )
+    return normalized
+
+
+def build_matchup_analysis(
+    pitcher_id: Optional[int],
+    pitcher_name: Optional[str],
+    pitcher_hand: Optional[str],
+    lineup: List[Dict[str, Any]],
+    lineup_source: str,
+    arsenal_rows: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a stable matchup-analysis payload.
+
+    Uses real pitcher arsenal rows when provided, with a placeholder fallback
+    for early or incomplete data states.
+    """
+    lineup_player_count = len([p for p in lineup if p.get("id")])
+    arsenal = _normalize_real_arsenal_rows(arsenal_rows)
+    arsenal_source = "real_arsenal_rows" if arsenal else "placeholder_arsenal"
+    if not arsenal:
+        arsenal = _placeholder_pitch_arsenal(pitcher_id, pitcher_name, pitcher_hand)
+
+    pitch_type_matchups = []
+    for pitch in arsenal:
+        player_count_factor = min(1.0, lineup_player_count / 9.0)
+        batter_ba = round(0.240 + (player_count_factor * 0.020), 3) if lineup_player_count else None
+
+        edge_score = _edge_score_from_components(
+            batter_ba=batter_ba,
+            pitcher_xwoba=pitch.get("pitcher_xwoba"),
+            pitcher_hard_hit_pct=pitch.get("pitcher_hard_hit_pct"),
+            usage_pct=pitch.get("pitcher_usage_pct"),
+        )
+        confidence = _confidence_from_sample(
+            player_count=lineup_player_count,
+            usage_pct=pitch.get("pitcher_usage_pct"),
+            arsenal_source=arsenal_source,
+        )
+
+        pitch_type_matchups.append(
+            {
+                "pitch_type": pitch.get("pitch_type"),
+                "raw_pitch_type": pitch.get("raw_pitch_type"),
+                "pitcher_usage_pct": pitch.get("pitcher_usage_pct"),
+                "pitcher_whiff_pct": pitch.get("pitcher_whiff_pct"),
+                "pitcher_strikeout_pct": pitch.get("pitcher_strikeout_pct"),
+                "pitcher_xwoba": pitch.get("pitcher_xwoba"),
+                "pitcher_hard_hit_pct": pitch.get("pitcher_hard_hit_pct"),
+                "lineup_estimated_batting_avg": batter_ba,
+                "edge_score": edge_score,
+                "confidence": confidence,
+            }
+        )
+
+    pitch_type_matchups.sort(key=lambda x: x.get("pitcher_usage_pct") or 0.0, reverse=True)
+
+    biggest_edge = max(pitch_type_matchups, key=lambda x: x.get("edge_score", 0), default=None)
+    biggest_weakness = min(pitch_type_matchups, key=lambda x: x.get("edge_score", 0), default=None)
+
+    overall_confidence = (
+        round(sum(row["confidence"] for row in pitch_type_matchups) / len(pitch_type_matchups), 3)
+        if pitch_type_matchups
+        else 0.0
+    )
+
+    status = "partial" if pitch_type_matchups else "scaffold"
+    note = (
+        "Real pitch arsenal vs lineup scoring is available."
+        if pitch_type_matchups and arsenal_source == "real_arsenal_rows"
+        else "Initial placeholder pitch arsenal vs lineup scoring is available."
+        if pitch_type_matchups
+        else "Pitch arsenal vs hitter weakness analysis is not yet fully wired."
+    )
+
+    return {
+        "metadata": {
+            "source_type": "matchup_analysis_real_arsenal_v1" if arsenal_source == "real_arsenal_rows" else "matchup_analysis_v1",
+            "generated_from": "build_matchup_analysis",
+            "data_confidence": "medium" if arsenal_source == "real_arsenal_rows" and pitch_type_matchups else "low",
+            "arsenal_source": arsenal_source,
+            "pitcher_id": pitcher_id,
+            "pitcher_name": pitcher_name,
+            "pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "lineup_source": lineup_source,
+            "lineup_player_count": lineup_player_count,
+            **build_sample_metadata(
+                window_name="current_season",
+                sample_size=lineup_player_count,
+                sample_blend_policy="single_window_v1",
+                stabilizer_window=None,
+            ),
+        },
+        "pitchTypeMatchups": pitch_type_matchups,
+        "biggestEdge": biggest_edge,
+        "biggestWeakness": biggest_weakness,
+        "confidence": overall_confidence,
+        "summary": {
+            "status": status,
+            "note": note,
+        },
+    }

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -10,6 +10,12 @@ from .db_utils import get_pitch_arsenal_with_fallback, get_team_split
 from .matchup_generator import generate_matchups_for_date
 from .model_projection_formulas import bullpen_collapse_index, offensive_firepower_score, pitch_identity_disruption_score, pitching_volatility_score, safe_float
 
+from .bullpen_profile import build_bullpen_profile
+from .environment_profile import compute_environment_profile
+from .team_offense_prior import build_team_offense_prior
+from .simulation.pa_outcome_model import build_pa_outcome_probabilities
+from .simulation.game_simulator import simulate_game_with_bullpen
+
 
 def _obj_to_dict(obj: Any, fields: List[str]) -> Dict[str, Any]:
     return {field: getattr(obj, field, None) for field in fields} if obj is not None else {}
@@ -92,6 +98,208 @@ def _bullpen_inputs(session: Session, team_id: Optional[int], team_name: Optiona
         return {"source_table": table, "error": str(exc)}
 
 
+def _probability_model_card(
+    model_name: str,
+    score: Optional[float],
+    inputs: Dict[str, Any],
+    formula: str,
+    steps: List[str],
+    notes: List[str],
+    confidence: str = "low",
+) -> Dict[str, Any]:
+    missing = [key for key, value in inputs.items() if value is None]
+    return {
+        "model_name": model_name,
+        "status": "calculated" if score is not None and not missing else "partial" if score is not None else "missing_inputs",
+        "score": round(float(score), 3) if score is not None else None,
+        "formula": formula,
+        "inputs": inputs,
+        "calculation_steps": steps,
+        "missing_inputs": missing,
+        "data_confidence": confidence,
+        "source_notes": notes,
+    }
+
+
+def _team_offense_prior_pa_model(
+    team_id: Optional[int],
+    team_name: Optional[str],
+    opposing_pitcher_profile: Optional[Dict[str, Any]],
+    environment_profile: Dict[str, Any],
+) -> Dict[str, Any]:
+    offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
+    return build_pa_outcome_probabilities(
+        batter_profile=offense_profile,
+        pitcher_profile=opposing_pitcher_profile or {},
+        environment_profile=environment_profile,
+    )
+
+
+def _weather_context(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        return {"wind": value}
+    return {}
+
+
+def _build_projection_simulation_cards(
+    matchup: Dict[str, Any],
+    away: Dict[str, Any],
+    home: Dict[str, Any],
+) -> Dict[str, List[Dict[str, Any]]]:
+    away_team_id = away.get("team_id")
+    home_team_id = home.get("team_id")
+    away_team_name = away.get("team_name")
+    home_team_name = home.get("team_name")
+
+    environment_profile = compute_environment_profile({
+        "game_pk": matchup.get("game_pk"),
+        "game_date": matchup.get("game_date"),
+        "venue_name": matchup.get("venue"),
+        "weather": _weather_context(matchup.get("weather")),
+        "park_factor": matchup.get("park_factor"),
+        "home_team": home_team_name,
+        "away_team": away_team_name,
+    })
+
+    away_pitcher_profile = {}
+    home_pitcher_profile = {}
+
+    away_bullpen_profile = build_bullpen_profile(team_id=away_team_id, team_name=away_team_name)
+    home_bullpen_profile = build_bullpen_profile(team_id=home_team_id, team_name=home_team_name)
+
+    away_vs_home_starter_pa = _team_offense_prior_pa_model(
+        team_id=away_team_id,
+        team_name=away_team_name,
+        opposing_pitcher_profile=home_pitcher_profile,
+        environment_profile=environment_profile,
+    )
+    home_vs_away_starter_pa = _team_offense_prior_pa_model(
+        team_id=home_team_id,
+        team_name=home_team_name,
+        opposing_pitcher_profile=away_pitcher_profile,
+        environment_profile=environment_profile,
+    )
+    away_vs_home_bullpen_pa = _team_offense_prior_pa_model(
+        team_id=away_team_id,
+        team_name=away_team_name,
+        opposing_pitcher_profile=home_bullpen_profile,
+        environment_profile=environment_profile,
+    )
+    home_vs_away_bullpen_pa = _team_offense_prior_pa_model(
+        team_id=home_team_id,
+        team_name=home_team_name,
+        opposing_pitcher_profile=away_bullpen_profile,
+        environment_profile=environment_profile,
+    )
+
+    sim = simulate_game_with_bullpen(
+        away_starter_probabilities=away_vs_home_starter_pa.get("probabilities") or {},
+        home_starter_probabilities=home_vs_away_starter_pa.get("probabilities") or {},
+        away_bullpen_probabilities=away_vs_home_bullpen_pa.get("probabilities") or {},
+        home_bullpen_probabilities=home_vs_away_bullpen_pa.get("probabilities") or {},
+        simulations=3000,
+        seed=42,
+        innings=9,
+        starter_innings=5,
+        away_starter_quality=0.0,
+        home_starter_quality=0.0,
+        dynamic_starter_exit=True,
+    )
+
+    total_probs = sim.get("calibrated_total_probabilities") or sim.get("total_probabilities") or {}
+    team_total_probs = sim.get("calibrated_team_total_probabilities") or sim.get("team_total_probabilities") or {}
+
+    away_card = _probability_model_card(
+        model_name="Simulation: Away Team Run/Win Projection",
+        score=sim.get("away_expected_runs"),
+        formula="Team offense prior PA probabilities + opponent starter/bullpen profiles + environment + dynamic starter exit",
+        inputs={
+            "expected_runs": sim.get("away_expected_runs"),
+            "raw_expected_runs": sim.get("raw_away_expected_runs"),
+            "win_probability": sim.get("away_win_probability"),
+            "team_3_plus_runs": team_total_probs.get("away_3_plus"),
+            "team_4_plus_runs": team_total_probs.get("away_4_plus"),
+            "team_5_plus_runs": team_total_probs.get("away_5_plus"),
+            "offense_source": "team_offense_prior",
+            "opposing_bullpen_quality": (home_bullpen_profile.get("metadata") or {}).get("bullpen_quality_label"),
+            "run_environment_index": (environment_profile.get("run_environment") or {}).get("run_scoring_index"),
+        },
+        steps=[
+            "Build conservative team offense prior because Model Projections is game-level.",
+            "Convert offense, opponent starter prior, bullpen prior, and environment into PA probabilities.",
+            "Simulate regulation games with starter-to-bullpen transition and calibrated run distribution.",
+        ],
+        notes=[
+            "Uses low-confidence team priors until confirmed lineups and player-level projections are wired into this endpoint.",
+            "Raw and calibrated outputs are both retained in the simulation object; this card displays calibrated probabilities where available.",
+        ],
+        confidence="low",
+    )
+
+    home_card = _probability_model_card(
+        model_name="Simulation: Home Team Run/Win Projection",
+        score=sim.get("home_expected_runs"),
+        formula="Team offense prior PA probabilities + opponent starter/bullpen profiles + environment + dynamic starter exit",
+        inputs={
+            "expected_runs": sim.get("home_expected_runs"),
+            "raw_expected_runs": sim.get("raw_home_expected_runs"),
+            "win_probability": sim.get("home_win_probability"),
+            "team_3_plus_runs": team_total_probs.get("home_3_plus"),
+            "team_4_plus_runs": team_total_probs.get("home_4_plus"),
+            "team_5_plus_runs": team_total_probs.get("home_5_plus"),
+            "offense_source": "team_offense_prior",
+            "opposing_bullpen_quality": (away_bullpen_profile.get("metadata") or {}).get("bullpen_quality_label"),
+            "run_environment_index": (environment_profile.get("run_environment") or {}).get("run_scoring_index"),
+        },
+        steps=[
+            "Build conservative team offense prior because Model Projections is game-level.",
+            "Convert offense, opponent starter prior, bullpen prior, and environment into PA probabilities.",
+            "Simulate regulation games with starter-to-bullpen transition and calibrated run distribution.",
+        ],
+        notes=[
+            "Uses low-confidence team priors until confirmed lineups and player-level projections are wired into this endpoint.",
+            "Raw and calibrated outputs are both retained in the simulation object; this card displays calibrated probabilities where available.",
+        ],
+        confidence="low",
+    )
+
+    game_total_card = _probability_model_card(
+        model_name="Simulation: Game Total Projection",
+        score=sim.get("total_expected_runs"),
+        formula="Monte Carlo total runs from away/home PA distributions, bullpen priors, environment, and calibrated distribution",
+        inputs={
+            "total_expected_runs": sim.get("total_expected_runs"),
+            "raw_total_expected_runs": sim.get("raw_total_expected_runs"),
+            "over_6_5": total_probs.get("over_6.5"),
+            "over_7_5": total_probs.get("over_7.5"),
+            "over_8_5": total_probs.get("over_8.5"),
+            "over_9_5": total_probs.get("over_9.5"),
+            "under_7_5": total_probs.get("under_7.5"),
+            "under_8_5": total_probs.get("under_8.5"),
+            "under_9_5": total_probs.get("under_9.5"),
+            "tie_after_regulation": sim.get("tie_after_regulation_probability"),
+            "environment_label": (environment_profile.get("run_environment") or {}).get("scoring_environment_label"),
+        },
+        steps=[
+            "Generate PA outcome probabilities for each offense against starter and bullpen contexts.",
+            "Run full-game simulation with dynamic starter exit and bullpen transition.",
+            "Apply existing game-simulation calibration to expected runs and probability distribution.",
+        ],
+        notes=[
+            "This is the first Model Projections integration of the sandbox simulation engine.",
+            "Confidence is low until lineup-level and starter-profile inputs are connected directly into this endpoint.",
+        ],
+        confidence="low",
+    )
+
+    return {
+        "away": [away_card, game_total_card],
+        "home": [home_card],
+    }
+
+
 def _side_context(matchup: Dict[str, Any], side: str, session: Session, season: int) -> Dict[str, Any]:
     pitcher_id = matchup.get(f"{side}_pitcher_id")
     arsenal = matchup.get(f"{side}_pitch_arsenal") or {}
@@ -135,6 +343,11 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
         try:
             away = _side_context(matchup, "away", session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
+
+            simulation_cards = _build_projection_simulation_cards(matchup, away, home)
+            away["models"].extend(simulation_cards.get("away", []))
+            home["models"].extend(simulation_cards.get("home", []))
+
             games.append({
                 "game_pk": matchup.get("game_pk"),
                 "game_date": matchup.get("game_date") or target_date,

--- a/mlb_app/offense_profile_aggregation.py
+++ b/mlb_app/offense_profile_aggregation.py
@@ -1,0 +1,248 @@
+"""
+Offense profile aggregation utilities for matchup previews.
+
+This module builds projected-lineup-aware offense profiles by:
+- retrieving player-level split rows across multiple sample windows
+- converting those rows into hitter profiles
+- blending windowed hitter metrics
+- aggregating blended hitter profiles into one lineup offense profile
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List, Optional
+
+from .hitter_profile import compute_hitter_profile
+from .hitter_windows import fetch_player_splits_for_window
+from .sample_blending import HITTER_BLEND_WEIGHTS, blend_metric_dict
+
+
+def _average(values: List[Optional[float]]) -> Optional[float]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _extract_metric(profile: Dict[str, Any], section: str, field: str) -> Optional[float]:
+    return (profile.get(section) or {}).get(field)
+
+
+def _blend_hitter_profile_windows(window_profiles: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Blend multiple hitter profile windows into one player-level hitter profile.
+    """
+    return {
+        "metadata": {
+            "source_type": "player_split_blended",
+            "source_fields_used": ["last_30_days", "last_90_days", "current_season"],
+            "data_confidence": "medium" if window_profiles else "low",
+            "generated_from": "_blend_hitter_profile_windows",
+            "profile_granularity": "player",
+            "is_projected_lineup_derived": True,
+            "sample_window": "blended",
+            "sample_family": "blended",
+            "sample_description": "Weighted blend across hitter windows",
+            "sample_days": None,
+            "sample_size": None,
+            "sample_blend_policy": "hitter_v1_weighted_blend",
+            "stabilizer_window": "current_season",
+        },
+        "contact_skill": blend_metric_dict(
+            {
+                window_name: {
+                    "k_rate": _extract_metric(profile, "contact_skill", "k_rate"),
+                    "whiff_rate": _extract_metric(profile, "contact_skill", "whiff_rate"),
+                    "contact_rate": _extract_metric(profile, "contact_skill", "contact_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "plate_discipline": blend_metric_dict(
+            {
+                window_name: {
+                    "bb_rate": _extract_metric(profile, "plate_discipline", "bb_rate"),
+                    "chase_rate": _extract_metric(profile, "plate_discipline", "chase_rate"),
+                    "swing_rate": _extract_metric(profile, "plate_discipline", "swing_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "power": blend_metric_dict(
+            {
+                window_name: {
+                    "iso": _extract_metric(profile, "power", "iso"),
+                    "barrel_rate": _extract_metric(profile, "power", "barrel_rate"),
+                    "hard_hit_rate": _extract_metric(profile, "power", "hard_hit_rate"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "batted_ball_quality": blend_metric_dict(
+            {
+                window_name: {
+                    "avg_exit_velocity": _extract_metric(profile, "batted_ball_quality", "avg_exit_velocity"),
+                    "avg_launch_angle": _extract_metric(profile, "batted_ball_quality", "avg_launch_angle"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+        "platoon_profile": blend_metric_dict(
+            {
+                window_name: {
+                    "vs_lhp_woba": _extract_metric(profile, "platoon_profile", "vs_lhp_woba"),
+                    "vs_rhp_woba": _extract_metric(profile, "platoon_profile", "vs_rhp_woba"),
+                    "vs_lhp_iso": _extract_metric(profile, "platoon_profile", "vs_lhp_iso"),
+                    "vs_rhp_iso": _extract_metric(profile, "platoon_profile", "vs_rhp_iso"),
+                }
+                for window_name, profile in window_profiles.items()
+            },
+            HITTER_BLEND_WEIGHTS,
+        ),
+    }
+
+
+def aggregate_hitter_profiles(
+    hitter_profiles: List[Dict[str, Any]],
+    lineup_source: str,
+    pitcher_hand: Optional[str],
+    player_count_used: int,
+) -> Dict[str, Any]:
+    """
+    Aggregate player-level hitter profiles into one projected-lineup offense profile.
+    """
+    return {
+        "metadata": {
+            "source_type": "projected_lineup_profile",
+            "source_fields_used": ["player_splits", "compute_hitter_profile", "sample_blending"],
+            "data_confidence": "medium" if hitter_profiles else "low",
+            "generated_from": "aggregate_hitter_profiles",
+            "profile_granularity": "lineup_candidate_group",
+            "is_projected_lineup_derived": lineup_source == "official",
+            "lineup_source": lineup_source,
+            "opposing_pitcher_hand": pitcher_hand if pitcher_hand in {"L", "R"} else "unknown",
+            "player_count_used": player_count_used,
+            "sample_window": "blended",
+            "sample_family": "blended",
+            "sample_description": "Weighted blend across hitter windows",
+            "sample_days": None,
+            "sample_size": player_count_used,
+            "sample_blend_policy": "hitter_v1_weighted_blend",
+            "stabilizer_window": "current_season",
+        },
+        "contact_skill": {
+            "k_rate": _average([_extract_metric(p, "contact_skill", "k_rate") for p in hitter_profiles]),
+            "whiff_rate": _average([_extract_metric(p, "contact_skill", "whiff_rate") for p in hitter_profiles]),
+            "contact_rate": _average([_extract_metric(p, "contact_skill", "contact_rate") for p in hitter_profiles]),
+        },
+        "plate_discipline": {
+            "bb_rate": _average([_extract_metric(p, "plate_discipline", "bb_rate") for p in hitter_profiles]),
+            "chase_rate": _average([_extract_metric(p, "plate_discipline", "chase_rate") for p in hitter_profiles]),
+            "swing_rate": _average([_extract_metric(p, "plate_discipline", "swing_rate") for p in hitter_profiles]),
+        },
+        "power": {
+            "iso": _average([_extract_metric(p, "power", "iso") for p in hitter_profiles]),
+            "barrel_rate": _average([_extract_metric(p, "power", "barrel_rate") for p in hitter_profiles]),
+            "hard_hit_rate": _average([_extract_metric(p, "power", "hard_hit_rate") for p in hitter_profiles]),
+        },
+        "batted_ball_quality": {
+            "avg_exit_velocity": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_exit_velocity") for p in hitter_profiles]
+            ),
+            "avg_launch_angle": _average(
+                [_extract_metric(p, "batted_ball_quality", "avg_launch_angle") for p in hitter_profiles]
+            ),
+        },
+        "platoon_profile": {
+            "vs_lhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_lhp_woba") for p in hitter_profiles]),
+            "vs_rhp_woba": _average([_extract_metric(p, "platoon_profile", "vs_rhp_woba") for p in hitter_profiles]),
+            "vs_lhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_lhp_iso") for p in hitter_profiles]),
+            "vs_rhp_iso": _average([_extract_metric(p, "platoon_profile", "vs_rhp_iso") for p in hitter_profiles]),
+        },
+    }
+
+
+def build_projected_lineup_offense_profile(
+    lineup: List[Dict[str, Any]],
+    season: int,
+    pitcher_hand: Optional[str],
+    lineup_source: str,
+    target_date: Optional[datetime.date] = None,
+) -> Dict[str, Any]:
+    """
+    Build a projected-lineup offense profile from blended player split data.
+    """
+    if target_date is None:
+        target_date = datetime.date.today()
+
+    player_ids = [p.get("id") for p in lineup if p.get("id")]
+    if not player_ids:
+        return aggregate_hitter_profiles(
+            hitter_profiles=[],
+            lineup_source="missing",
+            pitcher_hand=pitcher_hand,
+            player_count_used=0,
+        )
+
+    split_code = "vr" if pitcher_hand == "R" else "vl" if pitcher_hand == "L" else None
+    if not split_code:
+        return aggregate_hitter_profiles(
+            hitter_profiles=[],
+            lineup_source=lineup_source,
+            pitcher_hand=pitcher_hand,
+            player_count_used=len(player_ids),
+        )
+
+    windows = ["last_30_days", "last_90_days", "current_season"]
+    window_rows = {
+        window_name: fetch_player_splits_for_window(
+            player_ids=player_ids,
+            season=season,
+            window_name=window_name,
+            target_date=target_date,
+        )
+        for window_name in windows
+    }
+
+    hitter_profiles = []
+    for player_id in player_ids:
+        per_window_profiles: Dict[str, Dict[str, Any]] = {}
+        for window_name, rows in window_rows.items():
+            selected_row = next(
+                (
+                    row for row in rows
+                    if row.get("player_id") == player_id and row.get("split") == split_code
+                ),
+                None,
+            )
+            if not selected_row:
+                continue
+
+            enriched_row = {
+                **selected_row,
+                "source_type": "player_split",
+                "source_fields_used": sorted(list(selected_row.keys())),
+                "data_confidence": "medium",
+                "generated_from": "fetch_player_splits_for_window",
+                "profile_granularity": "player",
+                "is_projected_lineup_derived": lineup_source == "official",
+                "sample_window": window_name,
+                "sample_blend_policy": "hitter_v1_weighted_blend",
+                "stabilizer_window": "current_season",
+            }
+            per_window_profiles[window_name] = compute_hitter_profile(enriched_row)
+
+        if per_window_profiles:
+            hitter_profiles.append(_blend_hitter_profile_windows(per_window_profiles))
+
+    return aggregate_hitter_profiles(
+        hitter_profiles=hitter_profiles,
+        lineup_source=lineup_source,
+        pitcher_hand=pitcher_hand,
+        player_count_used=len(player_ids),
+    )

--- a/mlb_app/pitcher_advanced_metrics.py
+++ b/mlb_app/pitcher_advanced_metrics.py
@@ -1,0 +1,275 @@
+"""
+Derived pitcher metric helpers from stored StatcastEvent rows.
+
+These helpers intentionally use only fields currently persisted in the
+StatcastEvent model. Metrics that require unavailable raw fields, such as
+CSW rate from pitch description, remain None until those fields are stored.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Iterable, Optional
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _average(values: Iterable[Optional[float]]) -> Optional[float]:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _get_field(event: Any, key: str) -> Any:
+    if isinstance(event, dict):
+        return event.get(key)
+    return getattr(event, key, None)
+
+
+def _is_in_approx_zone(event: Any) -> bool:
+    plate_x = _safe_float(_get_field(event, "plate_x"))
+    plate_z = _safe_float(_get_field(event, "plate_z"))
+    if plate_x is None or plate_z is None:
+        return False
+
+    # Approximate rulebook zone. This is intentionally conservative until
+    # batter-specific sz_top/sz_bot fields are available.
+    return abs(plate_x) <= 0.83 and 1.5 <= plate_z <= 3.5
+
+
+def _is_first_pitch(event: Any) -> bool:
+    return _get_field(event, "balls") == 0 and _get_field(event, "strikes") == 0
+
+
+def _is_first_pitch_strike(event: Any) -> bool:
+    if not _is_first_pitch(event):
+        return False
+
+    # Without Statcast description, use zone location as the safest persisted
+    # proxy for first-pitch strike. This excludes chase swings for now.
+    return _is_in_approx_zone(event)
+
+
+def _is_barrel_approx(event: Any) -> bool:
+    launch_speed = _safe_float(_get_field(event, "launch_speed"))
+    launch_angle = _safe_float(_get_field(event, "launch_angle"))
+    if launch_speed is None or launch_angle is None:
+        return False
+
+    # Lightweight barrel approximation. True Savant barrels use a variable
+    # launch-angle band by EV; this captures the high-value core region.
+    return launch_speed >= 98 and 26 <= launch_angle <= 30
+
+
+def _description(event: Any) -> Optional[str]:
+    value = _get_field(event, "description")
+    if value is None:
+        return None
+    value = str(value).strip().lower()
+    return value or None
+
+
+def _is_csw(event: Any) -> bool:
+    return _description(event) in {
+        "called_strike",
+        "swinging_strike",
+        "swinging_strike_blocked",
+    }
+
+
+def _event_name(event: Any) -> Optional[str]:
+    value = _get_field(event, "events")
+    if value is None:
+        return None
+    value = str(value).strip().lower()
+    return value or None
+
+
+TERMINAL_PA_EVENTS = {
+    "single",
+    "double",
+    "triple",
+    "home_run",
+    "strikeout",
+    "strikeout_double_play",
+    "walk",
+    "intent_walk",
+    "hit_by_pitch",
+    "field_out",
+    "force_out",
+    "double_play",
+    "grounded_into_double_play",
+    "fielders_choice",
+    "fielders_choice_out",
+    "sac_fly",
+    "sac_bunt",
+}
+
+
+def _batter_stand(event: Any) -> Optional[str]:
+    value = _get_field(event, "stand")
+    if value is None:
+        return None
+    value = str(value).strip().upper()
+    return value if value in {"L", "R"} else None
+
+
+def _platoon_summary(rows: Iterable[Any], stand: str) -> Dict[str, Optional[float]]:
+    stand_rows = [row for row in rows if _batter_stand(row) == stand]
+    terminal_rows = [
+        row for row in stand_rows
+        if _event_name(row) in TERMINAL_PA_EVENTS
+    ]
+    xwoba_rows = [
+        row for row in stand_rows
+        if _safe_float(_get_field(row, "estimated_woba_using_speedangle")) is not None
+    ]
+
+    pa = len(terminal_rows)
+    k_rate = (
+        sum(1 for row in terminal_rows if _event_name(row) in {"strikeout", "strikeout_double_play"}) / pa
+        if pa else None
+    )
+    bb_rate = (
+        sum(1 for row in terminal_rows if _event_name(row) == "walk") / pa
+        if pa else None
+    )
+    xwoba_allowed = _average(
+        _safe_float(_get_field(row, "estimated_woba_using_speedangle")) for row in xwoba_rows
+    )
+
+    return {
+        "rows": len(stand_rows),
+        "pa": pa,
+        "xwoba_allowed": xwoba_allowed,
+        "k_rate": k_rate,
+        "bb_rate": bb_rate,
+    }
+
+
+def derive_pitcher_advanced_metrics(events: Iterable[Any]) -> Dict[str, Optional[float]]:
+    """
+    Compute pitcher advanced metrics from stored StatcastEvent rows.
+
+    Returns rates as decimals, matching the existing profile schema.
+    """
+    rows = list(events or [])
+    if not rows:
+        return {
+            "csw_rate": None,
+            "zone_rate": None,
+            "first_pitch_strike_rate": None,
+            "barrel_rate_allowed": None,
+            "avg_exit_velocity_allowed": None,
+            "avg_launch_angle_allowed": None,
+            "vs_lhb_woba_allowed": None,
+            "vs_rhb_woba_allowed": None,
+            "vs_lhb_k_rate": None,
+            "vs_rhb_k_rate": None,
+            "vs_lhb_bb_rate": None,
+            "vs_rhb_bb_rate": None,
+            "_debug": {
+                "advanced_event_rows_used": 0,
+                "advanced_zone_rows_used": 0,
+                "advanced_first_pitch_rows_used": 0,
+                "advanced_batted_ball_rows_used": 0,
+                "advanced_metrics_available": [],
+            },
+        }
+
+    description_rows = [row for row in rows if _description(row) is not None]
+    plate_appearance_rows = [
+        row for row in rows
+        if _event_name(row) in TERMINAL_PA_EVENTS
+    ]
+    xba_rows = [
+        row for row in rows
+        if _safe_float(_get_field(row, "estimated_ba_using_speedangle")) is not None
+    ]
+    zone_known = [
+        row for row in rows
+        if _safe_float(_get_field(row, "plate_x")) is not None
+        and _safe_float(_get_field(row, "plate_z")) is not None
+    ]
+    first_pitch_rows = [row for row in rows if _is_first_pitch(row)]
+    batted_ball_rows = [
+        row for row in rows
+        if _safe_float(_get_field(row, "launch_speed")) is not None
+        or _safe_float(_get_field(row, "launch_angle")) is not None
+    ]
+
+    csw_rate = (
+        sum(1 for row in description_rows if _is_csw(row)) / len(description_rows)
+        if description_rows else None
+    )
+    bb_rate = (
+        sum(1 for row in plate_appearance_rows if _event_name(row) == "walk") / len(plate_appearance_rows)
+        if plate_appearance_rows else None
+    )
+    xba_allowed = _average(
+        _safe_float(_get_field(row, "estimated_ba_using_speedangle")) for row in xba_rows
+    )
+    zone_rate = (
+        sum(1 for row in zone_known if _is_in_approx_zone(row)) / len(zone_known)
+        if zone_known else None
+    )
+    first_pitch_strike_rate = (
+        sum(1 for row in first_pitch_rows if _is_first_pitch_strike(row)) / len(first_pitch_rows)
+        if first_pitch_rows else None
+    )
+    barrel_rate_allowed = (
+        sum(1 for row in batted_ball_rows if _is_barrel_approx(row)) / len(batted_ball_rows)
+        if batted_ball_rows else None
+    )
+
+    vs_lhb = _platoon_summary(rows, "L")
+    vs_rhb = _platoon_summary(rows, "R")
+
+    metrics = {
+        "csw_rate": csw_rate,
+        "bb_rate": bb_rate,
+        "zone_rate": zone_rate,
+        "first_pitch_strike_rate": first_pitch_strike_rate,
+        "barrel_rate_allowed": barrel_rate_allowed,
+        "avg_exit_velocity_allowed": _average(
+            _safe_float(_get_field(row, "launch_speed")) for row in batted_ball_rows
+        ),
+        "avg_launch_angle_allowed": _average(
+            _safe_float(_get_field(row, "launch_angle")) for row in batted_ball_rows
+        ),
+        "xba_allowed": xba_allowed,
+        "vs_lhb_woba_allowed": vs_lhb["xwoba_allowed"],
+        "vs_rhb_woba_allowed": vs_rhb["xwoba_allowed"],
+        "vs_lhb_k_rate": vs_lhb["k_rate"],
+        "vs_rhb_k_rate": vs_rhb["k_rate"],
+        "vs_lhb_bb_rate": vs_lhb["bb_rate"],
+        "vs_rhb_bb_rate": vs_rhb["bb_rate"],
+    }
+
+    metrics["_debug"] = {
+        "advanced_event_rows_used": len(rows),
+        "advanced_description_rows_used": len(description_rows),
+        "advanced_zone_rows_used": len(zone_known),
+        "advanced_first_pitch_rows_used": len(first_pitch_rows),
+        "advanced_batted_ball_rows_used": len(batted_ball_rows),
+        "advanced_lhb_rows_used": vs_lhb["rows"],
+        "advanced_rhb_rows_used": vs_rhb["rows"],
+        "advanced_lhb_pa_used": vs_lhb["pa"],
+        "advanced_rhb_pa_used": vs_rhb["pa"],
+        "advanced_metrics_available": sorted(
+            [key for key, value in metrics.items() if not key.startswith("_") and value is not None]
+        ),
+    }
+
+    return metrics

--- a/mlb_app/pitcher_profile.py
+++ b/mlb_app/pitcher_profile.py
@@ -1,0 +1,85 @@
+"""
+Utilities for building pitcher profile summaries for matchup previews.
+
+This module defines a player-level pitcher profile structure that can later
+be populated with real calculations from split and Statcast inputs.
+"""
+
+from .sample_windows import build_sample_metadata
+
+
+def compute_pitcher_profile(raw_stats: dict) -> dict:
+    """
+    Build a structured pitcher profile from raw pitcher inputs.
+
+    Parameters
+    ----------
+    raw_stats : dict
+        Dictionary of pitcher stats from upstream ingestion or transformed sources.
+
+    Returns
+    -------
+    dict
+        A structured player-level pitcher profile using raw metrics grouped
+        by trait. Missing fields are returned as None.
+    """
+    raw_stats = raw_stats or {}
+
+    return {
+        "metadata": {
+            "source_type": raw_stats.get("source_type", "unknown"),
+            "source_fields_used": raw_stats.get("source_fields_used", []),
+            "data_confidence": raw_stats.get("data_confidence", "unknown"),
+            "generated_from": raw_stats.get("generated_from", "compute_pitcher_profile"),
+            "advanced_event_rows_used": raw_stats.get("advanced_event_rows_used"),
+            "advanced_zone_rows_used": raw_stats.get("advanced_zone_rows_used"),
+            "advanced_first_pitch_rows_used": raw_stats.get("advanced_first_pitch_rows_used"),
+            "advanced_batted_ball_rows_used": raw_stats.get("advanced_batted_ball_rows_used"),
+            "advanced_metrics_available": raw_stats.get("advanced_metrics_available"),
+            **build_sample_metadata(
+                window_name=raw_stats.get("sample_window", "last_365_days"),
+                sample_size=raw_stats.get("sample_size"),
+                sample_blend_policy=raw_stats.get("sample_blend_policy", "single_window_v1"),
+                stabilizer_window=raw_stats.get("stabilizer_window"),
+            ),
+        },
+        "arsenal": {
+            "pitch_mix": raw_stats.get("pitch_mix"),
+            "avg_velocity": raw_stats.get("avg_velocity"),
+            "avg_spin_rate": raw_stats.get("avg_spin_rate", raw_stats.get("avg_spin")),
+        },
+        "bat_missing": {
+            "k_rate": raw_stats.get("k_rate", raw_stats.get("k_pct")),
+            "whiff_rate": raw_stats.get("whiff_rate"),
+            "csw_rate": raw_stats.get("csw_rate"),
+        },
+        "command_control": {
+            "bb_rate": raw_stats.get("bb_rate", raw_stats.get("bb_pct")),
+            "zone_rate": raw_stats.get("zone_rate"),
+            "first_pitch_strike_rate": raw_stats.get("first_pitch_strike_rate"),
+        },
+        "contact_management": {
+            "hard_hit_rate_allowed": raw_stats.get(
+                "hard_hit_rate_allowed", raw_stats.get("hard_hit_pct")
+            ),
+            "barrel_rate_allowed": raw_stats.get(
+                "barrel_rate_allowed", raw_stats.get("barrel_pct_allowed")
+            ),
+            "avg_exit_velocity_allowed": raw_stats.get(
+                "avg_exit_velocity_allowed", raw_stats.get("avg_exit_velocity")
+            ),
+            "avg_launch_angle_allowed": raw_stats.get(
+                "avg_launch_angle_allowed", raw_stats.get("avg_launch_angle")
+            ),
+            "xwoba_allowed": raw_stats.get("xwoba_allowed", raw_stats.get("xwoba")),
+            "xba_allowed": raw_stats.get("xba_allowed", raw_stats.get("xba")),
+        },
+        "platoon_profile": {
+            "vs_lhb_woba_allowed": raw_stats.get("vs_lhb_woba_allowed"),
+            "vs_rhb_woba_allowed": raw_stats.get("vs_rhb_woba_allowed"),
+            "vs_lhb_k_rate": raw_stats.get("vs_lhb_k_rate"),
+            "vs_rhb_k_rate": raw_stats.get("vs_rhb_k_rate"),
+            "vs_lhb_bb_rate": raw_stats.get("vs_lhb_bb_rate"),
+            "vs_rhb_bb_rate": raw_stats.get("vs_rhb_bb_rate"),
+        },
+    }

--- a/mlb_app/pitcher_windows.py
+++ b/mlb_app/pitcher_windows.py
@@ -1,0 +1,54 @@
+"""
+Pitcher multi-window retrieval utilities.
+
+This module provides a first-pass framework for retrieving pitcher metric
+data across named sample windows such as last 30 days, last 90 days,
+and last 365 days.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Optional
+
+from .pitcher_analysis import get_pitcher_metrics
+from .sample_windows import get_window_start_date
+
+
+def fetch_pitcher_metrics_for_window(
+    pitcher_id: int,
+    target_date: datetime.date,
+    window_name: str,
+) -> Dict[str, Optional[float]]:
+    """
+    Retrieve pitcher metrics for a named sample window.
+
+    This v1 implementation supports:
+    - last_365_days: real rolling retrieval using the existing pitcher metrics path
+    - rolling shorter windows: contract-safe scaffold that still uses the current
+      retrieval path shape while explicitly labeling the sample window
+
+    Future work can improve the shorter windows with more exact bounded retrieval.
+    """
+    if not pitcher_id:
+        return {}
+
+    end_date = target_date.isoformat()
+
+    if window_name == "last_365_days":
+        start_date = get_window_start_date(target_date, "last_365_days")
+        metrics = get_pitcher_metrics(pitcher_id, start_date, end_date)
+        metrics["sample_window"] = "last_365_days"
+        metrics["sample_target_date"] = end_date
+        metrics["sample_is_scaffold"] = False
+        return metrics
+
+    if window_name in {"last_30_days", "last_90_days"}:
+        start_date = get_window_start_date(target_date, window_name)
+        metrics = get_pitcher_metrics(pitcher_id, start_date, end_date)
+        metrics["sample_window"] = window_name
+        metrics["sample_target_date"] = end_date
+        metrics["sample_is_scaffold"] = True
+        return metrics
+
+    return {}

--- a/mlb_app/sample_blending.py
+++ b/mlb_app/sample_blending.py
@@ -1,0 +1,77 @@
+"""
+Weighted sample blending helpers for matchup analysis.
+
+This module provides reusable helpers for blending metric dictionaries
+across multiple sample windows such as last 30 days, last 90 days,
+current season, and last 365 days.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+
+HITTER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.50,
+    "last_90_days": 0.30,
+    "current_season": 0.20,
+}
+
+PITCHER_BLEND_WEIGHTS: Dict[str, float] = {
+    "last_30_days": 0.35,
+    "last_90_days": 0.35,
+    "last_365_days": 0.30,
+}
+
+
+def weighted_average(values: Dict[str, Optional[float]], weights: Dict[str, float]) -> Optional[float]:
+    """
+    Compute a weighted average using only non-null values.
+    """
+    numerator = 0.0
+    denominator = 0.0
+
+    for key, weight in weights.items():
+        value = values.get(key)
+        if value is None:
+            continue
+        numerator += value * weight
+        denominator += weight
+
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def blend_metric_dict(
+    metric_windows: Dict[str, Dict[str, Optional[float]]],
+    weights: Dict[str, float],
+) -> Dict[str, Optional[float]]:
+    """
+    Blend metric dictionaries across multiple windows.
+
+    Parameters
+    ----------
+    metric_windows : dict
+        Mapping of window_name -> metric dict
+    weights : dict
+        Mapping of window_name -> weight
+
+    Returns
+    -------
+    dict
+        Blended metric dictionary using weighted averages for shared keys.
+    """
+    all_keys = set()
+    for window_metrics in metric_windows.values():
+        all_keys.update(window_metrics.keys())
+
+    blended: Dict[str, Optional[float]] = {}
+    for metric_key in all_keys:
+        values = {
+            window_name: metrics.get(metric_key)
+            for window_name, metrics in metric_windows.items()
+        }
+        blended[metric_key] = weighted_average(values, weights)
+
+    return blended

--- a/mlb_app/sample_windows.py
+++ b/mlb_app/sample_windows.py
@@ -1,0 +1,89 @@
+"""
+Sample window definitions for matchup analysis.
+
+This module provides a stable framework for naming, describing, and
+eventually blending time windows used across hitter, pitcher, and
+matchup-analysis calculations.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict, Optional
+
+
+SAMPLE_WINDOWS: Dict[str, Dict[str, object]] = {
+    "last_30_days": {
+        "window_type": "rolling",
+        "days": 30,
+        "description": "Rolling last 30 days",
+    },
+    "last_90_days": {
+        "window_type": "rolling",
+        "days": 90,
+        "description": "Rolling last 90 days",
+    },
+    "last_365_days": {
+        "window_type": "rolling",
+        "days": 365,
+        "description": "Rolling last 365 days",
+    },
+    "current_season": {
+        "window_type": "season",
+        "days": None,
+        "description": "Current season to date",
+    },
+    "career": {
+        "window_type": "career",
+        "days": None,
+        "description": "Career baseline",
+    },
+}
+
+
+def get_window_definition(window_name: str) -> Dict[str, object]:
+    """Return metadata for a named sample window."""
+    return SAMPLE_WINDOWS.get(
+        window_name,
+        {
+            "window_type": "unknown",
+            "days": None,
+            "description": "Unknown sample window",
+        },
+    )
+
+
+def get_window_start_date(
+    target_date: datetime.date,
+    window_name: str,
+) -> Optional[str]:
+    """
+    Return an ISO start date for rolling windows.
+
+    Non-rolling windows return None because they are not anchored only by
+    a backwards-looking day count.
+    """
+    definition = get_window_definition(window_name)
+    days = definition.get("days")
+    if not days:
+        return None
+    return (target_date - datetime.timedelta(days=int(days))).isoformat()
+
+
+def build_sample_metadata(
+    window_name: str,
+    sample_size: Optional[int] = None,
+    sample_blend_policy: str = "single_window_v1",
+    stabilizer_window: Optional[str] = None,
+) -> Dict[str, object]:
+    """Build a reusable sample metadata block."""
+    definition = get_window_definition(window_name)
+    return {
+        "sample_window": window_name,
+        "sample_family": definition.get("window_type"),
+        "sample_description": definition.get("description"),
+        "sample_days": definition.get("days"),
+        "sample_size": sample_size,
+        "sample_blend_policy": sample_blend_policy,
+        "stabilizer_window": stabilizer_window,
+    }

--- a/mlb_app/simulation/game_simulator.py
+++ b/mlb_app/simulation/game_simulator.py
@@ -1,0 +1,527 @@
+"""
+Full-game simulation engine.
+
+Uses PA outcome probability distributions for each offense to simulate
+nine-inning run distributions and game-level probabilities.
+
+V1 is intentionally conservative:
+- fixed nine innings for both teams
+- no walk-off shortening
+- no extras
+- no bullpen transition yet
+- independent half-innings using one lineup-level PA distribution per team
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from typing import Any, Dict, Optional
+
+from .inning_simulator import simulate_half_inning
+
+
+def _distribution(counter: Counter, simulations: int) -> Dict[str, float]:
+    return {
+        str(value): round(count / simulations, 4)
+        for value, count in sorted(counter.items())
+    }
+
+
+def _calibrated_counter_by_mean_shift(counter: Counter, raw_mean: float, calibrated_mean: float) -> Counter:
+    """
+    Shift a discrete run distribution toward the calibrated mean.
+
+    V1 keeps the empirical shape but shifts integer run buckets by the rounded
+    mean difference. This is conservative and transparent, but intentionally
+    not a substitute for historical backtesting.
+    """
+    shift = round(calibrated_mean - raw_mean)
+    if shift == 0:
+        return Counter(counter)
+
+    adjusted = Counter()
+    for value, count in counter.items():
+        adjusted[max(0, value + shift)] += count
+    return adjusted
+
+
+def _prob_greater_than(counter: Counter, threshold: float, simulations: int) -> float:
+    return round(
+        sum(count for value, count in counter.items() if value > threshold) / simulations,
+        4,
+    )
+
+
+def _prob_less_than(counter: Counter, threshold: float, simulations: int) -> float:
+    return round(
+        sum(count for value, count in counter.items() if value < threshold) / simulations,
+        4,
+    )
+
+
+def _prob_at_least(counter: Counter, threshold: int, simulations: int) -> float:
+    return round(
+        sum(count for value, count in counter.items() if value >= threshold) / simulations,
+        4,
+    )
+
+
+GAME_SIM_CALIBRATION = {
+    "game_sim_calibration_version": "game_sim_calibration_v1",
+    # V1 sim uses starter/lineup-average PA distributions for all 9 innings.
+    # This shrinkage tempers that known inflation until bullpen/lineup-order
+    # state is modeled explicitly.
+    "starter_only_run_shrinkage": 0.92,
+    # Pull extreme team totals modestly toward a neutral MLB-ish scoring level.
+    "team_run_regression_anchor": 4.45,
+    "team_run_regression_weight": 0.12,
+}
+
+
+def _calibrate_expected_runs(raw_runs: float) -> float:
+    shrinkage = GAME_SIM_CALIBRATION["starter_only_run_shrinkage"]
+    anchor = GAME_SIM_CALIBRATION["team_run_regression_anchor"]
+    regression_weight = GAME_SIM_CALIBRATION["team_run_regression_weight"]
+
+    shrunk = raw_runs * shrinkage
+    calibrated = (shrunk * (1.0 - regression_weight)) + (anchor * regression_weight)
+    return round(calibrated, 4)
+
+
+def simulate_game(
+    away_probabilities: Dict[str, float],
+    home_probabilities: Dict[str, float],
+    simulations: int = 5000,
+    seed: Optional[int] = None,
+    innings: int = 9,
+) -> Dict[str, Any]:
+    rng = random.Random(seed)
+
+    away_runs_counter = Counter()
+    home_runs_counter = Counter()
+    total_runs_counter = Counter()
+    margin_counter = Counter()
+
+    away_wins = 0
+    home_wins = 0
+    ties_after_regulation = 0
+
+    for _ in range(simulations):
+        away_runs = 0
+        home_runs = 0
+
+        for _inning in range(innings):
+            away_half = simulate_half_inning(away_probabilities, rng=rng)
+            home_half = simulate_half_inning(home_probabilities, rng=rng)
+            away_runs += away_half["runs"]
+            home_runs += home_half["runs"]
+
+        total_runs = away_runs + home_runs
+        margin = home_runs - away_runs
+
+        away_runs_counter[away_runs] += 1
+        home_runs_counter[home_runs] += 1
+        total_runs_counter[total_runs] += 1
+        margin_counter[margin] += 1
+
+        if home_runs > away_runs:
+            home_wins += 1
+        elif away_runs > home_runs:
+            away_wins += 1
+        else:
+            ties_after_regulation += 1
+
+    raw_away_expected_runs = sum(runs * count for runs, count in away_runs_counter.items()) / simulations
+    raw_home_expected_runs = sum(runs * count for runs, count in home_runs_counter.items()) / simulations
+    raw_total_expected_runs = sum(runs * count for runs, count in total_runs_counter.items()) / simulations
+
+    away_expected_runs = _calibrate_expected_runs(raw_away_expected_runs)
+    home_expected_runs = _calibrate_expected_runs(raw_home_expected_runs)
+    total_expected_runs = round(away_expected_runs + home_expected_runs, 4)
+
+    # V1 has no extras. Split regulation ties evenly for a rough win-probability estimate.
+    home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
+    away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+
+    calibrated_total_runs_counter = _calibrated_counter_by_mean_shift(
+        total_runs_counter,
+        raw_mean=raw_total_expected_runs,
+        calibrated_mean=total_expected_runs,
+    )
+    calibrated_away_runs_counter = _calibrated_counter_by_mean_shift(
+        away_runs_counter,
+        raw_mean=raw_away_expected_runs,
+        calibrated_mean=away_expected_runs,
+    )
+    calibrated_home_runs_counter = _calibrated_counter_by_mean_shift(
+        home_runs_counter,
+        raw_mean=raw_home_expected_runs,
+        calibrated_mean=home_expected_runs,
+    )
+
+    common_totals = [6.5, 7.5, 8.5, 9.5, 10.5]
+    total_probabilities = {
+        f"over_{line}": _prob_greater_than(total_runs_counter, line, simulations)
+        for line in common_totals
+    }
+    total_probabilities.update({
+        f"under_{line}": _prob_less_than(total_runs_counter, line, simulations)
+        for line in common_totals
+    })
+    calibrated_total_probabilities = {
+        f"over_{line}": _prob_greater_than(calibrated_total_runs_counter, line, simulations)
+        for line in common_totals
+    }
+    calibrated_total_probabilities.update({
+        f"under_{line}": _prob_less_than(calibrated_total_runs_counter, line, simulations)
+        for line in common_totals
+    })
+
+    return {
+        "model_version": "full_game_sim_v1",
+        "simulations": simulations,
+        "innings": innings,
+        "away_expected_runs": away_expected_runs,
+        "home_expected_runs": home_expected_runs,
+        "total_expected_runs": total_expected_runs,
+        "raw_away_expected_runs": round(raw_away_expected_runs, 4),
+        "raw_home_expected_runs": round(raw_home_expected_runs, 4),
+        "raw_total_expected_runs": round(raw_total_expected_runs, 4),
+        "away_win_probability": round(away_win_probability, 4),
+        "home_win_probability": round(home_win_probability, 4),
+        "tie_after_regulation_probability": round(ties_after_regulation / simulations, 4),
+        "away_run_distribution": _distribution(away_runs_counter, simulations),
+        "home_run_distribution": _distribution(home_runs_counter, simulations),
+        "total_run_distribution": _distribution(total_runs_counter, simulations),
+        "calibrated_total_run_distribution": _distribution(calibrated_total_runs_counter, simulations),
+        "calibrated_away_run_distribution": _distribution(calibrated_away_runs_counter, simulations),
+        "calibrated_home_run_distribution": _distribution(calibrated_home_runs_counter, simulations),
+        "home_margin_distribution": _distribution(margin_counter, simulations),
+        "total_probabilities": total_probabilities,
+        "calibrated_total_probabilities": calibrated_total_probabilities,
+        "team_total_probabilities": {
+            "away_3_plus": _prob_at_least(away_runs_counter, 3, simulations),
+            "away_4_plus": _prob_at_least(away_runs_counter, 4, simulations),
+            "away_5_plus": _prob_at_least(away_runs_counter, 5, simulations),
+            "home_3_plus": _prob_at_least(home_runs_counter, 3, simulations),
+            "home_4_plus": _prob_at_least(home_runs_counter, 4, simulations),
+            "home_5_plus": _prob_at_least(home_runs_counter, 5, simulations),
+        },
+        "calibrated_team_total_probabilities": {
+            "away_3_plus": _prob_at_least(calibrated_away_runs_counter, 3, simulations),
+            "away_4_plus": _prob_at_least(calibrated_away_runs_counter, 4, simulations),
+            "away_5_plus": _prob_at_least(calibrated_away_runs_counter, 5, simulations),
+            "home_3_plus": _prob_at_least(calibrated_home_runs_counter, 3, simulations),
+            "home_4_plus": _prob_at_least(calibrated_home_runs_counter, 4, simulations),
+            "home_5_plus": _prob_at_least(calibrated_home_runs_counter, 5, simulations),
+        },
+        "metadata": {
+            "generated_from": "simulation.game_simulator.simulate_game",
+            "seed": seed,
+            "simulation_count": simulations,
+            "notes": [
+                "V1 uses fixed nine innings for both teams.",
+                "Ties after regulation are split evenly for win probability.",
+                "No bullpen, extras, walk-off shortening, or lineup-order state yet.",
+            ],
+        },
+    }
+
+def _sample_from_distribution(distribution: Dict[int, float], rng: random.Random) -> int:
+    draw = rng.random()
+    cumulative = 0.0
+    for value, probability in sorted(distribution.items()):
+        cumulative += probability
+        if draw <= cumulative:
+            return value
+    return max(distribution.keys())
+
+
+def _blend_distributions(a: Dict[int, float], b: Dict[int, float], b_weight: float) -> Dict[int, float]:
+    b_weight = max(0.0, min(1.0, b_weight))
+    a_weight = 1.0 - b_weight
+    keys = sorted(set(a) | set(b))
+    blended = {
+        key: (a.get(key, 0.0) * a_weight) + (b.get(key, 0.0) * b_weight)
+        for key in keys
+    }
+    total = sum(blended.values())
+    return {key: value / total for key, value in blended.items()} if total else dict(a)
+
+
+def _starter_exit_distribution_from_score(starter_quality_score: float) -> Dict[int, float]:
+    weak = {3: 0.08, 4: 0.27, 5: 0.40, 6: 0.20, 7: 0.05}
+    average = {4: 0.12, 5: 0.38, 6: 0.35, 7: 0.13, 8: 0.02}
+    strong = {4: 0.05, 5: 0.20, 6: 0.45, 7: 0.25, 8: 0.05}
+
+    score = max(-1.0, min(1.0, starter_quality_score or 0.0))
+    if score >= 0:
+        return _blend_distributions(average, strong, score)
+    return _blend_distributions(average, weak, abs(score))
+
+
+def _starter_quality_label(starter_quality_score: float) -> str:
+    score = starter_quality_score or 0.0
+    if score >= 0.55:
+        return "strong"
+    if score >= 0.20:
+        return "above_average"
+    if score <= -0.55:
+        return "weak"
+    if score <= -0.20:
+        return "below_average"
+    return "average"
+
+
+def starter_quality_score(pitcher_profile: Optional[Dict[str, Any]]) -> float:
+    if not pitcher_profile:
+        return 0.0
+
+    bat_missing = pitcher_profile.get("bat_missing") or {}
+    command = pitcher_profile.get("command_control") or {}
+    contact = pitcher_profile.get("contact_management") or {}
+
+    signals = []
+
+    def add_signal(value, strong_value, weak_value, higher_is_better=True):
+        if not isinstance(value, (int, float)):
+            return
+        if higher_is_better:
+            raw = (value - weak_value) / (strong_value - weak_value)
+        else:
+            raw = (weak_value - value) / (weak_value - strong_value)
+        signals.append(max(-1.0, min(1.0, (raw * 2.0) - 1.0)))
+
+    add_signal(bat_missing.get("k_rate"), strong_value=0.30, weak_value=0.17, higher_is_better=True)
+    add_signal(command.get("bb_rate"), strong_value=0.055, weak_value=0.12, higher_is_better=False)
+    add_signal(contact.get("xwoba_allowed"), strong_value=0.285, weak_value=0.365, higher_is_better=False)
+    add_signal(contact.get("hard_hit_rate_allowed"), strong_value=0.32, weak_value=0.47, higher_is_better=False)
+    add_signal(contact.get("barrel_rate_allowed"), strong_value=0.045, weak_value=0.105, higher_is_better=False)
+
+    if not signals:
+        return 0.0
+
+    return round(sum(signals) / len(signals), 3)
+
+
+def classify_starter_quality(pitcher_profile: Optional[Dict[str, Any]]) -> str:
+    return _starter_quality_label(starter_quality_score(pitcher_profile))
+
+
+def simulate_game_with_bullpen(
+    away_starter_probabilities: Dict[str, float],
+    home_starter_probabilities: Dict[str, float],
+    away_bullpen_probabilities: Dict[str, float],
+    home_bullpen_probabilities: Dict[str, float],
+    simulations: int = 5000,
+    seed: Optional[int] = None,
+    innings: int = 9,
+    starter_innings: int = 5,
+    away_starter_quality: str = "average",
+    home_starter_quality: str = "average",
+    dynamic_starter_exit: bool = True,
+) -> Dict[str, Any]:
+    """
+    Simulate a game with separate early-inning starter probabilities and
+    late-inning bullpen probabilities.
+
+    Naming convention:
+    - away_* probabilities describe the away offense.
+    - home_* probabilities describe the home offense.
+    """
+    rng = random.Random(seed)
+
+    away_runs_counter = Counter()
+    home_runs_counter = Counter()
+    total_runs_counter = Counter()
+    margin_counter = Counter()
+
+    away_wins = 0
+    home_wins = 0
+    ties_after_regulation = 0
+
+    away_quality_score = (
+        float(away_starter_quality)
+        if isinstance(away_starter_quality, (int, float))
+        else 0.0
+    )
+    home_quality_score = (
+        float(home_starter_quality)
+        if isinstance(home_starter_quality, (int, float))
+        else 0.0
+    )
+    away_quality_label = _starter_quality_label(away_quality_score)
+    home_quality_label = _starter_quality_label(home_quality_score)
+
+    away_exit_distribution = _starter_exit_distribution_from_score(away_quality_score)
+    home_exit_distribution = _starter_exit_distribution_from_score(home_quality_score)
+    away_starter_innings_counter = Counter()
+    home_starter_innings_counter = Counter()
+
+    for _ in range(simulations):
+        away_runs = 0
+        home_runs = 0
+
+        away_starter_innings = (
+            _sample_from_distribution(away_exit_distribution, rng)
+            if dynamic_starter_exit
+            else starter_innings
+        )
+        home_starter_innings = (
+            _sample_from_distribution(home_exit_distribution, rng)
+            if dynamic_starter_exit
+            else starter_innings
+        )
+
+        away_starter_innings_counter[away_starter_innings] += 1
+        home_starter_innings_counter[home_starter_innings] += 1
+
+        for inning_index in range(1, innings + 1):
+            away_probs = (
+                away_starter_probabilities
+                if inning_index <= home_starter_innings
+                else away_bullpen_probabilities
+            )
+            home_probs = (
+                home_starter_probabilities
+                if inning_index <= away_starter_innings
+                else home_bullpen_probabilities
+            )
+
+            away_half = simulate_half_inning(away_probs, rng=rng)
+            home_half = simulate_half_inning(home_probs, rng=rng)
+            away_runs += away_half["runs"]
+            home_runs += home_half["runs"]
+
+        total_runs = away_runs + home_runs
+        margin = home_runs - away_runs
+
+        away_runs_counter[away_runs] += 1
+        home_runs_counter[home_runs] += 1
+        total_runs_counter[total_runs] += 1
+        margin_counter[margin] += 1
+
+        if home_runs > away_runs:
+            home_wins += 1
+        elif away_runs > home_runs:
+            away_wins += 1
+        else:
+            ties_after_regulation += 1
+
+    raw_away_expected_runs = sum(runs * count for runs, count in away_runs_counter.items()) / simulations
+    raw_home_expected_runs = sum(runs * count for runs, count in home_runs_counter.items()) / simulations
+    raw_total_expected_runs = sum(runs * count for runs, count in total_runs_counter.items()) / simulations
+
+    away_expected_runs = _calibrate_expected_runs(raw_away_expected_runs)
+    home_expected_runs = _calibrate_expected_runs(raw_home_expected_runs)
+    total_expected_runs = round(away_expected_runs + home_expected_runs, 4)
+
+    home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
+    away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+
+    calibrated_total_runs_counter = _calibrated_counter_by_mean_shift(
+        total_runs_counter,
+        raw_mean=raw_total_expected_runs,
+        calibrated_mean=total_expected_runs,
+    )
+    calibrated_away_runs_counter = _calibrated_counter_by_mean_shift(
+        away_runs_counter,
+        raw_mean=raw_away_expected_runs,
+        calibrated_mean=away_expected_runs,
+    )
+    calibrated_home_runs_counter = _calibrated_counter_by_mean_shift(
+        home_runs_counter,
+        raw_mean=raw_home_expected_runs,
+        calibrated_mean=home_expected_runs,
+    )
+
+    common_totals = [6.5, 7.5, 8.5, 9.5, 10.5]
+    total_probabilities = {
+        f"over_{line}": _prob_greater_than(total_runs_counter, line, simulations)
+        for line in common_totals
+    }
+    total_probabilities.update({
+        f"under_{line}": _prob_less_than(total_runs_counter, line, simulations)
+        for line in common_totals
+    })
+    calibrated_total_probabilities = {
+        f"over_{line}": _prob_greater_than(calibrated_total_runs_counter, line, simulations)
+        for line in common_totals
+    }
+    calibrated_total_probabilities.update({
+        f"under_{line}": _prob_less_than(calibrated_total_runs_counter, line, simulations)
+        for line in common_totals
+    })
+
+    return {
+        "model_version": "full_game_sim_with_bullpen_v1",
+        "simulations": simulations,
+        "innings": innings,
+        "starter_innings": starter_innings,
+        "dynamic_starter_exit": dynamic_starter_exit,
+        "away_starter_quality": away_quality_label,
+        "home_starter_quality": home_quality_label,
+        "away_starter_quality_score": round(away_quality_score, 3),
+        "home_starter_quality_score": round(home_quality_score, 3),
+        "away_starter_innings_distribution": _distribution(away_starter_innings_counter, simulations),
+        "home_starter_innings_distribution": _distribution(home_starter_innings_counter, simulations),
+        "bullpen_innings": max(0, innings - starter_innings),
+        "away_expected_runs": away_expected_runs,
+        "home_expected_runs": home_expected_runs,
+        "total_expected_runs": total_expected_runs,
+        "raw_away_expected_runs": round(raw_away_expected_runs, 4),
+        "raw_home_expected_runs": round(raw_home_expected_runs, 4),
+        "raw_total_expected_runs": round(raw_total_expected_runs, 4),
+        "away_win_probability": round(away_win_probability, 4),
+        "home_win_probability": round(home_win_probability, 4),
+        "tie_after_regulation_probability": round(ties_after_regulation / simulations, 4),
+        "away_run_distribution": _distribution(away_runs_counter, simulations),
+        "home_run_distribution": _distribution(home_runs_counter, simulations),
+        "total_run_distribution": _distribution(total_runs_counter, simulations),
+        "calibrated_total_run_distribution": _distribution(calibrated_total_runs_counter, simulations),
+        "calibrated_away_run_distribution": _distribution(calibrated_away_runs_counter, simulations),
+        "calibrated_home_run_distribution": _distribution(calibrated_home_runs_counter, simulations),
+        "home_margin_distribution": _distribution(margin_counter, simulations),
+        "total_probabilities": total_probabilities,
+        "calibrated_total_probabilities": calibrated_total_probabilities,
+        "team_total_probabilities": {
+            "away_3_plus": _prob_at_least(away_runs_counter, 3, simulations),
+            "away_4_plus": _prob_at_least(away_runs_counter, 4, simulations),
+            "away_5_plus": _prob_at_least(away_runs_counter, 5, simulations),
+            "home_3_plus": _prob_at_least(home_runs_counter, 3, simulations),
+            "home_4_plus": _prob_at_least(home_runs_counter, 4, simulations),
+            "home_5_plus": _prob_at_least(home_runs_counter, 5, simulations),
+        },
+        "calibrated_team_total_probabilities": {
+            "away_3_plus": _prob_at_least(calibrated_away_runs_counter, 3, simulations),
+            "away_4_plus": _prob_at_least(calibrated_away_runs_counter, 4, simulations),
+            "away_5_plus": _prob_at_least(calibrated_away_runs_counter, 5, simulations),
+            "home_3_plus": _prob_at_least(calibrated_home_runs_counter, 3, simulations),
+            "home_4_plus": _prob_at_least(calibrated_home_runs_counter, 4, simulations),
+            "home_5_plus": _prob_at_least(calibrated_home_runs_counter, 5, simulations),
+        },
+        "metadata": {
+            "generated_from": "simulation.game_simulator.simulate_game_with_bullpen",
+            "seed": seed,
+            "simulation_count": simulations,
+            "starter_innings": starter_innings,
+            "dynamic_starter_exit": dynamic_starter_exit,
+            "away_starter_quality": away_quality_label,
+            "home_starter_quality": home_quality_label,
+            "away_starter_quality_score": round(away_quality_score, 3),
+            "home_starter_quality_score": round(home_quality_score, 3),
+            "away_starter_innings_distribution": _distribution(away_starter_innings_counter, simulations),
+            "home_starter_innings_distribution": _distribution(home_starter_innings_counter, simulations),
+            "bullpen_innings": max(0, innings - starter_innings),
+            **GAME_SIM_CALIBRATION,
+            "calibration_applied_to": ["expected_runs", "total_probabilities", "team_total_probabilities"],
+            "distribution_calibration_method": "integer_mean_shift_v1",
+            "notes": [
+                "V1 uses starter PA probabilities for early innings and bullpen PA probabilities for late innings.",
+                "Ties after regulation are split evenly for win probability.",
+                "No extras, walk-off shortening, individual reliever selection, or lineup-order state yet.",
+            ],
+        },
+    }
+

--- a/mlb_app/simulation/inning_simulator.py
+++ b/mlb_app/simulation/inning_simulator.py
@@ -1,0 +1,172 @@
+"""
+Half-inning simulator.
+
+Uses a plate appearance outcome probability distribution to simulate base/out
+state transitions until three outs are recorded.
+
+V1 is intentionally simple:
+- no steals
+- no errors
+- no double plays
+- conservative runner advancement rules
+- K and OUT both count as outs
+"""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from typing import Dict, Optional, Any
+
+
+OUTCOMES = ["k", "bb", "hbp", "single", "double", "triple", "hr", "reached_on_error", "out"]
+
+
+def _normalize_probabilities(probabilities: Dict[str, float]) -> Dict[str, float]:
+    cleaned = {key: max(0.0, float(probabilities.get(key, 0.0) or 0.0)) for key in OUTCOMES}
+    total = sum(cleaned.values())
+    if total <= 0:
+        return {
+            "k": 0.225,
+            "bb": 0.085,
+            "hbp": 0.011,
+            "single": 0.145,
+            "double": 0.045,
+            "triple": 0.004,
+            "hr": 0.030,
+            "reached_on_error": 0.007,
+            "out": 0.459,
+        }
+    return {key: value / total for key, value in cleaned.items()}
+
+
+def sample_pa_outcome(probabilities: Dict[str, float], rng: Optional[random.Random] = None) -> str:
+    rng = rng or random
+    probs = _normalize_probabilities(probabilities)
+    draw = rng.random()
+    cumulative = 0.0
+    for outcome in OUTCOMES:
+        cumulative += probs[outcome]
+        if draw <= cumulative:
+            return outcome
+    return "out"
+
+
+def advance_runners(
+    bases: tuple[bool, bool, bool],
+    outcome: str,
+) -> tuple[tuple[bool, bool, bool], int]:
+    """
+    Apply conservative base advancement rules.
+
+    bases = (runner_on_first, runner_on_second, runner_on_third)
+    returns (new_bases, runs_scored)
+    """
+    first, second, third = bases
+    runs = 0
+
+    if outcome in {"k", "out"}:
+        return bases, 0
+
+    if outcome in {"bb", "hbp"}:
+        # Force runners only as needed.
+        if first and second and third:
+            runs += 1
+        new_third = third or (first and second)
+        new_second = second or first
+        new_first = True
+        return (new_first, new_second, new_third), runs
+
+    if outcome in {"single", "reached_on_error"}:
+        # Conservative: runner on third scores; runner on second scores;
+        # runner on first advances to second.
+        runs += int(third) + int(second)
+        return (True, first, False), runs
+
+    if outcome == "double":
+        # Conservative: runners on second/third score; runner on first to third.
+        runs += int(third) + int(second)
+        return (False, True, first), runs
+
+    if outcome == "triple":
+        runs += int(first) + int(second) + int(third)
+        return (False, False, True), runs
+
+    if outcome == "hr":
+        runs += 1 + int(first) + int(second) + int(third)
+        return (False, False, False), runs
+
+    return bases, 0
+
+
+def simulate_half_inning(
+    probabilities: Dict[str, float],
+    rng: Optional[random.Random] = None,
+    max_plate_appearances: int = 30,
+) -> Dict[str, Any]:
+    rng = rng or random.Random()
+    outs = 0
+    runs = 0
+    bases = (False, False, False)
+    pa_count = 0
+    outcomes = []
+
+    while outs < 3 and pa_count < max_plate_appearances:
+        outcome = sample_pa_outcome(probabilities, rng)
+        pa_count += 1
+        outcomes.append(outcome)
+
+        if outcome in {"k", "out"}:
+            outs += 1
+            continue
+
+        bases, scored = advance_runners(bases, outcome)
+        runs += scored
+
+    return {
+        "runs": runs,
+        "plate_appearances": pa_count,
+        "outcomes": outcomes,
+        "ended_by_max_pa": outs < 3,
+    }
+
+
+def simulate_half_innings(
+    probabilities: Dict[str, float],
+    simulations: int = 5000,
+    seed: Optional[int] = None,
+) -> Dict[str, Any]:
+    rng = random.Random(seed)
+    run_counts = Counter()
+    pa_counts = []
+    ended_by_max_pa = 0
+
+    for _ in range(simulations):
+        result = simulate_half_inning(probabilities, rng=rng)
+        run_counts[result["runs"]] += 1
+        pa_counts.append(result["plate_appearances"])
+        if result["ended_by_max_pa"]:
+            ended_by_max_pa += 1
+
+    distribution = {
+        str(runs): round(count / simulations, 4)
+        for runs, count in sorted(run_counts.items())
+    }
+
+    expected_runs = sum(runs * count for runs, count in run_counts.items()) / simulations
+    average_pa = sum(pa_counts) / len(pa_counts) if pa_counts else 0.0
+
+    return {
+        "model_version": "half_inning_sim_v1",
+        "simulations": simulations,
+        "expected_runs": round(expected_runs, 4),
+        "average_plate_appearances": round(average_pa, 3),
+        "run_distribution": distribution,
+        "probability_scoreless": round(run_counts.get(0, 0) / simulations, 4),
+        "probability_1_plus_runs": round(1 - (run_counts.get(0, 0) / simulations), 4),
+        "probability_2_plus_runs": round(
+            sum(count for runs, count in run_counts.items() if runs >= 2) / simulations,
+            4,
+        ),
+        "ended_by_max_pa_rate": round(ended_by_max_pa / simulations, 4),
+    }

--- a/mlb_app/simulation/pa_outcome_model.py
+++ b/mlb_app/simulation/pa_outcome_model.py
@@ -1,0 +1,260 @@
+"""
+Plate appearance outcome probability model.
+
+This module converts hitter skill, pitcher skill, and environment context into
+a normalized plate appearance outcome distribution.
+
+The model is intentionally conservative for v1:
+- starts from MLB-like baseline outcome rates
+- blends batter and pitcher skill signals
+- applies environment adjustments by outcome type
+- normalizes probabilities so they sum to 1
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+BASE_PA_OUTCOMES = {
+    "k": 0.225,
+    "bb": 0.085,
+    "hbp": 0.011,
+    "single": 0.145,
+    "double": 0.045,
+    "triple": 0.004,
+    "hr": 0.030,
+    "reached_on_error": 0.007,
+    "out": 0.459,
+}
+
+MIN_OUTCOME = {
+    "k": 0.08,
+    "bb": 0.03,
+    "hbp": 0.002,
+    "single": 0.06,
+    "double": 0.015,
+    "triple": 0.0005,
+    "hr": 0.005,
+    "reached_on_error": 0.001,
+    "out": 0.25,
+}
+
+MAX_OUTCOME = {
+    "k": 0.42,
+    "bb": 0.18,
+    "hbp": 0.025,
+    "single": 0.24,
+    "double": 0.09,
+    "triple": 0.018,
+    "hr": 0.085,
+    "reached_on_error": 0.018,
+    "out": 0.68,
+}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _nested(profile: Optional[dict], section: str, key: str) -> Optional[float]:
+    if not profile:
+        return None
+    return _safe_float((profile.get(section) or {}).get(key))
+
+
+def _blend(values, fallback: float) -> float:
+    cleaned = [_safe_float(v) for v in values]
+    cleaned = [v for v in cleaned if v is not None]
+    if not cleaned:
+        return fallback
+    return sum(cleaned) / len(cleaned)
+
+
+def _normalize(probs: Dict[str, float]) -> Dict[str, float]:
+    bounded = {
+        key: _clamp(float(value), MIN_OUTCOME[key], MAX_OUTCOME[key])
+        for key, value in probs.items()
+    }
+    total = sum(bounded.values())
+    if total <= 0:
+        return dict(BASE_PA_OUTCOMES)
+    return {key: round(value / total, 4) for key, value in bounded.items()}
+
+
+def _env_index(environment_profile: Optional[dict], key: str, fallback: float = 1.0) -> float:
+    if not environment_profile:
+        return fallback
+    value = _safe_float((environment_profile.get("run_environment") or {}).get(key))
+    return value if value is not None else fallback
+
+
+def build_pa_outcome_probabilities(
+    batter_profile: Optional[dict],
+    pitcher_profile: Optional[dict],
+    environment_profile: Optional[dict],
+) -> Dict[str, Any]:
+    """
+    Build a normalized plate appearance outcome distribution.
+
+    Returns a dict containing:
+    - probabilities: normalized outcome probabilities
+    - inputs_used: key model inputs for debugging
+    - model_version: semantic version for future calibration/backtesting
+    """
+    batter_k = _nested(batter_profile, "contact_skill", "k_rate")
+    batter_bb = _nested(batter_profile, "plate_discipline", "bb_rate")
+    batter_iso = _nested(batter_profile, "power", "iso")
+    batter_barrel = _nested(batter_profile, "power", "barrel_rate")
+    batter_hard_hit = _nested(batter_profile, "power", "hard_hit_rate")
+    batter_contact = _nested(batter_profile, "contact_skill", "contact_rate")
+
+    pitcher_k = _nested(pitcher_profile, "bat_missing", "k_rate")
+    pitcher_bb = _nested(pitcher_profile, "command_control", "bb_rate")
+    pitcher_barrel_allowed = _nested(pitcher_profile, "contact_management", "barrel_rate_allowed")
+    pitcher_hard_hit_allowed = _nested(pitcher_profile, "contact_management", "hard_hit_rate_allowed")
+    pitcher_xba_allowed = _nested(pitcher_profile, "contact_management", "xba_allowed")
+
+    hr_index = _env_index(environment_profile, "hr_boost_index")
+    hit_index = _env_index(environment_profile, "hit_boost_index")
+    run_index = _env_index(environment_profile, "run_scoring_index")
+
+    k_rate = _blend([batter_k, pitcher_k], BASE_PA_OUTCOMES["k"])
+    bb_rate = _blend([batter_bb, pitcher_bb], BASE_PA_OUTCOMES["bb"])
+
+    # HBP and reached-on-error are included as conservative baseline events in v1.
+    # They can be upgraded later with player/team/defense-specific features.
+    hbp_rate = BASE_PA_OUTCOMES["hbp"]
+    reached_on_error_rate = BASE_PA_OUTCOMES["reached_on_error"]
+
+    contact_quality = _blend(
+        [
+            batter_hard_hit,
+            pitcher_hard_hit_allowed,
+            batter_contact,
+        ],
+        0.35,
+    )
+
+    power_signal = _blend(
+        [
+            batter_iso,
+            batter_barrel,
+            pitcher_barrel_allowed,
+        ],
+        0.12,
+    )
+
+    hit_skill = _blend(
+        [
+            batter_contact,
+            pitcher_xba_allowed,
+            contact_quality,
+        ],
+        0.30,
+    )
+
+    # Keep v1 conservative: environment indices are already calibrated, so apply
+    # only partial elasticity to avoid over-adjusting PA outcomes.
+    env_hr_multiplier = 1.0 + ((hr_index - 1.0) * 0.85)
+    env_hit_multiplier = 1.0 + ((hit_index - 1.0) * 0.60)
+    env_run_multiplier = 1.0 + ((run_index - 1.0) * 0.35)
+
+    hr_rate = BASE_PA_OUTCOMES["hr"] * (1.0 + (power_signal - 0.12) * 1.8) * env_hr_multiplier
+    double_rate = BASE_PA_OUTCOMES["double"] * (1.0 + (power_signal - 0.12) * 0.9) * env_hit_multiplier
+    triple_rate = BASE_PA_OUTCOMES["triple"] * env_hit_multiplier
+    single_rate = BASE_PA_OUTCOMES["single"] * (1.0 + (hit_skill - 0.30) * 0.75) * env_hit_multiplier
+
+    # Apply broad scoring environment lightly to non-HR hit outcomes.
+    single_rate *= env_run_multiplier
+    double_rate *= env_run_multiplier
+    triple_rate *= env_run_multiplier
+
+    out_rate = 1.0 - (
+        k_rate
+        + bb_rate
+        + hbp_rate
+        + single_rate
+        + double_rate
+        + triple_rate
+        + hr_rate
+        + reached_on_error_rate
+    )
+
+    probabilities = _normalize({
+        "k": k_rate,
+        "bb": bb_rate,
+        "hbp": hbp_rate,
+        "single": single_rate,
+        "double": double_rate,
+        "triple": triple_rate,
+        "hr": hr_rate,
+        "reached_on_error": reached_on_error_rate,
+        "out": out_rate,
+    })
+
+    summary = {
+        "hit_probability": round(
+            probabilities["single"] + probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            4,
+        ),
+        "on_base_probability": round(
+            probabilities["bb"]
+            + probabilities["hbp"]
+            + probabilities["single"]
+            + probabilities["double"]
+            + probabilities["triple"]
+            + probabilities["hr"]
+            + probabilities["reached_on_error"],
+            4,
+        ),
+        "extra_base_hit_probability": round(
+            probabilities["double"] + probabilities["triple"] + probabilities["hr"],
+            4,
+        ),
+        "total_out_probability": round(
+            probabilities["k"] + probabilities["out"],
+            4,
+        ),
+        "non_hit_on_base_probability": round(
+            probabilities["bb"] + probabilities["hbp"] + probabilities["reached_on_error"],
+            4,
+        ),
+        "contact_out_probability": probabilities["out"],
+    }
+
+    return {
+        "model_version": "pa_outcome_v1",
+        "probabilities": probabilities,
+        "summary": summary,
+        "inputs_used": {
+            "batter_k_rate": batter_k,
+            "batter_bb_rate": batter_bb,
+            "batter_iso": batter_iso,
+            "batter_barrel_rate": batter_barrel,
+            "batter_hard_hit_rate": batter_hard_hit,
+            "batter_contact_rate": batter_contact,
+            "pitcher_k_rate": pitcher_k,
+            "pitcher_bb_rate": pitcher_bb,
+            "pitcher_barrel_rate_allowed": pitcher_barrel_allowed,
+            "pitcher_hard_hit_rate_allowed": pitcher_hard_hit_allowed,
+            "pitcher_xba_allowed": pitcher_xba_allowed,
+            "hr_boost_index": hr_index,
+            "hit_boost_index": hit_index,
+            "run_scoring_index": run_index,
+            "blended_k_rate": k_rate,
+            "blended_bb_rate": bb_rate,
+            "contact_quality_signal": contact_quality,
+            "power_signal": power_signal,
+            "hit_skill_signal": hit_skill,
+        },
+    }

--- a/mlb_app/team_offense_prior.py
+++ b/mlb_app/team_offense_prior.py
@@ -1,0 +1,144 @@
+"""
+Team offense prior profile.
+
+Used when official/projected lineups are unavailable or do not produce enough
+usable hitter data. V1 provides a stable conservative profile so PA/game
+simulation can still run for future games before lineups are posted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+TEAM_OFFENSE_PRIOR_V1 = {
+    "contact_skill": {
+        "k_rate": 0.225,
+        "whiff_rate": 0.235,
+        "contact_rate": 0.765,
+    },
+    "plate_discipline": {
+        "bb_rate": 0.085,
+        "chase_rate": 0.300,
+        "swing_rate": 0.470,
+    },
+    "power": {
+        "iso": 0.165,
+        "barrel_rate": 0.075,
+        "hard_hit_rate": 0.395,
+    },
+    "batted_ball_quality": {
+        "avg_exit_velocity": 88.5,
+        "avg_launch_angle": 12.5,
+    },
+    "platoon_profile": {
+        "vs_lhp_woba": 0.315,
+        "vs_rhp_woba": 0.315,
+        "vs_lhp_iso": 0.160,
+        "vs_rhp_iso": 0.160,
+    },
+}
+
+
+# Conservative team offense quality layer.
+# Positive score = stronger than prior offense.
+# Negative score = weaker than prior offense.
+# This should later be replaced by live/team aggregate batting data.
+TEAM_OFFENSE_QUALITY_V1 = {
+    119: {"quality_score": 0.08, "label": "strong_offense"},       # Dodgers
+    147: {"quality_score": 0.07, "label": "strong_offense"},       # Yankees
+    141: {"quality_score": 0.06, "label": "above_average_offense"},# Blue Jays
+    140: {"quality_score": 0.05, "label": "above_average_offense"},# Rangers
+    108: {"quality_score": 0.05, "label": "above_average_offense"},# Angels
+    116: {"quality_score": 0.04, "label": "above_average_offense"},# Tigers
+
+    115: {"quality_score": -0.04, "label": "below_average_offense"},# Rockies
+    146: {"quality_score": -0.04, "label": "below_average_offense"},# Marlins
+    120: {"quality_score": -0.04, "label": "below_average_offense"},# Nationals
+    133: {"quality_score": -0.03, "label": "slightly_below_average_offense"},# Athletics
+}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _deepcopy_profile(profile: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    return {
+        section: dict(values)
+        for section, values in profile.items()
+    }
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _apply_team_quality(profile: Dict[str, Dict[str, Any]], quality_score: float) -> None:
+    q = _clamp(quality_score, -0.12, 0.12)
+
+    profile["contact_skill"]["k_rate"] = round(_clamp(profile["contact_skill"]["k_rate"] - (q * 0.16), 0.17, 0.30), 3)
+    profile["contact_skill"]["whiff_rate"] = round(_clamp(profile["contact_skill"]["whiff_rate"] - (q * 0.14), 0.18, 0.30), 3)
+    profile["contact_skill"]["contact_rate"] = round(_clamp(profile["contact_skill"]["contact_rate"] + (q * 0.14), 0.70, 0.82), 3)
+
+    profile["plate_discipline"]["bb_rate"] = round(_clamp(profile["plate_discipline"]["bb_rate"] + (q * 0.08), 0.055, 0.125), 3)
+    profile["plate_discipline"]["chase_rate"] = round(_clamp(profile["plate_discipline"]["chase_rate"] - (q * 0.10), 0.24, 0.36), 3)
+    profile["plate_discipline"]["swing_rate"] = round(_clamp(profile["plate_discipline"]["swing_rate"] + (q * 0.04), 0.42, 0.52), 3)
+
+    profile["power"]["iso"] = round(_clamp(profile["power"]["iso"] + (q * 0.22), 0.115, 0.230), 3)
+    profile["power"]["barrel_rate"] = round(_clamp(profile["power"]["barrel_rate"] + (q * 0.08), 0.045, 0.115), 3)
+    profile["power"]["hard_hit_rate"] = round(_clamp(profile["power"]["hard_hit_rate"] + (q * 0.16), 0.32, 0.48), 3)
+
+    profile["batted_ball_quality"]["avg_exit_velocity"] = round(_clamp(profile["batted_ball_quality"]["avg_exit_velocity"] + (q * 5.0), 86.0, 91.5), 1)
+    profile["batted_ball_quality"]["avg_launch_angle"] = round(_clamp(profile["batted_ball_quality"]["avg_launch_angle"] + (q * 3.0), 8.0, 17.0), 1)
+
+    profile["platoon_profile"]["vs_lhp_woba"] = round(_clamp(profile["platoon_profile"]["vs_lhp_woba"] + (q * 0.14), 0.275, 0.365), 3)
+    profile["platoon_profile"]["vs_rhp_woba"] = round(_clamp(profile["platoon_profile"]["vs_rhp_woba"] + (q * 0.14), 0.275, 0.365), 3)
+    profile["platoon_profile"]["vs_lhp_iso"] = round(_clamp(profile["platoon_profile"]["vs_lhp_iso"] + (q * 0.12), 0.115, 0.220), 3)
+    profile["platoon_profile"]["vs_rhp_iso"] = round(_clamp(profile["platoon_profile"]["vs_rhp_iso"] + (q * 0.12), 0.115, 0.220), 3)
+
+
+def build_team_offense_prior(
+    team_id: Optional[int] = None,
+    team_name: Optional[str] = None,
+    raw_context: Optional[dict] = None,
+) -> Dict[str, Any]:
+    raw_context = raw_context or {}
+    profile = _deepcopy_profile(TEAM_OFFENSE_PRIOR_V1)
+
+    team_quality = TEAM_OFFENSE_QUALITY_V1.get(team_id, {})
+    quality_score = _safe_float(raw_context.get("quality_score", team_quality.get("quality_score")))
+    quality_label = raw_context.get("quality_label", team_quality.get("label", "league_average_offense"))
+
+    if quality_score is not None:
+        _apply_team_quality(profile, quality_score)
+    else:
+        quality_score = 0.0
+
+    profile["metadata"] = {
+        "source_type": raw_context.get("source_type", "team_offense_prior_v1"),
+        "team_id": team_id,
+        "team_name": team_name,
+        "data_confidence": raw_context.get("data_confidence", "low"),
+        "generated_from": "build_team_offense_prior",
+        "profile_granularity": "team_offense_prior",
+        "sample_window": raw_context.get("sample_window", "prior"),
+        "sample_size": raw_context.get("sample_size"),
+        "team_offense_prior_version": "team_offense_prior_v1",
+        "team_offense_quality_version": "team_offense_quality_v1",
+        "team_offense_quality_score": quality_score,
+        "team_offense_quality_label": quality_label,
+        "team_quality_adjustment_applied": quality_score != 0.0,
+        "notes": [
+            "V1 uses conservative team offense priors when lineup data is unavailable.",
+            "Future versions should aggregate projected/active hitters and recent team offense data.",
+            "Use this profile only as a low-confidence fallback for pre-lineup games.",
+        ],
+    }
+
+    return profile

--- a/tests/test_environment_data.py
+++ b/tests/test_environment_data.py
@@ -1,0 +1,38 @@
+from mlb_app.environment_data import build_environment_context, get_park_factors
+
+
+def test_get_park_factors_returns_contract_for_unknown_venue():
+    result = get_park_factors("Unknown Park")
+    assert "run_factor" in result
+    assert "home_run_factor" in result
+    assert "hit_factor" in result
+    assert "source_fields_used" in result
+    assert "park_readiness" in result
+    assert result["park_readiness"] == "stub"
+
+
+def test_build_environment_context_returns_stable_contract_for_unknown_venue():
+    game = {
+        "gameDate": "2026-04-22T18:05:00Z",
+        "venue": {"name": "Unknown Park"},
+        "teams": {
+            "home": {"team": {"name": "Home Team"}},
+            "away": {"team": {"name": "Away Team"}},
+        },
+    }
+
+    result = build_environment_context(game)
+
+    assert "venue_name" in result
+    assert "temperature_f" in result
+    assert "wind_speed_mph" in result
+    assert "run_factor" in result
+    assert "home_run_factor" in result
+    assert "hit_factor" in result
+    assert "source_type" in result
+    assert "source_fields_used" in result
+    assert "data_confidence" in result
+    assert "generated_from" in result
+    assert "is_stub" in result
+    assert "readiness" in result
+    assert "missing_inputs" in result

--- a/tests/test_hitter_blending_integration.py
+++ b/tests/test_hitter_blending_integration.py
@@ -1,0 +1,41 @@
+import datetime
+
+from mlb_app.offense_profile_aggregation import build_projected_lineup_offense_profile
+
+
+def test_build_projected_lineup_offense_profile_returns_stable_contract_when_no_lineup():
+    result = build_projected_lineup_offense_profile(
+        lineup=[],
+        season=2026,
+        pitcher_hand="R",
+        lineup_source="missing",
+        target_date=datetime.date(2026, 4, 22),
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["sample_window"] == "blended"
+    assert metadata["sample_blend_policy"] == "hitter_v1_weighted_blend"
+    assert metadata["player_count_used"] == 0
+
+
+def test_build_projected_lineup_offense_profile_marks_blended_metadata():
+    result = build_projected_lineup_offense_profile(
+        lineup=[{"id": 1, "fullName": "Test Batter", "batting_order": 1}],
+        season=2026,
+        pitcher_hand=None,
+        lineup_source="roster",
+        target_date=datetime.date(2026, 4, 22),
+    )
+
+    metadata = result["metadata"]
+    assert metadata["sample_window"] == "blended"
+    assert metadata["sample_family"] == "blended"
+    assert metadata["sample_blend_policy"] == "hitter_v1_weighted_blend"
+    assert metadata["stabilizer_window"] == "current_season"

--- a/tests/test_hitter_windows.py
+++ b/tests/test_hitter_windows.py
@@ -1,0 +1,23 @@
+import datetime
+
+from mlb_app.hitter_windows import fetch_player_splits_for_window
+
+
+def test_returns_empty_for_no_players():
+    result = fetch_player_splits_for_window(
+        player_ids=[],
+        season=2026,
+        window_name="current_season",
+        target_date=datetime.date(2026, 4, 22),
+    )
+    assert result == []
+
+
+def test_unknown_window_returns_empty():
+    result = fetch_player_splits_for_window(
+        player_ids=[1],
+        season=2026,
+        window_name="unknown_window",
+        target_date=datetime.date(2026, 4, 22),
+    )
+    assert result == []

--- a/tests/test_lineup_offense_profile_contract.py
+++ b/tests/test_lineup_offense_profile_contract.py
@@ -1,0 +1,44 @@
+from mlb_app.offense_profile_aggregation import build_projected_lineup_offense_profile
+
+
+def test_projected_lineup_offense_profile_contract_when_lineup_missing():
+    result = build_projected_lineup_offense_profile(
+        lineup=[],
+        season=2026,
+        pitcher_hand=None,
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "projected_lineup_profile"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["opposing_pitcher_hand"] == "unknown"
+    assert metadata["player_count_used"] == 0
+
+
+def test_projected_lineup_offense_profile_contract_with_roster_source():
+    result = build_projected_lineup_offense_profile(
+        lineup=[{"id": 1, "fullName": "Test Batter", "batting_order": 1}],
+        season=2026,
+        pitcher_hand="R",
+        lineup_source="roster",
+    )
+
+    assert "metadata" in result
+    assert "contact_skill" in result
+    assert "plate_discipline" in result
+    assert "power" in result
+    assert "batted_ball_quality" in result
+    assert "platoon_profile" in result
+
+    metadata = result["metadata"]
+    assert metadata["lineup_source"] == "roster"
+    assert metadata["opposing_pitcher_hand"] == "R"
+    assert metadata["player_count_used"] == 1

--- a/tests/test_matchup_analysis_contract.py
+++ b/tests/test_matchup_analysis_contract.py
@@ -1,0 +1,58 @@
+from mlb_app.matchup_analysis import build_matchup_analysis
+
+
+def test_matchup_analysis_contract_with_missing_lineup():
+    result = build_matchup_analysis(
+        pitcher_id=None,
+        pitcher_name=None,
+        pitcher_hand=None,
+        lineup=[],
+        lineup_source="missing",
+    )
+
+    assert "metadata" in result
+    assert "pitchTypeMatchups" in result
+    assert "biggestEdge" in result
+    assert "biggestWeakness" in result
+    assert "confidence" in result
+    assert "summary" in result
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "matchup_analysis_v1"
+    assert metadata["pitcher_hand"] == "unknown"
+    assert metadata["lineup_source"] == "missing"
+    assert metadata["lineup_player_count"] == 0
+
+    assert result["pitchTypeMatchups"] == []
+    assert result["biggestEdge"] is None
+    assert result["biggestWeakness"] is None
+    assert result["confidence"] == 0.0
+    assert result["summary"]["status"] == "scaffold"
+
+
+def test_matchup_analysis_contract_with_lineup_players():
+    result = build_matchup_analysis(
+        pitcher_id=123,
+        pitcher_name="Pitcher Example",
+        pitcher_hand="R",
+        lineup=[
+            {"id": 1, "fullName": "Batter One", "batting_order": 1},
+            {"id": 2, "fullName": "Batter Two", "batting_order": 2},
+        ],
+        lineup_source="official",
+    )
+
+    metadata = result["metadata"]
+    assert metadata["source_type"] == "matchup_analysis_v1"
+    assert metadata["pitcher_id"] == 123
+    assert metadata["pitcher_name"] == "Pitcher Example"
+    assert metadata["pitcher_hand"] == "R"
+    assert metadata["lineup_source"] == "official"
+    assert metadata["lineup_player_count"] == 2
+
+    assert isinstance(result["pitchTypeMatchups"], list)
+    assert len(result["pitchTypeMatchups"]) > 0
+    assert result["biggestEdge"] is not None
+    assert result["biggestWeakness"] is not None
+    assert result["confidence"] > 0.0
+    assert result["summary"]["status"] == "partial"

--- a/tests/test_matchup_profile_contract.py
+++ b/tests/test_matchup_profile_contract.py
@@ -1,0 +1,84 @@
+from mlb_app.analysis_pipeline import generate_daily_matchups
+
+
+def test_generate_daily_matchups_profile_contract(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_schedule",
+        lambda date_str: [
+            {
+                "gamePk": 123,
+                "gameDate": "2026-04-22T18:05:00Z",
+                "teams": {
+                    "home": {
+                        "team": {"id": 1, "name": "Home Team"},
+                        "probablePitcher": {"id": 1001},
+                    },
+                    "away": {
+                        "team": {"id": 2, "name": "Away Team"},
+                        "probablePitcher": {"id": 1002},
+                    },
+                },
+                "venue": {"name": "Sample Park"},
+            }
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_records",
+        lambda season: [
+            {"team": {"id": 1}, "wins": 10, "losses": 5, "runDifferential": 12},
+            {"team": {"id": 2}, "wins": 8, "losses": 7, "runDifferential": -3},
+        ],
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.fetch_team_splits",
+        lambda team_id, season, split: {},
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.get_pitcher_metrics",
+        lambda player_id, start_date, end_date: {},
+    )
+
+    matchups = generate_daily_matchups("2026-04-22")
+    assert len(matchups) == 1
+
+    matchup = matchups[0]
+
+    # Top-level contract
+    assert "homePitcherProfile" in matchup
+    assert "awayPitcherProfile" in matchup
+    assert "homeTeamOffenseProfile" in matchup
+    assert "awayTeamOffenseProfile" in matchup
+    assert "environmentProfile" in matchup
+
+    # Pitcher profile nested sections
+    for key in ("homePitcherProfile", "awayPitcherProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "arsenal" in profile
+        assert "bat_missing" in profile
+        assert "command_control" in profile
+        assert "contact_management" in profile
+        assert "platoon_profile" in profile
+
+    # Offense profile nested sections
+    for key in ("homeTeamOffenseProfile", "awayTeamOffenseProfile"):
+        profile = matchup[key]
+        assert "metadata" in profile
+        assert "contact_skill" in profile
+        assert "plate_discipline" in profile
+        assert "power" in profile
+        assert "batted_ball_quality" in profile
+        assert "platoon_profile" in profile
+
+    # Environment profile nested sections
+    environment = matchup["environmentProfile"]
+    assert "metadata" in environment
+    assert "weather" in environment
+    assert "park_factors" in environment
+    assert "game_context" in environment
+    assert "run_environment" in environment
+    assert "risk_flags" in environment
+    assert "status" in environment

--- a/tests/test_pitcher_blending_integration.py
+++ b/tests/test_pitcher_blending_integration.py
@@ -1,0 +1,20 @@
+from mlb_app.pitcher_profile import compute_pitcher_profile
+
+
+def test_compute_pitcher_profile_marks_blended_metadata():
+    result = compute_pitcher_profile(
+        {
+            "avg_velocity": 95.0,
+            "k_rate": 0.28,
+            "bb_rate": 0.08,
+            "sample_window": "blended",
+            "sample_blend_policy": "pitcher_v1_weighted_blend",
+            "stabilizer_window": "last_365_days",
+            "sample_size": None,
+        }
+    )
+
+    metadata = result["metadata"]
+    assert metadata["sample_window"] == "blended"
+    assert metadata["sample_blend_policy"] == "pitcher_v1_weighted_blend"
+    assert metadata["stabilizer_window"] == "last_365_days"

--- a/tests/test_pitcher_handedness_resolution.py
+++ b/tests/test_pitcher_handedness_resolution.py
@@ -1,0 +1,35 @@
+from mlb_app.analysis_pipeline import _determine_hand
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_determine_hand_returns_pitch_hand_code(monkeypatch):
+    monkeypatch.setattr(
+        "mlb_app.analysis_pipeline.requests.get",
+        lambda url, timeout=10: DummyResponse(
+            {"people": [{"pitchHand": {"code": "R"}}]}
+        ),
+    )
+
+    assert _determine_hand(12345) == "R"
+
+
+def test_determine_hand_returns_none_on_request_failure(monkeypatch):
+    class DummyException(Exception):
+        pass
+
+    def raise_error(url, timeout=10):
+        raise DummyException("network error")
+
+    monkeypatch.setattr("mlb_app.analysis_pipeline.requests.get", raise_error)
+
+    assert _determine_hand(12345) is None

--- a/tests/test_pitcher_windows.py
+++ b/tests/test_pitcher_windows.py
@@ -1,0 +1,21 @@
+import datetime
+
+from mlb_app.pitcher_windows import fetch_pitcher_metrics_for_window
+
+
+def test_returns_empty_for_missing_pitcher_id():
+    result = fetch_pitcher_metrics_for_window(
+        pitcher_id=0,
+        target_date=datetime.date(2026, 4, 22),
+        window_name="last_365_days",
+    )
+    assert result == {}
+
+
+def test_unknown_window_returns_empty():
+    result = fetch_pitcher_metrics_for_window(
+        pitcher_id=123,
+        target_date=datetime.date(2026, 4, 22),
+        window_name="unknown_window",
+    )
+    assert result == {}

--- a/tests/test_sample_blending.py
+++ b/tests/test_sample_blending.py
@@ -1,0 +1,44 @@
+from mlb_app.sample_blending import (
+    HITTER_BLEND_WEIGHTS,
+    PITCHER_BLEND_WEIGHTS,
+    blend_metric_dict,
+    weighted_average,
+)
+
+
+def test_weighted_average_ignores_none_values():
+    values = {
+        "last_30_days": 0.300,
+        "last_90_days": None,
+        "current_season": 0.250,
+    }
+    weights = {
+        "last_30_days": 0.50,
+        "last_90_days": 0.30,
+        "current_season": 0.20,
+    }
+
+    result = weighted_average(values, weights)
+    expected = (0.300 * 0.50 + 0.250 * 0.20) / (0.50 + 0.20)
+    assert round(result, 6) == round(expected, 6)
+
+
+def test_blend_metric_dict_blends_shared_keys():
+    metric_windows = {
+        "last_30_days": {"k_rate": 0.22, "bb_rate": 0.08},
+        "last_90_days": {"k_rate": 0.24, "bb_rate": 0.09},
+        "current_season": {"k_rate": 0.23, "bb_rate": 0.10},
+    }
+
+    result = blend_metric_dict(metric_windows, HITTER_BLEND_WEIGHTS)
+
+    assert "k_rate" in result
+    assert "bb_rate" in result
+    assert result["k_rate"] is not None
+    assert result["bb_rate"] is not None
+
+
+def test_pitcher_blend_weights_exist_for_expected_windows():
+    assert PITCHER_BLEND_WEIGHTS["last_30_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_90_days"] == 0.35
+    assert PITCHER_BLEND_WEIGHTS["last_365_days"] == 0.30

--- a/tests/test_sample_windows.py
+++ b/tests/test_sample_windows.py
@@ -1,0 +1,37 @@
+import datetime
+
+from mlb_app.sample_windows import (
+    build_sample_metadata,
+    get_window_definition,
+    get_window_start_date,
+)
+
+
+def test_get_window_definition_known_window():
+    result = get_window_definition("last_30_days")
+    assert result["window_type"] == "rolling"
+    assert result["days"] == 30
+    assert result["description"] == "Rolling last 30 days"
+
+
+def test_get_window_start_date_for_rolling_window():
+    target_date = datetime.date(2026, 4, 22)
+    result = get_window_start_date(target_date, "last_90_days")
+    assert result == "2026-01-22"
+
+
+def test_build_sample_metadata_contract():
+    result = build_sample_metadata(
+        window_name="current_season",
+        sample_size=120,
+        sample_blend_policy="single_window_v1",
+        stabilizer_window=None,
+    )
+
+    assert result["sample_window"] == "current_season"
+    assert result["sample_family"] == "season"
+    assert result["sample_description"] == "Current season to date"
+    assert result["sample_days"] is None
+    assert result["sample_size"] == 120
+    assert result["sample_blend_policy"] == "single_window_v1"
+    assert result["stabilizer_window"] is None


### PR DESCRIPTION
Adds the sandbox simulation model stack into the production Model Projections pipeline without replacing the existing main site shell.

This update:
- brings in additive modeling modules for environment, pitcher/hitter profiles, sample windows, bullpen profiles, team offense priors, and simulation engines
- extends `mlb_app/model_projections.py` to append simulation-based model cards to the existing `/models/projections` payload
- keeps the existing Model Projections frontend contract intact by returning additional `models[]` cards rather than replacing the page
- adds away/home run and win projection cards plus a game total projection card
- uses conservative team offense priors and bullpen priors for this first integration, with low confidence labels until lineup/player-level inputs are wired into the endpoint

This lets the live `Model Projections` tab consume the simulation system while preserving the existing production routes, nav, frontend page, and deployment config.