### PR TITLE
Add canonical probability context to AI Data Assistant

### DIFF
--- a/mlb_app/ai_data_assistant_performance.py
+++ b/mlb_app/ai_data_assistant_performance.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import time
 from contextvars import ContextVar
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from . import ai_data_assistant as core
 from .model_projections import build_model_projection_payload as uncached_build_model_projection_payload
@@ -95,6 +95,134 @@ def _response_cache_key(message: str, date: Optional[str], game_pk: Optional[int
     return (normalized_message, date, game_pk, player_id, team_id, bool(use_llm))
 
 
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pct(value: Any) -> Optional[str]:
+    number = _safe_float(value)
+    if number is None:
+        return None
+    return f"{round(number * 100, 1)}%"
+
+
+def _canonical_games_from_projection_payload(payload: Dict[str, Any], game_pk: Optional[int] = None, limit: int = 6) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for game in payload.get("games") or []:
+        if game_pk is not None and str(game.get("game_pk")) != str(game_pk):
+            continue
+        probs = game.get("main_matchup_probabilities") or {}
+        home_team = (game.get("home_team") or {}).get("name") if isinstance(game.get("home_team"), dict) else game.get("home_team")
+        away_team = (game.get("away_team") or {}).get("name") if isinstance(game.get("away_team"), dict) else game.get("away_team")
+        home_prob = _safe_float(probs.get("home_win_prob") or game.get("home_win_prob"))
+        away_prob = _safe_float(probs.get("away_win_prob") or game.get("away_win_prob"))
+        favorite = None
+        favorite_probability = None
+        if home_prob is not None and away_prob is not None:
+            favorite = home_team if home_prob >= away_prob else away_team
+            favorite_probability = max(home_prob, away_prob)
+        simulation_diag = probs.get("simulation_diagnostic") or (game.get("workspace") or {}).get("sharedSimulationDiagnostics") or {}
+        rows.append({
+            "game_pk": game.get("game_pk"),
+            "label": f"{away_team or 'Away'} @ {home_team or 'Home'}",
+            "favorite": favorite,
+            "favorite_probability": favorite_probability,
+            "home_win_prob": home_prob,
+            "away_win_prob": away_prob,
+            "model_version": probs.get("model_version") or game.get("model_version"),
+            "lineup_status": probs.get("lineup_status") or game.get("lineup_status"),
+            "data_confidence": probs.get("data_confidence") or game.get("data_confidence"),
+            "missing_inputs": probs.get("missing_inputs") or game.get("missing_inputs") or [],
+            "probability_component_keys": sorted((probs.get("probability_components") or game.get("probability_components") or {}).keys()),
+            "simulation_role": simulation_diag.get("status") or "diagnostic_only_not_final_probability",
+            "simulation_is_final_probability": False,
+        })
+        if len(rows) >= limit and game_pk is None:
+            break
+    return rows
+
+
+def _build_canonical_probability_context(session, context: Dict[str, Any], game_pk: Optional[int] = None) -> Dict[str, Any]:
+    date = context.get("date") or core.today()
+    start = _now()
+    try:
+        payload = cached_build_model_projection_payload(session, date)
+        _add_timing("canonical_probability_context_ms", _ms(start))
+    except Exception as exc:
+        return {
+            "available": False,
+            "date": date,
+            "error": str(exc),
+            "final_probability_source": "matchups.home_win_prob_and_away_win_prob",
+            "simulation_role": "diagnostic_only_not_final_probability",
+        }
+    games = _canonical_games_from_projection_payload(payload, game_pk=game_pk or context.get("game_pk"))
+    return {
+        "available": bool(games),
+        "date": date,
+        "final_probability_source": "matchups.home_win_prob_and_away_win_prob",
+        "model_version": "canonical_matchup_win_probability_v2",
+        "legacy_model_version": "legacy_matchup_win_probability_v1",
+        "simulation_role": "diagnostic_only_not_final_probability",
+        "games": games,
+        "source_note": "AI Data Assistant treats home_win_prob and away_win_prob as canonical v2. Simulation output is run-distribution and diagnostic context only.",
+    }
+
+
+def _canonical_answer_prefix(canonical_context: Dict[str, Any]) -> str:
+    if not canonical_context.get("available"):
+        return (
+            "Canonical probability note\n"
+            "The assistant attempted to load canonical matchup probability v2 context, but it was not available for this query. "
+            "Do not treat simulation output as the final side probability.\n"
+        )
+    games = canonical_context.get("games") or []
+    best = games[0] if games else {}
+    favorite = best.get("favorite") or "no clear side"
+    favorite_prob = _pct(best.get("favorite_probability")) or "missing"
+    confidence = best.get("data_confidence") or "unknown"
+    lineup = best.get("lineup_status") or "unknown"
+    components = ", ".join(best.get("probability_component_keys") or []) or "component diagnostics missing"
+    return (
+        "Canonical probability note\n"
+        f"Final side probability comes from canonical v2 `home_win_prob` and `away_win_prob`, not the simulation diagnostic. "
+        f"Top loaded game: {best.get('label') or 'unknown game'}; side lean {favorite} at {favorite_prob}; confidence {confidence}; lineup status {lineup}. "
+        f"Components available: {components}.\n"
+    )
+
+
+def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_context: Dict[str, Any]) -> Dict[str, Any]:
+    enriched = copy.deepcopy(result)
+    enriched["canonical_probability_context"] = canonical_context
+    sources = list(enriched.get("sources_used") or [])
+    for source in ["canonical_matchup_probability_v2", "matchups.home_win_prob_and_away_win_prob"]:
+        if source not in sources:
+            sources.append(source)
+    enriched["sources_used"] = sources
+    enriched.setdefault("data_quality", {})
+    if isinstance(enriched["data_quality"], dict):
+        enriched["data_quality"]["canonical_probability"] = {
+            "available": canonical_context.get("available"),
+            "final_probability_source": canonical_context.get("final_probability_source"),
+            "simulation_role": canonical_context.get("simulation_role"),
+            "games_loaded": len(canonical_context.get("games") or []),
+        }
+    note = _canonical_answer_prefix(canonical_context)
+    answer = enriched.get("answer") or ""
+    if "Canonical probability note" not in answer:
+        enriched["answer"] = note + "\n" + answer
+    confidence_note = enriched.get("confidence_note") or ""
+    canonical_note = " Canonical v2 is the final side probability; simulations are diagnostic/run-distribution context only."
+    if canonical_note.strip() not in confidence_note:
+        enriched["confidence_note"] = confidence_note + canonical_note
+    return enriched
+
+
 def build_ai_data_assistant_response(
     session,
     message: str,
@@ -110,6 +238,7 @@ def build_ai_data_assistant_response(
     - process-level TTL response cache for repeated chip clicks
     - process-level TTL Model Projection cache by date
     - deterministic answers by default
+    - canonical probability context on every response
     - timing metadata on every response
     """
     apply_performance_patch()
@@ -136,12 +265,15 @@ def build_ai_data_assistant_response(
         )
         timing["context_build_ms"] = _ms(context_start)
 
+        canonical_context = _build_canonical_probability_context(session, context, game_pk=game_pk)
+
         answer_start = _now()
         result = core.answer_with_optional_llm(message, context, use_llm=use_llm)
         timing["answer_render_ms"] = _ms(answer_start)
         timing["llm_requested"] = 1 if use_llm else 0
         timing["total_ms"] = _ms(total_start)
 
+        result = _enrich_result_with_canonical_context(result, canonical_context)
         result["timing"] = dict(timing)
         result["cache_status"] = "miss"
         _cache_set(_response_cache, key, result)


### PR DESCRIPTION
## Summary

This PR continues the canonical probability v2 sprint by updating the AI Data Assistant response wrapper so every assistant response carries and explains canonical matchup probability context.

The app already routes AI Data Assistant calls through `mlb_app/ai_data_assistant_performance.py`, so this change avoids a risky full rewrite of the large core `ai_data_assistant.py` module. Instead, it safely enriches the existing assistant result after the core context/answer logic runs.

## Files changed

- `mlb_app/ai_data_assistant_performance.py`

## What was completed

### Canonical probability context on every response

Added canonical context extraction from the cached Model Projections payload, which now exposes canonical `/matchups` probability after PR #325.

Each assistant response now includes:

- `canonical_probability_context`
- `canonical_probability_context.final_probability_source`
- `canonical_probability_context.model_version`
- `canonical_probability_context.legacy_model_version`
- `canonical_probability_context.simulation_role`
- loaded game-level canonical probability summary rows

The final source is explicitly labeled as:

- `matchups.home_win_prob_and_away_win_prob`

The model version is explicitly labeled as:

- `canonical_matchup_win_probability_v2`

### Answer text now states the correct probability contract

Every deterministic or LLM-polished answer is prefixed with a short canonical probability note unless it already has one.

The note explains:

- final side probability comes from canonical v2 `home_win_prob` and `away_win_prob`
- simulation is diagnostic/run-distribution context only
- top loaded game side lean
- favorite probability
- data confidence
- lineup status
- available component diagnostic keys

### Sources and data quality enriched

The wrapper now appends these sources where needed:

- `canonical_matchup_probability_v2`
- `matchups.home_win_prob_and_away_win_prob`

It also adds a data quality block:

```json
"canonical_probability": {
  "available": true,
  "final_probability_source": "matchups.home_win_prob_and_away_win_prob",
  "simulation_role": "diagnostic_only_not_final_probability",
  "games_loaded": 6
}
```

### Confidence note updated

The assistant `confidence_note` now includes:

- canonical v2 is the final side probability
- simulations are diagnostic/run-distribution context only

### Cache-safe implementation

The enrichment runs before response caching, so repeat chip clicks return the same enriched canonical context and answer text.

## What was intentionally deferred

This PR does not rewrite the large core `ai_data_assistant.py` file. That is intentional because this safer wrapper-level patch gives the assistant the correct canonical probability contract without destabilizing all intent renderers.

Still remaining for later sprints:

- Model Tracker guarded schema/migration work
- Starter overview formula enrichment for FIP/xFIP/SIERA only where inputs exist
- Batter vs Arsenal v2 nullable bat-tracking schema
- Frontend null hiding and expandable diagnostics

## Validation performed

- Confirmed PR #325 was merged before starting.
- Created branch `canonical-ai-assistant-v2` from the PR #325 merge commit.
- Confirmed branch is 1 commit ahead of `main` and 0 commits behind.
- Confirmed only `mlb_app/ai_data_assistant_performance.py` changed.

## Manual validation still needed

- Hit `/ai-data-assistant` with common chips:
  - `Summarize today's slate`
  - `What is the strongest model edge?`
  - `What does Daily Odds tell us?`
  - `Which game has the cleanest signal?`
- Confirm responses include `Canonical probability note`.
- Confirm JSON response includes `canonical_probability_context`.
- Confirm `sources_used` includes `canonical_matchup_probability_v2`.
- Confirm `data_quality.canonical_probability` appears.
- Confirm simulation is described as diagnostic only, not final side probability.

## Risk areas

- This calls the cached Model Projections payload once more during assistant response enrichment. The function is TTL-cached and uses the existing projection cache path, but very high AI Assistant traffic may still increase cache pressure.
- The prefix is intentionally blunt so users and downstream UI know the probability contract. If the frontend wants a quieter display, it can render `canonical_probability_context` separately later.