### PR TITLE
Hotfix: temporarily disable unstable Batter route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,8 +4,6 @@ import HomePage from './pages/HomePage'
 import MatchupDetailPage from './pages/MatchupDetailPage'
 import PitcherPage from './pages/PitcherPage'
 import RollingPitcherPage from './pages/RollingPitcherPage'
-import BatterPage from './pages/BatterPage'
-import RollingBatterPage from './pages/RollingBatterPage'
 import TeamPage from './pages/TeamPage'
 import StandingsPage from './pages/StandingsPage'
 import CompetitiveAnalysisPage from './pages/CompetitiveAnalysisPage'
@@ -15,6 +13,24 @@ import LiveScoreboardPage from './pages/LiveScoreboardPage'
 import LiveGamePageRestored from './pages/LiveGamePageRestored'
 import DailyOddsPage from './pages/DailyOddsPage'
 import ModelProjectionsPage from './pages/ModelProjectionsPage'
+
+function BatterTemporarilyUnavailable() {
+  return (
+    <div style={{
+      background: '#161b22',
+      border: '1px solid #30363d',
+      borderRadius: '10px',
+      padding: '24px',
+      color: '#e6edf3',
+    }}>
+      <h1 style={{ marginTop: 0, fontSize: '22px' }}>Batter page temporarily disabled</h1>
+      <p style={{ color: '#8b949e', lineHeight: 1.5 }}>
+        The Batter dashboard was disabled temporarily because the new leaderboard endpoint is causing production instability.
+        Matchups, pitchers, teams, odds, live scores, and the rest of the app remain available.
+      </p>
+    </div>
+  )
+}
 
 const styles = {
   nav: {
@@ -84,9 +100,9 @@ export default function App() {
           <Route path="/pitcher" element={<PitcherPage />} />
           <Route path="/pitcher/:id" element={<PitcherPage />} />
           <Route path="/pitcher/:id/rolling" element={<RollingPitcherPage />} />
-          <Route path="/batter" element={<BatterPage />} />
-          <Route path="/batter/:id" element={<BatterPage />} />
-          <Route path="/batter/:id/rolling" element={<RollingBatterPage />} />
+          <Route path="/batter" element={<BatterTemporarilyUnavailable />} />
+          <Route path="/batter/:id" element={<BatterTemporarilyUnavailable />} />
+          <Route path="/batter/:id/rolling" element={<BatterTemporarilyUnavailable />} />
           <Route path="/team" element={<TeamPage />} />
           <Route path="/team/:id" element={<TeamPage />} />
           <Route path="/calendar" element={<YesterdayTodayPage />} />


### PR DESCRIPTION
## Summary

Emergency production stabilization hotfix.

This PR temporarily disables the Batter page routes that were introduced/expanded during the recent Batter leaderboard rollout. The new Batter dashboard/leaderboard path appears to be causing frontend instability, while the rest of the app and API routes are still functioning.

## What changed

- Replaced `/batter`, `/batter/:id`, and `/batter/:id/rolling` route targets with a lightweight temporary unavailable component.
- Removed the Batter page import from `App.jsx`, so the unstable Batter page bundle/component path is not loaded by the frontend router.
- Left Matchups, Daily Odds, Model Projections, Standings, Pitcher, Team, Calendar, AI, and Live routes untouched.

## Why

Railway logs show the API service itself is starting and serving core endpoints successfully, including `/health`, `/matchups`, `/players/search`, `/pitcher`, odds, and matchup detail routes. The visible cron logs show the refresh job running heavy hitting matchup work and upserting data, but the uploaded section does not show a fatal traceback.

The safest immediate fix is to remove the unstable Batter dashboard route from the frontend while preserving the rest of production.

## Follow-up

After production is stable:

1. Rebuild Batter leaderboards behind a cached backend snapshot.
2. Stop computing leaderboards live on page load.
3. Split Batter page into smaller components.
4. Re-enable `/batter` only after frontend build and endpoint behavior are verified.

## Validation

Expected after deploy:

- `/` Matchups still loads.
- `/pitcher` still loads.
- `/team` still loads.
- `/daily-odds` still loads.
- `/live` still loads.
- `/batter` shows a temporary disabled message instead of crashing/fetching leaderboards.