### PR TITLE
Add projection simulation contract snapshots

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -451,6 +451,7 @@ def _build_projection_simulation_cards(
         "awayMatchupAnalysis": _matchup_workspace_analysis(away, home),
         "homeMatchupAnalysis": _matchup_workspace_analysis(home, away),
         "bullpenAdjustedGameSimulation": sim,
+        "debug_marker": "SIM_CONTRACT_V1",
         # -----------------------------
         # Simulation Contract (DEBUG)
         # -----------------------------

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -451,6 +451,30 @@ def _build_projection_simulation_cards(
         "awayMatchupAnalysis": _matchup_workspace_analysis(away, home),
         "homeMatchupAnalysis": _matchup_workspace_analysis(home, away),
         "bullpenAdjustedGameSimulation": sim,
+        # -----------------------------
+        # Simulation Contract (DEBUG)
+        # -----------------------------
+        "simulationContract": {
+            "source_builder": "model_projections._build_projection_simulation_cards",
+            "game_pk": matchup.get("game_pk"),
+            "simulation_model_version": sim.get("model_version"),
+            "simulation_count": sim.get("simulations") or (sim.get("metadata") or {}).get("simulation_count"),
+            "seed": (sim.get("metadata") or {}).get("seed"),
+            "dynamic_starter_exit": (sim.get("metadata") or {}).get("dynamic_starter_exit"),
+            "away_starter_pa_model_version": (away_vs_home_starter_pa or {}).get("model_version"),
+            "home_starter_pa_model_version": (home_vs_away_starter_pa or {}).get("model_version"),
+            "away_bullpen_pa_model_version": (away_vs_home_bullpen_pa or {}).get("model_version"),
+            "home_bullpen_pa_model_version": (home_vs_away_bullpen_pa or {}).get("model_version"),
+        },
+
+        # -----------------------------
+        # PA Model Snapshots
+        # -----------------------------
+        "awayStarterPAOutcomeModel": away_vs_home_starter_pa,
+        "homeStarterPAOutcomeModel": home_vs_away_starter_pa,
+        "awayBullpenPAOutcomeModel": away_vs_home_bullpen_pa,
+        "homeBullpenPAOutcomeModel": home_vs_away_bullpen_pa,
+
         "metadata": {
             "workspace_version": "model_projection_workspace_v1",
             "generated_from": "model_projections._build_projection_simulation_cards",


### PR DESCRIPTION
This PR carries the commits that landed after PR #167 was merged early.

Adds the missing Model Projections debug/contract fields needed to verify that production is running the expected simulation path:

- `debug_marker: SIM_CONTRACT_V1`
- `simulationContract`
- starter PA model snapshots
- bullpen PA model snapshots

Why this is needed:
- PR #167 merged at commit `cde6ab5`, before the later commits `d1d3e2a` and `bd976b2` were included.
- `upstream/main` does not currently contain `SIM_CONTRACT_V1` or `simulationContract`.
- `origin/feature/model-projections-simulation-contract` does contain them.

Validation already run locally:
- `python -m compileall mlb_app/model_projections.py`

After this merges/deploys, production should show the marker via:

```bash
curl -s "https://mlb-prediction-app-production-732c.up.railway.app/models/projections?date=2026-05-01" | grep debug_marker
```

Then we can compare PA model versions and align the production projection path with the sandbox/full matchup simulation path.