### PR TITLE
Design arsenal schema normalization

### DIFF
--- a/docs/layer_5C_arsenal_schema_normalization_design.md
+++ b/docs/layer_5C_arsenal_schema_normalization_design.md
@@ -1,0 +1,142 @@
+# Layer 5C-M — Arsenal Schema Normalization Design
+
+## Diagnosis
+
+arsenal_schema_normalization_design_ready
+
+## Purpose
+
+This layer defines canonical normalization rules for real generated arsenal payloads before any research-only shadow composite calculations.
+
+This layer does not activate realism, modify production simulation, mutate _build_pa_model, change probabilities, or integrate shadow composites.
+
+## Confirmed Real Payload Fields
+
+Validated in Layer 5C-LA:
+
+- whiff_pct: present/numeric
+- usage_pct: present/numeric
+- rv_per_100: present/numeric
+- strikeout_pct: present/numeric
+- xwoba: present/numeric
+- xba: present/numeric
+- hard_hit_pct: fragmented
+- hr_rate: not canonical
+- pitch_mix: not canonical
+
+## Canonical Arsenal Schema
+
+Core canonical fields:
+
+- canonical_pitch_type
+- canonical_usage_pct
+- canonical_whiff_pct
+- canonical_strikeout_pct
+- canonical_rv_per_100
+- canonical_xwoba
+- canonical_xba
+- canonical_hard_hit_pct
+- canonical_pitch_mix_weight
+- canonical_damage_proxy
+
+## Canonical Pitch Type Mapping
+
+Normalize pitch labels:
+
+- FF -> four_seam
+- FA -> four_seam
+- SI -> sinker
+- FT -> sinker
+- SL -> slider
+- CU -> curveball
+- CH -> changeup
+- KC -> knuckle_curve
+- FC -> cutter
+
+Unknown labels should preserve raw label and flag a validation warning.
+
+## Source Mapping Rules
+
+Accepted pitcher arsenal sources:
+
+- home_pitch_arsenal.<pitch>.<metric>
+- away_pitch_arsenal.<pitch>.<metric>
+- home_pitcher_features.<metric>
+- away_pitcher_features.<metric>
+
+Explicitly exclude hitter/offense paths from pitcher arsenal normalization.
+
+## Scale Normalization
+
+Percentage-like fields may arrive in probability scale or percentage scale.
+
+Rules:
+
+- values between 0 and 1 are treated as already normalized
+- values greater than 1 and less than or equal to 100 are divided by 100
+- values less than 0 or greater than 100 are invalid
+- ambiguous scales should be flagged
+
+## Derived Canonical Fields
+
+canonical_pitch_mix_weight should derive from normalized usage_pct because exact pitch_mix is not canonical in real payloads.
+
+canonical_damage_proxy should derive from rv_per_100, xwoba, hard_hit_pct, and/or xba until a true canonical hr_rate source exists.
+
+## Role Normalization
+
+Supported roles:
+
+- home starter
+- away starter
+- aggregate pitcher features
+
+Deferred roles:
+
+- bullpen
+- opener chains
+- reliever sequences
+
+## Validation Rules
+
+pit_k_shadow requires:
+
+- whiff_pct
+- usage_pct
+- strikeout_pct
+
+pit_xwoba_shadow requires:
+
+- xwoba
+- rv_per_100
+
+pit_hard_hit_shadow requires:
+
+- hard_hit_pct or xwoba proxy
+
+pit_hr_shadow requires:
+
+- damage proxy or future canonical hr_rate
+
+Minimum standards:
+
+- numeric_rate >= 0.70
+- null_rate <= 0.30
+- schema fragmentation monitored
+- scale ambiguity warning
+- invalid ranges fail
+
+## Future Layer Dependency
+
+If accepted, Layer 5C-N may implement research-only canonical extractors.
+
+Still prohibited:
+
+- realism activation
+- production simulation mutation
+- shadow composite integration
+- edge detection
+
+## Final Conclusion
+
+The realism architecture is structurally viable, payload-validated, and now normalization-constrained.

