### PR TITLE
Add My Dashboard dynamic filters and saved configs

### DIFF
--- a/frontend/src/pages/MyDashboardPage.jsx
+++ b/frontend/src/pages/MyDashboardPage.jsx
@@ -1,48 +1,114 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
+const SAVED_DASHBOARDS_KEY = 'mlb_saved_dashboards_v1'
+const LOCAL_USER_KEY = 'mlb_dashboard_user_id'
 
 const COMPONENTS = [
-  {
-    key: 'hitters',
-    title: 'My Top Hitters Today',
-    description: 'Unique hitter board from Batter vs Arsenal, pitch usage, damage quality, and model context.',
-  },
-  {
-    key: 'pitchers',
-    title: 'My Top Pitchers Today',
-    description: 'Pitcher lean board using K profile, contact suppression, opponent offense, and arsenal context.',
-  },
-  {
-    key: 'teams',
-    title: 'My Top Teams Today',
-    description: 'Team board from model side edge, expected runs, offense profile, and opponent weaknesses.',
-  },
-  {
-    key: 'totals',
-    title: 'My Top Totals Today',
-    description: 'Game total watchlist from projected runs, run environment, and simulation context.',
-  },
-  {
-    key: 'overall_players',
-    title: 'My Top Overall Players Today',
-    description: 'Combined unique player board blending hitter and pitcher model-solver scores.',
-  },
+  { key: 'hitters', title: 'My Top Hitters Today', description: 'Unique hitter board from Batter vs Arsenal, pitch usage, damage quality, and model context.' },
+  { key: 'pitchers', title: 'My Top Pitchers Today', description: 'Pitcher lean board using K profile, contact suppression, opponent offense, and arsenal context.' },
+  { key: 'teams', title: 'My Top Teams Today', description: 'Team board from model side edge, expected runs, offense profile, and opponent weaknesses.' },
+  { key: 'totals', title: 'My Top Totals Today', description: 'Game total watchlist from projected runs, run environment, and simulation context.' },
+  { key: 'overall_players', title: 'My Top Overall Players Today', description: 'Combined unique player board blending hitter and pitcher model-solver scores.' },
 ]
