### PR TITLE
Add Model Tracker page for daily model output snapshots

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import LiveGamePageRestored from './pages/LiveGamePageRestored'
 import DailyOddsPage from './pages/DailyOddsPage'
 import ModelProjectionsPage from './pages/ModelProjectionsPage'
 import MyDashboardPage from './pages/MyDashboardPage'
+import ModelTrackerPage from './pages/ModelTrackerPage'
 
 // Set VITE_ENABLE_BATTER_PAGE=true in Railway env vars to re-enable the Batter routes.
 // Keep false until the leaderboard endpoint is validated stable in production.
@@ -56,12 +57,14 @@ export default function App() {
           <NavLink to="/calendar" className={navLinkClass}>Calendar</NavLink>
           <NavLink to="/ai-data-assistant" className={navLinkClass}>AI Data Assistant</NavLink>
           <NavLink to="/live" className={navLinkClass}>Live</NavLink>
+          <NavLink to="/model-tracker" className={navLinkClass}>Model Tracker</NavLink>
         </nav>
         <main className="app-main">
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/daily-odds" element={<DailyOddsPage />} />
             <Route path="/models/projections" element={<ModelProjectionsPage />} />
+            <Route path="/model-tracker" element={<ModelTrackerPage />} />
             <Route path="/my-dashboard" element={<MyDashboardPage />} />
             <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
             <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />

--- a/frontend/src/pages/ModelTrackerPage.jsx
+++ b/frontend/src/pages/ModelTrackerPage.jsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { API_BASE, getMlbLiveDate } from '../lib/api'
+
+const API = API_BASE
+
+const s = {
+  page: { display: 'grid', gap: 18 },
+  hero: { border: '1px solid var(--border-subtle)', borderRadius: 18, padding: 22, background: 'rgba(15, 23, 42, 0.72)' },
+  header: { display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'flex-start', flexWrap: 'wrap' },
+  controls: { display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: 12 },
+  card: { border: '1px solid var(--border-subtle)', borderRadius: 14, padding: 14, background: 'rgba(7, 11, 18, 0.55)' },
+  value: { fontSize: 28, fontWeight: 900, color: 'var(--text-primary)', letterSpacing: '-0.05em' },
+  label: { fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 850 },
+  section: { border: '1px solid var(--border-subtle)', borderRadius: 16, padding: 16, background: 'rgba(15, 23, 42, 0.56)' },
+  sectionHeader: { display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap', marginBottom: 12 },
+  sectionTitle: { fontSize: 18, fontWeight: 900, color: 'var(--text-primary)' },
+  filters: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10 },
+  input: { width: '100%', boxSizing: 'border-box' },
+  button: { cursor: 'pointer' },
+  gameCard: { border: '1px solid var(--border-subtle)', borderRadius: 14, padding: 14, background: 'rgba(7, 11, 18, 0.42)', marginTop: 12 },
+  gameTop: { display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' },
+  gameTitle: { fontSize: 17, fontWeight: 900, color: 'var(--text-primary)' },
+  miniGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10, marginTop: 12 },
+  rowCard: { border: '1px solid var(--border-subtle)', borderRadius: 12, padding: 11, background: 'rgba(17, 24, 39, 0.72)' },
+  rowTitle: { color: 'var(--text-primary)', fontSize: 13, fontWeight: 850, overflowWrap: 'anywhere' },
+  rowMeta: { color: 'var(--text-muted)', fontSize: 12, marginTop: 5, lineHeight: 1.45, overflowWrap: 'anywhere' },
+  tableWrap: { overflowX: 'auto', border: '1px solid var(--border-subtle)', borderRadius: 14 },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 12 },
+  th: { textAlign: 'left', padding: '9px 10px', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-muted)', whiteSpace: 'nowrap' },
+  td: { padding: '9px 10px', borderBottom: '1px solid rgba(148, 163, 184, 0.14)', color: 'var(--text-secondary)', whiteSpace: 'nowrap' },
+  detail: { marginTop: 8, whiteSpace: 'pre-wrap', color: 'var(--text-muted)', fontSize: 12, lineHeight: 1.45 },
+}
+
+function StatCard({ label, value }) {
+  return <div style={s.card}><div style={s.label}>{label}</div><div style={s.value}>{value ?? 0}</div></div>
+}
+
+function fmt(value, digits = 3) {
+  if (value === null || value === undefined || value === '') return 'Unavailable'
+  const n = Number(value)
+  if (Number.isNaN(n)) return String(value)
+  return Number.isInteger(n) ? String(n) : n.toFixed(digits)
+}
+
+function gradeLabel(row) {
+  if (row.grade === 'pending') return 'Snapshot Pending'
+  if (row.result_status === 'live') return 'Live Tracking'
+  if (row.result_status === 'final' && row.grade === 'ungraded') return 'Final Ungraded'
+  if (['won', 'lost', 'push', 'partial'].includes(row.grade)) return 'Graded'
+  if (row.grade === 'watchlist_only') return 'Watchlist Only'
+  if (row.grade === 'ungraded') return 'Needs Result Mapping'
+  return row.grade || 'Untracked'
+}
+
+function GameTrackerCard({ game }) {
+  const title = game.game_pk ? `${game.away_team || 'Away'} @ ${game.home_team || 'Home'}` : 'Ungrouped model outputs'
+  const rows = game.rows || []
+  const sideRows = rows.filter(row => ['side', 'moneyline'].includes(String(row.pick_type || '').toLowerCase())).slice(0, 2)
+  const totalRows = rows.filter(row => String(row.market_type || '').toLowerCase().includes('total')).slice(0, 2)
+  const hitterRows = rows.filter(row => String(row.source_component || '').includes('hitter')).slice(0, 3)
+  const pitcherRows = rows.filter(row => String(row.source_component || '').includes('pitcher')).slice(0, 3)
+  const propRows = rows.filter(row => String(row.pick_type || '').includes('prop') || String(row.market_type || '').includes('prop')).slice(0, 4)
+  const previewRows = [...sideRows, ...totalRows, ...hitterRows, ...pitcherRows, ...propRows].slice(0, 8)
+
+  return <article style={s.gameCard}>
+    <div style={s.gameTop}>
+      <div>
+        <div style={s.gameTitle}>{title}</div>
+        <div style={s.rowMeta}>Game PK {game.game_pk || 'N/A'} · {game.row_count} tracked outputs · Sources: {(game.sources || []).join(', ') || 'none'}</div>
+      </div>
+      <span className="status-badge">{Object.entries(game.grades || {}).map(([k, v]) => `${k}: ${v}`).join(' · ') || 'No grades'}</span>
+    </div>
+    <div style={s.miniGrid}>
+      {previewRows.length === 0 && <div style={s.rowMeta}>No model rows available for this game.</div>}
+      {previewRows.map(row => <div key={row.id || row.tracker_key} style={s.rowCard}>
+        <div style={s.rowTitle}>{row.pick_label || row.player_name || row.team_name || row.model_name || 'Tracked output'}</div>
+        <div style={s.rowMeta}>{row.source} / {row.source_component} · {row.market_type || 'model'} · {gradeLabel(row)}</div>
+        <div style={s.rowMeta}>Score {fmt(row.score)} · Confidence {fmt(row.confidence)} · Edge {fmt(row.edge)}</div>
+        {row.primary_reason && <details style={s.detail}><summary>Reason</summary>{row.primary_reason}</details>}
+      </div>)}
+    </div>
+  </article>
+}
+
+export default function ModelTrackerPage() {
+  const [date, setDate] = useState(getMlbLiveDate())
+  const [payload, setPayload] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [resultRefreshing, setResultRefreshing] = useState(false)
+  const [error, setError] = useState(null)
+  const [sourceFilter, setSourceFilter] = useState('all')
+  const [gradeFilter, setGradeFilter] = useState('all')
+  const [gameFilter, setGameFilter] = useState('all')
+  const [search, setSearch] = useState('')
+
+  function load() {
+    setLoading(true)
+    setError(null)
+    fetch(`${API}/model-tracker?date=${date}`)
+      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+      .then(json => { setPayload(json); setLoading(false) })
+      .catch(err => { setError(String(err?.message || err)); setLoading(false) })
+  }
+
+  function refreshSnapshot() {
+    setRefreshing(true)
+    setError(null)
+    fetch(`${API}/model-tracker/snapshot?date=${date}`, { method: 'POST' })
+      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+      .then(() => { setRefreshing(false); load() })
+      .catch(err => { setError(String(err?.message || err)); setRefreshing(false) })
+  }
+
+  function refreshResults() {
+    setResultRefreshing(true)
+    setError(null)
+    fetch(`${API}/model-tracker/results/refresh?date=${date}`, { method: 'POST' })
+      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+      .then(() => { setResultRefreshing(false); load() })
+      .catch(err => { setError(String(err?.message || err)); setResultRefreshing(false) })
+  }
+
+  useEffect(() => { load() }, [date])
+
+  const rows = payload?.rows || []
+  const games = payload?.games || []
+  const sources = useMemo(() => ['all', ...Array.from(new Set(rows.map(r => r.source).filter(Boolean))).sort()], [rows])
+  const grades = useMemo(() => ['all', ...Array.from(new Set(rows.map(r => r.grade).filter(Boolean))).sort()], [rows])
+  const gameOptions = useMemo(() => ['all', ...games.map(g => String(g.game_pk || 'ungrouped'))], [games])
+
+  const filteredRows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return rows.filter(row => {
+      if (sourceFilter !== 'all' && row.source !== sourceFilter) return false
+      if (gradeFilter !== 'all' && row.grade !== gradeFilter) return false
+      if (gameFilter !== 'all' && String(row.game_pk || 'ungrouped') !== gameFilter) return false
+      if (!q) return true
+      return [row.pick_label, row.player_name, row.team_name, row.away_team, row.home_team, row.model_name, row.primary_reason]
+        .some(value => String(value || '').toLowerCase().includes(q))
+    })
+  }, [rows, sourceFilter, gradeFilter, gameFilter, search])
+
+  const filteredGames = useMemo(() => {
+    const allowedIds = new Set(filteredRows.map(row => String(row.game_pk || 'ungrouped')))
+    return games.map(game => ({ ...game, rows: (game.rows || []).filter(row => filteredRows.some(fr => fr.id === row.id)) }))
+      .filter(game => allowedIds.has(String(game.game_pk || 'ungrouped')))
+  }, [games, filteredRows])
+
+  const summary = payload?.summary || {}
+
+  return <div style={s.page}>
+    <section style={s.hero}>
+      <div style={s.header}>
+        <div>
+          <p className="page-kicker">Model Accountability</p>
+          <h1 className="page-title">Model Tracker</h1>
+          <p className="page-subtitle">Daily snapshots of model outputs, live comparison state, final-result grading where safe, and ungraded watchlist preservation.</p>
+        </div>
+        <div style={s.controls}>
+          <input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} />
+          <button className="button-primary" type="button" style={s.button} onClick={refreshSnapshot} disabled={refreshing}>{refreshing ? 'Saving...' : 'Refresh Snapshot'}</button>
+          <button className="button-secondary" type="button" style={s.button} onClick={refreshResults} disabled={resultRefreshing}>{resultRefreshing ? 'Comparing...' : 'Refresh Results'}</button>
+        </div>
+      </div>
+    </section>
+
+    {error && <div className="state-panel error">{error}</div>}
+    {loading && <div className="state-panel">Loading tracker rows...</div>}
+
+    <section style={s.grid}>
+      <StatCard label="Tracked Rows" value={summary.total_rows || filteredRows.length} />
+      <StatCard label="Games Tracked" value={summary.games_tracked} />
+      <StatCard label="Pending" value={summary.pending_rows} />
+      <StatCard label="Live" value={summary.live_rows} />
+      <StatCard label="Graded" value={summary.graded_rows} />
+      <StatCard label="Won" value={summary.won} />
+      <StatCard label="Lost" value={summary.lost} />
+      <StatCard label="Ungraded" value={summary.ungraded_rows} />
+    </section>
+
+    <section style={s.section}>
+      <div style={s.sectionHeader}>
+        <div style={s.sectionTitle}>Filters</div>
+        <span className="status-badge">{filteredRows.length} visible rows</span>
+      </div>
+      <div style={s.filters}>
+        <label><div style={s.label}>Source</div><select className="input-control" style={s.input} value={sourceFilter} onChange={e => setSourceFilter(e.target.value)}>{sources.map(source => <option key={source} value={source}>{source}</option>)}</select></label>
+        <label><div style={s.label}>Grade</div><select className="input-control" style={s.input} value={gradeFilter} onChange={e => setGradeFilter(e.target.value)}>{grades.map(grade => <option key={grade} value={grade}>{grade}</option>)}</select></label>
+        <label><div style={s.label}>Game</div><select className="input-control" style={s.input} value={gameFilter} onChange={e => setGameFilter(e.target.value)}>{gameOptions.map(game => <option key={game} value={game}>{game}</option>)}</select></label>
+        <label><div style={s.label}>Search</div><input className="input-control" style={s.input} value={search} onChange={e => setSearch(e.target.value)} placeholder="player, team, pick, reason" /></label>
+      </div>
+    </section>
+
+    <section style={s.section}>
+      <div style={s.sectionHeader}>
+        <div><div style={s.sectionTitle}>Game Grouped Tracker</div><div style={s.rowMeta}>Grouped by MLB game, with sides, totals, hitters, pitchers, props, watchlists, and grades in one place.</div></div>
+      </div>
+      {filteredGames.length === 0 && <div className="state-panel">No tracker rows found. Click Refresh Snapshot to save today's model outputs.</div>}
+      {filteredGames.map(game => <GameTrackerCard key={String(game.game_pk || 'ungrouped')} game={game} />)}
+    </section>
+
+    <section style={s.section}>
+      <div style={s.sectionHeader}>
+        <div><div style={s.sectionTitle}>Table View</div><div style={s.rowMeta}>Every stored model output, including ungraded watchlist rows and final comparison state.</div></div>
+      </div>
+      <div style={s.tableWrap}>
+        <table style={s.table}>
+          <thead><tr><th style={s.th}>Date</th><th style={s.th}>Source</th><th style={s.th}>Game</th><th style={s.th}>Type</th><th style={s.th}>Pick</th><th style={s.th}>Player/Team</th><th style={s.th}>Model</th><th style={s.th}>Score</th><th style={s.th}>Confidence</th><th style={s.th}>Line</th><th style={s.th}>Price</th><th style={s.th}>Status</th><th style={s.th}>Grade</th><th style={s.th}>Reason</th></tr></thead>
+          <tbody>
+            {filteredRows.map(row => <tr key={row.id || row.tracker_key}>
+              <td style={s.td}>{row.snapshot_date}</td>
+              <td style={s.td}>{row.source}</td>
+              <td style={s.td}>{row.away_team || 'Away'} @ {row.home_team || 'Home'}</td>
+              <td style={s.td}>{row.market_type || row.pick_type}</td>
+              <td style={s.td}>{row.pick_label || 'N/A'}</td>
+              <td style={s.td}>{row.player_name || row.team_name || 'N/A'}</td>
+              <td style={s.td}>{row.model_name || 'N/A'}</td>
+              <td style={s.td}>{fmt(row.score)}</td>
+              <td style={s.td}>{fmt(row.confidence)}</td>
+              <td style={s.td}>{fmt(row.line)}</td>
+              <td style={s.td}>{fmt(row.price, 0)}</td>
+              <td style={s.td}>{row.result_status}</td>
+              <td style={s.td}>{row.grade}</td>
+              <td style={{ ...s.td, whiteSpace: 'normal', minWidth: 260 }}>{row.grade_reason || row.primary_reason || 'N/A'}</td>
+            </tr>)}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+}

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -8,9 +8,11 @@ from fastapi import APIRouter, HTTPException
 
 from .database import create_tables, get_engine, get_session
 from .model_projections import build_model_projection_payload
