### PR TITLE
Organize Daily Odds board and make recap on demand

### DIFF
--- a/frontend/src/pages/DailyOddsPage.jsx
+++ b/frontend/src/pages/DailyOddsPage.jsx
@@ -10,80 +10,62 @@ const s = {
   header: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' },
   eyebrow: { color: '#58a6ff', fontSize: 12, fontWeight: 900, textTransform: 'uppercase', letterSpacing: 1.2, marginBottom: 8 },
   title: { fontSize: 30, lineHeight: 1.05, fontWeight: 900, color: '#e6edf3', margin: 0 },
-  subtitle: { color: '#8b949e', fontSize: 14, marginTop: 8, maxWidth: 820 },
+  subtitle: { color: '#8b949e', fontSize: 14, marginTop: 8, maxWidth: 900 },
   controls: { display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' },
   input: { background: '#0d1117', border: '1px solid #30363d', color: '#e6edf3', borderRadius: 10, padding: '10px 12px', fontSize: 14, outline: 'none' },
-  select: { background: '#0d1117', border: '1px solid #30363d', color: '#e6edf3', borderRadius: 10, padding: '9px 11px', fontSize: 13, outline: 'none', maxWidth: '100%' },
   button: { background: '#238636', border: '1px solid #2ea043', color: '#fff', borderRadius: 10, padding: '10px 14px', fontSize: 13, fontWeight: 900, cursor: 'pointer' },
-  mutedButton: { background: '#21262d', border: '1px solid #30363d', color: '#58a6ff', borderRadius: 9, padding: '8px 11px', fontSize: 12, fontWeight: 900, cursor: 'pointer' },
+  mutedButton: { background: '#21262d', border: '1px solid #30363d', color: '#58a6ff', borderRadius: 9, padding: '9px 12px', fontSize: 12, fontWeight: 900, cursor: 'pointer' },
   stats: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(145px, 1fr))', gap: 10, marginTop: 18 },
   statCard: { background: 'rgba(13,17,23,0.72)', border: '1px solid #30363d', borderRadius: 12, padding: '13px 14px' },
   statLabel: { color: '#8b949e', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.9, fontWeight: 900 },
   statValue: { color: '#e6edf3', fontSize: 24, fontWeight: 900, marginTop: 5 },
-  toolbar: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', background: '#161b22', border: '1px solid #30363d', borderRadius: 12, padding: '12px 14px' },
-  toolbarText: { color: '#8b949e', fontSize: 13 },
-  grid: { display: 'grid', gap: 12 },
+  section: { background: '#161b22', border: '1px solid #30363d', borderRadius: 14, padding: 16 },
+  sectionHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 12 },
+  sectionTitle: { color: '#e6edf3', fontSize: 18, fontWeight: 900 },
+  modelSubtitle: { color: '#8b949e', fontSize: 12, marginTop: 4 },
+  boardGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))', gap: 12, alignItems: 'end' },
+  label: { color: '#8b949e', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.8, fontWeight: 900, marginBottom: 6 },
+  select: { width: '100%', background: '#0d1117', border: '1px solid #30363d', color: '#e6edf3', borderRadius: 10, padding: '10px 11px', fontSize: 13, outline: 'none' },
+  detailGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, marginTop: 14 },
+  panel: { border: '1px solid #30363d', borderRadius: 12, background: '#0d1117', padding: 12 },
+  panelTitle: { color: '#58a6ff', fontSize: 11, fontWeight: 900, textTransform: 'uppercase', letterSpacing: 0.7, marginBottom: 8 },
+  propName: { color: '#e6edf3', fontSize: 14, fontWeight: 900, lineHeight: 1.25 },
+  propDetail: { color: '#8b949e', fontSize: 12, marginTop: 5, lineHeight: 1.45 },
+  chip: { color: '#8b949e', border: '1px solid #30363d', background: '#0d1117', borderRadius: 999, padding: '4px 8px', fontSize: 11, fontWeight: 800 },
+  badge: matched => ({ display: 'inline-block', borderRadius: 999, padding: '5px 10px', fontSize: 11, fontWeight: 900, background: matched ? 'rgba(35,134,54,0.18)' : 'rgba(248,81,73,0.14)', border: matched ? '1px solid rgba(63,185,80,0.45)' : '1px solid rgba(248,81,73,0.45)', color: matched ? '#3fb950' : '#f85149' }),
   card: { background: '#161b22', border: '1px solid #30363d', borderRadius: 14, padding: 0, overflow: 'hidden' },
   cardTop: { display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) auto', gap: 14, alignItems: 'center', padding: '15px 16px', borderBottom: '1px solid #30363d', background: '#111820' },
   matchup: { color: '#e6edf3', fontSize: 18, fontWeight: 900 },
   metaRow: { display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 8 },
-  chip: { color: '#8b949e', border: '1px solid #30363d', background: '#0d1117', borderRadius: 999, padding: '4px 8px', fontSize: 11, fontWeight: 800 },
-  badge: matched => ({ display: 'inline-block', borderRadius: 999, padding: '5px 10px', fontSize: 11, fontWeight: 900, background: matched ? 'rgba(35,134,54,0.18)' : 'rgba(248,81,73,0.14)', border: matched ? '1px solid rgba(63,185,80,0.45)' : '1px solid rgba(248,81,73,0.45)', color: matched ? '#3fb950' : '#f85149' }),
-  lockBadge: { display: 'inline-block', borderRadius: 999, padding: '5px 10px', fontSize: 11, fontWeight: 900, background: 'rgba(210,153,34,0.18)', border: '1px solid rgba(210,153,34,0.55)', color: '#d29922' },
   markets: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, padding: '14px 16px' },
   market: { border: '1px solid #30363d', borderRadius: 12, padding: 12, background: '#0d1117' },
   marketTitle: { color: '#8b949e', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.9, fontWeight: 900, marginBottom: 9 },
   oddsLine: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, color: '#e6edf3', fontSize: 13, marginTop: 6, padding: '5px 0', borderTop: '1px solid rgba(48,54,61,0.55)' },
   price: { fontWeight: 900, color: '#e6edf3', whiteSpace: 'nowrap' },
-  props: { borderTop: '1px solid #30363d', padding: '15px 16px 16px', background: '#111820' },
-  propControls: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', alignItems: 'end', gap: 10, marginBottom: 12 },
-  controlLabel: { color: '#8b949e', fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.8, fontWeight: 900, marginBottom: 6 },
-  propsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(235px, 1fr))', gap: 9 },
-  propCard: { border: '1px solid #30363d', borderRadius: 10, padding: 10, background: '#0d1117' },
-  propMarket: { color: '#d29922', fontSize: 10, fontWeight: 900, textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 6 },
-  propName: { color: '#e6edf3', fontSize: 13, fontWeight: 900, lineHeight: 1.25 },
-  propDetail: { color: '#8b949e', fontSize: 12, marginTop: 4 },
+  tableWrap: { overflowX: 'auto', marginTop: 12, border: '1px solid #30363d', borderRadius: 12 },
   table: { width: '100%', borderCollapse: 'collapse', fontSize: 12 },
-  th: { textAlign: 'left', padding: '7px 8px', color: '#8b949e', borderBottom: '1px solid #30363d', fontWeight: 900, whiteSpace: 'nowrap' },
-  td: { padding: '7px 8px', color: '#c9d1d9', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
-  modelPanel: { borderTop: '1px solid #30363d', padding: '14px 16px 16px', background: '#0f1720' },
-  modelTitle: { color: '#e6edf3', fontSize: 14, fontWeight: 900 },
-  modelSubtitle: { color: '#8b949e', fontSize: 12, marginTop: 4 },
-  section: { background: '#161b22', border: '1px solid #30363d', borderRadius: 14, padding: 16 },
-  sectionHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 12 },
-  sectionTitle: { color: '#e6edf3', fontSize: 18, fontWeight: 900 },
-  recapCard: { border: '1px solid #30363d', borderRadius: 14, background: '#0d1117', overflow: 'hidden' },
-  recapSummary: { cursor: 'pointer', listStyle: 'none', padding: '14px 16px', background: '#111820', borderBottom: '1px solid #30363d' },
-  recapBody: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(245px, 1fr))', gap: 12, padding: 14 },
-  recapPanel: { border: '1px solid #30363d', borderRadius: 12, background: '#161b22', padding: 12 },
-  recapPanelTitle: { color: '#58a6ff', fontSize: 12, fontWeight: 900, textTransform: 'uppercase', letterSpacing: 0.8, marginBottom: 8 },
-  bulletList: { margin: 0, paddingLeft: 18, color: '#c9d1d9', fontSize: 12, lineHeight: 1.55 },
+  th: { textAlign: 'left', padding: '9px 10px', color: '#8b949e', borderBottom: '1px solid #30363d', fontWeight: 900, whiteSpace: 'nowrap', background: '#111820' },
+  td: { padding: '9px 10px', color: '#c9d1d9', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
+  recapGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 10 },
   error: { color: '#f85149', background: '#1f1116', border: '1px solid #3b2222', borderRadius: 12, padding: 14 },
-  loader: { color: '#8b949e', textAlign: 'center', padding: 40 },
-  empty: { color: '#8b949e', textAlign: 'center', padding: 34, border: '1px solid #30363d', borderRadius: 14, background: '#161b22' },
+  loader: { color: '#8b949e', textAlign: 'center', padding: 30 },
+  empty: { color: '#8b949e', textAlign: 'center', padding: 30, border: '1px solid #30363d', borderRadius: 14, background: '#161b22' },
 }
 
+function asArray(value) { return Array.isArray(value) ? value : [] }
 function normalizeTeamName(name) { return String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '').replace(/^the/, '') }
 function matchupKey(away, home) { return `${normalizeTeamName(away)}@${normalizeTeamName(home)}` }
 function keyFromMatchup(m) { return matchupKey(m.away_team_name || m.away_team || m.away_name, m.home_team_name || m.home_team || m.home_name) }
 function keyFromEvent(e) { return matchupKey(e?.away_team?.name || e?.away_team || '', e?.home_team?.name || e?.home_team || '') }
