### PR TITLE
Polish enterprise frontend shell and matchup slate UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,104 +24,64 @@ const RollingBatterPage = ENABLE_BATTER_PAGE ? React.lazy(() => import('./pages/
 
 function BatterTemporarilyUnavailable() {
   return (
-    <div style={{
-      background: '#161b22',
-      border: '1px solid #30363d',
-      borderRadius: '10px',
-      padding: '24px',
-      color: '#e6edf3',
-    }}>
-      <h1 style={{ marginTop: 0, fontSize: '22px' }}>Batter page temporarily disabled</h1>
-      <p style={{ color: '#8b949e', lineHeight: 1.5 }}>
-        The Batter dashboard is temporarily unavailable while the backend leaderboard endpoint is being stabilised.
-        Matchups, pitchers, teams, odds, live scores, and the rest of the app remain available.
+    <section className="state-panel">
+      <div className="status-badge warning" style={{ marginBottom: 12 }}>Temporarily Disabled</div>
+      <h1 className="page-title" style={{ fontSize: 24 }}>Batter dashboard validation in progress</h1>
+      <p className="page-subtitle" style={{ margin: '10px auto 0' }}>
+        The Batter dashboard is temporarily unavailable while the backend leaderboard endpoint is validated for production stability. Matchups, pitchers, teams, odds, live scores, and model projections remain available.
       </p>
-    </div>
+    </section>
   )
 }
 
-const styles = {
-  nav: {
-    background: '#161b22',
-    borderBottom: '1px solid #30363d',
-    padding: '0 24px',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '28px',
-    minHeight: '56px',
-    flexWrap: 'wrap',
-  },
-  brand: {
-    fontSize: '18px',
-    fontWeight: '700',
-    color: '#58a6ff',
-    textDecoration: 'none',
-    letterSpacing: '-0.5px',
-    marginRight: '4px',
-  },
-  link: {
-    color: '#8b949e',
-    textDecoration: 'none',
-    fontSize: '14px',
-    fontWeight: '500',
-    padding: '4px 0',
-    borderBottom: '2px solid transparent',
-    transition: 'color 0.15s, border-color 0.15s',
-  },
-  activeLink: {
-    color: '#e6edf3',
-    borderBottomColor: '#58a6ff',
-  },
-  main: {
-    maxWidth: '1200px',
-    margin: '0 auto',
-    padding: '32px 24px',
-  },
-}
-
-const link = ({ isActive }) => ({ ...styles.link, ...(isActive ? styles.activeLink : {}) })
+const navLinkClass = ({ isActive }) => `app-nav-link${isActive ? ' active' : ''}`
 
 export default function App() {
   return (
     <BrowserRouter>
-      <nav style={styles.nav}>
-        <NavLink to="/" style={styles.brand}>⚾ MLB Predict</NavLink>
-        <NavLink to="/" end style={link}>Matchups</NavLink>
-        <NavLink to="/daily-odds" style={link}>Daily Odds</NavLink>
-        <NavLink to="/models/projections" style={link}>Model Projections</NavLink>
-        <NavLink to="/my-dashboard" style={link}>My Dashboard</NavLink>
-        <NavLink to="/standings" style={link}>Standings</NavLink>
-        <NavLink to="/pitcher" style={link}>Pitcher</NavLink>
-        <NavLink to="/batter" style={link}>Batter</NavLink>
-        <NavLink to="/team" style={link}>Team</NavLink>
-        <NavLink to="/calendar" style={link}>Calendar</NavLink>
-        <NavLink to="/ai-data-assistant" style={link}>AI Data Assistant</NavLink>
-        <NavLink to="/live" style={link}>Live</NavLink>
-      </nav>
-      <main style={styles.main}>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/daily-odds" element={<DailyOddsPage />} />
-          <Route path="/models/projections" element={<ModelProjectionsPage />} />
-          <Route path="/my-dashboard" element={<MyDashboardPage />} />
-          <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
-          <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />
-          <Route path="/standings" element={<StandingsPage />} />
-          <Route path="/pitcher" element={<PitcherPage />} />
-          <Route path="/pitcher/:id" element={<PitcherPage />} />
-          <Route path="/pitcher/:id/rolling" element={<RollingPitcherPage />} />
-          <Route path="/batter" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><BatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
-          <Route path="/batter/:id" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><BatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
-          <Route path="/batter/:id/rolling" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><RollingBatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
-          <Route path="/team" element={<TeamPage />} />
-          <Route path="/team/:id" element={<TeamPage />} />
-          <Route path="/calendar" element={<YesterdayTodayPage />} />
-          <Route path="/ai" element={<AIPage />} />
-          <Route path="/ai-data-assistant" element={<AIPage />} />
-          <Route path="/live" element={<LiveScoreboardPage />} />
-          <Route path="/live/:game_pk" element={<LiveGamePageRestored />} />
-        </Routes>
-      </main>
+      <div className="app-shell">
+        <nav className="app-nav" aria-label="Primary navigation">
+          <NavLink to="/" className="app-brand">
+            <span className="app-brand-mark">◆</span>
+            <span>MLB Prediction Engine</span>
+          </NavLink>
+          <NavLink to="/" end className={navLinkClass}>Matchups</NavLink>
+          <NavLink to="/daily-odds" className={navLinkClass}>Daily Odds</NavLink>
+          <NavLink to="/models/projections" className={navLinkClass}>Model Projections</NavLink>
+          <NavLink to="/my-dashboard" className={navLinkClass}>My Dashboard</NavLink>
+          <NavLink to="/standings" className={navLinkClass}>Standings</NavLink>
+          <NavLink to="/pitcher" className={navLinkClass}>Pitcher</NavLink>
+          <NavLink to="/batter" className={navLinkClass}>Batter</NavLink>
+          <NavLink to="/team" className={navLinkClass}>Team</NavLink>
+          <NavLink to="/calendar" className={navLinkClass}>Calendar</NavLink>
+          <NavLink to="/ai-data-assistant" className={navLinkClass}>AI Data Assistant</NavLink>
+          <NavLink to="/live" className={navLinkClass}>Live</NavLink>
+        </nav>
+        <main className="app-main">
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/daily-odds" element={<DailyOddsPage />} />
+            <Route path="/models/projections" element={<ModelProjectionsPage />} />
+            <Route path="/my-dashboard" element={<MyDashboardPage />} />
+            <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
+            <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />
+            <Route path="/standings" element={<StandingsPage />} />
+            <Route path="/pitcher" element={<PitcherPage />} />
+            <Route path="/pitcher/:id" element={<PitcherPage />} />
+            <Route path="/pitcher/:id/rolling" element={<RollingPitcherPage />} />
+            <Route path="/batter" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><BatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
+            <Route path="/batter/:id" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><BatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
+            <Route path="/batter/:id/rolling" element={ENABLE_BATTER_PAGE ? <React.Suspense fallback={null}><RollingBatterPage /></React.Suspense> : <BatterTemporarilyUnavailable />} />
+            <Route path="/team" element={<TeamPage />} />
+            <Route path="/team/:id" element={<TeamPage />} />
+            <Route path="/calendar" element={<YesterdayTodayPage />} />
+            <Route path="/ai" element={<AIPage />} />
+            <Route path="/ai-data-assistant" element={<AIPage />} />
+            <Route path="/live" element={<LiveScoreboardPage />} />
+            <Route path="/live/:game_pk" element={<LiveGamePageRestored />} />
+          </Routes>
+        </main>
+      </div>
     </BrowserRouter>
   )
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import './styles/theme.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,75 +1,44 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { API_BASE, getMlbLiveDate } from '../lib/api'
 
-const API = import.meta.env.VITE_API_BASE_URL || ''
-
-function getMlbToday() {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'America/New_York',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(new Date())
-
-  const values = Object.fromEntries(parts.map(part => [part.type, part.value]))
-  return `${values.year}-${values.month}-${values.day}`
-}
+const API = API_BASE
 
 const s = {
-  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '24px', flexWrap: 'wrap', gap: '12px' },
-  title: { fontSize: '24px', fontWeight: '700', color: '#e6edf3' },
-  datePicker: {
-    background: '#161b22', border: '1px solid #30363d', color: '#e6edf3',
-    borderRadius: '6px', padding: '8px 12px', fontSize: '14px', cursor: 'pointer',
-  },
-  grid: { display: 'grid', gap: '12px' },
-  card: {
-    background: '#161b22', border: '1px solid #30363d', borderRadius: '10px',
-    padding: '16px 20px', cursor: 'pointer', transition: 'border-color 0.15s',
-  },
-  cardHover: { borderColor: '#58a6ff' },
-  meta: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px', fontSize: '12px', color: '#8b949e' },
-  venue: { display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' },
-  statusBadge: (status) => ({
-    display: 'inline-block', borderRadius: '4px', padding: '2px 7px',
-    fontSize: '11px', fontWeight: '600',
-    background: status === 'Final' ? '#21262d' : status?.includes('Progress') ? '#1f3a1f' : '#21262d',
-    color: status === 'Final' ? '#8b949e' : status?.includes('Progress') ? '#3fb950' : '#58a6ff',
-  }),
-  matchupRow: {
-    display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'center', gap: '12px',
-  },
-  team: { display: 'flex', flexDirection: 'column', gap: '3px' },
-  teamName: { fontSize: '16px', fontWeight: '600', color: '#e6edf3' },
-  record: { fontSize: '12px', color: '#8b949e' },
-  pitcher: { fontSize: '12px', color: '#58a6ff' },
-  prob: { fontSize: '26px', fontWeight: '700' },
-  vs: { textAlign: 'center', fontSize: '13px', color: '#8b949e', fontWeight: '600', letterSpacing: '1px' },
-  noData: { color: '#8b949e', fontSize: '14px', textAlign: 'center', padding: '48px' },
-  loader: { color: '#8b949e', textAlign: 'center', padding: '48px' },
-  error: { color: '#f85149', textAlign: 'center', padding: '24px', background: '#1f1116', borderRadius: '8px' },
-  oddsBox: { marginTop: '14px', padding: '12px', border: '1px solid #30363d', borderRadius: '8px', background: '#0d1117' },
-  oddsHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px', marginBottom: '10px' },
-  oddsTitle: { color: '#e6edf3', fontSize: '13px', fontWeight: '700' },
-  oddsSubtle: { color: '#8b949e', fontSize: '11px' },
-  oddsGrid: { display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: '8px' },
-  marketCard: { border: '1px solid #21262d', borderRadius: '7px', padding: '8px', background: '#161b22' },
-  marketLabel: { color: '#8b949e', fontSize: '10px', textTransform: 'uppercase', letterSpacing: '0.7px', marginBottom: '6px', fontWeight: '700' },
-  oddsLine: { display: 'flex', justifyContent: 'space-between', gap: '8px', fontSize: '12px', color: '#e6edf3', marginTop: '3px' },
-  propButton: { marginTop: '10px', background: '#21262d', border: '1px solid #30363d', color: '#58a6ff', borderRadius: '6px', padding: '7px 10px', fontSize: '12px', cursor: 'pointer', fontWeight: '700' },
-  propsPanel: { marginTop: '10px', borderTop: '1px solid #30363d', paddingTop: '10px' },
-  propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '8px' },
-  propCard: { border: '1px solid #21262d', borderRadius: '7px', padding: '8px', background: '#161b22' },
-  propMarket: { color: '#d29922', fontSize: '11px', fontWeight: '700', marginBottom: '5px' },
-  propName: { color: '#e6edf3', fontSize: '12px', fontWeight: '700' },
-  propDetails: { color: '#8b949e', fontSize: '12px', marginTop: '3px' },
+  matchupGrid: { display: 'grid', gap: '16px' },
+  card: { cursor: 'pointer' },
+  slateMeta: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16, gap: 12, flexWrap: 'wrap' },
+  venue: { display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: 12 },
+  matchupRow: { display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'stretch', gap: 16 },
+  teamPanel: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', padding: 14, background: 'rgba(7, 11, 18, 0.34)' },
+  teamPanelRight: { textAlign: 'right' },
+  teamName: { fontSize: 18, fontWeight: 850, color: 'var(--text-primary)', letterSpacing: '-0.03em' },
+  record: { fontSize: 12, color: 'var(--text-muted)', marginTop: 2 },
+  pitcher: { fontSize: 13, color: 'var(--accent)', marginTop: 10, minHeight: 20 },
+  prob: { fontSize: 30, fontWeight: 900, letterSpacing: '-0.06em', marginTop: 12 },
+  vs: { display: 'grid', placeItems: 'center', color: 'var(--text-muted)', fontWeight: 900, letterSpacing: '0.18em', fontSize: 12 },
+  oddsBox: { marginTop: 16, padding: 14, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', background: 'rgba(7, 11, 18, 0.46)' },
+  oddsHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 12 },
+  oddsTitle: { color: 'var(--text-primary)', fontSize: 13, fontWeight: 850, letterSpacing: '0.02em' },
+  oddsSubtle: { color: 'var(--text-muted)', fontSize: 12 },
+  oddsGrid: { display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10 },
+  marketCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.76)' },
+  marketLabel: { color: 'var(--text-muted)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 7, fontWeight: 850 },
+  oddsLine: { display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 12, color: 'var(--text-secondary)', marginTop: 4 },
+  propButton: { marginTop: 12, padding: '8px 11px', fontSize: 12, fontWeight: 800 },
+  propsPanel: { marginTop: 12, borderTop: '1px solid var(--border-subtle)', paddingTop: 12 },
+  propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 },
+  propCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.78)' },
+  propMarket: { color: 'var(--warning)', fontSize: 11, fontWeight: 850, marginBottom: 5 },
+  propName: { color: 'var(--text-primary)', fontSize: 12, fontWeight: 800 },
+  propDetails: { color: 'var(--text-muted)', fontSize: 12, marginTop: 3 },
 }
 
 function probColor(p) {
-  if (p == null) return '#8b949e'
-  if (p >= 0.62) return '#3fb950'
-  if (p >= 0.50) return '#d29922'
-  return '#f85149'
+  if (p == null) return 'var(--text-muted)'
+  if (p >= 0.62) return 'var(--success)'
+  if (p >= 0.50) return 'var(--warning)'
+  return 'var(--danger)'
 }
 
 function formatTime(iso) {
@@ -90,7 +59,7 @@ function weatherLabel(weather) {
 }
 
 function american(v) {
-  if (v == null || v === '') return '—'
+  if (v == null || v === '') return 'Unavailable'
   const n = Number(v)
   if (Number.isNaN(n)) return String(v)
   return n > 0 ? `+${n}` : `${n}`
@@ -141,8 +110,8 @@ function OddsMarket({ label, market }) {
       <div style={s.marketLabel}>{label}</div>
       {selections.slice(0, 2).map((sel, idx) => (
         <div key={`${label}-${idx}`} style={s.oddsLine}>
-          <span>{sel.name || sel.description || '—'}{sel.line != null ? ` ${sel.line}` : ''}</span>
-          <strong>{american(sel.price)}</strong>
+          <span>{sel.name || sel.description || 'Unavailable'}{sel.line != null ? ` ${sel.line}` : ''}</span>
+          <strong style={{ color: 'var(--text-primary)' }}>{american(sel.price)}</strong>
         </div>
       ))}
     </div>
@@ -182,12 +151,12 @@ function PropPreview({ eventId }) {
   return (
     <div onClick={e => e.stopPropagation()}>
       <button type="button" style={s.propButton} onClick={toggle}>
-        {open ? 'Hide player props' : 'Show player props'}
+        {open ? 'Hide Player Props' : 'Show Player Props'}
       </button>
       {open && (
         <div style={s.propsPanel}>
           {loading && <div style={s.oddsSubtle}>Loading DraftKings props…</div>}
-          {error && <div style={{ color: '#f85149', fontSize: '12px' }}>Props error: {error}</div>}
+          {error && <div className="state-panel error" style={{ padding: 12, textAlign: 'left' }}>Props unavailable: {error}</div>}
           {!loading && !error && propsData && cards.length === 0 && (
             <div style={s.oddsSubtle}>No player props returned for this event.</div>
           )}
@@ -196,7 +165,7 @@ function PropPreview({ eventId }) {
               <div key={`${market.market_key}-${sel.description}-${sel.name}-${idx}`} style={s.propCard}>
                 <div style={s.propMarket}>{String(market.market_name || market.market_key || '').replaceAll('_', ' ')}</div>
                 <div style={s.propName}>{sel.description}</div>
-                <div style={s.propDetails}>{sel.name} {sel.line} · <strong style={{ color: '#e6edf3' }}>{american(sel.price)}</strong></div>
+                <div style={s.propDetails}>{sel.name} {sel.line} · <strong style={{ color: 'var(--text-primary)' }}>{american(sel.price)}</strong></div>
               </div>
             ))}
           </div>
@@ -214,8 +183,11 @@ function OddsSnapshot({ event }) {
   return (
     <div style={s.oddsBox} onClick={e => e.stopPropagation()}>
       <div style={s.oddsHeader}>
-        <div style={s.oddsTitle}>DraftKings Odds</div>
-        <div style={s.oddsSubtle}>{event.event_id ? `Event ${String(event.event_id).slice(0, 8)}` : 'Matched event'}</div>
+        <div>
+          <div style={s.oddsTitle}>DraftKings Market Snapshot</div>
+          <div style={s.oddsSubtle}>Moneyline, run line, totals, and available props</div>
+        </div>
+        <div className="status-badge">Market Context</div>
       </div>
       <div style={s.oddsGrid}>
         <OddsMarket label="Moneyline" market={moneyline} />
@@ -229,23 +201,30 @@ function OddsSnapshot({ event }) {
 
 function ProbBar({ homeProb, awayProb }) {
   const hp = homeProb != null ? Math.round(homeProb * 100) : 50
-  const ap = 100 - hp
+  const ap = awayProb != null ? Math.round(awayProb * 100) : 100 - hp
   return (
-    <div style={{ marginTop: '12px' }}>
-      <div style={{ display: 'flex', height: '5px', borderRadius: '3px', overflow: 'hidden', background: '#21262d' }}>
-        <div style={{ width: `${ap}%`, background: '#58a6ff', transition: 'width 0.4s' }} />
-        <div style={{ width: `${hp}%`, background: '#3fb950', transition: 'width 0.4s' }} />
+    <div style={{ marginTop: 14 }}>
+      <div style={{ display: 'flex', height: 6, borderRadius: 999, overflow: 'hidden', background: 'rgba(148, 163, 184, 0.14)' }}>
+        <div style={{ width: `${ap}%`, background: 'linear-gradient(90deg, #5aa7ff, #7bbcff)', transition: 'width 0.4s' }} />
+        <div style={{ width: `${hp}%`, background: 'linear-gradient(90deg, #41d695, #8ee8bd)', transition: 'width 0.4s' }} />
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', color: '#8b949e', marginTop: '3px' }}>
-        <span>{ap}% away</span>
-        <span>{hp}% home</span>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--text-muted)', marginTop: 5 }}>
+        <span>{awayProb != null ? `${ap}% away` : 'Away pending'}</span>
+        <span>{homeProb != null ? `${hp}% home` : 'Home pending'}</span>
       </div>
     </div>
   )
 }
 
+function statusClass(status) {
+  if (!status) return ''
+  if (status === 'Final') return ''
+  if (String(status).toLowerCase().includes('progress') || String(status).toLowerCase().includes('live')) return 'success'
+  return 'warning'
+}
+
 export default function HomePage() {
-  const today = getMlbToday()
+  const today = getMlbLiveDate()
   const [date, setDate] = useState(today)
   const [matchups, setMatchups] = useState([])
   const [oddsEvents, setOddsEvents] = useState([])
@@ -253,7 +232,6 @@ export default function HomePage() {
   const [oddsLoading, setOddsLoading] = useState(false)
   const [error, setError] = useState(null)
   const [oddsError, setOddsError] = useState(null)
-  const [hovered, setHovered] = useState(null)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -285,76 +263,87 @@ export default function HomePage() {
 
   return (
     <div>
-      <div style={s.header}>
-        <h1 style={s.title}>Daily Matchups</h1>
-        <input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.datePicker} />
-      </div>
+      <header className="page-header">
+        <div>
+          <p className="page-kicker">Live Slate</p>
+          <h1 className="page-title">Daily Matchups</h1>
+          <p className="page-subtitle">Validated MLB schedule, probable starters, model win probabilities, weather context, and DraftKings market snapshots in one production slate.</p>
+        </div>
+        <div className="control-row">
+          <span className="status-badge success">Live Data</span>
+          <input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} />
+        </div>
+      </header>
 
-      {loading && <div style={s.loader}>Loading matchups…</div>}
-      {error && <div style={s.error}>Error: {error}</div>}
-      {!loading && !error && oddsError && <div style={{ ...s.error, marginBottom: '12px' }}>Odds error: {oddsError}</div>}
-      {!loading && !error && !oddsError && oddsLoading && <div style={s.oddsSubtle}>Loading DraftKings odds…</div>}
+      {loading && (
+        <div className="state-panel">
+          <div className="skeleton-line" style={{ maxWidth: 420, margin: '0 auto 12px' }} />
+          <div className="skeleton-line" style={{ maxWidth: 300, margin: '0 auto' }} />
+        </div>
+      )}
+      {error && <div className="state-panel error">Matchup data unavailable: {error}</div>}
+      {!loading && !error && oddsError && <div className="state-panel error" style={{ marginBottom: 16 }}>Odds data unavailable: {oddsError}</div>}
+      {!loading && !error && !oddsError && oddsLoading && <div className="card-meta" style={{ marginBottom: 14 }}>Loading DraftKings market context…</div>}
       {!loading && !error && matchups.length === 0 && (
-        <div style={s.noData}>No games scheduled for {date}.</div>
+        <div className="state-panel">No games are scheduled for {date}.</div>
       )}
 
-      <div style={s.grid}>
+      <div style={s.matchupGrid}>
         {matchups.map((m, i) => {
           const oddsEvent = oddsByMatchup.get(keyFromMatchup(m))
           return (
-            <div
+            <article
               key={m.game_pk || i}
-              style={{ ...s.card, ...(hovered === i ? s.cardHover : {}) }}
-              onMouseEnter={() => setHovered(i)}
-              onMouseLeave={() => setHovered(null)}
+              className="pro-card pro-card-hover card-pad"
+              style={s.card}
               onClick={() => m.game_pk && navigate(`/matchup/${m.game_pk}`)}
             >
-              <div style={s.meta}>
+              <div style={s.slateMeta}>
                 <div style={s.venue}>
-                  <span>{m.venue || '—'}</span>
+                  <span>{m.venue || 'Venue pending'}</span>
                   {m.game_time && <span>· {formatTime(m.game_time)}</span>}
                   {weatherLabel(m.weather) && <span>· {weatherLabel(m.weather)}</span>}
                 </div>
-                {m.status && <span style={s.statusBadge(m.status)}>{m.status}</span>}
+                {m.status && <span className={`status-badge ${statusClass(m.status)}`}>{m.status}</span>}
               </div>
 
               <div style={s.matchupRow}>
-                <div style={s.team}>
+                <div style={s.teamPanel}>
                   <div style={s.teamName}>{m.away_team_name || `Team ${m.away_team_id}`}</div>
-                  <div style={s.record}>{m.away_team_record || ''}</div>
+                  <div style={s.record}>{m.away_team_record || 'Record pending'}</div>
                   <div style={s.pitcher}>
                     {m.away_pitcher_name
-                      ? <Link to={`/pitcher/${m.away_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                      ? <Link to={`/pitcher/${m.away_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750 }}>
                           {m.away_pitcher_name}
                         </Link>
-                      : <span style={{ color: '#8b949e' }}>TBD</span>}
+                      : <span className="status-badge warning">Pitcher Pending</span>}
                   </div>
                   <div style={{ ...s.prob, color: probColor(m.away_win_prob) }}>
-                    {m.away_win_prob != null ? `${Math.round(m.away_win_prob * 100)}%` : '—'}
+                    {m.away_win_prob != null ? `${Math.round(m.away_win_prob * 100)}%` : 'Pending'}
                   </div>
                 </div>
 
-                <div style={s.vs}>@</div>
+                <div style={s.vs}>AT</div>
 
-                <div style={{ ...s.team, textAlign: 'right' }}>
+                <div style={{ ...s.teamPanel, ...s.teamPanelRight }}>
                   <div style={s.teamName}>{m.home_team_name || `Team ${m.home_team_id}`}</div>
-                  <div style={s.record}>{m.home_team_record || ''}</div>
+                  <div style={s.record}>{m.home_team_record || 'Record pending'}</div>
                   <div style={{ ...s.pitcher, textAlign: 'right' }}>
                     {m.home_pitcher_name
-                      ? <Link to={`/pitcher/${m.home_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: '#58a6ff', textDecoration: 'none' }}>
+                      ? <Link to={`/pitcher/${m.home_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750 }}>
                           {m.home_pitcher_name}
                         </Link>
-                      : <span style={{ color: '#8b949e' }}>TBD</span>}
+                      : <span className="status-badge warning">Pitcher Pending</span>}
                   </div>
                   <div style={{ ...s.prob, color: probColor(m.home_win_prob), textAlign: 'right' }}>
-                    {m.home_win_prob != null ? `${Math.round(m.home_win_prob * 100)}%` : '—'}
+                    {m.home_win_prob != null ? `${Math.round(m.home_win_prob * 100)}%` : 'Pending'}
                   </div>
                 </div>
               </div>
 
               <ProbBar homeProb={m.home_win_prob} awayProb={m.away_win_prob} />
               <OddsSnapshot event={oddsEvent} />
-            </div>
+            </article>
           )
         })}
       </div>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,0 +1,391 @@
+:root {
+  color-scheme: dark;
+  --bg-page: #070b12;
+  --bg-shell: rgba(10, 15, 25, 0.92);
+  --bg-panel: #0d1320;
+  --bg-card: #111827;
+  --bg-card-elevated: #151f2f;
+  --bg-soft: #0b111c;
+  --border-subtle: rgba(148, 163, 184, 0.16);
+  --border-strong: rgba(148, 163, 184, 0.28);
+  --text-primary: #f3f7fb;
+  --text-secondary: #b6c2d2;
+  --text-muted: #7c8ba1;
+  --accent: #5aa7ff;
+  --accent-soft: rgba(90, 167, 255, 0.12);
+  --success: #41d695;
+  --success-soft: rgba(65, 214, 149, 0.12);
+  --warning: #f5c451;
+  --warning-soft: rgba(245, 196, 81, 0.12);
+  --danger: #ff6b7a;
+  --danger-soft: rgba(255, 107, 122, 0.12);
+  --shadow-card: 0 18px 45px rgba(0, 0, 0, 0.28);
+  --shadow-nav: 0 12px 36px rgba(0, 0, 0, 0.24);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --radius-xl: 24px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --font-system: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at top left, rgba(31, 111, 235, 0.16), transparent 34rem),
+    radial-gradient(circle at top right, rgba(65, 214, 149, 0.08), transparent 28rem),
+    linear-gradient(180deg, #070b12 0%, #080c13 42%, #05070c 100%);
+  color: var(--text-primary);
+  font-family: var(--font-system);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+button, input, select, textarea {
+  font: inherit;
+}
+
+a {
+  color: var(--accent);
+}
+
+button, .btn {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, rgba(27, 39, 59, 0.98), rgba(18, 27, 43, 0.98));
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: transform 0.14s ease, border-color 0.14s ease, background 0.14s ease, color 0.14s ease;
+}
+
+button:hover, .btn:hover {
+  border-color: rgba(90, 167, 255, 0.55);
+  transform: translateY(-1px);
+}
+
+input, select, textarea {
+  background: rgba(10, 15, 25, 0.82);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+input:focus, select:focus, textarea:focus {
+  border-color: rgba(90, 167, 255, 0.72);
+  box-shadow: 0 0 0 3px rgba(90, 167, 255, 0.12);
+}
+
+.app-shell {
+  min-height: 100vh;
+}
+
+.app-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  min-height: 64px;
+  padding: 0 28px;
+  background: var(--bg-shell);
+  border-bottom: 1px solid var(--border-subtle);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-nav);
+}
+
+.app-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: 4px;
+  color: var(--text-primary);
+  text-decoration: none;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+}
+
+.app-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(90, 167, 255, 0.28), rgba(65, 214, 149, 0.16));
+  border: 1px solid rgba(90, 167, 255, 0.32);
+  color: var(--accent);
+}
+
+.app-nav-link {
+  position: relative;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  padding: 22px 0 20px;
+  transition: color 0.14s ease;
+  white-space: nowrap;
+}
+
+.app-nav-link:hover {
+  color: var(--text-secondary);
+}
+
+.app-nav-link.active {
+  color: var(--text-primary);
+}
+
+.app-nav-link.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--success));
+}
+
+.app-main {
+  width: min(1280px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 34px 0 56px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+  margin-bottom: var(--space-6);
+}
+
+.page-kicker {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.page-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(26px, 3vw, 38px);
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+.page-subtitle {
+  max-width: 720px;
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.control-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.input-control {
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.card-grid {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.pro-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, rgba(22, 31, 48, 0.96), rgba(13, 19, 32, 0.96)),
+    var(--bg-card);
+  box-shadow: var(--shadow-card);
+}
+
+.pro-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.16), transparent);
+  pointer-events: none;
+}
+
+.pro-card-hover {
+  transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.pro-card-hover:hover {
+  border-color: rgba(90, 167, 255, 0.42);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.34);
+  transform: translateY(-2px);
+}
+
+.card-pad {
+  padding: var(--space-5);
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.card-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.card-meta {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  padding: 4px 9px;
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.status-badge.success {
+  border-color: rgba(65, 214, 149, 0.28);
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.status-badge.warning {
+  border-color: rgba(245, 196, 81, 0.28);
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.status-badge.danger {
+  border-color: rgba(255, 107, 122, 0.28);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-3);
+}
+
+.metric-tile {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  background: rgba(7, 11, 18, 0.42);
+}
+
+.metric-label {
+  margin-bottom: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric-value {
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 850;
+  letter-spacing: -0.04em;
+}
+
+.metric-context {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.state-panel {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  background: rgba(13, 19, 32, 0.8);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.state-panel.error {
+  border-color: rgba(255, 107, 122, 0.25);
+  background: rgba(255, 107, 122, 0.08);
+  color: #ffc4ca;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.18), rgba(148, 163, 184, 0.08));
+  background-size: 200% 100%;
+  animation: shimmer 1.4s infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (max-width: 980px) {
+  .app-nav {
+    gap: 16px;
+    overflow-x: auto;
+    padding: 0 18px;
+  }
+
+  .app-main {
+    width: min(100% - 28px, 1280px);
+    padding-top: 24px;
+  }
+
+  .page-header {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first low-risk enterprise UI polish pass for the MLB Prediction Engine without touching backend logic, scoring formulas, model projections, odds providers, refresh jobs, database models, or API route contracts.

This PR adds a shared dark enterprise design system and applies it to the global app shell plus the Daily Matchups page, which is the primary demo surface.

## Files changed

- `frontend/src/styles/theme.css`
- `frontend/src/main.jsx`
- `frontend/src/App.jsx`
- `frontend/src/pages/HomePage.jsx`

## Design system added

Adds shared CSS tokens and primitives for:

- near-black graphite page background
- refined card/panel backgrounds
- subtle borders and shadows
- text, muted text, accent, success, warning, and danger colors
- spacing scale
- border radius scale
- sticky professional navigation shell
- page headers
- cards
- status badges
- metric tiles
- loading/empty/error state panels
- input/button styling

## Screens improved

### Global shell

- Replaces inline nav styling with a unified app shell.
- Adds a more professional `MLB Prediction Engine` brand treatment.
- Adds sticky blurred navigation.
- Improves active nav states and density.
- Keeps all existing routes intact.

### Daily Matchups

- Uses the shared `API_BASE` from `frontend/src/lib/api.js` instead of the unsafe empty relative fallback.
- Uses `getMlbLiveDate()` for slate-date behavior.
- Refines matchup cards into premium slate-board cards.
- Improves team panels, pitcher status, venue/weather metadata, win probability display, and probability bar.
- Integrates DraftKings market snapshot styling so odds feel part of the card instead of bolted on.
- Replaces rough missing states with `Pending`, `Unavailable`, and professional state panels.

## Production logic intentionally not touched

- No backend files changed.
- No FastAPI routes changed.
- No matchup generation logic changed.
- No scoring/model formulas changed.
- No odds provider logic changed.
- No database models changed.
- No refresh/cron jobs changed.
- No API route paths changed.
- Batter page feature flag behavior preserved.

## Build/test results

Not run in this environment. Required validation before merge:

```bash
cd frontend
npm run build
```

Recommended smoke checks after deploy:

```bash
curl https://mlb-prediction-app-production-732c.up.railway.app/health
curl "https://mlb-prediction-app-production-732c.up.railway.app/matchups?date=2026-05-13"
```

Manual UI smoke:

- `/`
- `/daily-odds`
- `/models/projections`
- `/my-dashboard`
- `/pitcher`
- `/team`
- `/calendar`
- `/ai-data-assistant`
- `/live`

## Remaining UI debt for follow-up

This PR deliberately keeps scope narrow and starts with the app shell and primary Daily Matchups surface. Follow-up PRs should apply the same shared primitives to:

- `DailyOddsPage.jsx`
- `ModelProjectionsPage.jsx`
- `MyDashboardPage.jsx`
- `AIPage.jsx`
- `MatchupDetailPage.jsx`
- `CompetitiveAnalysisPage.jsx`
- `PitcherPage.jsx`
- `TeamPage.jsx`
- `LiveScoreboardPage.jsx`

The next pass should also remove remaining inline styling gradually and standardize all empty/loading/error states across those pages.