### PR TITLE
Rank and organize X intel by matchup engagement

### DIFF
--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -59,6 +59,17 @@ function emptyMessage(payload) {
   if (payload?.status === 'provider_not_configured') return 'Provider missing. Enable RSS on the backend or configure a paid provider.'
   return `No items in this bucket yet. Status: ${statusLabel(payload?.status)}.`
 }
+function compactNumber(v) { const n = Number(v || 0); return Number.isFinite(n) ? n.toLocaleString() : '0' }
+function engagementText(item) {
+  const e = item?.engagement || {}
+  const parts = []
+  if (e.likes) parts.push(`${compactNumber(e.likes)} likes`)
+  if (e.reposts) parts.push(`${compactNumber(e.reposts)} reposts`)
+  if (e.replies) parts.push(`${compactNumber(e.replies)} replies`)
+  if (e.views) parts.push(`${compactNumber(e.views)} views`)
+  if (!parts.length && e.engagement_total) parts.push(`${compactNumber(e.engagement_total)} interactions`)
+  return parts.join(' · ')
+}
 
 function Ticker({ rows, status, provider }) {
   const emptyText = ['rss', 'rss_network', 'rss_feed_network'].includes(provider)
@@ -82,9 +93,10 @@ function NewsCard({ item }) {
 
 function TweetCard({ item }) {
   const handle = item.handle || item.author || 'X/Twitter'
+  const eText = engagementText(item)
   return <article style={{ ...s.card, minHeight: 0 }}>
-    <div style={s.row}><strong style={{ color: '#e6edf3' }}>{handle}</strong><span style={s.badge}>X/Twitter</span></div>
-    <div style={s.meta}>{item.author && item.handle ? item.author : 'Twitter/X post'} · {fmtTime(item.published_at)}</div>
+    <div style={s.row}><strong style={{ color: '#e6edf3' }}>{handle}</strong><span style={s.badge}>Quality {score(item.twitter_quality_score)}</span></div>
+    <div style={s.meta}>{item.author && item.handle ? item.author : 'Twitter/X post'} · {fmtTime(item.published_at)}{eText ? ` · ${eText}` : ''}</div>
     <div style={{ color: '#c9d1d9', fontSize: 13, lineHeight: 1.45, marginTop: 9 }}>{item.summary || item.title || 'No post text returned.'}</div>
     <div style={s.tagRow}>{asArray(item.tags).slice(0, 6).map(tag => <span key={tag} style={s.tag}>{tag}</span>)}{item.url && <a href={item.url} target="_blank" rel="noreferrer" style={s.tag}>Open</a>}</div>
   </article>
@@ -112,10 +124,11 @@ function MatchupTwitterIntel({ date, teams }) {
   const [error, setError] = useState(null)
 
   function endpoint() {
-    if (mode === 'betting') return `${API}/news/twitter/betting?date=${date}&limit=10`
-    if (mode === 'team') return `${API}/news/twitter/team?team=${encodeURIComponent(team || 'CHC')}&date=${date}&limit=10`
-    if (mode === 'search') return `${API}/news/twitter/search?query=${encodeURIComponent(query || 'MLB lineup')}&date=${date}&limit=10`
-    return `${API}/news/twitter/matchups?date=${date}&limit=10`
+    if (mode === 'betting') return `${API}/news/twitter/betting?date=${date}&limit=50`
+    if (mode === 'team') return `${API}/news/twitter/team?team=${encodeURIComponent(team || 'CHC')}&date=${date}&limit=50`
+    if (mode === 'search') return `${API}/news/twitter/search?query=${encodeURIComponent(query || 'MLB lineup')}&date=${date}&limit=50`
+    if (mode === 'baseball_feed') return `${API}/news/twitter/baseball-feed?date=${date}&limit=50`
+    return `${API}/news/twitter/matchups?date=${date}&limit=20`
   }
 
   function loadTwitter() {
@@ -133,28 +146,30 @@ function MatchupTwitterIntel({ date, teams }) {
   const blocks = asArray(payload?.matchups)
   const flatItems = asArray(payload?.items)
   const disabled = ['provider_not_configured', 'provider_missing_dependency'].includes(payload?.status)
+  const flatCap = mode === 'matchups' ? 20 : 50
 
   return <section style={s.section}>
     <div style={s.row}>
-      <div><div style={s.sectionTitle}>Matchup Twitter Intel</div><div style={s.meta}>Optional Twikit-backed X/Twitter layer for matchup, team, and betting chatter. It is isolated from the core News provider.</div></div>
+      <div><div style={s.sectionTitle}>Matchup Twitter Intel</div><div style={s.meta}>Apify-backed X/Twitter layer ranked by engagement, relevance, and baseball signal. Matchups cap at 20 quality tweets per game; search/team/feed modes return up to 50.</div></div>
       <div style={s.tabs}>
-        {['matchups', 'betting', 'team', 'search'].map(name => <button key={name} type="button" style={s.tab(mode === name)} onClick={() => setMode(name)}>{name === 'matchups' ? 'Twitter Matchups' : name === 'betting' ? 'Twitter Betting' : name === 'team' ? 'Twitter Team Search' : 'Twitter Search'}</button>)}
+        {['matchups', 'betting', 'team', 'search', 'baseball_feed'].map(name => <button key={name} type="button" style={s.tab(mode === name)} onClick={() => setMode(name)}>{name === 'matchups' ? 'Twitter Matchups' : name === 'betting' ? 'Twitter Betting' : name === 'team' ? 'Twitter Team Search' : name === 'baseball_feed' ? 'Baseball Feed' : 'Twitter Search'}</button>)}
         <button type="button" style={s.muted} onClick={loadTwitter} disabled={loading}>{loading ? 'Loading...' : 'Refresh Twitter'}</button>
       </div>
     </div>
+    <div style={s.meta}>Ranking: {payload?.ranking || 'twitter_quality_score_desc'} · Cache: {payload?.cache_hit ? 'Hit' : 'Fresh'} · Cap: {payload?.tweet_cap_per_game || payload?.tweet_cap || flatCap}</div>
     {mode === 'team' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Team</div><select style={s.select} value={team} onChange={e => setTeam(e.target.value)}>{asArray(teams).map(t => <option key={t} value={t}>{t}</option>)}</select></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search Team</button></div></div>}
     {mode === 'search' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Keyword Search</div><input style={s.input} value={query} onChange={e => setQuery(e.target.value)} placeholder="Cubs lineup, MLB sharp money" /></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search X/Twitter</button></div></div>}
     {error && <div style={{ ...s.error, marginTop: 12 }}>{error}</div>}
-    {disabled && <div style={{ ...s.empty, marginTop: 12 }}>Twitter/X provider is disabled or missing credentials. Configure NEWS_ENABLE_TWIKIT and TWIKIT_* env vars to enable matchup intel.</div>}
+    {disabled && <div style={{ ...s.empty, marginTop: 12 }}>Twitter/X provider is disabled or missing credentials. Configure NEWS_X_PROVIDER=apify, APIFY_TOKEN, and TWITTER_X_ACTOR_ID to enable matchup intel.</div>}
     {!disabled && message && <div style={{ ...s.error, marginTop: 12 }}>{message}</div>}
     {!disabled && mode === 'matchups' && blocks.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No matchup Twitter intel returned yet.</div>}
     {!disabled && mode === 'matchups' && blocks.length > 0 && <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>{blocks.map(block => <article key={block.game_id} style={s.card}>
-      <div style={s.row}><div><div style={s.cardTitle}>{block.away_team || 'Away'} at {block.home_team || 'Home'}</div><div style={s.meta}>{block.away_pitcher || 'Away pitcher pending'} vs {block.home_pitcher || 'Home pitcher pending'}</div></div><span style={s.badge}>{asArray(block.items).length} posts</span></div>
+      <div style={s.row}><div><div style={s.cardTitle}>{block.away_team || 'Away'} at {block.home_team || 'Home'}</div><div style={s.meta}>{block.away_pitcher || 'Away pitcher pending'} vs {block.home_pitcher || 'Home pitcher pending'} · {block.matchup_source || 'source pending'}</div></div><span style={s.badge}>{asArray(block.items).length}/20 posts</span></div>
       <div style={s.tagRow}>{asArray(block.queries).map(q => <span key={q} style={s.tag}>{q}</span>)}</div>
-      {asArray(block.items).length === 0 ? <div style={s.empty}>No posts returned for this matchup.</div> : <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{asArray(block.items).slice(0, 10).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+      {asArray(block.items).length === 0 ? <div style={s.empty}>No high-quality posts returned for this matchup yet.</div> : <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{asArray(block.items).slice(0, 20).map(item => <TweetCard key={item.id} item={item} />)}</div>}
     </article>)}</div>}
     {!disabled && mode !== 'matchups' && flatItems.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Twitter/X posts returned for this search.</div>}
-    {!disabled && mode !== 'matchups' && flatItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{flatItems.slice(0, 10).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+    {!disabled && mode !== 'matchups' && flatItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{flatItems.slice(0, 50).map(item => <TweetCard key={item.id} item={item} />)}</div>}
   </section>
 }
 

--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -60,6 +60,8 @@ function emptyMessage(payload) {
   return `No items in this bucket yet. Status: ${statusLabel(payload?.status)}.`
 }
 function compactNumber(v) { const n = Number(v || 0); return Number.isFinite(n) ? n.toLocaleString() : '0' }
+function tweetTime(item) { const t = Date.parse(item?.published_at || ''); return Number.isFinite(t) ? t : 0 }
+function newestFirst(items) { return asArray(items).slice().sort((a, b) => tweetTime(b) - tweetTime(a)) }
 function engagementText(item) {
   const e = item?.engagement || {}
   const parts = []
@@ -96,7 +98,7 @@ function TweetCard({ item }) {
   const eText = engagementText(item)
   return <article style={{ ...s.card, minHeight: 0 }}>
     <div style={s.row}><strong style={{ color: '#e6edf3' }}>{handle}</strong><span style={s.badge}>Quality {score(item.twitter_quality_score)}</span></div>
-    <div style={s.meta}>{item.author && item.handle ? item.author : 'Twitter/X post'} · {fmtTime(item.published_at)}{eText ? ` · ${eText}` : ''}</div>
+    <div style={s.meta}>{item.matchup_label ? `${item.matchup_label} · ` : ''}{item.author && item.handle ? item.author : 'Twitter/X post'} · {fmtTime(item.published_at)}{eText ? ` · ${eText}` : ''}</div>
     <div style={{ color: '#c9d1d9', fontSize: 13, lineHeight: 1.45, marginTop: 9 }}>{item.summary || item.title || 'No post text returned.'}</div>
     <div style={s.tagRow}>{asArray(item.tags).slice(0, 6).map(tag => <span key={tag} style={s.tag}>{tag}</span>)}{item.url && <a href={item.url} target="_blank" rel="noreferrer" style={s.tag}>Open</a>}</div>
   </article>
@@ -117,6 +119,7 @@ function TeamIntel({ boards }) {
 
 function MatchupTwitterIntel({ date, teams }) {
   const [mode, setMode] = useState('matchups')
+  const [view, setView] = useState('cards')
   const [payload, setPayload] = useState(null)
   const [team, setTeam] = useState('CHC')
   const [query, setQuery] = useState('Cubs lineup')
@@ -147,29 +150,35 @@ function MatchupTwitterIntel({ date, teams }) {
   const flatItems = asArray(payload?.items)
   const disabled = ['provider_not_configured', 'provider_missing_dependency'].includes(payload?.status)
   const flatCap = mode === 'matchups' ? 20 : 50
+  const timelineItems = newestFirst(mode === 'matchups'
+    ? blocks.flatMap(block => newestFirst(block.items).map(item => ({ ...item, matchup_label: `${block.away_team || 'Away'} at ${block.home_team || 'Home'}` })))
+    : flatItems)
 
   return <section style={s.section}>
     <div style={s.row}>
-      <div><div style={s.sectionTitle}>Matchup Twitter Intel</div><div style={s.meta}>Apify-backed X/Twitter layer ranked by engagement, relevance, and baseball signal. Matchups cap at 20 quality tweets per game; search/team/feed modes return up to 50.</div></div>
+      <div><div style={s.sectionTitle}>Matchup Twitter Intel</div><div style={s.meta}>Latest-first X/Twitter intel ranked for quality. Timeline always shows the newest posts first; matchup cards stay capped at 20 tweets per game.</div></div>
       <div style={s.tabs}>
-        {['matchups', 'betting', 'team', 'search', 'baseball_feed'].map(name => <button key={name} type="button" style={s.tab(mode === name)} onClick={() => setMode(name)}>{name === 'matchups' ? 'Twitter Matchups' : name === 'betting' ? 'Twitter Betting' : name === 'team' ? 'Twitter Team Search' : name === 'baseball_feed' ? 'Baseball Feed' : 'Twitter Search'}</button>)}
+        {['matchups', 'betting', 'team', 'search', 'baseball_feed'].map(name => <button key={name} type="button" style={s.tab(mode === name)} onClick={() => { setMode(name); setView(name === 'matchups' ? 'cards' : 'timeline') }}>{name === 'matchups' ? 'Twitter Matchups' : name === 'betting' ? 'Twitter Betting' : name === 'team' ? 'Twitter Team Search' : name === 'baseball_feed' ? 'Baseball Feed' : 'Twitter Search'}</button>)}
+        <button type="button" style={s.tab(view === 'timeline')} onClick={() => setView(view === 'timeline' ? 'cards' : 'timeline')}>Timeline</button>
         <button type="button" style={s.muted} onClick={loadTwitter} disabled={loading}>{loading ? 'Loading...' : 'Refresh Twitter'}</button>
       </div>
     </div>
-    <div style={s.meta}>Ranking: {payload?.ranking || 'twitter_quality_score_desc'} · Cache: {payload?.cache_hit ? 'Hit' : 'Fresh'} · Cap: {payload?.tweet_cap_per_game || payload?.tweet_cap || flatCap}</div>
+    <div style={s.meta}>Display: {view === 'timeline' ? 'Latest-first timeline' : 'Game cards'} · Ranking: newest first after quality filtering · Cache: {payload?.cache_hit ? 'Hit' : 'Fresh'} · Cap: {payload?.tweet_cap_per_game || payload?.tweet_cap || flatCap}</div>
     {mode === 'team' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Team</div><select style={s.select} value={team} onChange={e => setTeam(e.target.value)}>{asArray(teams).map(t => <option key={t} value={t}>{t}</option>)}</select></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search Team</button></div></div>}
     {mode === 'search' && <div style={{ ...s.filters, marginTop: 12 }}><label><div style={s.label}>Keyword Search</div><input style={s.input} value={query} onChange={e => setQuery(e.target.value)} placeholder="Cubs lineup, MLB sharp money" /></label><div style={{ display: 'flex', alignItems: 'end' }}><button type="button" style={s.button} onClick={loadTwitter}>Search X/Twitter</button></div></div>}
     {error && <div style={{ ...s.error, marginTop: 12 }}>{error}</div>}
     {disabled && <div style={{ ...s.empty, marginTop: 12 }}>Twitter/X provider is disabled or missing credentials. Configure NEWS_X_PROVIDER=apify, APIFY_TOKEN, and TWITTER_X_ACTOR_ID to enable matchup intel.</div>}
     {!disabled && message && <div style={{ ...s.error, marginTop: 12 }}>{message}</div>}
-    {!disabled && mode === 'matchups' && blocks.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No matchup Twitter intel returned yet.</div>}
-    {!disabled && mode === 'matchups' && blocks.length > 0 && <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>{blocks.map(block => <article key={block.game_id} style={s.card}>
+    {!disabled && view === 'timeline' && timelineItems.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No timeline tweets returned yet.</div>}
+    {!disabled && view === 'timeline' && timelineItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{timelineItems.slice(0, mode === 'matchups' ? 100 : 50).map(item => <TweetCard key={`${item.id}-${item.matchup_label || ''}`} item={item} />)}</div>}
+    {!disabled && view !== 'timeline' && mode === 'matchups' && blocks.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No matchup Twitter intel returned yet.</div>}
+    {!disabled && view !== 'timeline' && mode === 'matchups' && blocks.length > 0 && <div style={{ display: 'grid', gap: 12, marginTop: 12 }}>{blocks.map(block => <article key={block.game_id} style={s.card}>
       <div style={s.row}><div><div style={s.cardTitle}>{block.away_team || 'Away'} at {block.home_team || 'Home'}</div><div style={s.meta}>{block.away_pitcher || 'Away pitcher pending'} vs {block.home_pitcher || 'Home pitcher pending'} · {block.matchup_source || 'source pending'}</div></div><span style={s.badge}>{asArray(block.items).length}/20 posts</span></div>
       <div style={s.tagRow}>{asArray(block.queries).map(q => <span key={q} style={s.tag}>{q}</span>)}</div>
-      {asArray(block.items).length === 0 ? <div style={s.empty}>No high-quality posts returned for this matchup yet.</div> : <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{asArray(block.items).slice(0, 20).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+      {asArray(block.items).length === 0 ? <div style={s.empty}>No high-quality posts returned for this matchup yet.</div> : <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{newestFirst(block.items).slice(0, 20).map(item => <TweetCard key={item.id} item={item} />)}</div>}
     </article>)}</div>}
-    {!disabled && mode !== 'matchups' && flatItems.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Twitter/X posts returned for this search.</div>}
-    {!disabled && mode !== 'matchups' && flatItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{flatItems.slice(0, 50).map(item => <TweetCard key={item.id} item={item} />)}</div>}
+    {!disabled && view !== 'timeline' && mode !== 'matchups' && flatItems.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Twitter/X posts returned for this search.</div>}
+    {!disabled && view !== 'timeline' && mode !== 'matchups' && flatItems.length > 0 && <div style={{ display: 'grid', gap: 10, marginTop: 12 }}>{newestFirst(flatItems).slice(0, 50).map(item => <TweetCard key={item.id} item={item} />)}</div>}
   </section>
 }
 

--- a/mlb_app/news_routes.py
+++ b/mlb_app/news_routes.py
@@ -58,11 +58,11 @@ def _twitter_ttl() -> int:
         return 120
 
 
-def _limit(value: int = 10) -> int:
+def _limit(value: int = 10, maximum: int = 50) -> int:
     try:
-        return max(1, min(25, int(value)))
+        return max(1, min(maximum, int(value)))
     except Exception:
-        return 10
+        return min(10, maximum)
 
 
 @router.get("/news/health")
@@ -111,6 +111,10 @@ def news_health():
             "TWITTER_X_CACHE_TTL_SECONDS",
             "TWITTER_X_TIMEOUT_SECONDS",
             "TWITTER_X_MAX_RESULTS",
+            "TWITTER_X_MATCHUP_TWEET_CAP",
+            "TWITTER_X_GENERAL_TWEET_CAP",
+            "TWITTER_X_MIN_ENGAGEMENT",
+            "TWITTER_X_BASEBALL_FEED_QUERIES",
             "TWITTER_X_MAX_QUERIES_PER_MATCHUP",
             "NEWS_ENABLE_TWIKIT",
             "TWIKIT_USERNAME",
@@ -205,9 +209,9 @@ def news_team_intel(team: Optional[str] = None, date: Optional[str] = None):
 
 
 @router.get("/news/twitter/search")
-def news_twitter_search(query: str = Query("MLB lineup"), date: Optional[str] = None, limit: int = Query(10)):
+def news_twitter_search(query: str = Query("MLB lineup"), date: Optional[str] = None, limit: int = Query(50)):
     target_date = _date(date)
-    safe_limit = _limit(limit)
+    safe_limit = _limit(limit, maximum=50)
     safe_query = str(query or "").strip()
     return _cached(
         f"twitter:{_x_provider_name()}:search:{safe_query}:{target_date}:{safe_limit}",
@@ -218,9 +222,9 @@ def news_twitter_search(query: str = Query("MLB lineup"), date: Optional[str] = 
 
 
 @router.get("/news/twitter/team")
-def news_twitter_team(team: str = Query(...), date: Optional[str] = None, limit: int = Query(10)):
+def news_twitter_team(team: str = Query(...), date: Optional[str] = None, limit: int = Query(50)):
     target_date = _date(date)
-    safe_limit = _limit(limit)
+    safe_limit = _limit(limit, maximum=50)
     safe_team = str(team or "").strip().upper()
     return _cached(
         f"twitter:{_x_provider_name()}:team:{safe_team}:{target_date}:{safe_limit}",
@@ -231,9 +235,9 @@ def news_twitter_team(team: str = Query(...), date: Optional[str] = None, limit:
 
 
 @router.get("/news/twitter/matchups")
-def news_twitter_matchups(date: Optional[str] = None, limit: int = Query(10)):
+def news_twitter_matchups(date: Optional[str] = None, limit: int = Query(20)):
     target_date = _date(date)
-    safe_limit = _limit(limit)
+    safe_limit = _limit(limit, maximum=20)
     return _cached(
         f"twitter:{_x_provider_name()}:matchups:{target_date}:{safe_limit}",
         "twitter",
@@ -243,13 +247,25 @@ def news_twitter_matchups(date: Optional[str] = None, limit: int = Query(10)):
 
 
 @router.get("/news/twitter/betting")
-def news_twitter_betting(date: Optional[str] = None, limit: int = Query(10)):
+def news_twitter_betting(date: Optional[str] = None, limit: int = Query(50)):
     target_date = _date(date)
-    safe_limit = _limit(limit)
+    safe_limit = _limit(limit, maximum=50)
     return _cached(
         f"twitter:{_x_provider_name()}:betting:{target_date}:{safe_limit}",
         "twitter",
         lambda: _twitter_provider().search_betting(target_date, limit=safe_limit),
+        ttl_override=_twitter_ttl(),
+    )
+
+
+@router.get("/news/twitter/baseball-feed")
+def news_twitter_baseball_feed(date: Optional[str] = None, limit: int = Query(50)):
+    target_date = _date(date)
+    safe_limit = _limit(limit, maximum=100)
+    return _cached(
+        f"twitter:{_x_provider_name()}:baseball-feed:{target_date}:{safe_limit}",
+        "twitter",
+        lambda: _twitter_provider().search_baseball_feed(target_date, limit=safe_limit) if hasattr(_twitter_provider(), "search_baseball_feed") else _twitter_provider().search("MLB Statcast baseball", limit=safe_limit, date=target_date),
         ttl_override=_twitter_ttl(),
     )
 

--- a/mlb_app/news_x_apify_provider.py
+++ b/mlb_app/news_x_apify_provider.py
@@ -115,6 +115,18 @@ def _to_int(value: Any) -> int:
         return 0
 
 
+def _tweet_epoch(value: Any) -> float:
+    if not value:
+        return 0.0
+    try:
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.timestamp()
+    except Exception:
+        return 0.0
+
+
 def _nested_get(row: Any, *keys: str) -> Any:
     current = row
     for key in keys:
@@ -271,6 +283,7 @@ class ApifyXNewsProvider:
             "apify_x_actor_configured": self.actor_configured(),
             "apify_x_matchup_schedule_fallback": True,
             "apify_x_engagement_ranking": True,
+            "apify_x_newest_first": True,
             "apify_x_matchup_tweet_cap": self.matchup_cap,
             "apify_x_general_tweet_cap": self.general_cap,
             "apify_x_min_engagement": self.min_engagement,
@@ -303,7 +316,7 @@ class ApifyXNewsProvider:
             payload = {"queries": [query], max_key: limit}
         else:
             payload = {"searchTerms": [query], max_key: limit}
-        raw_sort = os.getenv("TWITTER_X_ACTOR_SORT", "Top").strip()
+        raw_sort = os.getenv("TWITTER_X_ACTOR_SORT", "Latest").strip()
         if raw_sort:
             payload.setdefault("sort", raw_sort)
         return payload
@@ -480,10 +493,10 @@ class ApifyXNewsProvider:
         return sorted(
             filtered,
             key=lambda row: (
+                _tweet_epoch(row.get("published_at")),
                 row.get("twitter_quality_score") or 0,
                 (row.get("engagement") or {}).get("weighted_engagement") or 0,
                 row.get("importance_score") or 0,
-                row.get("published_at") or "",
             ),
             reverse=True,
         )[:limit]
@@ -508,7 +521,7 @@ class ApifyXNewsProvider:
                 "query": query,
                 "items": items,
                 "errors": [],
-                "ranking": "twitter_quality_score_desc",
+                "ranking": "published_at_desc_quality_tiebreaker",
             }
         except Exception as exc:
             self.last_error = str(exc)
@@ -552,7 +565,7 @@ class ApifyXNewsProvider:
             if result.get("status") == "provider_not_configured":
                 return result
         items = self._rank_items(items, safe_limit)
-        return {"date": date[:10], "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "team": team, "queries": queries, "items": items, "errors": errors[:3], "ranking": "twitter_quality_score_desc"}
+        return {"date": date[:10], "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "team": team, "queries": queries, "items": items, "errors": errors[:3], "ranking": "published_at_desc_quality_tiebreaker"}
 
     def _matchup_queries(self, matchup: Dict[str, Any]) -> List[str]:
         away = _first_present(matchup, ["away_team_name", "away_team", "away_name", "away"]) or "Away"
@@ -606,7 +619,7 @@ class ApifyXNewsProvider:
                 "errors": errors[:3],
                 "matchup_source": matchup_source,
                 "tweet_cap": cap,
-                "ranking": "twitter_quality_score_desc",
+                "ranking": "published_at_desc_quality_tiebreaker",
             })
         return {
             "date": target_date,
@@ -618,7 +631,7 @@ class ApifyXNewsProvider:
             "matchup_count": len(blocks),
             "matchup_source": matchup_source,
             "tweet_cap_per_game": cap,
-            "ranking": "twitter_quality_score_desc",
+            "ranking": "published_at_desc_quality_tiebreaker",
             "message": "No matchup rows loaded from generator or MLB schedule fallback." if not blocks else None,
         }
 
@@ -639,7 +652,7 @@ class ApifyXNewsProvider:
             if result.get("status") == "provider_not_configured":
                 return result
         items = self._rank_items(items, safe_limit)
-        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "queries": queries, "items": items, "errors": errors[:3], "ranking": "twitter_quality_score_desc"}
+        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "queries": queries, "items": items, "errors": errors[:3], "ranking": "published_at_desc_quality_tiebreaker"}
 
     def baseball_feed_queries(self) -> List[str]:
         raw = os.getenv("TWITTER_X_BASEBALL_FEED_QUERIES", "").strip()
@@ -671,6 +684,6 @@ class ApifyXNewsProvider:
             "queries": queries,
             "items": items,
             "errors": errors[:5],
-            "ranking": "twitter_quality_score_desc",
+            "ranking": "published_at_desc_quality_tiebreaker",
             "tweet_cap": safe_limit,
         }

--- a/mlb_app/news_x_apify_provider.py
+++ b/mlb_app/news_x_apify_provider.py
@@ -2,17 +2,74 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
+import json
+import math
 import os
 import re
 import urllib.parse
 import urllib.request
-import json
 from typing import Any, Dict, Iterable, List, Optional
 
 from .news_classifier import classify_text, score_importance
 from .news_keywords import BETTING_TERMS
 from .news_provider import stable_id, utc_now
 from .news_sources import get_news_sources, team_lookup
+
+DEFAULT_BASEBALL_FEED_QUERIES = [
+    "from:PitchingNinja",
+    "from:CodifyBaseball",
+    "from:baseballsavant",
+    "from:MLBPipeline",
+    "from:fangraphs",
+    "from:enosarris",
+    "from:BenLindbergh",
+    "from:TheAthleticMLB",
+    "from:MLBNetwork",
+    "baseball biomechanics pitching mechanics",
+    "MLB Statcast barrel rate xwOBA",
+]
+
+CLICKBAIT_TERMS = {
+    "you won't believe",
+    "shocking",
+    "destroyed",
+    "cooked",
+    "exposed",
+    "fraud",
+    "ratio",
+    "clown",
+    "hot take",
+    "insane parlay",
+    "lock of the day",
+}
+
+QUALITY_TERMS = {
+    "statcast",
+    "xwoba",
+    "barrel",
+    "hard-hit",
+    "hard hit",
+    "savant",
+    "release point",
+    "extension",
+    "ivb",
+    "sweeper",
+    "arsenal",
+    "pitch design",
+    "biomechanics",
+    "mechanics",
+    "swing decision",
+    "run value",
+    "stuff+",
+    "location+",
+    "lineup",
+    "injury",
+    "scratch",
+    "bullpen",
+    "weather",
+    "odds",
+    "line movement",
+}
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -34,6 +91,30 @@ def _safe_text(value: Any) -> str:
     return re.sub(r"\s+", " ", str(value or "")).strip()
 
 
+def _to_int(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return max(0, int(value))
+    text = str(value).strip().replace(",", "")
+    if not text:
+        return 0
+    multiplier = 1
+    lowered = text.lower()
+    if lowered.endswith("k"):
+        multiplier = 1_000
+        text = text[:-1]
+    elif lowered.endswith("m"):
+        multiplier = 1_000_000
+        text = text[:-1]
+    try:
+        return max(0, int(float(text) * multiplier))
+    except Exception:
+        return 0
+
+
 def _nested_get(row: Any, *keys: str) -> Any:
     current = row
     for key in keys:
@@ -44,6 +125,14 @@ def _nested_get(row: Any, *keys: str) -> Any:
         if current is None:
             return None
     return current
+
+
+def _first_from_paths(row: Dict[str, Any], paths: Iterable[tuple[str, ...]]) -> Any:
+    for path in paths:
+        value = _nested_get(row, *path)
+        if value is not None and value != "":
+            return value
+    return None
 
 
 def _first_present(row: Dict[str, Any], keys: Iterable[str]) -> str:
@@ -68,7 +157,6 @@ def _post_datetime(value: Any) -> str:
 
 
 def _load_matchups_from_generator(date: str) -> List[Dict[str, Any]]:
-    # Same safe read-only path used by the existing Twikit provider and news keyword layer.
     try:
         from .app import _get_session
         from .matchup_generator import generate_matchups_for_date
@@ -82,12 +170,6 @@ def _load_matchups_from_generator(date: str) -> List[Dict[str, Any]]:
 
 
 def _load_matchups_from_mlb_schedule(date: str) -> List[Dict[str, Any]]:
-    """Fallback schedule source for News Twitter Intel only.
-
-    This intentionally does not change /matchups or the production matchup analyzer. It gives the
-    Twitter/X intel layer enough team/pitcher context to build search queries when the internal
-    matchup generator returns an empty list.
-    """
     target_date = (date or dt.date.today().isoformat())[:10]
     params = urllib.parse.urlencode({
         "sportId": 1,
@@ -148,8 +230,11 @@ class ApifyXNewsProvider:
 
     def __init__(self) -> None:
         self.timeout_seconds = _int_env("TWITTER_X_TIMEOUT_SECONDS", _int_env("TWIKIT_TIMEOUT_SECONDS", 20, 3, 60), 3, 120)
-        self.max_results = _int_env("TWITTER_X_MAX_RESULTS", _int_env("TWIKIT_MAX_RESULTS", 10, 1, 25), 1, 50)
+        self.max_results = _int_env("TWITTER_X_MAX_RESULTS", _int_env("TWIKIT_MAX_RESULTS", 50, 1, 50), 1, 50)
+        self.matchup_cap = _int_env("TWITTER_X_MATCHUP_TWEET_CAP", 20, 1, 50)
+        self.general_cap = _int_env("TWITTER_X_GENERAL_TWEET_CAP", 50, 1, 100)
         self.max_queries_per_matchup = _int_env("TWITTER_X_MAX_QUERIES_PER_MATCHUP", _int_env("TWIKIT_MAX_QUERIES_PER_MATCHUP", 5, 1, 8), 1, 8)
+        self.min_engagement = _int_env("TWITTER_X_MIN_ENGAGEMENT", 0, 0, 1000000)
         self.last_error: Optional[str] = None
 
     @staticmethod
@@ -185,6 +270,10 @@ class ApifyXNewsProvider:
             "apify_x_configured": self.configured(),
             "apify_x_actor_configured": self.actor_configured(),
             "apify_x_matchup_schedule_fallback": True,
+            "apify_x_engagement_ranking": True,
+            "apify_x_matchup_tweet_cap": self.matchup_cap,
+            "apify_x_general_tweet_cap": self.general_cap,
+            "apify_x_min_engagement": self.min_engagement,
         }
 
     def _not_configured(self, date: Optional[str] = None, items_key: str = "items") -> Dict[str, Any]:
@@ -214,7 +303,7 @@ class ApifyXNewsProvider:
             payload = {"queries": [query], max_key: limit}
         else:
             payload = {"searchTerms": [query], max_key: limit}
-        raw_sort = os.getenv("TWITTER_X_ACTOR_SORT", "Latest").strip()
+        raw_sort = os.getenv("TWITTER_X_ACTOR_SORT", "Top").strip()
         if raw_sort:
             payload.setdefault("sort", raw_sort)
         return payload
@@ -231,15 +320,15 @@ class ApifyXNewsProvider:
         if not actor_id:
             raise RuntimeError("TWITTER_X_ACTOR_ID is not configured")
         client = self._client()
-        run_input = self._actor_input(query, limit)
-        timeout_secs = self.timeout_seconds
+        pull_limit = max(limit, min(100, limit * 3))
+        run_input = self._actor_input(query, pull_limit)
         actor = client.actor(actor_id)
-        run = actor.call(run_input=run_input, timeout_secs=timeout_secs)
+        run = actor.call(run_input=run_input, timeout_secs=self.timeout_seconds)
         dataset_id = (run or {}).get("defaultDatasetId") or (run or {}).get("default_dataset_id")
         if not dataset_id:
             return []
         dataset_client = client.dataset(dataset_id)
-        rows = dataset_client.list_items(limit=limit).items
+        rows = dataset_client.list_items(limit=pull_limit).items
         return [row for row in rows if isinstance(row, dict)]
 
     def _extract_author(self, row: Dict[str, Any]) -> tuple[str, str]:
@@ -268,6 +357,46 @@ class ApifyXNewsProvider:
         if handle_text and not handle_text.startswith("@"):
             handle_text = f"@{handle_text}"
         return author_text, handle_text
+
+    def _engagement_metrics(self, row: Dict[str, Any]) -> Dict[str, int]:
+        likes = _to_int(_first_from_paths(row, [("likeCount",), ("likes",), ("favoriteCount",), ("favorite_count",), ("public_metrics", "like_count"), ("metrics", "likes")]))
+        replies = _to_int(_first_from_paths(row, [("replyCount",), ("replies",), ("reply_count",), ("public_metrics", "reply_count"), ("metrics", "replies")]))
+        reposts = _to_int(_first_from_paths(row, [("retweetCount",), ("retweets",), ("retweet_count",), ("repostCount",), ("public_metrics", "retweet_count"), ("metrics", "retweets")]))
+        quotes = _to_int(_first_from_paths(row, [("quoteCount",), ("quotes",), ("quote_count",), ("public_metrics", "quote_count"), ("metrics", "quotes")]))
+        views = _to_int(_first_from_paths(row, [("viewCount",), ("views",), ("view_count",), ("impressionCount",), ("public_metrics", "impression_count"), ("metrics", "views")]))
+        bookmarks = _to_int(_first_from_paths(row, [("bookmarkCount",), ("bookmarks",), ("bookmark_count",), ("public_metrics", "bookmark_count"), ("metrics", "bookmarks")]))
+        weighted = likes + (2 * replies) + (3 * reposts) + (2 * quotes) + (2 * bookmarks) + min(views // 100, 500)
+        raw = likes + replies + reposts + quotes + bookmarks
+        return {
+            "likes": likes,
+            "replies": replies,
+            "reposts": reposts,
+            "quotes": quotes,
+            "views": views,
+            "bookmarks": bookmarks,
+            "engagement_total": raw,
+            "weighted_engagement": weighted,
+        }
+
+    def _quality_score(self, text: str, tags: List[str], metrics: Dict[str, int], query: str) -> float:
+        lower = text.lower()
+        score = float(metrics.get("weighted_engagement") or 0)
+        if metrics.get("engagement_total", 0) > 0:
+            score += math.log1p(metrics["engagement_total"]) * 8
+        if any(term in lower for term in QUALITY_TERMS):
+            score += 25
+        if any(term in lower for term in BETTING_TERMS):
+            score += 12
+        if set(tags).intersection({"injury", "lineup", "starter", "weather", "odds", "betting", "scratch"}):
+            score += 20
+        for token in query.lower().split():
+            if len(token) >= 4 and token in lower:
+                score += 2
+        if any(term in lower for term in CLICKBAIT_TERMS):
+            score -= 35
+        if len(text) < 20:
+            score -= 20
+        return round(score, 3)
 
     def _detect_teams(self, text: str, preferred: Optional[List[str]] = None) -> List[str]:
         found: List[str] = []
@@ -300,7 +429,9 @@ class ApifyXNewsProvider:
             url = f"https://x.com/{username}/status/{tweet_id}"
         published_at = _post_datetime(row.get("createdAt") or row.get("created_at") or row.get("date") or row.get("timestamp"))
         tags = classify_text(text[:140], text, "X/Twitter")
+        metrics = self._engagement_metrics(row)
         is_betting = bool(set(tags).intersection({"odds", "betting"})) or any(term in text.lower() for term in BETTING_TERMS)
+        quality_score = self._quality_score(text, tags, metrics, query)
         item = {
             "id": stable_id(tweet_id, url, text, query),
             "title": text[:140] or "X/Twitter post",
@@ -317,6 +448,8 @@ class ApifyXNewsProvider:
             "players": [],
             "games": games or [],
             "importance_score": 0.0,
+            "twitter_quality_score": quality_score,
+            "engagement": metrics,
             "is_breaking": False,
             "is_local": True,
             "is_beat_report": True,
@@ -339,7 +472,23 @@ class ApifyXNewsProvider:
             out.append(item)
         return out
 
-    def search(self, query: str, limit: int = 10, date: Optional[str] = None, bucket: str = "beat", teams: Optional[List[str]] = None, games: Optional[List[str]] = None) -> Dict[str, Any]:
+    def _rank_items(self, items: Iterable[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+        deduped = self._dedupe(items)
+        filtered = [item for item in deduped if (item.get("engagement") or {}).get("engagement_total", 0) >= self.min_engagement]
+        if not filtered and deduped:
+            filtered = deduped
+        return sorted(
+            filtered,
+            key=lambda row: (
+                row.get("twitter_quality_score") or 0,
+                (row.get("engagement") or {}).get("weighted_engagement") or 0,
+                row.get("importance_score") or 0,
+                row.get("published_at") or "",
+            ),
+            reverse=True,
+        )[:limit]
+
+    def search(self, query: str, limit: int = 50, date: Optional[str] = None, bucket: str = "beat", teams: Optional[List[str]] = None, games: Optional[List[str]] = None) -> Dict[str, Any]:
         target_date = (date or dt.date.today().isoformat())[:10]
         safe_limit = max(1, min(50, int(limit or self.max_results)))
         query = _safe_text(query)
@@ -350,7 +499,7 @@ class ApifyXNewsProvider:
         try:
             rows = self._raw_search(query, safe_limit)
             items = [self._normalize(row, query=query, bucket=bucket, teams=teams, games=games) for row in rows]
-            items = self._dedupe(items)[:safe_limit]
+            items = self._rank_items(items, safe_limit)
             return {
                 "date": target_date,
                 "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
@@ -359,6 +508,7 @@ class ApifyXNewsProvider:
                 "query": query,
                 "items": items,
                 "errors": [],
+                "ranking": "twitter_quality_score_desc",
             }
         except Exception as exc:
             self.last_error = str(exc)
@@ -378,7 +528,7 @@ class ApifyXNewsProvider:
         if not row:
             row = next((src for src in get_news_sources() if wanted in {src.get("team"), str(src.get("team_name", "")).upper()}), None)
         if not row:
-            return [f"{team} lineup", f"{team} injury", f"{team} beat writer"]
+            return [f"{team} lineup", f"{team} injury", f"{team} beat writer", f"{team} Statcast"]
         name = row.get("team_name") or wanted
         alias = (row.get("aliases") or [name])[0]
         return [
@@ -386,21 +536,23 @@ class ApifyXNewsProvider:
             f"{alias} injury",
             f"{alias} probable starter",
             f"{alias} beat writer",
+            f"{alias} Statcast",
             f"{alias} pregame",
         ]
 
-    def search_team(self, team: str, date: str, limit: int = 10) -> Dict[str, Any]:
+    def search_team(self, team: str, date: str, limit: int = 50) -> Dict[str, Any]:
+        safe_limit = max(1, min(50, int(limit or self.max_results)))
         queries = self.team_queries(team)[: self.max_queries_per_matchup]
         items: List[Dict[str, Any]] = []
         errors: List[str] = []
         for query in queries:
-            result = self.search(query, limit=limit, date=date, teams=[str(team).upper()])
+            result = self.search(query, limit=safe_limit, date=date, teams=[str(team).upper()])
             items.extend(result.get("items") or [])
             errors.extend(result.get("errors") or [])
             if result.get("status") == "provider_not_configured":
                 return result
-        items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
-        return {"date": date[:10], "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "team": team, "queries": queries, "items": items, "errors": errors[:3]}
+        items = self._rank_items(items, safe_limit)
+        return {"date": date[:10], "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "team": team, "queries": queries, "items": items, "errors": errors[:3], "ranking": "twitter_quality_score_desc"}
 
     def _matchup_queries(self, matchup: Dict[str, Any]) -> List[str]:
         away = _first_present(matchup, ["away_team_name", "away_team", "away_name", "away"]) or "Away"
@@ -410,11 +562,9 @@ class ApifyXNewsProvider:
         short_away = away.split()[-1]
         short_home = home.split()[-1]
         queries = [
-            f"{short_away} {short_home} lineup",
-            f"{short_away} {short_home} injury",
-            f"{short_away} {short_home} bullpen",
-            f"{short_away} {short_home} weather",
-            f"{short_away} {short_home} odds",
+            f"{short_away} {short_home} lineup injury starter",
+            f"{short_away} {short_home} bullpen weather odds",
+            f"{short_away} {short_home} Statcast",
         ]
         if away_pitcher:
             queries.append(f"{away_pitcher} {short_home}")
@@ -422,8 +572,9 @@ class ApifyXNewsProvider:
             queries.append(f"{home_pitcher} {short_away}")
         return list(dict.fromkeys(q for q in queries if q and "Away Home" not in q))[: self.max_queries_per_matchup]
 
-    def search_matchups(self, date: str, limit: int = 10) -> Dict[str, Any]:
+    def search_matchups(self, date: str, limit: int = 20) -> Dict[str, Any]:
         target_date = date[:10]
+        cap = max(1, min(self.matchup_cap, int(limit or self.matchup_cap)))
         if not self.available():
             return self._not_configured(target_date, items_key="matchups")
         matchup_rows, matchup_source = _load_matchups(target_date)
@@ -440,10 +591,10 @@ class ApifyXNewsProvider:
             teams = [str(away).upper(), str(home).upper()]
             games = [game_id] if game_id else []
             for query in queries:
-                result = self.search(query, limit=limit, date=target_date, teams=teams, games=games)
+                result = self.search(query, limit=cap, date=target_date, teams=teams, games=games)
                 items.extend(result.get("items") or [])
                 errors.extend(result.get("errors") or [])
-            items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
+            items = self._rank_items(items, cap)
             blocks.append({
                 "game_id": game_id or stable_id(target_date, away, home),
                 "away_team": away,
@@ -454,6 +605,8 @@ class ApifyXNewsProvider:
                 "items": items,
                 "errors": errors[:3],
                 "matchup_source": matchup_source,
+                "tweet_cap": cap,
+                "ranking": "twitter_quality_score_desc",
             })
         return {
             "date": target_date,
@@ -464,25 +617,60 @@ class ApifyXNewsProvider:
             "errors": [],
             "matchup_count": len(blocks),
             "matchup_source": matchup_source,
+            "tweet_cap_per_game": cap,
+            "ranking": "twitter_quality_score_desc",
             "message": "No matchup rows loaded from generator or MLB schedule fallback." if not blocks else None,
         }
 
-    def search_betting(self, date: str, limit: int = 10) -> Dict[str, Any]:
+    def search_betting(self, date: str, limit: int = 50) -> Dict[str, Any]:
         target_date = date[:10]
+        safe_limit = max(1, min(50, int(limit or self.max_results)))
         queries = [
-            "MLB odds steam",
-            "MLB line movement",
-            "MLB prop injury",
-            "MLB lineup scratch odds",
-            "MLB sharp money",
+            "MLB odds steam line movement",
+            "MLB prop injury lineup scratch odds",
+            "MLB sharp money baseball",
         ][: self.max_queries_per_matchup]
         items: List[Dict[str, Any]] = []
         errors: List[str] = []
         for query in queries:
-            result = self.search(query, limit=limit, date=target_date, bucket="betting")
+            result = self.search(query, limit=safe_limit, date=target_date, bucket="betting")
             items.extend(result.get("items") or [])
             errors.extend(result.get("errors") or [])
             if result.get("status") == "provider_not_configured":
                 return result
-        items = sorted(self._dedupe(items), key=lambda row: (row.get("importance_score") or 0, row.get("published_at") or ""), reverse=True)[:limit]
-        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "queries": queries, "items": items, "errors": errors[:3]}
+        items = self._rank_items(items, safe_limit)
+        return {"date": target_date, "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"), "provider": self.name, "status": "ok" if items else "empty", "queries": queries, "items": items, "errors": errors[:3], "ranking": "twitter_quality_score_desc"}
+
+    def baseball_feed_queries(self) -> List[str]:
+        raw = os.getenv("TWITTER_X_BASEBALL_FEED_QUERIES", "").strip()
+        if raw:
+            queries = [part.strip() for part in raw.split(",") if part.strip()]
+            if queries:
+                return queries[:25]
+        return DEFAULT_BASEBALL_FEED_QUERIES
+
+    def search_baseball_feed(self, date: str, limit: int = 50) -> Dict[str, Any]:
+        target_date = date[:10]
+        safe_limit = max(1, min(self.general_cap, int(limit or self.general_cap)))
+        if not self.available():
+            return self._not_configured(target_date)
+        queries = self.baseball_feed_queries()
+        items: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        per_query_limit = max(10, min(25, safe_limit))
+        for query in queries:
+            result = self.search(query, limit=per_query_limit, date=target_date, bucket="baseball_feed")
+            items.extend(result.get("items") or [])
+            errors.extend(result.get("errors") or [])
+        items = self._rank_items(items, safe_limit)
+        return {
+            "date": target_date,
+            "generated_at": utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "provider": self.name,
+            "status": "ok" if items else "empty",
+            "queries": queries,
+            "items": items,
+            "errors": errors[:5],
+            "ranking": "twitter_quality_score_desc",
+            "tweet_cap": safe_limit,
+        }


### PR DESCRIPTION
## Summary

This fixes the actual product behavior for the News page Twitter/X module.

The issue was not just that `/news/twitter/matchups` could be blank. The product goal is:

- use the existing game-card UI,
- attach relevant X/Twitter posts to each game,
- rank posts by engagement and baseball relevance,
- cap matchup intel at 20 posts per game,
- allow broader team/search/betting modes to return up to 50 posts,
- add a general high-quality baseball feed for Statcast, analytics, biomechanics, pitching mechanics, and trusted baseball accounts.

## What changed

### Backend: `mlb_app/news_x_apify_provider.py`

Added explicit Twitter/X quality ranking:

- Extracts engagement metrics from common Apify actor fields:
  - likes
  - replies
  - reposts/retweets
  - quotes
  - views
  - bookmarks
- Computes:
  - `engagement.engagement_total`
  - `engagement.weighted_engagement`
  - `twitter_quality_score`
- Ranks by:
  - `twitter_quality_score`
  - weighted engagement
  - existing News importance score
  - published time
- Penalizes obvious clickbait terms.
- Boosts baseball-signal terms like Statcast, xwOBA, barrel, biomechanics, pitch design, arsenal, run value, lineup, injury, weather, odds, and line movement.
- Adds `TWITTER_X_MIN_ENGAGEMENT` to optionally filter out low-engagement junk.
- Pulls more rows from Apify than the final cap, then ranks and trims.

### Caps

- Matchup mode: `TWITTER_X_MATCHUP_TWEET_CAP`, default 20 per game.
- Team/search/betting modes: default up to 50.
- General baseball feed: `TWITTER_X_GENERAL_TWEET_CAP`, default 50.

### General Baseball Feed

Added `search_baseball_feed()` and default feed queries for high-signal baseball accounts/topics:

- PitchingNinja
- CodifyBaseball
- Baseball Savant
- MLB Pipeline
- FanGraphs
- Enos Sarris
- Ben Lindbergh
- The Athletic MLB
- MLB Network
- baseball biomechanics / pitching mechanics
- MLB Statcast / barrel rate / xwOBA

Can be overridden with:

```env
TWITTER_X_BASEBALL_FEED_QUERIES=from:PitchingNinja,from:baseballsavant,baseball biomechanics pitching mechanics
```

### Backend routes: `mlb_app/news_routes.py`

- `/news/twitter/matchups` now defaults to `limit=20`, max 20.
- `/news/twitter/team` defaults to `limit=50`, max 50.
- `/news/twitter/search` defaults to `limit=50`, max 50.
- `/news/twitter/betting` defaults to `limit=50`, max 50.
- Added `/news/twitter/baseball-feed`, max 100 route limit but provider default cap is 50.
- `/news/health` now reports:
  - `apify_x_engagement_ranking`
  - `apify_x_matchup_tweet_cap`
  - `apify_x_general_tweet_cap`
  - `apify_x_min_engagement`

### Frontend: `frontend/src/pages/NewsPage.jsx`

- Matchup cards now render up to 20 tweets per game.
- Team/search/betting/general feed modes render up to 50 tweets.
- Adds `Baseball Feed` tab.
- Shows tweet engagement metrics on each card.
- Shows `twitter_quality_score` on each card.
- Updates explanatory copy so the UI matches the Apify-backed ranking behavior.

## Env vars

Recommended production settings:

```env
NEWS_PROVIDER=rss
NEWS_ENABLE_RSS_PROVIDER=true
NEWS_ENABLE_TWIKIT=false
NEWS_X_PROVIDER=apify
APIFY_TOKEN=<configured in Railway>
TWITTER_X_ACTOR_ID=<configured Apify actor>
TWITTER_X_CACHE_TTL_SECONDS=120
TWITTER_X_ACTOR_INPUT_MODE=searchTerms
TWITTER_X_ACTOR_MAX_ITEMS_KEY=maxItems
TWITTER_X_ACTOR_SORT=Top
TWITTER_X_MATCHUP_TWEET_CAP=20
TWITTER_X_GENERAL_TWEET_CAP=50
TWITTER_X_MIN_ENGAGEMENT=0
```

Optional curated feed override:

```env
TWITTER_X_BASEBALL_FEED_QUERIES=from:PitchingNinja,from:CodifyBaseball,from:baseballsavant,baseball biomechanics pitching mechanics,MLB Statcast xwOBA barrel rate
```

## Safety

No changes to:

- matchup analyzer formulas
- Daily Odds formulas
- model projections
- RSS provider behavior
- database schema
- public `/matchups` route behavior

## Manual smoke checks after deploy

```text
/news/health
/news/twitter/team?team=CHC&limit=50
/news/twitter/search?query=Cubs%20lineup&limit=50
/news/twitter/betting?limit=50
/news/twitter/baseball-feed?limit=50
/news/twitter/matchups?limit=20
```

Expected behavior:

- Team/search/betting/baseball-feed should show ranked quality tweets.
- Matchup mode should show game cards and no more than 20 tweets per game.
- Tweets should include engagement fields when the Apify actor returns them.
- Low-signal tweets can be filtered later by raising `TWITTER_X_MIN_ENGAGEMENT`.