### PR TITLE
Add My Dashboard model solver prototype

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import LiveScoreboardPage from './pages/LiveScoreboardPage'
 import LiveGamePageRestored from './pages/LiveGamePageRestored'
 import DailyOddsPage from './pages/DailyOddsPage'
 import ModelProjectionsPage from './pages/ModelProjectionsPage'
+import MyDashboardPage from './pages/MyDashboardPage'
 
 // Set VITE_ENABLE_BATTER_PAGE=true in Railway env vars to re-enable the Batter routes.
 // Keep false until the leaderboard endpoint is validated stable in production.
@@ -47,7 +48,7 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     gap: '28px',
-    height: '56px',
+    minHeight: '56px',
     flexWrap: 'wrap',
   },
   brand: {
@@ -88,6 +89,7 @@ export default function App() {
         <NavLink to="/" end style={link}>Matchups</NavLink>
         <NavLink to="/daily-odds" style={link}>Daily Odds</NavLink>
         <NavLink to="/models/projections" style={link}>Model Projections</NavLink>
+        <NavLink to="/my-dashboard" style={link}>My Dashboard</NavLink>
         <NavLink to="/standings" style={link}>Standings</NavLink>
         <NavLink to="/pitcher" style={link}>Pitcher</NavLink>
         <NavLink to="/batter" style={link}>Batter</NavLink>
@@ -101,6 +103,7 @@ export default function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/daily-odds" element={<DailyOddsPage />} />
           <Route path="/models/projections" element={<ModelProjectionsPage />} />
+          <Route path="/my-dashboard" element={<MyDashboardPage />} />
           <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
           <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />
           <Route path="/standings" element={<StandingsPage />} />

--- a/frontend/src/pages/MyDashboardPage.jsx
+++ b/frontend/src/pages/MyDashboardPage.jsx
@@ -1,0 +1,263 @@
+import React, { useState } from 'react'
+
+const API = import.meta.env.VITE_API_BASE_URL || ''
+
+const COMPONENTS = [
+  {
+    key: 'hitters',
+    title: 'My Top Hitters Today',
+    description: 'Unique hitter board from Batter vs Arsenal, pitch usage, damage quality, and model context.',
+  },
+  {
+    key: 'pitchers',
+    title: 'My Top Pitchers Today',
+    description: 'Pitcher lean board using K profile, contact suppression, opponent offense, and arsenal context.',
+  },
+  {
+    key: 'teams',
+    title: 'My Top Teams Today',
+    description: 'Team board from model side edge, expected runs, offense profile, and opponent weaknesses.',
+  },
+  {
+    key: 'totals',
+    title: 'My Top Totals Today',
+    description: 'Game total watchlist from projected runs, run environment, and simulation context.',
+  },
+  {
+    key: 'overall_players',
+    title: 'My Top Overall Players Today',
+    description: 'Combined unique player board blending hitter and pitcher model-solver scores.',
+  },
+]
+
+export default function MyDashboardPage() {
+  const today = new Date().toISOString().slice(0, 10)
+  const [date, setDate] = useState(today)
+  const [results, setResults] = useState({})
+  const [loading, setLoading] = useState({})
+  const [errors, setErrors] = useState({})
+
+  async function runSolver(component) {
+    setLoading(prev => ({ ...prev, [component]: true }))
+    setErrors(prev => ({ ...prev, [component]: null }))
+    try {
+      const params = new URLSearchParams({ date, component })
+      const res = await fetch(`${API}/my-dashboard/solver?${params.toString()}`)
+      const json = await res.json()
+      if (!res.ok) throw new Error(JSON.stringify(json.detail || json))
+      setResults(prev => ({ ...prev, [component]: json }))
+    } catch (err) {
+      console.error('My Dashboard solver failed:', err)
+      setErrors(prev => ({ ...prev, [component]: err.message || 'Solver failed' }))
+    } finally {
+      setLoading(prev => ({ ...prev, [component]: false }))
+    }
+  }
+
+  async function runAll() {
+    for (const component of COMPONENTS) {
+      // Run sequentially to avoid hammering the backend/model projection cache on first load.
+      // eslint-disable-next-line no-await-in-loop
+      await runSolver(component.key)
+    }
+  }
+
+  return (
+    <div>
+      <section style={heroStyle}>
+        <div>
+          <div style={eyebrowStyle}>Personal analyst workspace prototype</div>
+          <h1 style={titleStyle}>My Dashboard</h1>
+          <p style={subtitleStyle}>
+            Your daily analyst board for model edges, players, teams, totals, notes, and future saved picks.
+          </p>
+        </div>
+        <div style={dateBoxStyle}>
+          <label style={labelStyle}>Board Date</label>
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} style={inputStyle} />
+          <button onClick={runAll} style={primaryButtonStyle}>Populate All</button>
+        </div>
+      </section>
+
+      <section style={signupBannerStyle}>
+        <div>
+          <strong>Coming soon: sign in to save your daily boards, picks, tags, and notes across devices.</strong>
+          <p style={{ margin: '6px 0 0', color: '#8b949e', lineHeight: 1.5 }}>
+            For now, this page uses today’s app-owned model data and local dashboard actions. Save, Tag, and Add Note are placeholders for the future user-owned object system.
+          </p>
+        </div>
+        <button disabled style={disabledButtonStyle}>Sign-in coming soon</button>
+      </section>
+
+      <section style={gridStyle}>
+        {COMPONENTS.map(component => (
+          <DashboardCard
+            key={component.key}
+            component={component}
+            result={results[component.key]}
+            loading={loading[component.key]}
+            error={errors[component.key]}
+            onRun={() => runSolver(component.key)}
+          />
+        ))}
+      </section>
+    </div>
+  )
+}
+
+function DashboardCard({ component, result, loading, error, onRun }) {
+  const items = result?.items || []
+  return (
+    <div style={cardStyle}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start' }}>
+        <div>
+          <h2 style={cardTitleStyle}>{component.title}</h2>
+          <p style={cardDescriptionStyle}>{component.description}</p>
+        </div>
+        <span style={countBadgeStyle}>{items.length || 0}/10</span>
+      </div>
+
+      <button onClick={onRun} disabled={loading} style={solverButtonStyle}>
+        {loading ? 'Solving...' : 'Use Model Solver To Populate Top 10 Today'}
+      </button>
+
+      {error && <div style={errorStyle}>{error}</div>}
+
+      {!result && !loading && !error && (
+        <div style={emptyStyle}>
+          No saved results yet. Run the model solver to populate this component from existing app-owned data.
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gap: '10px', marginTop: '14px' }}>
+        {items.map(item => <ResultItem key={item.dedupe_key || `${item.entity_type}-${item.entity_id}-${item.rank}`} item={item} />)}
+      </div>
+
+      {result && (
+        <details style={{ marginTop: '14px' }}>
+          <summary style={summaryStyle}>Data quality and missing data</summary>
+          <pre style={preStyle}>{JSON.stringify({ data_quality: result.data_quality, missing_data: result.missing_data }, null, 2)}</pre>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function ResultItem({ item }) {
+  const metrics = item.metrics || {}
+  const chart = item.chart_data || { labels: [], values: [] }
+  const maxValue = Math.max(...(chart.values || []).map(v => Math.abs(Number(v) || 0)), 1)
+  return (
+    <div style={itemStyle}>
+      <div style={itemHeaderStyle}>
+        <div>
+          <div style={rankStyle}>#{item.rank} {item.entity_name || item.entity_id}</div>
+          <div style={metaStyle}>
+            {item.player_type ? `${item.player_type} | ` : ''}{item.team || 'Team missing'} vs {item.opponent || 'Opponent missing'} {item.game_pk ? `| Game ${item.game_pk}` : ''}
+          </div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div style={scoreStyle}>{formatNumber(item.score)}</div>
+          <div style={confidenceStyle(item.confidence)}>{item.confidence || 'low'}</div>
+        </div>
+      </div>
+
+      <p style={reasonStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</p>
+      <ScoreBar value={Number(item.score) || 0} />
+
+      {chart.labels?.length > 0 && (
+        <div style={barsWrapStyle}>
+          {chart.labels.map((label, idx) => {
+            const value = Number(chart.values[idx]) || 0
+            const width = Math.max(8, Math.min(100, Math.abs(value) / maxValue * 100))
+            return (
+              <div key={`${label}-${idx}`} style={metricRowStyle}>
+                <span style={metricLabelStyle}>{label}</span>
+                <div style={metricTrackStyle}><div style={{ ...metricFillStyle, width: `${width}%` }} /></div>
+                <span style={metricValueStyle}>{formatNumber(value)}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {item.best_pitch_angles?.length > 0 && (
+        <div style={pitchAnglesStyle}>
+          <strong>Best pitch angles:</strong>
+          {item.best_pitch_angles.map((angle, idx) => (
+            <div key={`${angle.pitch_type}-${idx}`} style={smallTextStyle}>• {angle.reason}</div>
+          ))}
+        </div>
+      )}
+
+      <details>
+        <summary style={summaryStyle}>View reasoning</summary>
+        <ul style={reasonListStyle}>
+          {(item.reasoning || []).map((reason, idx) => <li key={idx}>{reason}</li>)}
+        </ul>
+        <pre style={preStyle}>{JSON.stringify({ metrics, missing_data: item.missing_data || [], source: item.source, dedupe_key: item.dedupe_key }, null, 2)}</pre>
+      </details>
+
+      <div style={actionsStyle}>
+        <button disabled style={placeholderButtonStyle}>Save</button>
+        <button disabled style={placeholderButtonStyle}>Tag</button>
+        <button disabled style={placeholderButtonStyle}>Add Note</button>
+      </div>
+    </div>
+  )
+}
+
+function ScoreBar({ value }) {
+  const width = Math.max(4, Math.min(100, Math.abs(value) * 35))
+  return <div style={scoreTrackStyle}><div style={{ ...scoreFillStyle, width: `${width}%` }} /></div>
+}
+
+function formatNumber(value) {
+  const num = Number(value)
+  if (!Number.isFinite(num)) return 'N/A'
+  return Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(3)
+}
+
+const heroStyle = {
+  display: 'flex', justifyContent: 'space-between', gap: '20px', flexWrap: 'wrap',
+  background: 'linear-gradient(135deg, #161b22, #0d1117)', border: '1px solid #30363d', borderRadius: '16px', padding: '24px', marginBottom: '16px'
+}
+const eyebrowStyle = { color: '#58a6ff', fontSize: '13px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em' }
+const titleStyle = { margin: '6px 0 8px', fontSize: '34px', color: '#e6edf3' }
+const subtitleStyle = { margin: 0, color: '#8b949e', maxWidth: '720px', lineHeight: 1.55 }
+const dateBoxStyle = { minWidth: '220px', display: 'grid', gap: '8px', alignContent: 'start' }
+const labelStyle = { color: '#8b949e', fontSize: '13px' }
+const inputStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '8px', padding: '10px' }
+const primaryButtonStyle = { background: '#238636', color: '#fff', border: 0, borderRadius: '8px', padding: '10px 12px', cursor: 'pointer', fontWeight: 700 }
+const signupBannerStyle = { display: 'flex', justifyContent: 'space-between', gap: '16px', alignItems: 'center', flexWrap: 'wrap', background: '#0f1a2e', border: '1px solid #1f6feb55', borderRadius: '14px', padding: '16px', marginBottom: '18px', color: '#e6edf3' }
+const disabledButtonStyle = { background: '#21262d', color: '#8b949e', border: '1px solid #30363d', borderRadius: '8px', padding: '10px 12px' }
+const gridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))', gap: '16px' }
+const cardStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: '14px', padding: '16px', color: '#e6edf3' }
+const cardTitleStyle = { margin: 0, fontSize: '20px' }
+const cardDescriptionStyle = { color: '#8b949e', lineHeight: 1.45, margin: '6px 0 0', fontSize: '13px' }
+const countBadgeStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: '999px', padding: '4px 8px', color: '#8b949e', fontSize: '12px' }
+const solverButtonStyle = { width: '100%', marginTop: '14px', background: '#58a6ff', color: '#07111f', border: 0, borderRadius: '8px', padding: '10px', fontWeight: 800, cursor: 'pointer' }
+const errorStyle = { background: '#2d1b1b', border: '1px solid #a33', borderRadius: '8px', padding: '10px', marginTop: '12px', color: '#ffb4b4' }
+const emptyStyle = { marginTop: '14px', padding: '14px', background: '#0d1117', border: '1px dashed #30363d', borderRadius: '10px', color: '#8b949e', lineHeight: 1.45 }
+const itemStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: '10px', padding: '12px' }
+const itemHeaderStyle = { display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'start' }
+const rankStyle = { fontWeight: 800, color: '#e6edf3' }
+const metaStyle = { color: '#8b949e', fontSize: '12px', marginTop: '4px' }
+const scoreStyle = { fontWeight: 900, color: '#58a6ff' }
+const confidenceStyle = (level) => ({ marginTop: '4px', color: level === 'high' ? '#3fb950' : level === 'medium' ? '#d29922' : '#8b949e', fontSize: '12px', textTransform: 'uppercase', fontWeight: 700 })
+const reasonStyle = { color: '#c9d1d9', lineHeight: 1.45, fontSize: '13px' }
+const scoreTrackStyle = { height: '8px', background: '#21262d', borderRadius: '999px', overflow: 'hidden', margin: '10px 0' }
+const scoreFillStyle = { height: '100%', background: '#58a6ff', borderRadius: '999px' }
+const barsWrapStyle = { display: 'grid', gap: '6px', margin: '10px 0' }
+const metricRowStyle = { display: 'grid', gridTemplateColumns: '92px 1fr 52px', alignItems: 'center', gap: '8px' }
+const metricLabelStyle = { color: '#8b949e', fontSize: '11px' }
+const metricTrackStyle = { height: '6px', background: '#21262d', borderRadius: '999px', overflow: 'hidden' }
+const metricFillStyle = { height: '100%', background: '#3fb950', borderRadius: '999px' }
+const metricValueStyle = { color: '#c9d1d9', fontSize: '11px', textAlign: 'right' }
+const pitchAnglesStyle = { margin: '10px 0', color: '#c9d1d9', fontSize: '12px', lineHeight: 1.5 }
+const smallTextStyle = { color: '#8b949e', marginTop: '3px' }
+const summaryStyle = { cursor: 'pointer', color: '#58a6ff', fontSize: '13px', marginTop: '8px' }
+const reasonListStyle = { color: '#c9d1d9', fontSize: '13px', lineHeight: 1.5, paddingLeft: '18px' }
+const preStyle = { background: '#010409', border: '1px solid #30363d', borderRadius: '8px', padding: '10px', overflowX: 'auto', color: '#8b949e', fontSize: '11px' }
+const actionsStyle = { display: 'flex', gap: '8px', marginTop: '10px' }
+const placeholderButtonStyle = { background: '#21262d', color: '#8b949e', border: '1px solid #30363d', borderRadius: '6px', padding: '6px 8px', fontSize: '12px' }

--- a/mlb_app/ai_data_assistant_routes.py
+++ b/mlb_app/ai_data_assistant_routes.py
@@ -11,8 +11,10 @@ from pydantic import BaseModel
 from .ai_data_assistant import PROMPT_CHIPS, classify_assistant_intent
 from .ai_data_assistant_performance import build_ai_data_assistant_response, clear_ai_data_assistant_caches
 from .database import create_tables, get_engine, get_session
+from .my_dashboard_routes import router as my_dashboard_router
 
 router = APIRouter()
+router.include_router(my_dashboard_router)
 
 
 class AIDataAssistantRequest(BaseModel):

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from .database import create_tables, get_engine, get_session
+from .my_dashboard_solver import build_dashboard_solver_payload, SUPPORTED_COMPONENTS
+
+router = APIRouter()
+
+
+class MyDashboardSolverRequest(BaseModel):
+    date: Optional[str] = None
+    component: str
+
+
+def session_factory():
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    return get_session(engine)
+
+
+@router.get("/my-dashboard/health")
+def my_dashboard_health() -> Dict[str, Any]:
+    return {
+        "name": "My Dashboard",
+        "status": "ok",
+        "auth_required": False,
+        "supported_components": sorted(SUPPORTED_COMPONENTS),
+    }
+
+
+@router.get("/my-dashboard/solver")
+def my_dashboard_solver_get(
+    date: Optional[str] = Query(default=None),
+    component: str = Query(default="hitters"),
+) -> Dict[str, Any]:
+    return _run_solver(date=date, component=component)
+
+
+@router.post("/my-dashboard/solver")
+def my_dashboard_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any]:
+    return _run_solver(date=payload.date, component=payload.component)
+
+
+def _run_solver(date: Optional[str], component: str) -> Dict[str, Any]:
+    target_date = (date or dt.date.today().isoformat())[:10]
+    try:
+        dt.date.fromisoformat(target_date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
+
+    try:
+        factory = session_factory()
+        with factory() as session:
+            return build_dashboard_solver_payload(session=session, date=target_date, component=component)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "My Dashboard solver failed", "error": str(exc)}) from exc

--- a/mlb_app/my_dashboard_solver.py
+++ b/mlb_app/my_dashboard_solver.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Callable, Dict, List, Optional
+
+from .ai_data_assistant import (
+    build_pitcher_lean_context,
+    build_stored_365_sweep_context,
+    nested_get,
+    safe_float,
+    safe_int,
+    score_projection_edges,
+)
+from .ai_data_assistant_performance import apply_performance_patch, cached_build_model_projection_payload
+
+SUPPORTED_COMPONENTS = {"hitters", "pitchers", "teams", "totals", "overall_players"}
+
+COMPONENT_TITLES = {
+    "hitters": "My Top Hitters Today",
+    "pitchers": "My Top Pitchers Today",
+    "teams": "My Top Teams Today",
+    "totals": "My Top Totals Today",
+    "overall_players": "My Top Overall Players Today",
+}
+
+
+def today() -> str:
+    return dt.date.today().isoformat()
+
+
+def confidence_label(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    num = safe_float(value)
+    if num is None:
+        return "low"
+    if num >= 0.72:
+        return "high"
+    if num >= 0.5:
+        return "medium"
+    return "low"
+
+
+def rounded(value: Any, digits: int = 3) -> Optional[float]:
+    num = safe_float(value)
+    return round(num, digits) if num is not None else None
+
+
+def build_chart_data(metrics: Dict[str, Any]) -> Dict[str, Any]:
+    labels: List[str] = []
+    values: List[float] = []
+    for key, value in metrics.items():
+        num = safe_float(value)
+        if num is None:
+            continue
+        labels.append(key)
+        values.append(round(num, 3))
+    return {"labels": labels[:8], "values": values[:8]}
+
+
+def dedupe_ranked_items(items: List[Dict[str, Any]], key_fn: Callable[[Dict[str, Any]], str], limit: int = 10) -> List[Dict[str, Any]]:
+    best_by_key: Dict[str, Dict[str, Any]] = {}
+    for item in items:
+        key = key_fn(item)
+        if not key:
+            continue
+        item["dedupe_key"] = key
+        existing = best_by_key.get(key)
+        if existing is None or (safe_float(item.get("score")) or -999) > (safe_float(existing.get("score")) or -999):
+            best_by_key[key] = item
+        elif item.get("best_pitch_angles") and existing is not None:
+            existing_angles = existing.setdefault("best_pitch_angles", [])
+            seen = {angle.get("pitch_type") for angle in existing_angles if isinstance(angle, dict)}
+            for angle in item.get("best_pitch_angles") or []:
+                if isinstance(angle, dict) and angle.get("pitch_type") not in seen:
+                    existing_angles.append(angle)
+                    seen.add(angle.get("pitch_type"))
+            existing["best_pitch_angles"] = sorted(existing_angles, key=lambda row: safe_float(row.get("score")) or -999, reverse=True)[:3]
+    ranked = sorted(best_by_key.values(), key=lambda row: safe_float(row.get("score")) or -999, reverse=True)[:limit]
+    for idx, row in enumerate(ranked, start=1):
+        row["rank"] = idx
+    return ranked
+
+
+def projection_payload(session, date: str) -> Dict[str, Any]:
+    apply_performance_patch()
+    try:
+        return cached_build_model_projection_payload(session, date) or {}
+    except Exception:
+        return {}
+
+
+def solve_top_hitters(session, date: str) -> Dict[str, Any]:
+    context = build_stored_365_sweep_context(session, date)
+    candidates: List[Dict[str, Any]] = []
+    for row in context.get("top_matchups") or []:
+        hitter_id = row.get("batter_id")
+        if not hitter_id:
+            continue
+        metrics = {
+            "xwOBA": rounded(row.get("hitter_xwoba")),
+            "xBA": rounded(row.get("hitter_xba")),
+            "EV": rounded(row.get("hitter_avg_ev"), 1),
+            "LA": rounded(row.get("hitter_avg_la"), 1),
+            "HardHit": rounded(row.get("hitter_hard_hit_pct")),
+            "Usage": rounded(row.get("pitcher_usage_pct")),
+            "Pitcher xwOBA": rounded(row.get("pitcher_xwoba_allowed")),
+        }
+        pitch_label = row.get("pitch_name") or row.get("pitch_type") or "pitch"
+        candidate = {
+            "entity_type": "hitter",
+            "entity_id": str(hitter_id),
+            "entity_name": row.get("batter_name") or f"Batter {hitter_id}",
+            "team": row.get("batter_team_id"),
+            "opponent": row.get("opposing_pitcher_name") or row.get("opposing_pitcher_id"),
+            "game_pk": row.get("game_pk"),
+            "score": rounded(row.get("rank_score")),
+            "confidence": row.get("confidence_tier") or confidence_label(row.get("confidence")),
+            "primary_reason": f"Best pitch angle: {pitch_label} with hitter xwOBA {metrics.get('xwOBA')} and EV {metrics.get('EV')}.",
+            "reasoning": [
+                f"Pitch angle: {pitch_label}",
+                f"Pitcher usage: {metrics.get('Usage')}",
+                f"Hitter xwOBA/xBA: {metrics.get('xwOBA')} / {metrics.get('xBA')}",
+                f"Batted-ball quality: EV {metrics.get('EV')}, LA {metrics.get('LA')}, HardHit {metrics.get('HardHit')}",
+                f"Pitcher allowed profile: xwOBA {metrics.get('Pitcher xwOBA')}",
+            ],
+            "metrics": metrics,
+            "chart_data": build_chart_data(metrics),
+            "source": "batter_pitch_type_matchups + model_projection_pitch_arsenal",
+            "missing_data": row.get("missing_inputs") or [],
+            "best_pitch_angles": [
+                {
+                    "pitch_type": row.get("pitch_type"),
+                    "pitch_name": row.get("pitch_name"),
+                    "score": rounded(row.get("rank_score")),
+                    "reason": f"{pitch_label}: xwOBA {metrics.get('xwOBA')}, EV {metrics.get('EV')}, usage {metrics.get('Usage')}",
+                }
+            ],
+        }
+        candidates.append(candidate)
+    items = dedupe_ranked_items(candidates, lambda row: f"hitter:{row.get('entity_id')}:{date}", limit=10)
+    return build_response(date, "hitters", items, context.get("data_quality"), context.get("missing_data"))
+
+
+def solve_top_pitchers(session, date: str) -> Dict[str, Any]:
+    context = build_pitcher_lean_context(session, date)
+    candidates: List[Dict[str, Any]] = []
+    for row in context.get("pitcher_leans") or []:
+        pitcher_id = row.get("pitcher_id")
+        if not pitcher_id:
+            continue
+        profile = row.get("pitcher_profile") or {}
+        opp = row.get("opponent_offense") or {}
+        metrics = {
+            "K%": rounded(profile.get("k_pct")),
+            "BB%": rounded(profile.get("bb_pct")),
+            "xwOBA Allowed": rounded(profile.get("xwoba_allowed")),
+            "HardHit Allowed": rounded(profile.get("hard_hit_allowed")),
+            "Opp K%": rounded(opp.get("k_pct")),
+            "Opp ISO": rounded(opp.get("iso")),
+            "Score": rounded(row.get("score")),
+        }
+        candidate = {
+            "entity_type": "pitcher",
+            "entity_id": str(pitcher_id),
+            "entity_name": row.get("pitcher_name") or f"Pitcher {pitcher_id}",
+            "team": row.get("team"),
+            "opponent": row.get("opponent"),
+            "game_pk": row.get("game_pk"),
+            "score": rounded(row.get("score")),
+            "confidence": row.get("confidence_tier") or confidence_label(row.get("confidence")),
+            "category": row.get("category"),
+            "primary_reason": ", ".join(row.get("reasons") or []) or "Model projection pitcher context created this lean.",
+            "reasoning": row.get("reasons") or [],
+            "metrics": metrics,
+            "chart_data": build_chart_data(metrics),
+            "source": "model_projections + ai_data_assistant_pitcher_lean_context",
+            "missing_data": row.get("missing_inputs") or [],
+        }
+        candidates.append(candidate)
+    items = dedupe_ranked_items(candidates, lambda row: f"pitcher:{row.get('entity_id')}:{date}", limit=10)
+    return build_response(date, "pitchers", items, context.get("data_quality"), context.get("missing_data"))
+
+
+def solve_top_teams(session, date: str) -> Dict[str, Any]:
+    payload = projection_payload(session, date)
+    edges = score_projection_edges(payload) if payload else []
+    candidates: List[Dict[str, Any]] = []
+    for edge in edges:
+        for side in ("away", "home"):
+            signals = edge.get(f"{side}_signals") or {}
+            team_id = signals.get("team_id")
+            team_name = signals.get("team_name")
+            if not team_id and not team_name:
+                continue
+            favorite_bonus = 0.2 if edge.get("model_favorite_side") == side else 0.0
+            offense = signals.get("offense") or {}
+            metrics = {
+                "Edge Score": rounded((safe_float(edge.get("score")) or 0) + favorite_bonus),
+                "Win Edge": rounded(edge.get("win_probability_edge")),
+                "Run Diff": rounded(edge.get("expected_run_differential")),
+                "ISO": rounded(offense.get("iso")),
+                "OBP": rounded(offense.get("obp")),
+                "SLG": rounded(offense.get("slg")),
+            }
+            score = (safe_float(edge.get("score")) or 0) + favorite_bonus + ((safe_float(offense.get("iso")) or 0) * 0.6)
+            candidate = {
+                "entity_type": "team",
+                "entity_id": str(team_id or team_name),
+                "entity_name": team_name or f"Team {team_id}",
+                "team": team_name,
+                "opponent": signals.get("opponent_team"),
+                "game_pk": edge.get("game_pk"),
+                "score": rounded(score),
+                "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")),
+                "primary_reason": f"Model edge context: win edge {metrics.get('Win Edge')}, run diff {metrics.get('Run Diff')}, ISO {metrics.get('ISO')}.",
+                "reasoning": edge.get("why") or [],
+                "metrics": metrics,
+                "chart_data": build_chart_data(metrics),
+                "source": "model_projections",
+                "missing_data": edge.get("missing_inputs") or [],
+            }
+            candidates.append(candidate)
+    items = dedupe_ranked_items(candidates, lambda row: f"team:{row.get('entity_id')}:{date}", limit=10)
+    return build_response(date, "teams", items, {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [])
+
+
+def solve_top_totals(session, date: str) -> Dict[str, Any]:
+    payload = projection_payload(session, date)
+    edges = score_projection_edges(payload) if payload else []
+    candidates: List[Dict[str, Any]] = []
+    for edge in edges:
+        game_pk = edge.get("game_pk")
+        total = edge.get("total_projection") or {}
+        projected_total = safe_float(total.get("total_expected_runs"))
+        run_index = safe_float(total.get("run_scoring_index"))
+        raw_total = safe_float(total.get("raw_total_expected_runs"))
+        if projected_total is None and run_index is None:
+            continue
+        total_gap = abs((projected_total or 8.5) - 8.5)
+        raw_gap = abs(projected_total - raw_total) if projected_total is not None and raw_total is not None else 0
+        score = total_gap + (abs((run_index or 1.0) - 1.0) * 2.5) - min(0.5, raw_gap * 0.1)
+        angle = "over_watchlist" if projected_total is not None and projected_total >= 8.8 else "under_watchlist" if projected_total is not None and projected_total <= 7.6 else "data_limited"
+        metrics = {
+            "Projected Total": rounded(projected_total),
+            "Raw Total": rounded(raw_total),
+            "Run Index": rounded(run_index),
+            "Score": rounded(score),
+        }
+        candidate = {
+            "entity_type": "game_total",
+            "entity_id": str(game_pk),
+            "entity_name": edge.get("label"),
+            "team": None,
+            "opponent": None,
+            "game_pk": game_pk,
+            "score": rounded(score),
+            "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")),
+            "category": angle,
+            "primary_reason": f"{angle}: projected total {metrics.get('Projected Total')} with run index {metrics.get('Run Index')}. No sportsbook total is assumed.",
+            "reasoning": [
+                f"Projected total: {metrics.get('Projected Total')}",
+                f"Raw total: {metrics.get('Raw Total')}",
+                f"Run-scoring index: {metrics.get('Run Index')}",
+                f"Environment label: {total.get('environment_label') or 'not labeled'}",
+                "This is a model total watchlist only, not a priced market edge.",
+            ],
+            "metrics": metrics,
+            "chart_data": build_chart_data(metrics),
+            "source": "model_projections.total_projection",
+            "missing_data": edge.get("missing_inputs") or [],
+        }
+        candidates.append(candidate)
+    items = dedupe_ranked_items(candidates, lambda row: f"game_total:{row.get('game_pk')}:{date}", limit=10)
+    return build_response(date, "totals", items, {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [])
+
+
+def solve_top_overall_players(session, date: str) -> Dict[str, Any]:
+    hitters = solve_top_hitters(session, date).get("items") or []
+    pitchers = solve_top_pitchers(session, date).get("items") or []
+    candidates: List[Dict[str, Any]] = []
+    for row in hitters + pitchers:
+        entity_type = row.get("entity_type")
+        entity_id = row.get("entity_id")
+        if not entity_id:
+            continue
+        adjusted = dict(row)
+        adjusted["entity_type"] = "player"
+        adjusted["player_type"] = entity_type
+        adjusted["score"] = rounded((safe_float(row.get("score")) or 0) + (0.08 if row.get("confidence") == "high" else 0))
+        adjusted["source"] = f"overall_players:{row.get('source')}"
+        candidates.append(adjusted)
+    items = dedupe_ranked_items(candidates, lambda row: f"player:{row.get('entity_id')}:{date}", limit=10)
+    return build_response(date, "overall_players", items, {"hitter_candidates": len(hitters), "pitcher_candidates": len(pitchers)}, [])
+
+
+def build_response(date: str, component: str, items: List[Dict[str, Any]], data_quality: Any = None, missing_data: Any = None) -> Dict[str, Any]:
+    return {
+        "date": date,
+        "component": component,
+        "title": COMPONENT_TITLES.get(component, component),
+        "items": items[:10],
+        "data_quality": data_quality or {},
+        "missing_data": missing_data or [],
+        "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    }
+
+
+def build_dashboard_solver_payload(session, date: Optional[str], component: str) -> Dict[str, Any]:
+    target_date = (date or today())[:10]
+    normalized = (component or "").strip().lower()
+    if normalized not in SUPPORTED_COMPONENTS:
+        return {
+            "date": target_date,
+            "component": normalized,
+            "title": "Unsupported dashboard component",
+            "items": [],
+            "data_quality": {"supported_components": sorted(SUPPORTED_COMPONENTS)},
+            "missing_data": [f"Unsupported component: {component}"],
+            "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        }
+    if normalized == "hitters":
+        return solve_top_hitters(session, target_date)
+    if normalized == "pitchers":
+        return solve_top_pitchers(session, target_date)
+    if normalized == "teams":
+        return solve_top_teams(session, target_date)
+    if normalized == "totals":
+        return solve_top_totals(session, target_date)
+    return solve_top_overall_players(session, target_date)


### PR DESCRIPTION
## Summary

Adds the first **My Dashboard** prototype for the user-side analyst workspace.

This is design-first and intentionally does **not** add a login wall, real auth, groups, social sharing, or backend user persistence yet.

The page gives users five daily dashboard components and a deterministic model-solver button for each:

1. My Top Hitters Today
2. My Top Pitchers Today
3. My Top Teams Today
4. My Top Totals Today
5. My Top Overall Players Today

## New frontend route

- `GET /my-dashboard` frontend route
- Nav link: `My Dashboard`

## New backend solver endpoints

Because `mlb_app/app.py` is large and risky to rewrite directly, this PR wires the new route through the already-registered AI Data Assistant router:

- `GET /my-dashboard/health`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=hitters|pitchers|teams|totals|overall_players`
- `POST /my-dashboard/solver`

## Files changed

- `frontend/src/App.jsx`
- `frontend/src/pages/MyDashboardPage.jsx`
- `mlb_app/ai_data_assistant_routes.py`
- `mlb_app/my_dashboard_routes.py`
- `mlb_app/my_dashboard_solver.py`

## How it reuses existing architecture

The dashboard solver does not call the LLM and does not create a duplicate model engine.

It reuses the existing AI/model architecture:

- `ai_data_assistant_performance.cached_build_model_projection_payload`
- `ai_data_assistant.build_stored_365_sweep_context`
- `ai_data_assistant.build_pitcher_lean_context`
- `ai_data_assistant.score_projection_edges`
- existing Model Projection payload structure
- existing Stored 365 / Batter vs Arsenal logic
- existing pitcher lean logic

## Component logic

### My Top Hitters Today

Uses Stored 365 / Batter vs Arsenal context, then collapses pitch-level rows to unique hitters.

Ranks by available fields like:

- hitter xwOBA
- hitter xBA
- exit velocity
- launch angle
- hard-hit percentage
- pitcher pitch usage
- pitcher xwOBA allowed
- sample/confidence context

### My Top Pitchers Today

Uses existing AI Data Assistant pitcher-lean context.

Ranks unique pitchers by:

- pitcher K profile
- BB profile
- xwOBA allowed
- hard-hit allowed
- opponent offense profile
- arsenal context
- confidence/missing inputs

### My Top Teams Today

Uses Model Projections first.

Ranks unique teams by:

- projection edge score
- win probability separation
- expected run differential
- offense profile
- model context

### My Top Totals Today

Uses Model Projection total/run-environment context.

Ranks unique game totals by:

- projected total
- raw total
- run-scoring index
- total watchlist category

No sportsbook total is invented. These are model total watchlist items only.

### My Top Overall Players Today

Combines top hitters and top pitchers, then dedupes by player ID.

## Duplicate prevention

Every component uses stable dedupe keys:

- hitters: `hitter:{player_id}:{date}`
- pitchers: `pitcher:{pitcher_id}:{date}`
- teams: `team:{team_id}:{date}`
- totals: `game_total:{game_pk}:{date}`
- overall players: `player:{player_id}:{date}`

For hitters, pitch-level rows are collapsed into one hitter row with `best_pitch_angles`, so the same hitter should not appear multiple times because of multiple pitch types.

## Frontend design

The page includes:

- dark-theme dashboard layout
- date selector
- soft future sign-up banner
- five dashboard cards
- `Use Model Solver To Populate Top 10 Today` button per card
- loading and error states
- top 10 list per card
- simple CSS metric bars/charts
- expandable reasoning
- data quality / missing data details
- placeholder Save / Tag / Add Note buttons

## Deferred intentionally

- real login
- forced sign-in page
- backend user persistence
- groups/social feed
- cross-device saved boards
- paid/user tiers
- LLM-driven dashboard actions
- real Save/Tag/Add Note persistence
- user object permissions

## Important notes

- This branch currently diverged from latest `main` because `main` moved after the branch was created. It may need a merge/rebase before final merge.
- No LLM calls are made by the dashboard solver.
- Existing AI Data Assistant and Model Projections routes are not replaced.

## Test checklist after deploy

Frontend:

- `/my-dashboard`
- `/ai-data-assistant`
- `/models/projections`
- `/daily-odds`

Backend:

- `GET /my-dashboard/health`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=hitters`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=pitchers`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=teams`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=totals`
- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=overall_players`

Verify:

- max 10 items returned
- no duplicate entity IDs inside each component
- hitter pitch-level reasons are collapsed under one row
- missing data is visible
- no sportsbook lines are invented
- no login page appears