### PR TITLE
Add RSS-first News Terminal provider network

### DIFF
--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -46,11 +46,26 @@ function asArray(value) { return Array.isArray(value) ? value : [] }
 function fmtTime(iso) { if (!iso) return 'Pending'; try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) } catch { return 'Pending' } }
 function score(v) { const n = Number(v); return Number.isFinite(n) ? n.toFixed(0) : '0' }
 function bucketCount(payload) { return BUCKETS.reduce((sum, bucket) => sum + asArray(payload?.buckets?.[bucket]).length, 0) }
+function providerLabel(provider) { return ['rss', 'rss_network', 'rss_feed_network'].includes(provider) ? 'RSS Feed Network' : (provider || 'loading') }
+function statusLabel(status) {
+  if (status === 'ok') return 'Connected'
+  if (status === 'empty') return 'Connected, no items returned'
+  if (status === 'provider_not_configured') return 'Provider Missing'
+  return status || 'loading'
+}
+function emptyMessage(payload) {
+  if (['rss', 'rss_network', 'rss_feed_network'].includes(payload?.provider) && payload?.status === 'empty') return 'RSS provider is connected, but no matching MLB news items were returned for this date/filter.'
+  if (payload?.status === 'provider_not_configured') return 'Provider missing. Enable RSS on the backend or configure a paid provider.'
+  return `No items in this bucket yet. Status: ${statusLabel(payload?.status)}.`
+}
 
