### PR TITLE
Add Layer 6F initial-state half-inning support

### DIFF
--- a/mlb_app/simulation/inning_simulator.py
+++ b/mlb_app/simulation/inning_simulator.py
@@ -103,11 +103,29 @@ def simulate_half_inning(
     probabilities: Dict[str, float],
     rng: Optional[random.Random] = None,
     max_plate_appearances: int = 30,
+    initial_bases: Tuple[bool, bool, bool] = (False, False, False),
+    initial_outs: int = 0,
 ) -> Dict[str, Any]:
     rng = rng or random.Random()
-    outs = 0
+
+    bases = tuple(bool(x) for x in initial_bases)
+
+    if len(bases) != 3:
+        raise ValueError(
+            "initial_bases must contain exactly three booleans"
+        )
+
+    outs = int(initial_outs)
+
+    if outs < 0 or outs > 2:
+        raise ValueError(
+            "initial_outs must be 0, 1, or 2"
+        )
+
+    starting_bases = bases
+    starting_outs = outs
+
     runs = 0
-    bases = (False, False, False)
     pa_count = 0
     outcomes = []
 
@@ -128,6 +146,10 @@ def simulate_half_inning(
         "plate_appearances": pa_count,
         "outcomes": outcomes,
         "ended_by_max_pa": outs < 3,
+        "initial_bases": starting_bases,
+        "initial_outs": starting_outs,
+        "ending_bases": bases,
+        "ending_outs": outs,
     }
 
 

