### PR TITLE
Fix Model Tracker dict serialization 500

### DIFF
--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -6,14 +6,12 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
-from .best_plays_engine import build_best_plays_payload, normalize_best_play_rows
 from .database import create_tables, get_engine, get_session
 from .model_tracker import (
-    build_tracker_snapshot,
     list_tracker_rows,
     refresh_tracker_results,
-    upsert_tracker_rows,
 )
+from .model_tracker_safe_snapshot import build_tracker_snapshot_safe
 
 router = APIRouter(prefix="/model-tracker", tags=["model-tracker"])
 
@@ -34,30 +32,6 @@ def _target_date(value: Optional[str]) -> str:
     return target
 
 
-def _append_best_plays_snapshot(session, target: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Add Best Plays rows to the existing additive tracker snapshot response."""
-    try:
-        best_plays_payload = build_best_plays_payload(session, target)
-        best_play_rows = normalize_best_play_rows(best_plays_payload, target)
-        best_play_upsert = upsert_tracker_rows(session, best_play_rows)
-        payload["rows_collected"] = int(payload.get("rows_collected") or 0) + len(best_play_rows)
-        payload.setdefault("upsert", {})["best_plays"] = best_play_upsert
-        payload["best_plays"] = {
-            "rows_collected": len(best_play_rows),
-            "summary": best_plays_payload.get("summary") or {},
-            "errors": best_plays_payload.get("errors") or [],
-        }
-        if best_plays_payload.get("errors"):
-            payload.setdefault("errors", []).extend(
-                {"source": "best_plays", **error} if isinstance(error, dict) else {"source": "best_plays", "error": str(error)}
-                for error in best_plays_payload.get("errors") or []
-            )
-        return payload
-    except Exception as exc:
-        payload.setdefault("errors", []).append({"source": "best_plays", "error": str(exc), "type": exc.__class__.__name__})
-        return payload
-
-
 @router.get("/health")
 def model_tracker_health() -> Dict[str, Any]:
     return {
@@ -74,8 +48,7 @@ def model_tracker_snapshot(date: Optional[str] = Query(default=None)) -> Dict[st
     try:
         Session = _session_factory()
         with Session() as session:
-            payload = build_tracker_snapshot(session, target)
-            return _append_best_plays_snapshot(session, target, payload)
+            return build_tracker_snapshot_safe(session, target)
     except HTTPException:
         raise
     except Exception as exc:

--- a/mlb_app/model_tracker_safe_snapshot.py
+++ b/mlb_app/model_tracker_safe_snapshot.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any, Dict, List
+
+from sqlalchemy.orm import Session
+
+from .best_plays_engine import build_best_plays_payload, normalize_best_play_rows
+from .matchup_generator import generate_matchups_for_date
+from .model_projections import build_model_projection_payload
+from .my_dashboard_solver import build_dashboard_solver_payload
+from .model_tracker import (
+    AI_TRACKER_PROMPTS,
+    DASHBOARD_COMPONENTS,
+    ModelTrackerSnapshot,
+    _safe_float,
+    _safe_int,
+    _tracker_key,
+    normalize_ai_data_assistant_rows,
+    normalize_daily_odds_rows,
+    normalize_dashboard_rows,
+    normalize_matchup_rows,
+    normalize_model_projection_rows,
+)
+
+JSON_COLUMNS = {"reasoning_json", "features_used_json", "missing_inputs_json", "raw_payload_json", "actual_result_json"}
+INTEGER_COLUMNS = {"game_pk", "team_id", "player_id"}
+FLOAT_COLUMNS = {
+    "model_probability",
+    "market_implied_probability",
+    "edge",
+    "score",
+    "confidence",
+    "line",
+    "price",
+    "expected_value",
+    "projected_total",
+    "projected_home_runs",
+    "projected_away_runs",
+    "home_win_probability",
+    "away_win_probability",
+}
+
+
+def _json(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str, sort_keys=True)
+    except Exception:
+        return json.dumps(str(value))
+
+
+def _coerce_value(key: str, value: Any) -> Any:
+    if key == "snapshot_date" and isinstance(value, str):
+        return dt.date.fromisoformat(value[:10])
+    if key in INTEGER_COLUMNS:
+        return _safe_int(value)
+    if key in FLOAT_COLUMNS:
+        return _safe_float(value)
+    if key in JSON_COLUMNS:
+        return _json(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        return _json(value)
+    return value
+
+
+def safe_upsert_tracker_rows(session: Session, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    inserted = 0
+    updated = 0
+    now = dt.datetime.utcnow()
+    for row in rows:
+        tracker_key = row.get("tracker_key") or _tracker_key(row)
+        existing = session.query(ModelTrackerSnapshot).filter(ModelTrackerSnapshot.tracker_key == tracker_key).first()
+        if existing:
+            target = existing
+            updated += 1
+        else:
+            target = ModelTrackerSnapshot(tracker_key=tracker_key)
+            session.add(target)
+            inserted += 1
+        for key, value in row.items():
+            if not hasattr(target, key):
+                continue
+            setattr(target, key, _coerce_value(key, value))
+        target.updated_at = now
+    session.commit()
+    return {"inserted": inserted, "updated": updated, "total_rows_seen": len(rows)}
+
+
+def build_tracker_snapshot_safe(session: Session, target_date: str) -> Dict[str, Any]:
+    target_date = target_date[:10]
+    dt.date.fromisoformat(target_date)
+    errors: List[Dict[str, Any]] = []
+    rows: List[Dict[str, Any]] = []
+    best_plays_summary: Dict[str, Any] = {"rows_collected": 0, "summary": {}, "errors": []}
+
+    try:
+        matchups = generate_matchups_for_date(session, target_date)
+        rows.extend(normalize_matchup_rows(matchups, target_date))
+    except Exception as exc:
+        errors.append({"source": "matchups", "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        from .daily_odds_routes import daily_odds_models
+        payload = daily_odds_models(date=target_date, include_unified=True)
+        rows.extend(normalize_daily_odds_rows(payload, target_date))
+    except Exception as exc:
+        errors.append({"source": "daily_odds", "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        payload = build_model_projection_payload(session, target_date)
+        rows.extend(normalize_model_projection_rows(payload, target_date))
+    except Exception as exc:
+        errors.append({"source": "model_projections", "error": str(exc), "type": exc.__class__.__name__})
+
+    for component in DASHBOARD_COMPONENTS:
+        try:
+            payload = build_dashboard_solver_payload(session=session, date=target_date, component=component)
+            rows.extend(normalize_dashboard_rows(component, payload, target_date))
+        except Exception as exc:
+            errors.append({"source": "my_dashboard", "component": component, "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        from .ai_data_assistant_performance import build_ai_data_assistant_response
+        for prompt in AI_TRACKER_PROMPTS:
+            try:
+                payload = build_ai_data_assistant_response(session=session, message=prompt, date=target_date, use_llm=False)
+                rows.extend(normalize_ai_data_assistant_rows(payload, target_date, prompt))
+            except Exception as prompt_exc:
+                errors.append({"source": "ai_data_assistant", "prompt": prompt, "error": str(prompt_exc), "type": prompt_exc.__class__.__name__})
+    except Exception as exc:
+        errors.append({"source": "ai_data_assistant", "error": str(exc), "type": exc.__class__.__name__})
+
+    try:
+        best_plays_payload = build_best_plays_payload(session, target_date)
+        best_play_rows = normalize_best_play_rows(best_plays_payload, target_date)
+        rows.extend(best_play_rows)
+        best_plays_errors = best_plays_payload.get("errors") or []
+        best_plays_summary = {
+            "rows_collected": len(best_play_rows),
+            "summary": best_plays_payload.get("summary") or {},
+            "errors": best_plays_errors,
+        }
+        if best_plays_errors:
+            errors.extend(
+                {"source": "best_plays", **error} if isinstance(error, dict) else {"source": "best_plays", "error": str(error)}
+                for error in best_plays_errors
+            )
+    except Exception as exc:
+        best_plays_summary = {"rows_collected": 0, "summary": {}, "errors": [{"error": str(exc), "type": exc.__class__.__name__}]}
+        errors.append({"source": "best_plays", "error": str(exc), "type": exc.__class__.__name__})
+
+    upsert_result = safe_upsert_tracker_rows(session, rows)
+    return {
+        "date": target_date,
+        "rows_collected": len(rows),
+        "upsert": upsert_result,
+        "best_plays": best_plays_summary,
+        "errors": errors,
+    }


### PR DESCRIPTION
## Summary

Fixes the Model Tracker snapshot 500 caused by Postgres receiving a raw Python `dict` value during `model_tracker_snapshots` insertion.

## Problem

The production error was:

```text
psycopg2.ProgrammingError: can't adapt type 'dict'
```

The failing path was `/model-tracker/snapshot`. The existing tracker upsert coerced ints/floats/dates but did not defensively serialize raw `dict`, `list`, `tuple`, or `set` values before setting SQLAlchemy model attributes.

## Fix

- Added `mlb_app/model_tracker_safe_snapshot.py`
  - Reuses the existing tracker normalizers.
  - Adds `safe_upsert_tracker_rows()`.
  - Coerces JSON columns and any raw dict/list/tuple/set values to JSON strings before Postgres sees them.
  - Includes Best Plays rows in the same safe snapshot flow.

- Updated `mlb_app/model_tracker_routes.py`
  - `/model-tracker/snapshot` now calls `build_tracker_snapshot_safe()` directly.
  - Removed the route-level append step that called the old crashing upsert path first.

## Why this is scoped

This does not change the schema. It does not rewrite the tracker page. It only makes snapshot persistence safe for nested payloads and prevents Postgres from rejecting dict/list values.

## Test command after deploy

```bash
python scripts/smoke_test_production_paths.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --date 2026-05-15 --include-mutating-tracker-checks
```

Manual smoke path:

```bash
curl -X POST 'https://mlb-prediction-app-production-732c.up.railway.app/model-tracker/snapshot?date=2026-05-15'
```
