### PR TITLE
Revert unified projections patch

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -548,61 +548,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             away = _side_context(matchup, "away", session, date_obj.year)
             home = _side_context(matchup, "home", session, date_obj.year)
 
-            # -----------------------------
-            # Unified Simulation (Matchup Engine)
-            # -----------------------------
-            from .matchup_detail import build_matchup_detail
+            simulation_cards = _build_projection_simulation_cards(matchup, away, home)
 
-            full_matchup = build_matchup_detail(matchup.get("game_pk"))
+            away["models"].extend(simulation_cards.get("away", []))
+            home["models"].extend(simulation_cards.get("home", []))
 
-            sim = (
-                full_matchup.get("bullpenAdjustedGameSimulation")
-                or full_matchup.get("gameSimulation")
-                or {}
-            )
+            workspace = simulation_cards.get("workspace") or {}
 
-            away_expected = sim.get("away_expected_runs")
-            home_expected = sim.get("home_expected_runs")
-            total_expected = sim.get("total_expected_runs")
-
-            away_win = sim.get("away_win_probability")
-            home_win = sim.get("home_win_probability")
-
-            away["models"].append({
-                "model_name": "Simulation: Away Team Run/Win Projection",
-                "score": away_expected,
-                "status": "calculated",
-                "data_confidence": "high",
-                "inputs": sim,
-            })
-
-            home["models"].append({
-                "model_name": "Simulation: Home Team Run/Win Projection",
-                "score": home_expected,
-                "status": "calculated",
-                "data_confidence": "high",
-                "inputs": sim,
-            })
-
-            away["models"].append({
-                "model_name": "Simulation: Game Total Projection",
-                "score": total_expected,
-                "status": "calculated",
-                "data_confidence": "high",
-                "inputs": sim,
-            })
-
-            workspace = {
-                "simulationContract": {
-                    "source_builder": "matchup_detail",
-                    "game_pk": matchup.get("game_pk"),
-                    "simulation_model_version": sim.get("model_version"),
-                    "engine": "unified_matchup_engine"
-                }
-            }
-
-
-            
             games.append({
                 "game_pk": matchup.get("game_pk"),
                 "game_date": matchup.get("game_date") or target_date,


### PR DESCRIPTION
Reverts PR #171 / commit `5ec4a7c` because the direct unified simulation patch broke `/models/projections`.

Observed issue after deploy:
- `/models/projections?date=2026-05-01` returned an empty `games` array or otherwise no game payload.
- The verification script failed with `IndexError: list index out of range` because `(m.get("games") or [])[0]` had no elements.

Reason:
- The patch attempted to call a guessed matchup-detail helper path instead of first extracting the real `/matchup/:game_pk` builder from `mlb_app/app.py`.

This revert restores the prior working Model Projections path while preserving the earlier simulation contract / lineup availability debugging work from PR #170.

Local validation:
- `python -m compileall mlb_app/model_projections.py`
- Diff vs upstream/main shows only `mlb_app/model_projections.py` reverting the PR #171 changes.