### PR TITLE
Wire lineup handedness mix into offense inputs

### DIFF
--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -251,6 +251,8 @@ def compute_environment_profile(raw_context: dict) -> dict:
     run_factor = _safe_float(raw_run_factor)
 
     raw_home_run_factor = _safe_float(raw_context.get("home_run_factor"))
+    raw_home_run_factor_lhb = _safe_float(raw_context.get("home_run_factor_lhb"))
+    raw_home_run_factor_rhb = _safe_float(raw_context.get("home_run_factor_rhb"))
     raw_hit_factor = _safe_float(raw_context.get("hit_factor"))
 
     park_factor_profile_found = bool(park_factor_profile.get("park_factor_profile_found"))
@@ -261,10 +263,16 @@ def compute_environment_profile(raw_context: dict) -> dict:
         static_park_factor_used = run_factor is not None and park_factor_profile.get("source") != "neutral_fallback_unmapped_venue"
 
     home_run_factor = raw_home_run_factor
+    home_run_factor_lhb = raw_home_run_factor_lhb
+    home_run_factor_rhb = raw_home_run_factor_rhb
     hit_factor = raw_hit_factor
 
     if home_run_factor is None:
         home_run_factor = _safe_float(park_factor_profile.get("home_run_factor"))
+    if home_run_factor_lhb is None:
+        home_run_factor_lhb = _safe_float(park_factor_profile.get("home_run_factor_lhb"))
+    if home_run_factor_rhb is None:
+        home_run_factor_rhb = _safe_float(park_factor_profile.get("home_run_factor_rhb"))
     if hit_factor is None:
         hit_factor = _safe_float(park_factor_profile.get("hit_factor"))
 
