### PR TITLE
Calibrate simulation win probabilities with confidence shrinkage

### DIFF
--- a/mlb_app/simulation/game_simulator.py
+++ b/mlb_app/simulation/game_simulator.py
@@ -76,6 +76,10 @@ GAME_SIM_CALIBRATION = {
     # Pull extreme team totals modestly toward a neutral MLB-ish scoring level.
     "team_run_regression_anchor": 4.45,
     "team_run_regression_weight": 0.12,
+    # First-pass probability calibration. Backtest showed run means were
+    # calibrated but win probabilities were too confident at the extremes.
+    # Keep direction/order, but shrink raw simulation win frequency toward 50%.
+    "win_probability_confidence_scale": 0.75,
 }
 
 
@@ -87,6 +91,18 @@ def _calibrate_expected_runs(raw_runs: float) -> float:
     shrunk = raw_runs * shrinkage
     calibrated = (shrunk * (1.0 - regression_weight)) + (anchor * regression_weight)
     return round(calibrated, 4)
+
+
+def _calibrate_win_probability(raw_probability: float) -> float:
+    """
+    Shrink raw simulation win frequency toward 50%.
+
+    This is intentionally conservative. It addresses observed overconfidence
+    in probability extremes without changing the underlying run simulation.
+    """
+    scale = GAME_SIM_CALIBRATION["win_probability_confidence_scale"]
+    calibrated = 0.5 + ((raw_probability - 0.5) * scale)
+    return max(0.001, min(0.999, calibrated))
 
 
 def simulate_game(
@@ -141,8 +157,10 @@ def simulate_game(
     total_expected_runs = round(away_expected_runs + home_expected_runs, 4)
 
     # V1 has no extras. Split regulation ties evenly for a rough win-probability estimate.
-    home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
-    away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+    raw_home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
+    raw_away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+    home_win_probability = _calibrate_win_probability(raw_home_win_probability)
+    away_win_probability = _calibrate_win_probability(raw_away_win_probability)
 
     calibrated_total_runs_counter = _calibrated_counter_by_mean_shift(
         total_runs_counter,
@@ -190,6 +208,10 @@ def simulate_game(
         "raw_total_expected_runs": round(raw_total_expected_runs, 4),
         "away_win_probability": round(away_win_probability, 4),
         "home_win_probability": round(home_win_probability, 4),
+        "raw_away_win_probability": round(raw_away_win_probability, 4),
+        "raw_home_win_probability": round(raw_home_win_probability, 4),
+        "raw_away_win_probability": round(raw_away_win_probability, 4),
+        "raw_home_win_probability": round(raw_home_win_probability, 4),
         "tie_after_regulation_probability": round(ties_after_regulation / simulations, 4),
         "away_run_distribution": _distribution(away_runs_counter, simulations),
         "home_run_distribution": _distribution(home_runs_counter, simulations),
@@ -417,8 +439,10 @@ def simulate_game_with_bullpen(
     home_expected_runs = _calibrate_expected_runs(raw_home_expected_runs)
     total_expected_runs = round(away_expected_runs + home_expected_runs, 4)
 
-    home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
-    away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+    raw_home_win_probability = (home_wins + (ties_after_regulation * 0.5)) / simulations
+    raw_away_win_probability = (away_wins + (ties_after_regulation * 0.5)) / simulations
+    home_win_probability = _calibrate_win_probability(raw_home_win_probability)
+    away_win_probability = _calibrate_win_probability(raw_away_win_probability)
 
     calibrated_total_runs_counter = _calibrated_counter_by_mean_shift(
         total_runs_counter,
@@ -515,7 +539,7 @@ def simulate_game_with_bullpen(
             "home_starter_innings_distribution": _distribution(home_starter_innings_counter, simulations),
             "bullpen_innings": max(0, innings - starter_innings),
             **GAME_SIM_CALIBRATION,
-            "calibration_applied_to": ["expected_runs", "total_probabilities", "team_total_probabilities"],
+            "calibration_applied_to": ["expected_runs", "win_probability", "total_probabilities", "team_total_probabilities"],
             "distribution_calibration_method": "integer_mean_shift_v1",
             "notes": [
                 "V1 uses starter PA probabilities for early innings and bullpen PA probabilities for late innings.",


### PR DESCRIPTION
## Summary

Adds a conservative final win-probability calibration layer to reduce overconfidence in simulation probability extremes.

## Changes

- Adds `win_probability_confidence_scale = 0.75` to `GAME_SIM_CALIBRATION`
- Adds `_calibrate_win_probability(...)`
- Applies calibration to final `home_win_probability` and `away_win_probability`
- Preserves raw simulation frequencies as:
  - `raw_home_win_probability`
  - `raw_away_win_probability`
- Updates metadata `calibration_applied_to` to include `win_probability`

## Why this matters

Backtesting showed the run model was well-calibrated on aggregate, but raw simulated win frequencies were too confident in the extremes. This PR does not change the PA model, run simulation, expected runs, totals, or distributions. It only calibrates the final mapping from raw simulated win frequency to user-facing win probability.

Formula:

```python
calibrated_p = 0.5 + ((raw_p - 0.5) * 0.75)
```

Examples:

- `0.70 → 0.65`
- `0.60 → 0.575`
- `0.55 → 0.5375`
- `0.40 → 0.425`
- `0.30 → 0.35`

## Validation

Backtest range:

```bash
BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 python scripts/backtest_simulation.py
```

Before probability calibration:

- Winner accuracy: `0.5514`
- Brier score: `0.2493`
- Log loss: `0.6928`

After probability calibration:

- Winner accuracy: `0.5514`
- Brier score: `0.2468`
- Log loss: `0.6870`

Run outputs were unchanged as expected:

- Away run MAE: `2.6947`
- Home run MAE: `2.2823`
- Total run MAE: `3.6124`
- Total run bias: `+0.0859`

## Risk

Low-to-medium. This changes final user-facing win probabilities but preserves the raw probabilities for diagnostics and does not alter the underlying simulation mechanics.

## Notes

This should remain separate from the PA hit-probability calibration PR because it calibrates a different layer:

- PA PR: improves run-generation shape
- This PR: improves final probability confidence calibration