### PR TITLE
Expose lineup availability in projections

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -461,6 +461,11 @@ def _build_projection_simulation_cards(
         # -----------------------------
         "simulationContract": {
             "source_builder": "model_projections._build_projection_simulation_cards",
+            "away_offense_source": ((away.get("offense_inputs") or {}).get("source")),
+            "home_offense_source": ((home.get("offense_inputs") or {}).get("source")),
+            "away_lineup_available": bool(matchup.get("away_lineup") or matchup.get("awayLineup") or matchup.get("away_projected_lineup")),
+            "home_lineup_available": bool(matchup.get("home_lineup") or matchup.get("homeLineup") or matchup.get("home_projected_lineup")),
+            "away_matchup_keys": sorted([k for k in matchup.keys() if "lineup" in str(k).lower() or "offense" in str(k).lower()]),
             "game_pk": matchup.get("game_pk"),
             "simulation_model_version": sim.get("model_version"),
             "simulation_count": sim.get("simulations") or (sim.get("metadata") or {}).get("simulation_count"),
@@ -542,8 +547,6 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
         try:
             away = _side_context(matchup, "away", session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
-            matchup["awayProjectedLineupOffenseProfile"] = away.get("offense_inputs")
-            matchup["homeProjectedLineupOffenseProfile"] = home.get("offense_inputs")
 
             simulation_cards = _build_projection_simulation_cards(matchup, away, home)
 


### PR DESCRIPTION
Follow-up cleanup after the projection alignment debugging.

This PR removes the fake projected-lineup injection that mapped `offense_inputs` into `awayProjectedLineupOffenseProfile` / `homeProjectedLineupOffenseProfile`. That was misleading because `offense_inputs` is a team-splits fallback, not the sandbox `projected_lineup_profile` generated from player-level hitter profiles.

It also adds lineup availability/source fields into the `simulationContract` so the production `/models/projections` endpoint can tell us whether actual lineup objects are present before attempting to build `build_projected_lineup_offense_profile(...)`.

Context from debugging:
- Sandbox lineup profile is generated by `aggregate_hitter_profiles` and contains `contact_skill`, `plate_discipline`, `power`, `batted_ball_quality`, and `platoon_profile`.
- Main Model Projections offense profile currently comes from `team_splits` and remains `pa_outcome_v1`.
- The correct next step is to wire the real `build_projected_lineup_offense_profile(lineup, season, pitcher_hand, lineup_source, target_date)` builder only if `/models/projections` has access to an actual lineup list.

Validated locally:
- `python -m compileall mlb_app/model_projections.py`