### PR TITLE
Optimize AI Data Assistant context caching and latency

### DIFF
--- a/mlb_app/ai_data_assistant_performance.py
+++ b/mlb_app/ai_data_assistant_performance.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+import time
+from contextvars import ContextVar
+from typing import Any, Dict, Optional, Tuple
+
+from . import ai_data_assistant as core
+from .model_projections import build_model_projection_payload as uncached_build_model_projection_payload
+
+AI_CONTEXT_TTL_SECONDS = 600
+AI_RESPONSE_TTL_SECONDS = 180
+
+_projection_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+_response_cache: Dict[Tuple[Any, ...], Tuple[float, Dict[str, Any]]] = {}
+_timing_var: ContextVar[Optional[Dict[str, float]]] = ContextVar("ai_data_assistant_timing", default=None)
+_original_projection_builder = uncached_build_model_projection_payload
+_patch_applied = False
+
+
+def _now() -> float:
+    return time.perf_counter()
+
+
+def _ms(start: float) -> int:
+    return int(round((_now() - start) * 1000))
+
+
+def _cache_get(cache: Dict[Any, Tuple[float, Any]], key: Any, ttl_seconds: int) -> Optional[Any]:
+    record = cache.get(key)
+    if not record:
+        return None
+    created_at, value = record
+    if _now() - created_at > ttl_seconds:
+        cache.pop(key, None)
+        return None
+    return copy.deepcopy(value)
+
+
+def _cache_set(cache: Dict[Any, Tuple[float, Any]], key: Any, value: Any) -> None:
+    cache[key] = (_now(), copy.deepcopy(value))
+
+
+def _timing() -> Optional[Dict[str, float]]:
+    return _timing_var.get()
+
+
+def _add_timing(name: str, elapsed_ms: int) -> None:
+    timing = _timing()
+    if timing is None:
+        return
+    timing[name] = timing.get(name, 0) + elapsed_ms
+
+
+def cached_build_model_projection_payload(session, target_date: str) -> Dict[str, Any]:
+    """Process-local TTL cache for the expensive model projection payload.
+
+    This monkey-patches the imported symbol inside `mlb_app.ai_data_assistant`, so
+    all existing v2 builders keep their current code path while sharing one
+    cached projection payload by date.
+    """
+    cache_key = f"ai_projection_payload:{target_date}"
+    cached = _cache_get(_projection_cache, cache_key, AI_CONTEXT_TTL_SECONDS)
+    if cached is not None:
+        timing = _timing()
+        if timing is not None:
+            timing["projection_cache_hit"] = timing.get("projection_cache_hit", 0) + 1
+        return cached
+
+    start = _now()
+    payload = _original_projection_builder(session, target_date)
+    _add_timing("projection_payload_ms", _ms(start))
+    _cache_set(_projection_cache, cache_key, payload)
+    timing = _timing()
+    if timing is not None:
+        timing["projection_cache_miss"] = timing.get("projection_cache_miss", 0) + 1
+    return copy.deepcopy(payload)
+
+
+def apply_performance_patch() -> None:
+    """Patch the existing v1/v2 service path once per process.
+
+    No new route, page, or duplicate assistant service is created. The existing
+    `ai_data_assistant.py` functions still do the product logic.
+    """
+    global _patch_applied
+    if _patch_applied:
+        return
+    core.build_model_projection_payload = cached_build_model_projection_payload
+    _patch_applied = True
+
+
+def _response_cache_key(message: str, date: Optional[str], game_pk: Optional[int], player_id: Optional[int], team_id: Optional[int], use_llm: bool) -> Tuple[Any, ...]:
+    normalized_message = " ".join((message or "").strip().lower().split())
+    return (normalized_message, date, game_pk, player_id, team_id, bool(use_llm))
+
+
+def build_ai_data_assistant_response(
+    session,
+    message: str,
+    date: Optional[str] = None,
+    game_pk: Optional[int] = None,
+    player_id: Optional[int] = None,
+    team_id: Optional[int] = None,
+    use_llm: bool = False,
+) -> Dict[str, Any]:
+    """Fast wrapper for the existing AI Data Assistant service.
+
+    Adds:
+    - process-level TTL response cache for repeated chip clicks
+    - process-level TTL Model Projection cache by date
+    - deterministic answers by default
+    - timing metadata on every response
+    """
+    apply_performance_patch()
+    total_start = _now()
+    timing: Dict[str, float] = {}
+    token = _timing_var.set(timing)
+    key = _response_cache_key(message, date, game_pk, player_id, team_id, use_llm)
+    try:
+        cached = _cache_get(_response_cache, key, AI_RESPONSE_TTL_SECONDS)
+        if cached is not None:
+            cached.setdefault("timing", {})
+            cached["timing"].update({"response_cache_hit": 1, "total_ms": _ms(total_start)})
+            cached["cache_status"] = "response_cache_hit"
+            return cached
+
+        context_start = _now()
+        context = core.build_assistant_context(
+            session=session,
+            message=message,
+            date=date,
+            game_pk=game_pk,
+            player_id=player_id,
+            team_id=team_id,
+        )
+        timing["context_build_ms"] = _ms(context_start)
+
+        answer_start = _now()
+        result = core.answer_with_optional_llm(message, context, use_llm=use_llm)
+        timing["answer_render_ms"] = _ms(answer_start)
+        timing["llm_requested"] = 1 if use_llm else 0
+        timing["total_ms"] = _ms(total_start)
+
+        result["timing"] = dict(timing)
+        result["cache_status"] = "miss"
+        _cache_set(_response_cache, key, result)
+        return result
+    finally:
+        _timing_var.reset(token)
+
+
+def clear_ai_data_assistant_caches() -> Dict[str, Any]:
+    projection_count = len(_projection_cache)
+    response_count = len(_response_cache)
+    _projection_cache.clear()
+    _response_cache.clear()
+    return {"cleared": True, "projection_cache_entries": projection_count, "response_cache_entries": response_count}