@@ -371,6 +379,8 @@ def compute_environment_profile(raw_context: dict) -> dict:
             "park_component": {
                 "run_factor": run_factor,
                 "home_run_factor": home_run_factor,
+                "home_run_factor_lhb": home_run_factor_lhb,
+                "home_run_factor_rhb": home_run_factor_rhb,
                 "hit_factor": hit_factor,
                 "source": park_component_source,
                 "park_factor_profile_found": park_factor_profile_found,
@@ -410,6 +420,8 @@ def compute_environment_profile(raw_context: dict) -> dict:
         "park_factors": {
             "run_factor": run_factor,
             "home_run_factor": home_run_factor,
+            "home_run_factor_lhb": home_run_factor_lhb,
+            "home_run_factor_rhb": home_run_factor_rhb,
             "hit_factor": hit_factor,
         },
         "game_context": {

--- a/mlb_app/lineup_profile.py
+++ b/mlb_app/lineup_profile.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import datetime as dt
+
 from typing import Any, Dict, List, Optional
 
 import requests
+
+from .lineup_handedness import build_lineup_handedness_mix
 from sqlalchemy.orm import Session
 
 from .db_utils import get_batter_aggregate, get_player_split
@@ -388,7 +392,7 @@ def build_lineup_offense_inputs(
     if len(profiles) < MIN_USABLE_HITTERS:
         return None
 
-    return _aggregate_hitter_profiles(
+    aggregate = _aggregate_hitter_profiles(
         profiles=profiles,
         team_id=team_id,
         season=season,
@@ -396,6 +400,53 @@ def build_lineup_offense_inputs(
         team_fallback=team_fallback,
         fallback_player_count=fallback_player_count,
     )
+
+    lineup_handedness_mix = None
+    lineup_handedness_unavailable_reason = None
+
+    try:
+        target_date = dt.date(int(season), 12, 31)
+        season_start = dt.date(int(season), 1, 1)
+
+        hitter_ids_for_handedness = []
+        for profile in profiles:
+            player_id = profile.get("player_id") or profile.get("batter_id")
+            if player_id is not None:
+                try:
+                    hitter_ids_for_handedness.append(int(player_id))
+                except Exception:
+                    continue
+
+        if hitter_ids_for_handedness:
+            lineup_handedness_mix = build_lineup_handedness_mix(
+                session,
+                hitter_ids_for_handedness,
+                season_start,
+                target_date,
+            )
+        else:
+            lineup_handedness_unavailable_reason = "missing_hitter_ids"
+
+    except Exception as exc:
+        lineup_handedness_mix = None
+        lineup_handedness_unavailable_reason = f"handedness_mix_error:{exc}"
+
+    aggregate["lineup_handedness_mix"] = lineup_handedness_mix
+    aggregate["lineup_handedness_mix_source"] = (
+        lineup_handedness_mix or {}
+    ).get("source") if lineup_handedness_mix else None
+    aggregate["lineup_handedness_coverage_rate"] = (
+        lineup_handedness_mix or {}
+    ).get("coverage_rate") if lineup_handedness_mix else None
+    aggregate["lineup_handedness_counts"] = (
+        lineup_handedness_mix or {}
+    ).get("counts") if lineup_handedness_mix else None
+    aggregate["lineup_handedness_player_count"] = (
+        lineup_handedness_mix or {}
+    ).get("hitter_count") if lineup_handedness_mix else None
+    aggregate["lineup_handedness_unavailable_reason"] = lineup_handedness_unavailable_reason
+
+    return aggregate
 
 
 __all__ = [

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -195,7 +195,7 @@ def _pitcher_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
 
 def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
     inputs = team.get("offense_inputs") or {}
-    return {
+    profile = {
         "metadata": {
             "source_type": inputs.get("source") or "team_split_or_prior",
             "generated_from": "model_projections._offense_workspace_profile",
@@ -203,7 +203,7 @@ def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
             "team_id": team.get("team_id"),
             "team_name": team.get("team_name"),
             "lineup_source": inputs.get("lineup_source"),
-            "profile_granularity": "team_offense",
+            "profile_granularity": inputs.get("profile_granularity") or "team_offense",
             "sample_blend": inputs.get("sample_blend"),
         },
         "contact_skill": {
@@ -229,6 +229,19 @@ def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
             "strikeouts": safe_float(inputs.get("strikeouts")),
         },
     }
+
+    for passthrough_key in (
+        "lineup_handedness_mix",
+        "lineup_handedness_mix_source",
+        "lineup_handedness_coverage_rate",
+        "lineup_handedness_counts",
+        "lineup_handedness_player_count",
+        "lineup_handedness_unavailable_reason",
+    ):
+        if passthrough_key in inputs:
+            profile[passthrough_key] = inputs.get(passthrough_key)
+
+    return profile
 
 
 def _matchup_workspace_analysis(offense_team: Dict[str, Any], opposing_pitcher: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Wires lineup handedness mix into confirmed lineup offense inputs so the existing fallback-safe handedness HR park adjustment hook can consume it.

This PR connects the data path required by the environment hook added in PR #201.

## Changes

- Adds `lineup_handedness_mix` to confirmed lineup offense inputs in `lineup_profile.py`
- Preserves handedness fields through `model_projections._offense_workspace_profile`
- Exposes L/R HR park factors through `environment_profile.py`
- Keeps team_splits fallback unchanged
- Keeps all missing-data fallback behavior intact

## Why this matters

The handedness HR adjustment hook was previously falling back because it lacked:

- lineup handedness mix
- L/R HR park factor fields in the environment profile

This PR makes those inputs available upstream without adding DB/session access inside `game_engine_v2.py`.

## Activation evidence

Confirmed in the model projection payload:

```text
active_model_input_changed: true
fallback_reason: null
home_run_factor_lhb: 0.95
home_run_factor_rhb: 0.95
handedness_counts: {"L": 3, "R": 5, "S": 1, "unknown": 0}
```

## Validation

Run locally:

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app
python scripts/debug_source_inputs.py
python scripts/audit_model_projections.py
python scripts/audit_pa_models.py
BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 python scripts/backtest_simulation.py
```

Backtest remained stable:

| Metric | Baseline | Latest |
|---|---:|---:|
| Games evaluated | 185 | 185 |
| Games skipped | 0 | 0 |
| Total runs MAE | 3.6569 | 3.6564 |
| Total runs bias | +0.2842 | +0.2843 |
| Winner accuracy | 0.5730 | 0.5730 |
| Brier | 0.2468 | 0.2468 |
| Log loss | 0.6869 | 0.6870 |

## What this does NOT do

- Does not change PA formulas directly
- Does not change run scoring logic
- Does not query DB inside `game_engine_v2.py`
- Does not change `run_scoring_index`
- Does not change `hit_boost_index`
- Does not remove team_splits fallback
- Does not add roof state or venue-specific wind geometry

## Risk

Low. The active effect is bounded by the existing conservative hook, and validation showed effectively neutral backtest movement.