### PR TITLE
Add workspace tabs to model projections

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -54,6 +54,12 @@ const s = {
     gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
     gap: '14px',
   },
+  splitGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))',
+    gap: '14px',
+    marginTop: '14px',
+  },
   metricCard: {
     background: '#161b22',
     border: '1px solid #30363d',
@@ -70,12 +76,6 @@ const s = {
   },
   metricValue: { color: '#58a6ff', fontSize: '30px', fontWeight: 850, lineHeight: 1 },
   metricSub: { color: '#c9d1d9', fontSize: '13px', marginTop: '8px' },
-  splitGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))',
-    gap: '14px',
-    marginTop: '14px',
-  },
   sectionTitle: {
     color: '#58a6ff',
     fontSize: '18px',
@@ -92,6 +92,29 @@ const s = {
   },
   key: { color: '#8b949e' },
   val: { color: '#e6edf3', fontWeight: 750, textAlign: 'right' },
+  tabBar: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    border: '1px solid #30363d',
+    borderRadius: '10px',
+    overflow: 'hidden',
+    margin: '16px 0',
+    width: 'fit-content',
+    maxWidth: '100%',
+  },
+  tab: {
+    border: 0,
+    borderRight: '1px solid #30363d',
+    background: '#0d1117',
+    color: '#8b949e',
+    padding: '10px 14px',
+    fontWeight: 800,
+    cursor: 'pointer',
+  },
+  tabActive: {
+    background: '#58a6ff',
+    color: '#0d1117',
+  },
   details: {
     marginTop: '14px',
     background: '#0a0f14',
@@ -155,6 +178,32 @@ function MetricCard({ labelText, value, sub, format = 'num' }) {
   )
 }
 
+function GenericPanel({ title, subtitle, children }) {
+  return (
+    <div style={s.metricCard}>
+      <div style={s.metricLabel}>{title}</div>
+      {subtitle ? <h3 style={{ margin: '0 0 12px', color: '#e6edf3' }}>{subtitle}</h3> : null}
+      {children}
+    </div>
+  )
+}
+
+function DataSection({ title, data, formatHint = {} }) {
+  if (!data || typeof data !== 'object') {
+    return <GenericPanel title={title}><div style={s.noData}>No data available.</div></GenericPanel>
+  }
+
+  return (
+    <GenericPanel title={title}>
+      {Object.entries(data).map(([key, value]) => {
+        if (value && typeof value === 'object') return null
+        const format = formatHint[key] || (typeof value === 'number' && Math.abs(value) <= 1 ? 'pct' : 'text')
+        return <StatRow key={key} k={label(key)} v={value} format={format} />
+      })}
+    </GenericPanel>
+  )
+}
+
 function TeamProjectionPanel({ side, teamName, pitcherName, model }) {
   const inputs = model?.inputs || {}
 
@@ -213,6 +262,256 @@ function TotalProjectionPanel({ model }) {
   )
 }
 
