### PR TITLE
Enrich starter overview with DB-first pitcher stats

### DIFF
--- a/mlb_app/canonical_matchup_probability.py
+++ b/mlb_app/canonical_matchup_probability.py
@@ -8,8 +8,10 @@ producing one canonical probability payload for /matchups and downstream consume
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+import requests
 from sqlalchemy.orm import Session
 
 from .bullpen_profile import build_bullpen_profile
@@ -23,6 +25,7 @@ log = logging.getLogger(__name__)
 CANONICAL_MODEL_VERSION = "canonical_matchup_win_probability_v2"
 LEGACY_MODEL_VERSION = "legacy_matchup_win_probability_v1"
 BATTER_VS_ARSENAL_SCHEMA_VERSION = "batter_vs_arsenal_v2"
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 
 COMPONENT_WEIGHTS = {
     "simulation": 0.35,
@@ -33,11 +36,42 @@ COMPONENT_WEIGHTS = {
     "market_context": 0.05,
 }
 
+STARTER_OVERVIEW_FIELDS = [
+    ("era", "ERA"),
+    ("fip", "FIP"),
+    ("xfip", "xFIP"),
+    ("siera", "SIERA"),
+    ("xsiera", "xSIERA"),
+    ("k_pct", "K%"),
+    ("bb_pct", "BB%"),
+    ("k_minus_bb_pct", "K-BB%"),
+    ("hr_per_9", "HR/9"),
+    ("gb_pct", "GB%"),
+    ("fb_pct", "FB%"),
+    ("hr_fb", "HR/FB"),
+    ("babip", "BABIP"),
+    ("lob_pct", "LOB%"),
+    ("xwoba_allowed", "xwOBA Allowed"),
+    ("xba_allowed", "xBA Allowed"),
+    ("hard_hit_rate_allowed", "Hard Hit% Allowed"),
+    ("barrel_rate_allowed", "Barrel% Allowed"),
+    ("average_exit_velocity_allowed", "Avg EV Allowed"),
+    ("average_launch_angle_allowed", "Avg LA Allowed"),
+    ("whiff_rate", "Whiff%"),
+    ("csw_rate", "CSW%"),
+    ("pitch_count_sample_size", "Pitch Count / Sample"),
+    ("innings_pitched", "IP"),
+    ("batters_faced", "Batters Faced"),
+    ("pitches_thrown", "Pitches"),
+]
+
 
 def _safe_float(value: Any) -> Optional[float]:
     if value is None:
         return None
     try:
+        if isinstance(value, str) and value.strip().lower() in {"", "none", "null", "nan", "n/a", "na", "-.--"}:
+            return None
         return float(value)
     except (TypeError, ValueError):
         return None
@@ -54,6 +88,35 @@ def _round_prob(value: float) -> float:
 def _normalize_pair(home_probability: float) -> Tuple[float, float]:
     home_probability = _round_prob(home_probability)
     return home_probability, round(1.0 - home_probability, 4)
+
+
+def _pct(value: Any) -> Optional[float]:
+    number = _safe_float(value)
+    if number is None:
+        return None
+    return round(number / 100.0, 4) if number > 1.5 else round(number, 4)
+
+
+def _round_stat(value: Any, digits: int = 3) -> Optional[float]:
+    number = _safe_float(value)
+    return round(number, digits) if number is not None else None
+
+
+def _innings_to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        if "." in text:
+            whole, frac = text.split(".", 1)
+            outs = int(frac[:1] or 0)
+            if outs in {0, 1, 2}:
+                return round(float(int(whole)) + outs / 3.0, 3)
+        return float(text)
+    except (TypeError, ValueError):
+        return None
 
 
 def _component(score: Optional[float], weight: float, source: str, confidence: str = "low", missing_inputs: Optional[List[str]] = None, diagnostics: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -133,8 +196,93 @@ def _data_confidence(lineup_status: str, components: Dict[str, Dict[str, Any]], 
     return "low"
 
 
+@lru_cache(maxsize=512)
+def _fetch_mlb_pitching_season_stats(pitcher_id: int, season: int) -> Dict[str, Any]:
+    """Official MLB Stats API direct-on-load fallback for starter overview fields."""
+    if not pitcher_id or not season:
+        return {"available": False, "source": "missing_pitcher_or_season", "stat": {}}
+    try:
+        response = requests.get(
+            f"{MLB_STATS_BASE}/people/{int(pitcher_id)}",
+            params={"hydrate": f"stats(group=[pitching],type=[season],season={int(season)})"},
+            timeout=8,
+        )
+        response.raise_for_status()
+        person = (response.json().get("people") or [{}])[0]
+        splits = (((person.get("stats") or [{}])[0]).get("splits") or [])
+        stat = (splits[0] or {}).get("stat") if splits else {}
+        return {"available": bool(stat), "source": "mlb_stats_api_people_pitching_season", "person": person, "stat": stat or {}}
+    except Exception as exc:
+        log.warning("MLB pitching overview fallback failed pitcher_id=%s season=%s: %s", pitcher_id, season, exc)
+        return {"available": False, "source": "mlb_stats_api_people_pitching_season", "error": str(exc), "stat": {}}
+
+
+def _first_stat(stats: Dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in stats and stats.get(key) not in {None, ""}:
+            return stats.get(key)
+    return None
+
+
+def _put_metric(overview: Dict[str, Any], key: str, value: Any, source: str, missing_reason: str, digits: int = 3) -> None:
+    overview[key] = _round_stat(value, digits=digits)
+    overview.setdefault("metric_sources", {})[key] = source if overview[key] is not None else "missing"
+    if overview[key] is None:
+        overview.setdefault("missing_inputs", []).append(f"{key}.{missing_reason}")
+
+
+def _derive_standard_pitching_metrics(stats: Dict[str, Any]) -> Dict[str, Any]:
+    ip = _innings_to_float(_first_stat(stats, "inningsPitched", "ip"))
+    bf = _safe_float(_first_stat(stats, "battersFaced", "totalBattersFaced"))
+    so = _safe_float(_first_stat(stats, "strikeOuts", "strikeouts", "so"))
+    bb = _safe_float(_first_stat(stats, "baseOnBalls", "walks", "bb"))
+    hbp = _safe_float(_first_stat(stats, "hitBatsmen", "hitByPitch", "hbp")) or 0.0
+    hr = _safe_float(_first_stat(stats, "homeRuns", "homeRunsAllowed", "hr"))
+    hits = _safe_float(_first_stat(stats, "hits", "h"))
+    runs = _safe_float(_first_stat(stats, "runs", "r"))
+    at_bats = _safe_float(_first_stat(stats, "atBats", "ab"))
+    sac_flies = _safe_float(_first_stat(stats, "sacFlies", "sf")) or 0.0
+    ground_outs = _safe_float(_first_stat(stats, "groundOuts", "groundouts"))
+    air_outs = _safe_float(_first_stat(stats, "airOuts", "flyOuts", "airouts"))
+    pitches = _safe_float(_first_stat(stats, "numberOfPitches", "pitchesThrown", "pitches"))
+    derived: Dict[str, Any] = {"innings_pitched": ip, "batters_faced": bf, "pitches_thrown": pitches}
+    if ip and hr is not None:
+        derived["hr_per_9"] = (hr * 9.0) / ip
+    if bf and so is not None:
+        derived["k_pct"] = so / bf
+    if bf and bb is not None:
+        derived["bb_pct"] = bb / bf
+    if ground_outs is not None and air_outs is not None and (ground_outs + air_outs) > 0:
+        derived["gb_pct"] = ground_outs / (ground_outs + air_outs)
+        derived["fb_pct"] = air_outs / (ground_outs + air_outs)
+    if hr is not None and air_outs is not None and air_outs > 0:
+        derived["hr_fb"] = hr / air_outs
+    if hits is not None and hr is not None and at_bats is not None and so is not None:
+        denominator = at_bats - so - hr + sac_flies
+        if denominator > 0:
+            derived["babip"] = (hits - hr) / denominator
+    if hits is not None and bb is not None and runs is not None and hr is not None:
+        denominator = hits + bb + hbp - hr
+        if denominator > 0:
+            derived["lob_pct"] = (hits + bb + hbp - runs) / denominator
+    return derived
+
+
+def _arm_slot_label(release_pos_z: Optional[float]) -> str:
+    if release_pos_z is None:
+        return "unknown"
+    if release_pos_z >= 6.1:
+        return "high three-quarter"
+    if release_pos_z >= 5.5:
+        return "three-quarter"
+    if release_pos_z >= 4.7:
+        return "low three-quarter"
+    return "sidearm"
+
+
 def _pitcher_profile(pitcher_id: Optional[int], pitcher_name: Optional[str], features: Optional[Dict[str, Any]], arsenal: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     features = features or {}
+    release_z = _safe_float(features.get("avg_release_pos_z"))
     return {
         "metadata": {
             "source_type": "matchup_generator_pitcher_features",
@@ -144,11 +292,11 @@ def _pitcher_profile(pitcher_id: Optional[int], pitcher_name: Optional[str], fea
             "pitcher_name": pitcher_name,
             "missing_inputs": [k for k, v in features.items() if v is None],
         },
-        "bat_missing": {"k_rate": _safe_float(features.get("k_pct")), "whiff_rate": _safe_float(features.get("whiff_rate")), "csw_rate": _safe_float(features.get("csw_rate"))},
-        "command_control": {"bb_rate": _safe_float(features.get("bb_pct")), "zone_rate": None, "first_pitch_strike_rate": None},
+        "bat_missing": {"k_rate": _pct(features.get("k_pct")), "whiff_rate": _pct(features.get("whiff_rate")), "csw_rate": _pct(features.get("csw_rate"))},
+        "command_control": {"bb_rate": _pct(features.get("bb_pct")), "zone_rate": _pct(features.get("zone_rate")), "first_pitch_strike_rate": _pct(features.get("first_pitch_strike_rate"))},
         "contact_management": {
-            "hard_hit_rate_allowed": _safe_float(features.get("hard_hit_pct")),
-            "barrel_rate_allowed": _safe_float(features.get("barrel_pct")),
+            "hard_hit_rate_allowed": _pct(features.get("hard_hit_pct")),
+            "barrel_rate_allowed": _pct(features.get("barrel_pct")),
             "avg_exit_velocity_allowed": _safe_float(features.get("avg_exit_velocity")),
             "avg_launch_angle_allowed": _safe_float(features.get("avg_launch_angle")),
             "xwoba_allowed": _safe_float(features.get("xwoba")),
@@ -156,11 +304,20 @@ def _pitcher_profile(pitcher_id: Optional[int], pitcher_name: Optional[str], fea
         },
         "arsenal": {"pitch_mix": arsenal or {}, "avg_velocity": _safe_float(features.get("avg_velocity")), "avg_spin_rate": _safe_float(features.get("avg_spin_rate"))},
         "release_profile": {
+            "arm_slot_label": _arm_slot_label(release_z),
+            "arm_slot_source": "derived_from_release_pos_z" if release_z is not None else "missing",
+            "arm_angle": _safe_float(features.get("arm_angle")),
             "release_pos_x": _safe_float(features.get("avg_release_pos_x")),
-            "release_pos_z": _safe_float(features.get("avg_release_pos_z")),
+            "release_pos_z": release_z,
             "release_extension": _safe_float(features.get("avg_release_extension")),
             "avg_horizontal_break": _safe_float(features.get("avg_horiz_break")),
             "avg_vertical_break": _safe_float(features.get("avg_vert_break")),
+            "avg_velocity": _safe_float(features.get("avg_velocity")),
+            "avg_spin_rate": _safe_float(features.get("avg_spin_rate")),
+            "pitch_mix": arsenal or {},
+            "release_consistency": None,
+            "extension_advantage": None,
+            "vertical_approach_angle": None,
             "source": "statcast_aggregate_fields_when_available",
         },
     }
@@ -177,46 +334,87 @@ def _offense_profile(team_id: Optional[int], team_name: Optional[str], inputs: O
     }
 
 
-def _starter_overview(profile: Dict[str, Any]) -> Dict[str, Any]:
+def _starter_overview(profile: Dict[str, Any], season: Optional[int] = None) -> Dict[str, Any]:
     metadata = profile.get("metadata") or {}
     bat = profile.get("bat_missing") or {}
     cmd = profile.get("command_control") or {}
     contact = profile.get("contact_management") or {}
     arsenal = profile.get("arsenal") or {}
+    pitcher_id = metadata.get("pitcher_id")
+    fallback = _fetch_mlb_pitching_season_stats(int(pitcher_id), int(season)) if pitcher_id and season else {"available": False, "stat": {}, "source": "missing_pitcher_or_season"}
+    stats = fallback.get("stat") or {}
+    derived = _derive_standard_pitching_metrics(stats)
     missing: List[str] = []
-    overview = {
-        "pitcher_id": metadata.get("pitcher_id"),
+    overview: Dict[str, Any] = {
+        "pitcher_id": pitcher_id,
         "pitcher_name": metadata.get("pitcher_name"),
-        "k_pct": bat.get("k_rate"),
-        "bb_pct": cmd.get("bb_rate"),
-        "k_minus_bb_pct": None,
-        "xwoba_allowed": contact.get("xwoba_allowed"),
-        "xba_allowed": contact.get("xba_allowed"),
-        "hard_hit_rate_allowed": contact.get("hard_hit_rate_allowed"),
-        "barrel_rate_allowed": contact.get("barrel_rate_allowed"),
-        "average_exit_velocity_allowed": contact.get("avg_exit_velocity_allowed"),
-        "average_launch_angle_allowed": contact.get("avg_launch_angle_allowed"),
-        "whiff_rate": bat.get("whiff_rate"),
-        "csw_rate": bat.get("csw_rate"),
-        "avg_velocity": arsenal.get("avg_velocity"),
-        "avg_spin_rate": arsenal.get("avg_spin_rate"),
-        "release_profile": profile.get("release_profile") or {},
         "metric_sources": {},
         "missing_inputs": missing,
-        "data_window_used": "90d_pitcher_aggregate_with_existing_fallbacks",
+        "data_window_used": "DB 90d pitcher aggregate first; MLB Stats API season fallback for standard overview stats",
+        "overview_source_priority": ["db_pitcher_aggregates_or_current_matchup_features", "mlb_stats_api_people_pitching_season", "formula_derived_from_complete_standard_stats", "missing"],
+        "mlb_stats_api_available": bool(fallback.get("available")),
     }
-    if overview["k_pct"] is not None and overview["bb_pct"] is not None:
-        overview["k_minus_bb_pct"] = round(float(overview["k_pct"]) - float(overview["bb_pct"]), 4)
-    for key, value in list(overview.items()):
-        if key in {"release_profile", "metric_sources", "missing_inputs"}:
-            continue
-        overview["metric_sources"][key] = "db_or_statcast_aggregate" if value is not None else "missing"
-        if value is None:
-            missing.append(key)
-    for key in ("era", "fip", "xfip", "siera", "xsiera", "hr_per_9", "gb_pct", "fb_pct", "hr_fb", "babip", "lob_pct", "pitch_count_sample_size"):
+    for key, aliases in {
+        "era": ("era",),
+        "whip": ("whip",),
+        "wins": ("wins",),
+        "losses": ("losses",),
+        "games_pitched": ("gamesPitched", "games"),
+        "games_started": ("gamesStarted",),
+        "strikeouts": ("strikeOuts", "strikeouts"),
+        "walks": ("baseOnBalls", "walks"),
+        "home_runs_allowed": ("homeRuns", "homeRunsAllowed"),
+        "earned_runs": ("earnedRuns",),
+        "runs_allowed": ("runs",),
+        "hits_allowed": ("hits",),
+    }.items():
+        raw = _first_stat(stats, *aliases)
+        _put_metric(overview, key, raw, fallback.get("source") if raw is not None else "missing", "mlb_standard_stat_missing")
+    _put_metric(overview, "k_pct", bat.get("k_rate") if bat.get("k_rate") is not None else derived.get("k_pct"), "db_or_statcast_aggregate" if bat.get("k_rate") is not None else "formula_derived_from_mlb_standard_stats", "k_pct_missing")
+    _put_metric(overview, "bb_pct", cmd.get("bb_rate") if cmd.get("bb_rate") is not None else derived.get("bb_pct"), "db_or_statcast_aggregate" if cmd.get("bb_rate") is not None else "formula_derived_from_mlb_standard_stats", "bb_pct_missing")
+    overview["k_minus_bb_pct"] = round(float(overview["k_pct"]) - float(overview["bb_pct"]), 4) if overview.get("k_pct") is not None and overview.get("bb_pct") is not None else None
+    overview["metric_sources"]["k_minus_bb_pct"] = "formula_derived_from_k_pct_and_bb_pct" if overview.get("k_minus_bb_pct") is not None else "missing"
+    if overview.get("k_minus_bb_pct") is None:
+        missing.append("k_minus_bb_pct.requires_k_pct_and_bb_pct")
+    hr9_api = _first_stat(stats, "homeRunsPer9")
+    _put_metric(overview, "hr_per_9", hr9_api if hr9_api is not None else derived.get("hr_per_9"), fallback.get("source") if hr9_api is not None else "formula_derived_from_mlb_standard_stats", "hr_per_9_missing")
+    _put_metric(overview, "gb_pct", derived.get("gb_pct"), "estimated_from_mlb_standard_groundouts_airouts", "groundouts_airouts_missing")
+    _put_metric(overview, "fb_pct", derived.get("fb_pct"), "estimated_from_mlb_standard_groundouts_airouts", "groundouts_airouts_missing")
+    _put_metric(overview, "hr_fb", derived.get("hr_fb"), "estimated_from_hr_and_airouts", "home_runs_or_airouts_missing")
+    babip_api = _first_stat(stats, "babip")
+    _put_metric(overview, "babip", babip_api if babip_api is not None else derived.get("babip"), fallback.get("source") if babip_api is not None else "formula_derived_from_mlb_standard_stats", "babip_inputs_missing")
+    _put_metric(overview, "lob_pct", derived.get("lob_pct"), "estimated_from_standard_hits_walks_hbp_runs_hr", "lob_inputs_missing")
+    _put_metric(overview, "xwoba_allowed", contact.get("xwoba_allowed"), "db_or_statcast_aggregate", "xwoba_missing")
+    _put_metric(overview, "xba_allowed", contact.get("xba_allowed"), "db_or_statcast_aggregate", "xba_missing")
+    _put_metric(overview, "hard_hit_rate_allowed", contact.get("hard_hit_rate_allowed"), "db_or_statcast_aggregate", "hard_hit_missing")
+    _put_metric(overview, "barrel_rate_allowed", contact.get("barrel_rate_allowed"), "db_or_statcast_aggregate", "barrel_missing")
+    _put_metric(overview, "average_exit_velocity_allowed", contact.get("avg_exit_velocity_allowed"), "db_or_statcast_aggregate", "avg_ev_missing")
+    _put_metric(overview, "average_launch_angle_allowed", contact.get("avg_launch_angle_allowed"), "db_or_statcast_aggregate", "avg_la_missing")
+    _put_metric(overview, "whiff_rate", bat.get("whiff_rate"), "db_or_statcast_aggregate", "whiff_rate_missing")
+    _put_metric(overview, "csw_rate", bat.get("csw_rate"), "db_or_statcast_aggregate", "csw_rate_missing")
+    _put_metric(overview, "avg_velocity", arsenal.get("avg_velocity"), "db_or_statcast_aggregate", "avg_velocity_missing")
+    _put_metric(overview, "avg_spin_rate", arsenal.get("avg_spin_rate"), "db_or_statcast_aggregate", "avg_spin_rate_missing")
+    _put_metric(overview, "innings_pitched", derived.get("innings_pitched"), fallback.get("source") if derived.get("innings_pitched") is not None else "missing", "innings_pitched_missing")
+    _put_metric(overview, "batters_faced", derived.get("batters_faced"), fallback.get("source") if derived.get("batters_faced") is not None else "missing", "batters_faced_missing")
+    _put_metric(overview, "pitches_thrown", derived.get("pitches_thrown"), fallback.get("source") if derived.get("pitches_thrown") is not None else "missing", "pitches_thrown_missing")
+    _put_metric(overview, "pitch_count_sample_size", derived.get("pitches_thrown") or derived.get("batters_faced"), fallback.get("source") if derived.get("pitches_thrown") or derived.get("batters_faced") else "missing", "pitch_count_or_batters_faced_missing")
+    for key, required in {
+        "fip": "requires_hr_bb_hbp_k_ip_and_verified_season_fip_constant",
+        "xfip": "requires_fly_balls_league_hr_fb_bb_hbp_k_ip_and_verified_season_constant",
+        "siera": "requires_documented_formula_and_all_input_rates",
+        "xsiera": "requires_existing_internal_or_trusted_external_source",
+    }.items():
         overview[key] = None
         overview["metric_sources"][key] = "missing"
-        missing.append(key)
+        missing.append(f"{key}.{required}")
+    overview["release_profile"] = profile.get("release_profile") or {}
+    overview["display_metrics"] = [
+        {"key": key, "label": label, "value": overview.get(key), "source": overview.get("metric_sources", {}).get(key), "available": overview.get(key) is not None}
+        for key, label in STARTER_OVERVIEW_FIELDS
+    ]
+    overview["available_metric_count"] = sum(1 for row in overview["display_metrics"] if row.get("available"))
+    overview["requested_metric_count"] = len(overview["display_metrics"])
+    overview["missing_inputs"] = sorted(set(missing))
     return overview
 
 
@@ -259,15 +457,21 @@ def _offense_component(home_inputs: Optional[Dict[str, Any]], away_inputs: Optio
         inputs = inputs or {}
         values: List[float] = []
         obp, slg, iso, bb, k = (_safe_float(inputs.get(k)) for k in ("on_base_pct", "slugging_pct", "iso", "bb_pct", "k_pct"))
-        if obp is not None: values.append((obp - 0.320) * 1.8)
-        if slg is not None: values.append((slg - 0.410) * 1.1)
-        if iso is not None: values.append((iso - 0.160) * 1.4)
-        if bb is not None and k is not None: values.append((bb - k + 0.140) * 0.7)
+        if obp is not None:
+            values.append((obp - 0.320) * 1.8)
+        if slg is not None:
+            values.append((slg - 0.410) * 1.1)
+        if iso is not None:
+            values.append((iso - 0.160) * 1.4)
+        if bb is not None and k is not None:
+            values.append((bb - k + 0.140) * 0.7)
         return None if not values else sum(values) / len(values)
     home_signal, away_signal = signal(home_inputs), signal(away_inputs)
     missing = []
-    if home_signal is None: missing.append("home_offense_inputs")
-    if away_signal is None: missing.append("away_offense_inputs")
+    if home_signal is None:
+        missing.append("home_offense_inputs")
+    if away_signal is None:
+        missing.append("away_offense_inputs")
     if home_signal is None or away_signal is None:
         return _component(None, COMPONENT_WEIGHTS["batter_vs_arsenal"], "offense_inputs_proxy_until_batter_vs_arsenal_v2", missing_inputs=missing)
     score = 0.5 + max(-0.08, min(0.08, home_signal - away_signal))
@@ -340,7 +544,7 @@ def compute_canonical_matchup_probability(session: Session, home_pitcher_id: int
         "lineup_status": status,
         "data_confidence": confidence,
         "probability_components": components,
-        "pitcher_overview": {"home": _starter_overview(home_pitcher), "away": _starter_overview(away_pitcher)},
+        "pitcher_overview": {"home": _starter_overview(home_pitcher, season=season), "away": _starter_overview(away_pitcher, season=season)},
         "batter_vs_arsenal_schema_version": BATTER_VS_ARSENAL_SCHEMA_VERSION,
         "batter_vs_arsenal_summary": {
             "schema_version": BATTER_VS_ARSENAL_SCHEMA_VERSION,
@@ -352,4 +556,4 @@ def compute_canonical_matchup_probability(session: Session, home_pitcher_id: int
     }
 
 
-__all__ = ["BATTER_VS_ARSENAL_SCHEMA_VERSION", "CANONICAL_MODEL_VERSION", "LEGACY_MODEL_VERSION", "compute_canonical_matchup_probability"]
+__all__ = ["BATTER_VS_ARSENAL_SCHEMA_VERSION", "CANONICAL_MODEL_VERSION", "LEGACY_MODEL_VERSION", "STARTER_OVERVIEW_FIELDS", "compute_canonical_matchup_probability"]


### PR DESCRIPTION
## Summary

This PR enriches the existing starter/pitcher overview payload without redesigning the UI.

The existing matchup payload already exposes:

- `pitcher_overview.home`
- `pitcher_overview.away`

This PR keeps that same contract and expands the backend object so each matchup overview has the requested starter overview fields available to render.

## Files changed

- `mlb_app/canonical_matchup_probability.py`

## What was completed

### DB/current aggregate first

The overview still uses the current matchup pitcher feature payload first for fields already available from `pitcher_aggregates` / Statcast aggregate logic:

- K%
- BB%
- K-BB%
- xwOBA allowed
- xBA allowed
- hard-hit rate allowed
- barrel rate allowed
- average exit velocity allowed
- average launch angle allowed
- whiff rate if present
- CSW rate if present
- average velocity
- average spin rate
- release position X
- release position Z
- release extension
- horizontal movement
- vertical movement
- pitch mix

### MLB Stats API direct-on-load fallback

Added a cached direct-on-load fallback using the official MLB Stats API people endpoint for standard season pitching overview stats when they are not available in the current DB aggregate payload.

The fallback attempts to fill:

- ERA
- WHIP
- wins
- losses
- games pitched
- games started
- strikeouts
- walks
- home runs allowed
- earned runs
- runs allowed
- hits allowed
- innings pitched
- batters faced
- pitches thrown / sample size where available
- HR/9 if supplied by MLB or derivable from HR and IP

This fallback is cached with `lru_cache(maxsize=512)` and is non-fatal. If the MLB API fails, the matchup response still returns and the missing fields are explicitly diagnosed.

### Derived standard metrics when complete inputs exist

Added safe derivations from complete MLB standard stat inputs only:

- K% from strikeouts / batters faced
- BB% from walks / batters faced
- K-BB% from K% and BB%
- HR/9 from HR and IP
- estimated GB% from ground outs / ground outs plus air outs
- estimated FB% from air outs / ground outs plus air outs
- estimated HR/FB from HR / air outs
- BABIP from standard inputs where possible
- estimated LOB% from standard hits, walks, HBP, runs, and HR where possible

Estimated/derived fields are source-labeled so the UI or diagnostics can tell what came from DB, MLB standard stats, or formulas.

### Advanced estimator fields preserved but not fabricated

The requested advanced fields are present in the overview object, but remain null unless a trusted source exists:

- FIP
- xFIP
- SIERA
- xSIERA

They include explicit missing reasons:

- FIP requires HR, BB, HBP, K, IP, and a verified season FIP constant
- xFIP requires fly balls, league HR/FB, BB, HBP, K, IP, and a verified season constant
- SIERA requires documented formula and all input rates
- xSIERA requires an existing internal or trusted external source

No fake FIP/xFIP/SIERA/xSIERA values are generated.

### Release profile enrichment

The overview now includes a fuller release profile:

- arm slot label
- arm slot source
- arm angle if available
- release position X
- release position Z
- release extension
- average horizontal break
- average vertical break
- average velocity
- average spin rate
- pitch mix
- release consistency placeholder
- extension advantage placeholder
- vertical approach angle placeholder

Arm slot is conservatively derived from release position Z only when available and is clearly source-labeled.

### Display-ready metric array

Added `display_metrics` to each starter overview.

This includes every requested overview stat as a stable list of rows:

- key
- label
- value
- source
- available

This lets the existing overview UI render the fields without needing a redesign. Null/missing values remain present in diagnostics but can be hidden by the existing UI if it already hides unavailable values.

### Field count diagnostics

Each starter overview now includes:

- `available_metric_count`
- `requested_metric_count`
- `metric_sources`
- `missing_inputs`
- `overview_source_priority`
- `mlb_stats_api_available`

## Requested fields covered

The `display_metrics` array includes:

- ERA
- FIP
- xFIP
- SIERA
- xSIERA
- K%
- BB%
- K-BB%
- HR/9
- GB%
- FB%
- HR/FB
- BABIP
- LOB%
- xwOBA allowed
- xBA allowed
- hard-hit rate allowed
- barrel rate allowed
- average exit velocity allowed
- average launch angle allowed
- whiff rate
- CSW rate
- pitch count / sample size
- innings pitched
- batters faced
- pitches thrown

## What was intentionally not changed

- No frontend redesign.
- No database schema migration.
- No new DB columns.
- No fabricated advanced metrics.
- No probability blend changes.
- No changes to `home_win_prob` / `away_win_prob` semantics.

## Validation performed

- Confirmed PR #328 was merged before starting.
- Created branch `starter-overview-enrichment` from the merged Model Tracker baseline.
- Confirmed only `mlb_app/canonical_matchup_probability.py` changed.
- Confirmed the new overview fields remain under the existing `pitcher_overview.home` and `pitcher_overview.away` contract.

## Manual validation still needed

- Hit `/matchups?date=YYYY-MM-DD` for a date with probable pitchers.
- Inspect `pitcher_overview.home.display_metrics` and `pitcher_overview.away.display_metrics`.
- Confirm ERA and standard MLB season stats populate when MLB Stats API has the season stat split.
- Confirm DB/Statcast aggregate values populate for K%, BB%, xwOBA, xBA, hard-hit, velocity, spin, and release profile.
- Confirm FIP/xFIP/SIERA/xSIERA stay null unless trusted source inputs exist.
- Confirm the existing overview page does not display fake values.

## Branch note

This branch is ahead by 1 commit and behind current `main` by 2 unrelated commits. The changed file is only `mlb_app/canonical_matchup_probability.py`; the branch may need an update/rebase before merge if GitHub reports a conflict.

## Expected result

Each matchup starter overview now has every requested stat available in the backend payload. Values are filled from current DB/Statcast aggregates first, official MLB season stats second, and safe formula derivations only when the required inputs exist. Missing values are explicit and source-labeled instead of fabricated.