### PR TITLE
Fix production API base usage, slate date consistency, cache safety, and route protection

### DIFF
--- a/frontend/src/pages/AIPage.jsx
+++ b/frontend/src/pages/AIPage.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
-
-const API = import.meta.env.VITE_API_BASE_URL || ''
+import { API_BASE, getMlbLiveDate } from '../lib/api'
 
 const PROMPT_CHIPS = [
   "Summarize today's slate",
@@ -16,7 +15,7 @@ const PROMPT_CHIPS = [
 ]
 
 export default function AIPage() {
-  const today = new Date().toISOString().slice(0, 10)
+  const today = getMlbLiveDate()
   const [message, setMessage] = useState("Summarize today's slate")
   const [date, setDate] = useState(today)
   const [gamePk, setGamePk] = useState('')
@@ -37,7 +36,7 @@ export default function AIPage() {
         player_id: playerId ? Number(playerId) : null,
       }
 
-      const res = await fetch(`${API}/ai-data-assistant`, {
+      const res = await fetch(`${API_BASE}/ai-data-assistant`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/scripts/run_refresh_job.py
+++ b/scripts/run_refresh_job.py
@@ -9,6 +9,7 @@ Default fast mode:
 - runs the hittingMatchups refresh so batter_pitch_type_matchups / Stored 365 rows are populated
 - refreshes live matchup payloads for today and tomorrow
 - warms matchup snapshots for today and tomorrow
+- clears process-local AI Data Assistant caches on each refreshed API target
 
 Optional heavy recovery mode:
 - set RUN_STATCAST_ETL=1 to run Statcast ETL/backfill
@@ -38,6 +39,7 @@ REQUEST_TIMEOUT_SECONDS = int(os.environ.get("REFRESH_TIMEOUT_SECONDS", "60"))
 RUN_FAST_MATCHUP_REFRESH = os.environ.get("RUN_FAST_MATCHUP_REFRESH", "1") == "1"
 WARM_SNAPSHOTS = os.environ.get("WARM_MATCHUP_SNAPSHOTS", "1") == "1"
 REFRESH_MATCHUPS_FIRST = os.environ.get("REFRESH_MATCHUPS_FIRST", "1") == "1"
+CLEAR_AI_CACHE_AFTER_REFRESH = os.environ.get("CLEAR_AI_CACHE_AFTER_REFRESH", "1") == "1"
 RUN_STATCAST_ETL = os.environ.get("RUN_STATCAST_ETL", "0") == "1"
 RUN_HITTER_STATCAST_BACKFILL = os.environ.get("RUN_HITTER_STATCAST_BACKFILL", "0") == "1"
 RUN_HITTING_MATCHUPS_REFRESH = os.environ.get("RUN_HITTING_MATCHUPS_REFRESH", "1") == "1"
@@ -133,6 +135,25 @@ def _warm_snapshot_for_date(label: str, base_url: str, target_date: dt.date) -> 
     _log(f"[{label}] Warming matchup snapshot for {target_date.isoformat()} via {url}")
     result = _request_json(url, method="POST")
     _log(f"[{label}] Snapshot response for {target_date.isoformat()}: {result}")
+
+
+def _clear_ai_data_assistant_cache(label: str, base_url: str) -> None:
+    """Best-effort cache clear for process-local AI/model projection caches.
+
+    This intentionally never raises. A cache clear failure should not turn an
+    otherwise successful refresh into a failed Railway cron run.
+    """
+    if not CLEAR_AI_CACHE_AFTER_REFRESH:
+        _log(f"[{label}] Skipping AI Data Assistant cache clear because CLEAR_AI_CACHE_AFTER_REFRESH=0")
+        return
+
+    url = f"{base_url}/ai-data-assistant/cache/clear"
+    try:
+        _log(f"[{label}] Clearing AI Data Assistant cache via {url}")
+        result = _request_json(url, method="POST")
+        _log(f"[{label}] AI Data Assistant cache clear response: {result}")
+    except Exception as exc:
+        _log(f"[{label}] AI Data Assistant cache clear failed but refresh will continue: {exc}")
 
 
 def _run_statcast_etl_refresh() -> None:
@@ -241,6 +262,8 @@ def _run_target(label: str, base_url: str) -> None:
         if WARM_SNAPSHOTS:
             _warm_snapshot_for_date(label, base_url, target_date)
 
+    _clear_ai_data_assistant_cache(label, base_url)
+
 
 def _run_fast_matchup_refresh() -> None:
     if not RUN_FAST_MATCHUP_REFRESH:
@@ -289,7 +312,8 @@ def main() -> int:
         f"run_statcast_etl={int(RUN_STATCAST_ETL)}, "
         f"etl_backfill_days={REFRESH_ETL_BACKFILL_DAYS}, "
         f"run_hitter_statcast_backfill={int(RUN_HITTER_STATCAST_BACKFILL)}, "
-        f"run_hitting_matchups_refresh={int(RUN_HITTING_MATCHUPS_REFRESH)}"
+        f"run_hitting_matchups_refresh={int(RUN_HITTING_MATCHUPS_REFRESH)}, "
+        f"clear_ai_cache_after_refresh={int(CLEAR_AI_CACHE_AFTER_REFRESH)}"
     )
 
     try:

--- a/scripts/smoke_test_production_paths.py
+++ b/scripts/smoke_test_production_paths.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Smoke-test production-critical backend paths.
+
+Usage:
+    python scripts/smoke_test_production_paths.py \
+        --base-url https://mlb-prediction-app-production-732c.up.railway.app \
+        --date 2026-05-12
+
+The script intentionally treats empty odds as non-fatal. It fails on HTTP errors,
+invalid JSON, or structurally broken responses for the production-critical paths.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable
+
+
+DEFAULT_BACKEND_BASE_URL = "https://mlb-prediction-app-production-732c.up.railway.app"
+
+
+class SmokeFailure(Exception):
+    pass
+
+
+def _today_eastern_iso() -> str:
+    # Avoid external dependencies; this is sufficient for a smoke-test default.
+    return dt.datetime.utcnow().date().isoformat()
+
+
+def _request_json(base_url: str, path: str, timeout: int = 45) -> tuple[int, Any]:
+    url = f"{base_url.rstrip('/')}{path}"
+    request = urllib.request.Request(url=url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = int(response.status)
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        raise SmokeFailure(f"HTTP {exc.code} for {path}: {detail[:500]}") from exc
+    except urllib.error.URLError as exc:
+        raise SmokeFailure(f"Network error for {path}: {exc}") from exc
+
+    if status >= 400:
+        raise SmokeFailure(f"HTTP {status} for {path}")
+
+    try:
+        return status, json.loads(body) if body else None
+    except json.JSONDecodeError as exc:
+        raise SmokeFailure(f"Invalid JSON for {path}: {body[:500]}") from exc
+
+
+def _expect_dict(data: Any, path: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise SmokeFailure(f"Expected object for {path}, got {type(data).__name__}")
+    return data
+
+
+def _check_health(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    if not payload:
+        raise SmokeFailure(f"Empty health payload for {path}")
+
+
+def _check_matchups(data: Any, path: str) -> None:
+    if not isinstance(data, list):
+        raise SmokeFailure(f"Expected matchup list for {path}, got {type(data).__name__}")
+
+
+def _check_daily_odds(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    missing = [key for key in ["date", "errors"] if key not in payload]
+    if missing:
+        raise SmokeFailure(f"Daily Odds payload missing {missing} for {path}")
+    if not any(key in payload for key in ["models", "games", "model_games"]):
+        raise SmokeFailure("Daily Odds payload missing models/games/model_games container")
+
+
+def _check_model_projections(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    if not any(key in payload for key in ["games", "models", "count"]):
+        raise SmokeFailure("Model Projections payload missing games/models/count")
+
+
+def _check_dashboard_solver(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    missing = [key for key in ["items", "component", "date"] if key not in payload]
+    if missing:
+        raise SmokeFailure(f"My Dashboard solver payload missing {missing} for {path}")
+    if not isinstance(payload.get("items"), list):
+        raise SmokeFailure("My Dashboard solver items must be a list")
+
+
+def _run_check(
+    base_url: str,
+    label: str,
+    path: str,
+    validator: Callable[[Any, str], None],
+) -> bool:
+    try:
+        status, data = _request_json(base_url, path)
+        validator(data, path)
+        print(f"PASS {label}: HTTP {status} {path}")
+        return True
+    except SmokeFailure as exc:
+        print(f"FAIL {label}: {exc}")
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Smoke-test production-critical MLB backend paths.")
+    parser.add_argument("--base-url", default=os.getenv("BACKEND_BASE_URL", DEFAULT_BACKEND_BASE_URL))
+    parser.add_argument("--date", default=os.getenv("SMOKE_TEST_DATE", _today_eastern_iso()))
+    args = parser.parse_args()
+
+    date = args.date[:10]
+    query_date = urllib.parse.urlencode({"date": date})
+    dashboard_query = urllib.parse.urlencode({"date": date, "component": "hitters"})
+
+    checks: list[tuple[str, str, Callable[[Any, str], None]]] = [
+        ("health", "/health", _check_health),
+        ("matchups", f"/matchups?{query_date}", _check_matchups),
+        ("daily_odds_models", f"/daily-odds/models?{query_date}", _check_daily_odds),
+        ("model_projections", f"/models/projections?{query_date}", _check_model_projections),
+        ("ai_data_assistant_health", "/ai-data-assistant/health", _check_health),
+        ("my_dashboard_health", "/my-dashboard/health", _check_health),
+        ("my_dashboard_solver", f"/my-dashboard/solver?{dashboard_query}", _check_dashboard_solver),
+    ]
+
+    print(f"Backend base URL: {args.base_url.rstrip('/')}")
+    print(f"Smoke-test date: {date}")
+
+    passed = 0
+    for label, path, validator in checks:
+        if _run_check(args.base_url, label, path, validator):
+            passed += 1
+
+    failed = len(checks) - passed
+    print(f"Summary: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Production-safety implementation based on the uploaded prompt, with one architecture decision clarified: My Dashboard should remain registered through the AI Data Assistant router. That coupling is intentional for now and should stay intact.

Implemented in this branch:

- Updated `frontend/src/pages/AIPage.jsx` to use the shared `API_BASE` from `frontend/src/lib/api.js` instead of the unsafe empty fallback pattern.
- Updated `AIPage.jsx` to use `getMlbLiveDate()` for the default MLB slate date instead of raw UTC `new Date().toISOString().slice(0, 10)`.
- Updated `scripts/run_refresh_job.py` to clear the AI Data Assistant process-local cache after each refreshed backend target, using `POST /ai-data-assistant/cache/clear` as a best-effort operation that logs failure but does not crash the refresh job.
- Added `scripts/smoke_test_production_paths.py` to validate core production backend paths after deploy, including both `/ai-data-assistant/health` and `/my-dashboard/health` so the intentional router relationship stays protected.

## Files changed

- `frontend/src/pages/AIPage.jsx`
- `scripts/run_refresh_job.py`
- `scripts/smoke_test_production_paths.py`

## Architecture decision: keep My Dashboard attached to AI Data Assistant

The current route structure is intentional:

- `mlb_app/my_dashboard_routes.py` owns the My Dashboard endpoints.
- `mlb_app/ai_data_assistant_routes.py` includes `my_dashboard_router`.
- `mlb_app/app.py` includes `ai_data_assistant_router`, which keeps My Dashboard available.

Do not move My Dashboard direct-router registration into `app.py` in this PR. The safety requirement is now to preserve the relationship and smoke-test both routes so future AI route refactors do not accidentally remove My Dashboard.

## Why this is safe

- No matchup generator logic was changed.
- No model projection logic was changed.
- No scoring formulas were changed.
- No odds logic was changed.
- No Batter page behavior was changed.
- CORS and Railway deployment files were not changed.
- Cache clearing is best-effort and cannot fail the refresh job.
- My Dashboard router registration behavior was left intact by design.

## Golden-path logic preserved

The production matchup analyzer path remains untouched:

`HomePage.jsx` → `GET /matchups?date=YYYY-MM-DD` → `mlb_app.matchup_generator.generate_matchups_for_date()` → rendered game cards.

## Validation commands to run locally or in CI

```bash
python -m compileall mlb_app scripts
cd frontend && npm run build
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-12
```

## Manual post-deploy smoke checklist

- `/health`
- `/matchups?date=YYYY-MM-DD`
- `/daily-odds/models?date=YYYY-MM-DD`
- `/models/projections?date=YYYY-MM-DD`
- `/ai-data-assistant/health`
- `/my-dashboard/health`
- `/my-dashboard/solver?date=YYYY-MM-DD&component=hitters`

## Remaining follow-up work

This PR intentionally stays narrow. Follow-up work can still standardize other frontend pages that use unsafe API base fallbacks or raw UTC slate dates, but this PR does not touch larger production-critical pages blindly.

## Source prompt

This implements the safe subset of the uploaded production-safety prompt: API base cleanup for AI Data Assistant, slate date consistency for AI Data Assistant, AI cache safety after refresh, production smoke testing, Batter preservation, and Railway/CORS preservation.