--- a/mlb_app/ai_data_assistant_routes.py
+++ b/mlb_app/ai_data_assistant_routes.py
@@ -8,7 +8,8 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from .ai_data_assistant import PROMPT_CHIPS, answer_with_optional_llm, build_assistant_context, classify_assistant_intent
+from .ai_data_assistant import PROMPT_CHIPS, classify_assistant_intent
+from .ai_data_assistant_performance import build_ai_data_assistant_response, clear_ai_data_assistant_caches
 from .database import create_tables, get_engine, get_session
 
 router = APIRouter()
@@ -20,7 +21,7 @@ class AIDataAssistantRequest(BaseModel):
     game_pk: Optional[int] = None
     player_id: Optional[int] = None
     team_id: Optional[int] = None
-    use_llm: bool = True
+    use_llm: bool = False
 
 
 def session_factory():
@@ -70,6 +71,7 @@ def ai_data_assistant_page() -> str:
           <label>Date <input id="date" type="date" value="{today}" /></label>
           <label>Game PK <input id="gamePk" type="number" placeholder="optional" /></label>
           <label>Player ID <input id="playerId" type="number" placeholder="optional" /></label>
+          <label><input id="useLlm" type="checkbox" /> Use LLM polish</label>
           <button id="askBtn" type="button">Ask</button>
         </div>
         <textarea id="message" placeholder="Ask about today's slate, model edges, Daily Odds, Stored 365, missing data, or a specific matchup.">Summarize today's slate</textarea>
@@ -80,7 +82,7 @@ def ai_data_assistant_page() -> str:
         <pre id="answer">Ask a question to query the app-owned data packet.</pre>
         <div class="meta">
           <div class="card"><strong>Sources used</strong><div id="sources" class="muted">None yet</div></div>