+
+const DEFAULT_METRICS = {
+  hitters: ['xwOBA', 'xBA', 'EV', 'LA', 'HardHit', 'Usage', 'Pitcher xwOBA'],
+  pitchers: ['K%', 'BB%', 'xwOBA Allowed', 'HardHit Allowed', 'Opp K%', 'Opp ISO', 'Score'],
+  teams: ['Edge Score', 'Win Edge', 'Run Diff', 'ISO', 'OBP', 'SLG'],
+  totals: ['Projected Total', 'Raw Total', 'Run Index', 'Score'],
+  overall_players: ['Score', 'xwOBA', 'EV', 'K%', 'xwOBA Allowed'],
+}
+
+function ensureLocalUserId() {
+  let id = window.localStorage.getItem(LOCAL_USER_KEY)
+  if (!id) {
+    id = `local-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    window.localStorage.setItem(LOCAL_USER_KEY, id)
+  }
+  return id
+}
+
+function loadSavedDashboards() {
+  try {
+    return JSON.parse(window.localStorage.getItem(SAVED_DASHBOARDS_KEY) || '[]')
+  } catch {
+    return []
+  }
+}
+
+function saveSavedDashboards(rows) {
+  window.localStorage.setItem(SAVED_DASHBOARDS_KEY, JSON.stringify(rows))
+}
+
+function cleanFilters(filters) {
+  const out = {}
+  Object.entries(filters || {}).forEach(([key, value]) => {
+    if (key === 'metrics' || key === 'weights') return
+    if (value !== '' && value !== null && value !== undefined) out[key] = value
+  })
+  const metrics = {}
+  Object.entries(filters?.metrics || {}).forEach(([metric, rule]) => {
+    const entry = {}
+    if (rule?.min !== '' && rule?.min !== undefined && rule?.min !== null) entry.min = Number(rule.min)
+    if (rule?.max !== '' && rule?.max !== undefined && rule?.max !== null) entry.max = Number(rule.max)
+    if (Object.keys(entry).length) metrics[metric] = entry
+  })
+  const weights = {}
+  Object.entries(filters?.weights || {}).forEach(([metric, value]) => {
+    if (value !== '' && value !== undefined && value !== null && Number(value) !== 1) weights[metric] = Number(value)
+  })
+  if (Object.keys(metrics).length) out.metrics = metrics
+  if (Object.keys(weights).length) out.weights = weights
+  return out
+}
+
+function activeFilterChips(filters) {
+  const clean = cleanFilters(filters)
+  const chips = []
+  Object.entries(clean).forEach(([key, value]) => {
+    if (key === 'metrics') {
+      Object.entries(value).forEach(([metric, rule]) => chips.push(`${metric}: ${rule.min ?? ''}${rule.min !== undefined ? '+' : ''}${rule.max !== undefined ? ` <= ${rule.max}` : ''}`))
+    } else if (key === 'weights') {
+      Object.entries(value).forEach(([metric, weight]) => chips.push(`${metric} weight ${weight}`))
+    } else {
+      chips.push(`${key}: ${value}`)
+    }
+  })
+  return chips
+}
 
 export default function MyDashboardPage() {
   const today = new Date().toISOString().slice(0, 10)
   const [date, setDate] = useState(today)
+  const [dateMode, setDateMode] = useState('today')
   const [results, setResults] = useState({})
+  const [filters, setFilters] = useState({})
+  const [enabled, setEnabled] = useState(Object.fromEntries(COMPONENTS.map(c => [c.key, true])))
   const [loading, setLoading] = useState({})
   const [errors, setErrors] = useState({})
+  const [savedDashboards, setSavedDashboards] = useState([])
+  const [dashboardName, setDashboardName] = useState('')
+  const [dashboardDescription, setDashboardDescription] = useState('')
+  const [userId, setUserId] = useState('')
 
-  async function runSolver(component) {
+  useEffect(() => {
+    setUserId(ensureLocalUserId())
+    setSavedDashboards(loadSavedDashboards())
+  }, [])
+
+  const effectiveDate = dateMode === 'today' ? today : date
+
+  async function runSolver(component, overrideFilters = filters[component] || {}) {
     setLoading(prev => ({ ...prev, [component]: true }))
     setErrors(prev => ({ ...prev, [component]: null }))
     try {
-      const params = new URLSearchParams({ date, component })
-      const res = await fetch(`${API}/my-dashboard/solver?${params.toString()}`)
+      const payload = { date: effectiveDate, component, filters: cleanFilters(overrideFilters) }
+      const res = await fetch(`${API}/my-dashboard/solver`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
       const json = await res.json()
       if (!res.ok) throw new Error(JSON.stringify(json.detail || json))
       setResults(prev => ({ ...prev, [component]: json }))
@@ -56,10 +122,101 @@ export default function MyDashboardPage() {
 
   async function runAll() {
     for (const component of COMPONENTS) {
-      // Run sequentially to avoid hammering the backend/model projection cache on first load.
+      if (!enabled[component.key]) continue
       // eslint-disable-next-line no-await-in-loop
       await runSolver(component.key)
     }
+  }
+
+  function updateComponentFilters(component, nextFilters) {
+    setFilters(prev => ({ ...prev, [component]: nextFilters }))
+  }
+
+  function resetComponentFilters(component) {
+    const next = { ...filters, [component]: {} }
+    setFilters(next)
+    runSolver(component, {})
+  }
+
+  function currentDashboardConfig() {
+    const components = {}
+    COMPONENTS.forEach(component => {
+      components[component.key] = {
+        enabled: Boolean(enabled[component.key]),
+        filters: cleanFilters(filters[component.key] || {}),
+        weights: cleanFilters(filters[component.key] || {}).weights || {},
+      }
+    })
+    return { components }
+  }
+
+  function saveCurrentDashboard() {
+    const name = dashboardName.trim() || `My Dashboard ${new Date().toLocaleString()}`
+    const now = new Date().toISOString()
+    const row = {
+      id: `dash-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      user_id: userId || ensureLocalUserId(),
+      name,
+      description: dashboardDescription.trim(),
+      date_mode: dateMode,
+      fixed_date: dateMode === 'fixed' ? date : null,
+      config: currentDashboardConfig(),
+      created_at: now,
+      updated_at: now,
+      last_run_at: null,
+      persistence: 'localStorage_v1',
+    }
+    const next = [row, ...savedDashboards]
+    setSavedDashboards(next)
+    saveSavedDashboards(next)
+    setDashboardName('')
+    setDashboardDescription('')
+  }
+
+  function deleteSavedDashboard(id) {
+    const next = savedDashboards.filter(row => row.id !== id)
+    setSavedDashboards(next)
+    saveSavedDashboards(next)
+  }
+
+  function loadSavedDashboard(row) {
+    setDateMode(row.date_mode || 'today')
+    if (row.fixed_date) setDate(row.fixed_date)
+    const nextFilters = {}
+    const nextEnabled = { ...enabled }
+    Object.entries(row.config?.components || {}).forEach(([component, config]) => {
+      nextEnabled[component] = config.enabled !== false
+      nextFilters[component] = { ...(config.filters || {}), weights: config.weights || config.filters?.weights || {} }
+    })
+    setEnabled(nextEnabled)
+    setFilters(nextFilters)
+  }
+
+  async function rerunSavedDashboard(row) {
+    loadSavedDashboard(row)
+    const runDate = row.date_mode === 'fixed' && row.fixed_date ? row.fixed_date : today
+    const nextResults = {}
+    for (const component of COMPONENTS) {
+      const config = row.config?.components?.[component.key]
+      if (!config || config.enabled === false) continue
+      setLoading(prev => ({ ...prev, [component.key]: true }))
+      try {
+        const payload = { date: runDate, component: component.key, filters: config.filters || {} }
+        const res = await fetch(`${API}/my-dashboard/solver`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+        const json = await res.json()
+        if (!res.ok) throw new Error(JSON.stringify(json.detail || json))
+        nextResults[component.key] = json
+      } catch (err) {
+        setErrors(prev => ({ ...prev, [component.key]: err.message || 'Saved dashboard rerun failed' }))
+      } finally {
+        setLoading(prev => ({ ...prev, [component.key]: false }))
+      }
+    }
+    setResults(prev => ({ ...prev, ...nextResults }))
+    const now = new Date().toISOString()
+    const next = savedDashboards.map(item => item.id === row.id ? { ...item, last_run_at: now } : item)
+    setSavedDashboards(next)
+    saveSavedDashboards(next)
   }
 
   return (
@@ -68,26 +225,39 @@ export default function MyDashboardPage() {
         <div>
           <div style={eyebrowStyle}>Personal analyst workspace prototype</div>
           <h1 style={titleStyle}>My Dashboard</h1>
-          <p style={subtitleStyle}>
-            Your daily analyst board for model edges, players, teams, totals, notes, and future saved picks.
-          </p>
+          <p style={subtitleStyle}>Your daily analyst board for model edges, players, teams, totals, notes, future saved picks, and rerunnable report configurations.</p>
         </div>
         <div style={dateBoxStyle}>
+          <label style={labelStyle}>Date Mode</label>
+          <select value={dateMode} onChange={e => setDateMode(e.target.value)} style={inputStyle}>
+            <option value="today">Today each time it runs</option>
+            <option value="fixed">Fixed selected date</option>
+          </select>
           <label style={labelStyle}>Board Date</label>
-          <input type="date" value={date} onChange={e => setDate(e.target.value)} style={inputStyle} />
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} style={inputStyle} disabled={dateMode === 'today'} />
           <button onClick={runAll} style={primaryButtonStyle}>Populate All</button>
         </div>
       </section>
 
       <section style={signupBannerStyle}>
         <div>
-          <strong>Coming soon: sign in to save your daily boards, picks, tags, and notes across devices.</strong>
-          <p style={{ margin: '6px 0 0', color: '#8b949e', lineHeight: 1.5 }}>
-            For now, this page uses today’s app-owned model data and local dashboard actions. Save, Tag, and Add Note are placeholders for the future user-owned object system.
-          </p>
+          <strong>Save dashboards so your filters, weights, and model-solver setup can be rerun later.</strong>
+          <p style={{ margin: '6px 0 0', color: '#8b949e', lineHeight: 1.5 }}>Full sign-in is coming soon. For now, saved dashboards are tied to this browser/session: <code>{userId || 'loading'}</code>.</p>
         </div>
-        <button disabled style={disabledButtonStyle}>Sign-in coming soon</button>
+        <button disabled style={disabledButtonStyle}>Real sign-in coming soon</button>
       </section>
+
+      <SavedDashboardsPanel
+        savedDashboards={savedDashboards}
+        dashboardName={dashboardName}
+        setDashboardName={setDashboardName}
+        dashboardDescription={dashboardDescription}
+        setDashboardDescription={setDashboardDescription}
+        onSave={saveCurrentDashboard}
+        onLoad={loadSavedDashboard}
+        onRerun={rerunSavedDashboard}
+        onDelete={deleteSavedDashboard}
+      />
 
       <section style={gridStyle}>
         {COMPONENTS.map(component => (
@@ -97,7 +267,12 @@ export default function MyDashboardPage() {
             result={results[component.key]}
             loading={loading[component.key]}
             error={errors[component.key]}
+            filters={filters[component.key] || {}}
+            enabled={enabled[component.key]}
+            onEnabledChange={(value) => setEnabled(prev => ({ ...prev, [component.key]: value }))}
+            onFilterChange={(next) => updateComponentFilters(component.key, next)}
             onRun={() => runSolver(component.key)}
+            onReset={() => resetComponentFilters(component.key)}
           />
         ))}
       </section>
@@ -105,10 +280,55 @@ export default function MyDashboardPage() {
   )
 }
 
-function DashboardCard({ component, result, loading, error, onRun }) {
-  const items = result?.items || []
+function SavedDashboardsPanel({ savedDashboards, dashboardName, setDashboardName, dashboardDescription, setDashboardDescription, onSave, onLoad, onRerun, onDelete }) {
   return (
-    <div style={cardStyle}>
+    <section style={savedPanelStyle}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '14px', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        <div>
+          <h2 style={{ ...cardTitleStyle, fontSize: '22px' }}>My Saved Dashboards</h2>
+          <p style={cardDescriptionStyle}>Save the report configuration, not stale result rows. Rerun uses fresh app-owned model data for the saved date mode and filters.</p>
+        </div>
+        <div style={saveBoxStyle}>
+          <input value={dashboardName} onChange={e => setDashboardName(e.target.value)} placeholder="Dashboard name" style={inputStyle} />
+          <input value={dashboardDescription} onChange={e => setDashboardDescription(e.target.value)} placeholder="Optional description" style={inputStyle} />
+          <button onClick={onSave} style={primaryButtonStyle}>Save Current Dashboard</button>
+        </div>
+      </div>
+      {savedDashboards.length === 0 ? (
+        <div style={emptyStyle}>No saved dashboards yet. Configure filters/weights, then save the current dashboard so you can rerun it later.</div>
+      ) : (
+        <div style={savedListStyle}>
+          {savedDashboards.map(row => (
+            <div key={row.id} style={savedItemStyle}>
+              <div>
+                <strong>{row.name}</strong>
+                <div style={metaStyle}>{row.description || 'No description'} | {row.date_mode} {row.fixed_date ? `| ${row.fixed_date}` : ''}</div>
+                <div style={metaStyle}>Created {formatDate(row.created_at)} | Last run {row.last_run_at ? formatDate(row.last_run_at) : 'never'} | Components {Object.values(row.config?.components || {}).filter(c => c.enabled !== false).length}</div>
+              </div>
+              <div style={actionsStyle}>
+                <button onClick={() => onLoad(row)} style={miniButtonStyle}>Load</button>
+                <button onClick={() => onRerun(row)} style={miniPrimaryButtonStyle}>Rerun</button>
+                <button onClick={() => onDelete(row.id)} style={miniDangerButtonStyle}>Delete</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function DashboardCard({ component, result, loading, error, filters, enabled, onEnabledChange, onFilterChange, onRun, onReset }) {
+  const [showFilters, setShowFilters] = useState(false)
+  const items = result?.items || []
+  const metricNames = useMemo(() => {
+    const fromResult = result?.available_filters?.metrics || []
+    const fromItems = Array.from(new Set(items.flatMap(item => Object.keys(item.metrics || {}))))
+    return fromResult.length ? fromResult : fromItems.length ? fromItems : (DEFAULT_METRICS[component.key] || [])
+  }, [result, items, component.key])
+  const chips = activeFilterChips(filters)
+  return (
+    <div style={{ ...cardStyle, opacity: enabled ? 1 : 0.68 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start' }}>
         <div>
           <h2 style={cardTitleStyle}>{component.title}</h2>
@@ -117,28 +337,45 @@ function DashboardCard({ component, result, loading, error, onRun }) {
         <span style={countBadgeStyle}>{items.length || 0}/10</span>
       </div>
 
-      <button onClick={onRun} disabled={loading} style={solverButtonStyle}>
-        {loading ? 'Solving...' : 'Use Model Solver To Populate Top 10 Today'}
-      </button>
-
-      {error && <div style={errorStyle}>{error}</div>}
-
-      {!result && !loading && !error && (
-        <div style={emptyStyle}>
-          No saved results yet. Run the model solver to populate this component from existing app-owned data.
-        </div>
-      )}
-
-      <div style={{ display: 'grid', gap: '10px', marginTop: '14px' }}>
-        {items.map(item => <ResultItem key={item.dedupe_key || `${item.entity_type}-${item.entity_id}-${item.rank}`} item={item} />)}
+      <div style={toolbarStyle}>
+        <label style={checkLabelStyle}><input type="checkbox" checked={enabled} onChange={e => onEnabledChange(e.target.checked)} /> Enabled</label>
+        <button onClick={() => setShowFilters(!showFilters)} style={miniButtonStyle}>{showFilters ? 'Hide Filters' : 'Edit Filters'}</button>
       </div>
 
-      {result && (
-        <details style={{ marginTop: '14px' }}>
-          <summary style={summaryStyle}>Data quality and missing data</summary>
-          <pre style={preStyle}>{JSON.stringify({ data_quality: result.data_quality, missing_data: result.missing_data }, null, 2)}</pre>
-        </details>
-      )}
+      <button onClick={onRun} disabled={loading || !enabled} style={solverButtonStyle}>{loading ? 'Solving...' : 'Use Model Solver To Populate Top 10 Today'}</button>
+      {chips.length > 0 && <div style={chipWrapStyle}>{chips.map(chip => <span key={chip} style={filterChipStyle}>{chip}</span>)}</div>}
+      {showFilters && <FilterPanel component={component} filters={filters} metricNames={metricNames} available={result?.available_filters} onChange={onFilterChange} onApply={onRun} onReset={onReset} />}
+      {error && <div style={errorStyle}>{error}</div>}
+      {!result && !loading && !error && <div style={emptyStyle}>No saved results yet. Run the model solver to populate this component from existing app-owned data.</div>}
+      <div style={{ display: 'grid', gap: '10px', marginTop: '14px' }}>{items.map(item => <ResultItem key={item.dedupe_key || `${item.entity_type}-${item.entity_id}-${item.rank}`} item={item} />)}</div>
+      {result && <details style={{ marginTop: '14px' }}><summary style={summaryStyle}>Data quality, filters, and missing data</summary><pre style={preStyle}>{JSON.stringify({ filters_applied: result.filters_applied, available_filters: result.available_filters, result_count_before_filters: result.result_count_before_filters, result_count_after_filters: result.result_count_after_filters, filter_warnings: result.filter_warnings, data_quality: result.data_quality, missing_data: result.missing_data }, null, 2)}</pre></details>}
+    </div>
+  )
+}
+
+function FilterPanel({ filters, metricNames, available, onChange, onApply, onReset }) {
+  function setBasic(key, value) { onChange({ ...filters, [key]: value }) }
+  function setMetric(metric, key, value) { onChange({ ...filters, metrics: { ...(filters.metrics || {}), [metric]: { ...((filters.metrics || {})[metric] || {}), [key]: value } } }) }
+  function setWeight(metric, value) { onChange({ ...filters, weights: { ...(filters.weights || {}), [metric]: value } }) }
+  return (
+    <div style={filterPanelStyle}>
+      <div style={filterSectionTitleStyle}>Basic Filters</div>
+      <div style={filterGridStyle}>
+        <input placeholder="Search player/team/reason" value={filters.search_text || ''} onChange={e => setBasic('search_text', e.target.value)} style={inputStyle} />
+        <input placeholder="Team contains" value={filters.team || ''} onChange={e => setBasic('team', e.target.value)} style={inputStyle} />
+        <input placeholder="Opponent contains" value={filters.opponent || ''} onChange={e => setBasic('opponent', e.target.value)} style={inputStyle} />
+        <select value={filters.min_confidence || ''} onChange={e => setBasic('min_confidence', e.target.value)} style={inputStyle}><option value="">Any confidence</option><option value="low">Low+</option><option value="medium">Medium+</option><option value="high">High only</option></select>
+        <input type="number" step="0.01" placeholder="Min score" value={filters.min_score || ''} onChange={e => setBasic('min_score', e.target.value)} style={inputStyle} />
+        <input type="number" step="0.01" placeholder="Max score" value={filters.max_score || ''} onChange={e => setBasic('max_score', e.target.value)} style={inputStyle} />
+        <input placeholder="Category exact" value={filters.category || ''} onChange={e => setBasic('category', e.target.value)} style={inputStyle} />
+        <input placeholder="Player type hitter/pitcher" value={filters.player_type || ''} onChange={e => setBasic('player_type', e.target.value)} style={inputStyle} />
+      </div>
+      <div style={filterSectionTitleStyle}>Metric Filters</div>
+      <div style={metricFilterGridStyle}>{metricNames.map(metric => <div key={metric} style={metricFilterStyle}><strong>{metric}</strong><input type="number" step="0.001" placeholder="min" value={filters.metrics?.[metric]?.min ?? ''} onChange={e => setMetric(metric, 'min', e.target.value)} style={smallInputStyle} /><input type="number" step="0.001" placeholder="max" value={filters.metrics?.[metric]?.max ?? ''} onChange={e => setMetric(metric, 'max', e.target.value)} style={smallInputStyle} /></div>)}</div>
+      <div style={filterSectionTitleStyle}>Scoring Weights</div>
+      <div style={metricFilterGridStyle}>{metricNames.map(metric => <div key={metric} style={metricFilterStyle}><strong>{metric}</strong><input type="range" min="0" max="2" step="0.05" value={filters.weights?.[metric] ?? 1} onChange={e => setWeight(metric, e.target.value)} /><span style={smallTextStyle}>{filters.weights?.[metric] ?? 1}</span></div>)}</div>
+      {available?.categories?.length > 0 && <div style={smallTextStyle}>Known categories: {available.categories.join(', ')}</div>}
+      <div style={actionsStyle}><button onClick={onApply} style={miniPrimaryButtonStyle}>Apply Filters</button><button onClick={onReset} style={miniButtonStyle}>Reset Filters</button><button disabled style={placeholderButtonStyle}>Save View coming soon</button></div>
     </div>
   )
 }
@@ -147,96 +384,46 @@ function ResultItem({ item }) {
   const metrics = item.metrics || {}
   const chart = item.chart_data || { labels: [], values: [] }
   const maxValue = Math.max(...(chart.values || []).map(v => Math.abs(Number(v) || 0)), 1)
-  return (
-    <div style={itemStyle}>
-      <div style={itemHeaderStyle}>
-        <div>
-          <div style={rankStyle}>#{item.rank} {item.entity_name || item.entity_id}</div>
-          <div style={metaStyle}>
-            {item.player_type ? `${item.player_type} | ` : ''}{item.team || 'Team missing'} vs {item.opponent || 'Opponent missing'} {item.game_pk ? `| Game ${item.game_pk}` : ''}
-          </div>
-        </div>
-        <div style={{ textAlign: 'right' }}>
-          <div style={scoreStyle}>{formatNumber(item.score)}</div>
-          <div style={confidenceStyle(item.confidence)}>{item.confidence || 'low'}</div>
-        </div>
-      </div>
-
-      <p style={reasonStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</p>
-      <ScoreBar value={Number(item.score) || 0} />
-
-      {chart.labels?.length > 0 && (
-        <div style={barsWrapStyle}>
-          {chart.labels.map((label, idx) => {
-            const value = Number(chart.values[idx]) || 0
-            const width = Math.max(8, Math.min(100, Math.abs(value) / maxValue * 100))
-            return (
-              <div key={`${label}-${idx}`} style={metricRowStyle}>
-                <span style={metricLabelStyle}>{label}</span>
-                <div style={metricTrackStyle}><div style={{ ...metricFillStyle, width: `${width}%` }} /></div>
-                <span style={metricValueStyle}>{formatNumber(value)}</span>
-              </div>
-            )
-          })}
-        </div>
-      )}
-
-      {item.best_pitch_angles?.length > 0 && (
-        <div style={pitchAnglesStyle}>
-          <strong>Best pitch angles:</strong>
-          {item.best_pitch_angles.map((angle, idx) => (
-            <div key={`${angle.pitch_type}-${idx}`} style={smallTextStyle}>• {angle.reason}</div>
-          ))}
-        </div>
-      )}
-
-      <details>
-        <summary style={summaryStyle}>View reasoning</summary>
-        <ul style={reasonListStyle}>
-          {(item.reasoning || []).map((reason, idx) => <li key={idx}>{reason}</li>)}
-        </ul>
-        <pre style={preStyle}>{JSON.stringify({ metrics, missing_data: item.missing_data || [], source: item.source, dedupe_key: item.dedupe_key }, null, 2)}</pre>
-      </details>
-
-      <div style={actionsStyle}>
-        <button disabled style={placeholderButtonStyle}>Save</button>
-        <button disabled style={placeholderButtonStyle}>Tag</button>
-        <button disabled style={placeholderButtonStyle}>Add Note</button>
-      </div>
-    </div>
-  )
+  return <div style={itemStyle}><div style={itemHeaderStyle}><div><div style={rankStyle}>#{item.rank} {item.entity_name || item.entity_id}</div><div style={metaStyle}>{item.player_type ? `${item.player_type} | ` : ''}{item.team || 'Team missing'} vs {item.opponent || 'Opponent missing'} {item.game_pk ? `| Game ${item.game_pk}` : ''}</div></div><div style={{ textAlign: 'right' }}><div style={scoreStyle}>{formatNumber(item.score)}</div><div style={confidenceStyle(item.confidence)}>{item.confidence || 'low'}</div></div></div><p style={reasonStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</p>{item.weight_explanation?.length > 0 && <div style={smallTextStyle}>{item.weight_explanation.join(' | ')}</div>}<ScoreBar value={Number(item.score) || 0} />{chart.labels?.length > 0 && <div style={barsWrapStyle}>{chart.labels.map((label, idx) => { const value = Number(chart.values[idx]) || 0; const width = Math.max(8, Math.min(100, Math.abs(value) / maxValue * 100)); return <div key={`${label}-${idx}`} style={metricRowStyle}><span style={metricLabelStyle}>{label}</span><div style={metricTrackStyle}><div style={{ ...metricFillStyle, width: `${width}%` }} /></div><span style={metricValueStyle}>{formatNumber(value)}</span></div> })}</div>}{item.best_pitch_angles?.length > 0 && <div style={pitchAnglesStyle}><strong>Best pitch angles:</strong>{item.best_pitch_angles.map((angle, idx) => <div key={`${angle.pitch_type}-${idx}`} style={smallTextStyle}>• {angle.reason}</div>)}</div>}<details><summary style={summaryStyle}>View reasoning</summary><ul style={reasonListStyle}>{(item.reasoning || []).map((reason, idx) => <li key={idx}>{reason}</li>)}</ul><pre style={preStyle}>{JSON.stringify({ metrics, base_score: item.base_score, adjusted_score: item.adjusted_score, missing_data: item.missing_data || [], source: item.source, dedupe_key: item.dedupe_key }, null, 2)}</pre></details><div style={actionsStyle}><button disabled style={placeholderButtonStyle}>Save</button><button disabled style={placeholderButtonStyle}>Tag</button><button disabled style={placeholderButtonStyle}>Add Note</button></div></div>
 }
 
-function ScoreBar({ value }) {
-  const width = Math.max(4, Math.min(100, Math.abs(value) * 35))
-  return <div style={scoreTrackStyle}><div style={{ ...scoreFillStyle, width: `${width}%` }} /></div>
-}
+function ScoreBar({ value }) { const width = Math.max(4, Math.min(100, Math.abs(value) * 35)); return <div style={scoreTrackStyle}><div style={{ ...scoreFillStyle, width: `${width}%` }} /></div> }
+function formatNumber(value) { const num = Number(value); if (!Number.isFinite(num)) return 'N/A'; return Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(3) }
+function formatDate(value) { try { return new Date(value).toLocaleString() } catch { return value || 'N/A' } }
 
-function formatNumber(value) {
-  const num = Number(value)
-  if (!Number.isFinite(num)) return 'N/A'
-  return Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(3)
-}
-
-const heroStyle = {
-  display: 'flex', justifyContent: 'space-between', gap: '20px', flexWrap: 'wrap',
-  background: 'linear-gradient(135deg, #161b22, #0d1117)', border: '1px solid #30363d', borderRadius: '16px', padding: '24px', marginBottom: '16px'
-}
+const heroStyle = { display: 'flex', justifyContent: 'space-between', gap: '20px', flexWrap: 'wrap', background: 'linear-gradient(135deg, #161b22, #0d1117)', border: '1px solid #30363d', borderRadius: '16px', padding: '24px', marginBottom: '16px' }
 const eyebrowStyle = { color: '#58a6ff', fontSize: '13px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em' }
 const titleStyle = { margin: '6px 0 8px', fontSize: '34px', color: '#e6edf3' }
 const subtitleStyle = { margin: 0, color: '#8b949e', maxWidth: '720px', lineHeight: 1.55 }
 const dateBoxStyle = { minWidth: '220px', display: 'grid', gap: '8px', alignContent: 'start' }
 const labelStyle = { color: '#8b949e', fontSize: '13px' }
 const inputStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '8px', padding: '10px' }
+const smallInputStyle = { ...inputStyle, padding: '7px', width: '82px' }
 const primaryButtonStyle = { background: '#238636', color: '#fff', border: 0, borderRadius: '8px', padding: '10px 12px', cursor: 'pointer', fontWeight: 700 }
 const signupBannerStyle = { display: 'flex', justifyContent: 'space-between', gap: '16px', alignItems: 'center', flexWrap: 'wrap', background: '#0f1a2e', border: '1px solid #1f6feb55', borderRadius: '14px', padding: '16px', marginBottom: '18px', color: '#e6edf3' }
 const disabledButtonStyle = { background: '#21262d', color: '#8b949e', border: '1px solid #30363d', borderRadius: '8px', padding: '10px 12px' }
+const savedPanelStyle = { ...signupBannerStyle, display: 'block', background: '#111827' }
+const saveBoxStyle = { display: 'grid', gap: '8px', minWidth: '280px' }
+const savedListStyle = { display: 'grid', gap: '10px', marginTop: '14px' }
+const savedItemStyle = { display: 'flex', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap', background: '#0d1117', border: '1px solid #30363d', borderRadius: '10px', padding: '12px' }
 const gridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))', gap: '16px' }
 const cardStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: '14px', padding: '16px', color: '#e6edf3' }
 const cardTitleStyle = { margin: 0, fontSize: '20px' }
 const cardDescriptionStyle = { color: '#8b949e', lineHeight: 1.45, margin: '6px 0 0', fontSize: '13px' }
 const countBadgeStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: '999px', padding: '4px 8px', color: '#8b949e', fontSize: '12px' }
-const solverButtonStyle = { width: '100%', marginTop: '14px', background: '#58a6ff', color: '#07111f', border: 0, borderRadius: '8px', padding: '10px', fontWeight: 800, cursor: 'pointer' }
+const toolbarStyle = { display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center', marginTop: '12px' }
+const checkLabelStyle = { color: '#8b949e', fontSize: '12px' }
+const solverButtonStyle = { width: '100%', marginTop: '12px', background: '#58a6ff', color: '#07111f', border: 0, borderRadius: '8px', padding: '10px', fontWeight: 800, cursor: 'pointer' }
+const chipWrapStyle = { display: 'flex', gap: '6px', flexWrap: 'wrap', marginTop: '10px' }
+const filterChipStyle = { background: '#0f1a2e', border: '1px solid #1f6feb55', borderRadius: '999px', color: '#c9d1d9', padding: '4px 8px', fontSize: '11px' }
+const filterPanelStyle = { marginTop: '12px', background: '#0d1117', border: '1px solid #30363d', borderRadius: '10px', padding: '12px' }
+const filterSectionTitleStyle = { color: '#58a6ff', fontSize: '12px', fontWeight: 800, textTransform: 'uppercase', margin: '10px 0 8px' }
+const filterGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '8px' }
+const metricFilterGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '8px' }
+const metricFilterStyle = { background: '#010409', border: '1px solid #30363d', borderRadius: '8px', padding: '8px', display: 'grid', gap: '6px', color: '#c9d1d9', fontSize: '12px' }
+const miniButtonStyle = { background: '#21262d', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: '6px', padding: '7px 9px', cursor: 'pointer' }
+const miniPrimaryButtonStyle = { ...miniButtonStyle, background: '#238636', color: '#fff' }
+const miniDangerButtonStyle = { ...miniButtonStyle, background: '#3b1111', color: '#ffb4b4' }
 const errorStyle = { background: '#2d1b1b', border: '1px solid #a33', borderRadius: '8px', padding: '10px', marginTop: '12px', color: '#ffb4b4' }
 const emptyStyle = { marginTop: '14px', padding: '14px', background: '#0d1117', border: '1px dashed #30363d', borderRadius: '10px', color: '#8b949e', lineHeight: 1.45 }
 const itemStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: '10px', padding: '12px' }
@@ -255,9 +442,9 @@ const metricTrackStyle = { height: '6px', background: '#21262d', borderRadius: '
 const metricFillStyle = { height: '100%', background: '#3fb950', borderRadius: '999px' }
 const metricValueStyle = { color: '#c9d1d9', fontSize: '11px', textAlign: 'right' }
 const pitchAnglesStyle = { margin: '10px 0', color: '#c9d1d9', fontSize: '12px', lineHeight: 1.5 }
-const smallTextStyle = { color: '#8b949e', marginTop: '3px' }
+const smallTextStyle = { color: '#8b949e', marginTop: '3px', fontSize: '12px' }
 const summaryStyle = { cursor: 'pointer', color: '#58a6ff', fontSize: '13px', marginTop: '8px' }
 const reasonListStyle = { color: '#c9d1d9', fontSize: '13px', lineHeight: 1.5, paddingLeft: '18px' }
 const preStyle = { background: '#010409', border: '1px solid #30363d', borderRadius: '8px', padding: '10px', overflowX: 'auto', color: '#8b949e', fontSize: '11px' }
-const actionsStyle = { display: 'flex', gap: '8px', marginTop: '10px' }
+const actionsStyle = { display: 'flex', gap: '8px', marginTop: '10px', flexWrap: 'wrap' }
 const placeholderButtonStyle = { background: '#21262d', color: '#8b949e', border: '1px solid #30363d', borderRadius: '6px', padding: '6px 8px', fontSize: '12px' }

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -16,6 +16,7 @@ router = APIRouter()
 class MyDashboardSolverRequest(BaseModel):
     date: Optional[str] = None
     component: str
+    filters: Optional[Dict[str, Any]] = None
 
 
 def session_factory():
@@ -31,6 +32,7 @@ def my_dashboard_health() -> Dict[str, Any]:
         "name": "My Dashboard",
         "status": "ok",
         "auth_required": False,
+        "persistence": "frontend_localStorage_v1",
         "supported_components": sorted(SUPPORTED_COMPONENTS),
     }
 
@@ -40,15 +42,15 @@ def my_dashboard_solver_get(
     date: Optional[str] = Query(default=None),
     component: str = Query(default="hitters"),
 ) -> Dict[str, Any]:
-    return _run_solver(date=date, component=component)
+    return _run_solver(date=date, component=component, filters=None)
 
 
 @router.post("/my-dashboard/solver")
 def my_dashboard_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any]:
-    return _run_solver(date=payload.date, component=payload.component)
+    return _run_solver(date=payload.date, component=payload.component, filters=payload.filters)
 
 
-def _run_solver(date: Optional[str], component: str) -> Dict[str, Any]:
+def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     target_date = (date or dt.date.today().isoformat())[:10]
     try:
         dt.date.fromisoformat(target_date)
@@ -58,7 +60,7 @@ def _run_solver(date: Optional[str], component: str) -> Dict[str, Any]:
     try:
         factory = session_factory()
         with factory() as session:
-            return build_dashboard_solver_payload(session=session, date=target_date, component=component)
+            return build_dashboard_solver_payload(session=session, date=target_date, component=component, filters=filters)
     except HTTPException:
         raise
     except Exception as exc:

--- a/mlb_app/my_dashboard_solver.py
+++ b/mlb_app/my_dashboard_solver.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .ai_data_assistant import (
     build_pitcher_lean_context,
     build_stored_365_sweep_context,
-    nested_get,
     safe_float,
-    safe_int,
     score_projection_edges,
 )
 from .ai_data_assistant_performance import apply_performance_patch, cached_build_model_projection_payload
@@ -23,6 +21,8 @@ COMPONENT_TITLES = {
     "overall_players": "My Top Overall Players Today",
 }
 
+CONFIDENCE_ORDER = {"low": 1, "medium": 2, "high": 3}
+
 
 def today() -> str:
     return dt.date.today().isoformat()
@@ -30,7 +30,7 @@ def today() -> str:
 
 def confidence_label(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return value.lower()
     num = safe_float(value)
     if num is None:
         return "low"
@@ -67,19 +67,29 @@ def dedupe_ranked_items(items: List[Dict[str, Any]], key_fn: Callable[[Dict[str,
         item["dedupe_key"] = key
         existing = best_by_key.get(key)
         if existing is None or (safe_float(item.get("score")) or -999) > (safe_float(existing.get("score")) or -999):
+            if existing and existing.get("best_pitch_angles") and item.get("best_pitch_angles"):
+                item["best_pitch_angles"] = merge_pitch_angles(existing.get("best_pitch_angles"), item.get("best_pitch_angles"))
             best_by_key[key] = item
         elif item.get("best_pitch_angles") and existing is not None:
-            existing_angles = existing.setdefault("best_pitch_angles", [])
-            seen = {angle.get("pitch_type") for angle in existing_angles if isinstance(angle, dict)}
-            for angle in item.get("best_pitch_angles") or []:
-                if isinstance(angle, dict) and angle.get("pitch_type") not in seen:
-                    existing_angles.append(angle)
-                    seen.add(angle.get("pitch_type"))
-            existing["best_pitch_angles"] = sorted(existing_angles, key=lambda row: safe_float(row.get("score")) or -999, reverse=True)[:3]
+            existing["best_pitch_angles"] = merge_pitch_angles(existing.get("best_pitch_angles"), item.get("best_pitch_angles"))
     ranked = sorted(best_by_key.values(), key=lambda row: safe_float(row.get("score")) or -999, reverse=True)[:limit]
     for idx, row in enumerate(ranked, start=1):
         row["rank"] = idx
     return ranked
+
+
+def merge_pitch_angles(a: Any, b: Any) -> List[Dict[str, Any]]:
+    rows = []
+    seen = set()
+    for angle in list(a or []) + list(b or []):
+        if not isinstance(angle, dict):
+            continue
+        key = angle.get("pitch_type") or angle.get("pitch_name") or angle.get("reason")
+        if key in seen:
+            continue
+        rows.append(angle)
+        seen.add(key)
+    return sorted(rows, key=lambda row: safe_float(row.get("score")) or -999, reverse=True)[:3]
 
 
 def projection_payload(session, date: str) -> Dict[str, Any]:
@@ -90,7 +100,214 @@ def projection_payload(session, date: str) -> Dict[str, Any]:
         return {}
 
 
-def solve_top_hitters(session, date: str) -> Dict[str, Any]:
+def normalize_filter_payload(filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(filters, dict):
+        return {}
+    normalized: Dict[str, Any] = {}
+    for key in ["search_text", "team", "opponent", "category", "entity_type", "player_type"]:
+        value = filters.get(key)
+        if value not in (None, ""):
+            normalized[key] = str(value).strip()
+    for key in ["confidence", "min_confidence"]:
+        value = filters.get(key)
+        if value not in (None, ""):
+            normalized["min_confidence"] = str(value).strip().lower()
+    for key in ["min_score", "max_score"]:
+        value = safe_float(filters.get(key))
+        if value is not None:
+            normalized[key] = value
+    metrics = filters.get("metrics") if isinstance(filters.get("metrics"), dict) else {}
+    normalized_metrics: Dict[str, Dict[str, float]] = {}
+    for metric, rules in metrics.items():
+        if not isinstance(rules, dict):
+            continue
+        entry: Dict[str, float] = {}
+        min_value = safe_float(rules.get("min"))
+        max_value = safe_float(rules.get("max"))
+        if min_value is not None:
+            entry["min"] = min_value
+        if max_value is not None:
+            entry["max"] = max_value
+        if entry:
+            normalized_metrics[str(metric)] = entry
+    if normalized_metrics:
+        normalized["metrics"] = normalized_metrics
+    weights = filters.get("weights") if isinstance(filters.get("weights"), dict) else {}
+    normalized_weights: Dict[str, float] = {}
+    for metric, value in weights.items():
+        weight = safe_float(value)
+        if weight is None:
+            continue
+        normalized_weights[str(metric)] = max(0.0, min(2.0, weight))
+    if normalized_weights:
+        normalized["weights"] = normalized_weights
+    return normalized
+
+
+def text_blob(item: Dict[str, Any]) -> str:
+    parts = [
+        item.get("entity_name"), item.get("team"), item.get("opponent"), item.get("primary_reason"), item.get("category"), item.get("entity_type"), item.get("player_type"),
+    ]
+    parts.extend(item.get("reasoning") or [])
+    for angle in item.get("best_pitch_angles") or []:
+        if isinstance(angle, dict):
+            parts.extend([angle.get("pitch_type"), angle.get("pitch_name"), angle.get("reason")])
+    return " ".join(str(part) for part in parts if part not in (None, "")).lower()
+
+
+def passes_basic_filters(item: Dict[str, Any], filters: Dict[str, Any]) -> bool:
+    score = safe_float(item.get("score"))
+    if filters.get("min_score") is not None and (score is None or score < filters["min_score"]):
+        return False
+    if filters.get("max_score") is not None and (score is None or score > filters["max_score"]):
+        return False
+    min_conf = filters.get("min_confidence")
+    if min_conf and CONFIDENCE_ORDER.get(confidence_label(item.get("confidence")), 0) < CONFIDENCE_ORDER.get(min_conf, 0):
+        return False
+    for key in ["team", "opponent"]:
+        value = filters.get(key)
+        if value and value.lower() not in str(item.get(key) or "").lower():
+            return False
+    for key in ["category", "entity_type", "player_type"]:
+        value = filters.get(key)
+        if value and str(item.get(key) or "").lower() != value.lower():
+            return False
+    search = filters.get("search_text")
+    if search and search.lower() not in text_blob(item):
+        return False
+    return True
+
+
+def passes_metric_filters(item: Dict[str, Any], metric_filters: Dict[str, Dict[str, float]], warnings: List[str]) -> bool:
+    metrics = item.get("metrics") or {}
+    for metric, rules in metric_filters.items():
+        if metric not in metrics or safe_float(metrics.get(metric)) is None:
+            return False
+        value = safe_float(metrics.get(metric))
+        if rules.get("min") is not None and value < rules["min"]:
+            return False
+        if rules.get("max") is not None and value > rules["max"]:
+            return False
+    return True
+
+
+def normalize_metric_for_weight(metric_name: str, metric_value: Any) -> float:
+    value = safe_float(metric_value)
+    if value is None:
+        return 0.0
+    name = metric_name.lower()
+    if "ev" in name or "velocity" in name:
+        return max(-1.0, min(1.0, (value - 88.0) / 12.0))
+    if "total" in name:
+        return max(-1.0, min(1.0, (value - 8.5) / 4.0))
+    if "score" in name or "edge" in name or "diff" in name:
+        return max(-1.0, min(1.0, value))
+    if "bb" in name:
+        return max(-1.0, min(1.0, (0.085 - value) * 8.0))
+    if "allowed" in name and ("xwoba" in name or "hardhit" in name):
+        return max(-1.0, min(1.0, (0.34 - value) * 5.0))
+    return max(-1.0, min(1.0, value))
+
+
+def apply_weight_overrides(item: Dict[str, Any], weights: Dict[str, float]) -> Dict[str, Any]:
+    if not weights:
+        return item
+    updated = dict(item)
+    metrics = updated.get("metrics") or {}
+    base_score = safe_float(updated.get("base_score"))
+    if base_score is None:
+        base_score = safe_float(updated.get("score")) or 0.0
+    adjusted = base_score
+    explanations: List[str] = []
+    for metric_name, weight in weights.items():
+        if metric_name not in metrics:
+            continue
+        normalized_metric = normalize_metric_for_weight(metric_name, metrics.get(metric_name))
+        adjusted += normalized_metric * (weight - 1.0) * 0.25
+        if abs(weight - 1.0) >= 0.01:
+            verb = "emphasized" if weight > 1.0 else "deemphasized"
+            explanations.append(f"{metric_name} {verb} at {round(weight, 2)}")
+    updated["base_score"] = rounded(base_score)
+    updated["adjusted_score"] = rounded(adjusted)
+    updated["score"] = rounded(adjusted)
+    updated["weight_explanation"] = explanations
+    return updated
+
+
+def available_filters_for_component(component: str, items: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+    metric_names = set()
+    categories = set()
+    player_types = set()
+    teams = set()
+    opponents = set()
+    for item in items or []:
+        metric_names.update((item.get("metrics") or {}).keys())
+        if item.get("category"):
+            categories.add(item.get("category"))
+        if item.get("player_type"):
+            player_types.add(item.get("player_type"))
+        if item.get("team"):
+            teams.add(str(item.get("team")))
+        if item.get("opponent"):
+            opponents.add(str(item.get("opponent")))
+    default_metrics = {
+        "hitters": ["xwOBA", "xBA", "EV", "LA", "HardHit", "Usage", "Pitcher xwOBA"],
+        "pitchers": ["K%", "BB%", "xwOBA Allowed", "HardHit Allowed", "Opp K%", "Opp ISO", "Score"],
+        "teams": ["Edge Score", "Win Edge", "Run Diff", "ISO", "OBP", "SLG"],
+        "totals": ["Projected Total", "Raw Total", "Run Index", "Score"],
+        "overall_players": sorted(metric_names) or ["Score"],
+    }
+    metrics = sorted(metric_names) if metric_names else default_metrics.get(component, [])
+    return {
+        "basic": ["search_text", "team", "opponent", "min_confidence", "category", "entity_type", "player_type", "min_score", "max_score"],
+        "metrics": metrics,
+        "weights": metrics,
+        "categories": sorted(categories),
+        "player_types": sorted(player_types),
+        "teams": sorted(teams)[:30],
+        "opponents": sorted(opponents)[:30],
+    }
+
+
+def apply_dashboard_filters(items: List[Dict[str, Any]], filters: Optional[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any], List[str], int, int]:
+    normalized = normalize_filter_payload(filters)
+    warnings: List[str] = []
+    before = len(items)
+    metric_filters = normalized.get("metrics") or {}
+    weights = normalized.get("weights") or {}
+    known_metrics = {metric for item in items for metric in (item.get("metrics") or {}).keys()}
+    for metric in metric_filters.keys():
+        if metric not in known_metrics:
+            warnings.append(f"No items had metric {metric}")
+    filtered: List[Dict[str, Any]] = []
+    for item in items:
+        if not passes_basic_filters(item, normalized):
+            continue
+        if metric_filters and not passes_metric_filters(item, metric_filters, warnings):
+            continue
+        filtered.append(apply_weight_overrides(item, weights))
+    after = len(filtered)
+    if before and after == 0 and normalized:
+        warnings.append("Active filters removed all items")
+    return filtered, normalized, warnings, before, after
+
+
+def finalize_component_response(date: str, component: str, candidates: List[Dict[str, Any]], key_fn: Callable[[Dict[str, Any]], str], data_quality: Any = None, missing_data: Any = None, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    deduped_pool = dedupe_ranked_items(candidates, key_fn, limit=100)
+    filtered, filters_applied, warnings, before, after = apply_dashboard_filters(deduped_pool, filters)
+    final_items = dedupe_ranked_items(filtered, key_fn, limit=10)
+    response = build_response(date, component, final_items, data_quality, missing_data)
+    response.update({
+        "filters_applied": filters_applied,
+        "available_filters": available_filters_for_component(component, deduped_pool),
+        "result_count_before_filters": before,
+        "result_count_after_filters": after,
+        "filter_warnings": warnings,
+    })
+    return response
+
+
+def solve_top_hitters(session, date: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     context = build_stored_365_sweep_context(session, date)
     candidates: List[Dict[str, Any]] = []
     for row in context.get("top_matchups") or []:
@@ -107,7 +324,7 @@ def solve_top_hitters(session, date: str) -> Dict[str, Any]:
             "Pitcher xwOBA": rounded(row.get("pitcher_xwoba_allowed")),
         }
         pitch_label = row.get("pitch_name") or row.get("pitch_type") or "pitch"
-        candidate = {
+        candidates.append({
             "entity_type": "hitter",
             "entity_id": str(hitter_id),
             "entity_name": row.get("batter_name") or f"Batter {hitter_id}",
@@ -115,6 +332,7 @@ def solve_top_hitters(session, date: str) -> Dict[str, Any]:
             "opponent": row.get("opposing_pitcher_name") or row.get("opposing_pitcher_id"),
             "game_pk": row.get("game_pk"),
             "score": rounded(row.get("rank_score")),
+            "base_score": rounded(row.get("rank_score")),
             "confidence": row.get("confidence_tier") or confidence_label(row.get("confidence")),
             "primary_reason": f"Best pitch angle: {pitch_label} with hitter xwOBA {metrics.get('xwOBA')} and EV {metrics.get('EV')}.",
             "reasoning": [
@@ -128,21 +346,12 @@ def solve_top_hitters(session, date: str) -> Dict[str, Any]:
             "chart_data": build_chart_data(metrics),
             "source": "batter_pitch_type_matchups + model_projection_pitch_arsenal",
             "missing_data": row.get("missing_inputs") or [],
-            "best_pitch_angles": [
-                {
-                    "pitch_type": row.get("pitch_type"),
-                    "pitch_name": row.get("pitch_name"),
-                    "score": rounded(row.get("rank_score")),
-                    "reason": f"{pitch_label}: xwOBA {metrics.get('xwOBA')}, EV {metrics.get('EV')}, usage {metrics.get('Usage')}",
-                }
-            ],
-        }
-        candidates.append(candidate)
-    items = dedupe_ranked_items(candidates, lambda row: f"hitter:{row.get('entity_id')}:{date}", limit=10)
-    return build_response(date, "hitters", items, context.get("data_quality"), context.get("missing_data"))
+            "best_pitch_angles": [{"pitch_type": row.get("pitch_type"), "pitch_name": row.get("pitch_name"), "score": rounded(row.get("rank_score")), "reason": f"{pitch_label}: xwOBA {metrics.get('xwOBA')}, EV {metrics.get('EV')}, usage {metrics.get('Usage')}"}],
+        })
+    return finalize_component_response(date, "hitters", candidates, lambda row: f"hitter:{row.get('entity_id')}:{date}", context.get("data_quality"), context.get("missing_data"), filters)
 
 
-def solve_top_pitchers(session, date: str) -> Dict[str, Any]:
+def solve_top_pitchers(session, date: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     context = build_pitcher_lean_context(session, date)
     candidates: List[Dict[str, Any]] = []
     for row in context.get("pitcher_leans") or []:
@@ -151,38 +360,14 @@ def solve_top_pitchers(session, date: str) -> Dict[str, Any]:
             continue
         profile = row.get("pitcher_profile") or {}
         opp = row.get("opponent_offense") or {}
-        metrics = {
-            "K%": rounded(profile.get("k_pct")),
-            "BB%": rounded(profile.get("bb_pct")),
-            "xwOBA Allowed": rounded(profile.get("xwoba_allowed")),
-            "HardHit Allowed": rounded(profile.get("hard_hit_allowed")),
-            "Opp K%": rounded(opp.get("k_pct")),
-            "Opp ISO": rounded(opp.get("iso")),
-            "Score": rounded(row.get("score")),
-        }
-        candidate = {
-            "entity_type": "pitcher",
-            "entity_id": str(pitcher_id),
-            "entity_name": row.get("pitcher_name") or f"Pitcher {pitcher_id}",
-            "team": row.get("team"),
-            "opponent": row.get("opponent"),
-            "game_pk": row.get("game_pk"),
-            "score": rounded(row.get("score")),
-            "confidence": row.get("confidence_tier") or confidence_label(row.get("confidence")),
-            "category": row.get("category"),
-            "primary_reason": ", ".join(row.get("reasons") or []) or "Model projection pitcher context created this lean.",
-            "reasoning": row.get("reasons") or [],
-            "metrics": metrics,
-            "chart_data": build_chart_data(metrics),
-            "source": "model_projections + ai_data_assistant_pitcher_lean_context",
-            "missing_data": row.get("missing_inputs") or [],
-        }
-        candidates.append(candidate)
-    items = dedupe_ranked_items(candidates, lambda row: f"pitcher:{row.get('entity_id')}:{date}", limit=10)
-    return build_response(date, "pitchers", items, context.get("data_quality"), context.get("missing_data"))
+        metrics = {"K%": rounded(profile.get("k_pct")), "BB%": rounded(profile.get("bb_pct")), "xwOBA Allowed": rounded(profile.get("xwoba_allowed")), "HardHit Allowed": rounded(profile.get("hard_hit_allowed")), "Opp K%": rounded(opp.get("k_pct")), "Opp ISO": rounded(opp.get("iso")), "Score": rounded(row.get("score"))}
+        candidates.append({
+            "entity_type": "pitcher", "entity_id": str(pitcher_id), "entity_name": row.get("pitcher_name") or f"Pitcher {pitcher_id}", "team": row.get("team"), "opponent": row.get("opponent"), "game_pk": row.get("game_pk"), "score": rounded(row.get("score")), "base_score": rounded(row.get("score")), "confidence": row.get("confidence_tier") or confidence_label(row.get("confidence")), "category": row.get("category"), "primary_reason": ", ".join(row.get("reasons") or []) or "Model projection pitcher context created this lean.", "reasoning": row.get("reasons") or [], "metrics": metrics, "chart_data": build_chart_data(metrics), "source": "model_projections + ai_data_assistant_pitcher_lean_context", "missing_data": row.get("missing_inputs") or []
+        })
+    return finalize_component_response(date, "pitchers", candidates, lambda row: f"pitcher:{row.get('entity_id')}:{date}", context.get("data_quality"), context.get("missing_data"), filters)
 
 
-def solve_top_teams(session, date: str) -> Dict[str, Any]:
+def solve_top_teams(session, date: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     payload = projection_payload(session, date)
     edges = score_projection_edges(payload) if payload else []
     candidates: List[Dict[str, Any]] = []
@@ -195,37 +380,15 @@ def solve_top_teams(session, date: str) -> Dict[str, Any]:
                 continue
             favorite_bonus = 0.2 if edge.get("model_favorite_side") == side else 0.0
             offense = signals.get("offense") or {}
-            metrics = {
-                "Edge Score": rounded((safe_float(edge.get("score")) or 0) + favorite_bonus),
-                "Win Edge": rounded(edge.get("win_probability_edge")),
-                "Run Diff": rounded(edge.get("expected_run_differential")),
-                "ISO": rounded(offense.get("iso")),
-                "OBP": rounded(offense.get("obp")),
-                "SLG": rounded(offense.get("slg")),
-            }
+            metrics = {"Edge Score": rounded((safe_float(edge.get("score")) or 0) + favorite_bonus), "Win Edge": rounded(edge.get("win_probability_edge")), "Run Diff": rounded(edge.get("expected_run_differential")), "ISO": rounded(offense.get("iso")), "OBP": rounded(offense.get("obp")), "SLG": rounded(offense.get("slg"))}
             score = (safe_float(edge.get("score")) or 0) + favorite_bonus + ((safe_float(offense.get("iso")) or 0) * 0.6)
-            candidate = {
-                "entity_type": "team",
-                "entity_id": str(team_id or team_name),
-                "entity_name": team_name or f"Team {team_id}",
-                "team": team_name,
-                "opponent": signals.get("opponent_team"),
-                "game_pk": edge.get("game_pk"),
-                "score": rounded(score),
-                "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")),
-                "primary_reason": f"Model edge context: win edge {metrics.get('Win Edge')}, run diff {metrics.get('Run Diff')}, ISO {metrics.get('ISO')}.",
-                "reasoning": edge.get("why") or [],
-                "metrics": metrics,
-                "chart_data": build_chart_data(metrics),
-                "source": "model_projections",
-                "missing_data": edge.get("missing_inputs") or [],
-            }
-            candidates.append(candidate)
-    items = dedupe_ranked_items(candidates, lambda row: f"team:{row.get('entity_id')}:{date}", limit=10)
-    return build_response(date, "teams", items, {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [])
+            candidates.append({
+                "entity_type": "team", "entity_id": str(team_id or team_name), "entity_name": team_name or f"Team {team_id}", "team": team_name, "opponent": signals.get("opponent_team"), "game_pk": edge.get("game_pk"), "score": rounded(score), "base_score": rounded(score), "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")), "primary_reason": f"Model edge context: win edge {metrics.get('Win Edge')}, run diff {metrics.get('Run Diff')}, ISO {metrics.get('ISO')}.", "reasoning": edge.get("why") or [], "metrics": metrics, "chart_data": build_chart_data(metrics), "source": "model_projections", "missing_data": edge.get("missing_inputs") or []
+            })
+    return finalize_component_response(date, "teams", candidates, lambda row: f"team:{row.get('entity_id')}:{date}", {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [], filters)
 
 
-def solve_top_totals(session, date: str) -> Dict[str, Any]:
+def solve_top_totals(session, date: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     payload = projection_payload(session, date)
     edges = score_projection_edges(payload) if payload else []
     candidates: List[Dict[str, Any]] = []
@@ -241,90 +404,46 @@ def solve_top_totals(session, date: str) -> Dict[str, Any]:
         raw_gap = abs(projected_total - raw_total) if projected_total is not None and raw_total is not None else 0
         score = total_gap + (abs((run_index or 1.0) - 1.0) * 2.5) - min(0.5, raw_gap * 0.1)
         angle = "over_watchlist" if projected_total is not None and projected_total >= 8.8 else "under_watchlist" if projected_total is not None and projected_total <= 7.6 else "data_limited"
-        metrics = {
-            "Projected Total": rounded(projected_total),
-            "Raw Total": rounded(raw_total),
-            "Run Index": rounded(run_index),
-            "Score": rounded(score),
-        }
-        candidate = {
-            "entity_type": "game_total",
-            "entity_id": str(game_pk),
-            "entity_name": edge.get("label"),
-            "team": None,
-            "opponent": None,
-            "game_pk": game_pk,
-            "score": rounded(score),
-            "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")),
-            "category": angle,
-            "primary_reason": f"{angle}: projected total {metrics.get('Projected Total')} with run index {metrics.get('Run Index')}. No sportsbook total is assumed.",
-            "reasoning": [
-                f"Projected total: {metrics.get('Projected Total')}",
-                f"Raw total: {metrics.get('Raw Total')}",
-                f"Run-scoring index: {metrics.get('Run Index')}",
-                f"Environment label: {total.get('environment_label') or 'not labeled'}",
-                "This is a model total watchlist only, not a priced market edge.",
-            ],
-            "metrics": metrics,
-            "chart_data": build_chart_data(metrics),
-            "source": "model_projections.total_projection",
-            "missing_data": edge.get("missing_inputs") or [],
-        }
-        candidates.append(candidate)
-    items = dedupe_ranked_items(candidates, lambda row: f"game_total:{row.get('game_pk')}:{date}", limit=10)
-    return build_response(date, "totals", items, {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [])
+        metrics = {"Projected Total": rounded(projected_total), "Raw Total": rounded(raw_total), "Run Index": rounded(run_index), "Score": rounded(score)}
+        candidates.append({
+            "entity_type": "game_total", "entity_id": str(game_pk), "entity_name": edge.get("label"), "team": None, "opponent": None, "game_pk": game_pk, "score": rounded(score), "base_score": rounded(score), "confidence": edge.get("confidence_tier") or confidence_label(edge.get("confidence")), "category": angle, "primary_reason": f"{angle}: projected total {metrics.get('Projected Total')} with run index {metrics.get('Run Index')}. No sportsbook total is assumed.", "reasoning": [f"Projected total: {metrics.get('Projected Total')}", f"Raw total: {metrics.get('Raw Total')}", f"Run-scoring index: {metrics.get('Run Index')}", f"Environment label: {total.get('environment_label') or 'not labeled'}", "This is a model total watchlist only, not a priced market edge."], "metrics": metrics, "chart_data": build_chart_data(metrics), "source": "model_projections.total_projection", "missing_data": edge.get("missing_inputs") or []
+        })
+    return finalize_component_response(date, "totals", candidates, lambda row: f"game_total:{row.get('game_pk')}:{date}", {"projection_games": len(payload.get("games") or [])}, payload.get("errors") or [], filters)
 
 
-def solve_top_overall_players(session, date: str) -> Dict[str, Any]:
-    hitters = solve_top_hitters(session, date).get("items") or []
-    pitchers = solve_top_pitchers(session, date).get("items") or []
+def solve_top_overall_players(session, date: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    hitters = solve_top_hitters(session, date, None).get("items") or []
+    pitchers = solve_top_pitchers(session, date, None).get("items") or []
     candidates: List[Dict[str, Any]] = []
     for row in hitters + pitchers:
-        entity_type = row.get("entity_type")
         entity_id = row.get("entity_id")
         if not entity_id:
             continue
         adjusted = dict(row)
         adjusted["entity_type"] = "player"
-        adjusted["player_type"] = entity_type
+        adjusted["player_type"] = row.get("entity_type")
         adjusted["score"] = rounded((safe_float(row.get("score")) or 0) + (0.08 if row.get("confidence") == "high" else 0))
+        adjusted["base_score"] = adjusted["score"]
         adjusted["source"] = f"overall_players:{row.get('source')}"
         candidates.append(adjusted)
-    items = dedupe_ranked_items(candidates, lambda row: f"player:{row.get('entity_id')}:{date}", limit=10)
-    return build_response(date, "overall_players", items, {"hitter_candidates": len(hitters), "pitcher_candidates": len(pitchers)}, [])
+    return finalize_component_response(date, "overall_players", candidates, lambda row: f"player:{row.get('entity_id')}:{date}", {"hitter_candidates": len(hitters), "pitcher_candidates": len(pitchers)}, [], filters)
 
 
 def build_response(date: str, component: str, items: List[Dict[str, Any]], data_quality: Any = None, missing_data: Any = None) -> Dict[str, Any]:
-    return {
-        "date": date,
-        "component": component,
-        "title": COMPONENT_TITLES.get(component, component),
-        "items": items[:10],
-        "data_quality": data_quality or {},
-        "missing_data": missing_data or [],
-        "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
-    }
+    return {"date": date, "component": component, "title": COMPONENT_TITLES.get(component, component), "items": items[:10], "data_quality": data_quality or {}, "missing_data": missing_data or [], "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"}
 
 
-def build_dashboard_solver_payload(session, date: Optional[str], component: str) -> Dict[str, Any]:
+def build_dashboard_solver_payload(session, date: Optional[str], component: str, filters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     target_date = (date or today())[:10]
     normalized = (component or "").strip().lower()
     if normalized not in SUPPORTED_COMPONENTS:
-        return {
-            "date": target_date,
-            "component": normalized,
-            "title": "Unsupported dashboard component",
-            "items": [],
-            "data_quality": {"supported_components": sorted(SUPPORTED_COMPONENTS)},
-            "missing_data": [f"Unsupported component: {component}"],
-            "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        }
+        return {"date": target_date, "component": normalized, "title": "Unsupported dashboard component", "items": [], "filters_applied": normalize_filter_payload(filters), "available_filters": available_filters_for_component(normalized, []), "result_count_before_filters": 0, "result_count_after_filters": 0, "filter_warnings": [f"Unsupported component: {component}"], "data_quality": {"supported_components": sorted(SUPPORTED_COMPONENTS)}, "missing_data": [f"Unsupported component: {component}"], "generated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"}
     if normalized == "hitters":
-        return solve_top_hitters(session, target_date)
+        return solve_top_hitters(session, target_date, filters)
     if normalized == "pitchers":
-        return solve_top_pitchers(session, target_date)
+        return solve_top_pitchers(session, target_date, filters)
     if normalized == "teams":
-        return solve_top_teams(session, target_date)
+        return solve_top_teams(session, target_date, filters)
     if normalized == "totals":
-        return solve_top_totals(session, target_date)
-    return solve_top_overall_players(session, target_date)
+        return solve_top_totals(session, target_date, filters)
+    return solve_top_overall_players(session, target_date, filters)


### PR DESCRIPTION
## Summary

Enhances the existing **My Dashboard** page without changing the dashboard route, replacing the solver, or creating duplicate architecture.

This PR adds two layers on top of the working dashboard prototype:

1. Salesforce-style dynamic filters/report-builder controls for each dashboard component
2. Local saved dashboard configurations that can be loaded and rerun with fresh solver results

This follows the uploaded implementation prompt for dynamic filters and report-builder behavior while preserving the current five-card dashboard and solver architecture.

## Files changed

- `frontend/src/pages/MyDashboardPage.jsx`
- `mlb_app/my_dashboard_solver.py`
- `mlb_app/my_dashboard_routes.py`

## Existing architecture preserved

Preserved:

- Frontend route: `/my-dashboard`
- Backend GET solver: `GET /my-dashboard/solver?date=YYYY-MM-DD&component=...`
- Backend POST solver: `POST /my-dashboard/solver`
- Existing five components:
  - My Top Hitters Today
  - My Top Pitchers Today
  - My Top Teams Today
  - My Top Totals Today
  - My Top Overall Players Today

No new dashboard page was created.
No duplicate solver was created.
No LLM calls were added.
No login wall was added.

## Backend filter payload

`POST /my-dashboard/solver` now supports optional filters:

```json
{
  "date": "2026-05-11",
  "component": "hitters",
  "filters": {
    "min_score": 0.4,
    "min_confidence": "medium",
    "team": "LAD",
    "opponent": "SD",
    "search_text": "Ohtani",
    "metrics": {
      "xwOBA": { "min": 0.35 },
      "EV": { "min": 90 }
    },
    "weights": {
      "xwOBA": 1.25,
      "EV": 1.1
    }
  }
}
```

GET remains backwards compatible and runs with no filters.

## Dynamic metric filters

The solver now returns filter metadata:

- `filters_applied`
- `available_filters`
- `result_count_before_filters`
- `result_count_after_filters`
- `filter_warnings`

Every metric shown in the result cards can be used as a filter because the frontend builds controls dynamically from:

- `available_filters.metrics`
- `items[].metrics`

## Weight overrides

Weights are modest post-model adjustments, not a replacement for the underlying model.

Rules:

- default weight: `1.0`
- allowed range: `0.0` to `2.0`
- the backend returns `base_score`, `adjusted_score`, and `weight_explanation` where weights are applied

## Dedupe-after-filtering

The backend dedupes before and after filtering/rescoring.

Existing dedupe keys are preserved:

- hitters: `hitter:{player_id}:{date}`
- pitchers: `pitcher:{pitcher_id}:{date}`
- teams: `team:{team_id}:{date}`
- totals: `game_total:{game_pk}:{date}`
- overall players: `player:{player_id}:{date}`

Hitter pitch-type rows remain collapsed under `best_pitch_angles`.

## Frontend UX

Each dashboard card now has:

- `Edit Filters`
- active filter chips
- basic filters
- metric min/max controls
- scoring weight sliders
- Apply Filters
- Reset Filters
- enabled/disabled toggle for saved dashboard configs

## My Saved Dashboards

Adds a new section on the same My Dashboard page:

- `My Saved Dashboards`

Saved dashboards are currently stored in localStorage using:

- `mlb_dashboard_user_id`
- `mlb_saved_dashboards_v1`

A saved dashboard stores the report configuration, not stale rows:

- local user id
- name
- description
- date mode
- fixed date if selected
- enabled components
- per-component filters
- per-component weights
- created_at
- updated_at
- last_run_at

Users can:

- Save Current Dashboard
- Load a saved dashboard config into the UI
- Rerun a saved dashboard against fresh solver data
- Delete a saved dashboard

## Persistence choice

This PR uses **frontend localStorage persistence** only.

Reason: it lets us prove the Salesforce-style dashboard workflow without introducing full auth, database migrations, user permissions, or cross-device account complexity yet.

The saved-dashboard schema is intentionally shaped to migrate into a backend `UserSavedDashboard` model later.

## Deferred intentionally

- real OAuth/auth provider
- backend saved dashboard table
- cross-device accounts
- saved dashboard sharing
- group dashboards
- Salesforce-style backend permissions
- AI-generated filter suggestions
- comments on dashboards
- paid tiers

## Test plan

Frontend:

- Open `/my-dashboard`
- Run all five default solver cards
- Open `Edit Filters` on every card
- Apply min score filter
- Apply confidence filter
- Apply metric min/max filter
- Apply search text filter
- Apply weight adjustment
- Reset filters
- Save current dashboard
- Refresh page and verify saved dashboard remains listed
- Load saved dashboard
- Rerun saved dashboard
- Delete saved dashboard

Backend:

- `GET /my-dashboard/solver?date=YYYY-MM-DD&component=hitters`
- `POST /my-dashboard/solver` with filters for hitters
- repeat POST for pitchers, teams, totals, and overall_players

Verify:

- response includes filter metadata
- max 10 items returned
- no duplicate dedupe keys
- hitter pitch-type duplicates remain collapsed
- no LLM calls are made
- no sportsbook lines are invented