--- a/scripts/design_arsenal_schema_normalization.py
+++ b/scripts/design_arsenal_schema_normalization.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+
+CANONICAL_FIELDS = [
+    {
+        "canonical_field": "canonical_pitch_type",
+        "description": "normalized pitch label",
+    },
+    {
+        "canonical_field": "canonical_usage_pct",
+        "description": "normalized usage rate",
+    },
+    {
+        "canonical_field": "canonical_whiff_pct",
+        "description": "normalized whiff rate",
+    },
+    {
+        "canonical_field": "canonical_strikeout_pct",
+        "description": "normalized strikeout metric",
+    },
+    {
+        "canonical_field": "canonical_rv_per_100",
+        "description": "normalized run value metric",
+    },
+    {
+        "canonical_field": "canonical_xwoba",
+        "description": "normalized contact quality metric",
+    },
+    {
+        "canonical_field": "canonical_xba",
+        "description": "normalized batting average quality",
+    },
+    {
+        "canonical_field": "canonical_hard_hit_pct",
+        "description": "normalized hard-hit metric",
+    },
+    {
+        "canonical_field": "canonical_pitch_mix_weight",
+        "description": "derived usage-based pitch mix proxy",
+    },
+    {
+        "canonical_field": "canonical_damage_proxy",
+        "description": "derived damage realism proxy",
+    },
+]
+
+
+SOURCE_MAPPINGS = [
+    {
+        "source_pattern": "home_pitch_arsenal.<pitch>.<metric>",
+        "target": "canonical arsenal fields",
+        "role": "home starter",
+    },
+    {
+        "source_pattern": "away_pitch_arsenal.<pitch>.<metric>",
+        "target": "canonical arsenal fields",
+        "role": "away starter",
+    },
+    {
+        "source_pattern": "home_pitcher_features.<metric>",
+        "target": "aggregate pitcher features",
+        "role": "home starter",
+    },
+    {
+        "source_pattern": "away_pitcher_features.<metric>",
+        "target": "aggregate pitcher features",
+        "role": "away starter",
+    },
+]
+
+
+VALIDATION_RULES = [
+    {
+        "shadow_composite": "pit_k_shadow",
+        "required_fields": "whiff_pct;usage_pct;strikeout_pct",
+        "minimum_numeric_rate": 0.70,
+    },
+    {
+        "shadow_composite": "pit_xwoba_shadow",
+        "required_fields": "xwoba;rv_per_100",
+        "minimum_numeric_rate": 0.70,
+    },
+    {
+        "shadow_composite": "pit_hard_hit_shadow",
+        "required_fields": "hard_hit_pct OR xwoba proxy",
+        "minimum_numeric_rate": 0.70,
+    },
+    {
+        "shadow_composite": "pit_hr_shadow",
+        "required_fields": "damage_proxy",
+        "minimum_numeric_rate": 0.70,
+    },
+]
+
+
+def write_csv(path, rows):
+    if not rows:
+        path.write_text("")
+        return
+
+    fields = sorted({k for row in rows for k in row.keys()})
+
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main():
+    payload = {
+        "diagnosis": "arsenal_schema_normalization_design_ready",
+        "canonical_fields": CANONICAL_FIELDS,
+        "source_mappings": SOURCE_MAPPINGS,
+        "validation_rules": VALIDATION_RULES,
+        "design_constraints": [
+            "no production simulation mutation",
+            "no realism activation",
+            "no shadow composite integration",
+            "no edge detection",
+        ],
+    }
+
+    out_dir = Path("tmp")
+    out_dir.mkdir(exist_ok=True)
+
+    json_path = out_dir / "arsenal_schema_normalization_design.json"
+    canonical_csv = out_dir / "arsenal_schema_canonical_fields.csv"
+    mappings_csv = out_dir / "arsenal_schema_source_mappings.csv"
+    validation_csv = out_dir / "arsenal_schema_validation_rules.csv"
+
+    json_path.write_text(json.dumps(payload, indent=2))
+
+    write_csv(canonical_csv, CANONICAL_FIELDS)
+    write_csv(mappings_csv, SOURCE_MAPPINGS)
+    write_csv(validation_csv, VALIDATION_RULES)
+
+    print(json.dumps(payload, indent=2))
+    print(f"Wrote {json_path}")
+    print(f"Wrote {canonical_csv}")
+    print(f"Wrote {mappings_csv}")
+    print(f"Wrote {validation_csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Layer 5C-M documentation and a design-output script for canonical arsenal schema normalization.

What changed:
- Adds docs/layer_5C_arsenal_schema_normalization_design.md.
- Adds scripts/design_arsenal_schema_normalization.py.
- Defines canonical arsenal fields for future research-only extraction.
- Defines source mappings from real payload patterns.
- Defines validation rules for future shadow composite readiness.

Validated command:
python scripts/design_arsenal_schema_normalization.py

Result:
- diagnosis: arsenal_schema_normalization_design_ready

Canonical fields include:
- canonical_pitch_type
- canonical_usage_pct
- canonical_whiff_pct
- canonical_strikeout_pct
- canonical_rv_per_100
- canonical_xwoba
- canonical_xba
- canonical_hard_hit_pct
- canonical_pitch_mix_weight
- canonical_damage_proxy

Source mappings include:
- home_pitch_arsenal.<pitch>.<metric>
- away_pitch_arsenal.<pitch>.<metric>
- home_pitcher_features.<metric>
- away_pitcher_features.<metric>

Interpretation:
Layer 5C-M defines the canonical schema normalization design required before any research-only arsenal extractor or shadow-composite calculator. It maps real payload structures into stable canonical fields, defines scale normalization, excludes hitter/offense contexts, and establishes validation rules for future shadow composites.

Recommended next layer:
Layer 5C-N — research-only canonical arsenal extractor. Implement extraction of normalized canonical arsenal fields from real generated payloads, still disconnected from simulation and production behavior.

Notes:
- Design only.
- No production simulation changes.
- No model integration.
- No edge-detection logic.