### PR TITLE
Add historical hitter true-talent audit tooling

### DIFF
--- a/scripts/audit_historical_hitter_data_availability.py
+++ b/scripts/audit_historical_hitter_data_availability.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+from sqlalchemy import func
+
+from mlb_app.database import PlayerSplit, StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.lineup_profile import fetch_boxscore_lineup
+from mlb_app.matchup_generator import generate_matchups_for_date
+
+
+SEASONS = [2023, 2024, 2025, 2026]
+SPLITS = ["vsL", "vsR"]
+
+
+def _date_range(start: str, end: str) -> Iterable[str]:
+    current = dt.date.fromisoformat(start)
+    stop = dt.date.fromisoformat(end)
+    while current <= stop:
+        yield current.isoformat()
+        current += dt.timedelta(days=1)
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _distribution(values: List[Any]) -> Dict[str, Optional[float]]:
+    clean = sorted(float(v) for v in values if v is not None)
+    if not clean:
+        return {"min": None, "median": None, "avg": None, "max": None}
+    return {
+        "min": round(clean[0], 4),
+        "median": round(float(median(clean)), 4),
+        "avg": round(float(mean(clean)), 4),
+        "max": round(clean[-1], 4),
+    }
+
+
+def _season_bounds(season: int, audit_end: dt.date) -> tuple[dt.date, dt.date]:
+    start = dt.date(season, 3, 1)
+    end = dt.date(season, 12, 31)
+    if season == audit_end.year:
+        end = audit_end
+    return start, end
+
+
+def _collect_sample_hitters(session, start: str, end: str) -> List[Dict[str, Any]]:
+    hitters_by_id: Dict[int, Dict[str, Any]] = {}
+
+    for date_str in _date_range(start, end):
+        matchups = generate_matchups_for_date(session, date_str)
+
+        for matchup in matchups:
+            game_pk = _safe_int(matchup.get("game_pk"))
+            if not game_pk:
+                continue
+
+            try:
+                lineups = fetch_boxscore_lineup(game_pk)
+            except Exception:
+                continue
+
+            for side in ("away", "home"):
+                team_id = matchup.get(f"{side}_team_id")
+                team_name = matchup.get(f"{side}_team_name")
+
+                for hitter in lineups.get(side) or []:
+                    player_id = _safe_int(hitter.get("batter_id"))
+                    if player_id is None:
+                        continue
+
+                    existing = hitters_by_id.get(player_id)
+                    if existing is None:
+                        hitters_by_id[player_id] = {
+                            "player_id": player_id,
+                            "player_name": hitter.get("name"),
+                            "first_seen_date": date_str,
+                            "last_seen_date": date_str,
+                            "sample_lineup_appearances": 1,
+                            "sample_teams": {str(team_id): team_name},
+                        }
+                    else:
+                        existing["last_seen_date"] = date_str
+                        existing["sample_lineup_appearances"] += 1
+                        existing["sample_teams"][str(team_id)] = team_name
+
+    rows = []
+    for hitter in hitters_by_id.values():
+        teams = hitter.pop("sample_teams", {})
+        hitter["sample_team_ids"] = ",".join(sorted(teams.keys()))
+        hitter["sample_team_names"] = ",".join(sorted(str(v) for v in teams.values() if v))
+        rows.append(hitter)
+
+    return sorted(rows, key=lambda row: (row.get("player_name") or "", row["player_id"]))
+
+
+def _statcast_pa_count(session, player_id: int, start_date: dt.date, end_date: dt.date, split: Optional[str]) -> int:
+    query = (
+        session.query(StatcastEvent.game_pk, StatcastEvent.at_bat_number)
+        .filter(
+            StatcastEvent.batter_id == player_id,
+            StatcastEvent.game_date >= start_date,
+            StatcastEvent.game_date <= end_date,
+            StatcastEvent.at_bat_number.isnot(None),
+        )
+    )
+
+    if split == "vsR":
+        query = query.filter(StatcastEvent.p_throws == "R")
+    elif split == "vsL":
+        query = query.filter(StatcastEvent.p_throws == "L")
+
+    return len({(row[0], row[1]) for row in query.all()})
+
+
+def _statcast_event_count(session, player_id: int, start_date: dt.date, end_date: dt.date) -> int:
+    return int(
+        session.query(func.count(StatcastEvent.id))
+        .filter(
+            StatcastEvent.batter_id == player_id,
+            StatcastEvent.game_date >= start_date,
+            StatcastEvent.game_date <= end_date,
+        )
+        .scalar()
+        or 0
+    )
+
+
+def _player_split_pa(session, player_id: int, season: int, split: str) -> int:
+    row = (
+        session.query(PlayerSplit)
+        .filter(
+            PlayerSplit.player_id == player_id,
+            PlayerSplit.season == season,
+            PlayerSplit.split == split,
+        )
+        .one_or_none()
+    )
+    return int(row.pa or 0) if row else 0
+
+
+def _audit_hitter(session, hitter: Dict[str, Any], audit_end: dt.date) -> Dict[str, Any]:
+    player_id = int(hitter["player_id"])
+    row = dict(hitter)
+
+    for season in SEASONS:
+        start_date, end_date = _season_bounds(season, audit_end)
+
+        event_count = _statcast_event_count(session, player_id, start_date, end_date)
+        row[f"{season}_statcast_event_rows"] = event_count
+
+        total_statcast_pa = 0
+        total_player_split_pa = 0
+
+        for split in SPLITS:
+            statcast_pa = _statcast_pa_count(session, player_id, start_date, end_date, split)
+            player_split_pa = _player_split_pa(session, player_id, season, split)
+
+            row[f"{season}_{split}_statcast_pa"] = statcast_pa
+            row[f"{season}_{split}_player_split_pa"] = player_split_pa
+            row[f"{season}_{split}_has_statcast"] = statcast_pa > 0
+            row[f"{season}_{split}_has_player_split"] = player_split_pa > 0
+
+            total_statcast_pa += statcast_pa
+            total_player_split_pa += player_split_pa
+
+        row[f"{season}_statcast_pa"] = total_statcast_pa
+        row[f"{season}_player_split_pa"] = total_player_split_pa
+        row[f"{season}_has_statcast"] = total_statcast_pa > 0
+        row[f"{season}_has_player_split"] = total_player_split_pa > 0
+
+        if total_statcast_pa > 0 and total_player_split_pa == 0:
+            gap = "aggregate_missing"
+        elif total_statcast_pa == 0 and total_player_split_pa == 0:
+            gap = "source_missing"
+        elif total_statcast_pa == 0 and total_player_split_pa > 0:
+            gap = "split_exists_without_source_window"
+        else:
+            gap = "available"
+
+        row[f"{season}_gap_type"] = gap
+
+    return row
+
+
+def _summarize(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    summary: Dict[str, Any] = {
+        "hitters": len(rows),
+        "seasons": {},
+        "recommendation": None,
+    }
+
+    for season in SEASONS:
+        season_rows = rows
+        summary["seasons"][str(season)] = {
+            "hitters_with_statcast": sum(1 for row in season_rows if row.get(f"{season}_has_statcast")),
+            "hitters_with_player_split": sum(1 for row in season_rows if row.get(f"{season}_has_player_split")),
+            "statcast_pa_distribution": _distribution([row.get(f"{season}_statcast_pa") for row in season_rows]),
+            "player_split_pa_distribution": _distribution([row.get(f"{season}_player_split_pa") for row in season_rows]),
+            "gap_types": {},
+        }
+
+        gap_counts: Dict[str, int] = {}
+        for row in season_rows:
+            gap = row.get(f"{season}_gap_type") or "unknown"
+            gap_counts[gap] = gap_counts.get(gap, 0) + 1
+        summary["seasons"][str(season)]["gap_types"] = gap_counts
+
+    historical_statcast = sum(
+        summary["seasons"][str(season)]["hitters_with_statcast"]
+        for season in [2023, 2024, 2025]
+    )
+    historical_splits = sum(
+        summary["seasons"][str(season)]["hitters_with_player_split"]
+        for season in [2023, 2024, 2025]
+    )
+
+    if historical_statcast > 0 and historical_splits == 0:
+        summary["recommendation"] = (
+            "Historical Statcast exists but PlayerSplit aggregates are missing. "
+            "Next step: build a safe dry-run historical PlayerSplit backfill."
+        )
+    elif historical_statcast == 0:
+        summary["recommendation"] = (
+            "Historical Statcast is missing for the sampled hitters. "
+            "Next step: load historical Statcast first, then generate PlayerSplit aggregates."
+        )
+    else:
+        summary["recommendation"] = (
+            "Some historical splits are available. Next step: inspect coverage by season/split "
+            "and rerun the true-talent audit using historical components."
+        )
+
+    return summary
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("")
+        return
+
+    fieldnames = sorted({key for row in rows for key in row.keys()})
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    start = os.getenv("BACKTEST_START", "2026-04-20")
+    end = os.getenv("BACKTEST_END", "2026-05-03")
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+
+    audit_end = dt.date.fromisoformat(end)
+
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionLocal = get_session(engine)
+
+    with SessionLocal() as session:
+        hitters = _collect_sample_hitters(session, start, end)
+        rows = [_audit_hitter(session, hitter, audit_end) for hitter in hitters]
+
+    summary = _summarize(rows)
+
+    output_dir = Path("tmp")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prefix = f"historical_hitter_data_availability_{start}_to_{end}"
+    json_path = output_dir / f"{prefix}.json"
+    csv_path = output_dir / f"{prefix}.csv"
+
+    payload = {
+        "start": start,
+        "end": end,
+        "database_url": database_url,
+        "summary": summary,
+        "rows": rows,
+    }
+
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str))
+    _write_csv(csv_path, rows)
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print(f"Wrote {json_path}")
+    print(f"Wrote {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_player_true_talent_profiles.py
+++ b/scripts/audit_player_true_talent_profiles.py
@@ -1,0 +1,705 @@
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from mlb_app.database import (
+    PlayerSplit,
+    StatcastEvent,
+    TeamSplit,
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.db_utils import _calculate_batter_stats
+from mlb_app.lineup_profile import fetch_boxscore_lineup
+from mlb_app.matchup_generator import _format_team_offense_inputs, generate_matchups_for_date
+
+
+METRICS = [
+    "batting_avg",
+    "on_base_pct",
+    "slugging_pct",
+    "iso",
+    "k_pct",
+    "bb_pct",
+]
+
+COUNT_METRICS = [
+    "pa",
+    "hits",
+    "doubles",
+    "triples",
+    "home_runs",
+    "walks",
+    "strikeouts",
+]
+
+ALL_OUTPUT_METRICS = METRICS + COUNT_METRICS
+
+# Candidate weights before availability/PA filtering.
+# Missing or too-small windows are skipped and remaining weights are renormalized.
+DEFAULT_COMPONENT_WEIGHTS = {
+    "season_2023": 0.12,
+    "season_2024": 0.18,
+    "season_2025": 0.25,
+    "season_current": 0.25,
+    "last90": 0.12,
+    "last30": 0.08,
+}
+
+DEFAULT_MIN_PA_BY_COMPONENT = {
+    "season_2023": 50,
+    "season_2024": 50,
+    "season_2025": 50,
+    "season_current": 25,
+    "last90": 25,
+    "last30": 10,
+}
+
+
+def _date_range(start: str, end: str) -> Iterable[str]:
+    current = dt.date.fromisoformat(start)
+    stop = dt.date.fromisoformat(end)
+    while current <= stop:
+        yield current.isoformat()
+        current += dt.timedelta(days=1)
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _round(value: Any, ndigits: int = 4) -> Optional[float]:
+    number = _safe_float(value)
+    if number is None:
+        return None
+    return round(number, ndigits)
+
+
+def _distribution(values: List[Any]) -> Dict[str, Optional[float]]:
+    clean = sorted(float(v) for v in values if v is not None)
+    if not clean:
+        return {"min": None, "median": None, "avg": None, "max": None}
+    return {
+        "min": round(clean[0], 4),
+        "median": round(float(median(clean)), 4),
+        "avg": round(float(mean(clean)), 4),
+        "max": round(clean[-1], 4),
+    }
+
+
+def _season_window(season: int, target_date: dt.date) -> Tuple[dt.date, dt.date]:
+    start = dt.date(season, 3, 1)
+    end = dt.date(season, 12, 31)
+    if season == target_date.year:
+        end = target_date
+    return start, end
+
+
+def _component_windows(target_date: dt.date) -> Dict[str, Tuple[dt.date, dt.date]]:
+    current_season = target_date.year
+    return {
+        "season_2023": _season_window(2023, target_date),
+        "season_2024": _season_window(2024, target_date),
+        "season_2025": _season_window(2025, target_date),
+        "season_current": _season_window(current_season, target_date),
+        "last90": (target_date - dt.timedelta(days=90), target_date),
+        "last30": (target_date - dt.timedelta(days=30), target_date),
+    }
+
+
+def _events_for_window(
+    session,
+    player_id: int,
+    start_date: dt.date,
+    end_date: dt.date,
+    split: Optional[str],
+) -> List[StatcastEvent]:
+    query = (
+        session.query(StatcastEvent)
+        .filter(
+            StatcastEvent.batter_id == player_id,
+            StatcastEvent.game_date >= start_date,
+            StatcastEvent.game_date <= end_date,
+            StatcastEvent.events.isnot(None),
+        )
+        .order_by(
+            StatcastEvent.game_date.asc(),
+            StatcastEvent.game_pk.asc().nullslast(),
+            StatcastEvent.at_bat_number.asc().nullslast(),
+            StatcastEvent.pitch_number.asc().nullslast(),
+            StatcastEvent.id.asc(),
+        )
+    )
+
+    if split == "vsR":
+        query = query.filter(StatcastEvent.p_throws == "R")
+    elif split == "vsL":
+        query = query.filter(StatcastEvent.p_throws == "L")
+
+    return list(query.all())
+
+
+def _statcast_component_profile(
+    session,
+    player_id: int,
+    component: str,
+    start_date: dt.date,
+    end_date: dt.date,
+    split: str,
+) -> Dict[str, Any]:
+    events = _events_for_window(session, player_id, start_date, end_date, split)
+    stats = _calculate_batter_stats(events, raw_event_count=len(events))
+
+    pa = _safe_int(stats.get("actual_pa"))
+    batting_avg = _safe_float(stats.get("batting_avg"))
+    slugging_pct = _safe_float(stats.get("slugging_pct"))
+
+    return {
+        "component": component,
+        "source": "statcast_events",
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "pa": pa,
+        "hits": _safe_int(stats.get("hits")),
+        "doubles": None,
+        "triples": None,
+        "home_runs": _safe_int(stats.get("home_runs")),
+        "walks": _safe_int(stats.get("walks")),
+        "strikeouts": _safe_int(stats.get("strikeouts")),
+        "batting_avg": batting_avg,
+        "on_base_pct": _safe_float(stats.get("on_base_pct")),
+        "slugging_pct": slugging_pct,
+        "iso": (
+            round(max(slugging_pct - batting_avg, 0.0), 4)
+            if slugging_pct is not None and batting_avg is not None
+            else None
+        ),
+        "k_pct": _safe_float(stats.get("k_pct")),
+        "bb_pct": _safe_float(stats.get("bb_pct")),
+    }
+
+
+def _player_split_component_profile(
+    session,
+    player_id: int,
+    season: int,
+    split: str,
+    component: str,
+) -> Dict[str, Any]:
+    row = (
+        session.query(PlayerSplit)
+        .filter(
+            PlayerSplit.player_id == player_id,
+            PlayerSplit.season == season,
+            PlayerSplit.split == split,
+        )
+        .one_or_none()
+    )
+
+    if not row:
+        return {"component": component, "source": "player_splits_missing", "pa": 0}
+
+    batting_avg = _safe_float(row.batting_avg)
+    slugging_pct = _safe_float(row.slugging_pct)
+    explicit_iso = _safe_float(row.iso)
+    if explicit_iso is not None and 0.0 <= explicit_iso <= 0.45:
+        iso = explicit_iso
+    elif batting_avg is not None and slugging_pct is not None:
+        iso = max(slugging_pct - batting_avg, 0.0)
+    else:
+        iso = None
+
+    return {
+        "component": component,
+        "source": "player_splits",
+        "season": season,
+        "split": split,
+        "pa": _safe_int(row.pa),
+        "hits": _safe_int(row.hits),
+        "doubles": _safe_int(row.doubles),
+        "triples": _safe_int(row.triples),
+        "home_runs": _safe_int(row.home_runs),
+        "walks": _safe_int(row.walks),
+        "strikeouts": _safe_int(row.strikeouts),
+        "batting_avg": batting_avg,
+        "on_base_pct": _safe_float(row.on_base_pct),
+        "slugging_pct": slugging_pct,
+        "iso": _round(iso),
+        "k_pct": _safe_float(row.k_pct),
+        "bb_pct": _safe_float(row.bb_pct),
+    }
+
+
+def _component_profile(
+    session,
+    player_id: int,
+    target_date: dt.date,
+    component: str,
+    split: str,
+) -> Dict[str, Any]:
+    if component == "season_2023":
+        return _player_split_component_profile(session, player_id, 2023, split, component)
+    if component == "season_2024":
+        return _player_split_component_profile(session, player_id, 2024, split, component)
+    if component == "season_2025":
+        return _player_split_component_profile(session, player_id, 2025, split, component)
+    if component == "season_current":
+        return _player_split_component_profile(session, player_id, target_date.year, split, component)
+
+    start_date, end_date = _component_windows(target_date)[component]
+    return _statcast_component_profile(session, player_id, component, start_date, end_date, split)
+
+
+def _renormalized_weights(
+    components: List[Dict[str, Any]],
+    base_weights: Dict[str, float],
+    min_pa_by_component: Dict[str, int],
+) -> Tuple[Dict[str, float], List[Dict[str, Any]]]:
+    usable: List[Dict[str, Any]] = []
+
+    for component in components:
+        name = component["component"]
+        pa = _safe_int(component.get("pa")) or 0
+        min_pa = min_pa_by_component.get(name, 0)
+
+        reason = None
+        if base_weights.get(name, 0.0) <= 0:
+            reason = "zero_base_weight"
+        elif pa < min_pa:
+            reason = "below_min_pa"
+        elif all(_safe_float(component.get(metric)) is None for metric in METRICS):
+            reason = "no_rate_metrics"
+
+        component["min_pa"] = min_pa
+        component["is_usable"] = reason is None
+        component["skip_reason"] = reason
+
+        if reason is None:
+            usable.append(component)
+
+    weight_total = sum(base_weights.get(c["component"], 0.0) for c in usable)
+    if weight_total <= 0:
+        return {}, components
+
+    weights = {
+        c["component"]: round(base_weights.get(c["component"], 0.0) / weight_total, 6)
+        for c in usable
+    }
+    return weights, components
+
+
+def _weighted_rate(
+    components: List[Dict[str, Any]],
+    weights: Dict[str, float],
+    metric: str,
+) -> Optional[float]:
+    numerator = 0.0
+    denominator = 0.0
+
+    for component in components:
+        name = component["component"]
+        weight = weights.get(name)
+        value = _safe_float(component.get(metric))
+        if weight is None or value is None:
+            continue
+        numerator += value * weight
+        denominator += weight
+
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 4)
+
+
+def _weighted_count_proxy(
+    components: List[Dict[str, Any]],
+    weights: Dict[str, float],
+    metric: str,
+) -> Optional[int]:
+    value = _weighted_rate(components, weights, metric)
+    if value is None:
+        return None
+    return int(round(value))
+
+
+def _build_player_true_talent_profile(
+    session,
+    player_id: int,
+    player_name: Optional[str],
+    target_date: dt.date,
+    split: str,
+    base_weights: Dict[str, float],
+    min_pa_by_component: Dict[str, int],
+) -> Dict[str, Any]:
+    components = [
+        _component_profile(session, player_id, target_date, component, split)
+        for component in base_weights.keys()
+    ]
+    weights, components = _renormalized_weights(components, base_weights, min_pa_by_component)
+
+    profile: Dict[str, Any] = {
+        "player_id": player_id,
+        "player_name": player_name,
+        "split": split,
+        "source": "audit_player_true_talent",
+        "usable_component_count": len(weights),
+        "used_components": sorted(weights.keys()),
+        "component_weights": weights,
+        "components": components,
+        "has_usable_true_talent_profile": bool(weights),
+    }
+
+    for metric in METRICS:
+        profile[metric] = _weighted_rate(components, weights, metric)
+
+    for metric in COUNT_METRICS:
+        profile[metric] = _weighted_count_proxy(components, weights, metric)
+
+    profile["pa"] = sum(
+        _safe_int(c.get("pa")) or 0
+        for c in components
+        if c.get("component") in weights
+    )
+
+    return profile
+
+
+def _team_split_row(session, team_id: int, season: int, split: str) -> Optional[TeamSplit]:
+    return (
+        session.query(TeamSplit)
+        .filter(
+            TeamSplit.team_id == team_id,
+            TeamSplit.season == season,
+            TeamSplit.split == split,
+        )
+        .one_or_none()
+    )
+
+
+def _team_inputs(session, team_id: int, season: int, split: str) -> Dict[str, Any]:
+    return _format_team_offense_inputs(session, team_id, season, split)
+
+
+def _avg_metric(profiles: List[Dict[str, Any]], metric: str) -> Optional[float]:
+    values = [_safe_float(p.get(metric)) for p in profiles if _safe_float(p.get(metric)) is not None]
+    if not values:
+        return None
+    return round(sum(values) / len(values), 4)
+
+
+def _sum_metric(profiles: List[Dict[str, Any]], metric: str) -> Optional[int]:
+    values = [_safe_int(p.get(metric)) for p in profiles if _safe_int(p.get(metric)) is not None]
+    if not values:
+        return None
+    return int(sum(values))
+
+
+def _aggregate_lineup_profiles(
+    profiles: List[Dict[str, Any]],
+    lineup_count: int,
+    min_usable_hitters: int,
+) -> Dict[str, Any]:
+    usable = [p for p in profiles if p.get("has_usable_true_talent_profile")]
+
+    out: Dict[str, Any] = {
+        "source": "audit_confirmed_lineup_true_talent",
+        "starting_lineup_count": lineup_count,
+        "usable_hitter_profile_count": len(usable),
+        "min_usable_hitters": min_usable_hitters,
+        "would_activate": len(usable) >= min_usable_hitters,
+    }
+
+    for metric in METRICS:
+        out[metric] = _avg_metric(usable, metric)
+
+    for metric in COUNT_METRICS:
+        out[metric] = _sum_metric(usable, metric)
+
+    return out
+
+
+def _metric_deltas(team_inputs: Dict[str, Any], lineup_inputs: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for metric in ALL_OUTPUT_METRICS:
+        team_value = _safe_float(team_inputs.get(metric))
+        lineup_value = _safe_float(lineup_inputs.get(metric))
+        delta = None
+        if team_value is not None and lineup_value is not None:
+            delta = round(lineup_value - team_value, 4)
+
+        out[f"{metric}_team"] = team_value
+        out[f"{metric}_true_talent_lineup"] = lineup_value
+        out[f"{metric}_delta"] = delta
+
+    return out
+
+
+def _is_extreme_delta(row: Dict[str, Any]) -> bool:
+    return (
+        abs(_safe_float(row.get("iso_delta")) or 0.0) > 0.030
+        or abs(_safe_float(row.get("slugging_pct_delta")) or 0.0) > 0.050
+        or abs(_safe_float(row.get("k_pct_delta")) or 0.0) > 0.050
+        or abs(_safe_float(row.get("bb_pct_delta")) or 0.0) > 0.030
+    )
+
+
+def _side_context(matchup: Dict[str, Any], side: str) -> Dict[str, Any]:
+    offense = matchup.get(f"{side}_offense_inputs") or {}
+    return {
+        "game_pk": matchup.get("game_pk"),
+        "team_id": matchup.get(f"{side}_team_id"),
+        "team_name": matchup.get(f"{side}_team_name"),
+        "split": offense.get("split") or "vsR",
+    }
+
+
+def _audit_side(
+    session,
+    date_str: str,
+    matchup: Dict[str, Any],
+    side: str,
+    base_weights: Dict[str, float],
+    min_pa_by_component: Dict[str, int],
+    min_usable_hitters: int,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    target_date = dt.date.fromisoformat(date_str)
+    season = target_date.year
+    ctx = _side_context(matchup, side)
+    game_pk = _safe_int(ctx.get("game_pk"))
+    team_id = _safe_int(ctx.get("team_id"))
+    split = ctx.get("split") or "vsR"
+
+    if not game_pk or not team_id:
+        row = {
+            "date": date_str,
+            "game_pk": game_pk,
+            "side": side,
+            "team_id": team_id,
+            "team_name": ctx.get("team_name"),
+            "split": split,
+            "skip_reason": "missing_game_or_team_id",
+        }
+        return row, []
+
+    lineups = fetch_boxscore_lineup(game_pk)
+    lineup = lineups.get(side) or []
+    team_inputs = _team_inputs(session, team_id, season, split)
+
+    player_profiles: List[Dict[str, Any]] = []
+    hitter_rows: List[Dict[str, Any]] = []
+
+    for player in lineup:
+        player_id = _safe_int(player.get("batter_id"))
+        player_name = player.get("name")
+
+        if not player_id:
+            continue
+
+        profile = _build_player_true_talent_profile(
+            session=session,
+            player_id=player_id,
+            player_name=player_name,
+            target_date=target_date,
+            split=split,
+            base_weights=base_weights,
+            min_pa_by_component=min_pa_by_component,
+        )
+        player_profiles.append(profile)
+
+        component_pa = {
+            f"{component['component']}_pa": _safe_int(component.get("pa")) or 0
+            for component in profile.get("components", [])
+        }
+        component_used = {
+            f"{component['component']}_used": bool(component.get("is_usable"))
+            for component in profile.get("components", [])
+        }
+
+        hitter_rows.append({
+            "date": date_str,
+            "game_pk": game_pk,
+            "side": side,
+            "team_id": team_id,
+            "team_name": ctx.get("team_name"),
+            "split": split,
+            "player_id": player_id,
+            "player_name": player_name,
+            "lineup_slot": player.get("lineup_slot"),
+            "usable_component_count": profile.get("usable_component_count"),
+            "used_components": ",".join(profile.get("used_components") or []),
+            "has_usable_true_talent_profile": profile.get("has_usable_true_talent_profile"),
+            "pa": profile.get("pa"),
+            "batting_avg": profile.get("batting_avg"),
+            "on_base_pct": profile.get("on_base_pct"),
+            "slugging_pct": profile.get("slugging_pct"),
+            "iso": profile.get("iso"),
+            "k_pct": profile.get("k_pct"),
+            "bb_pct": profile.get("bb_pct"),
+            **component_pa,
+            **component_used,
+        })
+
+    lineup_inputs = _aggregate_lineup_profiles(
+        player_profiles,
+        lineup_count=len(lineup),
+        min_usable_hitters=min_usable_hitters,
+    )
+
+    row = {
+        "date": date_str,
+        "game_pk": game_pk,
+        "side": side,
+        "team_id": team_id,
+        "team_name": ctx.get("team_name"),
+        "split": split,
+        "starting_lineup_count": len(lineup),
+        "usable_true_talent_hitter_count": lineup_inputs.get("usable_hitter_profile_count"),
+        "min_usable_hitters": min_usable_hitters,
+        "would_activate": lineup_inputs.get("would_activate"),
+        "team_source": team_inputs.get("source"),
+        "true_talent_source": lineup_inputs.get("source"),
+        **_metric_deltas(team_inputs, lineup_inputs),
+    }
+    row["extreme_delta"] = _is_extreme_delta(row)
+
+    return row, hitter_rows
+
+
+def _summarize(rows: List[Dict[str, Any]], hitter_rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    component_names = list(DEFAULT_COMPONENT_WEIGHTS.keys())
+
+    component_availability: Dict[str, Dict[str, Any]] = {}
+    for component in component_names:
+        pa_key = f"{component}_pa"
+        used_key = f"{component}_used"
+        component_availability[component] = {
+            "hitters_with_any_pa": sum(1 for row in hitter_rows if (_safe_int(row.get(pa_key)) or 0) > 0),
+            "hitters_used": sum(1 for row in hitter_rows if bool(row.get(used_key))),
+            "pa_distribution": _distribution([row.get(pa_key) for row in hitter_rows]),
+        }
+
+    return {
+        "team_sides": len(rows),
+        "lineup_sides_would_activate": sum(1 for row in rows if row.get("would_activate")),
+        "extreme_delta_sides": sum(1 for row in rows if row.get("extreme_delta")),
+        "usable_true_talent_hitter_count_distribution": _distribution(
+            [row.get("usable_true_talent_hitter_count") for row in rows]
+        ),
+        "delta_distributions": {
+            metric: _distribution([row.get(f"{metric}_delta") for row in rows])
+            for metric in METRICS
+        },
+        "component_availability": component_availability,
+        "hitters": {
+            "rows": len(hitter_rows),
+            "with_usable_true_talent_profile": sum(
+                1 for row in hitter_rows if row.get("has_usable_true_talent_profile")
+            ),
+            "usable_component_count_distribution": _distribution(
+                [row.get("usable_component_count") for row in hitter_rows]
+            ),
+        },
+        "recommendation": (
+            "Audit only. Do not patch production lineup offense yet. "
+            "Use this report to compare true-talent deltas against prior raw lineup/team deltas."
+        ),
+    }
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("")
+        return
+
+    fieldnames = sorted({key for row in rows for key in row.keys()})
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    start = os.getenv("BACKTEST_START", "2026-04-20")
+    end = os.getenv("BACKTEST_END", "2026-05-03")
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    min_usable_hitters = int(os.getenv("MIN_USABLE_HITTERS", "7"))
+
+    base_weights = dict(DEFAULT_COMPONENT_WEIGHTS)
+    min_pa_by_component = dict(DEFAULT_MIN_PA_BY_COMPONENT)
+
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionLocal = get_session(engine)
+
+    side_rows: List[Dict[str, Any]] = []
+    hitter_rows: List[Dict[str, Any]] = []
+
+    with SessionLocal() as session:
+        for date_str in _date_range(start, end):
+            matchups = generate_matchups_for_date(session, date_str)
+            for matchup in matchups:
+                for side in ("away", "home"):
+                    side_row, side_hitter_rows = _audit_side(
+                        session=session,
+                        date_str=date_str,
+                        matchup=matchup,
+                        side=side,
+                        base_weights=base_weights,
+                        min_pa_by_component=min_pa_by_component,
+                        min_usable_hitters=min_usable_hitters,
+                    )
+                    side_rows.append(side_row)
+                    hitter_rows.extend(side_hitter_rows)
+
+    summary = _summarize(side_rows, hitter_rows)
+
+    output_dir = Path("tmp")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prefix = f"player_true_talent_profile_audit_{start}_to_{end}"
+    json_path = output_dir / f"{prefix}.json"
+    side_csv_path = output_dir / f"{prefix}_team_sides.csv"
+    hitter_csv_path = output_dir / f"{prefix}_hitters.csv"
+
+    payload = {
+        "start": start,
+        "end": end,
+        "database_url": database_url,
+        "component_weights": base_weights,
+        "min_pa_by_component": min_pa_by_component,
+        "summary": summary,
+        "rows": side_rows,
+    }
+
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    _write_csv(side_csv_path, side_rows)
+    _write_csv(hitter_csv_path, hitter_rows)
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print(f"Wrote {json_path}")
+    print(f"Wrote {side_csv_path}")
+    print(f"Wrote {hitter_csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_historical_hitter_statcast_sample.py
+++ b/scripts/backfill_historical_hitter_statcast_sample.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Backfill historical hitter Statcast for sampled lineup hitters.
+
+This is a production-safe helper for the player true-talent profile work.
+
+Default behavior is audit/dry-run only:
+    DRY_RUN=true
+    APPLY=false
+
+It targets hitters from the historical backtest lineup sample, not today's slate.
+It reuses the existing hitter Statcast upsert/checkpoint logic from:
+    scripts/backfill_hitter_statcast.py
+
+Typical dry run:
+    BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 \
+    python scripts/backfill_historical_hitter_statcast_sample.py
+
+Apply one season after reviewing dry-run:
+    APPLY=true DRY_RUN=false SEASONS=2025 \
+    BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 \
+    python scripts/backfill_historical_hitter_statcast_sample.py
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.lineup_profile import fetch_boxscore_lineup
+from mlb_app.matchup_generator import generate_matchups_for_date
+from mlb_app.statcast_utils import fetch_statcast_batter_data
+
+# Reuse proven fetch/upsert/checkpoint helpers from the existing script.
+from scripts.backfill_hitter_statcast import (  # noqa: E402
+    _ensure_checkpoint_table,
+    _insert_or_update_batter_statcast,
+)
+
+
+DEFAULT_SEASONS = [2023, 2024, 2025]
+
+
+def _log(message: str) -> None:
+    timestamp = dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    print(f"[{timestamp}] {message}", flush=True)
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _date_range(start: str, end: str) -> Iterable[str]:
+    current = dt.date.fromisoformat(start)
+    stop = dt.date.fromisoformat(end)
+    while current <= stop:
+        yield current.isoformat()
+        current += dt.timedelta(days=1)
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_seasons() -> List[int]:
+    raw = os.getenv("SEASONS")
+    if not raw:
+        return list(DEFAULT_SEASONS)
+
+    seasons: List[int] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        seasons.append(int(part))
+
+    return seasons
+
+
+def _season_window(season: int) -> Tuple[str, str]:
+    return f"{season}-03-01", f"{season}-11-30"
+
+
+def _collect_sample_hitters(session, start: str, end: str, max_hitters: Optional[int]) -> List[Dict[str, Any]]:
+    hitters_by_id: Dict[int, Dict[str, Any]] = {}
+
+    for date_str in _date_range(start, end):
+        matchups = generate_matchups_for_date(session, date_str)
+
+        for matchup in matchups:
+            game_pk = _safe_int(matchup.get("game_pk"))
+            if not game_pk:
+                continue
+
+            try:
+                lineups = fetch_boxscore_lineup(game_pk)
+            except Exception as exc:
+                _log(f"Lineup fetch failed game_pk={game_pk} date={date_str}: {exc}")
+                continue
+
+            for side in ("away", "home"):
+                team_id = matchup.get(f"{side}_team_id")
+                team_name = matchup.get(f"{side}_team_name")
+
+                for hitter in lineups.get(side) or []:
+                    player_id = _safe_int(hitter.get("batter_id"))
+                    if player_id is None:
+                        continue
+
+                    existing = hitters_by_id.get(player_id)
+                    if existing is None:
+                        hitters_by_id[player_id] = {
+                            "player_id": player_id,
+                            "player_name": hitter.get("name"),
+                            "first_seen_date": date_str,
+                            "last_seen_date": date_str,
+                            "sample_lineup_appearances": 1,
+                            "sample_team_ids": {str(team_id)} if team_id is not None else set(),
+                            "sample_team_names": {str(team_name)} if team_name else set(),
+                        }
+                    else:
+                        existing["last_seen_date"] = date_str
+                        existing["sample_lineup_appearances"] += 1
+                        if team_id is not None:
+                            existing["sample_team_ids"].add(str(team_id))
+                        if team_name:
+                            existing["sample_team_names"].add(str(team_name))
+
+    hitters: List[Dict[str, Any]] = []
+    for row in hitters_by_id.values():
+        row["sample_team_ids"] = ",".join(sorted(row["sample_team_ids"]))
+        row["sample_team_names"] = ",".join(sorted(row["sample_team_names"]))
+        hitters.append(row)
+
+    hitters.sort(key=lambda row: (row.get("player_name") or "", row["player_id"]))
+
+    if max_hitters is not None and max_hitters > 0:
+        hitters = hitters[:max_hitters]
+
+    return hitters
+
+
+def _existing_event_count(session, batter_id: int, start_date: str, end_date: str) -> int:
+    start = dt.date.fromisoformat(start_date)
+    end = dt.date.fromisoformat(end_date)
+    return int(
+        session.query(StatcastEvent.id)
+        .filter(
+            StatcastEvent.batter_id == batter_id,
+            StatcastEvent.game_date >= start,
+            StatcastEvent.game_date <= end,
+        )
+        .count()
+        or 0
+    )
+
+
+def _dry_run_fetch_estimate(batter: Dict[str, Any], start_date: str, end_date: str) -> Dict[str, Any]:
+    batter_id = int(batter["player_id"])
+    try:
+        df = fetch_statcast_batter_data(batter_id, start_date, end_date)
+    except Exception as exc:
+        return {
+            **batter,
+            "start_date": start_date,
+            "end_date": end_date,
+            "fetched_rows": 0,
+            "error": str(exc),
+        }
+
+    fetched_rows = 0 if df is None else int(len(df))
+    return {
+        **batter,
+        "start_date": start_date,
+        "end_date": end_date,
+        "fetched_rows": fetched_rows,
+    }
+
+
+def main() -> int:
+    start = os.getenv("BACKTEST_START", "2026-04-20")
+    end = os.getenv("BACKTEST_END", "2026-05-03")
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    seasons = _parse_seasons()
+
+    dry_run = _parse_bool_env("DRY_RUN", True)
+    apply = _parse_bool_env("APPLY", False)
+    should_write = bool(apply and not dry_run)
+
+    max_hitters_raw = os.getenv("MAX_HITTERS")
+    max_hitters = int(max_hitters_raw) if max_hitters_raw else None
+
+    fetch_in_dry_run = _parse_bool_env("FETCH_IN_DRY_RUN", False)
+
+    engine = get_engine(database_url)
+    create_tables(engine)
+    _ensure_checkpoint_table(engine)
+    SessionLocal = get_session(engine)
+
+    _log("=== HISTORICAL HITTER STATCAST SAMPLE BACKFILL ===")
+    _log(f"BACKTEST_START={start}")
+    _log(f"BACKTEST_END={end}")
+    _log(f"SEASONS={','.join(str(s) for s in seasons)}")
+    _log(f"DATABASE_URL={database_url}")
+    _log(f"DRY_RUN={dry_run}")
+    _log(f"APPLY={apply}")
+    _log(f"should_write={should_write}")
+    _log(f"FETCH_IN_DRY_RUN={fetch_in_dry_run}")
+    _log(f"MAX_HITTERS={max_hitters}")
+
+    rows: List[Dict[str, Any]] = []
+
+    with SessionLocal() as session:
+        hitters = _collect_sample_hitters(session, start, end, max_hitters=max_hitters)
+        _log(f"Collected sampled hitters: {len(hitters)}")
+
+        for season in seasons:
+            season_start, season_end = _season_window(season)
+            _log(f"Processing season={season} window={season_start} to {season_end}")
+
+            for index, hitter in enumerate(hitters, start=1):
+                batter_id = int(hitter["player_id"])
+                existing_rows = _existing_event_count(session, batter_id, season_start, season_end)
+
+                base_row = {
+                    **hitter,
+                    "season": season,
+                    "start_date": season_start,
+                    "end_date": season_end,
+                    "existing_rows_before": existing_rows,
+                    "dry_run": dry_run,
+                    "apply": apply,
+                    "should_write": should_write,
+                }
+
+                if dry_run and not fetch_in_dry_run:
+                    rows.append(
+                        {
+                            **base_row,
+                            "action": "dry_run_no_fetch",
+                            "fetched_rows": None,
+                            "inserted_rows": 0,
+                            "updated_rows": 0,
+                        }
+                    )
+                    continue
+
+                if should_write:
+                    result = _insert_or_update_batter_statcast(
+                        session=session,
+                        batter=hitter,
+                        start_date=season_start,
+                        end_date=season_end,
+                    )
+                    rows.append(
+                        {
+                            **base_row,
+                            **result,
+                            "action": "applied",
+                            "existing_rows_after": _existing_event_count(
+                                session, batter_id, season_start, season_end
+                            ),
+                        }
+                    )
+                else:
+                    result = _dry_run_fetch_estimate(hitter, season_start, season_end)
+                    rows.append(
+                        {
+                            **base_row,
+                            **result,
+                            "action": "dry_run_fetch_only",
+                            "inserted_rows": 0,
+                            "updated_rows": 0,
+                        }
+                    )
+
+                if index % 25 == 0:
+                    _log(f"season={season} progress={index}/{len(hitters)}")
+
+    summary: Dict[str, Any] = {
+        "backtest_start": start,
+        "backtest_end": end,
+        "database_url": database_url,
+        "seasons": seasons,
+        "dry_run": dry_run,
+        "apply": apply,
+        "should_write": should_write,
+        "fetch_in_dry_run": fetch_in_dry_run,
+        "rows": len(rows),
+        "targets": len({row["player_id"] for row in rows}) if rows else 0,
+        "existing_rows_before": sum(int(row.get("existing_rows_before") or 0) for row in rows),
+        "fetched_rows": sum(int(row.get("fetched_rows") or 0) for row in rows),
+        "inserted_rows": sum(int(row.get("inserted_rows") or 0) for row in rows),
+        "updated_rows": sum(int(row.get("updated_rows") or 0) for row in rows),
+        "errors": sum(1 for row in rows if row.get("error")),
+        "actions": {},
+    }
+
+    action_counts: Dict[str, int] = {}
+    for row in rows:
+        action = row.get("action") or "unknown"
+        action_counts[action] = action_counts.get(action, 0) + 1
+    summary["actions"] = action_counts
+
+    output_dir = Path("tmp")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"historical_hitter_statcast_sample_backfill_{start}_to_{end}"
+    output_path = output_dir / f"{prefix}.json"
+
+    output_path.write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "rows": rows,
+            },
+            indent=2,
+            sort_keys=True,
+            default=str,
+        )
+    )
+
+    _log("=== SUMMARY ===")
+    print(json.dumps(summary, indent=2, sort_keys=True, default=str))
+    _log(f"Wrote {output_path}")
+
+    if not should_write:
+        _log("No database writes were performed. Set APPLY=true DRY_RUN=false to apply.")
+    else:
+        _log("Database writes were applied.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_historical_player_splits_sample.py
+++ b/scripts/backfill_historical_player_splits_sample.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Backfill historical PlayerSplit rows for sampled lineup hitters.
+
+This is the second step after loading historical StatcastEvent rows.
+
+Default behavior is dry-run only:
+    DRY_RUN=true
+    APPLY=false
+
+It targets the same hitters from the historical backtest lineup sample and
+builds PlayerSplit rows from local StatcastEvent data by season and pitcher-hand
+split.
+
+Typical dry run:
+    SEASONS=2025 MAX_HITTERS=3 \
+    BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 \
+    python scripts/backfill_historical_player_splits_sample.py
+
+Apply:
+    APPLY=true DRY_RUN=false SEASONS=2025 MAX_HITTERS=3 \
+    BACKTEST_START=2026-04-20 BACKTEST_END=2026-05-03 \
+    python scripts/backfill_historical_player_splits_sample.py
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from mlb_app.database import PlayerSplit, StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.lineup_profile import fetch_boxscore_lineup
+from mlb_app.matchup_generator import generate_matchups_for_date
+
+from scripts.backfill_lineup_player_splits import (  # noqa: E402
+    calculate_split_metrics,
+    split_for_pitcher_hand,
+    upsert_player_split,
+)
+
+
+DEFAULT_SEASONS = [2023, 2024, 2025]
+
+
+def _log(message: str) -> None:
+    timestamp = dt.datetime.now(dt.UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    print(f"[{timestamp}] {message}", flush=True)
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or isinstance(value, bool):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _date_range(start: str, end: str) -> Iterable[str]:
+    current = dt.date.fromisoformat(start)
+    stop = dt.date.fromisoformat(end)
+    while current <= stop:
+        yield current.isoformat()
+        current += dt.timedelta(days=1)
+
+
+def _parse_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_seasons() -> List[int]:
+    raw = os.getenv("SEASONS")
+    if not raw:
+        return list(DEFAULT_SEASONS)
+
+    seasons: List[int] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        seasons.append(int(part))
+
+    return seasons
+
+
+def _season_window(season: int) -> Tuple[dt.date, dt.date]:
+    return dt.date(season, 3, 1), dt.date(season, 11, 30)
+
+
+def _collect_sample_hitters(session, start: str, end: str, max_hitters: Optional[int]) -> List[Dict[str, Any]]:
+    hitters_by_id: Dict[int, Dict[str, Any]] = {}
+
+    for date_str in _date_range(start, end):
+        matchups = generate_matchups_for_date(session, date_str)
+
+        for matchup in matchups:
+            game_pk = _safe_int(matchup.get("game_pk"))
+            if not game_pk:
+                continue
+
+            try:
+                lineups = fetch_boxscore_lineup(game_pk)
+            except Exception as exc:
+                _log(f"Lineup fetch failed game_pk={game_pk} date={date_str}: {exc}")
+                continue
+
+            for side in ("away", "home"):
+                team_id = matchup.get(f"{side}_team_id")
+                team_name = matchup.get(f"{side}_team_name")
+
+                for hitter in lineups.get(side) or []:
+                    player_id = _safe_int(hitter.get("batter_id"))
+                    if player_id is None:
+                        continue
+
+                    existing = hitters_by_id.get(player_id)
+                    if existing is None:
+                        hitters_by_id[player_id] = {
+                            "player_id": player_id,
+                            "player_name": hitter.get("name"),
+                            "first_seen_date": date_str,
+                            "last_seen_date": date_str,
+                            "sample_lineup_appearances": 1,
+                            "sample_team_ids": {str(team_id)} if team_id is not None else set(),
+                            "sample_team_names": {str(team_name)} if team_name else set(),
+                        }
+                    else:
+                        existing["last_seen_date"] = date_str
+                        existing["sample_lineup_appearances"] += 1
+                        if team_id is not None:
+                            existing["sample_team_ids"].add(str(team_id))
+                        if team_name:
+                            existing["sample_team_names"].add(str(team_name))
+
+    hitters: List[Dict[str, Any]] = []
+    for row in hitters_by_id.values():
+        row["sample_team_ids"] = ",".join(sorted(row["sample_team_ids"]))
+        row["sample_team_names"] = ",".join(sorted(row["sample_team_names"]))
+        hitters.append(row)
+
+    hitters.sort(key=lambda row: (row.get("player_name") or "", row["player_id"]))
+
+    if max_hitters is not None and max_hitters > 0:
+        hitters = hitters[:max_hitters]
+
+    return hitters
+
+
+def _existing_player_split_pa(session, player_id: int, season: int, split: str) -> int:
+    row = (
+        session.query(PlayerSplit)
+        .filter(
+            PlayerSplit.player_id == player_id,
+            PlayerSplit.season == season,
+            PlayerSplit.split == split,
+        )
+        .one_or_none()
+    )
+    return int(row.pa or 0) if row else 0
+
+
+def _load_events(session, player_id: int, start_date: dt.date, end_date: dt.date) -> List[StatcastEvent]:
+    return (
+        session.query(StatcastEvent)
+        .filter(
+            StatcastEvent.batter_id == player_id,
+            StatcastEvent.game_date >= start_date,
+            StatcastEvent.game_date <= end_date,
+        )
+        .all()
+    )
+
+
+def _process_hitter_season(
+    session,
+    hitter: Dict[str, Any],
+    season: int,
+    start_date: dt.date,
+    end_date: dt.date,
+    min_split_pa: int,
+    should_write: bool,
+) -> Dict[str, Any]:
+    player_id = int(hitter["player_id"])
+    events = _load_events(session, player_id, start_date, end_date)
+
+    by_split: Dict[str, List[StatcastEvent]] = {"vsL": [], "vsR": []}
+    ignored_unknown_hand = 0
+
+    for event in events:
+        split = split_for_pitcher_hand(event.p_throws)
+        if split is None:
+            ignored_unknown_hand += 1
+            continue
+        by_split[split].append(event)
+
+    split_rows: List[Dict[str, Any]] = []
+    created = 0
+    updated = 0
+    skipped = 0
+
+    for split, split_events in by_split.items():
+        existing_pa = _existing_player_split_pa(session, player_id, season, split)
+        metrics = calculate_split_metrics(split_events)
+
+        row = {
+            "split": split,
+            "raw_event_count": len(split_events),
+            "existing_player_split_pa": existing_pa,
+            "metrics": metrics,
+            "action": None,
+            "skipped": False,
+            "skipped_reason": None,
+        }
+
+        if metrics is None:
+            row["skipped"] = True
+            row["skipped_reason"] = "no_terminal_pa_events"
+            skipped += 1
+            split_rows.append(row)
+            continue
+
+        if int(metrics.get("pa") or 0) < min_split_pa:
+            row["skipped"] = True
+            row["skipped_reason"] = f"insufficient_pa:{metrics.get('pa')}"
+            skipped += 1
+            split_rows.append(row)
+            continue
+
+        if should_write:
+            action = upsert_player_split(
+                session=session,
+                player_id=player_id,
+                season=season,
+                split=split,
+                metrics=metrics,
+            )
+        else:
+            action = "would_update" if existing_pa > 0 else "would_create"
+
+        row["action"] = action
+        if action in {"created", "would_create"}:
+            created += 1
+        elif action in {"updated", "would_update"}:
+            updated += 1
+
+        split_rows.append(row)
+
+    return {
+        **hitter,
+        "season": season,
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "raw_event_count": len(events),
+        "ignored_unknown_hand_events": ignored_unknown_hand,
+        "splits": split_rows,
+        "splits_created_or_would_create": created,
+        "splits_updated_or_would_update": updated,
+        "splits_skipped": skipped,
+    }
+
+
+def main() -> int:
+    start = os.getenv("BACKTEST_START", "2026-04-20")
+    end = os.getenv("BACKTEST_END", "2026-05-03")
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    seasons = _parse_seasons()
+
+    dry_run = _parse_bool_env("DRY_RUN", True)
+    apply = _parse_bool_env("APPLY", False)
+    should_write = bool(apply and not dry_run)
+
+    min_split_pa = int(os.getenv("MIN_SPLIT_PA", "25"))
+
+    max_hitters_raw = os.getenv("MAX_HITTERS")
+    max_hitters = int(max_hitters_raw) if max_hitters_raw else None
+
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionLocal = get_session(engine)
+
+    _log("=== HISTORICAL PLAYER SPLIT SAMPLE BACKFILL ===")
+    _log(f"BACKTEST_START={start}")
+    _log(f"BACKTEST_END={end}")
+    _log(f"SEASONS={','.join(str(s) for s in seasons)}")
+    _log(f"DATABASE_URL={database_url}")
+    _log(f"MIN_SPLIT_PA={min_split_pa}")
+    _log(f"DRY_RUN={dry_run}")
+    _log(f"APPLY={apply}")
+    _log(f"should_write={should_write}")
+    _log(f"MAX_HITTERS={max_hitters}")
+
+    rows: List[Dict[str, Any]] = []
+
+    with SessionLocal() as session:
+        hitters = _collect_sample_hitters(session, start, end, max_hitters=max_hitters)
+        _log(f"Collected sampled hitters: {len(hitters)}")
+
+        for season in seasons:
+            season_start, season_end = _season_window(season)
+            _log(f"Processing season={season} window={season_start.isoformat()} to {season_end.isoformat()}")
+
+            for hitter in hitters:
+                rows.append(
+                    _process_hitter_season(
+                        session=session,
+                        hitter=hitter,
+                        season=season,
+                        start_date=season_start,
+                        end_date=season_end,
+                        min_split_pa=min_split_pa,
+                        should_write=should_write,
+                    )
+                )
+
+        if should_write:
+            session.commit()
+        else:
+            session.rollback()
+
+    summary: Dict[str, Any] = {
+        "backtest_start": start,
+        "backtest_end": end,
+        "database_url": database_url,
+        "seasons": seasons,
+        "dry_run": dry_run,
+        "apply": apply,
+        "should_write": should_write,
+        "min_split_pa": min_split_pa,
+        "rows": len(rows),
+        "targets": len({row["player_id"] for row in rows}) if rows else 0,
+        "raw_event_count": sum(int(row.get("raw_event_count") or 0) for row in rows),
+        "splits_created_or_would_create": sum(int(row.get("splits_created_or_would_create") or 0) for row in rows),
+        "splits_updated_or_would_update": sum(int(row.get("splits_updated_or_would_update") or 0) for row in rows),
+        "splits_skipped": sum(int(row.get("splits_skipped") or 0) for row in rows),
+        "split_actions": {},
+        "skipped_reasons": {},
+    }
+
+    split_actions: Dict[str, int] = {}
+    skipped_reasons: Dict[str, int] = {}
+    for row in rows:
+        for split_row in row.get("splits") or []:
+            action = split_row.get("action")
+            if action:
+                split_actions[action] = split_actions.get(action, 0) + 1
+            if split_row.get("skipped"):
+                reason = split_row.get("skipped_reason") or "unknown"
+                skipped_reasons[reason] = skipped_reasons.get(reason, 0) + 1
+
+    summary["split_actions"] = split_actions
+    summary["skipped_reasons"] = skipped_reasons
+
+    output_dir = Path("tmp")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"historical_player_splits_sample_backfill_{start}_to_{end}"
+    output_path = output_dir / f"{prefix}.json"
+
+    output_path.write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "rows": rows,
+            },
+            indent=2,
+            sort_keys=True,
+            default=str,
+        )
+    )
+
+    _log("=== SUMMARY ===")
+    print(json.dumps(summary, indent=2, sort_keys=True, default=str))
+    _log(f"Wrote {output_path}")
+
+    if not should_write:
+        _log("No database writes were performed. Set APPLY=true DRY_RUN=false to apply.")
+    else:
+        _log("Database writes were applied.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds audit/backfill tooling to evaluate multi-season hitter true-talent profiles without changing production simulation logic.

What changed:
- Add read-only true-talent profile audit.
- Add historical hitter data availability audit.
- Add sampled historical hitter Statcast backfill script with dry-run/apply guards.
- Add sampled historical PlayerSplit backfill script with dry-run/apply guards.

Validation:
- python -m compileall mlb_app scripts
- Loaded sampled historical hitter Statcast and PlayerSplit data for 2023, 2024, and 2025.
- Historical availability improved to:
  - 2023: 283 hitters with player splits, 352 with Statcast
  - 2024: 320 hitters with player splits, 377 with Statcast
  - 2025: 378 hitters with player splits, 407 with Statcast
  - 2026: 411 hitters with player splits and Statcast
- True-talent audit extreme_delta_sides improved:
  - no historical seasons: 137
  - after 2025: 124
  - after 2024: 118
  - after 2023: 116

Notes:
- No production simulation logic changed.
- No game_engine_v2 changes.
- No lineup activation changes.
- No edge detection logic added.
- Further shrinkage/grid testing is still needed before wiring into production.