### PR TITLE
Fix responsive matchup card layout and prevent mobile text overflow

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -4,34 +4,57 @@ import { API_BASE, getMlbLiveDate } from '../lib/api'
 
 const API = API_BASE
 
+function useIsMobile(breakpoint = 768) {
+  const getMatches = () => (typeof window !== 'undefined' ? window.innerWidth <= breakpoint : false)
+  const [isMobile, setIsMobile] = useState(getMatches)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const onResize = () => setIsMobile(getMatches())
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [breakpoint])
+
+  return isMobile
+}
+
 const s = {
-  matchupGrid: { display: 'grid', gap: '16px' },
-  card: { cursor: 'pointer' },
-  slateMeta: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16, gap: 12, flexWrap: 'wrap' },
-  venue: { display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: 12 },
-  matchupRow: { display: 'grid', gridTemplateColumns: '1fr auto 1fr', alignItems: 'stretch', gap: 16 },
-  teamPanel: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', padding: 14, background: 'rgba(7, 11, 18, 0.34)' },
+  matchupGrid: { display: 'grid', gap: '16px', minWidth: 0 },
+  card: { cursor: 'pointer', minWidth: 0 },
+  slateMeta: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16, gap: 12, flexWrap: 'wrap', minWidth: 0 },
+  slateMetaMobile: { flexDirection: 'column', alignItems: 'stretch' },
+  venue: { display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', color: 'var(--text-muted)', fontSize: 12, minWidth: 0, overflowWrap: 'anywhere' },
+  matchupRow: { display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto minmax(0, 1fr)', alignItems: 'stretch', gap: 16, minWidth: 0 },
+  matchupRowMobile: { gridTemplateColumns: '1fr', gap: 10 },
+  teamPanel: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', padding: 14, background: 'rgba(7, 11, 18, 0.34)', minWidth: 0 },
+  teamPanelMobile: { textAlign: 'left' },
   teamPanelRight: { textAlign: 'right' },
-  teamName: { fontSize: 18, fontWeight: 850, color: 'var(--text-primary)', letterSpacing: '-0.03em' },
-  record: { fontSize: 12, color: 'var(--text-muted)', marginTop: 2 },
-  pitcher: { fontSize: 13, color: 'var(--accent)', marginTop: 10, minHeight: 20 },
-  prob: { fontSize: 30, fontWeight: 900, letterSpacing: '-0.06em', marginTop: 12 },
-  vs: { display: 'grid', placeItems: 'center', color: 'var(--text-muted)', fontWeight: 900, letterSpacing: '0.18em', fontSize: 12 },
-  oddsBox: { marginTop: 16, padding: 14, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', background: 'rgba(7, 11, 18, 0.46)' },
-  oddsHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 12 },
-  oddsTitle: { color: 'var(--text-primary)', fontSize: 13, fontWeight: 850, letterSpacing: '0.02em' },
-  oddsSubtle: { color: 'var(--text-muted)', fontSize: 12 },
-  oddsGrid: { display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10 },
-  marketCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.76)' },
-  marketLabel: { color: 'var(--text-muted)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 7, fontWeight: 850 },
-  oddsLine: { display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 12, color: 'var(--text-secondary)', marginTop: 4 },
-  propButton: { marginTop: 12, padding: '8px 11px', fontSize: 12, fontWeight: 800 },
-  propsPanel: { marginTop: 12, borderTop: '1px solid var(--border-subtle)', paddingTop: 12 },
-  propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 },
-  propCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.78)' },
-  propMarket: { color: 'var(--warning)', fontSize: 11, fontWeight: 850, marginBottom: 5 },
-  propName: { color: 'var(--text-primary)', fontSize: 12, fontWeight: 800 },
-  propDetails: { color: 'var(--text-muted)', fontSize: 12, marginTop: 3 },
+  teamName: { fontSize: 18, fontWeight: 850, color: 'var(--text-primary)', letterSpacing: '-0.03em', minWidth: 0, overflowWrap: 'anywhere', lineHeight: 1.16 },
+  record: { fontSize: 12, color: 'var(--text-muted)', marginTop: 2, overflowWrap: 'anywhere' },
+  pitcher: { fontSize: 13, color: 'var(--accent)', marginTop: 10, minHeight: 20, minWidth: 0, overflowWrap: 'anywhere' },
+  prob: { fontSize: 30, fontWeight: 900, letterSpacing: '-0.06em', marginTop: 12, overflowWrap: 'anywhere' },
+  vs: { display: 'grid', placeItems: 'center', color: 'var(--text-muted)', fontWeight: 900, letterSpacing: '0.18em', fontSize: 12, minWidth: 0 },
+  vsMobile: { placeItems: 'start', padding: '0 2px', letterSpacing: '0.08em' },
+  oddsBox: { marginTop: 16, padding: 14, border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', background: 'rgba(7, 11, 18, 0.46)', minWidth: 0 },
+  oddsHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, marginBottom: 12, minWidth: 0 },
+  oddsHeaderMobile: { flexDirection: 'column', alignItems: 'stretch' },
+  oddsTitle: { color: 'var(--text-primary)', fontSize: 13, fontWeight: 850, letterSpacing: '0.02em', overflowWrap: 'anywhere' },
+  oddsSubtle: { color: 'var(--text-muted)', fontSize: 12, overflowWrap: 'anywhere' },
+  oddsGrid: { display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 10, minWidth: 0 },
+  oddsGridMobile: { gridTemplateColumns: '1fr' },
+  marketCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.76)', minWidth: 0 },
+  marketLabel: { color: 'var(--text-muted)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 7, fontWeight: 850, overflowWrap: 'anywhere' },
+  oddsLine: { display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 12, color: 'var(--text-secondary)', marginTop: 4, minWidth: 0, overflowWrap: 'anywhere' },
+  oddsLineText: { minWidth: 0, overflowWrap: 'anywhere', whiteSpace: 'normal' },
+  oddsPrice: { color: 'var(--text-primary)', whiteSpace: 'nowrap' },
+  propButton: { marginTop: 12, padding: '8px 11px', fontSize: 12, fontWeight: 800, maxWidth: '100%' },
+  propsPanel: { marginTop: 12, borderTop: '1px solid var(--border-subtle)', paddingTop: 12, minWidth: 0 },
+  propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, minWidth: 0 },
+  propsGridMobile: { gridTemplateColumns: '1fr' },
+  propCard: { border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-sm)', padding: 10, background: 'rgba(17, 24, 39, 0.78)', minWidth: 0 },
+  propMarket: { color: 'var(--warning)', fontSize: 11, fontWeight: 850, marginBottom: 5, overflowWrap: 'anywhere' },
+  propName: { color: 'var(--text-primary)', fontSize: 12, fontWeight: 800, overflowWrap: 'anywhere' },
+  propDetails: { color: 'var(--text-muted)', fontSize: 12, marginTop: 3, overflowWrap: 'anywhere' },
 }
 
 function probColor(p) {
@@ -101,7 +124,7 @@ function OddsMarket({ label, market }) {
     return (
       <div style={s.marketCard}>
         <div style={s.marketLabel}>{label}</div>
-        <div style={s.oddsLine}><span>Unavailable</span><span>—</span></div>
+        <div style={s.oddsLine}><span style={s.oddsLineText}>Unavailable</span><span>—</span></div>
       </div>
     )
   }
@@ -110,15 +133,15 @@ function OddsMarket({ label, market }) {
       <div style={s.marketLabel}>{label}</div>
       {selections.slice(0, 2).map((sel, idx) => (
         <div key={`${label}-${idx}`} style={s.oddsLine}>
-          <span>{sel.name || sel.description || 'Unavailable'}{sel.line != null ? ` ${sel.line}` : ''}</span>
-          <strong style={{ color: 'var(--text-primary)' }}>{american(sel.price)}</strong>
+          <span style={s.oddsLineText}>{sel.name || sel.description || 'Unavailable'}{sel.line != null ? ` ${sel.line}` : ''}</span>
+          <strong style={s.oddsPrice}>{american(sel.price)}</strong>
         </div>
       ))}
     </div>
   )
 }
 
