### PR TITLE
Wire starter quality into dynamic bullpen simulation

### DIFF
--- a/mlb_app/simulation/game_engine_v2.py
+++ b/mlb_app/simulation/game_engine_v2.py
@@ -393,6 +393,9 @@ def _build_bullpen_adjusted_game_sim(
     simulations,
     seed,
     starter_innings,
+    away_starter_quality=None,
+    home_starter_quality=None,
+    dynamic_starter_exit=True,
 ):
     # ✅ normalize inside function (NOT in signature)
     away_starter_pa_model = away_starter_pa_model or {}
@@ -409,6 +412,9 @@ def _build_bullpen_adjusted_game_sim(
         seed=seed,
         innings=9,
         starter_innings=starter_innings,
+        away_starter_quality=away_starter_quality,
+        home_starter_quality=home_starter_quality,
+        dynamic_starter_exit=dynamic_starter_exit,
     )
 
 def _source_summary(matchup: Dict[str, Any], environment_profile: Dict[str, Any]) -> Dict[str, Any]:
@@ -661,6 +667,9 @@ def run_full_game_simulation(game_pk: int, config: Optional[Dict[str, Any]] = No
         simulations=simulations,
         seed=seed,
         starter_innings=starter_innings,
+        away_starter_quality=away_starter_quality.get("score"),
+        home_starter_quality=home_starter_quality.get("score"),
+        dynamic_starter_exit=True,
     )
 
     sources = _source_summary(matchup, environment_profile) or {}
@@ -717,7 +726,7 @@ def run_full_game_simulation(game_pk: int, config: Optional[Dict[str, Any]] = No
                 "away_expected_starter_innings": away_expected_starter_innings,
                 "home_expected_starter_innings": home_expected_starter_innings,
                 "simulator_starter_innings": starter_innings,
-                "note": "simulate_game_with_bullpen currently accepts one shared starter_innings value; using average of away/home expected innings.",
+                "note": "simulate_game_with_bullpen now receives starter quality scores and samples starter exit innings dynamically per simulation.",
             },
         },
         "meta": {


### PR DESCRIPTION
## Summary

Wires the expected starter innings / starter quality layer into the bullpen-adjusted game simulation.

## Changes

- Passes starter quality scores into `_build_bullpen_adjusted_game_sim`.
- Forwards `away_starter_quality`, `home_starter_quality`, and `dynamic_starter_exit=True` into `simulate_game_with_bullpen`.
- Enables the simulator's existing quality-based starter exit distribution to affect starter/bullpen exposure across simulations.
- Updates the starter-exit diagnostic note to reflect dynamic per-simulation exit sampling.

## Local validation

```text
python -m compileall mlb_app
/matchup/823554 sharedGameSimulation:
STATUS: ok
ERROR: None
HAS_DERIVED: True
```

## Modeling context

This keeps the project focused on building the simulation distribution before introducing market comparison. The model now moves one layer closer to range-of-outcomes truth by allowing starter quality to influence bullpen exposure rather than relying only on a fixed starter innings assumption.