-function Ticker({ rows, status }) {
+function Ticker({ rows, status, provider }) {
+  const emptyText = ['rss', 'rss_network', 'rss_feed_network'].includes(provider)
+    ? 'RSS provider is connected, but no matching MLB news items were returned for this date/filter.'
+    : 'No provider items yet. Enable RSS or configure a paid provider to light up the terminal.'
   return <section style={s.ticker}>
-    <div style={s.tickerHead}><span style={s.hot}>Live Wire</span><span>MLB News Terminal</span><span style={s.badge}>{status || 'loading'}</span></div>
-    <div style={s.tickerRow}>{rows.length === 0 ? <span style={s.tickerItem}>No configured provider items yet. Add NEWS_PROVIDER and NEWS_API_KEY to light up the terminal.</span> : rows.map(row => <a key={row.id} href={row.url || '#'} target="_blank" rel="noreferrer" style={s.tickerItem}><span style={s.hot}>{row.tag || 'news'}</span><strong>{row.headline}</strong><span>{row.source}</span><span>{row.time_ago}</span></a>)}</div>
+    <div style={s.tickerHead}><span style={s.hot}>Live Wire</span><span>MLB News Terminal</span><span style={s.badge}>{statusLabel(status)}</span></div>
+    <div style={s.tickerRow}>{rows.length === 0 ? <span style={s.tickerItem}>{emptyText}</span> : rows.map(row => <a key={row.id} href={row.url || '#'} target="_blank" rel="noreferrer" style={s.tickerItem}><span style={s.hot}>{row.tag || 'news'}</span><strong>{row.headline}</strong><span>{row.source}</span><span>{row.time_ago}</span></a>)}</div>
   </section>
 }
 
@@ -68,7 +83,7 @@ function TeamIntel({ boards }) {
   const rows = Object.values(boards || {})
   if (!rows.length) return <div style={s.empty}>No team intel board available yet.</div>
   return <div style={s.grid}>{rows.map(board => <div key={board.team} style={s.card}>
-    <div style={s.row}><strong style={{ color: '#e6edf3' }}>{board.team}</strong><span style={s.badge}>{board.confidence_provider_status}</span></div>
+    <div style={s.row}><strong style={{ color: '#e6edf3' }}>{board.team}</strong><span style={s.badge}>{statusLabel(board.confidence_provider_status)}</span></div>
     <div style={s.meta}>{board.team_name}</div>
     <div style={s.meta}>Beat/local: {board.beat_report_count} · National: {board.national_headline_count} · Local sources: {board.local_source_count}</div>
     <div style={s.meta}>Latest local: {board.latest_local_item?.title || 'None configured'}</div>
@@ -131,22 +146,22 @@ export default function NewsPage() {
   }, [payload, activeBucket, team, tag, sourceType, search, breakingOnly, bettingOnly, localOnly])
 
   return <div style={s.page}>
-    <Ticker rows={asArray(payload?.ticker)} status={payload?.status} />
+    <Ticker rows={asArray(payload?.ticker)} status={payload?.status} provider={payload?.provider} />
     <section style={s.hero}>
       <div style={s.row}>
         <div><div style={s.eyebrow}>Bloomberg style MLB clubhouse and betting intelligence</div><h1 style={s.title}>News</h1><div style={s.subtitle}>A command center for injuries, lineup hints, starter changes, bullpen availability, local beat context, weather chatter, and betting-market relevant items. Provider placeholders are intentionally safe when credentials are missing.</div></div>
         <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}><input style={s.input} type="date" value={date} onChange={e => setDate(e.target.value)} /><button style={s.button} type="button" onClick={load} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh'}</button></div>
       </div>
       <div style={s.stats}>
-        <div style={s.stat}><div style={s.statLabel}>Provider</div><div style={s.statValue}>{payload?.provider || 'loading'}</div></div>
-        <div style={s.stat}><div style={s.statLabel}>Status</div><div style={s.statValue}>{payload?.status || 'loading'}</div></div>
+        <div style={s.stat}><div style={s.statLabel}>Provider</div><div style={s.statValue}>{providerLabel(payload?.provider)}</div></div>
+        <div style={s.stat}><div style={s.statLabel}>Status</div><div style={s.statValue}>{statusLabel(payload?.status)}</div></div>
         <div style={s.stat}><div style={s.statLabel}>Items</div><div style={s.statValue}>{bucketCount(payload)}</div></div>
         <div style={s.stat}><div style={s.statLabel}>Last Updated</div><div style={s.statValue}>{fmtTime(payload?.generated_at)}</div></div>
         <div style={s.stat}><div style={s.statLabel}>Cache</div><div style={s.statValue}>{payload?.cache_hit ? 'Hit' : 'Fresh'}</div></div>
       </div>
     </section>
     {error && <div style={s.error}>{error}</div>}
-    {asArray(payload?.errors).length > 0 && <div style={s.error}>{payload.errors.join(' · ')}</div>}
+    {asArray(payload?.errors).length > 0 && <div style={s.error}>{payload.errors.slice(0, 3).map(err => String(err).slice(0, 180)).join(' · ')}</div>}
     <section style={s.section}>
       <div style={s.row}><div><div style={s.sectionTitle}>Filters</div><div style={s.meta}>Team, tag, source, breaking, betting, local, and text search.</div></div><button type="button" style={s.muted} onClick={() => { setTeam(''); setTag(''); setSourceType(''); setSearch(''); setBreakingOnly(false); setBettingOnly(false); setLocalOnly(false) }}>Reset Filters</button></div>
       <div style={s.filters}>
@@ -159,7 +174,7 @@ export default function NewsPage() {
     </section>
     <section style={s.section}>
       <div style={s.row}><div><div style={s.sectionTitle}>Terminal Buckets</div><div style={s.meta}>Exclusive buckets prevent national wire spam from flooding every section.</div></div><div style={s.tabs}>{[...BUCKETS, 'team_intel'].map(bucket => <button key={bucket} type="button" style={s.tab(activeBucket === bucket)} onClick={() => setActiveBucket(bucket)}>{bucket.replace('_', ' ')}</button>)}</div></div>
-      {activeBucket === 'team_intel' ? <TeamIntel boards={intel?.team_intel} /> : visible.length === 0 ? <div style={s.empty}>No items in this bucket yet. Status: {payload?.status || 'loading'}. Missing provider config is a clean empty terminal state, not a broken app.</div> : <div style={s.grid}>{visible.map(item => <NewsCard key={item.id} item={item} />)}</div>}
+      {activeBucket === 'team_intel' ? <TeamIntel boards={intel?.team_intel} /> : visible.length === 0 ? <div style={s.empty}>{emptyMessage(payload)}</div> : <div style={s.grid}>{visible.map(item => <NewsCard key={item.id} item={item} />)}</div>}
     </section>
   </div>
 }

--- a/mlb_app/news_provider.py
+++ b/mlb_app/news_provider.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
 import datetime as dt
+from email.utils import parsedate_to_datetime
 import hashlib
 import json
 import os
+import re
 import urllib.parse
 import urllib.request
 from typing import Any, Dict, Iterable, List, Optional
 
+import feedparser
+
 from .news_classifier import classify_text, parse_datetime, score_importance
 from .news_keywords import build_keyword_groups
-from .news_sources import get_news_sources
+from .news_sources import get_news_sources, get_rss_sources, team_lookup
 
 BUCKETS = ["hourly", "daily", "weekly", "monthly", "beat", "betting"]
 
@@ -26,6 +30,13 @@ def iso_now() -> str:
 def stable_id(*parts: Any) -> str:
     raw = "|".join(str(p or "") for p in parts)
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 def empty_response(date: str, provider: str, status: str, errors: Optional[List[str]] = None, cache_hit: bool = False) -> Dict[str, Any]:
@@ -52,7 +63,7 @@ def normalize_item(raw: Dict[str, Any], bucket: str = "daily", source_type: str 
     published_at = raw.get("publishedAt") or raw.get("published_at") or raw.get("pubDate") or raw.get("updated_at")
     tags = classify_text(title, summary, str(source))
     is_betting = bool(set(tags).intersection({"odds", "betting"}))
-    is_local = source_type in {"local", "beat", "radio", "newspaper", "official", "blog", "x", "rss"}
+    is_local = source_type in {"local", "beat", "radio", "newspaper", "official", "blog", "x", "rss", "google_news"}
     return {
         "id": stable_id(url, title, published_at),
         "title": title,
@@ -78,15 +89,34 @@ def normalize_item(raw: Dict[str, Any], bucket: str = "daily", source_type: str 
     }
 
 
+def _normalized_title(title: str) -> str:
+    value = re.sub(r"\s+", " ", str(title or "").strip().lower())
+    value = re.sub(r"[^a-z0-9\s]", "", value)
+    return value[:180]
+
+
+def _canonical_url(url: str) -> str:
+    if not url:
+        return ""
+    parsed = urllib.parse.urlparse(url)
+    if "news.google." in parsed.netloc.lower():
+        return ""
+    clean = parsed._replace(query="", fragment="")
+    return urllib.parse.urlunparse(clean).rstrip("/").lower()
+
+
 def _dedupe(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     seen = set()
     out = []
     for item in items:
-        key = item.get("url") or item.get("title", "").strip().lower()
-        key = key[:160]
+        url_key = _canonical_url(str(item.get("url") or ""))
+        title_key = _normalized_title(str(item.get("title") or ""))
+        key = url_key or title_key
         if not key or key in seen:
             continue
         seen.add(key)
+        if title_key:
+            seen.add(title_key)
         out.append(item)
     return out
 
@@ -157,16 +187,163 @@ def build_ticker(buckets: Dict[str, List[Dict[str, Any]]]) -> List[Dict[str, Any
 
 class BaseNewsProvider:
     name = "base"
+    requires_api_key = False
+
     def configured(self) -> bool:
         return False
+
     def fetch(self, date: str, bucket: str = "all", team: Optional[str] = None) -> List[Dict[str, Any]]:
         return []
 
 
+class RSSProvider(BaseNewsProvider):
+    name = "rss"
+    requires_api_key = False
+
+    def __init__(self) -> None:
+        self.last_errors: List[str] = []
+
+    def configured(self) -> bool:
+        selected = os.getenv("NEWS_PROVIDER", "").strip().lower()
+        return selected in {"rss", "rss_network", "rss_feed_network"} or _env_bool("NEWS_ENABLE_RSS_PROVIDER")
+
+    def _sources_for(self, team: Optional[str]) -> List[Dict[str, Any]]:
+        if team:
+            return get_rss_sources(team, include_team_google=True)
+        return get_rss_sources(None, include_team_google=False)
+
+    def _entry_datetime(self, entry: Any) -> Optional[str]:
+        raw = (
+            getattr(entry, "published", None)
+            or getattr(entry, "updated", None)
+            or entry.get("published")
+            or entry.get("updated")
+        )
+        if raw:
+            parsed = parse_datetime(raw)
+            if parsed:
+                return parsed.isoformat().replace("+00:00", "Z")
+            try:
+                email_parsed = parsedate_to_datetime(str(raw))
+                if email_parsed.tzinfo is None:
+                    email_parsed = email_parsed.replace(tzinfo=dt.timezone.utc)
+                return email_parsed.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+            except Exception:
+                return str(raw)
+        return None
+
+    def _in_window(self, published_at: Optional[str], date: str) -> bool:
+        parsed = parse_datetime(published_at)
+        if not parsed:
+            return True
+        lookback_hours = int(os.getenv("NEWS_DEFAULT_LOOKBACK_HOURS", "48"))
+        try:
+            target = dt.datetime.fromisoformat(str(date)[:10]).replace(tzinfo=dt.timezone.utc)
+        except Exception:
+            target = utc_now()
+        start = target - dt.timedelta(hours=lookback_hours)
+        end = target + dt.timedelta(hours=lookback_hours)
+        return start <= parsed <= end
+
+    def _detect_teams(self, title: str, summary: str, source_team: Optional[str]) -> List[str]:
+        teams: List[str] = []
+        if source_team:
+            teams.append(str(source_team).upper())
+        text = f"{title} {summary}".lower()
+        for key, row in team_lookup().items():
+            if len(key) < 3:
+                continue
+            if key in text and row["team"] not in teams:
+                teams.append(row["team"])
+        return teams
+
+    def _confidence_for(self, source_type: str, published_at: Optional[str], url: str) -> float:
+        if source_type == "official":
+            base = 0.75
+        elif source_type == "google_news":
+            base = 0.6
+        else:
+            base = 0.65
+        if not parse_datetime(published_at):
+            base -= 0.1
+        if not url:
+            base -= 0.15
+        return round(max(base, 0.25), 2)
+
+    def _normalize_entry(self, entry: Any, source: Dict[str, Any], date: str) -> Optional[Dict[str, Any]]:
+        title = str(entry.get("title") or "").strip()
+        summary = str(entry.get("summary") or entry.get("description") or "").strip()
+        url = str(entry.get("link") or "").strip()
+        if not title and not url:
+            return None
+
+        source_name = source.get("name") or "RSS Feed"
+        source_type = source.get("source_type") or "rss"
+        published_at = self._entry_datetime(entry)
+        if not self._in_window(published_at, date):
+            return None
+
+        teams = self._detect_teams(title, summary, source.get("team"))
+        tags = classify_text(title, summary, source_name)
+        is_betting = bool(set(tags).intersection({"odds", "betting"}))
+        raw = {
+            "feed": source_name,
+            "source_type": source_type,
+            "team": source.get("team"),
+            "id": entry.get("id"),
+        }
+        return {
+            "id": stable_id(url, title, published_at),
+            "title": title or "Untitled RSS item",
+            "summary": summary,
+            "source": source_name,
+            "source_type": source_type,
+            "author": entry.get("author"),
+            "handle": None,
+            "url": url,
+            "published_at": published_at,
+            "bucket": "daily",
+            "tags": tags,
+            "teams": teams,
+            "players": [],
+            "games": [],
+            "importance_score": 0.0,
+            "is_breaking": False,
+            "is_local": source_type in {"official", "local", "beat", "blog", "google_news"},
+            "is_beat_report": source_type in {"beat", "x"},
+            "is_betting_relevant": is_betting,
+            "confidence_score": self._confidence_for(source_type, published_at, url),
+            "raw": raw,
+        }
+
+    def fetch(self, date: str, bucket: str = "all", team: Optional[str] = None) -> List[Dict[str, Any]]:
+        self.last_errors = []
+        items: List[Dict[str, Any]] = []
+        for source in self._sources_for(team):
+            url = source.get("url")
+            if not url:
+                continue
+            try:
+                parsed = feedparser.parse(url)
+                if getattr(parsed, "bozo", False):
+                    self.last_errors.append(f"{source.get('name', url)} feed warning: {getattr(parsed, 'bozo_exception', 'parse warning')}")
+                for entry in parsed.entries or []:
+                    normalized = self._normalize_entry(entry, source, date)
+                    if normalized:
+                        items.append(normalized)
+            except Exception as exc:
+                self.last_errors.append(f"{source.get('name', url)} failed: {exc}")
+                continue
+        return _dedupe(items)
+
+
 class NewsApiProvider(BaseNewsProvider):
     name = "newsapi"
+    requires_api_key = True
+
     def configured(self) -> bool:
         return bool(os.getenv("NEWS_API_KEY"))
+
     def fetch(self, date: str, bucket: str = "all", team: Optional[str] = None) -> List[Dict[str, Any]]:
         if not self.configured():
             return []
@@ -190,28 +367,37 @@ class NewsApiProvider(BaseNewsProvider):
 
 class RapidApiNewsProvider(BaseNewsProvider):
     name = "rapidapi"
+    requires_api_key = True
+
     def configured(self) -> bool:
         return bool(os.getenv("RAPIDAPI_KEY") and os.getenv("RAPIDAPI_NEWS_HOST"))
 
 
 class XProvider(BaseNewsProvider):
     name = "x_official_api"
+    requires_api_key = True
+
     def configured(self) -> bool:
         return os.getenv("NEWS_ENABLE_X_PROVIDER", "false").lower() == "true" and bool(os.getenv("X_BEARER_TOKEN"))
 
 
 class ProviderNotConfigured(BaseNewsProvider):
     name = "provider_not_configured"
+    requires_api_key = False
 
 
 def get_provider() -> BaseNewsProvider:
     selected = os.getenv("NEWS_PROVIDER", "").strip().lower()
+    if selected in {"rss", "rss_network", "rss_feed_network"}:
+        return RSSProvider()
     if selected in {"newsapi", "news_api"}:
         return NewsApiProvider()
     if selected == "rapidapi":
         return RapidApiNewsProvider()
     if selected in {"x", "twitter"}:
         return XProvider()
+    if _env_bool("NEWS_ENABLE_RSS_PROVIDER") and not os.getenv("NEWS_API_KEY"):
+        return RSSProvider()
     if os.getenv("NEWS_API_KEY"):
         return NewsApiProvider()
     return ProviderNotConfigured()
@@ -220,13 +406,19 @@ def get_provider() -> BaseNewsProvider:
 def build_news_payload(date: str, bucket: str = "all", team: Optional[str] = None) -> Dict[str, Any]:
     provider = get_provider()
     if not provider.configured():
-        payload = empty_response(date, provider.name, "provider_not_configured", ["Missing news provider config: set NEWS_PROVIDER plus NEWS_API_KEY, RAPIDAPI_KEY/RAPIDAPI_NEWS_HOST, or X_BEARER_TOKEN with NEWS_ENABLE_X_PROVIDER=true."])
+        payload = empty_response(
+            date,
+            provider.name,
+            "provider_not_configured",
+            ["Missing news provider config: set NEWS_PROVIDER=rss or NEWS_ENABLE_RSS_PROVIDER=true for free RSS, or configure a paid provider key."],
+        )
         payload["sources"] = get_news_sources(team)
         return payload
     try:
         items = provider.fetch(date, bucket=bucket, team=team)
         buckets = assign_buckets(items, date)
-        payload = empty_response(date, provider.name, "ok" if items else "empty")
+        provider_errors = list(getattr(provider, "last_errors", []) or [])
+        payload = empty_response(date, provider.name, "ok" if items else "empty", provider_errors)
         payload["buckets"] = buckets
         payload["ticker"] = build_ticker(buckets)
         payload["sources"] = get_news_sources(team)
@@ -250,7 +442,7 @@ def build_team_intel(date: str, team: Optional[str] = None, payload: Optional[Di
         team_items = []
         for item in all_items:
             text = f"{item.get('title', '')} {item.get('summary', '')}".lower()
-            if any(alias.lower() in text for alias in aliases):
+            if abbr in (item.get("teams") or []) or any(alias.lower() in text for alias in aliases):
                 team_items.append(item)
         team_items.sort(key=lambda row: row.get("importance_score") or 0, reverse=True)
         tags = []

--- a/mlb_app/news_routes.py
+++ b/mlb_app/news_routes.py
@@ -7,14 +7,21 @@ from typing import Optional
 from fastapi import APIRouter, Query
 
 from .news_cache import get_cache, set_cache, ttl_for
-from .news_provider import BUCKETS, build_news_payload, build_team_intel, empty_response
-from .news_sources import get_news_sources
+from .news_provider import BUCKETS, build_news_payload, build_team_intel, empty_response, get_provider
+from .news_sources import get_global_rss_sources, get_news_sources
 
 router = APIRouter()
 
 
 def _date(value: Optional[str]) -> str:
     return (value or dt.date.today().isoformat())[:10]
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 def _cached(key: str, ttl_key: str, builder):
@@ -33,17 +40,34 @@ def _cached(key: str, ttl_key: str, builder):
 
 @router.get("/news/health")
 def news_health():
-    configured = bool(os.getenv("NEWS_API_KEY") or os.getenv("RAPIDAPI_KEY") or os.getenv("X_BEARER_TOKEN"))
+    provider = get_provider()
+    rss_enabled = os.getenv("NEWS_PROVIDER", "").strip().lower() in {"rss", "rss_network", "rss_feed_network"} or _env_bool("NEWS_ENABLE_RSS_PROVIDER")
     return {
         "component": "news_terminal",
         "status": "ok",
-        "provider_configured": configured,
+        "provider_configured": provider.configured(),
+        "active_provider": provider.name,
+        "rss_enabled": rss_enabled,
+        "rss_supported": True,
+        "requires_api_key": bool(getattr(provider, "requires_api_key", False)),
         "env_vars_supported": [
-            "NEWS_PROVIDER", "NEWS_API_KEY", "NEWS_CACHE_TTL_SECONDS", "NEWS_DEFAULT_QUERY",
-            "RAPIDAPI_KEY", "RAPIDAPI_NEWS_HOST", "X_BEARER_TOKEN", "X_API_KEY", "X_API_SECRET",
-            "X_ACCESS_TOKEN", "X_ACCESS_TOKEN_SECRET", "NEWS_ENABLE_X_PROVIDER", "NEWS_ENABLE_RSS_PROVIDER",
-            "NEWS_ENABLE_BETTING_WIRE", "NEWS_ENABLE_LOCAL_SOURCES", "NEWS_MAX_ITEMS_PER_BUCKET",
+            "NEWS_PROVIDER",
+            "NEWS_ENABLE_RSS_PROVIDER",
+            "NEWS_CACHE_TTL_SECONDS",
+            "NEWS_MAX_ITEMS_PER_BUCKET",
             "NEWS_DEFAULT_LOOKBACK_HOURS",
+            "NEWS_API_KEY",
+            "NEWS_ENABLE_X_PROVIDER",
+            "X_BEARER_TOKEN",
+            "NEWS_DEFAULT_QUERY",
+            "RAPIDAPI_KEY",
+            "RAPIDAPI_NEWS_HOST",
+            "X_API_KEY",
+            "X_API_SECRET",
+            "X_ACCESS_TOKEN",
+            "X_ACCESS_TOKEN_SECRET",
+            "NEWS_ENABLE_BETTING_WIRE",
+            "NEWS_ENABLE_LOCAL_SOURCES",
         ],
     }
 
@@ -127,4 +151,9 @@ def news_team_intel(team: Optional[str] = None, date: Optional[str] = None):
 
 @router.get("/news/sources")
 def news_sources(team: Optional[str] = None):
-    return {"status": "ok", "team": team, "sources": get_news_sources(team)}
+    return {
+        "status": "ok",
+        "team": team,
+        "sources": get_news_sources(team),
+        "rss_sources": get_global_rss_sources(),
+    }

--- a/mlb_app/news_sources.py
+++ b/mlb_app/news_sources.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import urllib.parse
 from typing import Any, Dict, List, Optional
 
 _TEAM_ROWS = [
@@ -35,6 +36,79 @@ _TEAM_ROWS = [
     ("WSH", "Washington Nationals", ["Nationals", "Nats", "Washington"], ["Nationals Park"]),
 ]
 
+TEAM_SLUGS = {
+    "ARI": "dbacks",
+    "ATL": "braves",
+    "BAL": "orioles",
+    "BOS": "redsox",
+    "CHC": "cubs",
+    "CWS": "whitesox",
+    "CIN": "reds",
+    "CLE": "guardians",
+    "COL": "rockies",
+    "DET": "tigers",
+    "HOU": "astros",
+    "KC": "royals",
+    "LAA": "angels",
+    "LAD": "dodgers",
+    "MIA": "marlins",
+    "MIL": "brewers",
+    "MIN": "twins",
+    "NYM": "mets",
+    "NYY": "yankees",
+    "ATH": "athletics",
+    "PHI": "phillies",
+    "PIT": "pirates",
+    "SD": "padres",
+    "SEA": "mariners",
+    "SF": "giants",
+    "STL": "cardinals",
+    "TB": "rays",
+    "TEX": "rangers",
+    "TOR": "bluejays",
+    "WSH": "nationals",
+}
+
+GLOBAL_RSS_SOURCES = [
+    {
+        "name": "MLB.com News",
+        "url": "https://www.mlb.com/feeds/news/rss.xml",
+        "source_type": "official",
+        "team": None,
+        "reliability": "high",
+        "requires_api_key": False,
+    },
+    {
+        "name": "MLB Trade Rumors",
+        "url": "https://www.mlbtraderumors.com/feed",
+        "source_type": "transactions",
+        "team": None,
+        "reliability": "medium",
+        "requires_api_key": False,
+    },
+    {
+        "name": "Google News MLB",
+        "url": "https://news.google.com/rss/search?q=MLB+injury+lineup+probable+pitcher+odds+roster+weather+when:1d&hl=en-US&gl=US&ceid=US:en",
+        "source_type": "google_news",
+        "team": None,
+        "reliability": "medium",
+        "requires_api_key": False,
+    },
+]
+
+OPTIONAL_RSS_CANDIDATES = [
+    {
+        "name": "FOX Sports MLB",
+        "url": None,
+        "source_type": "national",
+        "team": None,
+        "reliability": "medium",
+        "requires_api_key": False,
+        "source_registry_status": "needs_verification",
+        "source_registry_note": "FOX Sports MLB is intentionally disabled until a stable RSS URL is confirmed.",
+    },
+]
+
 _SITUATION_TERMS = ["lineup", "injury", "probable pitcher", "bullpen", "weather", "roster move"]
 
 
@@ -43,24 +117,93 @@ def _queries(team_name: str, aliases: List[str], venues: List[str]) -> List[str]
     return base + [f"{team_name} {term}" for term in _SITUATION_TERMS]
 
 
+def _google_news_url(query: str) -> str:
+    return (
+        "https://news.google.com/rss/search?q="
+        f"{urllib.parse.quote_plus(query)}"
+        "&hl=en-US&gl=US&ceid=US:en"
+    )
+
+
+def _team_rss_sources(abbr: str, team_name: str) -> List[Dict[str, Any]]:
+    slug = TEAM_SLUGS.get(abbr)
+    sources: List[Dict[str, Any]] = []
+    if slug:
+        sources.append(
+            {
+                "name": f"MLB.com {team_name.split()[-1]} News",
+                "url": f"https://www.mlb.com/{slug}/feeds/news/rss.xml",
+                "source_type": "official",
+                "team": abbr,
+                "reliability": "high",
+                "requires_api_key": False,
+            }
+        )
+    sources.append(
+        {
+            "name": f"Google News {team_name}",
+            "url": _google_news_url(f"{team_name} injury lineup starter probable pitcher roster when:1d"),
+            "source_type": "google_news",
+            "team": abbr,
+            "reliability": "medium",
+            "requires_api_key": False,
+        }
+    )
+    return sources
+
+
+def get_global_rss_sources() -> List[Dict[str, Any]]:
+    return [dict(source) for source in GLOBAL_RSS_SOURCES]
+
+
+def get_rss_sources(team: Optional[str] = None, include_team_google: bool = True) -> List[Dict[str, Any]]:
+    wanted = str(team or "").upper()
+    sources = get_global_rss_sources()
+
+    for abbr, team_name, _aliases, _venues in _TEAM_ROWS:
+        if wanted and wanted != abbr:
+            continue
+        team_sources = _team_rss_sources(abbr, team_name)
+        if not include_team_google:
+            team_sources = [source for source in team_sources if source.get("source_type") != "google_news"]
+        sources.extend(team_sources)
+
+    seen = set()
+    unique: List[Dict[str, Any]] = []
+    for source in sources:
+        url = source.get("url")
+        key = (source.get("name"), url, source.get("team"))
+        if not url or key in seen:
+            continue
+        seen.add(key)
+        unique.append(source)
+    return unique
+
+
 def get_news_sources(team: Optional[str] = None) -> List[Dict[str, Any]]:
     wanted = str(team or "").upper()
     rows: List[Dict[str, Any]] = []
     for abbr, team_name, aliases, venues in _TEAM_ROWS:
         if wanted and wanted != abbr:
             continue
-        rows.append({
-            "team": abbr,
-            "team_name": team_name,
-            "aliases": aliases,
-            "city_aliases": aliases,
-            "venue_keywords": venues,
-            "queries": _queries(team_name, aliases, venues),
-            "beat_sources": [],
-            "local_outlets": [],
-            "source_registry_status": "needs_verification",
-            "source_registry_note": "Curated beat/local handles and RSS URLs are intentionally empty until verified. Broad provider queries remain available.",
-        })
+        rows.append(
+            {
+                "team": abbr,
+                "team_name": team_name,
+                "aliases": aliases,
+                "city_aliases": aliases,
+                "venue_keywords": venues,
+                "queries": _queries(team_name, aliases, venues),
+                "rss_sources": _team_rss_sources(abbr, team_name),
+                "beat_sources": [],
+                "local_outlets": [],
+                "source_registry_status": "rss_active_manual_sources_pending",
+                "source_registry_note": (
+                    "Official MLB.com team RSS and Google News RSS discovery are active. "
+                    "Curated beat/local handles and outlet feeds remain intentionally empty until verified."
+                ),
+            }
+        )
     return rows
 
 
@@ -68,5 +211,7 @@ def team_lookup() -> Dict[str, Dict[str, Any]]:
     lookup: Dict[str, Dict[str, Any]] = {}
     for row in get_news_sources():
         for key in [row["team"], row["team_name"], *row.get("aliases", []), *row.get("city_aliases", [])]:
-            lookup[str(key).strip().lower()] = row
+            value = str(key).strip().lower()
+            if value:
+                lookup[value] = row
     return lookup

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pandas>=2.0.0
 pybaseball>=2.2.5
 requests>=2.31.0
 apify-client>=1.8.0
+feedparser
 
 # Scheduling / utils
 python-dotenv>=1.0.0

--- a/scripts/smoke_test_news_terminal.py
+++ b/scripts/smoke_test_news_terminal.py
@@ -58,6 +58,14 @@ def _check_health(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     if payload.get("component") != "news_terminal" or payload.get("status") != "ok":
         raise SmokeFailure(f"Unexpected News health payload for {path}: {payload}")
+    env_vars = payload.get("env_vars_supported") or []
+    for key in ["NEWS_PROVIDER", "NEWS_ENABLE_RSS_PROVIDER", "NEWS_CACHE_TTL_SECONDS", "NEWS_MAX_ITEMS_PER_BUCKET", "NEWS_DEFAULT_LOOKBACK_HOURS", "NEWS_API_KEY", "NEWS_ENABLE_X_PROVIDER", "X_BEARER_TOKEN"]:
+        if key not in env_vars:
+            raise SmokeFailure(f"News health missing supported env var {key}")
+    if payload.get("rss_supported") is not True:
+        raise SmokeFailure("News health must indicate RSS support")
+    if payload.get("active_provider") in {"rss", "rss_network", "rss_feed_network"} and payload.get("requires_api_key") is not False:
+        raise SmokeFailure("RSS provider must not require NEWS_API_KEY")
 
 
 def _check_all(data: Any, path: str) -> None:
@@ -73,30 +81,46 @@ def _check_all(data: Any, path: str) -> None:
         raise SmokeFailure(f"News buckets missing {missing}")
     if not isinstance(payload.get("ticker"), list):
         raise SmokeFailure("News ticker must be an array")
+    if not isinstance(payload.get("errors"), list):
+        raise SmokeFailure("News errors must be an array")
+    if payload.get("status") == "provider_not_configured" and payload.get("provider") in {"rss", "rss_network", "rss_feed_network"}:
+        raise SmokeFailure("RSS provider returned provider_not_configured")
 
 
 def _check_ticker(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     if "ticker" not in payload or not isinstance(payload.get("ticker"), list):
         raise SmokeFailure("Ticker payload missing ticker array")
+    if not isinstance(payload.get("errors", []), list):
+        raise SmokeFailure("Ticker payload errors must be an array")
 
 
 def _check_items(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     if "items" not in payload or not isinstance(payload.get("items"), list):
         raise SmokeFailure(f"Expected items array for {path}")
+    if not isinstance(payload.get("errors", []), list):
+        raise SmokeFailure(f"Expected errors array for {path}")
 
 
 def _check_team_intel(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     if "team_intel" not in payload or not isinstance(payload.get("team_intel"), dict):
         raise SmokeFailure("Team intel payload missing team_intel object")
+    if not isinstance(payload.get("errors", []), list):
+        raise SmokeFailure("Team intel errors must be an array")
 
 
 def _check_sources(data: Any, path: str) -> None:
     payload = _expect_dict(data, path)
     if "sources" not in payload or not isinstance(payload.get("sources"), list):
         raise SmokeFailure("Sources payload missing sources array")
+    if "rss_sources" not in payload or not isinstance(payload.get("rss_sources"), list):
+        raise SmokeFailure("Sources payload missing rss_sources array")
+    if payload["sources"]:
+        first = payload["sources"][0]
+        if "rss_sources" not in first:
+            raise SmokeFailure("Team source missing rss_sources")
 
 
 def _run(base_url: str, label: str, path: str, validator) -> bool:


### PR DESCRIPTION
## Summary

This PR rewrites the existing News Terminal provider sourcing layer to support a home-built RSS-first MLB news network without requiring a paid NewsAPI key.

This is not a redesign. The existing `/news` page, frontend route, bucket structure, ticker structure, filters, and response shape remain in place. The backend provider architecture now supports RSS as the primary provider when `NEWS_PROVIDER=rss` or `NEWS_ENABLE_RSS_PROVIDER=true` is set.

## Root architecture change

- Adds `RSSProvider` in `mlb_app/news_provider.py`.
- Adds RSS source registry helpers in `mlb_app/news_sources.py`.
- Preserves the existing `NewsApiProvider`, `RapidApiNewsProvider`, `XProvider`, and `ProviderNotConfigured` paths.
- Reuses the existing `classify_text`, `score_importance`, `assign_buckets`, and `build_ticker` flow.
- Keeps endpoint response keys stable: `status`, `provider`, `buckets`, `ticker`, `team_intel`, `sources`, `errors`, `cache_hit`.

## RSS feeds added

Active direct/feed sources:

- MLB.com national RSS: `https://www.mlb.com/feeds/news/rss.xml`
- MLB Trade Rumors RSS: `https://www.mlbtraderumors.com/feed`
- Google News MLB RSS discovery query
- Official MLB.com team RSS feeds for all 30 clubs using team slugs
- Google News team RSS discovery queries for team-specific requests

FOX Sports MLB is intentionally left inactive as a future candidate until a stable RSS URL is confirmed. X/Twitter remains a future optional enrichment path and is not required for `/news` to work.

## How RSS works in production

Set backend Railway variables:

```bash
NEWS_PROVIDER=rss
NEWS_ENABLE_RSS_PROVIDER=true
NEWS_CACHE_TTL_SECONDS=300
NEWS_MAX_ITEMS_PER_BUCKET=40
NEWS_DEFAULT_LOOKBACK_HOURS=48
```

These go in Railway backend service variables. They are not `VITE` variables. Do not commit them to GitHub. After adding them, redeploy the backend service.

No `NEWS_API_KEY` is required.

## What was not touched

- `/matchups`
- `generate_matchups_for_date`
- scoring/model formulas
- odds logic
- `Dockerfile`
- `main.py`
- production launch path, which remains `uvicorn mlb_app.app:app`

## Validation

- Local syntax compile was performed against the generated changed Python modules before commit.
- `compare main...feature/rss-news-provider-network` shows only News Terminal provider/source/route/frontend/smoke-test/dependency files changed.

Not run in this environment:

- `python -m compileall mlb_app scripts`, because the full repository was not available locally through the connector environment.
- `npm --prefix frontend run build`, because the full frontend workspace was not available locally through the connector environment.
- deployed smoke test, because this branch is not deployed with the new RSS env vars yet.

Recommended post-deploy smoke command:

```bash
python scripts/smoke_test_news_terminal.py --base-url https://mlbgpt.com --date 2026-05-15
```

## Remaining limitations

- Google News RSS is a discovery layer, not a direct source of original reporting.
- Beat writer and local outlet registries remain placeholders until manually curated and verified.
- FOX Sports should only be activated after a valid, stable RSS URL is confirmed.
- RSS feed availability can vary by source, but one bad feed is isolated and should not break the page.