### PR TITLE
Inject lineup offense into model projections

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -121,18 +121,18 @@ def _probability_model_card(
     }
 
 
-def _team_offense_prior_pa_model(
+def build_pa_outcome_probabilities(
     team_id: Optional[int],
     team_name: Optional[str],
     opposing_pitcher_profile: Optional[Dict[str, Any]],
     environment_profile: Dict[str, Any],
-) -> Dict[str, Any]:
+, model_version="lineup_pa_outcome_v1") -> Dict[str, Any]:
     offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
     return build_pa_outcome_probabilities(
         batter_profile=offense_profile,
         pitcher_profile=opposing_pitcher_profile or {},
         environment_profile=environment_profile,
-    )
+    , model_version="lineup_pa_outcome_v1")
 
 
 def _weather_context(value: Any) -> Dict[str, Any]:
@@ -311,30 +311,30 @@ def _build_projection_simulation_cards(
     away_bullpen_profile = build_bullpen_profile(team_id=away_team_id, team_name=away_team_name)
     home_bullpen_profile = build_bullpen_profile(team_id=home_team_id, team_name=home_team_name)
 
-    away_vs_home_starter_pa = _team_offense_prior_pa_model(
+    away_vs_home_starter_pa = build_pa_outcome_probabilities(
         team_id=away_team_id,
         team_name=away_team_name,
         opposing_pitcher_profile=home_pitcher_profile,
         environment_profile=environment_profile,
-    )
-    home_vs_away_starter_pa = _team_offense_prior_pa_model(
+    , model_version="lineup_pa_outcome_v1")
+    home_vs_away_starter_pa = build_pa_outcome_probabilities(
         team_id=home_team_id,
         team_name=home_team_name,
         opposing_pitcher_profile=away_pitcher_profile,
         environment_profile=environment_profile,
-    )
-    away_vs_home_bullpen_pa = _team_offense_prior_pa_model(
+    , model_version="lineup_pa_outcome_v1")
+    away_vs_home_bullpen_pa = build_pa_outcome_probabilities(
         team_id=away_team_id,
         team_name=away_team_name,
         opposing_pitcher_profile=home_bullpen_profile,
         environment_profile=environment_profile,
-    )
-    home_vs_away_bullpen_pa = _team_offense_prior_pa_model(
+    , model_version="lineup_pa_outcome_v1")
+    home_vs_away_bullpen_pa = build_pa_outcome_probabilities(
         team_id=home_team_id,
         team_name=home_team_name,
         opposing_pitcher_profile=away_bullpen_profile,
         environment_profile=environment_profile,
-    )
+    , model_version="lineup_pa_outcome_v1")
 
     sim = simulate_game_with_bullpen(
         away_starter_probabilities=away_vs_home_starter_pa.get("probabilities") or {},

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -542,6 +542,8 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
         try:
             away = _side_context(matchup, "away", session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
+            matchup["awayProjectedLineupOffenseProfile"] = away.get("offense_inputs")
+            matchup["homeProjectedLineupOffenseProfile"] = home.get("offense_inputs")
 
             simulation_cards = _build_projection_simulation_cards(matchup, away, home)
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -540,7 +540,11 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
     errors: List[Dict[str, Any]] = []
     for matchup in matchups:
         try:
-            away = _side_context(matchup, "away", session, date_obj.year)
+            away = _side_context(matchup, "away"
+            # Inject lineup offense for PA model alignment
+            matchup["awayProjectedLineupOffenseProfile"] = away.get("offense_inputs")
+            matchup["homeProjectedLineupOffenseProfile"] = home.get("offense_inputs")
+, session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
 
             simulation_cards = _build_projection_simulation_cards(matchup, away, home)

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -126,8 +126,12 @@ def _team_offense_prior_pa_model(
     team_name: Optional[str],
     opposing_pitcher_profile: Optional[Dict[str, Any]],
     environment_profile: Dict[str, Any],
+    offense_profile: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
+    # Use provided offense profile (lineup-based if available)
+    if not offense_profile:
+        offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
+
     return build_pa_outcome_probabilities(
         batter_profile=offense_profile,
         pitcher_profile=opposing_pitcher_profile or {},

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -540,11 +540,7 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
     errors: List[Dict[str, Any]] = []
     for matchup in matchups:
         try:
-            away = _side_context(matchup, "away"
-            # Inject lineup offense for PA model alignment
-            matchup["awayProjectedLineupOffenseProfile"] = away.get("offense_inputs")
-            matchup["homeProjectedLineupOffenseProfile"] = home.get("offense_inputs")
-, session, date_obj.year)
+            away = _side_context(matchup, "away", session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
 
             simulation_cards = _build_projection_simulation_cards(matchup, away, home)

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -121,18 +121,18 @@ def _probability_model_card(
     }
 
 
-def build_pa_outcome_probabilities(
+def _team_offense_prior_pa_model(
     team_id: Optional[int],
     team_name: Optional[str],
     opposing_pitcher_profile: Optional[Dict[str, Any]],
     environment_profile: Dict[str, Any],
-, model_version="lineup_pa_outcome_v1") -> Dict[str, Any]:
+) -> Dict[str, Any]:
     offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
     return build_pa_outcome_probabilities(
         batter_profile=offense_profile,
         pitcher_profile=opposing_pitcher_profile or {},
         environment_profile=environment_profile,
-    , model_version="lineup_pa_outcome_v1")
+    )
 
 
 def _weather_context(value: Any) -> Dict[str, Any]:
@@ -311,30 +311,30 @@ def _build_projection_simulation_cards(
     away_bullpen_profile = build_bullpen_profile(team_id=away_team_id, team_name=away_team_name)
     home_bullpen_profile = build_bullpen_profile(team_id=home_team_id, team_name=home_team_name)
 
-    away_vs_home_starter_pa = build_pa_outcome_probabilities(
+    away_vs_home_starter_pa = _team_offense_prior_pa_model(
         team_id=away_team_id,
         team_name=away_team_name,
         opposing_pitcher_profile=home_pitcher_profile,
         environment_profile=environment_profile,
-    , model_version="lineup_pa_outcome_v1")
-    home_vs_away_starter_pa = build_pa_outcome_probabilities(
+    )
+    home_vs_away_starter_pa = _team_offense_prior_pa_model(
         team_id=home_team_id,
         team_name=home_team_name,
         opposing_pitcher_profile=away_pitcher_profile,
         environment_profile=environment_profile,
-    , model_version="lineup_pa_outcome_v1")
-    away_vs_home_bullpen_pa = build_pa_outcome_probabilities(
+    )
+    away_vs_home_bullpen_pa = _team_offense_prior_pa_model(
         team_id=away_team_id,
         team_name=away_team_name,
         opposing_pitcher_profile=home_bullpen_profile,
         environment_profile=environment_profile,
-    , model_version="lineup_pa_outcome_v1")
-    home_vs_away_bullpen_pa = build_pa_outcome_probabilities(
+    )
+    home_vs_away_bullpen_pa = _team_offense_prior_pa_model(
         team_id=home_team_id,
         team_name=home_team_name,
         opposing_pitcher_profile=away_bullpen_profile,
         environment_profile=environment_profile,
-    , model_version="lineup_pa_outcome_v1")
+    )
 
     sim = simulate_game_with_bullpen(
         away_starter_probabilities=away_vs_home_starter_pa.get("probabilities") or {},


### PR DESCRIPTION
Adds the follow-up projection alignment work after the simulation contract PRs.

This PR includes the latest commits on `feature/model-projections-simulation-contract`, including:
- simulation contract / PA model snapshots in the Model Projections workspace
- debug marker used to verify production deploy path
- targeted lineup-offense injection intended to move Model Projections closer to the sandbox/full matchup simulation path

Context:
- Production contract now confirms `/models/projections` uses `pa_outcome_v1`, while sandbox `/matchup/:game_pk` uses `lineup_pa_outcome_v1`.
- The goal is to expose and begin aligning the offense input source used by Model Projections.

Validation note:
- Colin reported the latest local compile/check flow before pushing the branch. Please verify CI/compile before merge because this branch has had prior syntax-repair commits during debugging.