+from .model_tracker_routes import router as model_tracker_router
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 
 router = APIRouter()
+router.include_router(model_tracker_router)
 
 
 def _session_factory():

--- a/mlb_app/model_tracker.py
+++ b/mlb_app/model_tracker.py
@@ -1,0 +1,780 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import re
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+from sqlalchemy import Column, Date, DateTime, Float, Index, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Session
+
+from .database import Base
+from .matchup_generator import generate_matchups_for_date
+from .model_projections import build_model_projection_payload
+from .my_dashboard_solver import build_dashboard_solver_payload
+
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+TRACKER_GRADES = {"pending", "live", "won", "lost", "push", "partial", "ungraded", "watchlist_only", "error"}
+DASHBOARD_COMPONENTS = ("hitters", "pitchers", "teams", "totals", "overall_players")
+AI_TRACKER_PROMPTS = (
+    "What is the strongest model edge?",
+    "Best Stored 365 hitter matchups",
+    "Top pitcher leans",
+    "What data is stale or weak?",
+)
+
+
+class ModelTrackerSnapshot(Base):
+    """Persistent, additive record of what an existing model surface said at snapshot time."""
+
+    __tablename__ = "model_tracker_snapshots"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    tracker_key = Column(String(500), nullable=False, unique=True, index=True)
+    snapshot_date = Column(Date, nullable=False, index=True)
+    created_at = Column(DateTime, default=dt.datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=dt.datetime.utcnow, nullable=False)
+
+    source = Column(String(80), nullable=True, index=True)
+    source_endpoint = Column(String(180), nullable=True)
+    source_component = Column(String(80), nullable=True, index=True)
+
+    game_pk = Column(Integer, nullable=True, index=True)
+    event_id = Column(String(120), nullable=True, index=True)
+    team_id = Column(Integer, nullable=True, index=True)
+    player_id = Column(Integer, nullable=True, index=True)
+    player_name = Column(String(180), nullable=True)
+    team_name = Column(String(180), nullable=True)
+    opponent_name = Column(String(180), nullable=True)
+    away_team = Column(String(180), nullable=True)
+    home_team = Column(String(180), nullable=True)
+
+    market_type = Column(String(80), nullable=True, index=True)
+    pick_type = Column(String(80), nullable=True, index=True)
+    pick_label = Column(String(240), nullable=True)
+    model_name = Column(String(120), nullable=True)
+    model_version = Column(String(80), nullable=True)
+
+    model_probability = Column(Float, nullable=True)
+    market_implied_probability = Column(Float, nullable=True)
+    edge = Column(Float, nullable=True)
+    score = Column(Float, nullable=True)
+    confidence = Column(Float, nullable=True)
+    line = Column(Float, nullable=True)
+    price = Column(Float, nullable=True)
+    expected_value = Column(Float, nullable=True)
+    projected_total = Column(Float, nullable=True)
+    projected_home_runs = Column(Float, nullable=True)
+    projected_away_runs = Column(Float, nullable=True)
+    home_win_probability = Column(Float, nullable=True)
+    away_win_probability = Column(Float, nullable=True)
+
+    primary_reason = Column(Text, nullable=True)
+    reasoning_json = Column(Text, nullable=True)
+    features_used_json = Column(Text, nullable=True)
+    missing_inputs_json = Column(Text, nullable=True)
+    raw_payload_json = Column(Text, nullable=True)
+
+    game_status_at_snapshot = Column(String(120), nullable=True)
+    result_status = Column(String(80), default="pending", nullable=False, index=True)
+    actual_result_json = Column(Text, nullable=True)
+    grade = Column(String(40), default="pending", nullable=False, index=True)
+    grade_reason = Column(Text, nullable=True)
+    last_compared_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("tracker_key", name="uq_model_tracker_snapshots_tracker_key"),
+        Index("ix_model_tracker_date_game", "snapshot_date", "game_pk"),
+        Index("ix_model_tracker_date_source", "snapshot_date", "source", "source_component"),
+    )
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value is None or value == "":
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        return json.dumps(value, default=str, sort_keys=True)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def _loads(value: Optional[str]) -> Any:
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except Exception:
+        return value
+
+
+def _short_reason(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    if isinstance(value, list):
+        return "; ".join(str(v) for v in value[:3])[:1000] or fallback
+    return str(value)[:1000] or fallback
+
+
+def _normalize_name(name: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(name or "").lower().replace("the", "", 1))
+
+
+def _tracker_key(row: Dict[str, Any]) -> str:
+    parts = [
+        row.get("snapshot_date"),
+        row.get("source"),
+        row.get("source_component"),
+        row.get("game_pk"),
+        row.get("event_id"),
+        row.get("player_id"),
+        row.get("team_id"),
+        row.get("market_type"),
+        row.get("pick_type"),
+        row.get("pick_label"),
+        row.get("model_name"),
+        row.get("line"),
+    ]
+    raw = "|".join(str(part or "") for part in parts)
+    if len(raw) <= 450:
+        return raw
+    return raw[:390] + "|" + hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def _base_row(source: str, target_date: str, **kwargs: Any) -> Dict[str, Any]:
+    row: Dict[str, Any] = {
+        "snapshot_date": target_date[:10],
+        "source": source,
+        "source_endpoint": kwargs.pop("source_endpoint", None),
+        "source_component": kwargs.pop("source_component", None),
+        "game_pk": kwargs.pop("game_pk", None),
+        "event_id": kwargs.pop("event_id", None),
+        "team_id": kwargs.pop("team_id", None),
+        "player_id": kwargs.pop("player_id", None),
+        "player_name": kwargs.pop("player_name", None),
+        "team_name": kwargs.pop("team_name", None),
+        "opponent_name": kwargs.pop("opponent_name", None),
+        "away_team": kwargs.pop("away_team", None),
+        "home_team": kwargs.pop("home_team", None),
+        "market_type": kwargs.pop("market_type", None),
+        "pick_type": kwargs.pop("pick_type", None),
+        "pick_label": kwargs.pop("pick_label", None),
+        "model_name": kwargs.pop("model_name", None),
+        "model_version": kwargs.pop("model_version", None),
+        "model_probability": kwargs.pop("model_probability", None),
+        "market_implied_probability": kwargs.pop("market_implied_probability", None),
+        "edge": kwargs.pop("edge", None),
+        "score": kwargs.pop("score", None),
+        "confidence": kwargs.pop("confidence", None),
+        "line": kwargs.pop("line", None),
+        "price": kwargs.pop("price", None),
+        "expected_value": kwargs.pop("expected_value", None),
+        "projected_total": kwargs.pop("projected_total", None),
+        "projected_home_runs": kwargs.pop("projected_home_runs", None),
+        "projected_away_runs": kwargs.pop("projected_away_runs", None),
+        "home_win_probability": kwargs.pop("home_win_probability", None),
+        "away_win_probability": kwargs.pop("away_win_probability", None),
+        "primary_reason": kwargs.pop("primary_reason", None),
+        "reasoning_json": kwargs.pop("reasoning_json", None),
+        "features_used_json": kwargs.pop("features_used_json", None),
+        "missing_inputs_json": kwargs.pop("missing_inputs_json", None),
+        "raw_payload_json": kwargs.pop("raw_payload_json", None),
+        "game_status_at_snapshot": kwargs.pop("game_status_at_snapshot", None),
+        "result_status": kwargs.pop("result_status", "pending"),
+        "grade": kwargs.pop("grade", "pending"),
+        "grade_reason": kwargs.pop("grade_reason", None),
+    }
+    for key, value in kwargs.items():
+        row[key] = value
+    row["tracker_key"] = _tracker_key(row)
+    return row
+
+
+def _team_pick_from_probs(matchup: Dict[str, Any]) -> tuple[Optional[str], Optional[float]]:
+    home_prob = _safe_float(matchup.get("home_win_prob") or matchup.get("home_win_probability"))
+    away_prob = _safe_float(matchup.get("away_win_prob") or matchup.get("away_win_probability"))
+    home_team = matchup.get("home_team_name") or matchup.get("home_team")
+    away_team = matchup.get("away_team_name") or matchup.get("away_team")
+    if home_prob is None or away_prob is None:
+        return None, None
+    return (home_team, home_prob) if home_prob >= away_prob else (away_team, away_prob)
+
+
+def normalize_matchup_rows(matchups: List[Dict[str, Any]], target_date: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for matchup in matchups or []:
+        home_team = matchup.get("home_team_name") or matchup.get("home_team")
+        away_team = matchup.get("away_team_name") or matchup.get("away_team")
+        pick, probability = _team_pick_from_probs(matchup)
+        rows.append(_base_row(
+            "matchups",
+            target_date,
+            source_endpoint="/matchups",
+            source_component="game_snapshot",
+            game_pk=matchup.get("game_pk"),
+            away_team=away_team,
+            home_team=home_team,
+            market_type="game",
+            pick_type="game_snapshot",
+            pick_label=f"{away_team} @ {home_team}",
+            model_name="daily_matchup_snapshot",
+            home_win_probability=_safe_float(matchup.get("home_win_prob")),
+            away_win_probability=_safe_float(matchup.get("away_win_prob")),
+            primary_reason="Daily matchup snapshot captured for tracker comparison.",
+            raw_payload_json=_json(matchup),
+            game_status_at_snapshot=matchup.get("status"),
+            grade="ungraded",
+            result_status="pending",
+        ))
+        if pick:
+            rows.append(_base_row(
+                "matchups",
+                target_date,
+                source_endpoint="/matchups",
+                source_component="moneyline_side",
+                game_pk=matchup.get("game_pk"),
+                away_team=away_team,
+                home_team=home_team,
+                team_name=pick,
+                market_type="moneyline",
+                pick_type="side",
+                pick_label=pick,
+                model_name="matchup_win_probability",
+                model_probability=probability,
+                score=probability,
+                confidence=probability,
+                home_win_probability=_safe_float(matchup.get("home_win_prob")),
+                away_win_probability=_safe_float(matchup.get("away_win_prob")),
+                primary_reason=f"Model side from matchup win probability: {pick}",
+                features_used_json=_json([
+                    {"name": "home_win_prob", "value": matchup.get("home_win_prob")},
+                    {"name": "away_win_prob", "value": matchup.get("away_win_prob")},
+                ]),
+                missing_inputs_json=_json(matchup.get("missing_inputs") or []),
+                raw_payload_json=_json(matchup),
+                game_status_at_snapshot=matchup.get("status"),
+                grade="pending",
+                result_status="pending",
+            ))
+    return rows
+
+
+def normalize_daily_odds_rows(payload: Dict[str, Any], target_date: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for game in payload.get("games") or payload.get("models") or []:
+        if not isinstance(game, dict):
+            continue
+        away_team = game.get("away_team") or game.get("away_team_name")
+        home_team = game.get("home_team") or game.get("home_team_name")
+        models = game.get("models") or {}
+        for market_key, model in models.items() if isinstance(models, dict) else []:
+            if not isinstance(model, dict):
+                continue
+            rows.append(_base_row(
+                "daily_odds",
+                target_date,
+                source_endpoint="/daily-odds/models",
+                source_component=str(market_key),
+                game_pk=game.get("game_pk"),
+                event_id=game.get("event_id"),
+                away_team=away_team,
+                home_team=home_team,
+                market_type=model.get("market") or market_key,
+                pick_type=market_key,
+                pick_label=model.get("pick") or model.get("selection"),
+                model_name=model.get("model") or "daily_odds_model",
+                model_probability=_safe_float(model.get("model_probability")),
+                market_implied_probability=_safe_float(model.get("market_implied_probability")),
+                edge=_safe_float(model.get("edge")),
+                score=_safe_float(model.get("score")),
+                confidence=_safe_float(model.get("confidence")),
+                line=_safe_float(model.get("line")),
+                price=_safe_float(model.get("price")),
+                expected_value=_safe_float(model.get("expected_value")),
+                primary_reason=_short_reason(model.get("drivers") or model.get("reasoning") or model.get("primary_reason"), "Daily Odds model output."),
+                reasoning_json=_json(model.get("drivers") or model.get("reasoning") or []),
+                features_used_json=_json(model.get("features_used") or []),
+                missing_inputs_json=_json(model.get("missing_inputs") or game.get("missing_inputs") or []),
+                raw_payload_json=_json({"game": game, "model": model}),
+                grade="pending" if model.get("pick") else "ungraded",
+                result_status="pending",
+            ))
+    for candidate in payload.get("top_prop_model_candidates") or []:
+        if not isinstance(candidate, dict):
+            continue
+        rows.append(_base_row(
+            "daily_odds",
+            target_date,
+            source_endpoint="/daily-odds/models",
+            source_component="top_prop_model_candidates",
+            game_pk=candidate.get("game_pk"),
+            event_id=candidate.get("event_id"),
+            away_team=candidate.get("away_team"),
+            home_team=candidate.get("home_team"),
+            player_id=candidate.get("player_id"),
+            player_name=candidate.get("player_name") or candidate.get("entity_name"),
+            market_type=candidate.get("market") or candidate.get("market_family") or "prop_watchlist",
+            pick_type="prop_watchlist",
+            pick_label=candidate.get("pick") or candidate.get("selection") or candidate.get("player_name"),
+            model_name=candidate.get("model") or "daily_odds_prop_candidate",
+            model_probability=_safe_float(candidate.get("model_probability")),
+            market_implied_probability=_safe_float(candidate.get("market_implied_probability")),
+            edge=_safe_float(candidate.get("edge")),
+            score=_safe_float(candidate.get("score")),
+            confidence=_safe_float(candidate.get("confidence")),
+            line=_safe_float(candidate.get("line")),
+            price=_safe_float(candidate.get("price")),
+            expected_value=_safe_float(candidate.get("expected_value")),
+            primary_reason=_short_reason(candidate.get("drivers") or candidate.get("reasoning") or candidate.get("primary_reason"), "Daily Odds prop/watchlist candidate."),
+            reasoning_json=_json(candidate.get("drivers") or candidate.get("reasoning") or []),
+            features_used_json=_json(candidate.get("features_used") or []),
+            missing_inputs_json=_json(candidate.get("missing_inputs") or []),
+            raw_payload_json=_json(candidate),
+            grade="ungraded",
+            grade_reason="Stored as watchlist output until explicit player-stat result mapping is available.",
+            result_status="pending",
+        ))
+    return rows
+
+
+def normalize_model_projection_rows(payload: Dict[str, Any], target_date: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for game in payload.get("games") or payload.get("models") or []:
+        if not isinstance(game, dict):
+            continue
+        workspace = game.get("workspace") or {}
+        simulation = workspace.get("bullpenAdjustedGameSimulation") or workspace.get("gameSimulation") or game.get("gameSimulation") or {}
+        away_team = game.get("away_team") or game.get("away_team_name")
+        home_team = game.get("home_team") or game.get("home_team_name")
+        home_prob = _safe_float(simulation.get("home_win_probability") or game.get("home_win_probability") or game.get("home_win_prob"))
+        away_prob = _safe_float(simulation.get("away_win_probability") or game.get("away_win_probability") or game.get("away_win_prob"))
+        projected_total = _safe_float(simulation.get("total_expected_runs") or game.get("total_expected_runs"))
+        projected_home = _safe_float(simulation.get("home_expected_runs") or game.get("home_expected_runs"))
+        projected_away = _safe_float(simulation.get("away_expected_runs") or game.get("away_expected_runs"))
+        pick = None
+        pick_prob = None
+        if home_prob is not None and away_prob is not None:
+            pick, pick_prob = (home_team, home_prob) if home_prob >= away_prob else (away_team, away_prob)
+        if pick:
+            rows.append(_base_row(
+                "model_projections",
+                target_date,
+                source_endpoint="/models/projections",
+                source_component="projected_side",
+                game_pk=game.get("game_pk"),
+                away_team=away_team,
+                home_team=home_team,
+                team_name=pick,
+                market_type="moneyline",
+                pick_type="side",
+                pick_label=pick,
+                model_name="model_projection_win_probability",
+                model_probability=pick_prob,
+                score=pick_prob,
+                confidence=pick_prob,
+                projected_total=projected_total,
+                projected_home_runs=projected_home,
+                projected_away_runs=projected_away,
+                home_win_probability=home_prob,
+                away_win_probability=away_prob,
+                primary_reason="Model Projection side captured from simulation win probability.",
+                missing_inputs_json=_json(game.get("missing_inputs") or workspace.get("missing_inputs") or []),
+                raw_payload_json=_json(game),
+                grade="pending",
+                result_status="pending",
+            ))
+        if projected_total is not None:
+            rows.append(_base_row(
+                "model_projections",
+                target_date,
+                source_endpoint="/models/projections",
+                source_component="projected_total",
+                game_pk=game.get("game_pk"),
+                away_team=away_team,
+                home_team=home_team,
+                market_type="total",
+                pick_type="projected_total",
+                pick_label=f"Projected total {projected_total}",
+                model_name="model_projection_total_runs",
+                score=projected_total,
+                projected_total=projected_total,
+                projected_home_runs=projected_home,
+                projected_away_runs=projected_away,
+                home_win_probability=home_prob,
+                away_win_probability=away_prob,
+                primary_reason="Model Projection total expected runs captured for comparison.",
+                missing_inputs_json=_json(game.get("missing_inputs") or workspace.get("missing_inputs") or []),
+                raw_payload_json=_json(game),
+                grade="ungraded",
+                grade_reason="Projected total stored for after-the-fact comparison; sportsbook line may be absent.",
+                result_status="pending",
+            ))
+    return rows
+
+
+def normalize_dashboard_rows(component: str, payload: Dict[str, Any], target_date: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for item in payload.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        metrics = item.get("metrics") or {}
+        rows.append(_base_row(
+            "my_dashboard",
+            target_date,
+            source_endpoint="/my-dashboard/solver",
+            source_component=component,
+            game_pk=item.get("game_pk"),
+            team_id=item.get("team_id") or item.get("entity_id") if item.get("entity_type") == "team" else item.get("team_id"),
+            player_id=item.get("player_id") or item.get("entity_id") if item.get("entity_type") in {"hitter", "pitcher", "player"} else item.get("player_id"),
+            player_name=item.get("player_name") or item.get("entity_name") if item.get("entity_type") in {"hitter", "pitcher", "player"} else item.get("player_name"),
+            team_name=item.get("team") or item.get("team_name") or item.get("entity_name") if item.get("entity_type") == "team" else item.get("team") or item.get("team_name"),
+            opponent_name=item.get("opponent"),
+            market_type=component,
+            pick_type="dashboard_watchlist",
+            pick_label=item.get("pick") or item.get("entity_name") or item.get("player_name") or item.get("category"),
+            model_name=f"my_dashboard_{component}",
+            score=_safe_float(item.get("score") or item.get("adjusted_score")),
+            confidence=_safe_float(item.get("confidence")),
+            projected_total=_safe_float(metrics.get("projected_total") or item.get("projected_total")),
+            primary_reason=_short_reason(item.get("primary_reason") or item.get("reasoning"), f"My Dashboard {component} watchlist output."),
+            reasoning_json=_json(item.get("reasoning") or []),
+            features_used_json=_json(item.get("features_used") or []),
+            missing_inputs_json=_json(item.get("missing_data") or item.get("missing_inputs") or []),
+            raw_payload_json=_json(item),
+            grade="ungraded",
+            grade_reason="Dashboard watchlist outputs are stored first and graded only when an explicit result mapping is available.",
+            result_status="pending",
+        ))
+    return rows
+
+
+def normalize_ai_data_assistant_rows(payload: Dict[str, Any], target_date: str, prompt: str) -> List[Dict[str, Any]]:
+    return [_base_row(
+        "ai_data_assistant",
+        target_date,
+        source_endpoint="/ai-data-assistant",
+        source_component="deterministic_summary",
+        game_pk=payload.get("game_pk"),
+        market_type="assistant_summary",
+        pick_type="ai_summary",
+        pick_label=prompt,
+        model_name="ai_data_assistant_deterministic",
+        primary_reason=_short_reason(payload.get("answer"), "AI Data Assistant deterministic answer captured."),
+        reasoning_json=_json(payload.get("sections") or []),
+        features_used_json=_json(payload.get("sources_used") or []),
+        missing_inputs_json=_json(payload.get("missing_data") or []),
+        raw_payload_json=_json(payload),
+        grade="ungraded",
+        grade_reason="Assistant summaries are stored as explainability snapshots, not direct betting outcomes.",
+        result_status="pending",
+    )]
+
+
+def upsert_tracker_rows(session: Session, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    inserted = 0
+    updated = 0
+    now = dt.datetime.utcnow()
+    for row in rows:
+        tracker_key = row.get("tracker_key") or _tracker_key(row)
+        existing = session.query(ModelTrackerSnapshot).filter(ModelTrackerSnapshot.tracker_key == tracker_key).first()
+        if existing:
+            target = existing
+            updated += 1
+        else:
+            target = ModelTrackerSnapshot(tracker_key=tracker_key)
+            session.add(target)
+            inserted += 1
+        for key, value in row.items():
+            if not hasattr(target, key):
+                continue
+            if key == "snapshot_date" and isinstance(value, str):
+                value = dt.date.fromisoformat(value[:10])
+            elif key in {"game_pk", "team_id", "player_id"}:
+                value = _safe_int(value)
+            elif key in {
+                "model_probability", "market_implied_probability", "edge", "score", "confidence", "line", "price",
+                "expected_value", "projected_total", "projected_home_runs", "projected_away_runs",
+                "home_win_probability", "away_win_probability",
+            }:
+                value = _safe_float(value)
+            setattr(target, key, value)
+        target.updated_at = now
+    session.commit()
+    return {"inserted": inserted, "updated": updated, "total_rows_seen": len(rows)}
+
+
+def build_tracker_snapshot(session: Session, target_date: str) -> Dict[str, Any]:
+    target_date = target_date[:10]
+    dt.date.fromisoformat(target_date)
+    errors: List[Dict[str, Any]] = []
+    rows: List[Dict[str, Any]] = []
+
+    try:
+        matchups = generate_matchups_for_date(session, target_date)
+        rows.extend(normalize_matchup_rows(matchups, target_date))
+    except Exception as exc:
+        errors.append({"source": "matchups", "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        from .daily_odds_routes import daily_odds_models
+        payload = daily_odds_models(date=target_date, include_unified=True)
+        rows.extend(normalize_daily_odds_rows(payload, target_date))
+    except Exception as exc:
+        errors.append({"source": "daily_odds", "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        payload = build_model_projection_payload(session, target_date)
+        rows.extend(normalize_model_projection_rows(payload, target_date))
+    except Exception as exc:
+        errors.append({"source": "model_projections", "error": str(exc), "type": exc.__class__.__name__})
+
+    for component in DASHBOARD_COMPONENTS:
+        try:
+            payload = build_dashboard_solver_payload(session=session, date=target_date, component=component)
+            rows.extend(normalize_dashboard_rows(component, payload, target_date))
+        except Exception as exc:
+            errors.append({"source": "my_dashboard", "component": component, "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        from .ai_data_assistant_performance import build_ai_data_assistant_response
+        for prompt in AI_TRACKER_PROMPTS:
+            try:
+                payload = build_ai_data_assistant_response(session=session, message=prompt, date=target_date, use_llm=False)
+                rows.extend(normalize_ai_data_assistant_rows(payload, target_date, prompt))
+            except Exception as prompt_exc:
+                errors.append({"source": "ai_data_assistant", "prompt": prompt, "error": str(prompt_exc), "type": prompt_exc.__class__.__name__})
+    except Exception as exc:
+        errors.append({"source": "ai_data_assistant", "error": str(exc), "type": exc.__class__.__name__})
+
+    upsert_result = upsert_tracker_rows(session, rows)
+    return {
+        "date": target_date,
+        "rows_collected": len(rows),
+        "upsert": upsert_result,
+        "errors": errors,
+    }
+
+
+def _row_payload(row: ModelTrackerSnapshot) -> Dict[str, Any]:
+    return {
+        "id": row.id,
+        "tracker_key": row.tracker_key,
+        "snapshot_date": row.snapshot_date.isoformat() if row.snapshot_date else None,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        "source": row.source,
+        "source_endpoint": row.source_endpoint,
+        "source_component": row.source_component,
+        "game_pk": row.game_pk,
+        "event_id": row.event_id,
+        "team_id": row.team_id,
+        "player_id": row.player_id,
+        "player_name": row.player_name,
+        "team_name": row.team_name,
+        "opponent_name": row.opponent_name,
+        "away_team": row.away_team,
+        "home_team": row.home_team,
+        "market_type": row.market_type,
+        "pick_type": row.pick_type,
+        "pick_label": row.pick_label,
+        "model_name": row.model_name,
+        "model_version": row.model_version,
+        "model_probability": row.model_probability,
+        "market_implied_probability": row.market_implied_probability,
+        "edge": row.edge,
+        "score": row.score,
+        "confidence": row.confidence,
+        "line": row.line,
+        "price": row.price,
+        "expected_value": row.expected_value,
+        "projected_total": row.projected_total,
+        "projected_home_runs": row.projected_home_runs,
+        "projected_away_runs": row.projected_away_runs,
+        "home_win_probability": row.home_win_probability,
+        "away_win_probability": row.away_win_probability,
+        "primary_reason": row.primary_reason,
+        "reasoning": _loads(row.reasoning_json) or [],
+        "features_used": _loads(row.features_used_json) or [],
+        "missing_inputs": _loads(row.missing_inputs_json) or [],
+        "raw_payload": _loads(row.raw_payload_json),
+        "game_status_at_snapshot": row.game_status_at_snapshot,
+        "result_status": row.result_status,
+        "actual_result": _loads(row.actual_result_json),
+        "grade": row.grade,
+        "grade_reason": row.grade_reason,
+        "last_compared_at": row.last_compared_at.isoformat() if row.last_compared_at else None,
+    }
+
+
+def list_tracker_rows(session: Session, target_date: str, game_pk: Optional[int] = None) -> Dict[str, Any]:
+    parsed = dt.date.fromisoformat(target_date[:10])
+    query = session.query(ModelTrackerSnapshot).filter(ModelTrackerSnapshot.snapshot_date == parsed)
+    if game_pk is not None:
+        query = query.filter(ModelTrackerSnapshot.game_pk == game_pk)
+    records = query.order_by(ModelTrackerSnapshot.game_pk.nullslast(), ModelTrackerSnapshot.source, ModelTrackerSnapshot.source_component, ModelTrackerSnapshot.id).all()
+    rows = [_row_payload(record) for record in records]
+    games: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        key = str(row.get("game_pk") or "ungrouped")
+        game = games.setdefault(key, {
+            "game_pk": row.get("game_pk"),
+            "away_team": row.get("away_team"),
+            "home_team": row.get("home_team"),
+            "row_count": 0,
+            "grades": {},
+            "sources": set(),
+            "rows": [],
+        })
+        game["row_count"] += 1
+        game["grades"][row.get("grade") or "unknown"] = game["grades"].get(row.get("grade") or "unknown", 0) + 1
+        if row.get("source"):
+            game["sources"].add(row.get("source"))
+        game["rows"].append(row)
+    game_payloads = []
+    for game in games.values():
+        game["sources"] = sorted(game["sources"])
+        game_payloads.append(game)
+    summary = {
+        "total_rows": len(rows),
+        "games_tracked": len([g for g in game_payloads if g.get("game_pk")]),
+        "pending_rows": sum(1 for r in rows if r.get("grade") == "pending"),
+        "live_rows": sum(1 for r in rows if r.get("result_status") == "live"),
+        "graded_rows": sum(1 for r in rows if r.get("grade") in {"won", "lost", "push", "partial"}),
+        "won": sum(1 for r in rows if r.get("grade") == "won"),
+        "lost": sum(1 for r in rows if r.get("grade") == "lost"),
+        "push": sum(1 for r in rows if r.get("grade") == "push"),
+        "ungraded_rows": sum(1 for r in rows if r.get("grade") in {"ungraded", "watchlist_only"}),
+        "source_count": len({r.get("source") for r in rows if r.get("source")}),
+        "sources": sorted({r.get("source") for r in rows if r.get("source")}),
+    }
+    return {
+        "date": parsed.isoformat(),
+        "snapshot_count": len({r.get("created_at") for r in rows if r.get("created_at")}),
+        "rows": rows,
+        "games": game_payloads,
+        "summary": summary,
+        "errors": [],
+    }
+
+
+def _fetch_schedule_results(target_date: str) -> Dict[int, Dict[str, Any]]:
+    response = requests.get(
+        f"{MLB_STATS_BASE}/schedule",
+        params={"sportId": 1, "date": target_date, "hydrate": "linescore,team"},
+        timeout=20,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    results: Dict[int, Dict[str, Any]] = {}
+    for date_row in payload.get("dates", []) or []:
+        for game in date_row.get("games", []) or []:
+            game_pk = game.get("gamePk")
+            if not game_pk:
+                continue
+            teams = game.get("teams") or {}
+            home = teams.get("home") or {}
+            away = teams.get("away") or {}
+            status = game.get("status") or {}
+            home_team = (home.get("team") or {}).get("name")
+            away_team = (away.get("team") or {}).get("name")
+            home_score = home.get("score")
+            away_score = away.get("score")
+            detailed_state = status.get("detailedState")
+            abstract_state = status.get("abstractGameState")
+            is_final = abstract_state == "Final" or status.get("codedGameState") == "F" or str(detailed_state or "").lower() == "final"
+            winner = None
+            if home_score is not None and away_score is not None and home_score != away_score:
+                winner = home_team if int(home_score) > int(away_score) else away_team
+            results[int(game_pk)] = {
+                "game_pk": int(game_pk),
+                "status": detailed_state or abstract_state,
+                "abstract_state": abstract_state,
+                "is_final": is_final,
+                "home_team": home_team,
+                "away_team": away_team,
+                "home_score": home_score,
+                "away_score": away_score,
+                "total_runs": int(home_score) + int(away_score) if home_score is not None and away_score is not None else None,
+                "winner": winner,
+                "raw": game,
+            }
+    return results
+
+
+def _grade_row(row: ModelTrackerSnapshot, actual: Dict[str, Any]) -> tuple[str, str]:
+    if not actual.get("is_final"):
+        return "live" if actual.get("abstract_state") == "Live" else "pending", "Game is not final yet."
+    pick_type = str(row.pick_type or "").lower()
+    market_type = str(row.market_type or "").lower()
+    pick_label = str(row.pick_label or "")
+    line = row.line
+    total_runs = actual.get("total_runs")
+    if market_type in {"moneyline", "side"} or pick_type in {"side", "moneyline"}:
+        winner = actual.get("winner")
+        if not winner:
+            return "push", "Final score ended tied or winner was unavailable."
+        if _normalize_name(pick_label) == _normalize_name(winner) or _normalize_name(row.team_name) == _normalize_name(winner):
+            return "won", f"Final winner was {winner}."
+        return "lost", f"Final winner was {winner}."
+    if market_type == "total" and line is not None and total_runs is not None:
+        wants_over = "over" in pick_label.lower() or pick_type == "over"
+        wants_under = "under" in pick_label.lower() or pick_type == "under"
+        if total_runs == line:
+            return "push", f"Final total {total_runs} landed on line {line}."
+        if wants_over:
+            return ("won" if total_runs > line else "lost", f"Final total {total_runs} compared to over {line}.")
+        if wants_under:
+            return ("won" if total_runs < line else "lost", f"Final total {total_runs} compared to under {line}.")
+        return "ungraded", "Total row has final score but no explicit over/under side."
+    return "ungraded", "Stored output has no safe automated final-result mapping yet."
+
+
+def refresh_tracker_results(session: Session, target_date: str) -> Dict[str, Any]:
+    parsed = dt.date.fromisoformat(target_date[:10])
+    actual_by_game = _fetch_schedule_results(parsed.isoformat())
+    records = session.query(ModelTrackerSnapshot).filter(ModelTrackerSnapshot.snapshot_date == parsed).all()
+    compared = 0
+    final_games = 0
+    now = dt.datetime.utcnow()
+    for row in records:
+        if not row.game_pk or row.game_pk not in actual_by_game:
+            continue
+        actual = actual_by_game[row.game_pk]
+        if actual.get("is_final"):
+            final_games += 1
+        grade, reason = _grade_row(row, actual)
+        row.result_status = "final" if actual.get("is_final") else ("live" if actual.get("abstract_state") == "Live" else "pending")
+        row.actual_result_json = _json(actual)
+        row.grade = grade if grade in TRACKER_GRADES else "ungraded"
+        row.grade_reason = reason
+        row.last_compared_at = now
+        row.updated_at = now
+        compared += 1
+    session.commit()
+    return {
+        "date": parsed.isoformat(),
+        "rows_compared": compared,
+        "games_found": len(actual_by_game),
+        "final_game_rows_seen": final_games,
+        "compared_at": now.isoformat() + "Z",
+    }

--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from .database import create_tables, get_engine, get_session
+from .model_tracker import (
+    build_tracker_snapshot,
+    list_tracker_rows,
+    refresh_tracker_results,
+)
+
+router = APIRouter(prefix="/model-tracker", tags=["model-tracker"])
+
+
+def _session_factory():
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    return get_session(engine)
+
+
+def _target_date(value: Optional[str]) -> str:
+    target = (value or dt.date.today().isoformat())[:10]
+    try:
+        dt.date.fromisoformat(target)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid date: {value}") from exc
+    return target
+
+
+@router.get("/health")
+def model_tracker_health() -> Dict[str, Any]:
+    return {
+        "status": "ok",
+        "component": "model_tracker",
+        "persistence": "model_tracker_snapshots",
+        "safe_mode": "additive_snapshot_layer",
+    }
+
+
+@router.post("/snapshot")
+def model_tracker_snapshot(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
+    target = _target_date(date)
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            return build_tracker_snapshot(session, target)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Model Tracker snapshot failed", "error": str(exc)}) from exc
+
+
+@router.get("")
+def model_tracker_list(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
+    target = _target_date(date)
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            return list_tracker_rows(session, target)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Model Tracker list failed", "error": str(exc)}) from exc
+
+
+@router.get("/game/{game_pk}")
+def model_tracker_game(game_pk: int, date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
+    target = _target_date(date)
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            payload = list_tracker_rows(session, target, game_pk=game_pk)
+            payload["game_pk"] = game_pk
+            return payload
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Model Tracker game lookup failed", "error": str(exc)}) from exc
+
+
+@router.post("/results/refresh")
+def model_tracker_results_refresh(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
+    target = _target_date(date)
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            return refresh_tracker_results(session, target)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Model Tracker result refresh failed", "error": str(exc)}) from exc

--- a/scripts/smoke_test_production_paths.py
+++ b/scripts/smoke_test_production_paths.py
@@ -31,30 +31,29 @@ class SmokeFailure(Exception):
 
 
 def _today_eastern_iso() -> str:
-    # Avoid external dependencies; this is sufficient for a smoke-test default.
     return dt.datetime.utcnow().date().isoformat()
 
 
-def _request_json(base_url: str, path: str, timeout: int = 45) -> tuple[int, Any]:
+def _request_json(base_url: str, path: str, timeout: int = 45, method: str = "GET") -> tuple[int, Any]:
     url = f"{base_url.rstrip('/')}{path}"
-    request = urllib.request.Request(url=url, method="GET")
+    request = urllib.request.Request(url=url, method=method)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             status = int(response.status)
             body = response.read().decode("utf-8", errors="replace")
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
-        raise SmokeFailure(f"HTTP {exc.code} for {path}: {detail[:500]}") from exc
+        raise SmokeFailure(f"HTTP {exc.code} for {method} {path}: {detail[:500]}") from exc
     except urllib.error.URLError as exc:
-        raise SmokeFailure(f"Network error for {path}: {exc}") from exc
+        raise SmokeFailure(f"Network error for {method} {path}: {exc}") from exc
 
     if status >= 400:
-        raise SmokeFailure(f"HTTP {status} for {path}")
+        raise SmokeFailure(f"HTTP {status} for {method} {path}")
 
     try:
         return status, json.loads(body) if body else None
     except json.JSONDecodeError as exc:
-        raise SmokeFailure(f"Invalid JSON for {path}: {body[:500]}") from exc
+        raise SmokeFailure(f"Invalid JSON for {method} {path}: {body[:500]}") from exc
 
 
 def _expect_dict(data: Any, path: str) -> dict[str, Any]:
@@ -101,10 +100,6 @@ def _check_daily_odds_unified(data: Any, path: str) -> None:
         raise SmokeFailure(f"Daily Odds unified payload missing {missing_enhanced}")
     if payload.get("unified_loaded") is not True:
         raise SmokeFailure("Daily Odds unified payload should set unified_loaded=true")
-    data_quality = _expect_dict(payload.get("data_quality"), f"{path}.data_quality")
-    for key in ["matchup_count", "projection_count", "dashboard_solver_components_used", "batter_vs_arsenal_count", "generated_at"]:
-        if key not in data_quality:
-            raise SmokeFailure(f"Daily Odds data_quality missing {key}")
 
 
 def _check_model_projections(data: Any, path: str) -> None:
@@ -122,16 +117,37 @@ def _check_dashboard_solver(data: Any, path: str) -> None:
         raise SmokeFailure("My Dashboard solver items must be a list")
 
 
-def _run_check(
-    base_url: str,
-    label: str,
-    path: str,
-    validator: Callable[[Any, str], None],
-) -> bool:
+def _check_tracker_health(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    if payload.get("component") != "model_tracker" or payload.get("status") != "ok":
+        raise SmokeFailure(f"Unexpected Model Tracker health payload for {path}: {payload}")
+
+
+def _check_tracker_snapshot(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    for key in ["date", "rows_collected", "upsert", "errors"]:
+        if key not in payload:
+            raise SmokeFailure(f"Model Tracker snapshot payload missing {key}")
+    if not isinstance(payload.get("errors"), list):
+        raise SmokeFailure("Model Tracker snapshot errors must be a list")
+
+
+def _check_tracker_list(data: Any, path: str) -> None:
+    payload = _expect_dict(data, path)
+    for key in ["date", "rows", "games", "summary", "errors"]:
+        if key not in payload:
+            raise SmokeFailure(f"Model Tracker list payload missing {key}")
+    if not isinstance(payload.get("rows"), list):
+        raise SmokeFailure("Model Tracker rows must be a list")
+    if not isinstance(payload.get("games"), list):
+        raise SmokeFailure("Model Tracker games must be a list")
+
+
+def _run_check(base_url: str, label: str, path: str, validator: Callable[[Any, str], None], method: str = "GET") -> bool:
     try:
-        status, data = _request_json(base_url, path)
+        status, data = _request_json(base_url, path, method=method)
         validator(data, path)
-        print(f"PASS {label}: HTTP {status} {path}")
+        print(f"PASS {label}: HTTP {status} {method} {path}")
         return True
     except SmokeFailure as exc:
         print(f"FAIL {label}: {exc}")
@@ -142,6 +158,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Smoke-test production-critical MLB backend paths.")
     parser.add_argument("--base-url", default=os.getenv("BACKEND_BASE_URL", DEFAULT_BACKEND_BASE_URL))
     parser.add_argument("--date", default=os.getenv("SMOKE_TEST_DATE", _today_eastern_iso()))
+    parser.add_argument("--include-mutating-tracker-checks", action="store_true", help="Also POST a Model Tracker snapshot/results refresh.")
     args = parser.parse_args()
 
     date = args.date[:10]
@@ -150,24 +167,29 @@ def main() -> int:
     dashboard_hitter_query = urllib.parse.urlencode({"date": date, "component": "hitters"})
     dashboard_pitcher_query = urllib.parse.urlencode({"date": date, "component": "pitchers"})
 
-    checks: list[tuple[str, str, Callable[[Any, str], None]]] = [
-        ("health", "/health", _check_health),
-        ("matchups", f"/matchups?{query_date}", _check_matchups),
-        ("daily_odds_models_fast", f"/daily-odds/models?{query_date}", _check_daily_odds_fast),
-        ("daily_odds_models_unified", f"/daily-odds/models?{unified_query}", _check_daily_odds_unified),
-        ("model_projections", f"/models/projections?{query_date}", _check_model_projections),
-        ("ai_data_assistant_health", "/ai-data-assistant/health", _check_health),
-        ("my_dashboard_health", "/my-dashboard/health", _check_health),
-        ("my_dashboard_solver_hitters", f"/my-dashboard/solver?{dashboard_hitter_query}", _check_dashboard_solver),
-        ("my_dashboard_solver_pitchers", f"/my-dashboard/solver?{dashboard_pitcher_query}", _check_dashboard_solver),
+    checks: list[tuple[str, str, Callable[[Any, str], None], str]] = [
+        ("health", "/health", _check_health, "GET"),
+        ("matchups", f"/matchups?{query_date}", _check_matchups, "GET"),
+        ("daily_odds_models_fast", f"/daily-odds/models?{query_date}", _check_daily_odds_fast, "GET"),
+        ("daily_odds_models_unified", f"/daily-odds/models?{unified_query}", _check_daily_odds_unified, "GET"),
+        ("model_projections", f"/models/projections?{query_date}", _check_model_projections, "GET"),
+        ("ai_data_assistant_health", "/ai-data-assistant/health", _check_health, "GET"),
+        ("my_dashboard_health", "/my-dashboard/health", _check_health, "GET"),
+        ("my_dashboard_solver_hitters", f"/my-dashboard/solver?{dashboard_hitter_query}", _check_dashboard_solver, "GET"),
+        ("my_dashboard_solver_pitchers", f"/my-dashboard/solver?{dashboard_pitcher_query}", _check_dashboard_solver, "GET"),
+        ("model_tracker_health", "/model-tracker/health", _check_tracker_health, "GET"),
+        ("model_tracker_list", f"/model-tracker?{query_date}", _check_tracker_list, "GET"),
     ]
+    if args.include_mutating_tracker_checks:
+        checks.append(("model_tracker_snapshot", f"/model-tracker/snapshot?{query_date}", _check_tracker_snapshot, "POST"))
+        checks.append(("model_tracker_list_after_snapshot", f"/model-tracker?{query_date}", _check_tracker_list, "GET"))
 
     print(f"Backend base URL: {args.base_url.rstrip('/')}")
     print(f"Smoke-test date: {date}")
 
     passed = 0
-    for label, path, validator in checks:
-        if _run_check(args.base_url, label, path, validator):
+    for label, path, validator, method in checks:
+        if _run_check(args.base_url, label, path, validator, method=method):
             passed += 1
 
     failed = len(checks) - passed


### PR DESCRIPTION
Closes #300.

## Summary

Adds a safe, additive Model Tracker layer for daily prediction snapshots and live/final comparison. This PR stores copies of existing model outputs without changing the existing scoring logic, matchup analyzer, odds provider, model formulas, or current response contracts.

## What changed

### Backend tracker persistence and snapshot builder

Added `mlb_app/model_tracker.py` with:

- `ModelTrackerSnapshot` SQLAlchemy model backed by a new `model_tracker_snapshots` table
- stable `tracker_key` dedupe/upsert behavior so rerunning a snapshot updates rows instead of duplicating them
- row normalization for Daily Matchups, Daily Odds, Model Projections, My Dashboard, and deterministic AI Data Assistant summaries
- result-refresh logic that can compare final MLB game results where safely possible
- conservative grading rules

### Backend API routes

Added `mlb_app/model_tracker_routes.py` with:

- `GET /model-tracker/health`
- `POST /model-tracker/snapshot?date=YYYY-MM-DD`
- `GET /model-tracker?date=YYYY-MM-DD`
- `GET /model-tracker/game/{game_pk}?date=YYYY-MM-DD`
- `POST /model-tracker/results/refresh?date=YYYY-MM-DD`

The tracker router is mounted through the already-registered `model_projection_routes.py` router to avoid editing the large production-critical `mlb_app/app.py` file.

### Frontend tracker page

Added `frontend/src/pages/ModelTrackerPage.jsx` and wired it into `frontend/src/App.jsx` with:

- `/model-tracker` route
- `Model Tracker` nav link
- date picker
- refresh snapshot button
- refresh live/final results button
- source filter
- grade filter
- game filter
- search box
- summary cards
- game-grouped tracker cards
- full table view

### Smoke-test coverage

Updated `scripts/smoke_test_production_paths.py` with Model Tracker checks:

- `GET /model-tracker/health`
- `GET /model-tracker?date=YYYY-MM-DD`
- optional mutating snapshot check via `--include-mutating-tracker-checks`

## What is tracked

The tracker attempts to snapshot existing outputs from:

- `/matchups?date=YYYY-MM-DD`
- `/daily-odds/models?date=YYYY-MM-DD` using existing backend behavior
- `/models/projections?date=YYYY-MM-DD` using `build_model_projection_payload(...)`
- My Dashboard solver components: hitters, pitchers, teams, totals, overall players
- deterministic AI Data Assistant prompts for strongest edge, Stored 365 hitter matchups, pitcher leans, and weak/stale data

Each source failure is caught and returned in the snapshot `errors` list so one bad source does not kill the whole tracker snapshot.

## What is graded

Automated grading is intentionally conservative:

- Moneyline/side rows can be graded when final MLB score and winner are available.
- Total rows can be graded only when a clear line and final combined runs are available.

## What is stored but left ungraded

The following are stored for accountability and after-the-fact review but remain `ungraded` unless a safe result mapping exists:

- player props without final stat mapping
- hitter angles
- pitcher leans
- Batter vs Arsenal / Stored 365 watchlist outputs
- My Dashboard watchlist rows
- AI Data Assistant summary rows
- projection-only total rows without a sportsbook line

## Production safety

This PR does not change:

- `/matchups` response contract
- `/matchup/{game_pk}` response contract
- `/daily-odds/models` response contract
- `/models/projections` response contract
- `/my-dashboard/solver` response contract
- `/ai-data-assistant` behavior
- scoring formulas
- odds provider logic
- Railway config
- CORS config
- Batter feature flag behavior
- cron refresh behavior

The golden path remains preserved:

```text
HomePage.jsx -> GET /matchups?date=YYYY-MM-DD -> mlb_app.matchup_generator.generate_matchups_for_date() -> rendered game cards
```

## Validation commands

Not run in the connector environment.

Recommended:

```bash
python -m compileall mlb_app scripts
cd frontend && npm run build
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-14
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-14 --include-mutating-tracker-checks
```

Manual backend smoke:

```bash
curl "http://localhost:8000/model-tracker/health"
curl -X POST "http://localhost:8000/model-tracker/snapshot?date=2026-05-14"
curl "http://localhost:8000/model-tracker?date=2026-05-14"
curl -X POST "http://localhost:8000/model-tracker/results/refresh?date=2026-05-14"
```

## Files changed

- `mlb_app/model_tracker.py`
- `mlb_app/model_tracker_routes.py`
- `mlb_app/model_projection_routes.py`
- `frontend/src/pages/ModelTrackerPage.jsx`
- `frontend/src/App.jsx`
- `scripts/smoke_test_production_paths.py`

## Branch note

At PR creation time, `main` had moved ahead after this branch was cut. Review GitHub's mergeability status and update the branch before merge if required.