### PR TITLE
Add Layer 6AD bullpen state container prototype

### DIFF
--- a/mlb_app/simulation/bullpen_state.py
+++ b/mlb_app/simulation/bullpen_state.py
@@ -1,0 +1,216 @@
+from dataclasses import asdict
+from dataclasses import dataclass
+from typing import Optional
+
+
+BULLPEN_MODE_OFF = "off"
+
+BULLPEN_MODE_CANDIDATE_LEVERAGE = (
+    "candidate_leverage"
+)
+
+
+VALID_RELIEVER_ROLES = {
+    "closer",
+    "setup",
+    "high_leverage",
+    "middle_relief",
+    "long_relief",
+    "low_leverage",
+    "unknown",
+}
+
+
+VALID_HANDEDNESS = {
+    "L",
+    "R",
+    "S",
+    "unknown",
+}
+
+
+@dataclass
+class BullpenState:
+    team_id: str
+    available_relievers: list
+    used_pitchers: list
+    current_pitcher: Optional[str]
+    fatigue_by_pitcher: dict
+    role_by_pitcher: dict
+    handedness_by_pitcher: dict
+    usage_log: list
+
+
+def create_empty_bullpen_state(
+    team_id: str,
+) -> BullpenState:
+
+    if not isinstance(team_id, str):
+        raise ValueError(
+            "team_id must be a string"
+        )
+
+    if not team_id.strip():
+        raise ValueError(
+            "team_id cannot be empty"
+        )
+
+    return BullpenState(
+        team_id=team_id,
+        available_relievers=[],
+        used_pitchers=[],
+        current_pitcher=None,
+        fatigue_by_pitcher={},
+        role_by_pitcher={},
+        handedness_by_pitcher={},
+        usage_log=[],
+    )
+
+
+def validate_bullpen_state(
+    state: BullpenState,
+) -> bool:
+
+    if not isinstance(
+        state,
+        BullpenState,
+    ):
+        raise ValueError(
+            "state must be BullpenState"
+        )
+
+    if not isinstance(
+        state.team_id,
+        str,
+    ):
+        raise ValueError(
+            "team_id must be string"
+        )
+
+    if not state.team_id.strip():
+        raise ValueError(
+            "team_id cannot be empty"
+        )
+
+    if not isinstance(
+        state.available_relievers,
+        list,
+    ):
+        raise ValueError(
+            "available_relievers must be list"
+        )
+
+    if not isinstance(
+        state.used_pitchers,
+        list,
+    ):
+        raise ValueError(
+            "used_pitchers must be list"
+        )
+
+    if not isinstance(
+        state.usage_log,
+        list,
+    ):
+        raise ValueError(
+            "usage_log must be list"
+        )
+
+    for role in (
+        state.role_by_pitcher.values()
+    ):
+
+        if role not in VALID_RELIEVER_ROLES:
+            raise ValueError(
+                f"invalid role: {role}"
+            )
+
+    for handedness in (
+        state.handedness_by_pitcher.values()
+    ):
+
+        if handedness not in VALID_HANDEDNESS:
+            raise ValueError(
+                f"invalid handedness: "
+                f"{handedness}"
+            )
+
+    for fatigue in (
+        state.fatigue_by_pitcher.values()
+    ):
+
+        if not isinstance(
+            fatigue,
+            (int, float),
+        ):
+            raise ValueError(
+                "fatigue must be numeric"
+            )
+
+        if fatigue < 0.0 or fatigue > 1.0:
+            raise ValueError(
+                "fatigue must be between "
+                "0.0 and 1.0"
+            )
+
+    return True
+
+
+def bullpen_state_to_dict(
+    state: BullpenState,
+) -> dict:
+
+    validate_bullpen_state(state)
+
+    return asdict(state)
+
+
+def bullpen_state_from_dict(
+    payload: dict,
+) -> BullpenState:
+
+    if not isinstance(
+        payload,
+        dict,
+    ):
+        raise ValueError(
+            "payload must be dict"
+        )
+
+    state = BullpenState(
+        team_id=payload.get(
+            "team_id",
+            "",
+        ),
+        available_relievers=payload.get(
+            "available_relievers",
+            [],
+        ),
+        used_pitchers=payload.get(
+            "used_pitchers",
+            [],
+        ),
+        current_pitcher=payload.get(
+            "current_pitcher",
+        ),
+        fatigue_by_pitcher=payload.get(
+            "fatigue_by_pitcher",
+            {},
+        ),
+        role_by_pitcher=payload.get(
+            "role_by_pitcher",
+            {},
+        ),
+        handedness_by_pitcher=payload.get(
+            "handedness_by_pitcher",
+            {},
+        ),
+        usage_log=payload.get(
+            "usage_log",
+            [],
+        ),
+    )
+
+    validate_bullpen_state(state)
+
+    return state

