### PR TITLE
Document arsenal composite blending design

### DIFF
--- a/docs/layer_5C_arsenal_to_composite_design.md
+++ b/docs/layer_5C_arsenal_to_composite_design.md
@@ -1,0 +1,34 @@
+# Layer 5C — Arsenal-to-Composite Design Proposal
+
+Diagnosis: arsenal_realism_design_ready_for_research_phase
+
+The simulator currently consumes aggregate pitcher realism through active composites:
+- pit_k
+- pit_bb
+- pit_xba
+- pit_xwoba
+- pit_hard_hit
+- pit_hr
+
+Dormant arsenal fields include:
+- whiff_pct
+- usage_pct
+- rv_per_100
+- arsenal
+- pitch_mix
+
+Key conclusion:
+Detailed arsenal realism should blend into composite construction layers, NOT late-stage probability mutation.
+
+Important safety constraints:
+- research-flag only
+- disabled by default
+- no direct probability overrides
+- no additive double counting
+- recalibration required before activation
+
+Candidate insertion seams:
+- whiff_pct -> pit_k
+- rv_per_100 -> pit_xwoba
+- pitch_mix -> pit_hard_hit
+- arsenal quality -> pit_hr

--- a/scripts/design_arsenal_composite_blending_plan.py
+++ b/scripts/design_arsenal_composite_blending_plan.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+
+def write_csv(path, rows):
+
+    if not rows:
+        path.write_text('')
+        return
+
+    fields = sorted(
+        {
+            key
+            for row in rows
+            for key in row.keys()
+        }
+    )
+
+    with path.open(
+        'w',
+        newline='',
+    ) as handle:
+
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fields,
+        )
+
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main():
+
+    candidate_mappings = [
+        {
+            'dormant_field': 'whiff_pct',
+            'candidate_composite': 'pit_k',
+            'double_count_risk': 'very_high',
+            'recommended_strategy': 'shrinkage_residual_only',
+        },
+        {
+            'dormant_field': 'rv_per_100',
+            'candidate_composite': 'pit_xwoba',
+            'double_count_risk': 'high',
+            'recommended_strategy': 'residual_adjustment',
+        },
+        {
+            'dormant_field': 'pitch_mix',
+            'candidate_composite': 'pit_hard_hit',
+            'double_count_risk': 'moderate',
+            'recommended_strategy': 'bounded_blending',
+        },
+    ]
+
+    guardrails = [
+        {
+            'guardrail': 'research_flag_required',
+            'description': 'Arsenal realism disabled by default.',
+        },
+        {
+            'guardrail': 'no_probability_overrides',
+            'description': 'No late-stage probability mutation.',
+        },
+        {
+            'guardrail': 'mandatory_recalibration',
+            'description': 'Layer 4 and 5 recalibration required.',
+        },
+    ]
+
+    payload = {
+        'diagnosis':
+            'arsenal_realism_design_ready_for_research_phase',
+        'recommended_insertion_layer':
+            'composite_construction',
+        'dormant_arsenal_fields': [
+            'whiff_pct',
+            'usage_pct',
+            'rv_per_100',
+            'arsenal',
+            'pitch_mix',
+        ],
+    }
+
+    out_dir = Path('tmp')
+    out_dir.mkdir(exist_ok=True)
+
+    json_path = (
+        out_dir
+        / 'arsenal_composite_design_summary.json'
+    )
+
+    mappings_csv = (
+        out_dir
+        / 'arsenal_composite_candidate_mappings.csv'
+    )
+
+    guardrails_csv = (
+        out_dir
+        / 'arsenal_realism_guardrails.csv'
+    )
+
+    json_path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    write_csv(
+        mappings_csv,
+        candidate_mappings,
+    )
+
+    write_csv(
+        guardrails_csv,
+        guardrails,
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(f'Wrote {json_path}')
+    print(f'Wrote {mappings_csv}')
+    print(f'Wrote {guardrails_csv}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds Layer 5C-I documentation and a design-output script for arsenal-to-composite blending.

What changed:
- Adds docs/layer_5C_arsenal_to_composite_design.md.
- Adds scripts/design_arsenal_composite_blending_plan.py.
- Documents that aggregate pitcher realism is already active through composites.
- Identifies dormant detailed arsenal fields.
- Defines candidate composite insertion seams.
- Captures guardrails for future research-mode activation.

Validated command:
python scripts/design_arsenal_composite_blending_plan.py

Result:
- diagnosis: arsenal_realism_design_ready_for_research_phase
- recommended_insertion_layer: composite_construction
- dormant_arsenal_fields: whiff_pct, usage_pct, rv_per_100, arsenal, pitch_mix

Output files:
- tmp/arsenal_composite_design_summary.json
- tmp/arsenal_composite_candidate_mappings.csv
- tmp/arsenal_realism_guardrails.csv

Interpretation:
Detailed arsenal realism should blend into existing active pitcher composites, not mutate final probabilities directly. Future activation must be research-mode gated, disabled by default, double-count protected, and recalibrated through Layer 4/5 before production consideration.

Recommended next layer:
Layer 5C-J — shadow composite prototype design. Define research-only shadow composites such as pit_k_shadow, pit_xwoba_shadow, pit_hard_hit_shadow, and pit_hr_shadow without changing production simulation behavior.

Notes:
- Documentation/design only.
- No production simulation changes.
- No model integration.
- No edge-detection logic.