### PR TITLE
Add optional Twikit matchup Twitter intel to News page

### DIFF
--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -51,6 +51,7 @@ function statusLabel(status) {
   if (status === 'ok') return 'Connected'
   if (status === 'empty') return 'Connected, no items returned'
   if (status === 'provider_not_configured') return 'Provider Missing'
+  if (status === 'provider_missing_dependency') return 'Dependency Missing'
   return status || 'loading'
 }
 function emptyMessage(payload) {
@@ -79,6 +80,16 @@ function NewsCard({ item }) {
   </article>
 }
 
+function TweetCard({ item }) {
+  const handle = item.handle || item.author || 'X/Twitter'
+  return <article style={{ ...s.card, minHeight: 0 }}>
+    <div style={s.row}><strong style={{ color: '#e6edf3' }}>{handle}</strong><span style={s.badge}>X/Twitter</span></div>
+    <div style={s.meta}>{item.author && item.handle ? item.author : 'Twitter/X post'} · {fmtTime(item.published_at)}</div>
+    <div style={{ color: '#c9d1d9', fontSize: 13, lineHeight: 1.45, marginTop: 9 }}>{item.summary || item.title || 'No post text returned.'}</div>
+    <div style={s.tagRow}>{asArray(item.tags).slice(0, 6).map(tag => <span key={tag} style={s.tag}>{tag}</span>)}{item.url && <a href={item.url} target="_blank" rel="noreferrer" style={s.tag}>Open</a>}</div>
+  </article>
+}
+
 function TeamIntel({ boards }) {
   const rows = Object.values(boards || {})
   if (!rows.length) return <div style={s.empty}>No team intel board available yet.</div>
@@ -90,6 +101,61 @@ function TeamIntel({ boards }) {
     <div style={s.meta}>Injury/lineup/starter: {board.latest_injury_lineup_starter_item?.title || 'No item'}</div>
     <div style={s.tagRow}>{asArray(board.top_tags).slice(0, 6).map(tag => <span key={tag} style={s.tag}>{tag}</span>)}</div>
   </div>)}</div>
+}
+
+function MatchupTwitterIntel({ date, teams }) {
+  const [mode, setMode] = useState('matchups')
+  const [payload, setPayload] = useState(null)
+  const [team, setTeam] = useState('CHC')
+  const [query, setQuery] = useState('Cubs lineup')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  function endpoint() {
+    if (mode === 'betting') return `${API}/news/twitter/betting?date=${date}&limit=10`
+    if (mode === 'team') return `${API}/news/twitter/team?team=${encodeURIComponent(team || 'CHC')}&date=${date}&limit=10`
+    if (mode === 'search') return `${API}/news/twitter/search?query=${encodeURIComponent(query || 'MLB lineup')}&date=${date}&limit=10`
+    return `${API}/news/twitter/matchups?date=${date}&limit=10`
+  }
+
+  function loadTwitter() {
+    setLoading(true)
+    setError(null)
+    fetch(endpoint())
+      .then(async r => { if (!r.ok) throw new Error(`/news/twitter/${mode} failed ${r.status}: ${await r.text()}`); return r.json() })
+      .then(data => { setPayload(data); setLoading(false) })
+      .catch(err => { setPayload(null); setError(String(err?.message || err)); setLoading(false) })
+  }
+
+  useEffect(() => { loadTwitter() }, [date, mode])
+
+  const message = payload?.message || asArray(payload?.errors)[0]
+  const blocks = asArray(payload?.matchups)
+  const flatItems = asArray(payload?.items)
+  const disabled = ['provider_not_configured', 'provider_missing_dependency'].includes(payload?.status)
+
+  return <section style={s.section}>
+    <div style={s.row}>
+      <div><div style={s.sectionTitle}>Matchup Twitter Intel</div><div style={s.meta}>Optional Twikit-backed X/Twitter layer for matchup, team, and betting chatter. It is isolated from the core News provider.</div></div>
+      <div style={s.tabs}>
+        {['matchups', 'betting', 'team', 'search'].map(name => <button key={name} type="button" style={s.tab(mode === name)} onClick={() => setMode(name)}>{name === 'matchups' ? 'Twitter Matchups' : name === 'betting' ? 'Twitter Betting' : name === 'team' ? 'Twitter Team Search' : 'Twitter Search'}</button>)}
+        <button type="button" style={s.muted} onClick={loadTwitter} disabled={loading}>{loading ? 'Loading...' : 'Refresh Twitter'}</button>
+      </div>
+    </div>
+    {mode === 'team' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Team</div><select style={s.select} value={team} onChange={e => setTeam(e.target.value)}>{asArray(teams).map(t => <option key={t} value={t}>{t}</option>)}</select></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search Team</button></div></div>}
+    {mode === 'search' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Keyword Search</div><input style={s.input} value={query} onChange={e => setQuery(e.target.value)} placeholder="Cubs lineup, MLB sharp money" /></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search X/Twitter</button></div></div>}
+    {error && <div style={{ ...s.error, marginTop: 12 }}>{error}</div>}
+    {disabled && <div style={{ ...s.empty, marginTop: 12 }}>Twitter/X provider is disabled or missing credentials. Configure NEWS_ENABLE_TWIKIT and TWIKIT_* env vars to enable matchup intel.</div>}
+    {!disabled && message && <div style={{ ...s.error, marginTop: 12 }}>{message}</div>}
+    {!disabled && mode === 'matchups' && blocks.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No matchup Twitter intel returned yet.</div>}
+    {!disabled && mode === 'matchups' && blocks.length > 0 && <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>{blocks.map(block => <article key={block.game_id} style={s.card}>
+      <div style={s.row}><div><div style={s.cardTitle}>{block.away_team || 'Away'} at {block.home_team || 'Home'}</div><div style={s.meta}>{block.away_pitcher || 'Away pitcher pending'} vs {block.home_pitcher || 'Home pitcher pending'}</div></div><span style={s.badge}>{asArray(block.items).length} posts</span></div>
+      <div style={s.tagRow}>{asArray(block.queries).map(q => <span key={q} style={s.tag}>{q}</span>)}</div>
+      {asArray(block.items).length === 0 ? <div style={s.empty}>No posts returned for this matchup.</div> : <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{asArray(block.items).slice(0, 10).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+    </article>)}</div>}
+    {!disabled && mode !== 'matchups' && flatItems.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Twitter/X posts returned for this search.</div>}
+    {!disabled && mode !== 'matchups' && flatItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{flatItems.slice(0, 10).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+  </section>
 }
 
 export default function NewsPage() {
@@ -172,6 +238,7 @@ export default function NewsPage() {
       </div>
       <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 12 }}><button style={breakingOnly ? s.button : s.muted} type="button" onClick={() => setBreakingOnly(v => !v)}>Breaking Only</button><button style={bettingOnly ? s.button : s.muted} type="button" onClick={() => setBettingOnly(v => !v)}>Betting Relevant</button><button style={localOnly ? s.button : s.muted} type="button" onClick={() => setLocalOnly(v => !v)}>Beat/Local Only</button><Link style={s.muted} to="/daily-odds">Daily Odds</Link><Link style={s.muted} to="/models/projections">Model Projections</Link></div>
     </section>
+    <MatchupTwitterIntel date={date} teams={teams.length ? teams : ['CHC', 'CWS', 'STL', 'MIL']} />
     <section style={s.section}>
       <div style={s.row}><div><div style={s.sectionTitle}>Terminal Buckets</div><div style={s.meta}>Exclusive buckets prevent national wire spam from flooding every section.</div></div><div style={s.tabs}>{[...BUCKETS, 'team_intel'].map(bucket => <button key={bucket} type="button" style={s.tab(activeBucket === bucket)} onClick={() => setActiveBucket(bucket)}>{bucket.replace('_', ' ')}</button>)}</div></div>
       {activeBucket === 'team_intel' ? <TeamIntel boards={intel?.team_intel} /> : visible.length === 0 ? <div style={s.empty}>{emptyMessage(payload)}</div> : <div style={s.grid}>{visible.map(item => <NewsCard key={item.id} item={item} />)}</div>}

--- a/mlb_app/news_routes.py
+++ b/mlb_app/news_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Query
 from .news_cache import get_cache, set_cache, ttl_for
 from .news_provider import BUCKETS, build_news_payload, build_team_intel, empty_response, get_provider
 from .news_sources import get_global_rss_sources, get_news_sources
+from .news_twitter_provider import TwikitNewsProvider
 
 router = APIRouter()
 
@@ -24,7 +25,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
-def _cached(key: str, ttl_key: str, builder):
+def _cached(key: str, ttl_key: str, builder, ttl_override: Optional[int] = None):
     cached = get_cache(key)
     if cached is not None:
         if isinstance(cached, dict):
@@ -33,15 +34,34 @@ def _cached(key: str, ttl_key: str, builder):
             return out
         return cached
     data = builder()
-    ttl = int(os.getenv("NEWS_CACHE_TTL_SECONDS", str(ttl_for(ttl_key))))
+    ttl = ttl_override if ttl_override is not None else int(os.getenv("NEWS_CACHE_TTL_SECONDS", str(ttl_for(ttl_key))))
     set_cache(key, data, ttl)
     return data
+
+
+def _twitter_provider() -> TwikitNewsProvider:
+    return TwikitNewsProvider()
+
+
+def _twitter_ttl() -> int:
+    try:
+        return int(os.getenv("NEWS_TWITTER_CACHE_TTL_SECONDS", "120"))
+    except Exception:
+        return 120
+
+
+def _limit(value: int = 10) -> int:
+    try:
+        return max(1, min(25, int(value)))
+    except Exception:
+        return 10
 
 
 @router.get("/news/health")
 def news_health():
     provider = get_provider()
     rss_enabled = os.getenv("NEWS_PROVIDER", "").strip().lower() in {"rss", "rss_network", "rss_feed_network"} or _env_bool("NEWS_ENABLE_RSS_PROVIDER")
+    twikit = _twitter_provider()
     return {
         "component": "news_terminal",
         "status": "ok",
@@ -49,6 +69,7 @@ def news_health():
         "active_provider": provider.name,
         "rss_enabled": rss_enabled,
         "rss_supported": True,
+        **twikit.health(),
         "requires_api_key": bool(getattr(provider, "requires_api_key", False)),
         "env_vars_supported": [
             "NEWS_PROVIDER",
@@ -68,6 +89,16 @@ def news_health():
             "X_ACCESS_TOKEN_SECRET",
             "NEWS_ENABLE_BETTING_WIRE",
             "NEWS_ENABLE_LOCAL_SOURCES",
+            "NEWS_ENABLE_TWIKIT",
+            "TWIKIT_USERNAME",
+            "TWIKIT_EMAIL",
+            "TWIKIT_PASSWORD",
+            "TWIKIT_COOKIES_FILE",
+            "TWIKIT_LANGUAGE",
+            "TWIKIT_MAX_RESULTS",
+            "TWIKIT_TIMEOUT_SECONDS",
+            "TWIKIT_RATE_LIMIT_SLEEP_SECONDS",
+            "NEWS_TWITTER_CACHE_TTL_SECONDS",
         ],
     }
 
@@ -147,6 +178,56 @@ def news_team_intel(team: Optional[str] = None, date: Optional[str] = None):
         "errors": payload.get("errors") or [],
         "cache_hit": payload.get("cache_hit", False),
     }
+
+
+@router.get("/news/twitter/search")
+def news_twitter_search(query: str = Query("MLB lineup"), date: Optional[str] = None, limit: int = Query(10)):
+    target_date = _date(date)
+    safe_limit = _limit(limit)
+    safe_query = str(query or "").strip()
+    return _cached(
+        f"twitter:search:{safe_query}:{target_date}:{safe_limit}",
+        "twitter",
+        lambda: _twitter_provider().search(safe_query, limit=safe_limit, date=target_date),
+        ttl_override=_twitter_ttl(),
+    )
+
+
+@router.get("/news/twitter/team")
+def news_twitter_team(team: str = Query(...), date: Optional[str] = None, limit: int = Query(10)):
+    target_date = _date(date)
+    safe_limit = _limit(limit)
+    safe_team = str(team or "").strip().upper()
+    return _cached(
+        f"twitter:team:{safe_team}:{target_date}:{safe_limit}",
+        "twitter",
+        lambda: _twitter_provider().search_team(safe_team, target_date, limit=safe_limit),
+        ttl_override=_twitter_ttl(),
+    )
+
+
+@router.get("/news/twitter/matchups")
+def news_twitter_matchups(date: Optional[str] = None, limit: int = Query(10)):
+    target_date = _date(date)
+    safe_limit = _limit(limit)
+    return _cached(
+        f"twitter:matchups:{target_date}:{safe_limit}",
+        "twitter",
+        lambda: _twitter_provider().search_matchups(target_date, limit=safe_limit),
+        ttl_override=_twitter_ttl(),
+    )
+
+
+@router.get("/news/twitter/betting")
+def news_twitter_betting(date: Optional[str] = None, limit: int = Query(10)):
+    target_date = _date(date)
+    safe_limit = _limit(limit)
+    return _cached(
+        f"twitter:betting:{target_date}:{safe_limit}",
+        "twitter",
+        lambda: _twitter_provider().search_betting(target_date, limit=safe_limit),
+        ttl_override=_twitter_ttl(),
+    )
 
 
 @router.get("/news/sources")

--- a/mlb_app/news_twitter_provider.py
+++ b/mlb_app/news_twitter_provider.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import hashlib
+import inspect
+import os
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+from .news_classifier import classify_text, score_importance
+from .news_keywords import BETTING_TERMS
+from .news_provider import stable_id, utc_now
+from .news_sources import get_news_sources, team_lookup
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _int_env(name: str, default: int, minimum: int = 1, maximum: int = 100) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except Exception:
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _safe_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _run_maybe_await(value: Any, timeout_seconds: Optional[int] = None) -> Any:
+    if not inspect.isawaitable(value):
+        return value
+
+    async def _await_with_timeout() -> Any:
+        if timeout_seconds:
+            return await asyncio.wait_for(value, timeout=timeout_seconds)
+        return await value
+
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # FastAPI sync routes should not usually land here. Avoid nested loop crashes.
+            return None
+    except RuntimeError:
+        loop = None
+    return asyncio.run(_await_with_timeout())
+
+
+def _post_datetime(value: Any) -> str:
+    if value is None:
+        return utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    text = str(value)
+    try:
+        parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return text
+
+
+def _first_present(row: Dict[str, Any], keys: Iterable[str]) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _load_matchups(date: str) -> List[Dict[str, Any]]:
+    # Same safe access pattern as news_keywords.py. This reads the existing matchup generator without changing it.
+    try:
+        from .app import _get_session
+        from .matchup_generator import generate_matchups_for_date
+
+        Session = _get_session()
+        with Session() as session:
+            data = generate_matchups_for_date(session, date)
+            return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+class TwikitNewsProvider:
+    name = "twikit"
+    requires_api_key = True
+
+    def __init__(self) -> None:
+        self.language = os.getenv("TWIKIT_LANGUAGE", "en-US")
+        self.timeout_seconds = _int_env("TWIKIT_TIMEOUT_SECONDS", 20, 3, 60)
+        self.max_results = _int_env("TWIKIT_MAX_RESULTS", 10, 1, 25)
+        self.max_queries_per_matchup = _int_env("TWIKIT_MAX_QUERIES_PER_MATCHUP", 5, 1, 8)
+        self.last_error: Optional[str] = None
+
+    @staticmethod
+    def twikit_installed() -> bool:
+        try:
+            import twikit  # noqa: F401
+            return True
+        except Exception:
+            return False
+
+    def enabled(self) -> bool:
+        selected = os.getenv("NEWS_PROVIDER", "").strip().lower()
+        return _env_bool("NEWS_ENABLE_TWIKIT") or selected in {"twikit", "twitter"}
+
+    def configured(self) -> bool:
+        if not self.enabled():
+            return False
+        cookies_file = os.getenv("TWIKIT_COOKIES_FILE")
+        has_cookies = bool(cookies_file and os.path.exists(cookies_file))
+        has_login = bool(os.getenv("TWIKIT_USERNAME") and os.getenv("TWIKIT_PASSWORD"))
+        return has_cookies or has_login
+
+    def available(self) -> bool:
+        return self.enabled() and self.configured() and self.twikit_installed()
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "twikit_supported": True,
+            "twikit_installed": self.twikit_installed(),
+            "twikit_enabled": self.enabled(),
+            "twikit_configured": self.configured(),
+        }
+
+    def _not_configured(self, date: Optional[str] = None, items_key: str = "items") -> Dict[str, Any]:
+        status = "provider_not_configured"
+        if self.enabled() and self.configured() and not self.twikit_installed():
+            status = "provider_missing_dependency"
+        message = (
+            "Twitter/X provider is disabled or missing credentials. Configure NEWS_ENABLE_TWIKIT and TWIKIT_* env vars to enable matchup intel."
+            if status == "provider_not_configured"
+            else "Twitter/X provider is configured, but the twikit dependency is not installed."
+        )
+        payload = {
+            "date": (date or dt.date.today().isoformat())[:10],
+            "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "provider": self.name,
+            "status": status,
+            "message": message,
+            "errors": [message],
+        }
+        payload[items_key] = []
+        return payload
+
+    def _client(self) -> Any:
+        try:
+            from twikit import Client
+        except Exception as exc:
+            raise RuntimeError("twikit dependency is not installed") from exc
+
+        client = Client(self.language)
+        cookies_file = os.getenv("TWIKIT_COOKIES_FILE")
+        if cookies_file and os.path.exists(cookies_file):
+            loader = getattr(client, "load_cookies", None)
+            if callable(loader):
+                _run_maybe_await(loader(cookies_file), self.timeout_seconds)
+                return client
+
+        username = os.getenv("TWIKIT_USERNAME")
+        email = os.getenv("TWIKIT_EMAIL")
+        password = os.getenv("TWIKIT_PASSWORD")
+        login = getattr(client, "login", None)
+        if not callable(login) or not username or not password:
+            return client
+
+        try:
+            _run_maybe_await(login(auth_info_1=username, auth_info_2=email or username, password=password), self.timeout_seconds)
+        except TypeError:
+            _run_maybe_await(login(username, email or username, password), self.timeout_seconds)
+
+        if cookies_file:
+            saver = getattr(client, "save_cookies", None)
+            if callable(saver):
+                try:
+                    _run_maybe_await(saver(cookies_file), self.timeout_seconds)
+                except Exception:
+                    pass
+        return client
+
+    def _raw_search(self, query: str, limit: int) -> List[Any]:
+        client = self._client()
+        search = getattr(client, "search_tweet", None) or getattr(client, "search_tweets", None) or getattr(client, "search", None)
+        if not callable(search):
+            raise RuntimeError("Twikit client has no recognized search method")
+        try:
+            result = _run_maybe_await(search(query, "Latest", count=limit), self.timeout_seconds)
+        except TypeError:
+            try:
+                result = _run_maybe_await(search(query, "Latest"), self.timeout_seconds)
+            except TypeError:
+                result = _run_maybe_await(search(query), self.timeout_seconds)
+        if result is None:
+            return []
+        if isinstance(result, list):
+            return result[:limit]
+        if hasattr(result, "tweets"):
+            tweets = getattr(result, "tweets") or []
+            return list(tweets)[:limit]
+        try:
+            return list(result)[:limit]
+        except Exception:
+            return []
+
+    def _tweet_attr(self, tweet: Any, *names: str) -> Any:
+        if isinstance(tweet, dict):
+            for name in names:
+                if tweet.get(name) is not None:
+                    return tweet.get(name)
+            return None
+        for name in names:
+            if hasattr(tweet, name):
+                value = getattr(tweet, name)
+                if value is not None:
+                    return value
+        return None
+
+    def _author_fields(self, tweet: Any) -> tuple[str, str]:
+        user = self._tweet_attr(tweet, "user", "author")
+        author = ""
+        handle = ""
+        if isinstance(user, dict):
+            author = _safe_text(user.get("name") or user.get("display_name"))
+            handle = _safe_text(user.get("screen_name") or user.get("username"))
+        elif user is not None:
+            author = _safe_text(getattr(user, "name", "") or getattr(user, "display_name", ""))
+            handle = _safe_text(getattr(user, "screen_name", "") or getattr(user, "username", ""))
+        if handle and not handle.startswith("@"):
+            handle = f"@{handle}"
+        return author, handle
+
+    def _detect_teams(self, text: str, preferred: Optional[List[str]] = None) -> List[str]:
+        found: List[str] = []
+        for team in preferred or []:
+            if team and team not in found:
+                found.append(team)
+        lower = text.lower()
+        for alias, row in team_lookup().items():
+            if len(alias) < 3:
+                continue
+            if alias in lower and row["team"] not in found:
+                found.append(row["team"])
+        return found
+
+    def _normalize(self, tweet: Any, query: str, bucket: str = "beat", teams: Optional[List[str]] = None, games: Optional[List[str]] = None) -> Dict[str, Any]:
+        text = _safe_text(self._tweet_attr(tweet, "full_text", "text", "content"))
+        tweet_id = _safe_text(self._tweet_attr(tweet, "id", "id_str", "rest_id"))
+        author, handle = self._author_fields(tweet)
+        username = handle[1:] if handle.startswith("@") else handle
+        url = _safe_text(self._tweet_attr(tweet, "url", "tweet_url"))
+        if not url and tweet_id and username:
+            url = f"https://x.com/{username}/status/{tweet_id}"
+        published_at = _post_datetime(self._tweet_attr(tweet, "created_at", "createdAt", "date"))
+        tags = classify_text(text[:140], text, "X/Twitter")
+        is_betting = bool(set(tags).intersection({"odds", "betting"})) or any(term in text.lower() for term in BETTING_TERMS)
+        item = {
+            "id": stable_id(tweet_id, url, text, query),
+            "title": text[:140] or "X/Twitter post",
+            "summary": text,
+            "source": "X/Twitter",
+            "source_type": "x",
+            "author": author,
+            "handle": handle,
+            "url": url,
+            "published_at": published_at,
+            "bucket": "betting" if is_betting else bucket,
+            "tags": tags,
+            "teams": self._detect_teams(text, teams),
+            "players": [],
+            "games": games or [],
+            "importance_score": 0.0,
+            "is_breaking": False,
+            "is_local": True,
+            "is_beat_report": True,
+            "is_betting_relevant": is_betting,
+            "confidence_score": 0.55,
+            "raw": {"query": query, "tweet_id": tweet_id},
+        }
+        item["importance_score"] = score_importance(item, today_terms=[query, *BETTING_TERMS])
+        item["is_breaking"] = item["importance_score"] >= 70 or bool(set(tags).intersection({"injury", "lineup", "starter", "weather", "scratch"}))
+        return item
+
+    def _dedupe(self, items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        seen = set()
+        out: List[Dict[str, Any]] = []
+        for item in items:
+            key = item.get("url") or item.get("id") or hashlib.sha1(str(item.get("summary") or "").encode("utf-8")).hexdigest()[:16]
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(item)
+        return out
+
+    def search(self, query: str, limit: int = 10, date: Optional[str] = None, bucket: str = "beat", teams: Optional[List[str]] = None, games: Optional[List[str]] = None) -> Dict[str, Any]:
+        target_date = (date or dt.date.today().isoformat())[:10]
+        limit = max(1, min(25, int(limit or self.max_results)))
+        query = _safe_text(query)
+        if not self.available():
+            return self._not_configured(target_date)
+        if not query:
+            return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "empty", "query": query, "items": [], "errors": []}
+        try:
+            rows = self._raw_search(query, limit)
+            items = [self._normalize(tweet, query=query, bucket=bucket, teams=teams, games=games) for tweet in rows]
+            items = self._dedupe(items)[:limit]
+            return {
+                "date": target_date,
+                "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "provider": self.name,
+                "status": "ok" if items else "empty",
+                "query": query,
+                "items": items,
+                "errors": [],
+            }
+        except Exception as exc:
+            self.last_error = str(exc)
+            return {
+                "date": target_date,
+                "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                "provider": self.name,
+                "status": "provider_error",
+                "query": query,
+                "items": [],
+                "errors": [str(exc)],
+            }
+
+    def team_queries(self, team: str) -> List[str]:
+        wanted = str(team or "").upper()
+        row = next((src for src in get_news_sources(wanted) if src.get("team") == wanted), None)
+        if not row:
+            row = next((src for src in get_news_sources() if wanted in {src.get("team"), str(src.get("team_name", "")).upper()}), None)
+        if not row:
+            return [f"{team} lineup", f"{team} injury", f"{team} beat writer"]
+        name = row.get("team_name") or wanted
+        alias = (row.get("aliases") or [name])[0]
+        return [
+            f"{alias} lineup",
+            f"{alias} injury",
+            f"{alias} probable starter",
+            f"{alias} beat writer",
+            f"{alias} pregame",
+        ]
+
+    def search_team(self, team: str, date: str, limit: int = 10) -> Dict[str, Any]:
+        queries = self.team_queries(team)[: self.max_queries_per_matchup]
+        items: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        for query in queries:
+            result = self.search(query, limit=limit, date=date, teams=[str(team).upper()])
+            items.extend(result.get("items") or [])
+            errors.extend(result.get("errors") or [])
+            if result.get("status") == "provider_not_configured":
+                return result
+        items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
+        return {"date": date[:10], "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "team": team, "queries": queries, "items": items, "errors": errors[:3]}
+
+    def _matchup_queries(self, matchup: Dict[str, Any]) -> List[str]:
+        away = _first_present(matchup, ["away_team_name", "away_team", "away_name", "away"]) or "Away"
+        home = _first_present(matchup, ["home_team_name", "home_team", "home_name", "home"]) or "Home"
+        away_pitcher = _first_present(matchup, ["away_pitcher_name", "away_probable_pitcher", "away_pitcher"])
+        home_pitcher = _first_present(matchup, ["home_pitcher_name", "home_probable_pitcher", "home_pitcher"])
+        short_away = away.split()[-1]
+        short_home = home.split()[-1]
+        queries = [
+            f"{short_away} {short_home} lineup",
+            f"{short_away} {short_home} injury",
+            f"{short_away} {short_home} bullpen",
+            f"{short_away} {short_home} weather",
+            f"{short_away} {short_home} odds",
+        ]
+        if away_pitcher:
+            queries.append(f"{away_pitcher} {short_home}")
+        if home_pitcher:
+            queries.append(f"{home_pitcher} {short_away}")
+        return list(dict.fromkeys(q for q in queries if q and "Away Home" not in q))[: self.max_queries_per_matchup]
+
+    def search_matchups(self, date: str, limit: int = 10) -> Dict[str, Any]:
+        target_date = date[:10]
+        if not self.available():
+            return self._not_configured(target_date, items_key="matchups")
+        matchup_rows = _load_matchups(target_date)
+        blocks: List[Dict[str, Any]] = []
+        for matchup in matchup_rows:
+            game_id = _first_present(matchup, ["game_id", "gamePk", "game_pk", "id"])
+            away = _first_present(matchup, ["away_team_name", "away_team", "away_name", "away"])
+            home = _first_present(matchup, ["home_team_name", "home_team", "home_name", "home"])
+            away_pitcher = _first_present(matchup, ["away_pitcher_name", "away_probable_pitcher", "away_pitcher"])
+            home_pitcher = _first_present(matchup, ["home_pitcher_name", "home_probable_pitcher", "home_pitcher"])
+            queries = self._matchup_queries(matchup)
+            items: List[Dict[str, Any]] = []
+            errors: List[str] = []
+            teams = [str(away).upper(), str(home).upper()]
+            games = [game_id] if game_id else []
+            for query in queries:
+                result = self.search(query, limit=limit, date=target_date, teams=teams, games=games)
+                items.extend(result.get("items") or [])
+                errors.extend(result.get("errors") or [])
+            items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
+            blocks.append({
+                "game_id": game_id or stable_id(target_date, away, home),
+                "away_team": away,
+                "home_team": home,
+                "away_pitcher": away_pitcher,
+                "home_pitcher": home_pitcher,
+                "queries": queries,
+                "items": items,
+                "errors": errors[:3],
+            })
+        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if blocks else "empty", "matchups": blocks, "errors": []}
+
+    def search_betting(self, date: str, limit: int = 10) -> Dict[str, Any]:
+        target_date = date[:10]
+        queries = [
+            "MLB odds steam",
+            "MLB line movement",
+            "MLB prop injury",
+            "MLB lineup scratch odds",
+            "MLB sharp money",
+        ][: self.max_queries_per_matchup]
+        items: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        for query in queries:
+            result = self.search(query, limit=limit, date=target_date, bucket="betting")
+            items.extend(result.get("items") or [])
+            errors.extend(result.get("errors") or [])
+            if result.get("status") == "provider_not_configured":
+                return result
+        items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
+        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "queries": queries, "items": items, "errors": errors[:3]}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pybaseball>=2.2.5
 requests>=2.31.0
 apify-client>=1.8.0
 feedparser
+twikit>=2.3.3
 
 # Scheduling / utils
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary

Adds a guarded Twikit-backed Twitter/X intelligence layer to the existing News page without rebuilding the News system or touching matchup analyzer, Daily Odds, or projection formulas.

## What changed

- Added `mlb_app/news_twitter_provider.py`
  - Lazy-imports `twikit` only inside provider code
  - Supports disabled/missing-config/missing-dependency states without app startup crashes
  - Prefers `TWIKIT_COOKIES_FILE`, then falls back to username/email/password login
  - Builds team, matchup, keyword, and betting searches
  - Caps matchup query volume and returns up to 10 deduped/scored posts per matchup
  - Normalizes posts into the existing News item shape

- Updated `mlb_app/news_routes.py`
  - Extends `/news/health` with safe Twikit status fields
  - Adds `/news/twitter/search`
  - Adds `/news/twitter/team`
  - Adds `/news/twitter/matchups`
  - Adds `/news/twitter/betting`
  - Uses `NEWS_TWITTER_CACHE_TTL_SECONDS`, defaulting to 120 seconds

- Updated `frontend/src/pages/NewsPage.jsx`
  - Adds `Matchup Twitter Intel`
  - Adds modes for Twitter Matchups, Twitter Betting, Twitter Team Search, and Twitter Search
  - Renders matchup cards, probable pitchers, generated queries, and latest posts
  - Shows clean empty/disabled states when Twikit is not configured

- Updated `requirements.txt`
  - Adds `twikit>=2.3.3`

## Safety constraints preserved

- No changes to `/matchups`
- No changes to `generate_matchups_for_date`
- No changes to matchup analyzer scoring
- No changes to Daily Odds formulas
- No changes to model projection formulas
- Twikit is optional and isolated from app startup
- Missing credentials return HTTP 200 style stable payloads with empty arrays

## Notes

Twikit is an unofficial Twitter/X scraping client, so this PR treats it as an enrichment provider only. The production News page and existing RSS/news flows should continue working when Twikit is disabled, unavailable, rate-limited, or not installed.

## Validation

I could not run local compile/build in this environment because the GitHub repo cannot be cloned from the sandbox network. I did verify the GitHub diff is limited to the intended four files and that the implementation keeps the provider guarded and optional.