### PR TITLE
Unify Daily Odds recap data sources

### DIFF
--- a/mlb_app/daily_odds_routes.py
+++ b/mlb_app/daily_odds_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import re
 from typing import Any, Dict, List, Optional
 
@@ -9,9 +10,12 @@ from fastapi import APIRouter
 from .daily_odds_models import build_game_models, build_prop_models
 from .database import create_tables, get_engine, get_session
 from .matchup_generator import generate_matchups_for_date
+from .my_dashboard_solver import build_dashboard_solver_payload, projection_payload
 from .odds_provider import fetch_draftkings_event_odds, fetch_draftkings_events
 
 router = APIRouter()
+
+DASHBOARD_COMPONENTS = ("hitters", "pitchers", "teams", "totals", "overall_players")
 
 
 def _normalize_team_key(name: Any) -> str:
@@ -80,8 +84,6 @@ def _load_matchups(target_date: str) -> tuple[List[Dict[str, Any]], List[Dict[st
         errors.append({"stage": "generate_matchups_for_date_primary", "error": _safe_error(primary_exc)})
 
     try:
-        import os
-
         database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
         engine = get_engine(database_url)
         create_tables(engine)
@@ -91,6 +93,13 @@ def _load_matchups(target_date: str) -> tuple[List[Dict[str, Any]], List[Dict[st
     except Exception as fallback_exc:
         errors.append({"stage": "generate_matchups_for_date_fallback", "error": _safe_error(fallback_exc)})
         return [], errors
+
+
+def _session_factory():
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    return get_session(engine)
 
 
 def _candidate_sort_key(candidate: Dict[str, Any]) -> float:
@@ -113,12 +122,6 @@ def _candidate_sort_key(candidate: Dict[str, Any]) -> float:
 
 
 def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: int = 20) -> List[Dict[str, Any]]:
-    """Build a populated pre-game candidate board even when the odds provider returns zero events.
-
-    These are internal model candidates, not sportsbook-priced prop edges. They are
-    intentionally marked with market_implied_probability=None and source=no_odds_provider
-    so the UI has useful pre-game targets while still making the missing odds state clear.
-    """
     candidates: List[Dict[str, Any]] = []
 
     for matchup in matchups or []:
@@ -134,39 +137,37 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
             model_probability = max(home_prob, away_prob)
             gap = abs(home_prob - away_prob)
             confidence = round(_clamp(0.52 + gap, 0.52, 0.85), 3)
-            candidates.append(
-                {
-                    "model": "pregame_internal_moneyline_v1",
-                    "market": "pregame_moneyline",
-                    "market_name": "Pregame Moneyline Candidate",
-                    "market_family": "game",
-                    "pick": pick_team,
-                    "player_name": label,
-                    "selection": pick_team,
-                    "line": None,
-                    "price": None,
-                    "score": round(model_probability + gap, 4),
-                    "model_probability": round(model_probability, 4),
-                    "market_implied_probability": None,
-                    "edge": None,
-                    "confidence": confidence,
-                    "game_pk": game_pk,
-                    "event_id": None,
-                    "away_team": away_team,
-                    "home_team": home_team,
-                    "match_key": _key_from_matchup(matchup),
-                    "matched": True,
-                    "available": True,
-                    "source": "internal_matchups_no_odds_provider",
-                    "features_used": [
-                        {"name": "home_win_prob", "value": home_prob, "source": "matchups.home_win_prob", "transform": "raw"},
-                        {"name": "away_win_prob", "value": away_prob, "source": "matchups.away_win_prob", "transform": "raw"},
-                        {"name": "probability_gap", "value": gap, "source": "matchups.win_probability_gap", "transform": "absolute_difference"},
-                    ],
-                    "missing_inputs": ["sportsbook_event_id", "sportsbook_price", "market_implied_probability"],
-                    "drivers": ["internal win probability", "pregame matchup model", "odds provider returned zero events"],
-                }
-            )
+            candidates.append({
+                "model": "pregame_internal_moneyline_v1",
+                "market": "pregame_moneyline",
+                "market_name": "Pregame Moneyline Candidate",
+                "market_family": "game",
+                "pick": pick_team,
+                "player_name": label,
+                "selection": pick_team,
+                "line": None,
+                "price": None,
+                "score": round(model_probability + gap, 4),
+                "model_probability": round(model_probability, 4),
+                "market_implied_probability": None,
+                "edge": None,
+                "confidence": confidence,
+                "game_pk": game_pk,
+                "event_id": None,
+                "away_team": away_team,
+                "home_team": home_team,
+                "match_key": _key_from_matchup(matchup),
+                "matched": True,
+                "available": True,
+                "source": "internal_matchups_no_odds_provider",
+                "features_used": [
+                    {"name": "home_win_prob", "value": home_prob, "source": "matchups.home_win_prob", "transform": "raw"},
+                    {"name": "away_win_prob", "value": away_prob, "source": "matchups.away_win_prob", "transform": "raw"},
+                    {"name": "probability_gap", "value": gap, "source": "matchups.win_probability_gap", "transform": "absolute_difference"},
+                ],
+                "missing_inputs": ["sportsbook_event_id", "sportsbook_price", "market_implied_probability"],
+                "drivers": ["internal win probability", "pregame matchup model", "odds provider returned zero events"],
+            })
 
         home_pitcher = matchup.get("home_pitcher_name")
         away_pitcher = matchup.get("away_pitcher_name")
@@ -192,39 +193,37 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
                 continue
             score = round(sum(signal_parts) / len(signal_parts), 4)
             confidence = round(_clamp(0.50 + score, 0.50, 0.78), 3)
-            candidates.append(
-                {
-                    "model": "pregame_internal_pitcher_prop_watchlist_v1",
-                    "market": "pitcher_strikeouts_watchlist",
-                    "market_name": "Pitcher Strikeouts Watchlist",
-                    "market_family": "pitcher",
-                    "pick": f"{pitcher_name} strikeout lean",
-                    "player_name": pitcher_name,
-                    "selection": "strikeout lean",
-                    "line": None,
-                    "price": None,
-                    "score": score,
-                    "model_probability": None,
-                    "market_implied_probability": None,
-                    "edge": None,
-                    "confidence": confidence,
-                    "game_pk": game_pk,
-                    "event_id": None,
-                    "away_team": away_team,
-                    "home_team": home_team,
-                    "match_key": _key_from_matchup(matchup),
-                    "matched": True,
-                    "available": True,
-                    "source": "internal_matchups_no_odds_provider",
-                    "features_used": [
-                        {"name": "k_pct", "value": k_pct, "source": f"matchups.{side}_pitcher_features.k_pct", "transform": "raw"},
-                        {"name": "xwoba", "value": xwoba, "source": f"matchups.{side}_pitcher_features.xwoba", "transform": "raw"},
-                        {"name": "hard_hit_pct", "value": hard_hit, "source": f"matchups.{side}_pitcher_features.hard_hit_pct", "transform": "raw"},
-                    ],
-                    "missing_inputs": ["sportsbook_event_id", "sportsbook_prop_line", "sportsbook_price"],
-                    "drivers": ["pitcher K profile", "pitcher contact suppression", f"opponent: {opponent}", "odds provider returned zero events"],
-                }
-            )
+            candidates.append({
+                "model": "pregame_internal_pitcher_prop_watchlist_v1",
+                "market": "pitcher_strikeouts_watchlist",
+                "market_name": "Pitcher Strikeouts Watchlist",
+                "market_family": "pitcher",
+                "pick": f"{pitcher_name} strikeout lean",
+                "player_name": pitcher_name,
+                "selection": "strikeout lean",
+                "line": None,
+                "price": None,
+                "score": score,
+                "model_probability": None,
+                "market_implied_probability": None,
+                "edge": None,
+                "confidence": confidence,
+                "game_pk": game_pk,
+                "event_id": None,
+                "away_team": away_team,
+                "home_team": home_team,
+                "match_key": _key_from_matchup(matchup),
+                "matched": True,
+                "available": True,
+                "source": "internal_matchups_no_odds_provider",
+                "features_used": [
+                    {"name": "k_pct", "value": k_pct, "source": f"matchups.{side}_pitcher_features.k_pct", "transform": "raw"},
+                    {"name": "xwoba", "value": xwoba, "source": f"matchups.{side}_pitcher_features.xwoba", "transform": "raw"},
+                    {"name": "hard_hit_pct", "value": hard_hit, "source": f"matchups.{side}_pitcher_features.hard_hit_pct", "transform": "raw"},
+                ],
+                "missing_inputs": ["sportsbook_event_id", "sportsbook_prop_line", "sportsbook_price"],
+                "drivers": ["pitcher K profile", "pitcher contact suppression", f"opponent: {opponent}", "odds provider returned zero events"],
+            })
 
     candidates.sort(key=_candidate_sort_key, reverse=True)
     return candidates[:limit]
@@ -274,42 +273,312 @@ def _models_from_unpriced_matchups(matchups: List[Dict[str, Any]]) -> List[Dict[
         if home_prob is not None and away_prob is not None:
             pick = home_team if home_prob >= away_prob else away_team
             confidence = round(_clamp(max(home_prob, away_prob), 0.50, 0.85), 3)
-        outputs.append(
-            {
+        outputs.append({
+            "game_pk": matchup.get("game_pk"),
+            "event_id": None,
+            "away_team": away_team,
+            "home_team": home_team,
+            "matched": True,
+            "match_key": _key_from_matchup(matchup),
+            "odds_missing": True,
+            "missing_inputs": ["sportsbook_event_id", "sportsbook_markets"],
+            "models": {
                 "game_pk": matchup.get("game_pk"),
                 "event_id": None,
-                "away_team": away_team,
-                "home_team": home_team,
-                "matched": True,
-                "match_key": _key_from_matchup(matchup),
-                "odds_missing": True,
-                "missing_inputs": ["sportsbook_event_id", "sportsbook_markets"],
-                "models": {
-                    "game_pk": matchup.get("game_pk"),
-                    "event_id": None,
-                    "moneyline": {
-                        "model": "moneyline_internal_no_odds_v1",
-                        "market": "moneyline",
-                        "pick": pick or "No pick",
-                        "score": confidence or 0.0,
-                        "model_probability": confidence,
-                        "market_implied_probability": None,
-                        "edge": None,
-                        "confidence": confidence or 0.0,
-                        "features_used": [
-                            {"name": "home_win_prob", "value": home_prob, "source": "matchups.home_win_prob", "transform": "raw"},
-                            {"name": "away_win_prob", "value": away_prob, "source": "matchups.away_win_prob", "transform": "raw"},
-                        ],
-                        "missing_inputs": ["sportsbook_price", "market_implied_probability"],
-                        "drivers": ["internal matchup model", "odds provider returned zero events"],
-                        "available": pick is not None,
-                    },
-                    "spread": None,
-                    "total": None,
+                "moneyline": {
+                    "model": "moneyline_internal_no_odds_v1",
+                    "market": "moneyline",
+                    "pick": pick or "No pick",
+                    "score": confidence or 0.0,
+                    "model_probability": confidence,
+                    "market_implied_probability": None,
+                    "edge": None,
+                    "confidence": confidence or 0.0,
+                    "features_used": [
+                        {"name": "home_win_prob", "value": home_prob, "source": "matchups.home_win_prob", "transform": "raw"},
+                        {"name": "away_win_prob", "value": away_prob, "source": "matchups.away_win_prob", "transform": "raw"},
+                    ],
+                    "missing_inputs": ["sportsbook_price", "market_implied_probability"],
+                    "drivers": ["internal matchup model", "odds provider returned zero events"],
+                    "available": pick is not None,
                 },
-            }
-        )
+                "spread": None,
+                "total": None,
+            },
+        })
     return outputs
+
+
+def _compact_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "rank": item.get("rank"),
+        "entity_type": item.get("entity_type"),
+        "entity_id": item.get("entity_id"),
+        "entity_name": item.get("entity_name"),
+        "player_type": item.get("player_type"),
+        "team": item.get("team"),
+        "opponent": item.get("opponent"),
+        "game_pk": item.get("game_pk"),
+        "score": item.get("score"),
+        "confidence": item.get("confidence"),
+        "category": item.get("category"),
+        "primary_reason": item.get("primary_reason"),
+        "reasoning": item.get("reasoning") or [],
+        "metrics": item.get("metrics") or {},
+        "source": item.get("source"),
+        "missing_data": item.get("missing_data") or [],
+        "best_pitch_angles": item.get("best_pitch_angles") or [],
+    }
+
+
+def _compact_dashboard_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    items = [_compact_item(item) for item in payload.get("items") or []]
+    return {
+        "component": payload.get("component"),
+        "title": payload.get("title"),
+        "items": items,
+        "top_item": items[0] if items else None,
+        "item_count": len(items),
+        "data_quality": payload.get("data_quality") or {},
+        "missing_data": payload.get("missing_data") or [],
+        "filter_warnings": payload.get("filter_warnings") or [],
+        "generated_at": payload.get("generated_at"),
+    }
+
+
+def _empty_projection_summary() -> Dict[str, Any]:
+    return {
+        "projection_count": 0,
+        "games": [],
+        "source": "model_projections",
+        "missing_inputs": ["model_projection_payload_unavailable"],
+    }
+
+
+def _summarize_projection_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    games = payload.get("games") if isinstance(payload.get("games"), list) else []
+    compact_games: List[Dict[str, Any]] = []
+
+    for game in games[:20]:
+        if not isinstance(game, dict):
+            continue
+        workspace = game.get("workspace") or {}
+        simulation = workspace.get("bullpenAdjustedGameSimulation") or workspace.get("gameSimulation") or {}
+        compact_games.append({
+            "game_pk": game.get("game_pk"),
+            "away_team": game.get("away_team") or game.get("away_team_name"),
+            "home_team": game.get("home_team") or game.get("home_team_name"),
+            "away_pitcher": game.get("away_pitcher"),
+            "home_pitcher": game.get("home_pitcher"),
+            "home_win_probability": simulation.get("home_win_probability") or game.get("home_win_probability"),
+            "away_win_probability": simulation.get("away_win_probability") or game.get("away_win_probability"),
+            "home_expected_runs": simulation.get("home_expected_runs"),
+            "away_expected_runs": simulation.get("away_expected_runs"),
+            "total_expected_runs": simulation.get("total_expected_runs"),
+            "missing_inputs": game.get("missing_inputs") or workspace.get("missing_inputs") or [],
+        })
+
+    return {
+        "projection_count": len(games),
+        "games": compact_games,
+        "source": "model_projections",
+        "missing_inputs": payload.get("missing_inputs") or payload.get("errors") or [],
+        "generated_at": payload.get("generated_at"),
+    }
+
+
+def _load_dashboard_summary(target_date: str, errors: List[Dict[str, Any]]) -> Dict[str, Any]:
+    summary: Dict[str, Any] = {
+        "components": {},
+        "components_used": [],
+        "top_hitter_angles": [],
+        "top_pitcher_angles": [],
+        "top_team_edges": [],
+        "top_total_angles": [],
+        "top_overall_players": [],
+        "model_projection_summary": _empty_projection_summary(),
+    }
+
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            for component in DASHBOARD_COMPONENTS:
+                try:
+                    payload = build_dashboard_solver_payload(session, target_date, component)
+                    compact = _compact_dashboard_payload(payload)
+                    summary["components"][component] = compact
+                    summary["components_used"].append(component)
+                except Exception as exc:
+                    errors.append({"stage": f"dashboard_solver_{component}", "error": _safe_error(exc)})
+
+            try:
+                projection = projection_payload(session, target_date) or {}
+                summary["model_projection_summary"] = _summarize_projection_payload(projection)
+            except Exception as exc:
+                errors.append({"stage": "model_projection_payload", "error": _safe_error(exc)})
+    except Exception as exc:
+        errors.append({"stage": "daily_odds_unified_session", "error": _safe_error(exc)})
+
+    hitters = summary["components"].get("hitters", {}).get("items") or []
+    pitchers = summary["components"].get("pitchers", {}).get("items") or []
+    teams = summary["components"].get("teams", {}).get("items") or []
+    totals = summary["components"].get("totals", {}).get("items") or []
+    overall = summary["components"].get("overall_players", {}).get("items") or []
+
+    summary["top_hitter_angles"] = hitters[:10]
+    summary["top_pitcher_angles"] = pitchers[:10]
+    summary["top_team_edges"] = teams[:10]
+    summary["top_total_angles"] = totals[:10]
+    summary["top_overall_players"] = overall[:10]
+    summary["batter_vs_arsenal_edges"] = [
+        item for item in hitters if item.get("best_pitch_angles") or "batter_pitch_type_matchups" in str(item.get("source") or "")
+    ][:10]
+    summary["batter_vs_arsenal_count"] = len(summary["batter_vs_arsenal_edges"])
+
+    return summary
+
+
+def _best_game_signal(outputs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+
+    for row in outputs or []:
+        models = row.get("models") or {}
+        for market_key in ("moneyline", "spread", "run_line", "total"):
+            model = models.get(market_key)
+            if not isinstance(model, dict):
+                continue
+            if not model.get("pick") and model.get("available") is False:
+                continue
+            candidates.append({
+                "market": market_key,
+                "pick": model.get("pick"),
+                "score": model.get("score"),
+                "edge": model.get("edge"),
+                "confidence": model.get("confidence") or model.get("model_probability"),
+                "model_probability": model.get("model_probability"),
+                "market_implied_probability": model.get("market_implied_probability"),
+                "game_pk": row.get("game_pk"),
+                "event_id": row.get("event_id"),
+                "away_team": row.get("away_team"),
+                "home_team": row.get("home_team"),
+                "source": model.get("model") or "daily_odds_models",
+                "missing_inputs": model.get("missing_inputs") or row.get("missing_inputs") or [],
+                "features_used": model.get("features_used") or [],
+            })
+
+    if not candidates:
+        return None
+
+    return sorted(candidates, key=_candidate_sort_key, reverse=True)[0]
+
+
+def _first_item(summary: Dict[str, Any], component: str) -> Optional[Dict[str, Any]]:
+    item = summary.get("components", {}).get(component, {}).get("top_item")
+    return item if isinstance(item, dict) else None
+
+
+def _build_daily_recap(
+    outputs: List[Dict[str, Any]],
+    dashboard_summary: Dict[str, Any],
+    odds_status: Optional[str],
+    odds_event_count: int,
+) -> Dict[str, Any]:
+    best_side = _best_game_signal(outputs)
+    best_total = _first_item(dashboard_summary, "totals")
+    best_pitcher = _first_item(dashboard_summary, "pitchers")
+    best_hitter = _first_item(dashboard_summary, "hitters")
+    best_team = _first_item(dashboard_summary, "teams")
+
+    priced_count = sum(1 for row in outputs if row.get("event_id"))
+    pricing_note = (
+        "Sportsbook-priced markets are available and model sections distinguish price-backed edges from model-only signals."
+        if odds_event_count
+        else "No sportsbook event payload was available; all surfaced picks are model-only watchlist signals and do not assume a price or line."
+    )
+
+    missing_sections = [
+        name
+        for name, value in {
+            "best_side": best_side,
+            "best_total": best_total,
+            "best_pitcher": best_pitcher,
+            "best_hitter": best_hitter,
+            "best_team": best_team,
+        }.items()
+        if not value
+    ]
+
+    return {
+        "best_side": best_side,
+        "best_total": best_total,
+        "best_pitcher": best_pitcher,
+        "best_hitter": best_hitter,
+        "best_team": best_team,
+        "data_quality_note": (
+            f"Missing sections: {', '.join(missing_sections)}."
+            if missing_sections
+            else "Daily Odds is populated from shared My Dashboard, AI Data Assistant, Model Projection, and Batter vs Arsenal data paths."
+        ),
+        "pricing_note": pricing_note,
+        "odds_status": odds_status,
+        "priced_game_count": priced_count,
+        "model_only_game_count": max(len(outputs) - priced_count, 0),
+        "generated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    }
+
+
+def _collect_missing_inputs(
+    outputs: List[Dict[str, Any]],
+    dashboard_summary: Dict[str, Any],
+    projection_summary: Dict[str, Any],
+    errors: List[Dict[str, Any]],
+) -> List[Any]:
+    missing: List[Any] = []
+
+    for row in outputs:
+        missing.extend(row.get("missing_inputs") or [])
+        models = row.get("models") or {}
+        for model in models.values():
+            if isinstance(model, dict):
+                missing.extend(model.get("missing_inputs") or [])
+
+    for component_payload in dashboard_summary.get("components", {}).values():
+        missing.extend(component_payload.get("missing_data") or [])
+        for item in component_payload.get("items") or []:
+            missing.extend(item.get("missing_data") or [])
+
+    missing.extend(projection_summary.get("missing_inputs") or [])
+    missing.extend({"stage": item.get("stage"), "error": item.get("error")} for item in errors if item.get("stage"))
+
+    deduped: List[Any] = []
+    seen = set()
+    for item in missing:
+        key = str(item)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped[:50]
+
+
+def _sources_used(odds_payload: Dict[str, Any], dashboard_summary: Dict[str, Any]) -> List[str]:
+    sources = [
+        "daily_odds_models",
+        "matchup_generator.generate_matchups_for_date",
+        "odds_provider.fetch_draftkings_events",
+    ]
+
+    if dashboard_summary.get("components_used"):
+        sources.append("my_dashboard_solver.build_dashboard_solver_payload")
+        sources.append("ai_data_assistant Stored 365 / pitcher lean contexts")
+
+    if dashboard_summary.get("model_projection_summary", {}).get("projection_count", 0) > 0:
+        sources.append("model_projections.build_model_projection_payload")
+
+    if odds_payload.get("provider"):
+        sources.append(str(odds_payload.get("provider")))
+
+    return sources
 
 
 @router.get("/daily-odds/models")
@@ -323,7 +592,7 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
     try:
         odds_payload = fetch_draftkings_events(date=target_date, raw=False)
     except Exception as exc:
-        odds_payload = {"events": []}
+        odds_payload = {"events": [], "status": "provider_error"}
         errors.append({"stage": "fetch_draftkings_events", "error": _safe_error(exc)})
 
     events = odds_payload.get("events", []) if isinstance(odds_payload, dict) else []
@@ -365,6 +634,35 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
         outputs = _models_from_unpriced_matchups(matchups)
 
     top_prop_candidates = _build_global_prop_candidates(events, matchup_index, matchups, limit=20)
+    dashboard_summary = _load_dashboard_summary(target_date, errors)
+    projection_summary = dashboard_summary.get("model_projection_summary") or _empty_projection_summary()
+    daily_recap = _build_daily_recap(
+        outputs=outputs,
+        dashboard_summary=dashboard_summary,
+        odds_status=odds_payload.get("status") if isinstance(odds_payload, dict) else None,
+        odds_event_count=len(events),
+    )
+    missing_inputs = _collect_missing_inputs(outputs, dashboard_summary, projection_summary, errors)
+
+    fallbacks_used: List[str] = []
+    if not events:
+        fallbacks_used.append("internal_matchups_no_odds_provider")
+    if dashboard_summary.get("components_used"):
+        fallbacks_used.append("my_dashboard_solver_shared_context")
+    if projection_summary.get("projection_count", 0) > 0:
+        fallbacks_used.append("model_projection_shared_payload")
+
+    data_quality = {
+        "sources_used": _sources_used(odds_payload if isinstance(odds_payload, dict) else {}, dashboard_summary),
+        "missing_inputs": missing_inputs,
+        "fallbacks_used": fallbacks_used,
+        "odds_status": odds_payload.get("status") if isinstance(odds_payload, dict) else None,
+        "matchup_count": len(matchups),
+        "projection_count": projection_summary.get("projection_count", 0),
+        "dashboard_solver_components_used": dashboard_summary.get("components_used", []),
+        "batter_vs_arsenal_count": dashboard_summary.get("batter_vs_arsenal_count", 0),
+        "generated_at": daily_recap.get("generated_at"),
+    }
 
     return {
         "date": target_date,
@@ -378,7 +676,19 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
         "games": outputs,
         "top_prop_model_candidates": top_prop_candidates,
         "top_prop_candidate_count": len(top_prop_candidates),
+        "daily_recap": daily_recap,
+        "model_projection_summary": projection_summary,
+        "dashboard_solver_summary": dashboard_summary.get("components", {}),
+        "top_hitter_angles": dashboard_summary.get("top_hitter_angles", []),
+        "top_pitcher_angles": dashboard_summary.get("top_pitcher_angles", []),
+        "batter_vs_arsenal_edges": dashboard_summary.get("batter_vs_arsenal_edges", []),
+        "matchup_detail_signals": projection_summary.get("games", []),
+        "data_quality": data_quality,
+        "sources_used": data_quality["sources_used"],
+        "missing_inputs": missing_inputs,
+        "fallbacks_used": fallbacks_used,
         "errors": errors,
+        "generated_at": data_quality["generated_at"],
     }
 
 

--- a/scripts/smoke_test_production_paths.py
+++ b/scripts/smoke_test_production_paths.py
@@ -81,6 +81,22 @@ def _check_daily_odds(data: Any, path: str) -> None:
         raise SmokeFailure(f"Daily Odds payload missing {missing} for {path}")
     if not any(key in payload for key in ["models", "games", "model_games"]):
         raise SmokeFailure("Daily Odds payload missing models/games/model_games container")
+    enhanced_keys = [
+        "daily_recap",
+        "model_projection_summary",
+        "dashboard_solver_summary",
+        "data_quality",
+        "sources_used",
+        "missing_inputs",
+        "fallbacks_used",
+    ]
+    missing_enhanced = [key for key in enhanced_keys if key not in payload]
+    if missing_enhanced:
+        raise SmokeFailure(f"Daily Odds unified payload missing {missing_enhanced}")
+    data_quality = _expect_dict(payload.get("data_quality"), f"{path}.data_quality")
+    for key in ["matchup_count", "projection_count", "dashboard_solver_components_used", "batter_vs_arsenal_count", "generated_at"]:
+        if key not in data_quality:
+            raise SmokeFailure(f"Daily Odds data_quality missing {key}")
 
 
 def _check_model_projections(data: Any, path: str) -> None:
@@ -122,7 +138,8 @@ def main() -> int:
 
     date = args.date[:10]
     query_date = urllib.parse.urlencode({"date": date})
-    dashboard_query = urllib.parse.urlencode({"date": date, "component": "hitters"})
+    dashboard_hitter_query = urllib.parse.urlencode({"date": date, "component": "hitters"})
+    dashboard_pitcher_query = urllib.parse.urlencode({"date": date, "component": "pitchers"})
 
     checks: list[tuple[str, str, Callable[[Any, str], None]]] = [
         ("health", "/health", _check_health),
@@ -131,7 +148,8 @@ def main() -> int:
         ("model_projections", f"/models/projections?{query_date}", _check_model_projections),
         ("ai_data_assistant_health", "/ai-data-assistant/health", _check_health),
         ("my_dashboard_health", "/my-dashboard/health", _check_health),
-        ("my_dashboard_solver", f"/my-dashboard/solver?{dashboard_query}", _check_dashboard_solver),
+        ("my_dashboard_solver_hitters", f"/my-dashboard/solver?{dashboard_hitter_query}", _check_dashboard_solver),
+        ("my_dashboard_solver_pitchers", f"/my-dashboard/solver?{dashboard_pitcher_query}", _check_dashboard_solver),
     ]
 
     print(f"Backend base URL: {args.base_url.rstrip('/')}")


### PR DESCRIPTION
## Summary

Closes #286.

This PR starts the Daily Odds unification work by enhancing the existing `GET /daily-odds/models` backend response instead of replacing routes, model formulas, or frontend architecture.

The endpoint now preserves the existing `models`, `games`, and prop-candidate response keys while adding optional enriched sections sourced from the same proven data paths already powering My Dashboard, AI Data Assistant, Model Projections, and Batter vs Arsenal logic.

## Files changed

- `mlb_app/daily_odds_routes.py`
- `scripts/smoke_test_production_paths.py`

## Existing behavior preserved

- Existing `/daily-odds/models?date=YYYY-MM-DD` route remains in place.
- Existing response keys remain in place: `models`, `games`, `top_prop_model_candidates`, `errors`, counts, and odds metadata.
- Existing odds-provider behavior remains unchanged.
- Existing no-odds fallback candidate behavior remains in place.
- No production matchup analyzer logic was changed.
- No scoring formulas were changed.
- No Railway, CORS, deployment, or Batter feature-flag behavior was changed.

## New data sources reused

Daily Odds now reuses:

- `my_dashboard_solver.build_dashboard_solver_payload(...)`
- `my_dashboard_solver.projection_payload(...)`
- Existing AI Data Assistant contexts indirectly through My Dashboard solver:
  - Stored 365 / Batter vs Arsenal context
  - pitcher lean context
  - model projection edge scoring context
- Existing Model Projection payload data
- Existing matchup generator output
- Existing DraftKings odds provider output

## Backend response keys added

The Daily Odds models response now includes:

- `daily_recap`
- `model_projection_summary`
- `dashboard_solver_summary`
- `top_hitter_angles`
- `top_pitcher_angles`
- `batter_vs_arsenal_edges`
- `matchup_detail_signals`
- `data_quality`
- `sources_used`
- `missing_inputs`
- `fallbacks_used`
- `generated_at`

The `data_quality` object includes:

- `sources_used`
- `missing_inputs`
- `fallbacks_used`
- `odds_status`
- `matchup_count`
- `projection_count`
- `dashboard_solver_components_used`
- `batter_vs_arsenal_count`
- `generated_at`

## Frontend behavior changed

No frontend file is changed in this PR. This is intentional for the first safe increment.

The existing Daily Odds frontend already calls `/daily-odds/models`; this PR enriches that endpoint without changing the UI contract. A follow-up UI pass can render the new `daily_recap`, `top_hitter_angles`, `top_pitcher_angles`, and `batter_vs_arsenal_edges` sections directly once the enriched payload is verified in production/sandbox.

## Validation commands run

Not run in this connector environment.

Required before merge:

```bash
python -m compileall mlb_app scripts
cd frontend && npm run build
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-14
```

## Smoke test updates

`scripts/smoke_test_production_paths.py` now validates that `/daily-odds/models` includes the unified optional response keys and validates both My Dashboard hitter and pitcher solver paths:

- `/daily-odds/models?date=YYYY-MM-DD`
- `/models/projections?date=YYYY-MM-DD`
- `/my-dashboard/solver?date=YYYY-MM-DD&component=hitters`
- `/my-dashboard/solver?date=YYYY-MM-DD&component=pitchers`
- `/ai-data-assistant/health`
- `/matchups?date=YYYY-MM-DD`

## Manual QA checklist

- `/daily-odds`
- `/models/projections`
- `/my-dashboard`
- `/ai-data-assistant`
- `/matchup/:game_pk`
- `/matchup/:game_pk/competitive`

Confirm:

- Daily Odds still loads.
- Existing Daily Recap still appears.
- Existing odds markets still display when available.
- Missing sportsbook odds still produce internal model/watchlist candidates.
- `/daily-odds/models` response contains the new enriched keys.
- Model-only signals are clearly labeled by source/fallback fields in the backend payload.
- No production routes break.
- No CORS or Railway config changes were made.

## Risks and rollback plan

Risk: `GET /daily-odds/models` now does more backend work because it calls shared dashboard and projection builders. If latency is too high, rollback this PR or gate the enriched sections behind a query parameter such as `include_unified=true`.

Risk: A shared solver exception could add errors to the payload. The implementation catches component-level failures and keeps the existing Daily Odds response alive.

Rollback is clean because this PR only touches the Daily Odds route module and the smoke test script. Reverting the PR restores the previous endpoint behavior.