### PR TITLE
Add static park factors to environment profiles

### DIFF
--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -7,6 +7,8 @@ be populated with real weather, park factor, and contextual inputs.
 
 import re
 
+from .park_factors import get_park_factor_profile
+
 
 def compute_environment_profile(raw_context: dict) -> dict:
     """
@@ -240,14 +242,32 @@ def compute_environment_profile(raw_context: dict) -> dict:
     if parsed_wind_direction:
         wind_direction = parsed_wind_direction
 
-    run_factor = raw_context.get("run_factor", raw_context.get("park_factor"))
-    run_factor = _safe_float(run_factor)
+    park_factor_profile = raw_context.get("park_factor_profile") or {}
+    venue_name = raw_context.get("venue_name")
+    if not park_factor_profile and venue_name:
+        park_factor_profile = get_park_factor_profile(venue_name)
+
+    raw_run_factor = raw_context.get("run_factor", raw_context.get("park_factor"))
+    run_factor = _safe_float(raw_run_factor)
 
     raw_home_run_factor = _safe_float(raw_context.get("home_run_factor"))
     raw_hit_factor = _safe_float(raw_context.get("hit_factor"))
 
+    park_factor_profile_found = bool(park_factor_profile.get("park_factor_profile_found"))
+    static_park_factor_used = False
+
+    if run_factor is None:
+        run_factor = _safe_float(park_factor_profile.get("run_factor"))
+        static_park_factor_used = run_factor is not None and park_factor_profile.get("source") != "neutral_fallback_unmapped_venue"
+
     home_run_factor = raw_home_run_factor
     hit_factor = raw_hit_factor
+
+    if home_run_factor is None:
+        home_run_factor = _safe_float(park_factor_profile.get("home_run_factor"))
+    if hit_factor is None:
+        hit_factor = _safe_float(park_factor_profile.get("hit_factor"))
+
     park_factor_fallback_used = False
     park_factor_fallback_source = None
 
@@ -260,6 +280,15 @@ def compute_environment_profile(raw_context: dict) -> dict:
         park_factor_fallback_used = True
         park_factor_fallback_source = "run_factor_proxy"
 
+    if run_factor is None:
+        run_factor = calibration["neutral_index"]
+        park_factor_fallback_used = True
+        park_factor_fallback_source = "neutral_fallback_missing_venue_or_park_factor"
+    if home_run_factor is None:
+        home_run_factor = calibration["neutral_index"]
+    if hit_factor is None:
+        hit_factor = calibration["neutral_index"]
+
     wind_adjustments = _wind_adjustments(wind_speed_mph, wind_direction)
 
     run_scoring_index = raw_context.get(
@@ -267,13 +296,16 @@ def compute_environment_profile(raw_context: dict) -> dict:
         _run_scoring_index(run_factor, temperature_f, wind_speed_mph, wind_direction),
     )
     base_index = run_factor if run_factor is not None else calibration["neutral_index"]
+    hr_base_index = home_run_factor if home_run_factor is not None else base_index
+    hit_base_index = hit_factor if hit_factor is not None else base_index
+
     hr_boost_index = raw_context.get(
         "hr_boost_index",
-        _calibrated_index(base_index, _temperature_adjustment(temperature_f) + wind_adjustments["wind_hr_adjustment"]),
+        _calibrated_index(hr_base_index, _temperature_adjustment(temperature_f) + wind_adjustments["wind_hr_adjustment"]),
     )
     hit_boost_index = raw_context.get(
         "hit_boost_index",
-        _calibrated_index(base_index, (_temperature_adjustment(temperature_f) * 0.35) + wind_adjustments["wind_hit_adjustment"]),
+        _calibrated_index(hit_base_index, (_temperature_adjustment(temperature_f) * 0.35) + wind_adjustments["wind_hit_adjustment"]),
     )
 
     missing_inputs = []
@@ -281,7 +313,7 @@ def compute_environment_profile(raw_context: dict) -> dict:
         missing_inputs.append("temperature_f")
     if wind_speed_mph is None and not wind_direction:
         missing_inputs.append("wind")
-    if run_factor is None:
+    if not park_factor_profile_found and not static_park_factor_used:
         missing_inputs.append("run_factor")
 
     source_fields_used = [
@@ -298,8 +330,16 @@ def compute_environment_profile(raw_context: dict) -> dict:
     ]
 
     temperature_adjustment = _temperature_adjustment(temperature_f)
-    park_component_source = "real_or_schedule_provided" if run_factor is not None else "neutral_fallback"
-    if park_factor_fallback_used and park_factor_fallback_source:
+    if raw_run_factor is not None:
+        park_component_source = "real_or_schedule_provided"
+    elif static_park_factor_used:
+        park_component_source = park_factor_profile.get("source") or "static_park_factor_v1"
+    elif park_factor_profile.get("source"):
+        park_component_source = park_factor_profile.get("source")
+    else:
+        park_component_source = "neutral_fallback"
+
+    if park_factor_fallback_used and park_factor_fallback_source and not static_park_factor_used:
         park_component_source = park_factor_fallback_source
 
     weather_component_source = "schedule_weather" if temperature_f is not None or wind_speed_mph is not None or wind_direction else "missing_weather"
@@ -333,7 +373,13 @@ def compute_environment_profile(raw_context: dict) -> dict:
                 "home_run_factor": home_run_factor,
                 "hit_factor": hit_factor,
                 "source": park_component_source,
-                "neutral_fallback_used": run_factor is None,
+                "park_factor_profile_found": park_factor_profile_found,
+                "static_park_factor_used": static_park_factor_used,
+                "normalized_venue_name": park_factor_profile.get("normalized_venue_name"),
+                "venue_type": park_factor_profile.get("venue_type"),
+                "default_roof_status": park_factor_profile.get("default_roof_status"),
+                "weather_applies_default": park_factor_profile.get("weather_applies_default"),
+                "neutral_fallback_used": bool(park_factor_profile.get("neutral_park_fallback_used")),
                 "proxy_from_run_factor_used": park_factor_fallback_used,
                 "proxy_source": park_factor_fallback_source,
             },

--- a/mlb_app/park_factors.py
+++ b/mlb_app/park_factors.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Optional
+
+
+PARK_FACTOR_SOURCE = "static_park_factor_v1"
+
+
+def normalize_venue_name(name: Optional[str]) -> Optional[str]:
+    if not name:
+        return None
+    text = str(name).lower().strip()
+    text = text.replace("&", "and")
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
+
+
+def _profile(
+    venue_name: str,
+    run_factor: float,
+    home_run_factor: float,
+    hit_factor: float,
+    venue_type: str = "outdoor",
+    default_roof_status: str = "open",
+    weather_applies_default: bool | str = True,
+    aliases: Optional[list[str]] = None,
+) -> Dict[str, Any]:
+    normalized = normalize_venue_name(venue_name)
+    return {
+        "venue_name": venue_name,
+        "normalized_venue_name": normalized,
+        "aliases": aliases or [],
+        "run_factor": run_factor,
+        "home_run_factor": home_run_factor,
+        "hit_factor": hit_factor,
+        "venue_type": venue_type,
+        "default_roof_status": default_roof_status,
+        "weather_applies_default": weather_applies_default,
+        "source": PARK_FACTOR_SOURCE,
+        "park_factor_profile_found": True,
+        "neutral_park_fallback_used": False,
+    }
+
+
+# Conservative first-pass factors centered near 1.000.
+# These are intentionally shrinked; they should be refined only after backtesting.
+PARK_FACTORS: Dict[str, Dict[str, Any]] = {}
+
+_RAW_PROFILES = [
+    _profile("Angel Stadium", 0.99, 0.98, 1.00, aliases=["Angel Stadium of Anaheim"]),
+    _profile("Busch Stadium", 0.98, 0.96, 0.99),
+    _profile("Chase Field", 1.01, 1.02, 1.01, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown"),
+    _profile("Citi Field", 0.98, 0.96, 0.99),
+    _profile("Citizens Bank Park", 1.02, 1.08, 1.00),
+    _profile("Comerica Park", 1.00, 0.95, 1.02),
+    _profile("Coors Field", 1.10, 1.08, 1.06),
+    _profile("Daikin Park", 1.00, 1.02, 0.99, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown", aliases=["Minute Maid Park"]),
+    _profile("Dodger Stadium", 0.99, 1.00, 0.99),
+    _profile("Fenway Park", 1.03, 0.98, 1.04),
+    _profile("Globe Life Field", 0.99, 0.98, 0.99, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown"),
+    _profile("Great American Ball Park", 1.03, 1.10, 0.99),
+    _profile("Guaranteed Rate Field", 1.01, 1.05, 0.99, aliases=["Rate Field"]),
+    _profile("Kauffman Stadium", 1.01, 0.95, 1.03),
+    _profile("loanDepot park", 0.98, 0.96, 0.99, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown", aliases=["loanDepot Park", "Marlins Park"]),
+    _profile("Nationals Park", 1.00, 1.01, 1.00),
+    _profile("Oracle Park", 0.97, 0.91, 0.99),
+    _profile("Oriole Park at Camden Yards", 1.01, 1.04, 1.00, aliases=["Camden Yards"]),
+    _profile("PNC Park", 0.99, 0.97, 1.00),
+    _profile("Petco Park", 0.97, 0.94, 0.99),
+    _profile("Progressive Field", 0.99, 0.98, 1.00),
+    _profile("Rogers Centre", 1.01, 1.04, 1.00, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown"),
+    _profile("T-Mobile Park", 0.98, 0.96, 0.99, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown"),
+    _profile("Target Field", 0.99, 1.00, 0.99),
+    _profile("Truist Park", 1.01, 1.03, 1.00),
+    _profile("Tropicana Field", 0.98, 0.96, 0.99, venue_type="dome", default_roof_status="dome", weather_applies_default=False),
+    _profile("Wrigley Field", 1.02, 1.05, 1.00),
+    _profile("Yankee Stadium", 1.01, 1.07, 0.99),
+    _profile("American Family Field", 1.00, 1.03, 0.99, venue_type="retractable", default_roof_status="unknown", weather_applies_default="unknown", aliases=["Miller Park"]),
+    _profile("Sutter Health Park", 1.00, 1.00, 1.00, aliases=["Oakland Coliseum", "RingCentral Coliseum"]),
+]
+
+
+def _register(profile: Dict[str, Any]) -> None:
+    names = [profile["venue_name"], *(profile.get("aliases") or [])]
+    for name in names:
+        key = normalize_venue_name(name)
+        if key:
+            PARK_FACTORS[key] = profile
+
+
+for _row in _RAW_PROFILES:
+    _register(_row)
+
+
+def neutral_park_factor_profile(venue_name: Optional[str]) -> Dict[str, Any]:
+    normalized = normalize_venue_name(venue_name)
+    return {
+        "venue_name": venue_name,
+        "normalized_venue_name": normalized,
+        "aliases": [],
+        "run_factor": 1.0,
+        "home_run_factor": 1.0,
+        "hit_factor": 1.0,
+        "venue_type": "unknown",
+        "default_roof_status": "unknown",
+        "weather_applies_default": "unknown",
+        "source": "neutral_fallback_unmapped_venue",
+        "park_factor_profile_found": False,
+        "neutral_park_fallback_used": True,
+    }
+
+
+def get_park_factor_profile(venue_name: Optional[str]) -> Dict[str, Any]:
+    key = normalize_venue_name(venue_name)
+    if not key:
+        return neutral_park_factor_profile(venue_name)
+
+    profile = PARK_FACTORS.get(key)
+    if profile:
+        return dict(profile)
+
+    return neutral_park_factor_profile(venue_name)
+
+
+__all__ = [
+    "PARK_FACTOR_SOURCE",
+    "normalize_venue_name",
+    "get_park_factor_profile",
+    "neutral_park_factor_profile",
+]

--- a/mlb_app/simulation/game_engine_v2.py
+++ b/mlb_app/simulation/game_engine_v2.py
@@ -600,10 +600,13 @@ def run_full_game_simulation(game_pk: int, config: Optional[Dict[str, Any]] = No
         "offense_inputs": matchup.get("home_offense_inputs") or matchup.get("home_team_offense") or {},
     }
 
+    venue_name = matchup.get("venue_name") or matchup.get("venue")
+
     environment_profile = _compute_environment_profile_compatible({
         "game_pk": game_pk,
         "game_date": game_date,
-        "venue": matchup.get("venue_name") or matchup.get("venue"),
+        "venue_name": venue_name,
+        "venue": venue_name,
         "weather": matchup.get("weather") or {},
         "matchup": matchup,
     })

--- a/scripts/audit_environment_profiles.py
+++ b/scripts/audit_environment_profiles.py
@@ -187,6 +187,13 @@ def audit_game(game: Dict[str, Any]) -> Dict[str, Any]:
             "park_factor_source": park_component.get("source") or (
                 "real_or_schedule_provided" if has_real_run_factor else "neutral_fallback"
             ),
+            "park_factor_profile_found": park_component.get("park_factor_profile_found"),
+            "static_park_factor_used": park_component.get("static_park_factor_used"),
+            "normalized_venue_name": park_component.get("normalized_venue_name"),
+            "venue_type": park_component.get("venue_type"),
+            "default_roof_status": park_component.get("default_roof_status"),
+            "weather_applies_default": park_component.get("weather_applies_default"),
+            "neutral_park_fallback_used": park_component.get("neutral_fallback_used"),
             "temperature_f": temperature_f,
             "has_temperature": has_temperature,
             "temperature_source": "real_or_schedule_provided" if has_temperature else "missing",
@@ -252,8 +259,14 @@ def summarize(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
 
     return {
         "total_games": total,
-        "games_with_real_run_factor": count_true("has_real_run_factor"),
-        "games_defaulting_run_factor_to_neutral": total - count_true("has_real_run_factor"),
+        "games_with_any_park_factor": count_true("has_real_run_factor"),
+        "games_with_raw_run_factor": sum(
+            1 for row in audits
+            if row.get("park_factor_source") == "real_or_schedule_provided"
+        ),
+        "games_with_static_park_factor": count_true("static_park_factor_used"),
+        "games_with_neutral_park_fallback": count_true("neutral_park_fallback_used"),
+        "games_defaulting_run_factor_to_neutral": count_true("neutral_park_fallback_used"),
         "games_with_temperature": count_true("has_temperature"),
         "games_missing_temperature": total - count_true("has_temperature"),
         "games_with_wind": count_true("has_wind"),
@@ -274,6 +287,14 @@ def summarize(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
         "games_with_rain_delay_risk": count_true("rain_delay_risk"),
         "readiness_counts": value_counts("readiness"),
         "park_factor_sources": value_counts("park_factor_source"),
+        "venue_types": value_counts("venue_type"),
+        "default_roof_statuses": value_counts("default_roof_status"),
+        "weather_applies_defaults": value_counts("weather_applies_default"),
+        "unmapped_venues": sorted({
+            row.get("venue_name")
+            for row, audit in zip(rows, audits)
+            if audit.get("neutral_park_fallback_used")
+        }),
         "weather_component_sources": value_counts("weather_component_source"),
         "wind_direction_types": value_counts("wind_direction_type"),
         "combined_index_methods": value_counts("combined_index_method"),
@@ -292,6 +313,11 @@ def print_game(row: Dict[str, Any]) -> None:
         f"hr_factor={audit.get('home_run_factor')} "
         f"hit_factor={audit.get('hit_factor')} "
         f"source={audit.get('park_factor_source')} "
+        f"mapped={audit.get('park_factor_profile_found')} "
+        f"static={audit.get('static_park_factor_used')} "
+        f"venue_type={audit.get('venue_type')} "
+        f"roof={audit.get('default_roof_status')} "
+        f"weather_applies={audit.get('weather_applies_default')} "
         f"park_impact={audit.get('park_run_impact')}"
     )
     print(


### PR DESCRIPTION
## Summary

Adds conservative static park factors to the environment profile layer and wires venue names into the shared simulation path so park effects flow into PA probabilities and model projections.

## Why this matters

Before this PR, environment profiles had schedule weather and wind parsing, but all parks used neutral fallback. The model was weather-adjusted over a neutral park base.

This PR adds static venue-level park factors with explicit fallback diagnostics.

## Changes

- Adds `mlb_app/park_factors.py`
  - normalized venue lookup
  - venue aliases
  - conservative static run / HR / hit factors
  - venue type
  - default roof status
  - weather applicability default
  - neutral fallback profile for unmapped venues

- Updates `mlb_app/environment_profile.py`
  - uses static park factors when raw context has venue but no run_factor
  - preserves existing weather adjustment formulas
  - adds diagnostics:
    - park_factor_source
    - park_factor_profile_found
    - normalized_venue_name
    - venue_type
    - default_roof_status
    - weather_applies_default
    - neutral_park_fallback_used

- Updates `mlb_app/simulation/game_engine_v2.py`
  - passes `venue_name` into the environment profile builder
  - ensures static park factors flow into shared simulation / PA model path

- Updates `scripts/audit_environment_profiles.py`
  - reports mapped vs unmapped venues
  - reports park factor source
  - reports venue type / default roof status / weather applicability
  - summarizes static park factor coverage

## Validation

Run locally:

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app
AUDIT_DATE=2026-05-04 python scripts/audit_environment_profiles.py
python scripts/audit_pa_models.py
python scripts/audit_model_projections.py
BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 python scripts/backtest_simulation.py
```

Environment audit:

- games_with_any_park_factor: 12
- games_with_raw_run_factor: 0
- games_with_static_park_factor: 12
- games_with_neutral_park_fallback: 0
- games_defaulting_run_factor_to_neutral: 0
- unmapped_venues: []
- games_with_temperature: 12
- games_with_wind: 12
- games_with_parsed_wind_from_text: 12
- weather_component_sources: schedule_weather

PA model environment ranges after static park factors:

- run_scoring_index: 0.970 to 1.100
- hr_boost_index: 0.910 to 1.080
- hit_boost_index: 0.990 to 1.060

Model projections audit:

- shared_status_counts: {'ok': 15}
- missing_inputs: []

Backtest comparison:

| Metric | Before static park factors | After static park factors |
|---|---:|---:|
| Total runs MAE | 3.6980 | 3.6569 |
| Total runs bias | +0.2487 | +0.2842 |
| Winner accuracy | 0.5730 | 0.5730 |
| Brier score | 0.2468 | 0.2468 |
| Log loss | 0.6871 | 0.6869 |

## What this does NOT do

- Does not change PA formulas directly
- Does not change game simulator logic
- Does not add L/R park splits
- Does not add handedness-weighted park factors
- Does not add venue-specific wind geometry
- Does not add live roof-state sourcing
- Does not switch to multiplicative park/weather interaction

## Risk

Medium-low. This introduces real park signal, but factors are intentionally conservative and every fallback path is explicit. Backtest remained stable with slightly improved total-run MAE and log loss.