### PR TITLE
Add Layer 6T outcome subtype probability derivation prototype

### DIFF
--- a/mlb_app/simulation/outcome_subtypes.py
+++ b/mlb_app/simulation/outcome_subtypes.py
@@ -1,0 +1,309 @@
+from copy import deepcopy
+
+DEFAULT_OUT_SUBTYPE_SHARES = {
+    "groundout": 0.44,
+    "flyout": 0.31,
+    "lineout_popout": 0.18,
+    "other_out": 0.07,
+}
+
+REQUIRED_SUBTYPE_KEYS = [
+    "groundout",
+    "flyout",
+    "lineout_popout",
+    "other_out",
+]
+
+STRIKEOUT_KEYS = [
+    "k",
+    "strikeout",
+    "strikeouts",
+]
+
+OUT_KEYS = [
+    "out",
+    "generic_out",
+]
+
+EXCLUDED_KEYS = set(
+    STRIKEOUT_KEYS
+    + OUT_KEYS
+    + [
+        "strikeout",
+        "groundout",
+        "flyout",
+        "lineout_popout",
+        "other_out",
+        "generic_out_original",
+        "out_subtype_share_sum",
+        "pa_probability_sum_original",
+        "pa_probability_sum_derived",
+        "preserved_numeric_keys",
+        "excluded_decomposed_keys",
+        "missing_numeric_keys",
+    ]
+)
+
+def _is_numeric(value):
+
+    return isinstance(
+        value,
+        (int, float),
+    )
+
+def _first_numeric(
+    probabilities,
+    keys,
+    default=0.0,
+):
+
+    for key in keys:
+
+        value = probabilities.get(
+            key
+        )
+
+        if _is_numeric(value):
+
+            return float(value)
+
+    return float(default)
+
+def normalize_out_subtype_shares(
+    shares=None,
+):
+
+    if shares is None:
+
+        shares = deepcopy(
+            DEFAULT_OUT_SUBTYPE_SHARES
+        )
+
+    if not isinstance(
+        shares,
+        dict,
+    ):
+
+        raise TypeError(
+            "shares must be dict"
+        )
+
+    normalized = {}
+
+    for key in REQUIRED_SUBTYPE_KEYS:
+
+        if key not in shares:
+
+            raise ValueError(
+                f"missing share key: {key}"
+            )
+
+        value = shares[key]
+
+        if not _is_numeric(
+            value
+        ):
+
+            raise TypeError(
+                f"share must be numeric: {key}"
+            )
+
+        value = float(value)
+
+        if value < 0:
+
+            raise ValueError(
+                f"share cannot be negative: {key}"
+            )
+
+        normalized[key] = value
+
+    total = sum(
+        normalized.values()
+    )
+
+    if total <= 0:
+
+        raise ValueError(
+            "share total must be > 0"
+        )
+
+    return {
+        key: value / total
+        for key, value
+        in normalized.items()
+    }
+
+def derive_outcome_subtype_probabilities(
+    probabilities,
+    shares=None,
+    include_metadata=True,
+):
+
+    if not isinstance(
+        probabilities,
+        dict,
+    ):
+
+        raise TypeError(
+            "probabilities must be dict"
+        )
+
+    normalized_shares = (
+        normalize_out_subtype_shares(
+            shares
+        )
+    )
+
+    derived = {}
+
+    original_numeric_keys = []
+
+    preserved_numeric_keys = []
+
+    excluded_decomposed_keys = []
+
+    missing_numeric_keys = []
+
+    for key, value in (
+        probabilities.items()
+    ):
+
+        if not _is_numeric(
+            value
+        ):
+
+            continue
+
+        original_numeric_keys.append(
+            key
+        )
+
+        if key in EXCLUDED_KEYS:
+
+            excluded_decomposed_keys.append(
+                key
+            )
+
+            continue
+
+        derived[key] = float(value)
+
+        preserved_numeric_keys.append(
+            key
+        )
+
+    strikeout_prob = (
+        _first_numeric(
+            probabilities,
+            STRIKEOUT_KEYS,
+        )
+    )
+
+    out_prob = (
+        _first_numeric(
+            probabilities,
+            OUT_KEYS,
+        )
+    )
+
+    derived[
+        "strikeout"
+    ] = strikeout_prob
+
+    derived[
+        "groundout"
+    ] = (
+        out_prob
+        * normalized_shares[
+            "groundout"
+        ]
+    )
+
+    derived[
+        "flyout"
+    ] = (
+        out_prob
+        * normalized_shares[
+            "flyout"
+        ]
+    )
+
+    derived[
+        "lineout_popout"
+    ] = (
+        out_prob
+        * normalized_shares[
+            "lineout_popout"
+        ]
+    )
+
+    derived[
+        "other_out"
+    ] = (
+        out_prob
+        * normalized_shares[
+            "other_out"
+        ]
+    )
+
+    derived[
+        "generic_out_original"
+    ] = out_prob
+
+    derived[
+        "out_subtype_share_sum"
+    ] = sum(
+        normalized_shares.values()
+    )
+
+    original_sum = sum(
+        float(v)
+        for v in probabilities.values()
+        if _is_numeric(v)
+    )
+
+    derived_sum = sum(
+        float(v)
+        for k, v in derived.items()
+        if (
+            _is_numeric(v)
+            and k
+            not in {
+                "generic_out_original",
+                "out_subtype_share_sum",
+                "pa_probability_sum_original",
+                "pa_probability_sum_derived",
+            }
+        )
+    )
+
+    derived[
+        "pa_probability_sum_original"
+    ] = original_sum
+
+    derived[
+        "pa_probability_sum_derived"
+    ] = derived_sum
+
+    if include_metadata:
+
+        derived[
+            "preserved_numeric_keys"
+        ] = sorted(
+            preserved_numeric_keys
+        )
+
+        derived[
+            "excluded_decomposed_keys"
+        ] = sorted(
+            excluded_decomposed_keys
+        )
+
+        derived[
+            "missing_numeric_keys"
+        ] = sorted(
+            missing_numeric_keys
+        )
+
+    return derived

