### PR TITLE
Add Layer 6U subtype transition prototype

### DIFF
--- a/mlb_app/simulation/subtype_transitions.py
+++ b/mlb_app/simulation/subtype_transitions.py
@@ -1,0 +1,386 @@
+import random
+
+DEFAULT_SUBTYPE_TRANSITION_RATES = {
+    "groundout_double_play_rate": 0.11,
+    "groundout_runner_third_scores_rate": 0.25,
+    "groundout_runner_second_advances_rate": 0.35,
+    "flyout_runner_third_scores_rate": 0.38,
+    "flyout_runner_second_advances_rate": 0.22,
+    "lineout_popout_runner_third_scores_rate": 0.05,
+    "lineout_popout_runner_second_advances_rate": 0.05,
+}
+
+VALID_SUBTYPES = {
+    "strikeout",
+    "groundout",
+    "flyout",
+    "lineout_popout",
+    "other_out",
+}
+
+def resolve_subtype_transition_rates(
+    transition_rates=None,
+):
+
+    resolved = dict(
+        DEFAULT_SUBTYPE_TRANSITION_RATES
+    )
+
+    if transition_rates is None:
+
+        return resolved
+
+    if not isinstance(
+        transition_rates,
+        dict,
+    ):
+
+        raise TypeError(
+            "transition_rates must be dict"
+        )
+
+    for key, value in (
+        transition_rates.items()
+    ):
+
+        if (
+            key
+            not in DEFAULT_SUBTYPE_TRANSITION_RATES
+        ):
+
+            raise ValueError(
+                f"unknown transition rate: {key}"
+            )
+
+        if not isinstance(
+            value,
+            (int, float),
+        ):
+
+            raise ValueError(
+                f"rate must be numeric: {key}"
+            )
+
+        value = float(value)
+
+        if value < 0.0 or value > 1.0:
+
+            raise ValueError(
+                f"rate out of bounds: {key}"
+            )
+
+        resolved[key] = value
+
+    return resolved
+
+def _roll(
+    rng,
+    probability,
+):
+
+    return (
+        rng.random()
+        < probability
+    )
+
+def advance_runners_by_subtype(
+    bases,
+    outcome_subtype,
+    outs,
+    rng=None,
+    transition_rates=None,
+):
+
+    if (
+        outcome_subtype
+        not in VALID_SUBTYPES
+    ):
+
+        raise ValueError(
+            (
+                "invalid outcome subtype: "
+                f"{outcome_subtype}"
+            )
+        )
+
+    if rng is None:
+
+        rng = random.Random()
+
+    rates = (
+        resolve_subtype_transition_rates(
+            transition_rates
+        )
+    )
+
+    first, second, third = bases
+
+    runs_scored = 0
+
+    outs_added = 1
+
+    #
+    # STRIKEOUT
+    #
+
+    if (
+        outcome_subtype
+        == "strikeout"
+    ):
+
+        return (
+            (
+                first,
+                second,
+                third,
+            ),
+            0,
+            1,
+        )
+
+    #
+    # OTHER OUT
+    #
+
+    if (
+        outcome_subtype
+        == "other_out"
+    ):
+
+        return (
+            (
+                first,
+                second,
+                third,
+            ),
+            0,
+            1,
+        )
+
+    #
+    # GROUNDOUT
+    #
+
+    if (
+        outcome_subtype
+        == "groundout"
+    ):
+
+        #
+        # Double play case
+        #
+
+        if (
+            first
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "groundout_"
+                        "double_play_rate"
+                    )
+                ],
+            )
+        ):
+
+            outs_added = 2
+
+            return (
+                (
+                    False,
+                    second,
+                    third,
+                ),
+                0,
+                outs_added,
+            )
+
+        #
+        # Standard groundout
+        #
+
+        new_first = False
+        new_second = second
+        new_third = third
+
+        #
+        # Runner scores from third
+        #
+
+        if (
+            third
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "groundout_runner_"
+                        "third_scores_rate"
+                    )
+                ],
+            )
+        ):
+
+            runs_scored += 1
+            new_third = False
+
+        #
+        # Runner advances from second
+        #
+
+        if (
+            second
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "groundout_runner_"
+                        "second_advances_rate"
+                    )
+                ],
+            )
+        ):
+
+            new_second = False
+
+            if not new_third:
+
+                new_third = True
+
+        return (
+            (
+                new_first,
+                new_second,
+                new_third,
+            ),
+            runs_scored,
+            outs_added,
+        )
+
+    #
+    # FLYOUT
+    #
+
+    if (
+        outcome_subtype
+        == "flyout"
+    ):
+
+        new_first = first
+        new_second = second
+        new_third = third
+
+        if (
+            third
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "flyout_runner_"
+                        "third_scores_rate"
+                    )
+                ],
+            )
+        ):
+
+            runs_scored += 1
+            new_third = False
+
+        if (
+            second
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "flyout_runner_"
+                        "second_advances_rate"
+                    )
+                ],
+            )
+        ):
+
+            new_second = False
+
+            if not new_third:
+
+                new_third = True
+
+        return (
+            (
+                new_first,
+                new_second,
+                new_third,
+            ),
+            runs_scored,
+            outs_added,
+        )
+
+    #
+    # LINEOUT / POPOUT
+    #
+
+    if (
+        outcome_subtype
+        == "lineout_popout"
+    ):
+
+        new_first = first
+        new_second = second
+        new_third = third
+
+        if (
+            third
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "lineout_popout_"
+                        "runner_third_"
+                        "scores_rate"
+                    )
+                ],
+            )
+        ):
+
+            runs_scored += 1
+            new_third = False
+
+        if (
+            second
+            and outs < 2
+            and _roll(
+                rng,
+                rates[
+                    (
+                        "lineout_popout_"
+                        "runner_second_"
+                        "advances_rate"
+                    )
+                ],
+            )
+        ):
+
+            new_second = False
+
+            if not new_third:
+
+                new_third = True
+
+        return (
+            (
+                new_first,
+                new_second,
+                new_third,
+            ),
+            runs_scored,
+            outs_added,
+        )
+
+    raise RuntimeError(
+        "unreachable subtype path"
+    )

