### PR TITLE
Fix AI Data Assistant frontend wiring

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -93,7 +93,7 @@ export default function App() {
         <NavLink to="/batter" style={link}>Batter</NavLink>
         <NavLink to="/team" style={link}>Team</NavLink>
         <NavLink to="/calendar" style={link}>Calendar</NavLink>
-        <NavLink to="/ai" style={link}>AI</NavLink>
+        <NavLink to="/ai-data-assistant" style={link}>AI Data Assistant</NavLink>
         <NavLink to="/live" style={link}>Live</NavLink>
       </nav>
       <main style={styles.main}>
@@ -114,6 +114,7 @@ export default function App() {
           <Route path="/team/:id" element={<TeamPage />} />
           <Route path="/calendar" element={<YesterdayTodayPage />} />
           <Route path="/ai" element={<AIPage />} />
+          <Route path="/ai-data-assistant" element={<AIPage />} />
           <Route path="/live" element={<LiveScoreboardPage />} />
           <Route path="/live/:game_pk" element={<LiveGamePageRestored />} />
         </Routes>

--- a/frontend/src/pages/AIPage.jsx
+++ b/frontend/src/pages/AIPage.jsx
@@ -2,21 +2,45 @@ import React, { useState } from 'react'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
 
+const PROMPT_CHIPS = [
+  "Summarize today's slate",
+  'What is the strongest model edge?',
+  'Which games are missing data?',
+  'Best Stored 365 hitter matchups',
+  'Top pitcher leans',
+  'Explain this matchup',
+  'What does Daily Odds tell us?',
+  'Which game has the cleanest signal?',
+  'Show me the best hitter vs pitcher spots',
+  'What data is stale or weak?',
+]
+
 export default function AIPage() {
-  const [question, setQuestion] = useState('How many matchups are there today?')
+  const today = new Date().toISOString().slice(0, 10)
+  const [message, setMessage] = useState("Summarize today's slate")
+  const [date, setDate] = useState(today)
+  const [gamePk, setGamePk] = useState('')
+  const [playerId, setPlayerId] = useState('')
   const [response, setResponse] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
 
-  async function ask() {
+  async function ask(nextMessage = message) {
     setLoading(true)
     setError(null)
 
     try {
-      const res = await fetch(`${API}/ai/ask`, {
+      const payload = {
+        message: nextMessage,
+        date: date || null,
+        game_pk: gamePk ? Number(gamePk) : null,
+        player_id: playerId ? Number(playerId) : null,
+      }
+
+      const res = await fetch(`${API}/ai-data-assistant`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question }),
+        body: JSON.stringify(payload),
       })
 
       if (!res.ok) {
@@ -26,41 +50,90 @@ export default function AIPage() {
 
       const json = await res.json()
       setResponse(json)
-
     } catch (err) {
-      console.error('AI request failed:', err)
+      console.error('AI Data Assistant request failed:', err)
       setError(err.message || 'Request failed')
       setResponse(null)
-
     } finally {
       setLoading(false)
     }
   }
 
+  function runChip(chip) {
+    setMessage(chip)
+    ask(chip)
+  }
+
   return (
     <div>
-      <h1 style={{ fontSize: '24px', marginBottom: '12px' }}>AI Data Assistant</h1>
-      <p style={{ color: '#8b949e', marginBottom: '12px' }}>
-        Ask about matchups by day, weather, and team performance (e.g. "team 147").
+      <h1 style={{ fontSize: '28px', marginBottom: '8px' }}>AI Data Assistant</h1>
+      <p style={{ color: '#8b949e', marginBottom: '18px', lineHeight: 1.5 }}>
+        Ask the app to explain matchups, model edges, Daily Odds, Stored 365 hitter spots, and data quality using only app-owned data.
       </p>
 
-      <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
-        <input
-          value={question}
-          onChange={e => setQuestion(e.target.value)}
-          style={{
-            flex: 1,
-            background: '#161b22',
-            color: '#e6edf3',
-            border: '1px solid #30363d',
-            borderRadius: '6px',
-            padding: '10px'
-          }}
-        />
+      <div style={{
+        background: '#161b22',
+        border: '1px solid #30363d',
+        borderRadius: '12px',
+        padding: '16px',
+        marginBottom: '16px'
+      }}>
+        <div style={{ display: 'flex', gap: '10px', marginBottom: '12px', flexWrap: 'wrap' }}>
+          <label style={{ color: '#8b949e', fontSize: '13px' }}>
+            Date
+            <input
+              type="date"
+              value={date}
+              onChange={e => setDate(e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+          <label style={{ color: '#8b949e', fontSize: '13px' }}>
+            Game PK
+            <input
+              value={gamePk}
+              onChange={e => setGamePk(e.target.value)}
+              placeholder="optional"
+              style={{ ...inputStyle, width: '140px' }}
+            />
+          </label>
+          <label style={{ color: '#8b949e', fontSize: '13px' }}>
+            Player ID
+            <input
+              value={playerId}
+              onChange={e => setPlayerId(e.target.value)}
+              placeholder="optional"
+              style={{ ...inputStyle, width: '140px' }}
+            />
+          </label>
+        </div>
 
-        <button onClick={ask} disabled={loading}>
-          {loading ? 'Asking…' : 'Ask'}
-        </button>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
+          <input
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') ask() }}
+            style={{
+              flex: 1,
+              background: '#0d1117',
+              color: '#e6edf3',
+              border: '1px solid #30363d',
+              borderRadius: '8px',
+              padding: '12px'
+            }}
+          />
+          <button onClick={() => ask()} disabled={loading}>
+            {loading ? 'Asking...' : 'Ask'}
+          </button>
+        </div>
+
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          {PROMPT_CHIPS.map(chip => (
+            <button key={chip} onClick={() => runChip(chip)} disabled={loading} style={chipStyle}>
+              {chip}
+            </button>
+          ))}
+        </div>
       </div>
 
       {error && (
@@ -79,40 +152,69 @@ export default function AIPage() {
         <div style={{
           background: '#161b22',
           border: '1px solid #30363d',
-          borderRadius: '8px',
-          padding: '14px'
+          borderRadius: '12px',
+          padding: '16px'
         }}>
-
-          <div style={{ fontWeight: 700, marginBottom: '8px' }}>
-            Answer
-          </div>
-
-          <div style={{ marginBottom: '10px' }}>
+          <div style={{ fontWeight: 700, marginBottom: '8px' }}>Answer</div>
+          <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.55, marginBottom: '16px' }}>
             {response.answer}
           </div>
 
-          {response.sources?.length > 0 && (
-            <div style={{ fontSize: '12px', color: '#8b949e' }}>
-              Sources: {response.sources.join(', ')}
-            </div>
-          )}
+          <div style={metaGridStyle}>
+            <MetaCard title="Intent" value={response.intent || 'unknown'} />
+            <MetaCard title="Sources used" value={(response.sources_used || []).join(', ') || 'None'} />
+            <MetaCard title="Confidence note" value={response.confidence_note || 'None'} />
+          </div>
 
-          {response.data && (
-            <pre style={{
-              marginTop: '12px',
-              background: '#0d1117',
-              borderRadius: '6px',
-              padding: '10px',
-              overflowX: 'auto',
-              fontSize: '12px'
-            }}>
-              {JSON.stringify(response.data, null, 2)}
-            </pre>
-          )}
-
+          <details style={{ marginTop: '14px' }}>
+            <summary style={{ cursor: 'pointer', color: '#58a6ff' }}>Data quality and missing data</summary>
+            <pre style={preStyle}>{JSON.stringify({ data_quality: response.data_quality, missing_data: response.missing_data }, null, 2)}</pre>
+          </details>
         </div>
       )}
-
     </div>
   )
+}
+
+function MetaCard({ title, value }) {
+  return (
+    <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: '8px', padding: '10px' }}>
+      <div style={{ color: '#8b949e', fontSize: '12px', marginBottom: '6px' }}>{title}</div>
+      <div style={{ color: '#e6edf3', fontSize: '13px', overflowWrap: 'anywhere' }}>{value}</div>
+    </div>
+  )
+}
+
+const inputStyle = {
+  display: 'block',
+  marginTop: '6px',
+  background: '#0d1117',
+  color: '#e6edf3',
+  border: '1px solid #30363d',
+  borderRadius: '8px',
+  padding: '9px'
+}
+
+const chipStyle = {
+  background: '#0d1117',
+  color: '#58a6ff',
+  border: '1px solid #30363d',
+  borderRadius: '999px',
+  padding: '8px 10px',
+  cursor: 'pointer'
+}
+
+const metaGridStyle = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+  gap: '10px'
+}
+
+const preStyle = {
+  marginTop: '12px',
+  background: '#0d1117',
+  borderRadius: '6px',
+  padding: '10px',
+  overflowX: 'auto',
+  fontSize: '12px'
 }


### PR DESCRIPTION
## Summary

Fixes the reason the AI Data Assistant appeared to do nothing after the backend merge.

The backend routes from PR #231 were active, but the production frontend is a separate static React/Vite service. Requests to `/ai-data-assistant` on the frontend service were returning the React shell and cached bundle instead of the FastAPI HTML route. The frontend also still had the existing AI page wired to the old `/ai/ask` endpoint.

## Changes

- Updates `frontend/src/App.jsx`
  - Changes nav label from `AI` to `AI Data Assistant`
  - Points nav to `/ai-data-assistant`
  - Adds a React route for `/ai-data-assistant`
  - Keeps `/ai` as a backwards-compatible route to the same page

- Updates `frontend/src/pages/AIPage.jsx`
  - Renames the page behavior around AI Data Assistant
  - Adds date, optional game PK, optional player ID inputs
  - Adds the required prompt chips
  - Posts to `POST /ai-data-assistant` instead of the old `POST /ai/ask`
  - Displays answer, intent, sources used, confidence note, data quality, and missing data

## Root cause from deploy logs

Frontend service logs showed:

- `GET /ai-data-assistant` returned 200 from the static frontend service
- The same request loaded `/assets/index-DnZRaHjA.js`

Backend service logs showed:

- Existing frontend was still making `POST /ai/ask`
- No frontend request was actually using the new `POST /ai-data-assistant` endpoint

So the backend merge was real, but the frontend never routed to it.

## Expected result after merge and frontend redeploy

- `/ai-data-assistant` renders the React AI Data Assistant page
- The nav shows `AI Data Assistant`
- Submitting a question calls the new backend endpoint `POST /ai-data-assistant`
- The page surfaces sources used, missing data, and data-quality output

## Deployment note

This requires a frontend redeploy because the production bundle must change from `index-DnZRaHjA.js` to a new compiled asset.