-          <div class="card"><strong>Missing data</strong><div id="missing" class="muted">None yet</div></div>
+          <div class="card"><strong>Timing</strong><div id="timing" class="muted">None yet</div></div>
           <div class="card"><strong>Data quality</strong><div id="quality" class="muted">None yet</div></div>
         </div>
       </div>
@@ -88,7 +90,7 @@ def ai_data_assistant_page() -> str:
   </main>
 <script>
 const $ = (id) => document.getElementById(id);
-document.querySelectorAll('.chip').forEach(btn => btn.addEventListener('click', () => {{ $('message').value = btn.textContent; ask(); }}));
+document.querySelectorAll('.chip').forEach(btn => btn.addEventListener('click', () => {{ $('message').value = btn.textContent; $('useLlm').checked = false; ask(); }}));
 $('askBtn').addEventListener('click', ask);
 async function ask() {{
   $('status').textContent = 'Querying app-owned data...';
@@ -97,17 +99,18 @@ async function ask() {{
     message: $('message').value,
     date: $('date').value || null,
     game_pk: $('gamePk').value ? Number($('gamePk').value) : null,
-    player_id: $('playerId').value ? Number($('playerId').value) : null
+    player_id: $('playerId').value ? Number($('playerId').value) : null,
+    use_llm: $('useLlm').checked
   }};
   try {{
     const res = await fetch('/ai-data-assistant', {{ method: 'POST', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify(payload) }});
     const data = await res.json();
     if (!res.ok) throw new Error(JSON.stringify(data.detail || data));
-    $('status').textContent = `Intent: ${{data.intent || 'unknown'}} | Date: ${{data.date || ''}}`;
+    $('status').textContent = `Intent: ${{data.intent || 'unknown'}} | Date: ${{data.date || ''}} | Cache: ${{data.cache_status || 'none'}}`;
     $('answer').textContent = data.answer || 'No answer returned.';
     $('sources').textContent = (data.sources_used || []).join(', ') || 'None';
-    $('missing').textContent = JSON.stringify(data.missing_data || [], null, 2);
-    $('quality').textContent = JSON.stringify(data.data_quality || {{}}, null, 2);
+    $('timing').textContent = JSON.stringify(data.timing || {{}}, null, 2);
+    $('quality').textContent = JSON.stringify({{ data_quality: data.data_quality || {{}}, missing_data: data.missing_data || [] }}, null, 2);
   }} catch (err) {{
     $('status').textContent = 'Error';
     $('answer').textContent = String(err);
@@ -126,7 +129,7 @@ def ai_data_assistant_prompts() -> Dict[str, Any]:
 
 @router.get("/ai-data-assistant/health")
 def ai_data_assistant_health() -> Dict[str, Any]:
-    return {"name": "AI Data Assistant", "status": "ok", "llm_configured": bool(os.getenv("OPENAI_API_KEY"))}
+    return {"name": "AI Data Assistant", "status": "ok", "llm_configured": bool(os.getenv("OPENAI_API_KEY")), "deterministic_default": True}
 
 
 @router.post("/ai-data-assistant")
@@ -136,8 +139,15 @@ def ai_data_assistant_query(payload: AIDataAssistantRequest) -> Dict[str, Any]:
     try:
         factory = session_factory()
         with factory() as session:
-            context = build_assistant_context(session=session, message=payload.message, date=payload.date, game_pk=payload.game_pk, player_id=payload.player_id, team_id=payload.team_id)
-            result = answer_with_optional_llm(payload.message, context, use_llm=payload.use_llm)
+            result = build_ai_data_assistant_response(
+                session=session,
+                message=payload.message,
+                date=payload.date,
+                game_pk=payload.game_pk,
+                player_id=payload.player_id,
+                team_id=payload.team_id,
+                use_llm=payload.use_llm,
+            )
             result["name"] = "AI Data Assistant"
             result["intent"] = result.get("intent") or classify_assistant_intent(payload.message)
             return result
@@ -145,3 +155,8 @@ def ai_data_assistant_query(payload: AIDataAssistantRequest) -> Dict[str, Any]:
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "AI Data Assistant failed", "error": str(exc)}) from exc
+
+
+@router.post("/ai-data-assistant/cache/clear")
+def ai_data_assistant_cache_clear() -> Dict[str, Any]:
+    return clear_ai_data_assistant_caches()


### PR DESCRIPTION
## Summary

Performance-only follow-up for the existing AI Data Assistant. This keeps the same route/page and does not change the product scoring logic from v2.

No new assistant route, no duplicate frontend page, and no model-logic rewrite.

## Changes

### 1. Adds process-local TTL caching

New internal helper:

- `mlb_app/ai_data_assistant_performance.py`

Adds:

- Model Projection payload TTL cache by date
- Response TTL cache for repeated same-date prompt-chip clicks
- cache clear helper
- timing metadata collection

Projection payload cache:

- key pattern: `ai_projection_payload:{date}`
- TTL: 600 seconds

Response cache:

- key: message/date/game/player/team/use_llm
- TTL: 180 seconds

### 2. Patches the existing v2 service path

The wrapper monkey-patches the imported `build_model_projection_payload` symbol inside `mlb_app.ai_data_assistant`, so the existing v2 context builders still run through the same service file but share a cached projection payload.

This avoids changing or duplicating the AI Data Assistant scoring logic.

### 3. Deterministic answers are now default

`AIDataAssistantRequest.use_llm` now defaults to `False`.

This means prompt chips use the fast deterministic renderer unless the caller explicitly enables LLM polish.

The route-level HTML page includes a `Use LLM polish` checkbox for the fallback HTML route. The React frontend can keep using the default unless it explicitly sends `use_llm: true`.

### 4. Adds timing metadata

Each response now returns timing fields such as:

- `projection_payload_ms`
- `projection_cache_hit`
- `projection_cache_miss`
- `context_build_ms`
- `answer_render_ms`
- `llm_requested`
- `total_ms`

This makes future latency work measurable instead of guesswork.

### 5. Adds cache clear endpoint

Adds:

- `POST /ai-data-assistant/cache/clear`

This is an operational helper for clearing in-memory AI Assistant caches after refreshes or debugging.

## Existing routes preserved

- `GET /ai-data-assistant`
- `POST /ai-data-assistant`
- `GET /ai-data-assistant/prompts`
- `GET /ai-data-assistant/health`

## Files changed

- `mlb_app/ai_data_assistant_performance.py`
- `mlb_app/ai_data_assistant_routes.py`

## Expected improvement

Repeated same-date questions should be much faster, especially:

- `What is the strongest model edge?`
- `Top pitcher leans`
- `Best Stored 365 hitter matchups`
- `Which game has the cleanest signal?`

First request after cold start still pays the full Model Projection build cost. Subsequent requests within TTL reuse the projection payload and/or full response cache.

## Known limitations

- Cache is process-local and resets on deploy/container restart.
- Multi-replica deployments will have one cache per replica.
- Stored 365 row limit reduction is not included in this pass to avoid touching v2 scoring logic. That can be a separate micro-optimization if timing metadata proves Stored 365 scoring is the bottleneck.
- Cache clear endpoint is intentionally simple and unauthenticated because the existing app route layer does not currently enforce auth. If desired, we can remove it before merge or guard it with an environment flag.

## Test plan

After deploy:

1. Call `POST /ai-data-assistant` with `What is the strongest model edge?`.
2. Confirm first response includes `projection_cache_miss` and `total_ms`.
3. Call the same request again.
4. Confirm response includes `response_cache_hit` or `projection_cache_hit` and much lower `total_ms`.
5. Confirm prompt chips still work.
6. Confirm no `/ai/ask` regression.
7. Confirm `/ai-data-assistant/health` returns `deterministic_default: true`.