--- a/scripts/audit_subtype_transition_prototype.py
+++ b/scripts/audit_subtype_transition_prototype.py
@@ -1,0 +1,619 @@
+import csv
+import json
+import random
+from pathlib import Path
+
+from mlb_app.simulation.subtype_transitions import (
+    advance_runners_by_subtype,
+)
+
+TMP_DIR = Path("tmp")
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "subtype_transition_prototype.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "subtype_transition_prototype_checks.csv"
+)
+
+OUTPUT_ORDERING = (
+    TMP_DIR
+    / "subtype_transition_scoring_ordering.csv"
+)
+
+def write_csv(
+    path,
+    rows,
+):
+
+    if not rows:
+
+        rows = [
+            {
+                "status":
+                    "no_rows"
+            }
+        ]
+
+    with open(
+        path,
+        "w",
+        newline="",
+    ) as f:
+
+        writer = csv.DictWriter(
+            f,
+            fieldnames=list(
+                rows[0].keys()
+            ),
+        )
+
+        writer.writeheader()
+        writer.writerows(rows)
+
+checks = []
+
+def add_check(
+    name,
+    passed,
+):
+
+    checks.append(
+        {
+            "check": name,
+            "passed": passed,
+        }
+    )
+
+#
+# Strikeout deterministic
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            True,
+            True,
+            True,
+        ),
+        "strikeout",
+        0,
+        rng=random.Random(42),
+    )
+)
+
+add_check(
+    "strikeout_bases_hold",
+    bases == (
+        True,
+        True,
+        True,
+    ),
+)
+
+add_check(
+    "strikeout_no_runs",
+    runs == 0,
+)
+
+add_check(
+    "strikeout_one_out",
+    outs == 1,
+)
+
+#
+# Other out deterministic
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            True,
+            True,
+            True,
+        ),
+        "other_out",
+        0,
+        rng=random.Random(42),
+    )
+)
+
+add_check(
+    "other_out_bases_hold",
+    bases == (
+        True,
+        True,
+        True,
+    ),
+)
+
+add_check(
+    "other_out_no_runs",
+    runs == 0,
+)
+
+add_check(
+    "other_out_one_out",
+    outs == 1,
+)
+
+#
+# Groundout DP
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            True,
+            False,
+            False,
+        ),
+        "groundout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "groundout_"
+                "double_play_rate"
+            ): 1.0,
+        },
+    )
+)
+
+add_check(
+    "groundout_double_play",
+    (
+        outs == 2
+        and bases[0] is False
+    ),
+)
+
+#
+# Groundout no DP
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            True,
+            False,
+            False,
+        ),
+        "groundout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "groundout_"
+                "double_play_rate"
+            ): 0.0,
+        },
+    )
+)
+
+add_check(
+    "groundout_no_double_play",
+    (
+        outs == 1
+        and bases[0] is False
+    ),
+)
+
+#
+# Groundout runner scores
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            True,
+        ),
+        "groundout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "groundout_runner_"
+                "third_scores_rate"
+            ): 1.0,
+        },
+    )
+)
+
+add_check(
+    "groundout_runner_scores",
+    (
+        runs == 1
+        and bases[2] is False
+    ),
+)
+
+#
+# Flyout runner scores
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            True,
+        ),
+        "flyout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "flyout_runner_"
+                "third_scores_rate"
+            ): 1.0,
+        },
+    )
+)
+
+add_check(
+    "flyout_runner_scores",
+    (
+        runs == 1
+        and bases[2] is False
+    ),
+)
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            True,
+        ),
+        "flyout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "flyout_runner_"
+                "third_scores_rate"
+            ): 0.0,
+        },
+    )
+)
+
+add_check(
+    "flyout_runner_holds",
+    (
+        runs == 0
+        and bases[2] is True
+    ),
+)
+
+#
+# Lineout/popout
+#
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            True,
+        ),
+        "lineout_popout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "lineout_popout_"
+                "runner_third_"
+                "scores_rate"
+            ): 1.0,
+        },
+    )
+)
+
+add_check(
+    "lineout_runner_scores",
+    runs == 1,
+)
+
+bases, runs, outs = (
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            True,
+        ),
+        "lineout_popout",
+        0,
+        rng=random.Random(42),
+        transition_rates={
+            (
+                "lineout_popout_"
+                "runner_third_"
+                "scores_rate"
+            ): 0.0,
+        },
+    )
+)
+
+add_check(
+    "lineout_runner_holds",
+    runs == 0,
+)
+
+#
+# Invalid subtype
+#
+
+invalid_subtype_passed = False
+
+try:
+
+    advance_runners_by_subtype(
+        (
+            False,
+            False,
+            False,
+        ),
+        "bad_subtype",
+        0,
+    )
+
+except ValueError:
+
+    invalid_subtype_passed = True
+
+add_check(
+    "invalid_subtype_rejected",
+    invalid_subtype_passed,
+)
+
+#
+# Invalid rate
+#
+
+invalid_rate_cases = [
+    {
+        "bad_rate": 0.5
+    },
+
+    {
+        (
+            "groundout_"
+            "double_play_rate"
+        ): -1
+    },
+
+    {
+        (
+            "groundout_"
+            "double_play_rate"
+        ): 2
+    },
+
+    {
+        (
+            "groundout_"
+            "double_play_rate"
+        ): "bad"
+    },
+]
+
+invalid_rate_passes = 0
+
+for case in invalid_rate_cases:
+
+    try:
+
+        advance_runners_by_subtype(
+            (
+                False,
+                False,
+                False,
+            ),
+            "groundout",
+            0,
+            transition_rates=case,
+        )
+
+    except ValueError:
+
+        invalid_rate_passes += 1
+
+add_check(
+    "invalid_rates_rejected",
+    (
+        invalid_rate_passes
+        == len(
+            invalid_rate_cases
+        )
+    ),
+)
+
+#
+# Relative realism ordering
+#
+
+ordering_rows = []
+
+subtypes = [
+    "strikeout",
+    "groundout",
+    "flyout",
+    "lineout_popout",
+    "other_out",
+]
+
+scoring_rates = {}
+
+N = 1000
+
+for subtype in subtypes:
+
+    runs_scored = 0
+
+    for i in range(N):
+
+        _, runs, _ = (
+            advance_runners_by_subtype(
+                (
+                    False,
+                    False,
+                    True,
+                ),
+                subtype,
+                0,
+                rng=random.Random(i),
+            )
+        )
+
+        if runs > 0:
+
+            runs_scored += 1
+
+    rate = (
+        runs_scored / N
+    )
+
+    scoring_rates[
+        subtype
+    ] = rate
+
+    ordering_rows.append(
+        {
+            "subtype":
+                subtype,
+
+            "scoring_rate":
+                rate,
+        }
+    )
+
+ordering_passed = (
+    scoring_rates[
+        "flyout"
+    ]
+    >
+    scoring_rates[
+        "groundout"
+    ]
+    >
+    scoring_rates[
+        "lineout_popout"
+    ]
+    >=
+    scoring_rates[
+        "strikeout"
+    ]
+    and
+    scoring_rates[
+        "lineout_popout"
+    ]
+    >=
+    scoring_rates[
+        "other_out"
+    ]
+)
+
+add_check(
+    "relative_ordering_passed",
+    ordering_passed,
+)
+
+write_csv(
+    OUTPUT_CHECKS,
+    checks,
+)
+
+write_csv(
+    OUTPUT_ORDERING,
+    ordering_rows,
+)
+
+checks_failed = len(
+    [
+        row
+        for row in checks
+        if not row["passed"]
+    ]
+)
+
+if not ordering_passed:
+
+    diagnosis = (
+        "subtype_transition_"
+        "prototype_ordering_"
+        "failed"
+    )
+
+elif checks_failed > 0:
+
+    diagnosis = (
+        "subtype_transition_"
+        "prototype_rule_failed"
+    )
+
+else:
+
+    diagnosis = (
+        "subtype_transition_"
+        "prototype_safe"
+    )
+
+summary = {
+    "diagnosis":
+        diagnosis,
+
+    "checks_passed":
+        len(checks)
+        - checks_failed,
+
+    "checks_failed":
+        checks_failed,
+
+    "invalid_input_rejections_passed":
+        (
+            invalid_subtype_passed
+            and (
+                invalid_rate_passes
+                == len(
+                    invalid_rate_cases
+                )
+            )
+        ),
+
+    "relative_ordering_passed":
+        ordering_passed,
+
+    "default_activation_changed":
+        False,
+
+    "recommended_next_step":
+        (
+            "layer_6v_"
+            "subtype_transition_"
+            "integration_audit"
+        ),
+}
+
+with open(
+    OUTPUT_JSON,
+    "w",
+) as f:
+
+    json.dump(
+        summary,
+        f,
+        indent=2,
+    )
+
+print(
+    json.dumps(
+        summary,
+        indent=2,
+    )
+)