-function keyFromModelGame(game) { return matchupKey(game?.away_team || game?.away_team_name || game?.away || '', game?.home_team || game?.home_team_name || game?.home || '') }
-function american(v) { if (v == null || v === '') return 'N/A'; const n = Number(v); if (Number.isNaN(n)) return String(v); return n > 0 ? `+${n}` : `${n}` }
-function pct(v) { if (v == null || v === '') return 'N/A'; const n = Number(v); if (Number.isNaN(n)) return String(v); const pctValue = n <= 1 ? n * 100 : n; return `${Math.round(pctValue)}%` }
-function dec(v, digits = 3) { if (v == null || v === '') return 'N/A'; const n = Number(v); if (!Number.isFinite(n)) return String(v); return n.toFixed(digits) }
-function num(v, digits = 1) { if (v == null || v === '') return 'N/A'; const n = Number(v); if (!Number.isFinite(n)) return String(v); return n.toFixed(digits) }
-function label(v) { if (v == null || v === '') return 'N/A'; return String(v).replaceAll('_', ' ') }
-function formatTime(iso) { if (!iso) return 'N/A'; try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET' } catch { return 'N/A' } }
+function american(v) { if (v == null || v === '') return 'Unavailable'; const n = Number(v); if (Number.isNaN(n)) return String(v); return n > 0 ? `+${n}` : `${n}` }
+function pct(v) { if (v == null || v === '') return 'Unavailable'; const n = Number(v); if (Number.isNaN(n)) return String(v); const pctValue = n <= 1 ? n * 100 : n; return `${Math.round(pctValue)}%` }
 function cleanMarketName(name) { return String(name || 'Market').replaceAll('_', ' ') }
-function getMarkets(event) { return Array.isArray(event?.markets) ? event.markets : [] }
-function findMarket(event, keys) { const wanted = Array.isArray(keys) ? keys : [keys]; return getMarkets(event).find(m => wanted.includes(m.market_key) || wanted.includes(m.market_type) || wanted.includes(m.market_name)) }
-function selectionLabel(sel) { return `${sel?.name || sel?.description || 'N/A'}${sel?.line != null ? ` ${sel.line}` : ''}` }
-function asArray(value) { return Array.isArray(value) ? value : [] }
-function firstDefined(...values) { return values.find(v => v !== undefined && v !== null && v !== '') }
-function modelGamesFromPayload(payload) { if (Array.isArray(payload)) return payload; if (Array.isArray(payload?.games)) return payload.games; if (Array.isArray(payload?.models)) return payload.models; if (Array.isArray(payload?.game_models)) return payload.game_models; return [] }
-function propCandidatesFromPayload(payload) { if (Array.isArray(payload?.top_prop_model_candidates)) return payload.top_prop_model_candidates; if (Array.isArray(payload?.top_props)) return payload.top_props; if (Array.isArray(payload?.prop_candidates)) return payload.prop_candidates; if (Array.isArray(payload?.props)) return payload.props; return [] }
-
+function formatTime(iso) { if (!iso) return 'Time pending'; try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET' } catch { return 'Time pending' } }
 function marketKey(market) { return String(market?.market_key || market?.market_type || market?.market_name || '') }
+function getMarkets(event) { return Array.isArray(event?.markets) ? event.markets : [] }
+function findMarket(event, keys) { const wanted = Array.isArray(keys) ? keys : [keys]; return getMarkets(event).find(m => wanted.includes(marketKey(m)) || wanted.includes(m.market_name)) }
+function selectionLabel(sel) { return `${sel?.description || sel?.name || 'Selection'}${sel?.name && sel?.description ? ` ${sel.name}` : ''}${sel?.line != null ? ` ${sel.line}` : ''}` }
+function gameLabel(event) { return `${event?.away_team?.name || event?.away_team || 'Away'} @ ${event?.home_team?.name || event?.home_team || 'Home'}` }
 function propCategory(market) {
   const key = marketKey(market).toLowerCase()
   if (key.startsWith('batter_')) return 'Batter Props'
@@ -91,320 +73,95 @@ function propCategory(market) {
   if (['h2h', 'spreads', 'totals'].includes(key)) return 'Game Lines'
   return 'Other Props'
 }
-function propOptionLabel(market) { return cleanMarketName(market?.market_name || market?.market_key || market?.market_type) }
 function groupMarketsByCategory(markets) {
-  return markets.reduce((acc, market) => {
+  return asArray(markets).filter(m => asArray(m?.selections).length > 0).reduce((acc, market) => {
     const category = propCategory(market)
     if (!acc[category]) acc[category] = []
     acc[category].push(market)
     return acc
   }, {})
 }
-
-function getModelRoot(model) { return model?.models || model || {} }
-function getTeamProfile(game, side) { return game?.workspace?.[`${side}OffenseProfile`] || game?.teams?.[side] || {} }
-function getPitcherProfile(game, side) { return game?.workspace?.[`${side}PitcherProfile`] || {} }
-function getSimulation(game) { return game?.workspace?.bullpenAdjustedGameSimulation || {} }
-function getEnvironment(game, matchup) { return game?.workspace?.environmentProfile || matchup?.environment || {} }
-function getRunModel(game, side) { return asArray(game?.teams?.[side]?.models).find(m => String(m?.model_name || '').includes(side === 'away' ? 'Away Team Run/Win Projection' : 'Home Team Run/Win Projection')) || {} }
-function getTotalModel(game) { return [...asArray(game?.teams?.away?.models), ...asArray(game?.teams?.home?.models)].find(m => String(m?.model_name || '').includes('Game Total Projection')) || {} }
-function getPitcherMetric(profile, matchup, side, keys) {
-  const features = matchup?.[`${side}_pitcher_features`] || {}
-  const pools = [profile?.metadata, profile?.run_prevention, profile?.bat_missing, profile?.command_control, profile?.contact_management, features]
-  for (const key of keys) {
-    for (const pool of pools) {
-      if (pool && pool[key] !== undefined && pool[key] !== null && pool[key] !== '') return pool[key]
-    }
-  }
-  return null
-}
-function getOffenseMetric(profile, matchup, side, keys) {
-  const pools = [profile?.metadata, profile?.contact_skill, profile?.plate_discipline, profile?.power, profile?.run_creation, matchup?.[`${side}_offense_inputs`], matchup?.[`${side}_team_features`]]
-  for (const key of keys) {
-    for (const pool of pools) {
-      if (pool && pool[key] !== undefined && pool[key] !== null && pool[key] !== '') return pool[key]
-    }
-  }
-  return null
-}
-function getWeatherMetric(environment, matchup, keys) {
-  const weather = environment?.weather || matchup?.weather || {}
-  const run = environment?.run_environment || {}
-  const metadata = environment?.metadata || {}
-  for (const key of keys) {
-    for (const pool of [weather, run, metadata, environment, matchup?.weather]) {
-      if (pool && pool[key] !== undefined && pool[key] !== null && pool[key] !== '') return pool[key]
-    }
-  }
-  return null
-}
-function strongestGameCandidate(model) {
-  const root = getModelRoot(model)
-  return [root.moneyline, root.spread || root.run_line, root.total].filter(Boolean).sort((a, b) => Math.abs(Number(b?.edge) || 0) - Math.abs(Number(a?.edge) || 0))[0] || null
-}
-function candidateScore(candidate) {
-  const edge = Math.abs(Number(candidate?.edge) || 0)
-  const confidence = Number(candidate?.confidence) || Number(candidate?.model_probability) || 0
-  const score = Number(candidate?.score) || 0
-  return edge * 10 + confidence + score
-}
-function findLockKey(rows, topPropCandidates) {
-  const rankedProps = asArray(topPropCandidates).filter(c => c?.match_key).sort((a, b) => candidateScore(b) - candidateScore(a))
-  if (rankedProps[0]?.match_key) return rankedProps[0].match_key
-  const rankedGames = rows.map(row => ({ key: row.key, candidate: strongestGameCandidate(row.model) })).filter(row => row.candidate).sort((a, b) => candidateScore(b.candidate) - candidateScore(a.candidate))
-  return rankedGames[0]?.key || null
-}
-
-// Mirrors backend scoring.py PARK_FACTORS — keyed by normalized venue name
-const VENUE_PARK_FACTORS = {
-  'angel stadium': 0.97, 'angel stadium of anaheim': 0.97,
-  'american family field': 1.01, 'miller park': 1.01,
-  'busch stadium': 0.99,
-  'camden yards': 0.99, 'oriole park at camden yards': 0.99,
-  'chase field': 0.98,
-  'citi field': 0.98,
-  'citizens bank park': 1.04,
-  'comerica park': 0.95,
-  'coors field': 1.30,
-  'daikin park': 1.01, 'minute maid park': 1.01,
-  'dodger stadium': 0.96,
-  'fenway park': 1.05,
-  'globe life field': 1.03,
-  'great american ball park': 1.15,
-  'guaranteed rate field': 1.01, 'rate field': 1.01,
-  'kauffman stadium': 0.92,
-  'loandepot park': 0.94, 'marlins park': 0.94,
-  'nationals park': 0.98,
-  'oracle park': 0.95,
-  'petco park': 0.90,
-  'pnc park': 0.97,
-  'progressive field': 0.97,
-  'rogers centre': 1.03,
-  't mobile park': 0.88,
-  'target field': 0.97,
-  'tropicana field': 0.88,
-  'truist park': 0.99,
-  'wrigley field': 0.99,
-  'yankee stadium': 1.10,
-  'sutter health park': 0.93, 'oakland coliseum': 0.93, 'ringcentral coliseum': 0.93,
-}
-function normalizeVenueName(name) {
-  if (!name) return ''
-  return String(name).toLowerCase().replace(/&/g, 'and').replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()
-}
-function getParkFactor(venueName) {
-  const key = normalizeVenueName(venueName)
-  if (!key) return null
-  return VENUE_PARK_FACTORS[key] ?? null
-}
-
-function buildPitcherBullet(name, profile, matchup, side) {
-  const kPct = getPitcherMetric(profile, matchup, side, ['k_pct', 'strikeout_pct', 'k_rate'])
-  const bbPct = getPitcherMetric(profile, matchup, side, ['bb_pct', 'walk_pct', 'bb_rate'])
-  const xwoba = getPitcherMetric(profile, matchup, side, ['xwoba', 'xwoba_allowed'])
-  const hardHit = getPitcherMetric(profile, matchup, side, ['hard_hit_pct', 'hardhit_pct'])
-  const velo = getPitcherMetric(profile, matchup, side, ['avg_velocity'])
-  const parts = [
-    kPct != null ? `K% ${pct(kPct)}` : null,
-    bbPct != null ? `BB% ${pct(bbPct)}` : null,
-    xwoba != null ? `xwOBA ${dec(xwoba, 3)}` : null,
-    hardHit != null ? `Hard Hit ${pct(hardHit)}` : null,
-    velo != null ? `Velo ${num(velo)}` : null,
-  ].filter(Boolean)
-  return `${name}: ${parts.length > 0 ? parts.join(' | ') : 'No Statcast data available'}`
-}
+function modelGamesFromPayload(payload) { if (Array.isArray(payload?.games)) return payload.games; if (Array.isArray(payload?.models)) return payload.models; return [] }
 
 function MarketBox({ label, market }) {
-  const selections = market?.selections || []
-  return <div style={s.market}><div style={s.marketTitle}>{label}</div>{selections.length === 0 && <div style={s.oddsLine}><span>Unavailable</span><strong style={s.price}>N/A</strong></div>}{selections.slice(0, 3).map((sel, idx) => <div key={`${label}-${idx}`} style={s.oddsLine}><span>{selectionLabel(sel)}</span><strong style={s.price}>{american(sel.price)}</strong></div>)}</div>
+  const selections = asArray(market?.selections).slice(0, 3)
+  return <div style={s.market}><div style={s.marketTitle}>{label}</div>{selections.length === 0 ? <div style={s.oddsLine}><span>Unavailable</span><strong style={s.price}>Unavailable</strong></div> : selections.map((sel, idx) => <div key={`${label}-${idx}`} style={s.oddsLine}><span>{selectionLabel(sel)}</span><strong style={s.price}>{american(sel.price)}</strong></div>)}</div>
 }
 
-function PropsDropdownBoard({ eventId }) {
-  const [open, setOpen] = useState(false)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
-  const [data, setData] = useState(null)
+function DailyRecapPanel({ unifiedPayload, loading, onLoad }) {
+  const recap = unifiedPayload?.daily_recap
+  const hitters = asArray(unifiedPayload?.top_hitter_angles).slice(0, 3)
+  const pitchers = asArray(unifiedPayload?.top_pitcher_angles).slice(0, 3)
+  const arsenal = asArray(unifiedPayload?.batter_vs_arsenal_edges).slice(0, 3)
+  return <section style={s.section}>
+    <div style={s.sectionHeader}>
+      <div><div style={s.sectionTitle}>Daily Recap</div><div style={s.modelSubtitle}>Loads the heavier My Dashboard, AI Data Assistant, Model Projection, and Batter vs Arsenal context only when requested.</div></div>
+      <button type="button" style={s.mutedButton} onClick={onLoad} disabled={loading || Boolean(unifiedPayload)}>{loading ? 'Loading Recap...' : unifiedPayload ? 'Recap Loaded' : 'Load Model Recap'}</button>
+    </div>
+    {!unifiedPayload && <div style={s.empty}>Fast odds are loaded. Click “Load Model Recap” when you want the heavier model intelligence on this page.</div>}
+    {recap && <div style={s.recapGrid}>
+      <SummaryCard title="Best Side" item={recap.best_side} primary={recap.best_side?.pick} />
+      <SummaryCard title="Best Total" item={recap.best_total} primary={recap.best_total?.entity_name || recap.best_total?.category} />
+      <SummaryCard title="Best Pitcher" item={recap.best_pitcher} primary={recap.best_pitcher?.entity_name} />
+      <SummaryCard title="Best Hitter" item={recap.best_hitter} primary={recap.best_hitter?.entity_name} />
+    </div>}
+    {unifiedPayload && <div style={{ ...s.detailGrid, marginTop: 12 }}>
+      <CompactList title="Top Hitter Angles" rows={hitters} />
+      <CompactList title="Top Pitcher Angles" rows={pitchers} />
+      <CompactList title="Batter vs Arsenal" rows={arsenal} />
+    </div>}
+  </section>
+}
+
+function SummaryCard({ title, item, primary }) {
+  return <div style={s.panel}><div style={s.panelTitle}>{title}</div><div style={s.propName}>{primary || 'No signal loaded'}</div>{item?.primary_reason && <div style={s.propDetail}>{item.primary_reason}</div>}<div style={s.propDetail}>Score {item?.score ?? 'Unavailable'} · Confidence {typeof item?.confidence === 'number' ? pct(item.confidence) : item?.confidence || 'Unavailable'}</div></div>
+}
+
+function CompactList({ title, rows }) {
+  return <div style={s.panel}><div style={s.panelTitle}>{title}</div>{rows.length === 0 ? <div style={s.propDetail}>No rows returned.</div> : rows.map((row, idx) => <div key={`${title}-${idx}`} style={{ borderTop: idx ? '1px solid #30363d' : 'none', paddingTop: idx ? 8 : 0, marginTop: idx ? 8 : 0 }}><div style={s.propName}>{row.entity_name || row.pick || row.player_name || 'Signal'}</div><div style={s.propDetail}>{row.primary_reason || asArray(row.reasoning)[0] || row.source || 'Model signal'}</div></div>)}</div>
+}
+
+function OddsBoard({ events, selectedEventId, setSelectedEventId, propsData, propsLoading, propsError }) {
+  const selectedEvent = events.find(event => String(event.event_id) === String(selectedEventId)) || events[0]
+  const gameMarkets = getMarkets(selectedEvent)
+  const propMarkets = asArray(propsData?.markets).length ? propsData.markets : asArray(propsData?.event?.markets)
+  const allMarkets = [...gameMarkets, ...propMarkets]
+  const grouped = useMemo(() => groupMarketsByCategory(allMarkets), [allMarkets])
+  const categories = Object.keys(grouped)
   const [category, setCategory] = useState('')
   const [marketIndex, setMarketIndex] = useState('0')
   const [selectionIndex, setSelectionIndex] = useState('0')
-
-  function loadProps() {
-    if (!eventId || loading) return
-    setLoading(true)
-    setError(null)
-    fetch(`${API}/odds/draftkings/event/${eventId}/props`)
-      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
-      .then(json => { setData(json); setLoading(false) })
-      .catch(err => { setError(String(err?.message || err)); setLoading(false) })
-  }
-
-  function toggle() {
-    const next = !open
-    setOpen(next)
-    if (next && !data) loadProps()
-  }
-
-  const rawMarkets = useMemo(() => {
-    const direct = asArray(data?.markets)
-    const nested = asArray(data?.event?.markets)
-    const markets = direct.length ? direct : nested
-    return markets.filter(m => asArray(m?.selections).length > 0)
-  }, [data])
-
-  const grouped = useMemo(() => groupMarketsByCategory(rawMarkets), [rawMarkets])
-  const categories = useMemo(() => Object.keys(grouped), [grouped])
-  const activeCategory = category || categories[0] || ''
+  const activeCategory = category && categories.includes(category) ? category : categories[0] || ''
   const activeMarkets = grouped[activeCategory] || []
   const activeMarket = activeMarkets[Number(marketIndex)] || activeMarkets[0] || null
   const selections = asArray(activeMarket?.selections)
   const activeSelection = selections[Number(selectionIndex)] || selections[0] || null
 
-  useEffect(() => {
-    if (!categories.includes(category)) setCategory(categories[0] || '')
-  }, [categories.join('|')])
-
-  useEffect(() => { setMarketIndex('0'); setSelectionIndex('0') }, [activeCategory])
+  useEffect(() => { if (!category && categories[0]) setCategory(categories[0]) }, [categories.join('|')])
+  useEffect(() => { setMarketIndex('0'); setSelectionIndex('0') }, [activeCategory, selectedEventId])
   useEffect(() => { setSelectionIndex('0') }, [marketIndex])
 
-  return <div style={s.props}>
-    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap', marginBottom: open ? 12 : 0 }}>
-      <div><div style={s.modelTitle}>DraftKings Props</div><div style={s.modelSubtitle}>Game → type of prop → dropdown of every available prop in that category.</div></div>
-      <button type="button" style={s.mutedButton} onClick={toggle}>{open ? 'Hide Prop Board' : 'Load Prop Board'}</button>
-    </div>
+  if (!selectedEvent) return <section style={s.section}><div style={s.empty}>No DraftKings events returned.</div></section>
 
-    {open && loading && <div style={s.loader}>Loading DraftKings props...</div>}
-    {open && error && <div style={s.error}>Props error: {error}</div>}
-    {open && !loading && !error && data && rawMarkets.length === 0 && <div style={s.empty}>No DraftKings prop markets returned for this game.</div>}
-
-    {open && !loading && !error && rawMarkets.length > 0 && <>
-      <div style={s.propControls}>
-        <label><div style={s.controlLabel}>Type of Prop</div><select value={activeCategory} onChange={e => setCategory(e.target.value)} style={s.select}>{categories.map(cat => <option key={cat} value={cat}>{cat} ({grouped[cat].length})</option>)}</select></label>
-        <label><div style={s.controlLabel}>Prop Market</div><select value={marketIndex} onChange={e => setMarketIndex(e.target.value)} style={s.select}>{activeMarkets.map((market, idx) => <option key={`${marketKey(market)}-${idx}`} value={String(idx)}>{propOptionLabel(market)} ({asArray(market.selections).length})</option>)}</select></label>
-        <label><div style={s.controlLabel}>Available Props</div><select value={selectionIndex} onChange={e => setSelectionIndex(e.target.value)} style={s.select}>{selections.map((sel, idx) => <option key={`${sel.description || sel.name}-${sel.line}-${sel.price}-${idx}`} value={String(idx)}>{sel.description || sel.name || 'Selection'} · {sel.name || ''}{sel.line != null ? ` ${sel.line}` : ''} · {american(sel.price)}</option>)}</select></label>
-      </div>
-
-      {activeSelection && <div style={{ ...s.propCard, marginBottom: 12, borderColor: '#58a6ff' }}>
-        <div style={s.propMarket}>{activeCategory} · {propOptionLabel(activeMarket)}</div>
-        <div style={s.propName}>{activeSelection.description || activeSelection.name || 'N/A'}</div>
-        <div style={s.propDetail}>{selectionLabel(activeSelection)} · <strong style={{ color: '#e6edf3' }}>{american(activeSelection.price)}</strong> · Implied {pct(activeSelection?.odds?.implied_probability)}</div>
-      </div>}
-
-      <div style={{ overflowX: 'auto' }}>
-        <table style={s.table}>
-          <thead><tr><th style={s.th}>Player / Side</th><th style={s.th}>Selection</th><th style={s.th}>Line</th><th style={s.th}>Price</th><th style={s.th}>Implied</th><th style={s.th}>Market</th></tr></thead>
-          <tbody>{selections.map((sel, idx) => <tr key={`${sel.description || sel.name}-${sel.line}-${sel.price}-${idx}`}><td style={s.td}>{sel.description || sel.name || 'N/A'}</td><td style={s.td}>{sel.name || 'N/A'}</td><td style={s.td}>{sel.line ?? 'N/A'}</td><td style={{ ...s.td, fontWeight: 900, color: '#e6edf3' }}>{american(sel.price)}</td><td style={s.td}>{pct(sel?.odds?.implied_probability)}</td><td style={s.td}>{propOptionLabel(activeMarket)}</td></tr>)}</tbody>
-        </table>
-      </div>
-    </>}
-  </div>
-}
-
-function ModelSummary({ model }) {
-  if (!model) return null
-  const root = getModelRoot(model)
-  const moneyline = root.moneyline || {}
-  const spread = root.spread || root.run_line || {}
-  const total = root.total || {}
-  const cards = [
-    ['Moneyline', moneyline],
-    ['Run Line', spread],
-    ['Total', total],
-  ].filter(([, m]) => m && Object.keys(m).length)
-  if (!cards.length) return null
-  return <div style={s.modelPanel}><div style={s.modelTitle}>Model Snapshot</div><div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: 10, marginTop: 10 }}>{cards.map(([title, m]) => <div key={title} style={s.market}><div style={s.marketTitle}>{title}</div><div style={s.propName}>{m.pick || 'No pick'}</div><div style={s.propDetail}>Model {pct(m.model_probability)} · Market {pct(m.market_implied_probability)} · Edge {m.edge ?? 'N/A'}</div></div>)}</div></div>
-}
-
-function TopPropModelCandidates({ candidates }) {
-  const rows = asArray(candidates).slice(0, 20)
-  return <section style={s.section}><div style={s.sectionHeader}><div><div style={s.sectionTitle}>Top Prop Model Candidates</div><div style={s.modelSubtitle}>Ranked output from /daily-odds/models. Actual DraftKings prop menus are inside each game card.</div></div><span style={s.chip}>{rows.length} shown</span></div>{rows.length === 0 ? <div style={s.empty}>No top prop model candidates returned.</div> : <div style={s.propsGrid}>{rows.map((candidate, idx) => <div key={`${candidate.player_name || candidate.pick}-${idx}`} style={s.propCard}><div style={s.propMarket}>{cleanMarketName(candidate.market || candidate.market_name)}</div><div style={s.propName}>{candidate.player_name || candidate.pick || 'Candidate'}</div><div style={s.propDetail}>{candidate.pick || candidate.selection || 'N/A'} · Edge {candidate.edge ?? 'N/A'} · Confidence {pct(candidate.confidence)}</div></div>)}</div>}</section>
-}
-
-function DailyRecap({ rows, topPropCandidates }) {
-  if (!rows.length) return null
-  const lockKey = findLockKey(rows, topPropCandidates)
   return <section style={s.section}>
     <div style={s.sectionHeader}>
-      <div>
-        <div style={s.sectionTitle}>Daily Recap</div>
-        <div style={s.modelSubtitle}>Executive readout built from the loaded matchup analyzer, model projection, odds, and weather payloads.</div>
-      </div>
-      <span style={s.chip}>{rows.length} games</span>
+      <div><div style={s.sectionTitle}>Organized Odds Board</div><div style={s.modelSubtitle}>Game → Odds Category → Market → Player / selection. Props load only for the selected game.</div></div>
+      <span style={s.chip}>{propsLoading ? 'Loading selected game props...' : `${allMarkets.length} markets`}</span>
     </div>
-    <div style={s.grid}>{rows.map((row, idx) => <DailyRecapCard key={`${row.key}-${idx}`} row={row} isLock={row.key === lockKey} />)}</div>
+    <div style={s.boardGrid}>
+      <label><div style={s.label}>Game</div><select style={s.select} value={selectedEvent?.event_id || ''} onChange={e => setSelectedEventId(e.target.value)}>{events.map(event => <option key={event.event_id} value={event.event_id}>{gameLabel(event)}</option>)}</select></label>
+      <label><div style={s.label}>Odds Category</div><select style={s.select} value={activeCategory} onChange={e => setCategory(e.target.value)}>{categories.map(cat => <option key={cat} value={cat}>{cat} ({grouped[cat].length})</option>)}</select></label>
+      <label><div style={s.label}>Market</div><select style={s.select} value={marketIndex} onChange={e => setMarketIndex(e.target.value)}>{activeMarkets.map((market, idx) => <option key={`${marketKey(market)}-${idx}`} value={String(idx)}>{cleanMarketName(market.market_name || marketKey(market))} ({asArray(market.selections).length})</option>)}</select></label>
+      <label><div style={s.label}>Player / Selection</div><select style={s.select} value={selectionIndex} onChange={e => setSelectionIndex(e.target.value)}>{selections.map((sel, idx) => <option key={`${sel.description || sel.name}-${sel.line}-${sel.price}-${idx}`} value={String(idx)}>{selectionLabel(sel)} · {american(sel.price)}</option>)}</select></label>
+    </div>
+    {propsError && <div style={{ ...s.error, marginTop: 12 }}>Selected game props unavailable: {propsError}</div>}
+    {activeSelection && <div style={s.detailGrid}>
+      <div style={s.panel}><div style={s.panelTitle}>Selected Bet</div><div style={s.propName}>{activeSelection.description || activeSelection.name || 'Selection'}</div><div style={s.propDetail}>{selectionLabel(activeSelection)}</div></div>
+      <div style={s.panel}><div style={s.panelTitle}>Price</div><div style={s.propName}>{american(activeSelection.price)}</div><div style={s.propDetail}>Implied {pct(activeSelection?.odds?.implied_probability)}</div></div>
+      <div style={s.panel}><div style={s.panelTitle}>Market</div><div style={s.propName}>{cleanMarketName(activeMarket?.market_name || marketKey(activeMarket))}</div><div style={s.propDetail}>{activeCategory}</div></div>
+    </div>}
+    {selections.length > 0 && <div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>Player / Side</th><th style={s.th}>Selection</th><th style={s.th}>Line</th><th style={s.th}>Price</th><th style={s.th}>Implied</th><th style={s.th}>Market</th></tr></thead><tbody>{selections.map((sel, idx) => <tr key={`${sel.description || sel.name}-${sel.line}-${sel.price}-${idx}`}><td style={s.td}>{sel.description || sel.name || 'Selection'}</td><td style={s.td}>{sel.name || 'Selection'}</td><td style={s.td}>{sel.line ?? 'Unavailable'}</td><td style={{ ...s.td, fontWeight: 900, color: '#e6edf3' }}>{american(sel.price)}</td><td style={s.td}>{pct(sel?.odds?.implied_probability)}</td><td style={s.td}>{cleanMarketName(activeMarket?.market_name || marketKey(activeMarket))}</td></tr>)}</tbody></table></div>}
   </section>
-}
-
-function DailyRecapCard({ row, isLock }) {
-  const { event, matchup, model } = row
-  const away = event?.away_team?.name || event?.away_team || matchup?.away_team_name || model?.away_team || 'Away'
-  const home = event?.home_team?.name || event?.home_team || matchup?.home_team_name || model?.home_team || 'Home'
-  const root = getModelRoot(model)
-  const awayPitcher = matchup?.away_pitcher_name || model?.away_pitcher?.name || model?.teams?.away?.pitcher_name || 'Away Pitcher'
-  const homePitcher = matchup?.home_pitcher_name || model?.home_pitcher?.name || model?.teams?.home?.pitcher_name || 'Home Pitcher'
-  const awayPitcherProfile = getPitcherProfile(model, 'away')
-  const homePitcherProfile = getPitcherProfile(model, 'home')
-  const awayOffense = getTeamProfile(model, 'away')
-  const homeOffense = getTeamProfile(model, 'home')
-  const environment = getEnvironment(model, matchup)
-  const sim = getSimulation(model)
-  const awayRunModel = getRunModel(model, 'away')
-  const homeRunModel = getRunModel(model, 'home')
-  const totalModel = getTotalModel(model)
-  const strongest = strongestGameCandidate(model)
-  const awayWin = firstDefined(sim.away_win_probability, awayRunModel?.inputs?.win_probability, matchup?.away_win_prob, root.moneyline?.model_probability)
-  const homeWin = firstDefined(sim.home_win_probability, homeRunModel?.inputs?.win_probability, matchup?.home_win_prob)
-  const winLeader = Number(awayWin) > Number(homeWin) ? `${away} ${pct(awayWin)}` : Number(homeWin) > Number(awayWin) ? `${home} ${pct(homeWin)}` : 'N/A'
-  const totalRuns = firstDefined(sim.total_expected_runs, totalModel?.inputs?.total_expected_runs, totalModel?.score)
-  const runLean = totalRuns ? `Projected total ${num(totalRuns)}` : label(root.total?.pick)
-  const confidence = firstDefined(strongest?.confidence, root.moneyline?.confidence, root.total?.confidence, awayRunModel?.data_confidence, homeRunModel?.data_confidence)
-
-  const pitcherBullets = [
-    buildPitcherBullet(awayPitcher, awayPitcherProfile, matchup, 'away'),
-    buildPitcherBullet(homePitcher, homePitcherProfile, matchup, 'home'),
-  ]
-
-  const hitterBullets = [
-    `${away}: wOBA/xwOBA ${dec(getOffenseMetric(awayOffense, matchup, 'away', ['woba', 'xwoba']), 3)} | Hard Hit ${pct(getOffenseMetric(awayOffense, matchup, 'away', ['hard_hit_pct', 'hardhit_pct']))} | Barrel ${pct(getOffenseMetric(awayOffense, matchup, 'away', ['barrel_pct']))} | K% ${pct(getOffenseMetric(awayOffense, matchup, 'away', ['k_pct', 'strikeout_pct', 'k_rate']))} | BB% ${pct(getOffenseMetric(awayOffense, matchup, 'away', ['bb_pct', 'walk_pct', 'bb_rate']))}`,
-    `${home}: wOBA/xwOBA ${dec(getOffenseMetric(homeOffense, matchup, 'home', ['woba', 'xwoba']), 3)} | Hard Hit ${pct(getOffenseMetric(homeOffense, matchup, 'home', ['hard_hit_pct', 'hardhit_pct']))} | Barrel ${pct(getOffenseMetric(homeOffense, matchup, 'home', ['barrel_pct']))} | K% ${pct(getOffenseMetric(homeOffense, matchup, 'home', ['k_pct', 'strikeout_pct', 'k_rate']))} | BB% ${pct(getOffenseMetric(homeOffense, matchup, 'home', ['bb_pct', 'walk_pct', 'bb_rate']))}`,
-  ]
-
-  const environmentBullets = [
-    `Temp: ${firstDefined(getWeatherMetric(environment, matchup, ['temperature_f', 'temp_f', 'temp']), 'N/A')}${firstDefined(getWeatherMetric(environment, matchup, ['temperature_f', 'temp_f', 'temp']), null) !== null ? '°F' : ''}`,
-    `Wind Speed: ${firstDefined(getWeatherMetric(environment, matchup, ['wind_speed_mph']), label(getWeatherMetric(environment, matchup, ['wind'])))}`,
-    `Wind Direction: ${label(getWeatherMetric(environment, matchup, ['wind_direction', 'wind_run_impact']))}`,
-    `Humidity: ${firstDefined(pct(getWeatherMetric(environment, matchup, ['humidity'])), 'N/A')}`,
-    `Park Factor: ${dec(firstDefined(getWeatherMetric(environment, matchup, ['park_factor', 'run_factor', 'run_scoring_index']), matchup?.park_factor, getParkFactor(matchup?.venue)), 2)} | Weather Risk: ${label(firstDefined(getWeatherMetric(environment, matchup, ['weather_risk', 'scoring_environment_label']), getWeatherMetric(environment, matchup, ['weather_run_impact'])))}`,
-  ]
-
-  const consensusBullets = [
-    `Best projected edge: ${label(strongest?.pick || strongest?.selection || strongest?.market_name || strongest?.market)}`,
-    `Win probability leader: ${winLeader}`,
-    `Run projection lean: ${runLean}`,
-    `Confidence rating: ${typeof confidence === 'number' ? pct(confidence) : label(confidence)}`,
-    `LOCK OF THE DAY: ${isLock ? 'GUARANTEED LOCK OF THE DAY' : 'N/A'}`,
-  ]
-
-  return <details style={s.recapCard} open={isLock || false}>
-    <summary style={s.recapSummary}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
-        <div>
-          <div style={s.matchup}>{away} @ {home}</div>
-          <div style={s.metaRow}><span style={s.chip}>Time: {formatTime(matchup?.game_time || event?.start_time || event?.commence_time)}</span><span style={s.chip}>Game PK: {matchup?.game_pk || 'N/A'}</span></div>
-        </div>
-        {isLock && <span style={s.lockBadge}>GUARANTEED LOCK OF THE DAY</span>}
-      </div>
-    </summary>
-    <div style={s.recapBody}>
-      <RecapPanel title="Pitchers" bullets={pitcherBullets} />
-      <RecapPanel title="Hitters" bullets={hitterBullets} />
-      <RecapPanel title="Environment" bullets={environmentBullets} />
-      <RecapPanel title="Consensus" bullets={consensusBullets} />
-    </div>
-  </details>
-}
-
-function RecapPanel({ title, bullets }) {
-  return <div style={s.recapPanel}><div style={s.recapPanelTitle}>{title}</div><ul style={s.bulletList}>{bullets.map((bullet, idx) => <li key={`${title}-${idx}`}>{bullet || 'N/A'}</li>)}</ul></div>
 }
 
 export default function DailyOddsPage() {
@@ -413,7 +170,13 @@ export default function DailyOddsPage() {
   const [matchups, setMatchups] = useState([])
   const [events, setEvents] = useState([])
   const [modelPayload, setModelPayload] = useState(null)
+  const [unifiedPayload, setUnifiedPayload] = useState(null)
+  const [selectedEventId, setSelectedEventId] = useState('')
+  const [propsData, setPropsData] = useState(null)
+  const [propsLoading, setPropsLoading] = useState(false)
+  const [propsError, setPropsError] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [unifiedLoading, setUnifiedLoading] = useState(false)
   const [error, setError] = useState(null)
   const [modelError, setModelError] = useState(null)
   const [lastRefreshed, setLastRefreshed] = useState(null)
@@ -422,68 +185,87 @@ export default function DailyOddsPage() {
     setLoading(true)
     setError(null)
     setModelError(null)
+    setUnifiedPayload(null)
     Promise.all([
       fetch(`${API}/matchups?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/matchups failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
       fetch(`${API}/odds/draftkings/events?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/odds/draftkings/events failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
       fetch(`${API}/daily-odds/models?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/daily-odds/models failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }).catch(err => ({ __modelError: String(err?.message || err) })),
     ]).then(([matchupData, oddsData, modelsData]) => {
+      const nextEvents = Array.isArray(oddsData?.events) ? oddsData.events : []
       setMatchups(Array.isArray(matchupData) ? matchupData : [])
-      setEvents(Array.isArray(oddsData?.events) ? oddsData.events : [])
+      setEvents(nextEvents)
+      setSelectedEventId(nextEvents[0]?.event_id || '')
       if (modelsData?.__modelError) { setModelPayload(null); setModelError(modelsData.__modelError) } else { setModelPayload(modelsData) }
       setLastRefreshed(new Date())
       setLoading(false)
     }).catch(err => { setError(String(err?.message || err)); setLoading(false) })
   }
 
+  function loadUnified() {
+    setUnifiedLoading(true)
+    fetch(`${API}/daily-odds/models?date=${date}&include_unified=true`)
+      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+      .then(json => { setUnifiedPayload(json); setUnifiedLoading(false) })
+      .catch(err => { setModelError(String(err?.message || err)); setUnifiedLoading(false) })
+  }
+
   useEffect(() => { load() }, [date])
 
+  useEffect(() => {
+    if (!selectedEventId) { setPropsData(null); return }
+    setPropsLoading(true)
+    setPropsError(null)
+    fetch(`${API}/odds/draftkings/event/${selectedEventId}/props`)
+      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+      .then(json => { setPropsData(json); setPropsLoading(false) })
+      .catch(err => { setPropsData(null); setPropsError(String(err?.message || err)); setPropsLoading(false) })
+  }, [selectedEventId])
+
   const matchupByKey = useMemo(() => { const map = new Map(); matchups.forEach(m => { const key = keyFromMatchup(m); if (key !== '@') map.set(key, m) }); return map }, [matchups])
-  const modelByKey = useMemo(() => { const map = new Map(); modelGamesFromPayload(modelPayload).forEach(game => { const key = keyFromModelGame(game); if (key !== '@') map.set(key, game) }); return map }, [modelPayload])
-  const topPropCandidates = useMemo(() => propCandidatesFromPayload(modelPayload), [modelPayload])
-  const rows = useMemo(() => events.map(event => { const key = keyFromEvent(event); const matchup = matchupByKey.get(key); const model = modelByKey.get(key); return { event, matchup, model, matched: Boolean(matchup), key } }), [events, matchupByKey, modelByKey])
+  const modelByKey = useMemo(() => { const map = new Map(); modelGamesFromPayload(modelPayload).forEach(game => { const key = matchupKey(game?.away_team || game?.away_team_name || game?.away || '', game?.home_team || game?.home_team_name || game?.home || ''); if (key !== '@') map.set(key, game) }); return map }, [modelPayload])
+  const rows = useMemo(() => events.map(event => { const key = keyFromEvent(event); return { event, matchup: matchupByKey.get(key), model: modelByKey.get(key), matched: Boolean(matchupByKey.get(key)), key } }), [events, matchupByKey, modelByKey])
   const matchedCount = rows.filter(r => r.matched).length
-  const modelCount = modelGamesFromPayload(modelPayload).length
+  const selectedRow = rows.find(row => String(row.event?.event_id) === String(selectedEventId))
 
   return <div style={s.page}>
     <section style={s.hero}>
       <div style={s.header}>
-        <div><div style={s.eyebrow}>DraftKings board</div><h1 style={s.title}>Daily Odds</h1><div style={s.subtitle}>DraftKings odds organized by game, then prop type, then every available prop in that category. Open a game card and load the prop board.</div></div>
+        <div><div style={s.eyebrow}>DraftKings board</div><h1 style={s.title}>Daily Odds</h1><div style={s.subtitle}>Odds are organized by game, category, market, and player. The page loads fast first; heavier model recap data is pulled only when requested.</div></div>
         <div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={s.button} onClick={load} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh Odds'}</button></div>
       </div>
       <div style={s.stats}>
         <div style={s.statCard}><div style={s.statLabel}>MLB Games</div><div style={s.statValue}>{matchups.length}</div></div>
         <div style={s.statCard}><div style={s.statLabel}>DK Events</div><div style={s.statValue}>{events.length}</div></div>
         <div style={s.statCard}><div style={s.statLabel}>Matched</div><div style={s.statValue}>{matchedCount}</div></div>
-        <div style={s.statCard}><div style={s.statLabel}>Model Games</div><div style={s.statValue}>{modelCount}</div></div>
-        <div style={s.statCard}><div style={s.statLabel}>Top Props</div><div style={s.statValue}>{topPropCandidates.length}</div></div>
-        <div style={s.statCard}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: 15 }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'N/A'}</div></div>
+        <div style={s.statCard}><div style={s.statLabel}>Model Rows</div><div style={s.statValue}>{modelGamesFromPayload(modelPayload).length}</div></div>
+        <div style={s.statCard}><div style={s.statLabel}>Unified Recap</div><div style={{ ...s.statValue, fontSize: 15 }}>{unifiedPayload ? 'Loaded' : 'On demand'}</div></div>
+        <div style={s.statCard}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: 15 }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Not loaded'}</div></div>
       </div>
     </section>
 
-    <div style={s.toolbar}><div style={s.toolbarText}>{rows.length} DraftKings games loaded for {date}</div><div style={s.toolbarText}>Game → Type of Prop → Prop Market → Available Props</div></div>
     {error && <div style={s.error}>{error}</div>}
     {modelError && <div style={s.error}>Model panel error: {modelError}</div>}
     {loading && <div style={s.loader}>Loading daily odds...</div>}
-    {!loading && !error && rows.length === 0 && <div style={s.empty}>No DraftKings events returned for {date}. Confirm PR #130 is deployed, ODDS_API_KEY is valid, and the provider has events for this slate.</div>}
+    {!loading && !error && events.length === 0 && <div style={s.empty}>No DraftKings events returned for {date}. Internal model rows may still exist, but no sportsbook event board can be built without events.</div>}
 
-    {!loading && !error && <TopPropModelCandidates candidates={topPropCandidates} />}
-    {!loading && !error && <DailyRecap rows={rows} topPropCandidates={topPropCandidates} />}
+    {!loading && !error && events.length > 0 && <OddsBoard events={events} selectedEventId={selectedEventId} setSelectedEventId={setSelectedEventId} propsData={propsData} propsLoading={propsLoading} propsError={propsError} />}
 
-    <div style={s.grid}>{rows.map(({ event, matchup, model, matched, key }, idx) => {
-      const away = event?.away_team?.name || event?.away_team || matchup?.away_team_name || 'Away'
-      const home = event?.home_team?.name || event?.home_team || matchup?.home_team_name || 'Home'
-      const moneyline = findMarket(event, 'h2h')
-      const spread = findMarket(event, 'spreads')
-      const total = findMarket(event, 'totals')
-      return <article key={`${event.event_id || key || idx}`} style={s.card}>
-        <div style={s.cardTop}>
-          <div><div style={s.matchup}>{away} @ {home}</div><div style={s.metaRow}><span style={s.chip}>Time: {formatTime(matchup?.game_time || event?.start_time || event?.commence_time)}</span><span style={s.chip}>MLB: {matchup?.game_pk ? <Link to={`/matchup/${matchup.game_pk}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>{matchup.game_pk}</Link> : 'N/A'}</span><span style={s.chip}>DK: {event.event_id || 'N/A'}</span><span style={s.chip}>Model: {model ? 'loaded' : 'none'}</span></div></div>
-          <span style={s.badge(matched)}>{matched ? 'MATCHED' : 'UNMATCHED'}</span>
-        </div>
-        <div style={s.markets}><MarketBox label="Moneyline" market={moneyline} /><MarketBox label="Run Line" market={spread} /><MarketBox label="Total" market={total} /></div>
-        <PropsDropdownBoard eventId={event.event_id} />
-        <ModelSummary model={model} />
-      </article>
-    })}</div>
+    <DailyRecapPanel unifiedPayload={unifiedPayload} loading={unifiedLoading} onLoad={loadUnified} />
+
+    <section style={s.section}>
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Game Market Snapshot</div><div style={s.modelSubtitle}>Compact game-line view. Props are handled in the organized board above, not scattered cards.</div></div><span style={s.chip}>{rows.length} games</span></div>
+      <div style={{ display: 'grid', gap: 12 }}>{rows.map(({ event, matchup, model, matched, key }, idx) => {
+        const away = event?.away_team?.name || event?.away_team || matchup?.away_team_name || 'Away'
+        const home = event?.home_team?.name || event?.home_team || matchup?.home_team_name || 'Home'
+        return <article key={`${event.event_id || key || idx}`} style={{ ...s.card, borderColor: String(event.event_id) === String(selectedEventId) ? '#58a6ff' : '#30363d' }}>
+          <div style={s.cardTop}>
+            <div><div style={s.matchup}>{away} @ {home}</div><div style={s.metaRow}><span style={s.chip}>{formatTime(matchup?.game_time || event?.start_time || event?.commence_time)}</span><span style={s.chip}>MLB: {matchup?.game_pk ? <Link to={`/matchup/${matchup.game_pk}`} style={{ color: '#58a6ff', textDecoration: 'none' }}>{matchup.game_pk}</Link> : 'Unmatched'}</span><span style={s.chip}>DK: {event.event_id || 'Unavailable'}</span><span style={s.chip}>Model: {model ? 'loaded' : 'pending'}</span></div></div>
+            <span style={s.badge(matched)}>{matched ? 'MATCHED' : 'UNMATCHED'}</span>
+          </div>
+          <div style={s.markets}><MarketBox label="Moneyline" market={findMarket(event, 'h2h')} /><MarketBox label="Run Line" market={findMarket(event, 'spreads')} /><MarketBox label="Total" market={findMarket(event, 'totals')} /></div>
+          <div style={{ padding: '0 16px 14px' }}><button type="button" style={s.mutedButton} onClick={() => setSelectedEventId(event.event_id)}>Open in Odds Board</button>{selectedRow?.event?.event_id === event.event_id && <span style={{ ...s.chip, marginLeft: 8 }}>Selected</span>}</div>
+        </article>
+      })}</div>
+    </section>
   </div>
 }

--- a/mlb_app/daily_odds_routes.py
+++ b/mlb_app/daily_odds_routes.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter
 from .daily_odds_models import build_game_models, build_prop_models
 from .database import create_tables, get_engine, get_session
 from .matchup_generator import generate_matchups_for_date
-from .my_dashboard_solver import build_dashboard_solver_payload, projection_payload
 from .odds_provider import fetch_draftkings_event_odds, fetch_draftkings_events
 
 router = APIRouter()
@@ -46,15 +45,6 @@ def _team_name_from_event(event: Dict[str, Any], side: str) -> Optional[str]:
     return team.get("name") if isinstance(team, dict) else team
 
 
-def _build_matchup_index(matchups: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
-    index: Dict[str, Dict[str, Any]] = {}
-    for matchup in matchups or []:
-        key = _key_from_matchup(matchup)
-        if key != "@":
-            index[key] = matchup
-    return index
-
-
 def _safe_error(error: Exception) -> Dict[str, Any]:
     return {"type": error.__class__.__name__, "message": str(error)}
 
@@ -72,6 +62,13 @@ def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
     return max(low, min(high, value))
 
 
+def _session_factory():
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    return get_session(engine)
+
+
 def _load_matchups(target_date: str) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     errors: List[Dict[str, Any]] = []
     try:
@@ -84,10 +81,7 @@ def _load_matchups(target_date: str) -> tuple[List[Dict[str, Any]], List[Dict[st
         errors.append({"stage": "generate_matchups_for_date_primary", "error": _safe_error(primary_exc)})
 
     try:
-        database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
-        engine = get_engine(database_url)
-        create_tables(engine)
-        Session = get_session(engine)
+        Session = _session_factory()
         with Session() as session:
             return generate_matchups_for_date(session, target_date), errors
     except Exception as fallback_exc:
@@ -95,35 +89,24 @@ def _load_matchups(target_date: str) -> tuple[List[Dict[str, Any]], List[Dict[st
         return [], errors
 
 
-def _session_factory():
-    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
-    engine = get_engine(database_url)
-    create_tables(engine)
-    return get_session(engine)
+def _build_matchup_index(matchups: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    index: Dict[str, Dict[str, Any]] = {}
+    for matchup in matchups or []:
+        key = _key_from_matchup(matchup)
+        if key != "@":
+            index[key] = matchup
+    return index
 
 
 def _candidate_sort_key(candidate: Dict[str, Any]) -> float:
-    edge = candidate.get("edge")
-    confidence = candidate.get("confidence")
-    score = candidate.get("score")
-    try:
-        edge_component = abs(float(edge)) if edge is not None else 0.0
-    except (TypeError, ValueError):
-        edge_component = 0.0
-    try:
-        confidence_component = float(confidence) if confidence is not None else 0.0
-    except (TypeError, ValueError):
-        confidence_component = 0.0
-    try:
-        score_component = float(score) if score is not None else 0.0
-    except (TypeError, ValueError):
-        score_component = 0.0
-    return edge_component * 10.0 + confidence_component + score_component
+    edge = _safe_float(candidate.get("edge"))
+    confidence = _safe_float(candidate.get("confidence"))
+    score = _safe_float(candidate.get("score"))
+    return abs(edge or 0.0) * 10.0 + (confidence or 0.0) + (score or 0.0)
 
 
 def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: int = 20) -> List[Dict[str, Any]]:
     candidates: List[Dict[str, Any]] = []
-
     for matchup in matchups or []:
         game_pk = matchup.get("game_pk")
         away_team = matchup.get("away_team_name") or matchup.get("away_team") or matchup.get("away_name") or "Away"
@@ -136,7 +119,6 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
             pick_team = home_team if home_prob >= away_prob else away_team
             model_probability = max(home_prob, away_prob)
             gap = abs(home_prob - away_prob)
-            confidence = round(_clamp(0.52 + gap, 0.52, 0.85), 3)
             candidates.append({
                 "model": "pregame_internal_moneyline_v1",
                 "market": "pregame_moneyline",
@@ -151,7 +133,7 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
                 "model_probability": round(model_probability, 4),
                 "market_implied_probability": None,
                 "edge": None,
-                "confidence": confidence,
+                "confidence": round(_clamp(0.52 + gap, 0.52, 0.85), 3),
                 "game_pk": game_pk,
                 "event_id": None,
                 "away_team": away_team,
@@ -163,19 +145,14 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
                 "features_used": [
                     {"name": "home_win_prob", "value": home_prob, "source": "matchups.home_win_prob", "transform": "raw"},
                     {"name": "away_win_prob", "value": away_prob, "source": "matchups.away_win_prob", "transform": "raw"},
-                    {"name": "probability_gap", "value": gap, "source": "matchups.win_probability_gap", "transform": "absolute_difference"},
                 ],
                 "missing_inputs": ["sportsbook_event_id", "sportsbook_price", "market_implied_probability"],
                 "drivers": ["internal win probability", "pregame matchup model", "odds provider returned zero events"],
             })
 
-        home_pitcher = matchup.get("home_pitcher_name")
-        away_pitcher = matchup.get("away_pitcher_name")
-        home_features = matchup.get("home_pitcher_features") or {}
-        away_features = matchup.get("away_pitcher_features") or {}
         for side, pitcher_name, opponent, features in [
-            ("home", home_pitcher, away_team, home_features),
-            ("away", away_pitcher, home_team, away_features),
+            ("home", matchup.get("home_pitcher_name"), away_team, matchup.get("home_pitcher_features") or {}),
+            ("away", matchup.get("away_pitcher_name"), home_team, matchup.get("away_pitcher_features") or {}),
         ]:
             if not pitcher_name:
                 continue
@@ -192,7 +169,6 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
             if not signal_parts:
                 continue
             score = round(sum(signal_parts) / len(signal_parts), 4)
-            confidence = round(_clamp(0.50 + score, 0.50, 0.78), 3)
             candidates.append({
                 "model": "pregame_internal_pitcher_prop_watchlist_v1",
                 "market": "pitcher_strikeouts_watchlist",
@@ -207,7 +183,7 @@ def _fallback_candidates_from_matchups(matchups: List[Dict[str, Any]], limit: in
                 "model_probability": None,
                 "market_implied_probability": None,
                 "edge": None,
-                "confidence": confidence,
+                "confidence": round(_clamp(0.50 + score, 0.50, 0.78), 3),
                 "game_pk": game_pk,
                 "event_id": None,
                 "away_team": away_team,
@@ -241,7 +217,6 @@ def _build_global_prop_candidates(events: List[Dict[str, Any]], matchup_index: D
         ]
         if not prop_markets:
             continue
-
         models = build_prop_models(matchup, prop_markets, market_filter="all", limit=20)
         for candidate in models.get("top_candidates", []) if isinstance(models, dict) else []:
             enriched = dict(candidate)
@@ -347,18 +322,12 @@ def _compact_dashboard_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _empty_projection_summary() -> Dict[str, Any]:
-    return {
-        "projection_count": 0,
-        "games": [],
-        "source": "model_projections",
-        "missing_inputs": ["model_projection_payload_unavailable"],
-    }
+    return {"projection_count": 0, "games": [], "source": "model_projections", "missing_inputs": []}
 
 
 def _summarize_projection_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     games = payload.get("games") if isinstance(payload.get("games"), list) else []
     compact_games: List[Dict[str, Any]] = []
-
     for game in games[:20]:
         if not isinstance(game, dict):
             continue
@@ -377,7 +346,6 @@ def _summarize_projection_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
             "total_expected_runs": simulation.get("total_expected_runs"),
             "missing_inputs": game.get("missing_inputs") or workspace.get("missing_inputs") or [],
         })
-
     return {
         "projection_count": len(games),
         "games": compact_games,
@@ -388,6 +356,8 @@ def _summarize_projection_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _load_dashboard_summary(target_date: str, errors: List[Dict[str, Any]]) -> Dict[str, Any]:
+    from .my_dashboard_solver import build_dashboard_solver_payload, projection_payload
+
     summary: Dict[str, Any] = {
         "components": {},
         "components_used": [],
@@ -398,22 +368,18 @@ def _load_dashboard_summary(target_date: str, errors: List[Dict[str, Any]]) -> D
         "top_overall_players": [],
         "model_projection_summary": _empty_projection_summary(),
     }
-
     try:
         Session = _session_factory()
         with Session() as session:
             for component in DASHBOARD_COMPONENTS:
                 try:
                     payload = build_dashboard_solver_payload(session, target_date, component)
-                    compact = _compact_dashboard_payload(payload)
-                    summary["components"][component] = compact
+                    summary["components"][component] = _compact_dashboard_payload(payload)
                     summary["components_used"].append(component)
                 except Exception as exc:
                     errors.append({"stage": f"dashboard_solver_{component}", "error": _safe_error(exc)})
-
             try:
-                projection = projection_payload(session, target_date) or {}
-                summary["model_projection_summary"] = _summarize_projection_payload(projection)
+                summary["model_projection_summary"] = _summarize_projection_payload(projection_payload(session, target_date) or {})
             except Exception as exc:
                 errors.append({"stage": "model_projection_payload", "error": _safe_error(exc)})
     except Exception as exc:
@@ -424,7 +390,6 @@ def _load_dashboard_summary(target_date: str, errors: List[Dict[str, Any]]) -> D
     teams = summary["components"].get("teams", {}).get("items") or []
     totals = summary["components"].get("totals", {}).get("items") or []
     overall = summary["components"].get("overall_players", {}).get("items") or []
-
     summary["top_hitter_angles"] = hitters[:10]
     summary["top_pitcher_angles"] = pitchers[:10]
     summary["top_team_edges"] = teams[:10]
@@ -434,13 +399,11 @@ def _load_dashboard_summary(target_date: str, errors: List[Dict[str, Any]]) -> D
         item for item in hitters if item.get("best_pitch_angles") or "batter_pitch_type_matchups" in str(item.get("source") or "")
     ][:10]
     summary["batter_vs_arsenal_count"] = len(summary["batter_vs_arsenal_edges"])
-
     return summary
 
 
 def _best_game_signal(outputs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     candidates: List[Dict[str, Any]] = []
-
     for row in outputs or []:
         models = row.get("models") or {}
         for market_key in ("moneyline", "spread", "run_line", "total"):
@@ -465,11 +428,7 @@ def _best_game_signal(outputs: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]
                 "missing_inputs": model.get("missing_inputs") or row.get("missing_inputs") or [],
                 "features_used": model.get("features_used") or [],
             })
-
-    if not candidates:
-        return None
-
-    return sorted(candidates, key=_candidate_sort_key, reverse=True)[0]
+    return sorted(candidates, key=_candidate_sort_key, reverse=True)[0] if candidates else None
 
 
 def _first_item(summary: Dict[str, Any], component: str) -> Optional[Dict[str, Any]]:
@@ -477,49 +436,16 @@ def _first_item(summary: Dict[str, Any], component: str) -> Optional[Dict[str, A
     return item if isinstance(item, dict) else None
 
 
-def _build_daily_recap(
-    outputs: List[Dict[str, Any]],
-    dashboard_summary: Dict[str, Any],
-    odds_status: Optional[str],
-    odds_event_count: int,
-) -> Dict[str, Any]:
-    best_side = _best_game_signal(outputs)
-    best_total = _first_item(dashboard_summary, "totals")
-    best_pitcher = _first_item(dashboard_summary, "pitchers")
-    best_hitter = _first_item(dashboard_summary, "hitters")
-    best_team = _first_item(dashboard_summary, "teams")
-
+def _build_daily_recap(outputs: List[Dict[str, Any]], dashboard_summary: Dict[str, Any], odds_status: Optional[str], odds_event_count: int) -> Dict[str, Any]:
     priced_count = sum(1 for row in outputs if row.get("event_id"))
-    pricing_note = (
-        "Sportsbook-priced markets are available and model sections distinguish price-backed edges from model-only signals."
-        if odds_event_count
-        else "No sportsbook event payload was available; all surfaced picks are model-only watchlist signals and do not assume a price or line."
-    )
-
-    missing_sections = [
-        name
-        for name, value in {
-            "best_side": best_side,
-            "best_total": best_total,
-            "best_pitcher": best_pitcher,
-            "best_hitter": best_hitter,
-            "best_team": best_team,
-        }.items()
-        if not value
-    ]
-
     return {
-        "best_side": best_side,
-        "best_total": best_total,
-        "best_pitcher": best_pitcher,
-        "best_hitter": best_hitter,
-        "best_team": best_team,
-        "data_quality_note": (
-            f"Missing sections: {', '.join(missing_sections)}."
-            if missing_sections
-            else "Daily Odds is populated from shared My Dashboard, AI Data Assistant, Model Projection, and Batter vs Arsenal data paths."
-        ),
-        "pricing_note": pricing_note,
+        "best_side": _best_game_signal(outputs),
+        "best_total": _first_item(dashboard_summary, "totals"),
+        "best_pitcher": _first_item(dashboard_summary, "pitchers"),
+        "best_hitter": _first_item(dashboard_summary, "hitters"),
+        "best_team": _first_item(dashboard_summary, "teams"),
+        "data_quality_note": "Daily Odds unified recap is loaded on demand from shared My Dashboard, AI Data Assistant, Model Projection, and Batter vs Arsenal paths.",
+        "pricing_note": "Sportsbook-priced markets are available." if odds_event_count else "No sportsbook event payload was available; surfaced picks are model-only watchlist signals.",
         "odds_status": odds_status,
         "priced_game_count": priced_count,
         "model_only_game_count": max(len(outputs) - priced_count, 0),
@@ -527,29 +453,19 @@ def _build_daily_recap(
     }
 
 
-def _collect_missing_inputs(
-    outputs: List[Dict[str, Any]],
-    dashboard_summary: Dict[str, Any],
-    projection_summary: Dict[str, Any],
-    errors: List[Dict[str, Any]],
-) -> List[Any]:
+def _collect_missing_inputs(outputs: List[Dict[str, Any]], dashboard_summary: Dict[str, Any], projection_summary: Dict[str, Any], errors: List[Dict[str, Any]]) -> List[Any]:
     missing: List[Any] = []
-
     for row in outputs:
         missing.extend(row.get("missing_inputs") or [])
-        models = row.get("models") or {}
-        for model in models.values():
+        for model in (row.get("models") or {}).values():
             if isinstance(model, dict):
                 missing.extend(model.get("missing_inputs") or [])
-
     for component_payload in dashboard_summary.get("components", {}).values():
         missing.extend(component_payload.get("missing_data") or [])
         for item in component_payload.get("items") or []:
             missing.extend(item.get("missing_data") or [])
-
     missing.extend(projection_summary.get("missing_inputs") or [])
     missing.extend({"stage": item.get("stage"), "error": item.get("error")} for item in errors if item.get("stage"))
-
     deduped: List[Any] = []
     seen = set()
     for item in missing:
@@ -562,27 +478,36 @@ def _collect_missing_inputs(
 
 
 def _sources_used(odds_payload: Dict[str, Any], dashboard_summary: Dict[str, Any]) -> List[str]:
-    sources = [
-        "daily_odds_models",
-        "matchup_generator.generate_matchups_for_date",
-        "odds_provider.fetch_draftkings_events",
-    ]
-
+    sources = ["daily_odds_models", "matchup_generator.generate_matchups_for_date", "odds_provider.fetch_draftkings_events"]
     if dashboard_summary.get("components_used"):
-        sources.append("my_dashboard_solver.build_dashboard_solver_payload")
-        sources.append("ai_data_assistant Stored 365 / pitcher lean contexts")
-
+        sources.extend(["my_dashboard_solver.build_dashboard_solver_payload", "ai_data_assistant Stored 365 / pitcher lean contexts"])
     if dashboard_summary.get("model_projection_summary", {}).get("projection_count", 0) > 0:
         sources.append("model_projections.build_model_projection_payload")
-
     if odds_payload.get("provider"):
         sources.append(str(odds_payload.get("provider")))
-
     return sources
 
 
+def _base_response(target_date: str, outputs: List[Dict[str, Any]], events: List[Dict[str, Any]], odds_payload: Dict[str, Any], top_prop_candidates: List[Dict[str, Any]], errors: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "date": target_date,
+        "count": len(outputs),
+        "matched_count": sum(1 for row in outputs if row.get("matched")),
+        "unmatched_count": sum(1 for row in outputs if not row.get("matched")),
+        "odds_status": odds_payload.get("status") if isinstance(odds_payload, dict) else None,
+        "last_updated": odds_payload.get("last_updated") if isinstance(odds_payload, dict) else None,
+        "odds_event_count": len(events),
+        "models": outputs,
+        "games": outputs,
+        "top_prop_model_candidates": top_prop_candidates,
+        "top_prop_candidate_count": len(top_prop_candidates),
+        "errors": errors,
+        "generated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    }
+
+
 @router.get("/daily-odds/models")
-def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
+def daily_odds_models(date: Optional[str] = None, include_unified: bool = False) -> Dict[str, Any]:
     target_date = date or datetime.date.today().isoformat()
     errors: List[Dict[str, Any]] = []
 
@@ -613,13 +538,11 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
                 "missing_inputs": ["matched_mlb_game"],
             })
             continue
-
         try:
             models = build_game_models(matchup, event)
         except Exception as exc:
             models = None
             errors.append({"stage": "build_game_models", "event_id": event.get("event_id"), "match_key": key, "error": _safe_error(exc)})
-
         outputs.append({
             "game_pk": matchup.get("game_pk"),
             "event_id": event.get("event_id"),
@@ -634,16 +557,17 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
         outputs = _models_from_unpriced_matchups(matchups)
 
     top_prop_candidates = _build_global_prop_candidates(events, matchup_index, matchups, limit=20)
+    response = _base_response(target_date, outputs, events, odds_payload if isinstance(odds_payload, dict) else {}, top_prop_candidates, errors)
+
+    if not include_unified:
+        response["unified_available"] = True
+        response["unified_loaded"] = False
+        return response
+
     dashboard_summary = _load_dashboard_summary(target_date, errors)
     projection_summary = dashboard_summary.get("model_projection_summary") or _empty_projection_summary()
-    daily_recap = _build_daily_recap(
-        outputs=outputs,
-        dashboard_summary=dashboard_summary,
-        odds_status=odds_payload.get("status") if isinstance(odds_payload, dict) else None,
-        odds_event_count=len(events),
-    )
+    daily_recap = _build_daily_recap(outputs, dashboard_summary, response.get("odds_status"), len(events))
     missing_inputs = _collect_missing_inputs(outputs, dashboard_summary, projection_summary, errors)
-
     fallbacks_used: List[str] = []
     if not events:
         fallbacks_used.append("internal_matchups_no_odds_provider")
@@ -656,26 +580,16 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
         "sources_used": _sources_used(odds_payload if isinstance(odds_payload, dict) else {}, dashboard_summary),
         "missing_inputs": missing_inputs,
         "fallbacks_used": fallbacks_used,
-        "odds_status": odds_payload.get("status") if isinstance(odds_payload, dict) else None,
+        "odds_status": response.get("odds_status"),
         "matchup_count": len(matchups),
         "projection_count": projection_summary.get("projection_count", 0),
         "dashboard_solver_components_used": dashboard_summary.get("components_used", []),
         "batter_vs_arsenal_count": dashboard_summary.get("batter_vs_arsenal_count", 0),
         "generated_at": daily_recap.get("generated_at"),
     }
-
-    return {
-        "date": target_date,
-        "count": len(outputs),
-        "matched_count": sum(1 for row in outputs if row.get("matched")),
-        "unmatched_count": sum(1 for row in outputs if not row.get("matched")),
-        "odds_status": odds_payload.get("status") if isinstance(odds_payload, dict) else None,
-        "last_updated": odds_payload.get("last_updated") if isinstance(odds_payload, dict) else None,
-        "odds_event_count": len(events),
-        "models": outputs,
-        "games": outputs,
-        "top_prop_model_candidates": top_prop_candidates,
-        "top_prop_candidate_count": len(top_prop_candidates),
+    response.update({
+        "unified_available": True,
+        "unified_loaded": True,
         "daily_recap": daily_recap,
         "model_projection_summary": projection_summary,
         "dashboard_solver_summary": dashboard_summary.get("components", {}),
@@ -689,7 +603,8 @@ def daily_odds_models(date: Optional[str] = None) -> Dict[str, Any]:
         "fallbacks_used": fallbacks_used,
         "errors": errors,
         "generated_at": data_quality["generated_at"],
-    }
+    })
+    return response
 
 
 @router.get("/daily-odds/event/{event_id}/prop-models")

--- a/scripts/smoke_test_production_paths.py
+++ b/scripts/smoke_test_production_paths.py
@@ -74,13 +74,19 @@ def _check_matchups(data: Any, path: str) -> None:
         raise SmokeFailure(f"Expected matchup list for {path}, got {type(data).__name__}")
 
 
-def _check_daily_odds(data: Any, path: str) -> None:
+def _check_daily_odds_fast(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     missing = [key for key in ["date", "errors"] if key not in payload]
     if missing:
-        raise SmokeFailure(f"Daily Odds payload missing {missing} for {path}")
+        raise SmokeFailure(f"Daily Odds fast payload missing {missing} for {path}")
     if not any(key in payload for key in ["models", "games", "model_games"]):
-        raise SmokeFailure("Daily Odds payload missing models/games/model_games container")
+        raise SmokeFailure("Daily Odds fast payload missing models/games/model_games container")
+    if payload.get("unified_loaded") is not False:
+        raise SmokeFailure("Daily Odds fast payload should not load unified model/dashboard sections by default")
+
+
+def _check_daily_odds_unified(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
     enhanced_keys = [
         "daily_recap",
         "model_projection_summary",
@@ -93,6 +99,8 @@ def _check_daily_odds(data: Any, path: str) -> None:
     missing_enhanced = [key for key in enhanced_keys if key not in payload]
     if missing_enhanced:
         raise SmokeFailure(f"Daily Odds unified payload missing {missing_enhanced}")
+    if payload.get("unified_loaded") is not True:
+        raise SmokeFailure("Daily Odds unified payload should set unified_loaded=true")
     data_quality = _expect_dict(payload.get("data_quality"), f"{path}.data_quality")
     for key in ["matchup_count", "projection_count", "dashboard_solver_components_used", "batter_vs_arsenal_count", "generated_at"]:
         if key not in data_quality:
@@ -138,13 +146,15 @@ def main() -> int:
 
     date = args.date[:10]
     query_date = urllib.parse.urlencode({"date": date})
+    unified_query = urllib.parse.urlencode({"date": date, "include_unified": "true"})
     dashboard_hitter_query = urllib.parse.urlencode({"date": date, "component": "hitters"})
     dashboard_pitcher_query = urllib.parse.urlencode({"date": date, "component": "pitchers"})
 
     checks: list[tuple[str, str, Callable[[Any, str], None]]] = [
         ("health", "/health", _check_health),
         ("matchups", f"/matchups?{query_date}", _check_matchups),
-        ("daily_odds_models", f"/daily-odds/models?{query_date}", _check_daily_odds),
+        ("daily_odds_models_fast", f"/daily-odds/models?{query_date}", _check_daily_odds_fast),
+        ("daily_odds_models_unified", f"/daily-odds/models?{unified_query}", _check_daily_odds_unified),
         ("model_projections", f"/models/projections?{query_date}", _check_model_projections),
         ("ai_data_assistant_health", "/ai-data-assistant/health", _check_health),
         ("my_dashboard_health", "/my-dashboard/health", _check_health),


### PR DESCRIPTION
## Summary

This supersedes PR #287.

This PR moves the corrected Daily Odds work onto a new branch and focuses on two problems:

1. Daily Odds should not load expensive model/dashboard data by default.
2. Daily Odds should use a structured board UI instead of scattered prop cards.

## What changed

### Fast default backend behavior

`GET /daily-odds/models?date=YYYY-MM-DD` now stays fast by default and preserves existing response keys:

- `models`
- `games`
- `top_prop_model_candidates`
- count fields
- odds metadata
- `errors`

The heavier unified model/dashboard payload is opt-in only:

```text
GET /daily-odds/models?date=YYYY-MM-DD&include_unified=true
```

This prevents the page from automatically pulling My Dashboard, AI Data Assistant, Model Projections, and Batter vs Arsenal data during initial load.

### Organized frontend board

`frontend/src/pages/DailyOddsPage.jsx` now uses a structured board:

- Game dropdown
- Category dropdown
- Market dropdown
- Player / selection dropdown
- Selected-row detail panel
- Table of all selections in the active market

The previous scattered top-prop card grid is removed from the main page flow. Compact game-line snapshots remain below the board.

### On-demand recap

Daily Recap / unified model intelligence now loads only when clicking `Load Model Recap`.

That request calls:

```text
/daily-odds/models?date=YYYY-MM-DD&include_unified=true
```

and then displays the shared model/dashboard context returned by the backend.

## Files changed

- `frontend/src/pages/DailyOddsPage.jsx`
- `mlb_app/daily_odds_routes.py`
- `scripts/smoke_test_production_paths.py`

## Production safety

This PR does not change:

- `/matchups`
- matchup generator logic
- odds provider logic
- Model Projection formulas
- My Dashboard solver logic
- AI Data Assistant logic
- Railway config
- CORS config
- environment variables
- Batter feature flag behavior

## Testing required before merge

```bash
python -m compileall mlb_app scripts
cd frontend && npm run build
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-14
```

## Manual QA checklist

- `/daily-odds`
- Confirm page loads quickly on initial render.
- Confirm game/category/market/player dropdowns work.
- Confirm selected-game detail table renders correctly.
- Confirm compact game-line snapshots still render.
- Confirm `Load Model Recap` loads the heavier model context on demand.
- Confirm scattered card grid is no longer in the main page flow.
- Confirm `/models/projections`, `/my-dashboard`, `/ai-data-assistant`, and `/matchups` still load.

## Risk and rollback

Primary risk is frontend rendering. Heavy backend mode is explicitly gated behind `include_unified=true`.

Rollback is clean: revert this PR to restore the previous Daily Odds page and route behavior.