--- a/scripts/audit_initial_state_half_inning.py
+++ b/scripts/audit_initial_state_half_inning.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import csv
+import json
+import random
+from pathlib import Path
+from statistics import mean
+
+from mlb_app.simulation.inning_simulator import simulate_half_inning
+
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+PROBABILITIES = {
+    "k": 0.225,
+    "bb": 0.085,
+    "hbp": 0.011,
+    "single": 0.145,
+    "double": 0.045,
+    "triple": 0.004,
+    "hr": 0.030,
+    "reached_on_error": 0.007,
+    "out": 0.448,
+}
+
+
+def core_result(result):
+    return {
+        "runs": result["runs"],
+        "plate_appearances": result["plate_appearances"],
+        "outcomes": result["outcomes"],
+        "ended_by_max_pa": result["ended_by_max_pa"],
+    }
+
+
+equivalence_failures = []
+
+for seed in range(250):
+    default_result = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+    )
+
+    explicit_default_result = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+        initial_bases=(False, False, False),
+        initial_outs=0,
+    )
+
+    if core_result(default_result) != core_result(explicit_default_result):
+        equivalence_failures.append(
+            {
+                "seed": seed,
+                "default": core_result(default_result),
+                "explicit_default": core_result(explicit_default_result),
+            }
+        )
+
+
+determinism_failures = []
+
+for seed in range(100):
+    first = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+        initial_bases=(False, True, False),
+        initial_outs=0,
+    )
+
+    second = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+        initial_bases=(False, True, False),
+        initial_outs=0,
+    )
+
+    if core_result(first) != core_result(second):
+        determinism_failures.append({"seed": seed})
+
+
+empty_runs = []
+runner_second_runs = []
+one_out_runs = []
+
+for seed in range(1000):
+    empty = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+    )
+
+    runner_second = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+        initial_bases=(False, True, False),
+        initial_outs=0,
+    )
+
+    one_out = simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(seed),
+        initial_bases=(False, False, False),
+        initial_outs=1,
+    )
+
+    empty_runs.append(empty["runs"])
+    runner_second_runs.append(runner_second["runs"])
+    one_out_runs.append(one_out["runs"])
+
+
+invalid_checks = []
+
+try:
+    simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(1),
+        initial_bases=(False, True),
+    )
+    invalid_checks.append(
+        {
+            "case": "invalid_initial_bases_length",
+            "passed": False,
+        }
+    )
+except ValueError:
+    invalid_checks.append(
+        {
+            "case": "invalid_initial_bases_length",
+            "passed": True,
+        }
+    )
+
+try:
+    simulate_half_inning(
+        PROBABILITIES,
+        rng=random.Random(1),
+        initial_outs=3,
+    )
+    invalid_checks.append(
+        {
+            "case": "invalid_initial_outs",
+            "passed": False,
+        }
+    )
+except ValueError:
+    invalid_checks.append(
+        {
+            "case": "invalid_initial_outs",
+            "passed": True,
+        }
+    )
+
+
+sample_runner_second = simulate_half_inning(
+    PROBABILITIES,
+    rng=random.Random(42),
+    initial_bases=(False, True, False),
+    initial_outs=0,
+)
+
+sample_one_out = simulate_half_inning(
+    PROBABILITIES,
+    rng=random.Random(42),
+    initial_bases=(False, False, False),
+    initial_outs=1,
+)
+
+default_equivalence_passed = len(equivalence_failures) == 0
+determinism_passed = len(determinism_failures) == 0
+invalid_input_passed = all(check["passed"] for check in invalid_checks)
+
+runner_second_mean = mean(runner_second_runs)
+empty_mean = mean(empty_runs)
+one_out_mean = mean(one_out_runs)
+
+state_effect_passed = (
+    runner_second_mean > empty_mean
+    and one_out_mean < empty_mean
+)
+
+if not default_equivalence_passed:
+    diagnosis = "initial_state_half_inning_default_regression"
+elif not invalid_input_passed:
+    diagnosis = "initial_state_half_inning_invalid_input_failed"
+elif not state_effect_passed:
+    diagnosis = "initial_state_half_inning_state_effect_missing"
+elif not determinism_passed:
+    diagnosis = "initial_state_half_inning_audit_failed"
+else:
+    diagnosis = "initial_state_half_inning_backward_compatible"
+
+
+summary = {
+    "diagnosis": diagnosis,
+    "default_equivalence_passed": default_equivalence_passed,
+    "equivalence_failures": len(equivalence_failures),
+    "determinism_passed": determinism_passed,
+    "determinism_failures": len(determinism_failures),
+    "invalid_input_passed": invalid_input_passed,
+    "state_effect_passed": state_effect_passed,
+    "empty_bases_zero_outs_mean_runs": round(empty_mean, 6),
+    "runner_on_second_zero_outs_mean_runs": round(runner_second_mean, 6),
+    "empty_bases_one_out_mean_runs": round(one_out_mean, 6),
+    "sample_runner_second_initial_bases": sample_runner_second["initial_bases"],
+    "sample_runner_second_initial_outs": sample_runner_second["initial_outs"],
+    "sample_runner_second_ending_bases": sample_runner_second["ending_bases"],
+    "sample_runner_second_ending_outs": sample_runner_second["ending_outs"],
+    "sample_one_out_initial_bases": sample_one_out["initial_bases"],
+    "sample_one_out_initial_outs": sample_one_out["initial_outs"],
+    "sample_one_out_ending_bases": sample_one_out["ending_bases"],
+    "sample_one_out_ending_outs": sample_one_out["ending_outs"],
+    "recommended_next_step": (
+        "layer_6g_true_ghost_runner_extras_prototype"
+        if diagnosis == "initial_state_half_inning_backward_compatible"
+        else "repair_initial_state_half_inning_patch"
+    ),
+}
+
+rows = [
+    {
+        "check": "default_equivalence",
+        "passed": default_equivalence_passed,
+        "details": f"{len(equivalence_failures)} failures across 250 seeds",
+    },
+    {
+        "check": "determinism",
+        "passed": determinism_passed,
+        "details": f"{len(determinism_failures)} failures across 100 seeds",
+    },
+    {
+        "check": "invalid_input",
+        "passed": invalid_input_passed,
+        "details": json.dumps(invalid_checks),
+    },
+    {
+        "check": "runner_on_second_effect",
+        "passed": runner_second_mean > empty_mean,
+        "details": f"{runner_second_mean:.6f} > {empty_mean:.6f}",
+    },
+    {
+        "check": "one_out_effect",
+        "passed": one_out_mean < empty_mean,
+        "details": f"{one_out_mean:.6f} < {empty_mean:.6f}",
+    },
+]
+
+with (OUTPUT_DIR / "initial_state_half_inning_audit.json").open("w") as handle:
+    json.dump(summary, handle, indent=2)
+
+with (OUTPUT_DIR / "initial_state_half_inning_audit.csv").open("w", newline="") as handle:
+    writer = csv.DictWriter(
+        handle,
+        fieldnames=["check", "passed", "details"],
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+
+print(json.dumps(summary, indent=2))


### PR DESCRIPTION
## Summary

Adds backward-compatible initial base/out state support to `simulate_half_inning()`.

This is the first Layer 6 stateful inning API patch. It preserves existing default behavior while allowing future audit/prototype layers to initialize a half-inning with custom base occupancy and out count.

## What changed

- Adds optional `initial_bases` parameter
- Adds optional `initial_outs` parameter
- Validates initial base/out inputs
- Preserves empty-bases / zero-outs defaults
- Adds initial/ending state diagnostics to the return payload
- Adds `scripts/audit_initial_state_half_inning.py`

## Why

Layer 6E-B showed the base/out-state API is feasible with low risk:

- all observed callers use keyword args
- current inning state is local
- backward-compatible defaults are safe
- current callers do not rely on positional-only argument ordering

This unlocks future work on:

- true ghost runner
- double plays
- advancement realism
- sac flies
- steals/caught stealing
- wild pitches/passed balls
- walk-off state inheritance

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts

python scripts/audit_initial_state_half_inning.py
```

## Audit result

- diagnosis: `initial_state_half_inning_backward_compatible`
- default_equivalence_passed: true
- equivalence_failures: 0
- determinism_passed: true
- determinism_failures: 0
- invalid_input_passed: true
- state_effect_passed: true

Run environment sanity checks:

- empty_bases_zero_outs_mean_runs: 0.526
- runner_on_second_zero_outs_mean_runs: 1.127
- empty_bases_one_out_mean_runs: 0.312

Sample state payloads:

- runner-on-second initial_bases: `[false, true, false]`
- runner-on-second initial_outs: 0
- runner-on-second ending_bases: `[true, true, false]`
- runner-on-second ending_outs: 3
- one-out initial_bases: `[false, false, false]`
- one-out initial_outs: 1
- one-out ending_bases: `[false, false, false]`
- one-out ending_outs: 3

## Interpretation

The initial-state seam is backward-compatible and deterministic. Existing default behavior is preserved by paired-seed equivalence checks, while non-default initial states produce sensible run-environment changes.

## Recommended next step

`Layer 6G — true ghost-runner extras prototype`

## What this does not do

- Does not promote extras/walk-offs into production
- Does not modify `_build_pa_model()`
- Does not modify Model Projections UI/routes
- Does not add edge detection
- Does not add sportsbook logic
- Does not implement ghost runner production logic yet