### PR DESCRIPTION
## Summary

Adds Layer 6U subtype transition prototype tooling.

This PR introduces a standalone subtype-conditioned base/out transition helper that can be audited independently before any candidate-only half-inning integration.

## Why

Layer 6T added a schema-safe subtype probability derivation layer:

```text
generic out probability
→ groundout / flyout / lineout_popout / other_out
```

while keeping strikeouts separate and preserving total PA probability mass.

Layer 6U is the next modeling step: proving that subtype-specific transition mechanics are valid, deterministic where needed, probabilistically plausible, and safe before simulator integration.

## What this adds

- `mlb_app/simulation/subtype_transitions.py`
- `scripts/audit_subtype_transition_prototype.py`

## Prototype behavior

`advance_runners_by_subtype(...)` supports:

- `strikeout`: +1 out, no advancement
- `groundout`: GDP/force-out/conservative advancement logic
- `flyout`: sac-fly/tag-up style advancement logic
- `lineout_popout`: limited advancement logic
- `other_out`: conservative fallback

It also validates subtype transition rates and rejects invalid subtype/rate inputs.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts

python scripts/audit_subtype_transition_prototype.py
```

Result:

```json
{
  "diagnosis": "subtype_transition_prototype_safe",
  "checks_passed": 16,
  "checks_failed": 0,
  "invalid_input_rejections_passed": true,
  "relative_ordering_passed": true,
  "default_activation_changed": false,
  "recommended_next_step": "layer_6v_subtype_transition_integration_audit"
}
```

## Interpretation

The standalone subtype transition prototype is safe and baseball-plausible:

- strikeouts suppress runner advancement
- groundouts introduce GDP/force-out dynamics
- flyouts support sac-fly/tag-up behavior
- lineout/popout outcomes have limited advancement
- other outs remain conservative fallback
- relative scoring order is plausible

Expected scoring ordering was validated:

```text
flyout > groundout > lineout_popout >= strikeout/other_out
```

## Decision implication

Subtype-conditioned transition mechanics are safe enough for a candidate-only integration audit.

## Recommended next step

`Layer 6V — subtype transition integration audit`

## What this does not do

- Does not integrate subtype transitions into `simulate_half_inning()`
- Does not change production/default simulation behavior
- Does not activate transition realism by default
- Does not modify `_build_pa_model()`
- Does not modify Model Projections UI/routes
- Does not add edge detection
- Does not add sportsbook logic