--- a/scripts/audit_outcome_subtype_derivation.py
+++ b/scripts/audit_outcome_subtype_derivation.py
@@ -1,0 +1,578 @@
+import csv
+import json
+import os
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.matchup_generator import (
+    generate_matchups_for_date,
+)
+
+from mlb_app.simulation.game_engine_v2 import (
+    run_full_game_simulation,
+)
+
+from mlb_app.simulation.outcome_subtypes import (
+    derive_outcome_subtype_probabilities,
+    normalize_out_subtype_shares,
+)
+
+TMP_DIR = Path("tmp")
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "outcome_subtype_derivation.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "outcome_subtype_derivation_checks.csv"
+)
+
+OUTPUT_PAYLOADS = (
+    TMP_DIR
+    / "outcome_subtype_derivation_payloads.csv"
+)
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "sqlite:///mlb.db",
+)
+
+BACKTEST_START = os.environ.get(
+    "BACKTEST_START",
+    "2026-04-20",
+)
+
+MAX_GAMES = int(
+    os.environ.get(
+        "MAX_GAMES",
+        3,
+    )
+)
+
+SIMS_PER_GAME = int(
+    os.environ.get(
+        "SIMS_PER_GAME",
+        50,
+    )
+)
+
+SEED = int(
+    os.environ.get(
+        "SEED",
+        42,
+    )
+)
+
+TOLERANCE = 1e-9
+
+def approx_equal(a, b):
+
+    return (
+        abs(a - b)
+        <= TOLERANCE
+    )
+
+def write_csv(
+    path,
+    rows,
+):
+
+    if not rows:
+
+        rows = [
+            {
+                "status":
+                    "no_rows"
+            }
+        ]
+
+    with open(
+        path,
+        "w",
+        newline="",
+    ) as f:
+
+        writer = csv.DictWriter(
+            f,
+            fieldnames=list(
+                rows[0].keys()
+            ),
+        )
+
+        writer.writeheader()
+        writer.writerows(rows)
+
+def validate_invalid_rejections():
+
+    bad_cases = [
+        {
+            "groundout": -1,
+            "flyout": 1,
+            "lineout_popout": 1,
+            "other_out": 1,
+        },
+
+        {
+            "groundout": 1,
+            "flyout": 1,
+            "lineout_popout": 1,
+        },
+
+        {
+            "groundout": "bad",
+            "flyout": 1,
+            "lineout_popout": 1,
+            "other_out": 1,
+        },
+
+        {
+            "groundout": 0,
+            "flyout": 0,
+            "lineout_popout": 0,
+            "other_out": 0,
+        },
+    ]
+
+    passed = 0
+
+    for case in bad_cases:
+
+        try:
+
+            normalize_out_subtype_shares(
+                case
+            )
+
+        except Exception:
+
+            passed += 1
+
+    return (
+        passed
+        == len(bad_cases)
+    )
+
+def smoke_test_payloads():
+
+    engine = create_engine(
+        DATABASE_URL
+    )
+
+    Session = sessionmaker(
+        bind=engine
+    )
+
+    payload_rows = []
+
+    conservation_failures = 0
+
+    payloads_tested = 0
+
+    parser_blocked = False
+
+    with Session() as session:
+
+        matchups = (
+            generate_matchups_for_date(
+                session,
+                BACKTEST_START,
+            )
+        )
+
+        for sample_count, matchup in enumerate(
+            matchups[:MAX_GAMES]
+        ):
+
+            game_pk = (
+                matchup.get(
+                    "game_pk"
+                )
+                or matchup.get(
+                    "gamePk"
+                )
+            )
+
+            try:
+
+                result = (
+                    run_full_game_simulation(
+                        int(game_pk),
+                        config={
+                            "simulation_count":
+                                SIMS_PER_GAME,
+
+                            "seed":
+                                (
+                                    SEED
+                                    + sample_count
+                                ),
+
+                            "date":
+                                BACKTEST_START,
+
+                            "matchup": {
+                                "raw":
+                                    matchup,
+
+                                "game_date":
+                                    BACKTEST_START,
+                            },
+                        },
+                    )
+                )
+
+            except Exception:
+
+                parser_blocked = True
+
+                continue
+
+            pa_models = result.get(
+                "pa_models",
+                {},
+            )
+
+            for (
+                model_name,
+                payload,
+            ) in pa_models.items():
+
+                probs = payload.get(
+                    (
+                        "lineup_average_"
+                        "probabilities"
+                    ),
+                    {},
+                )
+
+                if not probs:
+
+                    continue
+
+                payloads_tested += 1
+
+                derived = (
+                    derive_outcome_subtype_probabilities(
+                        probs,
+                        include_metadata=True,
+                    )
+                )
+
+                original_sum = (
+                    derived[
+                        (
+                            "pa_probability_"
+                            "sum_original"
+                        )
+                    ]
+                )
+
+                derived_sum = (
+                    derived[
+                        (
+                            "pa_probability_"
+                            "sum_derived"
+                        )
+                    ]
+                )
+
+                conserved = (
+                    approx_equal(
+                        original_sum,
+                        derived_sum,
+                    )
+                )
+
+                if not conserved:
+
+                    conservation_failures += 1
+
+                original_numeric_keys = sorted(
+                    [
+                        key
+                        for key, value
+                        in probs.items()
+                        if isinstance(
+                            value,
+                            (int, float),
+                        )
+                    ]
+                )
+
+                preserved_keys = (
+                    derived[
+                        "preserved_numeric_keys"
+                    ]
+                )
+
+                excluded_keys = (
+                    derived[
+                        "excluded_decomposed_keys"
+                    ]
+                )
+
+                missing_keys = sorted(
+                    list(
+                        set(
+                            original_numeric_keys
+                        )
+                        - set(
+                            preserved_keys
+                        )
+                        - set(
+                            excluded_keys
+                        )
+                    )
+                )
+
+                missing_sum = sum(
+                    float(
+                        probs[key]
+                    )
+                    for key
+                    in missing_keys
+                    if isinstance(
+                        probs.get(key),
+                        (int, float),
+                    )
+                )
+
+                payload_rows.append(
+                    {
+                        "game_pk":
+                            game_pk,
+
+                        "model":
+                            model_name,
+
+                        "original_numeric_keys":
+                            json.dumps(
+                                original_numeric_keys
+                            ),
+
+                        "preserved_numeric_keys":
+                            json.dumps(
+                                preserved_keys
+                            ),
+
+                        "excluded_decomposed_keys":
+                            json.dumps(
+                                excluded_keys
+                            ),
+
+                        "missing_numeric_keys":
+                            json.dumps(
+                                missing_keys
+                            ),
+
+                        "missing_numeric_sum":
+                            missing_sum,
+
+                        "original_sum":
+                            original_sum,
+
+                        "derived_sum":
+                            derived_sum,
+
+                        "conserved":
+                            conserved,
+                    }
+                )
+
+    return {
+        "payloads_tested":
+            payloads_tested,
+
+        "conservation_failures":
+            conservation_failures,
+
+        "payload_rows":
+            payload_rows,
+
+        "parser_blocked":
+            parser_blocked,
+    }
+
+def main():
+
+    default_sum = sum(
+        normalize_out_subtype_shares().values()
+    )
+
+    invalid_rejections = (
+        validate_invalid_rejections()
+    )
+
+    payload_results = (
+        smoke_test_payloads()
+    )
+
+    write_csv(
+        OUTPUT_PAYLOADS,
+        payload_results[
+            "payload_rows"
+        ],
+    )
+
+    checks = [
+        {
+            "check":
+                "default_share_sum",
+
+            "passed":
+                approx_equal(
+                    default_sum,
+                    1.0,
+                ),
+        },
+
+        {
+            "check":
+                (
+                    "invalid_share_"
+                    "rejections"
+                ),
+
+            "passed":
+                invalid_rejections,
+        },
+
+        {
+            "check":
+                (
+                    "schema_"
+                    "reconciliation"
+                ),
+
+            "passed":
+                (
+                    payload_results[
+                        (
+                            "conservation_"
+                            "failures"
+                        )
+                    ]
+                    == 0
+                ),
+        },
+    ]
+
+    write_csv(
+        OUTPUT_CHECKS,
+        checks,
+    )
+
+    if (
+        payload_results[
+            "parser_blocked"
+        ]
+        and payload_results[
+            "payloads_tested"
+        ]
+        == 0
+    ):
+
+        diagnosis = (
+            "outcome_subtype_"
+            "derivation_payload_"
+            "parser_blocked"
+        )
+
+    elif not invalid_rejections:
+
+        diagnosis = (
+            "outcome_subtype_"
+            "derivation_invalid_"
+            "validation_failed"
+        )
+
+    elif (
+        payload_results[
+            "conservation_failures"
+        ]
+        > 0
+    ):
+
+        diagnosis = (
+            "outcome_subtype_"
+            "derivation_schema_"
+            "reconciliation_failed"
+        )
+
+    else:
+
+        diagnosis = (
+            "outcome_subtype_"
+            "derivation_prototype_"
+            "safe"
+        )
+
+    summary = {
+        "diagnosis":
+            diagnosis,
+
+        "default_share_sum":
+            default_sum,
+
+        "production_payloads_tested":
+            payload_results[
+                "payloads_tested"
+            ],
+
+        "conservation_failures":
+            payload_results[
+                "conservation_failures"
+            ],
+
+        "invalid_share_rejections_passed":
+            invalid_rejections,
+
+        "schema_reconciliation_passed":
+            (
+                payload_results[
+                    "conservation_failures"
+                ]
+                == 0
+            ),
+
+        "subtype_keys": [
+            "strikeout",
+            "groundout",
+            "flyout",
+            "lineout_popout",
+            "other_out",
+        ],
+
+        "recommended_next_step":
+            (
+                "layer_6u_"
+                "subtype_transition_"
+                "prototype"
+            ),
+    }
+
+    with open(
+        OUTPUT_JSON,
+        "w",
+    ) as f:
+
+        json.dump(
+            summary,
+            f,
+            indent=2,
+        )
+
+    print(
+        json.dumps(
+            summary,
+            indent=2,
+        )
+    )
+
+if __name__ == "__main__":
+
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6T outcome subtype probability derivation prototype and schema reconciliation audit.