--- a/scripts/audit_bullpen_state_container.py
+++ b/scripts/audit_bullpen_state_container.py
@@ -1,0 +1,375 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from mlb_app.simulation.bullpen_state import (
+    BULLPEN_MODE_CANDIDATE_LEVERAGE,
+    BULLPEN_MODE_OFF,
+    BullpenState,
+    bullpen_state_from_dict,
+    bullpen_state_to_dict,
+    create_empty_bullpen_state,
+    validate_bullpen_state,
+)
+
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "bullpen_state_container_audit.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "bullpen_state_container_checks.csv"
+)
+
+
+PRODUCTION_FILES = [
+    (
+        "mlb_app/simulation/"
+        "game_engine_v2.py"
+    ),
+    (
+        "mlb_app/simulation/"
+        "game_simulation_builder.py"
+    ),
+    (
+        "mlb_app/simulation/"
+        "inning_simulator.py"
+    ),
+]
+
+
+def check_raises(fn):
+
+    try:
+        fn()
+        return False
+
+    except ValueError:
+        return True
+
+
+def main():
+
+    checks = []
+
+    state = create_empty_bullpen_state(
+        "NYY"
+    )
+
+    checks.append(
+        {
+            "check": (
+                "empty_state_valid"
+            ),
+            "passed": (
+                validate_bullpen_state(
+                    state
+                )
+            ),
+            "detail": "validated",
+        }
+    )
+
+    payload = bullpen_state_to_dict(
+        state
+    )
+
+    restored = bullpen_state_from_dict(
+        payload
+    )
+
+    roundtrip_passed = (
+        payload
+        == bullpen_state_to_dict(
+            restored
+        )
+    )
+
+    checks.append(
+        {
+            "check": (
+                "roundtrip_preserves_state"
+            ),
+            "passed": roundtrip_passed,
+            "detail": (
+                "roundtrip_equal"
+            ),
+        }
+    )
+
+    checks.append(
+        {
+            "check": (
+                "invalid_empty_team_rejected"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    create_empty_bullpen_state(
+                        ""
+                    )
+                )
+            ),
+            "detail": (
+                "empty_team"
+            ),
+        }
+    )
+
+    invalid_role_state = (
+        create_empty_bullpen_state(
+            "CHC"
+        )
+    )
+
+    invalid_role_state.role_by_pitcher = {
+        "pitcher": "bad_role"
+    }
+
+    checks.append(
+        {
+            "check": (
+                "invalid_role_rejected"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    validate_bullpen_state(
+                        invalid_role_state
+                    )
+                )
+            ),
+            "detail": "bad_role",
+        }
+    )
+
+    invalid_hand_state = (
+        create_empty_bullpen_state(
+            "LAD"
+        )
+    )
+
+    invalid_hand_state.handedness_by_pitcher = {
+        "pitcher": "X"
+    }
+
+    checks.append(
+        {
+            "check": (
+                "invalid_handedness_rejected"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    validate_bullpen_state(
+                        invalid_hand_state
+                    )
+                )
+            ),
+            "detail": (
+                "bad_handedness"
+            ),
+        }
+    )
+
+    invalid_fatigue_state = (
+        create_empty_bullpen_state(
+            "SEA"
+        )
+    )
+
+    invalid_fatigue_state.fatigue_by_pitcher = {
+        "pitcher": 1.5
+    }
+
+    checks.append(
+        {
+            "check": (
+                "invalid_fatigue_rejected"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    validate_bullpen_state(
+                        invalid_fatigue_state
+                    )
+                )
+            ),
+            "detail": (
+                "fatigue_out_of_bounds"
+            ),
+        }
+    )
+
+    invalid_usage_log = (
+        create_empty_bullpen_state(
+            "BOS"
+        )
+    )
+
+    invalid_usage_log.usage_log = (
+        "bad"
+    )
+
+    checks.append(
+        {
+            "check": (
+                "usage_log_type_checked"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    validate_bullpen_state(
+                        invalid_usage_log
+                    )
+                )
+            ),
+            "detail": (
+                "usage_log_not_list"
+            ),
+        }
+    )
+
+    invalid_lists = (
+        create_empty_bullpen_state(
+            "ATL"
+        )
+    )
+
+    invalid_lists.used_pitchers = (
+        "bad"
+    )
+
+    checks.append(
+        {
+            "check": (
+                "lists_type_checked"
+            ),
+            "passed": check_raises(
+                lambda: (
+                    validate_bullpen_state(
+                        invalid_lists
+                    )
+                )
+            ),
+            "detail": (
+                "used_pitchers_not_list"
+            ),
+        }
+    )
+
+    checks.append(
+        {
+            "check": (
+                "candidate_mode_constants_present"
+            ),
+            "passed": (
+                BULLPEN_MODE_CANDIDATE_LEVERAGE
+                == "candidate_leverage"
+            ),
+            "detail": (
+                BULLPEN_MODE_CANDIDATE_LEVERAGE
+            ),
+        }
+    )
+
+    checks.append(
+        {
+            "check": (
+                "default_mode_off_confirmed"
+            ),
+            "passed": (
+                BULLPEN_MODE_OFF
+                == "off"
+            ),
+            "detail": (
+                BULLPEN_MODE_OFF
+            ),
+        }
+    )
+
+    integration_absent = True
+
+    for file_path in PRODUCTION_FILES:
+
+        path = Path(file_path)
+
+        if not path.exists():
+            continue
+
+        text = path.read_text()
+
+        if "bullpen_state" in text:
+            integration_absent = False
+
+    checks.append(
+        {
+            "check": (
+                "production_integration_absent"
+            ),
+            "passed": (
+                integration_absent
+            ),
+            "detail": (
+                integration_absent
+            ),
+        }
+    )
+
+    checks_df = pd.DataFrame(
+        checks
+    )
+
+    checks_df.to_csv(
+        OUTPUT_CHECKS,
+        index=False,
+    )
+
+    failures = int(
+        (~checks_df["passed"]).sum()
+    )
+
+    payload = {
+        "diagnosis": (
+            "bullpen_state_container_prototype_safe"
+            if failures == 0
+            else (
+                "bullpen_state_container_prototype_failed"
+            )
+        ),
+        "checks_passed": int(
+            checks_df["passed"].sum()
+        ),
+        "checks_failed": failures,
+        "candidate_mode": (
+            BULLPEN_MODE_CANDIDATE_LEVERAGE
+        ),
+        "default_mode": (
+            BULLPEN_MODE_OFF
+        ),
+        "production_integration_absent": (
+            integration_absent
+        ),
+        "recommended_next_step": (
+            "layer_6ae_bullpen_state_initialization_audit"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6AD bullpen state container prototype.

This PR follows Layer 6AC, which defined the safe candidate-only bullpen architecture and selected `bullpen_state_container` as the highest-priority implementation target.

## Why

Before implementing active bullpen sequencing, leverage deployment, fatigue scoring, or reliever selection, the simulator needs a safe state container that can represent candidate-only bullpen state without affecting production behavior.

## What this adds

- `mlb_app/simulation/bullpen_state.py`
- `scripts/audit_bullpen_state_container.py`

## Bullpen state prototype

Adds:

- `BullpenState` dataclass
- `BULLPEN_MODE_OFF = "off"`
- `BULLPEN_MODE_CANDIDATE_LEVERAGE = "candidate_leverage"`
- valid reliever role constants
- valid handedness constants
- `create_empty_bullpen_state(...)`
- `validate_bullpen_state(...)`
- `bullpen_state_to_dict(...)`
- `bullpen_state_from_dict(...)`

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/audit_bullpen_state_container.py
cat tmp/bullpen_state_container_checks.csv
```

Result:

```json
{
  "diagnosis": "bullpen_state_container_prototype_safe",
  "checks_passed": 11,
  "checks_failed": 0,
  "candidate_mode": "candidate_leverage",
  "default_mode": "off",
  "production_integration_absent": true,
  "recommended_next_step": "layer_6ae_bullpen_state_initialization_audit"
}
```

Checks:

```csv
check,passed,detail
empty_state_valid,True,validated
roundtrip_preserves_state,True,roundtrip_equal
invalid_empty_team_rejected,True,empty_team
invalid_role_rejected,True,bad_role
invalid_handedness_rejected,True,bad_handedness
invalid_fatigue_rejected,True,fatigue_out_of_bounds
usage_log_type_checked,True,usage_log_not_list
lists_type_checked,True,used_pitchers_not_list
candidate_mode_constants_present,True,candidate_leverage
default_mode_off_confirmed,True,off
production_integration_absent,True,True
```

## Interpretation

Layer 6AD creates the first candidate-only bullpen state structure while confirming it is not integrated into production simulation files.

This provides the safe foundation for future bullpen initialization and sequencing work.

## Recommended next step

`Layer 6AE — Bullpen State Initialization Audit`

## What this does not do

- Does not modify simulation mechanics
- Does not activate bullpen realism
- Does not add active reliever selection
- Does not add fatigue scoring behavior
- Does not change production/default behavior
- Does not modify UI/routes
- Does not add sportsbook logic