### PR TITLE
Add Layer 6O transition profile rate integration

### DIFF
--- a/mlb_app/simulation/inning_simulator.py
+++ b/mlb_app/simulation/inning_simulator.py
@@ -57,6 +57,34 @@ def sample_pa_outcome(probabilities: Dict[str, float], rng: Optional[random.Rand
     return "out"
 
 
+def _validate_transition_rates(
+    transition_rates: Optional[Dict[str, float]],
+) -> None:
+    if transition_rates is None:
+        return
+
+    valid_keys = {
+        "sac_fly_rate",
+        "double_play_rate",
+        "first_to_third_single_rate",
+        "first_to_home_double_rate",
+    }
+
+    for key, value in transition_rates.items():
+        if key not in valid_keys:
+            continue
+
+        if not isinstance(value, (int, float)):
+            raise ValueError(
+                f"Invalid transition rate type for {key}: {value}"
+            )
+
+        if value < 0.0 or value > 1.0:
+            raise ValueError(
+                f"Invalid transition rate range for {key}: {value}"
+            )
+
+
 def advance_runners(
     bases: tuple[bool, bool, bool],
     outcome: str,
@@ -109,6 +137,7 @@ def advance_runners_realism_candidate(
     outcome: str,
     outs: int,
     rng: Optional[random.Random] = None,
+    transition_rates: Optional[Dict[str, float]] = None,
 ) -> Tuple[Tuple[bool, bool, bool], int, int]:
     """
     Candidate transition realism helper.
@@ -119,6 +148,33 @@ def advance_runners_realism_candidate(
 
     rng = rng or random.Random()
 
+    sac_fly_rate = (
+        transition_rates.get("sac_fly_rate", SAC_FLY_RATE)
+        if transition_rates
+        else SAC_FLY_RATE
+    )
+    double_play_rate = (
+        transition_rates.get("double_play_rate", DOUBLE_PLAY_RATE)
+        if transition_rates
+        else DOUBLE_PLAY_RATE
+    )
+    first_to_third_single_rate = (
+        transition_rates.get(
+            "first_to_third_single_rate",
+            FIRST_TO_THIRD_SINGLE_RATE,
+        )
+        if transition_rates
+        else FIRST_TO_THIRD_SINGLE_RATE
+    )
+    first_to_home_double_rate = (
+        transition_rates.get(
+            "first_to_home_double_rate",
+            FIRST_TO_HOME_DOUBLE_RATE,
+        )
+        if transition_rates
+        else FIRST_TO_HOME_DOUBLE_RATE
+    )
+
     first, second, third = bases
     runs = 0
     extra_outs = 0
@@ -126,12 +182,12 @@ def advance_runners_realism_candidate(
     if outcome == "out":
 
         if third and outs < 2:
-            if rng.random() < SAC_FLY_RATE:
+            if rng.random() < sac_fly_rate:
                 third = False
                 runs += 1
 
         if first and outs < 2:
-            if rng.random() < DOUBLE_PLAY_RATE:
+            if rng.random() < double_play_rate:
                 first = False
                 extra_outs += 1
 
@@ -149,7 +205,7 @@ def advance_runners_realism_candidate(
             runs += 1
 
         if first:
-            if rng.random() < FIRST_TO_THIRD_SINGLE_RATE:
+            if rng.random() < first_to_third_single_rate:
                 new_third = True
                 new_second = False
             else:
@@ -174,7 +230,7 @@ def advance_runners_realism_candidate(
             runs += 1
 
         if first:
-            if rng.random() < FIRST_TO_HOME_DOUBLE_RATE:
+            if rng.random() < first_to_home_double_rate:
                 runs += 1
                 new_third = False
             else:
@@ -207,8 +263,11 @@ def simulate_half_inning(
     initial_bases: Tuple[bool, bool, bool] = (False, False, False),
     initial_outs: int = 0,
     transition_mode: str = "current",
+    transition_rates: Optional[Dict[str, float]] = None,
 ) -> Dict[str, Any]:
     rng = rng or random.Random()
+
+    _validate_transition_rates(transition_rates)
 
     if transition_mode not in {
         "current",
@@ -260,6 +319,7 @@ def simulate_half_inning(
                         outcome=outcome,
                         outs=outs,
                         rng=rng,
+                        transition_rates=transition_rates,
                     )
                 )
 

--- a/scripts/audit_transition_profile_rate_integration.py
+++ b/scripts/audit_transition_profile_rate_integration.py
@@ -1,0 +1,506 @@
+import csv
+import json
+import random
+from pathlib import Path
+
+from mlb_app.simulation.inning_simulator import (
+    simulate_half_inning,
+    advance_runners_realism_candidate,
+)
+
+from mlb_app.simulation.transition_profiles import (
+    TRANSITION_PROFILES,
+    resolve_transition_profile,
+)
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+CHECKS = []
+
+def add_check(name, passed, detail):
+
+    CHECKS.append(
+        {
+            "check": name,
+            "passed": passed,
+            "detail": detail,
+        }
+    )
+
+probabilities = {
+    "k": 0.22,
+    "bb": 0.08,
+    "hbp": 0.01,
+    "single": 0.15,
+    "double": 0.05,
+    "triple": 0.01,
+    "hr": 0.03,
+    "reached_on_error": 0.01,
+    "out": 0.44,
+}
+
+#
+# --------------------------------------------------
+# 1. default equivalence
+# --------------------------------------------------
+#
+
+default_equivalence_differences = 0
+
+for seed in range(250):
+
+    a = simulate_half_inning(
+        probabilities,
+        rng=random.Random(seed),
+    )
+
+    b = simulate_half_inning(
+        probabilities,
+        rng=random.Random(seed),
+        transition_mode="current",
+    )
+
+    if a != b:
+
+        default_equivalence_differences += 1
+
+add_check(
+    "default_equivalence_zero_diff",
+    default_equivalence_differences == 0,
+    default_equivalence_differences,
+)
+
+#
+# --------------------------------------------------
+# 2. current mode ignores rates
+# --------------------------------------------------
+#
+
+extreme_rates = {
+    "sac_fly_rate": 0.99,
+    "double_play_rate": 0.99,
+    "first_to_third_single_rate": 0.99,
+    "first_to_home_double_rate": 0.99,
+}
+
+current_mode_rate_ignored_differences = 0
+
+for seed in range(250):
+
+    a = simulate_half_inning(
+        probabilities,
+        rng=random.Random(seed),
+        transition_mode="current",
+    )
+
+    b = simulate_half_inning(
+        probabilities,
+        rng=random.Random(seed),
+        transition_mode="current",
+        transition_rates=extreme_rates,
+    )
+
+    if a != b:
+
+        current_mode_rate_ignored_differences += 1
+
+add_check(
+    "current_mode_ignores_rates",
+    current_mode_rate_ignored_differences == 0,
+    current_mode_rate_ignored_differences,
+)
+
+#
+# --------------------------------------------------
+# 3. deterministic crafted proofs
+# --------------------------------------------------
+#
+
+#
+# sac fly proof
+#
+
+sac_zero = (
+    advance_runners_realism_candidate(
+        bases=(False, False, True),
+        outcome="out",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "sac_fly_rate": 0.0,
+        },
+    )
+)
+
+sac_one = (
+    advance_runners_realism_candidate(
+        bases=(False, False, True),
+        outcome="out",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "sac_fly_rate": 1.0,
+        },
+    )
+)
+
+sac_fly_rate_consumed = (
+    sac_zero != sac_one
+)
+
+add_check(
+    "sac_fly_rate_consumed",
+    sac_fly_rate_consumed,
+    {
+        "zero": sac_zero,
+        "one": sac_one,
+    },
+)
+
+#
+# double play proof
+#
+
+dp_zero = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="out",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "double_play_rate": 0.0,
+        },
+    )
+)
+
+dp_one = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="out",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "double_play_rate": 1.0,
+        },
+    )
+)
+
+double_play_rate_consumed = (
+    dp_zero != dp_one
+)
+
+add_check(
+    "double_play_rate_consumed",
+    double_play_rate_consumed,
+    {
+        "zero": dp_zero,
+        "one": dp_one,
+    },
+)
+
+#
+# first to third proof
+#
+
+ftt_zero = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="single",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "first_to_third_single_rate": 0.0,
+        },
+    )
+)
+
+ftt_one = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="single",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "first_to_third_single_rate": 1.0,
+        },
+    )
+)
+
+first_to_third_rate_consumed = (
+    ftt_zero != ftt_one
+)
+
+add_check(
+    "first_to_third_rate_consumed",
+    first_to_third_rate_consumed,
+    {
+        "zero": ftt_zero,
+        "one": ftt_one,
+    },
+)
+
+#
+# first to home on double proof
+#
+
+fth_zero = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="double",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "first_to_home_double_rate": 0.0,
+        },
+    )
+)
+
+fth_one = (
+    advance_runners_realism_candidate(
+        bases=(True, False, False),
+        outcome="double",
+        outs=0,
+        rng=random.Random(1),
+        transition_rates={
+            "first_to_home_double_rate": 1.0,
+        },
+    )
+)
+
+first_to_home_double_rate_consumed = (
+    fth_zero != fth_one
+)
+
+add_check(
+    "first_to_home_double_rate_consumed",
+    first_to_home_double_rate_consumed,
+    {
+        "zero": fth_zero,
+        "one": fth_one,
+    },
+)
+
+deterministic_rate_consumption_passed = all([
+    sac_fly_rate_consumed,
+    double_play_rate_consumed,
+    first_to_third_rate_consumed,
+    first_to_home_double_rate_consumed,
+])
+
+add_check(
+    "deterministic_rate_consumption_passed",
+    deterministic_rate_consumption_passed,
+    deterministic_rate_consumption_passed,
+)
+
+#
+# --------------------------------------------------
+# 4. invalid rate rejection
+# --------------------------------------------------
+#
+
+invalid_rates_rejected = True
+
+invalid_payloads = [
+    {
+        "sac_fly_rate": -0.01,
+    },
+    {
+        "double_play_rate": 1.01,
+    },
+    {
+        "first_to_third_single_rate": "bad",
+    },
+]
+
+for payload in invalid_payloads:
+
+    try:
+
+        simulate_half_inning(
+            probabilities,
+            transition_mode="realism_candidate",
+            transition_rates=payload,
+        )
+
+        invalid_rates_rejected = False
+
+    except ValueError:
+
+        pass
+
+add_check(
+    "invalid_rates_rejected",
+    invalid_rates_rejected,
+    invalid_rates_rejected,
+)
+
+#
+# --------------------------------------------------
+# 5. registry immutability
+# --------------------------------------------------
+#
+
+candidate_profile = (
+    resolve_transition_profile(
+        "low_advancement"
+    )
+)
+
+candidate_profile[
+    "sac_fly_rate"
+] = 999
+
+profile_registry_unchanged = (
+    TRANSITION_PROFILES[
+        "low_advancement"
+    ]["sac_fly_rate"]
+    != 999
+)
+
+add_check(
+    "profile_registry_unchanged",
+    profile_registry_unchanged,
+    profile_registry_unchanged,
+)
+
+#
+# --------------------------------------------------
+# final diagnosis
+# --------------------------------------------------
+#
+
+diagnosis = (
+    "transition_profile_rates_integrated_safely"
+)
+
+if (
+    default_equivalence_differences
+    > 0
+):
+
+    diagnosis = (
+        "transition_profile_rates_default_regression"
+    )
+
+elif (
+    current_mode_rate_ignored_differences
+    > 0
+):
+
+    diagnosis = (
+        "transition_profile_rates_current_mode_leak"
+    )
+
+elif (
+    deterministic_rate_consumption_passed
+    is False
+):
+
+    diagnosis = (
+        "transition_profile_rates_not_consumed"
+    )
+
+elif (
+    invalid_rates_rejected
+    is False
+):
+
+    diagnosis = (
+        "transition_profile_rates_invalid_validation_failed"
+    )
+
+checks_passed = sum(
+    1
+    for row in CHECKS
+    if row["passed"]
+)
+
+checks_failed = sum(
+    1
+    for row in CHECKS
+    if not row["passed"]
+)
+
+summary = {
+    "diagnosis":
+        diagnosis,
+
+    "default_equivalence_differences":
+        default_equivalence_differences,
+
+    "current_mode_rate_ignored_differences":
+        current_mode_rate_ignored_differences,
+
+    "sac_fly_rate_consumed":
+        sac_fly_rate_consumed,
+
+    "double_play_rate_consumed":
+        double_play_rate_consumed,
+
+    "first_to_third_rate_consumed":
+        first_to_third_rate_consumed,
+
+    "first_to_home_double_rate_consumed":
+        first_to_home_double_rate_consumed,
+
+    "deterministic_rate_consumption_passed":
+        deterministic_rate_consumption_passed,
+
+    "invalid_rates_rejected":
+        invalid_rates_rejected,
+
+    "profile_registry_unchanged":
+        profile_registry_unchanged,
+
+    "checks_passed":
+        checks_passed,
+
+    "checks_failed":
+        checks_failed,
+
+    "recommended_next_step":
+        (
+            "layer_6p_profile_rate_"
+            "calibration_backtest"
+        ),
+}
+
+with open(
+    TMP_DIR
+    / "transition_profile_rate_integration.json",
+    "w",
+) as f:
+
+    json.dump(
+        summary,
+        f,
+        indent=2,
+    )
+
+with open(
+    TMP_DIR
+    / "transition_profile_rate_integration_checks.csv",
+    "w",
+    newline="",
+) as f:
+
+    writer = csv.DictWriter(
+        f,
+        fieldnames=[
+            "check",
+            "passed",
+            "detail",
+        ],
+    )
+
+    writer.writeheader()
+    writer.writerows(CHECKS)
+
+print(
+    json.dumps(
+        summary,
+        indent=2,
+    )
+)


### PR DESCRIPTION
## Summary

Adds Layer 6O transition profile rate integration and deterministic audit validation.

This PR updates `simulate_half_inning()` so candidate mode can optionally consume explicit transition-rate configs while preserving all default/current-mode behavior.

## Why

Layer 6N proved profile routing was safe but identified the key remaining gap:

`simulate_half_inning()` accepted `transition_mode`, but did not consume profile-specific rate values from `transition_profiles`.

Layer 6O closes that gap by adding optional `transition_rates` support and validating that supplied rates are consumed only in candidate mode.

## What changed

- Adds optional `transition_rates` parameter to `simulate_half_inning()`
- Passes `transition_rates` into `advance_runners_realism_candidate(...)`
- Allows candidate mode to use supplied rates instead of hardcoded constants
- Preserves existing hardcoded candidate behavior when no rates are supplied
- Validates transition-rate values and rejects invalid rates
- Adds `scripts/audit_transition_profile_rate_integration.py`

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts

python scripts/audit_transition_profile_rate_integration.py
```

Result:

```json
{
  "diagnosis": "transition_profile_rates_integrated_safely",
  "default_equivalence_differences": 0,
  "current_mode_rate_ignored_differences": 0,
  "sac_fly_rate_consumed": true,
  "double_play_rate_consumed": true,
  "first_to_third_rate_consumed": true,
  "first_to_home_double_rate_consumed": true,
  "deterministic_rate_consumption_passed": true,
  "invalid_rates_rejected": true,
  "profile_registry_unchanged": true,
  "checks_passed": 9,
  "checks_failed": 0,
  "recommended_next_step": "layer_6p_profile_rate_calibration_backtest"
}
```

## Interpretation

The profile-rate integration is safe:

- default behavior remains zero-diff protected
- current mode ignores supplied transition rates
- candidate mode consumes supplied rates
- each profile-rate knob has deterministic proof coverage
- invalid rates are rejected
- the transition profile registry remains immutable

## Recommended next step

`Layer 6P — profile-rate calibration backtest`

## What this does not do

- Does not activate transition realism by default
- Does not make `low_advancement` production default
- Does not modify `_build_pa_model()`
- Does not modify Model Projections UI/routes
- Does not add edge detection
- Does not add sportsbook logic