This PR introduces a safe decomposition layer that converts generic `out` probability into subtype buckets while preserving total PA probability mass.

## Why

Layer 6R showed that generic outs are too blended for realistic transition logic.
Layer 6S showed subtype probabilities appear derivable from existing repo features/artifacts instead of requiring a full PA model rewrite.

Layer 6T creates the first prototype decomposition layer:

```text
generic out probability
→ groundout / flyout / lineout_popout / other_out
```

while keeping strikeouts separate and preserving the original PA model contract.

## What this adds

- `mlb_app/simulation/outcome_subtypes.py`
- `scripts/audit_outcome_subtype_derivation.py`

## Key behavior

`derive_outcome_subtype_probabilities(...)`:

- keeps strikeouts separate as `strikeout`
- decomposes only generic `out`
- derives:
  - `groundout`
  - `flyout`
  - `lineout_popout`
  - `other_out`
- preserves unknown numeric non-out keys automatically
- supports strikeout aliases like `k`, `strikeout`, `strikeouts`
- supports out aliases like `out`, `generic_out`
- reports preserved/excluded key metadata for auditability
- preserves total numeric PA probability mass

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts

MAX_GAMES=3 \
SIMS_PER_GAME=50 \
SEED=42 \
python scripts/audit_outcome_subtype_derivation.py
```

Result:

```json
{
  "diagnosis": "outcome_subtype_derivation_prototype_safe",
  "default_share_sum": 1.0,
  "production_payloads_tested": 12,
  "conservation_failures": 0,
  "invalid_share_rejections_passed": true,
  "schema_reconciliation_passed": true,
  "subtype_keys": [
    "strikeout",
    "groundout",
    "flyout",
    "lineout_popout",
    "other_out"
  ],
  "recommended_next_step": "layer_6u_subtype_transition_prototype"
}
```

## Interpretation

The subtype derivation layer is now schema-safe against real production PA payloads:

- default subtype shares normalize correctly
- invalid shares are rejected
- unknown numeric keys are preserved
- decomposed keys are excluded intentionally
- 12 sampled production PA payloads conserve probability mass
- no production simulation behavior is activated

## Decision implication

The project now has a safe intermediate layer between PA probabilities and future subtype-conditioned transition mechanics.

This enables the next modeling layer to consume subtype outcomes without risking probability-mass loss.

## Recommended next step

`Layer 6U — subtype transition prototype`

## What this does not do

- Does not change production simulation behavior
- Does not activate transition realism by default
- Does not modify `_build_pa_model()`
- Does not modify Model Projections UI/routes
- Does not add edge detection
- Does not add sportsbook logic