### PR TITLE
Pass model projection matchup into shared simulation

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -565,6 +565,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                         "seed": 42,
                         "starter_exit_enabled": True,
                         "source_route": "/models/projections",
+                        "matchup": {
+                            "raw": matchup,
+                            "game_date": matchup.get("game_date") or target_date,
+                        },
                     },
                 )
             except Exception as shared_exc:


### PR DESCRIPTION
Passes the already-built Model Projections matchup into the shared simulation builder.

Key changes:
- Adds config.matchup.raw when calling build_shared_game_simulation from model_projections.py
- Adds config.matchup.game_date so the engine can use the current matchup context directly
- Avoids unnecessary rediscovery of the same game inside the shared simulation engine

Goal:
Make /models/projections more deterministic and keep shared simulation inputs aligned with the matchup payload already built by generate_matchups_for_date.

Validation performed locally:
- python -m compileall mlb_app
- cd frontend && npm run build