### PR TITLE
Add active-lineup dashboard solver

### DIFF
--- a/frontend/src/pages/MyDashboardPage.jsx
+++ b/frontend/src/pages/MyDashboardPage.jsx
@@ -12,6 +12,8 @@ const COMPONENTS = [
   { key: 'overall_players', title: 'My Top Overall Players Today', description: 'Combined unique player board blending hitter and pitcher model-solver scores.' },
 ]
 
+const ACTIVE_LINEUP_COMPONENTS = new Set(['hitters', 'overall_players'])
+
 const DEFAULT_METRICS = {
   hitters: ['xwOBA', 'xBA', 'EV', 'LA', 'HardHit', 'Usage', 'Pitcher xwOBA'],
   pitchers: ['K%', 'BB%', 'xwOBA Allowed', 'HardHit Allowed', 'Opp K%', 'Opp ISO', 'Score'],
@@ -78,6 +80,14 @@ function activeFilterChips(filters) {
   return chips
 }
 
+function lineupFilterMessage(result) {
+  const filter = result?.lineup_filter
+  if (!filter?.enabled) return null
+  if (filter.lineup_status === 'unavailable') return 'Starting lineup data is not available yet. Active-lineup solver did not include unverified hitters.'
+  const removed = Number(filter.removed_unconfirmed_count || 0)
+  return `Filtered to confirmed starting-lineup hitters from today's matchup cards. Removed ${removed} unconfirmed hitter${removed === 1 ? '' : 's'}.`
+}
+
 export default function MyDashboardPage() {
   const today = new Date().toISOString().slice(0, 10)
   const [date, setDate] = useState(today)
@@ -86,6 +96,7 @@ export default function MyDashboardPage() {
   const [filters, setFilters] = useState({})
   const [enabled, setEnabled] = useState(Object.fromEntries(COMPONENTS.map(c => [c.key, true])))
   const [loading, setLoading] = useState({})
+  const [activeLineupLoading, setActiveLineupLoading] = useState({})
   const [errors, setErrors] = useState({})
   const [savedDashboards, setSavedDashboards] = useState([])
   const [dashboardName, setDashboardName] = useState('')
@@ -117,6 +128,27 @@ export default function MyDashboardPage() {
       setErrors(prev => ({ ...prev, [component]: err.message || 'Solver failed' }))
     } finally {
       setLoading(prev => ({ ...prev, [component]: false }))
+    }
+  }
+
+  async function runActiveLineupSolver(component, overrideFilters = filters[component] || {}) {
+    setActiveLineupLoading(prev => ({ ...prev, [component]: true }))
+    setErrors(prev => ({ ...prev, [component]: null }))
+    try {
+      const payload = { date: effectiveDate, component, filters: cleanFilters(overrideFilters) }
+      const res = await fetch(`${API}/my-dashboard/solver/active-lineups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(JSON.stringify(json.detail || json))
+      setResults(prev => ({ ...prev, [component]: json }))
+    } catch (err) {
+      console.error('Active-lineup solver failed:', err)
+      setErrors(prev => ({ ...prev, [component]: err.message || 'Active-lineup solver failed' }))
+    } finally {
+      setActiveLineupLoading(prev => ({ ...prev, [component]: false }))
     }
   }
 
@@ -266,12 +298,14 @@ export default function MyDashboardPage() {
             component={component}
             result={results[component.key]}
             loading={loading[component.key]}
+            activeLineupLoading={activeLineupLoading[component.key]}
             error={errors[component.key]}
             filters={filters[component.key] || {}}
             enabled={enabled[component.key]}
             onEnabledChange={(value) => setEnabled(prev => ({ ...prev, [component.key]: value }))}
             onFilterChange={(next) => updateComponentFilters(component.key, next)}
             onRun={() => runSolver(component.key)}
+            onRunActiveLineups={() => runActiveLineupSolver(component.key)}
             onReset={() => resetComponentFilters(component.key)}
           />
         ))}
@@ -318,7 +352,7 @@ function SavedDashboardsPanel({ savedDashboards, dashboardName, setDashboardName
   )
 }
 
-function DashboardCard({ component, result, loading, error, filters, enabled, onEnabledChange, onFilterChange, onRun, onReset }) {
+function DashboardCard({ component, result, loading, activeLineupLoading, error, filters, enabled, onEnabledChange, onFilterChange, onRun, onRunActiveLineups, onReset }) {
   const [showFilters, setShowFilters] = useState(false)
   const items = result?.items || []
   const metricNames = useMemo(() => {
@@ -327,6 +361,8 @@ function DashboardCard({ component, result, loading, error, filters, enabled, on
     return fromResult.length ? fromResult : fromItems.length ? fromItems : (DEFAULT_METRICS[component.key] || [])
   }, [result, items, component.key])
   const chips = activeFilterChips(filters)
+  const canRunActiveLineups = ACTIVE_LINEUP_COMPONENTS.has(component.key)
+  const lineupMessage = lineupFilterMessage(result)
   return (
     <div style={{ ...cardStyle, opacity: enabled ? 1 : 0.68 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start' }}>
@@ -342,13 +378,15 @@ function DashboardCard({ component, result, loading, error, filters, enabled, on
         <button onClick={() => setShowFilters(!showFilters)} style={miniButtonStyle}>{showFilters ? 'Hide Filters' : 'Edit Filters'}</button>
       </div>
 
-      <button onClick={onRun} disabled={loading || !enabled} style={solverButtonStyle}>{loading ? 'Solving...' : 'Use Model Solver To Populate Top 10 Today'}</button>
+      <button onClick={onRun} disabled={loading || activeLineupLoading || !enabled} style={solverButtonStyle}>{loading ? 'Solving...' : 'Use Model Solver To Populate Top 10 Today'}</button>
+      {canRunActiveLineups && <button onClick={onRunActiveLineups} disabled={loading || activeLineupLoading || !enabled} style={activeLineupButtonStyle}>{activeLineupLoading ? 'Checking active lineups...' : 'Run Refreshed Solver for Active Lineups'}</button>}
+      {lineupMessage && <div style={lineupNoteStyle}>{lineupMessage}</div>}
       {chips.length > 0 && <div style={chipWrapStyle}>{chips.map(chip => <span key={chip} style={filterChipStyle}>{chip}</span>)}</div>}
       {showFilters && <FilterPanel component={component} filters={filters} metricNames={metricNames} available={result?.available_filters} onChange={onFilterChange} onApply={onRun} onReset={onReset} />}
       {error && <div style={errorStyle}>{error}</div>}
-      {!result && !loading && !error && <div style={emptyStyle}>No saved results yet. Run the model solver to populate this component from existing app-owned data.</div>}
+      {!result && !loading && !activeLineupLoading && !error && <div style={emptyStyle}>No saved results yet. Run the model solver to populate this component from existing app-owned data.</div>}
       <div style={{ display: 'grid', gap: '10px', marginTop: '14px' }}>{items.map(item => <ResultItem key={item.dedupe_key || `${item.entity_type}-${item.entity_id}-${item.rank}`} item={item} />)}</div>
-      {result && <details style={{ marginTop: '14px' }}><summary style={summaryStyle}>Data quality, filters, and missing data</summary><pre style={preStyle}>{JSON.stringify({ filters_applied: result.filters_applied, available_filters: result.available_filters, result_count_before_filters: result.result_count_before_filters, result_count_after_filters: result.result_count_after_filters, filter_warnings: result.filter_warnings, data_quality: result.data_quality, missing_data: result.missing_data }, null, 2)}</pre></details>}
+      {result && <details style={{ marginTop: '14px' }}><summary style={summaryStyle}>Data quality, filters, and missing data</summary><pre style={preStyle}>{JSON.stringify({ filters_applied: result.filters_applied, available_filters: result.available_filters, result_count_before_filters: result.result_count_before_filters, result_count_after_filters: result.result_count_after_filters, result_count_after_lineup_filter: result.result_count_after_lineup_filter, lineup_filter: result.lineup_filter, filter_warnings: result.filter_warnings, data_quality: result.data_quality, missing_data: result.missing_data }, null, 2)}</pre></details>}
     </div>
   )
 }
@@ -384,7 +422,7 @@ function ResultItem({ item }) {
   const metrics = item.metrics || {}
   const chart = item.chart_data || { labels: [], values: [] }
   const maxValue = Math.max(...(chart.values || []).map(v => Math.abs(Number(v) || 0)), 1)
-  return <div style={itemStyle}><div style={itemHeaderStyle}><div><div style={rankStyle}>#{item.rank} {item.entity_name || item.entity_id}</div><div style={metaStyle}>{item.player_type ? `${item.player_type} | ` : ''}{item.team || 'Team missing'} vs {item.opponent || 'Opponent missing'} {item.game_pk ? `| Game ${item.game_pk}` : ''}</div></div><div style={{ textAlign: 'right' }}><div style={scoreStyle}>{formatNumber(item.score)}</div><div style={confidenceStyle(item.confidence)}>{item.confidence || 'low'}</div></div></div><p style={reasonStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</p>{item.weight_explanation?.length > 0 && <div style={smallTextStyle}>{item.weight_explanation.join(' | ')}</div>}<ScoreBar value={Number(item.score) || 0} />{chart.labels?.length > 0 && <div style={barsWrapStyle}>{chart.labels.map((label, idx) => { const value = Number(chart.values[idx]) || 0; const width = Math.max(8, Math.min(100, Math.abs(value) / maxValue * 100)); return <div key={`${label}-${idx}`} style={metricRowStyle}><span style={metricLabelStyle}>{label}</span><div style={metricTrackStyle}><div style={{ ...metricFillStyle, width: `${width}%` }} /></div><span style={metricValueStyle}>{formatNumber(value)}</span></div> })}</div>}{item.best_pitch_angles?.length > 0 && <div style={pitchAnglesStyle}><strong>Best pitch angles:</strong>{item.best_pitch_angles.map((angle, idx) => <div key={`${angle.pitch_type}-${idx}`} style={smallTextStyle}>• {angle.reason}</div>)}</div>}<details><summary style={summaryStyle}>View reasoning</summary><ul style={reasonListStyle}>{(item.reasoning || []).map((reason, idx) => <li key={idx}>{reason}</li>)}</ul><pre style={preStyle}>{JSON.stringify({ metrics, base_score: item.base_score, adjusted_score: item.adjusted_score, missing_data: item.missing_data || [], source: item.source, dedupe_key: item.dedupe_key }, null, 2)}</pre></details><div style={actionsStyle}><button disabled style={placeholderButtonStyle}>Save</button><button disabled style={placeholderButtonStyle}>Tag</button><button disabled style={placeholderButtonStyle}>Add Note</button></div></div>
+  return <div style={itemStyle}><div style={itemHeaderStyle}><div><div style={rankStyle}>#{item.rank} {item.entity_name || item.entity_id}</div><div style={metaStyle}>{item.player_type ? `${item.player_type} | ` : ''}{item.team || 'Team missing'} vs {item.opponent || 'Opponent missing'} {item.game_pk ? `| Game ${item.game_pk}` : ''} {item.lineup_verified ? '| Starting lineup verified' : ''}</div></div><div style={{ textAlign: 'right' }}><div style={scoreStyle}>{formatNumber(item.score)}</div><div style={confidenceStyle(item.confidence)}>{item.confidence || 'low'}</div></div></div><p style={reasonStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</p>{item.weight_explanation?.length > 0 && <div style={smallTextStyle}>{item.weight_explanation.join(' | ')}</div>}<ScoreBar value={Number(item.score) || 0} />{chart.labels?.length > 0 && <div style={barsWrapStyle}>{chart.labels.map((label, idx) => { const value = Number(chart.values[idx]) || 0; const width = Math.max(8, Math.min(100, Math.abs(value) / maxValue * 100)); return <div key={`${label}-${idx}`} style={metricRowStyle}><span style={metricLabelStyle}>{label}</span><div style={metricTrackStyle}><div style={{ ...metricFillStyle, width: `${width}%` }} /></div><span style={metricValueStyle}>{formatNumber(value)}</span></div> })}</div>}{item.best_pitch_angles?.length > 0 && <div style={pitchAnglesStyle}><strong>Best pitch angles:</strong>{item.best_pitch_angles.map((angle, idx) => <div key={`${angle.pitch_type}-${idx}`} style={smallTextStyle}>• {angle.reason}</div>)}</div>}<details><summary style={summaryStyle}>View reasoning</summary><ul style={reasonListStyle}>{(item.reasoning || []).map((reason, idx) => <li key={idx}>{reason}</li>)}</ul><pre style={preStyle}>{JSON.stringify({ metrics, base_score: item.base_score, adjusted_score: item.adjusted_score, missing_data: item.missing_data || [], source: item.source, lineup_verified: item.lineup_verified, lineup_source: item.lineup_source, dedupe_key: item.dedupe_key }, null, 2)}</pre></details><div style={actionsStyle}><button disabled style={placeholderButtonStyle}>Save</button><button disabled style={placeholderButtonStyle}>Tag</button><button disabled style={placeholderButtonStyle}>Add Note</button></div></div>
 }
 
 function ScoreBar({ value }) { const width = Math.max(4, Math.min(100, Math.abs(value) * 35)); return <div style={scoreTrackStyle}><div style={{ ...scoreFillStyle, width: `${width}%` }} /></div> }
@@ -414,6 +452,8 @@ const countBadgeStyle = { background: '#0d1117', border: '1px solid #30363d', bo
 const toolbarStyle = { display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'center', marginTop: '12px' }
 const checkLabelStyle = { color: '#8b949e', fontSize: '12px' }
 const solverButtonStyle = { width: '100%', marginTop: '12px', background: '#58a6ff', color: '#07111f', border: 0, borderRadius: '8px', padding: '10px', fontWeight: 800, cursor: 'pointer' }
+const activeLineupButtonStyle = { width: '100%', marginTop: '8px', background: '#238636', color: '#fff', border: 0, borderRadius: '8px', padding: '10px', fontWeight: 800, cursor: 'pointer' }
+const lineupNoteStyle = { marginTop: '10px', padding: '10px', background: '#0f1a2e', border: '1px solid #1f6feb55', borderRadius: '8px', color: '#c9d1d9', fontSize: '12px', lineHeight: 1.45 }
 const chipWrapStyle = { display: 'flex', gap: '6px', flexWrap: 'wrap', marginTop: '10px' }
 const filterChipStyle = { background: '#0f1a2e', border: '1px solid #1f6feb55', borderRadius: '999px', color: '#c9d1d9', padding: '4px 8px', fontSize: '11px' }
 const filterPanelStyle = { marginTop: '12px', background: '#0d1117', border: '1px solid #30363d', borderRadius: '10px', padding: '12px' }

--- a/mlb_app/active_lineup_solver.py
+++ b/mlb_app/active_lineup_solver.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from sqlalchemy.orm import Session
+
+from .lineup_profile import fetch_boxscore_lineup
+from .matchup_generator import generate_matchups_for_date
+from .my_dashboard_solver import build_dashboard_solver_payload
+
+HITTER_COMPONENTS = {"hitters", "overall_players"}
+
+
+def _normalize_name(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
+
+
+def _string_id(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    try:
+        return str(int(value))
+    except Exception:
+        return str(value).strip()
+
+
+def _team_value(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    return str(value).strip().lower()
+
+
+def _is_hitter_item(item: Dict[str, Any]) -> bool:
+    entity_type = str(item.get("entity_type") or "").lower()
+    player_type = str(item.get("player_type") or "").lower()
+    return entity_type == "hitter" or player_type == "hitter"
+
+
+def _lineup_match_keys(player: Dict[str, Any], team_id: Any, team_name: Any) -> Tuple[Set[str], Set[Tuple[str, str]]]:
+    ids: Set[str] = set()
+    names: Set[Tuple[str, str]] = set()
+
+    player_id = _string_id(player.get("batter_id") or player.get("id") or player.get("person_id"))
+    if player_id:
+        ids.add(player_id)
+
+    name = _normalize_name(player.get("name") or player.get("fullName") or player.get("player_name"))
+    if name:
+        for team_value in (_team_value(team_id), _team_value(team_name)):
+            if team_value:
+                names.add((name, team_value))
+
+    return ids, names
+
+
+def _build_confirmed_lineup_index(session: Session, target_date: str) -> Dict[str, Any]:
+    warnings: List[str] = []
+    confirmed_ids: Set[str] = set()
+    confirmed_names: Set[Tuple[str, str]] = set()
+    games_checked = 0
+    games_with_lineups = 0
+    teams_with_lineups = 0
+
+    try:
+        matchups = generate_matchups_for_date(session, target_date)
+    except Exception as exc:
+        return {
+            "confirmed_ids": confirmed_ids,
+            "confirmed_names": confirmed_names,
+            "metadata": {
+                "enabled": True,
+                "source": "matchups_boxscore_lineups",
+                "lineup_status": "unavailable",
+                "confirmed_batter_count": 0,
+                "games_checked": 0,
+                "games_with_lineups": 0,
+                "teams_with_lineups": 0,
+                "removed_unconfirmed_count": 0,
+                "warnings": [f"Could not load matchup payload: {exc}"],
+            },
+        }
+
+    for matchup in matchups or []:
+        game_pk = matchup.get("game_pk")
+        if not game_pk:
+            warnings.append("Skipped matchup without game_pk while building active-lineup filter.")
+            continue
+
+        games_checked += 1
+        try:
+            lineups = fetch_boxscore_lineup(int(game_pk))
+        except Exception as exc:
+            warnings.append(f"Lineup fetch failed for game {game_pk}: {exc}")
+            continue
+
+        game_has_lineup = False
+        for side in ("away", "home"):
+            lineup = lineups.get(side) or []
+            if not lineup:
+                continue
+
+            game_has_lineup = True
+            teams_with_lineups += 1
+            team_id = matchup.get(f"{side}_team_id")
+            team_name = matchup.get(f"{side}_team_name")
+
+            for player in lineup:
+                ids, names = _lineup_match_keys(player, team_id=team_id, team_name=team_name)
+                confirmed_ids.update(ids)
+                confirmed_names.update(names)
+
+        if game_has_lineup:
+            games_with_lineups += 1
+
+    if confirmed_ids or confirmed_names:
+        lineup_status = "confirmed" if games_checked and games_with_lineups == games_checked else "partial"
+    else:
+        lineup_status = "unavailable"
+        warnings.append("No confirmed starting lineups were found in the matchup boxscore payload for this date.")
+
+    return {
+        "confirmed_ids": confirmed_ids,
+        "confirmed_names": confirmed_names,
+        "metadata": {
+            "enabled": True,
+            "source": "matchups_boxscore_lineups",
+            "lineup_status": lineup_status,
+            "confirmed_batter_count": len(confirmed_ids) or len(confirmed_names),
+            "games_checked": games_checked,
+            "games_with_lineups": games_with_lineups,
+            "teams_with_lineups": teams_with_lineups,
+            "removed_unconfirmed_count": 0,
+            "warnings": warnings,
+        },
+    }
+
+
+def _item_confirmed_in_lineup(item: Dict[str, Any], confirmed_ids: Set[str], confirmed_names: Set[Tuple[str, str]]) -> bool:
+    entity_id = _string_id(item.get("entity_id") or item.get("batter_id") or item.get("player_id"))
+    if entity_id and entity_id in confirmed_ids:
+        return True
+
+    name = _normalize_name(item.get("entity_name") or item.get("name") or item.get("player_name"))
+    if not name:
+        return False
+
+    team_values = [
+        _team_value(item.get("team")),
+        _team_value(item.get("team_id")),
+        _team_value(item.get("batter_team_id")),
+    ]
+    return any((name, team) in confirmed_names for team in team_values if team)
+
+
+def _rerank_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    reranked = []
+    for idx, item in enumerate(items[:10], start=1):
+        updated = dict(item)
+        updated["rank"] = idx
+        reranked.append(updated)
+    return reranked
+
+
+def _apply_active_lineup_filter(response: Dict[str, Any], lineup_index: Dict[str, Any], component: str) -> Dict[str, Any]:
+    updated = copy.deepcopy(response or {})
+    metadata = copy.deepcopy(lineup_index.get("metadata") or {})
+    confirmed_ids = lineup_index.get("confirmed_ids") or set()
+    confirmed_names = lineup_index.get("confirmed_names") or set()
+
+    if component not in HITTER_COMPONENTS:
+        metadata.update({
+            "enabled": False,
+            "lineup_status": "not_applicable",
+            "warnings": list(metadata.get("warnings") or []) + ["Active-lineup filtering only applies to hitter/player components."],
+        })
+        updated["lineup_filter"] = metadata
+        return updated
+
+    kept: List[Dict[str, Any]] = []
+    removed = 0
+
+    for item in updated.get("items") or []:
+        if not _is_hitter_item(item):
+            kept.append(item)
+            continue
+
+        if metadata.get("lineup_status") == "unavailable":
+            removed += 1
+            continue
+
+        if _item_confirmed_in_lineup(item, confirmed_ids, confirmed_names):
+            verified = dict(item)
+            verified["lineup_verified"] = True
+            verified["lineup_source"] = metadata.get("source")
+            kept.append(verified)
+        else:
+            removed += 1
+
+    metadata["removed_unconfirmed_count"] = removed
+    if removed:
+        metadata.setdefault("warnings", [])
+        metadata["warnings"].append(f"Removed {removed} hitter result(s) that were not confirmed in the starting lineup.")
+
+    updated["items"] = _rerank_items(kept)
+    updated["result_count_after_lineup_filter"] = len(updated["items"])
+    updated["lineup_filter"] = metadata
+    return updated
+
+
+def build_active_lineup_solver_payload(
+    session: Session,
+    date: Optional[str],
+    component: str,
+    filters: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run the existing dashboard solver, then filter hitter rows by confirmed starting lineups.
+
+    This wrapper is intentionally additive. It does not alter model scoring,
+    projection formulas, matchup generation, or the default dashboard solver.
+    """
+    target_date = str(date or "")[:10]
+    normalized_component = (component or "").strip().lower()
+    base_payload = build_dashboard_solver_payload(
+        session=session,
+        date=target_date,
+        component=normalized_component,
+        filters=filters,
+    )
+    lineup_index = _build_confirmed_lineup_index(session, target_date)
+    return _apply_active_lineup_filter(base_payload, lineup_index, normalized_component)

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+from .active_lineup_solver import build_active_lineup_solver_payload
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_solver import build_dashboard_solver_payload, normalize_filter_payload, SUPPORTED_COMPONENTS
 from .shared_payload_cache import env_ttl, get_or_set, make_cache_key, stable_hash
@@ -51,16 +52,31 @@ def my_dashboard_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any
     return _run_solver(date=payload.date, component=payload.component, filters=payload.filters)
 
 
-def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+@router.post("/my-dashboard/solver/active-lineups")
+def my_dashboard_active_lineup_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any]:
+    return _run_active_lineup_solver(date=payload.date, component=payload.component, filters=payload.filters)
+
+
+def _normalize_request(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     target_date = (date or dt.date.today().isoformat())[:10]
-    normalized_component = (component or "").strip().lower()
-    normalized_filters = normalize_filter_payload(filters)
-    filters_hash = stable_hash(normalized_filters)
-    cache_key = make_cache_key("dashboard_solver", "component", target_date, normalized_component, filters_hash)
     try:
         dt.date.fromisoformat(target_date)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
+    return {
+        "target_date": target_date,
+        "component": (component or "").strip().lower(),
+        "filters": normalize_filter_payload(filters),
+    }
+
+
+def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    normalized = _normalize_request(date, component, filters)
+    target_date = normalized["target_date"]
+    normalized_component = normalized["component"]
+    normalized_filters = normalized["filters"]
+    filters_hash = stable_hash(normalized_filters)
+    cache_key = make_cache_key("dashboard_solver", "component", target_date, normalized_component, filters_hash)
 
     try:
         def build() -> Dict[str, Any]:
@@ -78,3 +94,29 @@ def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str,
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "My Dashboard solver failed", "error": str(exc)}) from exc
+
+
+def _run_active_lineup_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    normalized = _normalize_request(date, component, filters)
+    target_date = normalized["target_date"]
+    normalized_component = normalized["component"]
+    normalized_filters = normalized["filters"]
+    filters_hash = stable_hash(normalized_filters)
+    cache_key = make_cache_key("dashboard_solver", "active_lineups", target_date, normalized_component, filters_hash)
+
+    try:
+        def build() -> Dict[str, Any]:
+            factory = session_factory()
+            with factory() as session:
+                return build_active_lineup_solver_payload(
+                    session=session,
+                    date=target_date,
+                    component=normalized_component,
+                    filters=normalized_filters,
+                )
+
+        return get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Active-lineup solver failed", "error": str(exc)}) from exc


### PR DESCRIPTION
## Summary

Adds a safe, additive active-lineup solver path for My Dashboard without changing the existing default model solver, model projection formulas, Daily Odds logic, matchup analyzer logic, or `/matchups` generation behavior.

## What changed

### Backend
- Added `mlb_app/active_lineup_solver.py`.
- Added new endpoint: `POST /my-dashboard/solver/active-lineups`.
- The new endpoint calls the existing dashboard solver first, then applies a confirmed-starting-lineup filter to hitter-based results.
- The default `POST /my-dashboard/solver` path remains unchanged in purpose and still uses the existing cached solver behavior.
- Active-lineup results use their own cache key namespace: `dashboard_solver:active_lineups:...`.

### Lineup source
- Uses the existing matchup source by calling `generate_matchups_for_date(session, target_date)`.
- Uses the existing confirmed-lineup helper `fetch_boxscore_lineup(game_pk)` from `lineup_profile.py`, which reads MLB boxscore batting-order slots.
- Builds a confirmed batter index by player ID first.
- Falls back to normalized player name plus team ID/name when ID matching is unavailable.

### Filtering behavior
- Applies only to `hitters` and `overall_players` components.
- Hitter rows must be confirmed in a starting lineup to remain in the active-lineup Top 10.
- Non-hitter rows in `overall_players`, such as pitchers, are left unchanged.
- If confirmed lineup data is unavailable, hitter rows are not included as verified results.
- Adds optional metadata under `lineup_filter`, including status, confirmed batter count, removed count, games checked, teams checked, and warnings.

### Frontend
- Adds a new button on hitter-relevant dashboard cards:
  - `Run Refreshed Solver for Active Lineups`
- The button calls the new active-lineup endpoint and does not auto-run on page load.
- Shows a small lineup-filter note above results.
- Adds lineup metadata to the existing data-quality details section.
- Marks verified hitter rows with `Starting lineup verified`.

## Safety constraints preserved

- No changes to model scoring formulas.
- No changes to `/matchups` generation logic.
- No changes to Daily Odds formulas.
- No changes to Model Projection formulas.
- No removal of the current Top 10/default solver button.
- No N/A-heavy card additions.

## Validation checklist

Please validate before merging:

```bash
pytest tests/test_model_projection_contract.py
python scripts/smoke_test_production_paths.py
```

Manual checks:
- Existing `POST /my-dashboard/solver` still works as before.
- New `POST /my-dashboard/solver/active-lineups` returns the same base shape plus `lineup_filter` metadata.
- Button appears only on hitters and overall players cards.
- Button does not auto-run on page load.
- Hitter rows shown after active-lineup refresh are confirmed by lineup data.
- If no confirmed lineups exist yet, unverified hitters are not shown as betting-ready picks.
- `/matchups`, Daily Odds, Model Projections, and Model Tracker remain unchanged.

## Notes

This PR is intentionally draft because I could not execute the repo test suite from this environment. The branch is based on current `main` and preserves the shared cache/performance changes already present there.