-function PropPreview({ eventId }) {
+function PropPreview({ eventId, isMobile }) {
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
   const [propsData, setPropsData] = useState(null)
@@ -150,7 +173,7 @@ function PropPreview({ eventId }) {
 
   return (
     <div onClick={e => e.stopPropagation()}>
-      <button type="button" style={s.propButton} onClick={toggle}>
+      <button type="button" style={{ ...s.propButton, ...(isMobile ? { width: '100%' } : {}) }} onClick={toggle}>
         {open ? 'Hide Player Props' : 'Show Player Props'}
       </button>
       {open && (
@@ -160,7 +183,7 @@ function PropPreview({ eventId }) {
           {!loading && !error && propsData && cards.length === 0 && (
             <div style={s.oddsSubtle}>No player props returned for this event.</div>
           )}
-          <div style={s.propsGrid}>
+          <div style={{ ...s.propsGrid, ...(isMobile ? s.propsGridMobile : {}) }}>
             {cards.map(({ market, sel }, idx) => (
               <div key={`${market.market_key}-${sel.description}-${sel.name}-${idx}`} style={s.propCard}>
                 <div style={s.propMarket}>{String(market.market_name || market.market_key || '').replaceAll('_', ' ')}</div>
@@ -175,26 +198,26 @@ function PropPreview({ eventId }) {
   )
 }
 
-function OddsSnapshot({ event }) {
+function OddsSnapshot({ event, isMobile }) {
   if (!event) return null
   const moneyline = findMarket(event, 'h2h')
   const spread = findMarket(event, 'spreads')
   const total = findMarket(event, 'totals')
   return (
     <div style={s.oddsBox} onClick={e => e.stopPropagation()}>
-      <div style={s.oddsHeader}>
-        <div>
+      <div style={{ ...s.oddsHeader, ...(isMobile ? s.oddsHeaderMobile : {}) }}>
+        <div style={{ minWidth: 0 }}>
           <div style={s.oddsTitle}>DraftKings Market Snapshot</div>
           <div style={s.oddsSubtle}>Moneyline, run line, totals, and available props</div>
         </div>
         <div className="status-badge">Market Context</div>
       </div>
-      <div style={s.oddsGrid}>
+      <div style={{ ...s.oddsGrid, ...(isMobile ? s.oddsGridMobile : {}) }}>
         <OddsMarket label="Moneyline" market={moneyline} />
         <OddsMarket label="Run Line" market={spread} />
         <OddsMarket label="Total" market={total} />
       </div>
-      {event.event_id && <PropPreview eventId={event.event_id} />}
+      {event.event_id && <PropPreview eventId={event.event_id} isMobile={isMobile} />}
     </div>
   )
 }
@@ -203,12 +226,12 @@ function ProbBar({ homeProb, awayProb }) {
   const hp = homeProb != null ? Math.round(homeProb * 100) : 50
   const ap = awayProb != null ? Math.round(awayProb * 100) : 100 - hp
   return (
-    <div style={{ marginTop: 14 }}>
+    <div style={{ marginTop: 14, minWidth: 0 }}>
       <div style={{ display: 'flex', height: 6, borderRadius: 999, overflow: 'hidden', background: 'rgba(148, 163, 184, 0.14)' }}>
         <div style={{ width: `${ap}%`, background: 'linear-gradient(90deg, #5aa7ff, #7bbcff)', transition: 'width 0.4s' }} />
         <div style={{ width: `${hp}%`, background: 'linear-gradient(90deg, #41d695, #8ee8bd)', transition: 'width 0.4s' }} />
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--text-muted)', marginTop: 5 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 11, color: 'var(--text-muted)', marginTop: 5, flexWrap: 'wrap' }}>
         <span>{awayProb != null ? `${ap}% away` : 'Away pending'}</span>
         <span>{homeProb != null ? `${hp}% home` : 'Home pending'}</span>
       </div>
@@ -224,6 +247,7 @@ function statusClass(status) {
 }
 
 export default function HomePage() {
+  const isMobile = useIsMobile()
   const today = getMlbLiveDate()
   const [date, setDate] = useState(today)
   const [matchups, setMatchups] = useState([])
@@ -291,14 +315,22 @@ export default function HomePage() {
       <div style={s.matchupGrid}>
         {matchups.map((m, i) => {
           const oddsEvent = oddsByMatchup.get(keyFromMatchup(m))
+          const awayPanelStyle = {
+            ...s.teamPanel,
+            ...(isMobile ? s.teamPanelMobile : {}),
+          }
+          const homePanelStyle = {
+            ...s.teamPanel,
+            ...(!isMobile ? s.teamPanelRight : s.teamPanelMobile),
+          }
           return (
             <article
               key={m.game_pk || i}
-              className="pro-card pro-card-hover card-pad"
+              className="pro-card pro-card-hover card-pad responsive-matchup-card"
               style={s.card}
               onClick={() => m.game_pk && navigate(`/matchup/${m.game_pk}`)}
             >
-              <div style={s.slateMeta}>
+              <div style={{ ...s.slateMeta, ...(isMobile ? s.slateMetaMobile : {}) }}>
                 <div style={s.venue}>
                   <span>{m.venue || 'Venue pending'}</span>
                   {m.game_time && <span>· {formatTime(m.game_time)}</span>}
@@ -307,13 +339,13 @@ export default function HomePage() {
                 {m.status && <span className={`status-badge ${statusClass(m.status)}`}>{m.status}</span>}
               </div>
 
-              <div style={s.matchupRow}>
-                <div style={s.teamPanel}>
+              <div style={{ ...s.matchupRow, ...(isMobile ? s.matchupRowMobile : {}) }}>
+                <div style={awayPanelStyle}>
                   <div style={s.teamName}>{m.away_team_name || `Team ${m.away_team_id}`}</div>
                   <div style={s.record}>{m.away_team_record || 'Record pending'}</div>
                   <div style={s.pitcher}>
                     {m.away_pitcher_name
-                      ? <Link to={`/pitcher/${m.away_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750 }}>
+                      ? <Link to={`/pitcher/${m.away_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750, overflowWrap: 'anywhere' }}>
                           {m.away_pitcher_name}
                         </Link>
                       : <span className="status-badge warning">Pitcher Pending</span>}
@@ -323,26 +355,26 @@ export default function HomePage() {
                   </div>
                 </div>
 
-                <div style={s.vs}>AT</div>
+                <div style={{ ...s.vs, ...(isMobile ? s.vsMobile : {}) }}>{isMobile ? 'AT' : 'AT'}</div>
 
-                <div style={{ ...s.teamPanel, ...s.teamPanelRight }}>
+                <div style={homePanelStyle}>
                   <div style={s.teamName}>{m.home_team_name || `Team ${m.home_team_id}`}</div>
                   <div style={s.record}>{m.home_team_record || 'Record pending'}</div>
-                  <div style={{ ...s.pitcher, textAlign: 'right' }}>
+                  <div style={{ ...s.pitcher, textAlign: isMobile ? 'left' : 'right' }}>
                     {m.home_pitcher_name
-                      ? <Link to={`/pitcher/${m.home_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750 }}>
+                      ? <Link to={`/pitcher/${m.home_pitcher_id}`} onClick={e => e.stopPropagation()} style={{ color: 'var(--accent)', textDecoration: 'none', fontWeight: 750, overflowWrap: 'anywhere' }}>
                           {m.home_pitcher_name}
                         </Link>
                       : <span className="status-badge warning">Pitcher Pending</span>}
                   </div>
-                  <div style={{ ...s.prob, color: probColor(m.home_win_prob), textAlign: 'right' }}>
+                  <div style={{ ...s.prob, color: probColor(m.home_win_prob), textAlign: isMobile ? 'left' : 'right' }}>
                     {m.home_win_prob != null ? `${Math.round(m.home_win_prob * 100)}%` : 'Pending'}
                   </div>
                 </div>
               </div>
 
               <ProbBar homeProb={m.home_win_prob} awayProb={m.away_win_prob} />
-              <OddsSnapshot event={oddsEvent} />
+              <OddsSnapshot event={oddsEvent} isMobile={isMobile} />
             </article>
           )
         })}

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -44,6 +44,11 @@ html, body, #root {
   min-height: 100%;
 }
 
+html, body {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
 body {
   margin: 0;
   min-width: 320px;
@@ -61,10 +66,25 @@ body {
 
 button, input, select, textarea {
   font: inherit;
+  max-width: 100%;
 }
 
 a {
   color: var(--accent);
+}
+
+img, svg, canvas, video {
+  max-width: 100%;
+}
+
+pre, code {
+  max-width: 100%;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+table {
+  max-width: 100%;
 }
 
 button, .btn {
@@ -96,6 +116,7 @@ input:focus, select:focus, textarea:focus {
 
 .app-shell {
   min-height: 100vh;
+  min-width: 0;
 }
 
 .app-nav {
@@ -111,6 +132,7 @@ input:focus, select:focus, textarea:focus {
   border-bottom: 1px solid var(--border-subtle);
   backdrop-filter: blur(18px);
   box-shadow: var(--shadow-nav);
+  min-width: 0;
 }
 
 .app-brand {
@@ -134,6 +156,7 @@ input:focus, select:focus, textarea:focus {
   background: linear-gradient(135deg, rgba(90, 167, 255, 0.28), rgba(65, 214, 149, 0.16));
   border: 1px solid rgba(90, 167, 255, 0.32);
   color: var(--accent);
+  flex: 0 0 auto;
 }
 
 .app-nav-link {
@@ -171,6 +194,7 @@ input:focus, select:focus, textarea:focus {
   width: min(1280px, calc(100% - 40px));
   margin: 0 auto;
   padding: 34px 0 56px;
+  min-width: 0;
 }
 
 .page-header {
@@ -179,6 +203,7 @@ input:focus, select:focus, textarea:focus {
   justify-content: space-between;
   gap: var(--space-5);
   margin-bottom: var(--space-6);
+  min-width: 0;
 }
 
 .page-kicker {
@@ -196,6 +221,7 @@ input:focus, select:focus, textarea:focus {
   font-size: clamp(26px, 3vw, 38px);
   line-height: 1.05;
   letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
 }
 
 .page-subtitle {
@@ -203,6 +229,7 @@ input:focus, select:focus, textarea:focus {
   margin: 10px 0 0;
   color: var(--text-secondary);
   font-size: 14px;
+  overflow-wrap: anywhere;
 }
 
 .control-row {
@@ -210,6 +237,7 @@ input:focus, select:focus, textarea:focus {
   align-items: center;
   gap: var(--space-3);
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .input-control {
@@ -220,6 +248,7 @@ input:focus, select:focus, textarea:focus {
 .card-grid {
   display: grid;
   gap: var(--space-4);
+  min-width: 0;
 }
 
 .pro-card {
@@ -231,6 +260,14 @@ input:focus, select:focus, textarea:focus {
     linear-gradient(180deg, rgba(22, 31, 48, 0.96), rgba(13, 19, 32, 0.96)),
     var(--bg-card);
   box-shadow: var(--shadow-card);
+  min-width: 0;
+}
+
+.pro-card *,
+.state-panel *,
+.metric-tile *,
+.card-grid * {
+  min-width: 0;
 }
 
 .pro-card::before {
@@ -262,6 +299,7 @@ input:focus, select:focus, textarea:focus {
   justify-content: space-between;
   gap: var(--space-4);
   margin-bottom: var(--space-4);
+  min-width: 0;
 }
 
 .card-title {
@@ -270,11 +308,13 @@ input:focus, select:focus, textarea:focus {
   font-size: 16px;
   font-weight: 800;
   letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
 }
 
 .card-meta {
   color: var(--text-muted);
   font-size: 12px;
+  overflow-wrap: anywhere;
 }
 
 .status-badge {
@@ -289,7 +329,9 @@ input:focus, select:focus, textarea:focus {
   font-size: 11px;
   font-weight: 750;
   letter-spacing: 0.02em;
-  white-space: nowrap;
+  white-space: normal;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .status-badge.success {
@@ -314,6 +356,7 @@ input:focus, select:focus, textarea:focus {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: var(--space-3);
+  min-width: 0;
 }
 
 .metric-tile {
@@ -321,6 +364,7 @@ input:focus, select:focus, textarea:focus {
   border-radius: var(--radius-md);
   padding: 12px;
   background: rgba(7, 11, 18, 0.42);
+  min-width: 0;
 }
 
 .metric-label {
@@ -330,6 +374,7 @@ input:focus, select:focus, textarea:focus {
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  overflow-wrap: anywhere;
 }
 
 .metric-value {
@@ -337,12 +382,14 @@ input:focus, select:focus, textarea:focus {
   font-size: 22px;
   font-weight: 850;
   letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
 }
 
 .metric-context {
   margin-top: 3px;
   color: var(--text-muted);
   font-size: 12px;
+  overflow-wrap: anywhere;
 }
 
 .state-panel {
@@ -352,6 +399,8 @@ input:focus, select:focus, textarea:focus {
   background: rgba(13, 19, 32, 0.8);
   color: var(--text-secondary);
   text-align: center;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .state-panel.error {
@@ -387,5 +436,104 @@ input:focus, select:focus, textarea:focus {
 
   .page-header {
     flex-direction: column;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-main {
+    width: min(100% - 20px, 1280px);
+    padding-top: 18px;
+    padding-bottom: 36px;
+  }
+
+  .app-nav {
+    min-height: auto;
+    align-items: center;
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .app-brand {
+    max-width: 210px;
+    white-space: normal;
+    line-height: 1.1;
+  }
+
+  .app-nav-link {
+    padding: 9px 0;
+    font-size: 12px;
+  }
+
+  .page-header,
+  .card-header,
+  .control-row {
+    align-items: stretch;
+  }
+
+  .control-row > *,
+  .page-header input,
+  .page-header select,
+  .page-header button {
+    max-width: 100%;
+  }
+
+  .card-grid,
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-pad {
+    padding: var(--space-4);
+  }
+
+  .state-panel {
+    padding: 20px;
+  }
+
+  .pro-card-hover:hover {
+    transform: none;
+  }
+
+  .status-badge {
+    justify-content: center;
+  }
+
+  table {
+    display: block;
+    overflow-x: auto;
+    width: 100%;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  th,
+  td {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 430px) {
+  .app-main {
+    width: min(100% - 16px, 1280px);
+  }
+
+  .page-title {
+    font-size: clamp(24px, 8vw, 32px);
+  }
+
+  .card-pad {
+    padding: var(--space-3);
+  }
+
+  .metric-value {
+    font-size: 20px;
   }
 }


### PR DESCRIPTION
## Summary

Closes #273.

This PR makes a focused responsive UI pass without changing backend logic, API payloads, model formulas, routes, scoring, odds logic, or Batter feature-flag behavior.

What changed:

- Keeps homepage matchup information in one cohesive game card on mobile.
- Stacks away/home team panels inside the same parent card at mobile widths instead of letting the layout feel fragmented.
- Adds safe text wrapping/min-width handling for long team names, pitcher names, venue/weather text, odds labels, prop names, statuses, and probability text.
- Makes homepage odds markets and prop preview cards stack cleanly on mobile.
- Adds global responsive guardrails in `theme.css` to prevent horizontal page overflow across cards, nav, badges, inputs, pre/code blocks, and dense tables.
- Preserves the desktop layout direction and only scopes stacking/fit behavior to smaller widths.

## Files changed

- `frontend/src/pages/HomePage.jsx`
- `frontend/src/styles/theme.css`

## Desktop behavior preserved

- Desktop homepage still uses the existing side-by-side away/at/home matchup structure.
- Desktop nav and app shell remain the same visual system.
- Desktop card styling, colors, borders, shadows, and hierarchy are preserved.
- No desktop-only redesign was attempted.

## Mobile improvements

Targeted behavior for 390px, 430px, and 768px widths:

- No horizontal page scroll from long text.
- Matchup card remains one outer game card.
- Away/home team, record, pitcher, status, probability, odds, and props stay inside card bounds.
- Market cards stack on mobile.
- Prop preview cards stack on mobile.
- Nav remains horizontally scrollable instead of forcing page overflow.
- Dense tables are contained with internal horizontal scrolling instead of widening the whole page.

## Validation commands

Not run through the connector. Please run before merge:

```bash
cd frontend && npm run build
python -m compileall mlb_app scripts
```

## Manual QA checklist

Use browser responsive mode and inspect:

- `/` at 390px, 430px, 768px, and desktop width
- `/daily-odds` at 390px, 430px, 768px, and desktop width
- `/models/projections` at 390px, 430px, 768px, and desktop width
- `/ai-data-assistant` at 390px, 430px, 768px, and desktop width
- `/my-dashboard` at 390px, 430px, 768px, and desktop width

Check:

- No text falls outside cards.
- No horizontal page scroll on mobile, except intentional table-internal scrolling.
- Homepage matchup card looks like one cohesive card.
- Team, pitcher, and record remain grouped together.
- Inputs/selects/buttons fit inside cards.
- Desktop still looks good.

## Guardrails preserved

- No backend files changed.
- No routes changed.
- No API contracts changed.
- No model math changed.
- No scoring changed.
- No performance optimization included.
- No arsenal realism included.
- Batter remains disabled unless `VITE_ENABLE_BATTER_PAGE=true` is explicitly set.

## Notes

This is a rough responsive-layout PR intended for visual review. The highest-confidence change is the homepage card layout. The global CSS guardrails are intentionally broad but conservative; they should be verified visually on Daily Odds, Model Projections, AI Data Assistant, and My Dashboard before merge.