+function OverviewTab({ game, awayRunModel, homeRunModel, totalModel }) {
+  const away = game?.teams?.away || {}
+  const home = game?.teams?.home || {}
+  const awayInputs = awayRunModel?.inputs || {}
+  const homeInputs = homeRunModel?.inputs || {}
+  const totalInputs = totalModel?.inputs || {}
+
+  return (
+    <>
+      <div style={s.grid}>
+        <MetricCard labelText="Projected Total" value={totalInputs.total_expected_runs ?? totalModel?.score} />
+        <MetricCard labelText={`${game?.away_team?.name || away?.team_name || 'Away'} Win`} value={awayInputs.win_probability} format="pct" />
+        <MetricCard labelText={`${game?.home_team?.name || home?.team_name || 'Home'} Win`} value={homeInputs.win_probability} format="pct" />
+        <MetricCard labelText="Over 8.5" value={totalInputs.over_8_5} format="pct" />
+      </div>
+
+      <div style={s.splitGrid}>
+        <TeamProjectionPanel
+          side="Away"
+          teamName={game?.away_team?.name || away?.team_name}
+          pitcherName={game?.away_pitcher?.name || away?.pitcher_name}
+          model={awayRunModel}
+        />
+        <TeamProjectionPanel
+          side="Home"
+          teamName={game?.home_team?.name || home?.team_name}
+          pitcherName={game?.home_pitcher?.name || home?.pitcher_name}
+          model={homeRunModel}
+        />
+      </div>
+
+      <div style={{ marginTop: '14px' }}>
+        <TotalProjectionPanel model={totalModel} />
+      </div>
+    </>
+  )
+}
+
+function PitcherTab({ workspace }) {
+  return (
+    <div style={s.splitGrid}>
+      <PitcherProfilePanel labelText="Away Starting Pitcher" profile={workspace?.awayPitcherProfile} />
+      <PitcherProfilePanel labelText="Home Starting Pitcher" profile={workspace?.homePitcherProfile} />
+    </div>
+  )
+}
+
+function PitcherProfilePanel({ labelText, profile }) {
+  const metadata = profile?.metadata || {}
+  const arsenal = profile?.arsenal || {}
+
+  return (
+    <div style={s.metricCard}>
+      <div style={s.metricLabel}>{labelText}</div>
+      <h3 style={{ margin: '0 0 4px', color: '#e6edf3' }}>{metadata.pitcher_name || 'Unknown pitcher'}</h3>
+      <div style={{ color: '#8b949e', fontSize: '13px', marginBottom: '12px' }}>
+        {metadata.source_type || 'pitcher profile'}
+        <span style={s.pill}>{metadata.data_confidence || 'unknown'} confidence</span>
+      </div>
+
+      <div style={s.grid}>
+        <DataSection title="Bat Missing" data={profile?.bat_missing} />
+        <DataSection title="Command / Control" data={profile?.command_control} />
+        <DataSection title="Contact Management" data={profile?.contact_management} />
+        <GenericPanel title="Arsenal">
+          <StatRow k="Avg Velocity" v={arsenal.avg_velocity} format="num" />
+          <StatRow k="Avg Spin Rate" v={arsenal.avg_spin_rate} format="num" />
+          <details style={{ marginTop: '10px' }}>
+            <summary style={s.summary}>Pitch mix</summary>
+            <pre style={{ whiteSpace: 'pre-wrap', color: '#c9d1d9', fontFamily: 'inherit' }}>
+              {JSON.stringify(arsenal.pitch_mix || {}, null, 2)}
+            </pre>
+          </details>
+        </GenericPanel>
+      </div>
+    </div>
+  )
+}
+
+function BatterTab({ workspace }) {
+  return (
+    <div style={s.splitGrid}>
+      <OffenseProfilePanel labelText="Away Offense" profile={workspace?.awayOffenseProfile} />
+      <OffenseProfilePanel labelText="Home Offense" profile={workspace?.homeOffenseProfile} />
+    </div>
+  )
+}
+
+function OffenseProfilePanel({ labelText, profile }) {
+  const metadata = profile?.metadata || {}
+
+  return (
+    <div style={s.metricCard}>
+      <div style={s.metricLabel}>{labelText}</div>
+      <h3 style={{ margin: '0 0 4px', color: '#e6edf3' }}>{metadata.team_name || 'Unknown team'}</h3>
+      <div style={{ color: '#8b949e', fontSize: '13px', marginBottom: '12px' }}>
+        {metadata.source_type || 'offense profile'}
+        <span style={s.pill}>{metadata.data_confidence || 'unknown'} confidence</span>
+      </div>
+
+      <div style={s.grid}>
+        <DataSection title="Contact Skill" data={profile?.contact_skill} />
+        <DataSection title="Plate Discipline" data={profile?.plate_discipline} />
+        <DataSection title="Power" data={profile?.power} />
+        <DataSection title="Run Creation" data={profile?.run_creation} />
+      </div>
+    </div>
+  )
+}
+
+function EnvironmentTab({ workspace }) {
+  const profile = workspace?.environmentProfile || {}
+  const run = profile.run_environment || {}
+  const weather = profile.weather || {}
+  const metadata = profile.metadata || {}
+
+  return (
+    <div style={s.splitGrid}>
+      <GenericPanel title="Run Environment" subtitle={label(run.scoring_environment_label)}>
+        <StatRow k="Run Scoring Index" v={run.run_scoring_index} format="num" />
+        <StatRow k="HR Boost Index" v={run.hr_boost_index} format="num" />
+        <StatRow k="Hit Boost Index" v={run.hit_boost_index} format="num" />
+        <StatRow k="Weather Impact" v={run.weather_run_impact} />
+        <StatRow k="Wind Impact" v={run.wind_run_impact} />
+      </GenericPanel>
+
+      <GenericPanel title="Weather">
+        <StatRow k="Temperature" v={weather.temperature_f} format="num" />
+        <StatRow k="Condition" v={weather.condition} />
+        <StatRow k="Wind Speed" v={weather.wind_speed_mph} format="num" />
+        <StatRow k="Wind Direction" v={weather.wind_direction} />
+      </GenericPanel>
+
+      <DataSection title="Metadata" data={metadata} />
+    </div>
+  )
+}
+
+function MatchupTab({ workspace }) {
+  return (
+    <div style={s.splitGrid}>
+      <MatchupPanel labelText="Away Offense vs Home Pitching" analysis={workspace?.awayMatchupAnalysis} />
+      <MatchupPanel labelText="Home Offense vs Away Pitching" analysis={workspace?.homeMatchupAnalysis} />
+    </div>
+  )
+}
+
+function MatchupPanel({ labelText, analysis }) {
+  const metadata = analysis?.metadata || {}
+  const summary = analysis?.summary || {}
+  const plate = analysis?.plate_discipline_matchup || {}
+  const arsenal = analysis?.arsenal_matchup || {}
+
+  return (
+    <div style={s.metricCard}>
+      <div style={s.metricLabel}>{labelText}</div>
+      <h3 style={{ margin: '0 0 8px', color: '#e6edf3' }}>
+        {metadata.offense_team_name || 'Offense'} vs {metadata.opposing_pitcher_name || 'Pitcher'}
+      </h3>
+      <StatRow k="Status" v={summary.status} />
+      <StatRow k="Biggest Edge" v={summary.biggest_edge} />
+      <StatRow k="Confidence" v={summary.confidence} format="pct" />
+      <StatRow k="Note" v={summary.note} />
+
+      <div style={s.grid}>
+        <DataSection title="Plate Discipline Matchup" data={plate} />
+        <GenericPanel title="Arsenal Matchup">
+          <StatRow k="Biggest Edge" v={arsenal.biggest_edge} />
+          <StatRow k="Pitch Count Used" v={arsenal.pitch_count_used} format="num" />
+          <details style={{ marginTop: '10px' }}>
+            <summary style={s.summary}>Pitch edges</summary>
+            <pre style={{ whiteSpace: 'pre-wrap', color: '#c9d1d9', fontFamily: 'inherit' }}>
+              {JSON.stringify(arsenal.pitch_edges || [], null, 2)}
+            </pre>
+          </details>
+        </GenericPanel>
+      </div>
+    </div>
+  )
+}
+
+function BullpenTab({ workspace }) {
+  return (
+    <div style={s.splitGrid}>
+      <BullpenProfilePanel labelText="Away Bullpen" profile={workspace?.awayBullpenProfile} />
+      <BullpenProfilePanel labelText="Home Bullpen" profile={workspace?.homeBullpenProfile} />
+    </div>
+  )
+}
+
+function BullpenProfilePanel({ labelText, profile }) {
+  const metadata = profile?.metadata || {}
+
+  return (
+    <div style={s.metricCard}>
+      <div style={s.metricLabel}>{labelText}</div>
+      <h3 style={{ margin: '0 0 4px', color: '#e6edf3' }}>{metadata.team_name || 'Unknown team'}</h3>
+      <div style={{ color: '#8b949e', fontSize: '13px', marginBottom: '12px' }}>
+        {metadata.bullpen_profile_version || 'bullpen profile'}
+        <span style={s.pill}>{label(metadata.bullpen_quality_label)}</span>
+      </div>
+      <div style={s.grid}>
+        <DataSection title="Bat Missing" data={profile?.bat_missing} />
+        <DataSection title="Command / Control" data={profile?.command_control} />
+        <DataSection title="Contact Management" data={profile?.contact_management} />
+        <DataSection title="Platoon Profile" data={profile?.platoon_profile} />
+        <DataSection title="Arsenal" data={profile?.arsenal} />
+      </div>
+    </div>
+  )
+}
+
+function SimulationTab({ workspace }) {
+  const sim = workspace?.bullpenAdjustedGameSimulation || {}
+  const totals = sim.calibrated_total_probabilities || sim.total_probabilities || {}
+  const teamTotals = sim.calibrated_team_total_probabilities || sim.team_total_probabilities || {}
+
+  return (
+    <div style={s.splitGrid}>
+      <GenericPanel title="Game Simulation" subtitle={sim.model_version || 'bullpen adjusted simulation'}>
+        <StatRow k="Total Expected Runs" v={sim.total_expected_runs} format="num" />
+        <StatRow k="Away Expected Runs" v={sim.away_expected_runs} format="num" />
+        <StatRow k="Home Expected Runs" v={sim.home_expected_runs} format="num" />
+        <StatRow k="Away Win Probability" v={sim.away_win_probability} format="pct" />
+        <StatRow k="Home Win Probability" v={sim.home_win_probability} format="pct" />
+        <StatRow k="Tie After Regulation" v={sim.tie_after_regulation_probability} format="pct" />
+        <StatRow k="Dynamic Starter Exit" v={sim.dynamic_starter_exit ? 'true' : 'false'} />
+      </GenericPanel>
+
+      <GenericPanel title="Game Totals">
+        <StatRow k="Over 6.5" v={totals['over_6.5']} format="pct" />
+        <StatRow k="Over 7.5" v={totals['over_7.5']} format="pct" />
+        <StatRow k="Over 8.5" v={totals['over_8.5']} format="pct" />
+        <StatRow k="Over 9.5" v={totals['over_9.5']} format="pct" />
+        <StatRow k="Under 8.5" v={totals['under_8.5']} format="pct" />
+        <StatRow k="Under 9.5" v={totals['under_9.5']} format="pct" />
+      </GenericPanel>
+
+      <GenericPanel title="Team Totals">
+        <StatRow k="Away 3+ Runs" v={teamTotals.away_3_plus} format="pct" />
+        <StatRow k="Away 4+ Runs" v={teamTotals.away_4_plus} format="pct" />
+        <StatRow k="Away 5+ Runs" v={teamTotals.away_5_plus} format="pct" />
+        <StatRow k="Home 3+ Runs" v={teamTotals.home_3_plus} format="pct" />
+        <StatRow k="Home 4+ Runs" v={teamTotals.home_4_plus} format="pct" />
+        <StatRow k="Home 5+ Runs" v={teamTotals.home_5_plus} format="pct" />
+      </GenericPanel>
+    </div>
+  )
+}
+
 function DiagnosticModelCard({ model }) {
   const inputs = model?.inputs || {}
   return (
@@ -248,22 +547,55 @@ function DiagnosticModelCard({ model }) {
   )
 }
 
-function GameProjectionCard({ game }) {
+function DiagnosticsTab({ game }) {
   const away = game?.teams?.away || {}
   const home = game?.teams?.home || {}
+  const diagnosticModels = [
+    ...(away.models || []),
+    ...(home.models || []),
+  ].filter(m => !isSimulationModel(m))
+
+  return (
+    <div>
+      {diagnosticModels.length ? diagnosticModels.map((model, idx) => (
+        <DiagnosticModelCard key={`${model?.model_name || 'model'}-${idx}`} model={model} />
+      )) : <div style={s.noData}>No diagnostic models available.</div>}
+    </div>
+  )
+}
+
+const TABS = [
+  ['overview', 'Overview'],
+  ['pitcher', 'Pitcher'],
+  ['batter', 'Batter'],
+  ['environment', 'Environment'],
+  ['matchup', 'Matchup Analysis'],
+  ['bullpen', 'Bullpen'],
+  ['simulation', 'Simulation'],
+  ['diagnostics', 'Diagnostics'],
+]
+
+function GameProjectionCard({ game }) {
+  const [activeTab, setActiveTab] = useState('overview')
+  const away = game?.teams?.away || {}
+  const home = game?.teams?.home || {}
+  const workspace = game?.workspace || {}
 
   const awayRunModel = findModel(away, 'Simulation: Away Team Run/Win Projection')
   const homeRunModel = findModel(home, 'Simulation: Home Team Run/Win Projection')
   const totalModel = findModel(away, 'Simulation: Game Total Projection') || findModel(home, 'Simulation: Game Total Projection')
 
-  const awayInputs = awayRunModel?.inputs || {}
-  const homeInputs = homeRunModel?.inputs || {}
-  const totalInputs = totalModel?.inputs || {}
-
-  const diagnosticModels = [
-    ...(away.models || []),
-    ...(home.models || []),
-  ].filter(m => !isSimulationModel(m))
+  function renderTab() {
+    if (activeTab === 'overview') return <OverviewTab game={game} awayRunModel={awayRunModel} homeRunModel={homeRunModel} totalModel={totalModel} />
+    if (activeTab === 'pitcher') return <PitcherTab workspace={workspace} />
+    if (activeTab === 'batter') return <BatterTab workspace={workspace} />
+    if (activeTab === 'environment') return <EnvironmentTab workspace={workspace} />
+    if (activeTab === 'matchup') return <MatchupTab workspace={workspace} />
+    if (activeTab === 'bullpen') return <BullpenTab workspace={workspace} />
+    if (activeTab === 'simulation') return <SimulationTab workspace={workspace} />
+    if (activeTab === 'diagnostics') return <DiagnosticsTab game={game} />
+    return null
+  }
 
   return (
     <article style={s.gameCard}>
@@ -277,51 +609,30 @@ function GameProjectionCard({ game }) {
           </div>
         </div>
         <div style={{ textAlign: 'right' }}>
-          <span style={s.pill}>Simulation Dashboard</span>
-          <span style={s.pill}>{totalModel?.data_confidence || 'low'} confidence</span>
+          <span style={s.pill}>Simulation Workspace</span>
+          <span style={s.pill}>{workspace?.metadata?.data_confidence || totalModel?.data_confidence || 'low'} confidence</span>
         </div>
+      </div>
+
+      <div style={s.tabBar}>
+        {TABS.map(([id, name]) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setActiveTab(id)}
+            style={{
+              ...s.tab,
+              ...(activeTab === id ? s.tabActive : {}),
+            }}
+          >
+            {name}
+          </button>
+        ))}
       </div>
 
       {!awayRunModel || !homeRunModel || !totalModel ? (
         <div style={s.noData}>Simulation projections are not available for this game yet.</div>
-      ) : (
-        <>
-          <div style={s.grid}>
-            <MetricCard labelText="Projected Total" value={totalInputs.total_expected_runs ?? totalModel.score} />
-            <MetricCard labelText={`${game?.away_team?.name || away?.team_name || 'Away'} Win`} value={awayInputs.win_probability} format="pct" />
-            <MetricCard labelText={`${game?.home_team?.name || home?.team_name || 'Home'} Win`} value={homeInputs.win_probability} format="pct" />
-            <MetricCard labelText="Over 8.5" value={totalInputs.over_8_5} format="pct" />
-          </div>
-
-          <div style={s.splitGrid}>
-            <TeamProjectionPanel
-              side="Away"
-              teamName={game?.away_team?.name || away?.team_name}
-              pitcherName={game?.away_pitcher?.name || away?.pitcher_name}
-              model={awayRunModel}
-            />
-            <TeamProjectionPanel
-              side="Home"
-              teamName={game?.home_team?.name || home?.team_name}
-              pitcherName={game?.home_pitcher?.name || home?.pitcher_name}
-              model={homeRunModel}
-            />
-          </div>
-
-          <div style={{ marginTop: '14px' }}>
-            <TotalProjectionPanel model={totalModel} />
-          </div>
-        </>
-      )}
-
-      <details style={s.details}>
-        <summary style={s.summary}>Legacy / diagnostic models</summary>
-        <div style={{ marginTop: '12px' }}>
-          {diagnosticModels.length ? diagnosticModels.map((model, idx) => (
-            <DiagnosticModelCard key={`${model?.model_name || 'model'}-${idx}`} model={model} />
-          )) : <div style={s.noData}>No diagnostic models available.</div>}
-        </div>
-      </details>
+      ) : renderTab()}
     </article>
   )
 }
@@ -374,7 +685,7 @@ export default function ModelProjectionsPage() {
       <header style={s.header}>
         <h1 style={s.title}>Model Projections</h1>
         <p style={s.subtitle}>
-          Simulation-first projections powered by team offense priors, bullpen profiles, environment, and calibrated game outcomes.
+          Full prediction workspace powered by pitcher profiles, offense profiles, environment, matchup analysis, bullpen modeling, and calibrated simulations.
         </p>
         <label style={{ color: '#c9d1d9' }}>
           Date:


### PR DESCRIPTION
Adds sandbox-style workspace tabs to the production Model Projections page.

This update:
- adds per-game tabs for Overview, Pitcher, Batter, Environment, Matchup Analysis, Bullpen, Simulation, and Diagnostics
- renders the new `game.workspace` payload fields added by the backend workspace PR
- keeps the simulation-first overview as the default tab
- surfaces pitcher profiles, offense profiles, environment profile, matchup analysis, bullpen profiles, and bullpen-adjusted simulation in structured panels
- preserves the existing route and `/models/projections` API contract

This moves the Model Projections tab closer to the full sandbox modeling workspace while keeping the main app layout intact.