### PR TITLE
Design shadow pitcher composite prototypes

### DIFF
--- a/docs/layer_5C_shadow_composite_prototypes.md
+++ b/docs/layer_5C_shadow_composite_prototypes.md
@@ -1,0 +1,280 @@
+# Layer 5C-J — Shadow Pitcher Composite Prototype Design
+
+## Status
+
+Diagnosis:
+
+shadow_composite_designs_ready_for_research_only_phase
+
+This layer defines research-only shadow composite concepts that prepare for future arsenal realism integration without changing production simulation behavior.
+
+IMPORTANT:
+
+This layer does NOT:
+- activate arsenal realism
+- modify _build_pa_model
+- mutate probabilities
+- change production calibration behavior
+- alter runtime simulation outputs
+
+This layer ONLY:
+- defines prototype research composites
+- documents realism insertion seams
+- defines double-count protections
+- establishes future calibration requirements
+
+---
+
+# Current Architecture Recap
+
+The simulator already consumes active aggregate pitcher composites:
+
+- pit_k
+- pit_bb
+- pit_xba
+- pit_xwoba
+- pit_hard_hit
+- pit_hr
+
+Detailed arsenal fields remain dormant:
+
+- whiff_pct
+- usage_pct
+- rv_per_100
+- arsenal
+- pitch_mix
+
+The realism boundary discovered in Layers 5C-H and 5C-I showed that:
+- aggregate realism is active
+- detailed arsenal realism is dormant
+- the correct insertion seam is the composite layer
+
+NOT:
+- downstream probability mutation
+- post-normalization overrides
+
+---
+
+# Shadow Composite Philosophy
+
+Shadow composites exist to safely prototype future realism systems.
+
+They are:
+- research-only abstractions
+- non-production structures
+- calibration-safe prototypes
+
+Their purpose is to:
+- test realism ideas safely
+- isolate arsenal concepts
+- avoid destabilizing the calibrated probability engine
+
+Shadow composites should remain upstream of probabilities.
+
+Future realism should follow:
+
+arsenal realism
+    ↓
+shadow composite layer
+    ↓
+aggregate composite layer
+    ↓
+stable probability engine
+
+NOT:
+
+arsenal realism
+    ↓
+late-stage probability mutation
+
+---
+
+# Prototype Shadow Composites
+
+## 1. pit_k_shadow
+
+Purpose:
+- prototype arsenal-adjusted strikeout realism
+
+Prototype concept:
+
+pit_k_shadow =
+    shrinkage(
+        aggregate_k = pit_k,
+        arsenal_whiff_signal = whiff_component,
+    )
+
+Candidate dormant inputs:
+- whiff_pct
+- usage_pct
+- pitch-level K expectation
+
+Risk:
+VERY HIGH double-count risk.
+
+Reason:
+pit_k already partially encodes latent whiff ability.
+
+Safe future direction:
+- shrinkage only
+- residual blending only
+- bounded influence only
+
+---
+
+## 2. pit_xwoba_shadow
+
+Purpose:
+- prototype arsenal-adjusted contact quality
+
+Prototype concept:
+
+pit_xwoba_shadow =
+    residual_blend(
+        baseline_xwoba = pit_xwoba,
+        arsenal_contact_signal = rv_contact_component,
+    )
+
+Candidate dormant inputs:
+- rv_per_100
+- pitch-type contact suppression
+- pitch-mix interaction quality
+
+Risk:
+HIGH double-count risk.
+
+Reason:
+xwOBA already captures significant contact quality information.
+
+---
+
+## 3. pit_hard_hit_shadow
+
+Purpose:
+- prototype arsenal-adjusted hard-contact suppression
+
+Prototype concept:
+
+pit_hard_hit_shadow =
+    bounded_blend(
+        baseline_hard_hit = pit_hard_hit,
+        arsenal_contact_shape = pitch_mix_contact_component,
+    )
+
+Candidate dormant inputs:
+- pitch_mix
+- contact-shape metrics
+- pitch-shape realism
+
+Risk:
+MODERATE.
+
+---
+
+## 4. pit_hr_shadow
+
+Purpose:
+- prototype arsenal-adjusted HR suppression
+
+Prototype concept:
+
+pit_hr_shadow =
+    bounded_blend(
+        baseline_hr = pit_hr,
+        arsenal_damage_component = barrel_suppression_signal,
+    )
+
+Candidate dormant inputs:
+- barrel suppression
+- fly-ball damage shaping
+- pitch-type HR suppression
+
+Risk:
+MODERATE.
+
+---
+
+# Double-Count Prevention Strategy
+
+This is the most important realism safety problem.
+
+Aggregate pitcher stats already contain latent arsenal information.
+
+Examples:
+- strikeout rate already contains bat-missing ability
+- xwOBA already reflects contact quality
+- HR suppression already reflects pitch quality
+
+Therefore:
+naive additive stacking would:
+- inflate variance
+- destabilize calibration
+- create fake edges
+- overfit historical noise
+
+Future realism blending should use:
+- shrinkage
+- residualization
+- bounded adjustments
+- capped influence
+
+NOT:
+- additive stacking
+- direct probability overrides
+
+---
+
+# Future Research Path
+
+## Phase 1 — Shadow Mode
+
+Goal:
+- construct research-only shadow composites
+- no production influence
+
+## Phase 2 — Calibration Harness
+
+Goal:
+- compare baseline vs shadow composites
+- perform sensitivity testing
+- run bootstrap analysis
+
+## Phase 3 — Controlled Activation Research
+
+Goal:
+- research-flag-only activation
+- no production default
+- no market-facing integration
+
+## Phase 4 — Future Layer 8 Integration
+
+Goal:
+- eventual arsenal matchup realism
+- pitch-level interaction modeling
+- matchup explainability
+
+Only after:
+- calibration stability
+- regime stability
+- overfitting protection
+- rollback validation
+
+---
+
+# Final Recommendation
+
+The simulator should evolve toward:
+
+detailed arsenal realism
+    ↓
+shadow composite layer
+    ↓
+aggregate composite layer
+    ↓
+stable probability engine
+
+This preserves:
+- calibration integrity
+- realism modularity
+- future matchup realism flexibility
+- long-term edge-detection discipline

--- a/scripts/design_shadow_pitcher_composites.py
+++ b/scripts/design_shadow_pitcher_composites.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+
+def write_csv(path, rows):
+
+    if not rows:
+        path.write_text("")
+        return
+
+    fields = sorted(
+        {
+            key
+            for row in rows
+            for key in row.keys()
+        }
+    )
+
+    with path.open(
+        "w",
+        newline="",
+    ) as handle:
+
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fields,
+        )
+
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main():
+
+    formulas = [
+        {
+            "shadow_composite": "pit_k_shadow",
+            "candidate_inputs": "whiff_pct,usage_pct",
+            "prototype_strategy": "shrinkage_residual_only",
+            "risk_level": "very_high",
+        },
+        {
+            "shadow_composite": "pit_xwoba_shadow",
+            "candidate_inputs": "rv_per_100",
+            "prototype_strategy": "residual_blend",
+            "risk_level": "high",
+        },
+        {
+            "shadow_composite": "pit_hard_hit_shadow",
+            "candidate_inputs": "pitch_mix",
+            "prototype_strategy": "bounded_blend",
+            "risk_level": "moderate",
+        },
+        {
+            "shadow_composite": "pit_hr_shadow",
+            "candidate_inputs": "barrel_suppression",
+            "prototype_strategy": "bounded_blend",
+            "risk_level": "moderate",
+        },
+    ]
+
+    guardrails = [
+        {
+            "guardrail":
+                "research_only",
+            "description":
+                "Shadow composites are not production composites.",
+        },
+        {
+            "guardrail":
+                "no_build_pa_model_mutation",
+            "description":
+                "No runtime probability mutation allowed.",
+        },
+        {
+            "guardrail":
+                "double_count_protection",
+            "description":
+                "Use shrinkage and residualization only.",
+        },
+        {
+            "guardrail":
+                "future_recalibration_required",
+            "description":
+                "Layer 4 and 5 recalibration required before activation.",
+        },
+    ]
+
+    payload = {
+        "diagnosis":
+            "shadow_composite_designs_ready_for_research_only_phase",
+        "shadow_composites": [
+            "pit_k_shadow",
+            "pit_xwoba_shadow",
+            "pit_hard_hit_shadow",
+            "pit_hr_shadow",
+        ],
+        "dormant_arsenal_fields": [
+            "whiff_pct",
+            "usage_pct",
+            "rv_per_100",
+            "arsenal",
+            "pitch_mix",
+        ],
+        "recommended_future_layer":
+            "layer_8_pitch_arsenal_matchup_realism",
+    }
+
+    out_dir = Path("tmp")
+    out_dir.mkdir(exist_ok=True)
+
+    json_path = (
+        out_dir
+        / "shadow_pitcher_composite_designs.json"
+    )
+
+    formulas_csv = (
+        out_dir
+        / "shadow_pitcher_composite_formulas.csv"
+    )
+
+    guardrails_csv = (
+        out_dir
+        / "shadow_pitcher_composite_guardrails.csv"
+    )
+
+    json_path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    write_csv(
+        formulas_csv,
+        formulas,
+    )
+
+    write_csv(
+        guardrails_csv,
+        guardrails,
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {formulas_csv}")
+    print(f"Wrote {guardrails_csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Layer 5C-J documentation and a design-output script for research-only shadow pitcher composite prototypes.

What changed:
- Adds docs/layer_5C_shadow_composite_prototypes.md.
- Adds scripts/design_shadow_pitcher_composites.py.
- Defines shadow composites for future research: pit_k_shadow, pit_xwoba_shadow, pit_hard_hit_shadow, and pit_hr_shadow.
- Documents that these are not production composites and do not change simulation behavior.
- Captures guardrails for future research-only arsenal realism work.

Validated command:
python scripts/design_shadow_pitcher_composites.py

Result:
- diagnosis: shadow_composite_designs_ready_for_research_only_phase
- shadow composites: pit_k_shadow, pit_xwoba_shadow, pit_hard_hit_shadow, pit_hr_shadow
- dormant arsenal fields: whiff_pct, usage_pct, rv_per_100, arsenal, pitch_mix
- recommended future layer: layer_8_pitch_arsenal_matchup_realism

Output files:
- tmp/shadow_pitcher_composite_designs.json
- tmp/shadow_pitcher_composite_formulas.csv
- tmp/shadow_pitcher_composite_guardrails.csv

Interpretation:
Research-only shadow composites provide a safe bridge from Layer 5 player/profile signal refinement into future Layer 8 pitch arsenal matchup realism without changing production simulation behavior.

Recommended next layer:
Layer 5C-K — shadow composite feasibility audit. Determine whether the dormant arsenal fields needed to calculate these shadow composites are sufficiently complete, stable, and schema-consistent before any prototype math or activation work.

Notes:
- Documentation/design only.
- No production simulation changes.
- No model integration.
- No edge-detection logic.