### PR TITLE
Add nightly Statcast refresh and freshness diagnostics

### DIFF
--- a/.github/workflows/nightly-statcast-refresh.yml
+++ b/.github/workflows/nightly-statcast-refresh.yml
@@ -1,0 +1,64 @@
+name: Nightly Statcast Refresh
+
+on:
+  schedule:
+    - cron: '15 8 * * *'
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Optional single date to refresh, YYYY-MM-DD'
+        required: false
+        type: string
+      days:
+        description: 'Recent MLB dates to refresh when date is omitted'
+        required: false
+        default: '2'
+        type: string
+      include_today:
+        description: 'Include current MLB Eastern date'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  refresh-statcast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Compile refresh code
+        run: python -m compileall mlb_app scripts
+
+      - name: Refresh Statcast data
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.date || '' }}" ]; then
+            python scripts/nightly_statcast_refresh.py --date "${{ github.event.inputs.date }}" | tee nightly_statcast_refresh_summary.json
+          else
+            DAYS="${{ github.event.inputs.days || '2' }}"
+            INCLUDE_TODAY="${{ github.event.inputs.include_today || 'true' }}"
+            if [ "$INCLUDE_TODAY" = "true" ]; then
+              python scripts/nightly_statcast_refresh.py --days "$DAYS" --include-today | tee nightly_statcast_refresh_summary.json
+            else
+              python scripts/nightly_statcast_refresh.py --days "$DAYS" | tee nightly_statcast_refresh_summary.json
+            fi
+          fi
+
+      - name: Upload refresh summary
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nightly-statcast-refresh-summary
+          path: nightly_statcast_refresh_summary.json
+          if-no-files-found: ignore

--- a/docs/statcast_refresh.md
+++ b/docs/statcast_refresh.md
@@ -1,0 +1,85 @@
+# Statcast Refresh and Data Freshness
+
+This app does not refresh Statcast data during normal user requests. The leaderboard, pitcher overview, and matchup detail pitcher sections are read paths over stored database rows.
+
+## Why this exists
+
+Pitcher overview and batter leaderboard cards can look empty or stale when the production database has not been refreshed. PR #330 enriched the starter overview payload, but that change does not fetch Statcast rows or create database aggregates by itself. It reads existing DB-backed fields first, uses MLB Stats API fallback for standard season pitching stats, and intentionally keeps FIP, xFIP, SIERA, and xSIERA null unless trusted inputs exist.
+
+## Nightly command
+
+The production refresh command is:
+
+```bash
+python scripts/nightly_statcast_refresh.py --days 2 --include-today
+```
+
+This is wired through `.github/workflows/nightly-statcast-refresh.yml` and can also be triggered manually through GitHub Actions.
+
+## Required production secret
+
+The workflow requires:
+
+```text
+DATABASE_URL
+```
+
+The refresh script refuses to silently use local SQLite unless `--allow-sqlite-local` is passed explicitly for local validation.
+
+## Tables refreshed
+
+The refresh job uses the existing ETL logic in `mlb_app/etl.py` and updates the surfaces the app already reads:
+
+- `statcast_events` for pitch-level Statcast rows used by pitcher/batter rolling views and batter leaderboards.
+- `pitcher_aggregates` for DB-first pitcher overview and matchup detail pitcher cards.
+- `pitch_arsenal` for current-season pitch mix, usage, whiff, xwOBA, and hard-hit context.
+- `team_splits` for matchup offense inputs and split fallback context.
+
+## Read-only surfaces
+
+These endpoints should not run live Statcast pulls:
+
+- `/batters/leaderboards`
+- `/batter/{id}/profile`
+- `/batter/{id}/rolling/*`
+- `/matchups`
+- `/matchup/{game_pk}`
+
+The right fix for stale data is the scheduled refresh job, not request-time scraping.
+
+## Freshness endpoint
+
+Use this endpoint to inspect production DB freshness without triggering ETL:
+
+```text
+GET /data/freshness
+```
+
+It returns:
+
+- latest Statcast event date
+- Statcast days stale
+- latest pitcher aggregate date
+- pitcher aggregate days stale
+- latest batter leaderboard source date
+- batter leaderboard days stale
+- current-season pitch arsenal count
+- current-season batter terminal row count
+- database URL type without exposing secrets
+- status: `fresh`, `stale`, or `empty`
+- warnings
+
+## Matchup detail pitcher overview
+
+The matchup detail page should show the enriched pitcher overview/profile data when a user clicks into a game. The implementation should not be rebuilt from scratch. The production problem is wiring, deployment, and data freshness: `/matchup/{game_pk}` must return the enriched pitcher fields already supported by the backend, the frontend must read the correct fields, and the nightly refresh must keep the underlying Statcast/PitcherAggregate/PitchArsenal data current.
+
+## Preservation rules
+
+Do not change these contracts as part of refresh work:
+
+- `home_win_prob`
+- `away_win_prob`
+- canonical matchup probability behavior
+- PR #330 DB-first starter overview enrichment
+- null/missing handling for FIP, xFIP, SIERA, and xSIERA
+- existing matchup detail route shape except for backward-compatible diagnostics

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -165,6 +165,15 @@ def _aggregate_to_dict(agg) -> Optional[Dict[str, Any]]:
     }
 
 
+@router.get("/data/freshness")
+def data_freshness() -> Dict[str, Any]:
+    from .data_freshness import build_data_freshness_payload
+
+    Session = _get_session()
+    with Session() as session:
+        return build_data_freshness_payload(session)
+
+
 @router.get("/batters/leaderboards")
 def batters_leaderboards(
     season: Optional[int] = None,

--- a/mlb_app/data_freshness.py
+++ b/mlb_app/data_freshness.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .database import BatterAggregate, PitchArsenal, PitcherAggregate, StatcastEvent
+from .db_utils import TERMINAL_EVENTS
+
+
+def _iso(value: Optional[Any]) -> Optional[str]:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _days_stale(value: Optional[dt.date], as_of: dt.date) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        value = value.date()
+    return (as_of - value).days
+
+
+def _db_type(database_url: Optional[str] = None) -> str:
+    raw = database_url or os.getenv("DATABASE_URL") or "sqlite:///mlb.db"
+    lowered = raw.lower()
+    if lowered.startswith(("postgresql", "postgres")):
+        return "postgresql"
+    if lowered.startswith("sqlite"):
+        return "sqlite"
+    return "other" if raw else "missing"
+
+
+def build_data_freshness_payload(session: Session, database_url: Optional[str] = None, as_of: Optional[dt.date] = None) -> Dict[str, Any]:
+    as_of = as_of or dt.date.today()
+    season = as_of.year
+    season_start = dt.date(season, 1, 1)
+    season_end = dt.date(season, 12, 31)
+
+    latest_statcast = session.query(func.max(StatcastEvent.game_date)).scalar()
+    latest_pitcher_agg = session.query(func.max(PitcherAggregate.end_date)).scalar()
+    latest_batter_agg = session.query(func.max(BatterAggregate.end_date)).scalar()
+    latest_batter_board = (
+        session.query(func.max(StatcastEvent.game_date))
+        .filter(
+            StatcastEvent.game_date >= season_start,
+            StatcastEvent.game_date <= season_end,
+            StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.events.in_(list(TERMINAL_EVENTS)),
+        )
+        .scalar()
+    )
+
+    pitch_arsenal_count = (
+        session.query(func.count(PitchArsenal.id)).filter(PitchArsenal.season == season).scalar() or 0
+    )
+    batter_terminal_rows = (
+        session.query(func.count(StatcastEvent.id))
+        .filter(
+            StatcastEvent.game_date >= season_start,
+            StatcastEvent.game_date <= season_end,
+            StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.events.in_(list(TERMINAL_EVENTS)),
+        )
+        .scalar()
+        or 0
+    )
+    statcast_rows = (
+        session.query(func.count(StatcastEvent.id))
+        .filter(StatcastEvent.game_date >= season_start, StatcastEvent.game_date <= season_end)
+        .scalar()
+        or 0
+    )
+
+    statcast_days = _days_stale(latest_statcast, as_of)
+    pitcher_days = _days_stale(latest_pitcher_agg, as_of)
+    batter_board_days = _days_stale(latest_batter_board, as_of)
+    batter_agg_days = _days_stale(latest_batter_agg, as_of)
+
+    warnings = []
+    if statcast_days is None:
+        warnings.append("No StatcastEvent rows found.")
+    elif statcast_days > 2:
+        warnings.append(f"StatcastEvent data is stale by {statcast_days} days.")
+    if pitcher_days is None:
+        warnings.append("No PitcherAggregate rows found.")
+    elif pitcher_days > 2:
+        warnings.append(f"PitcherAggregate data is stale by {pitcher_days} days.")
+    if batter_board_days is None:
+        warnings.append("No current-season terminal batter Statcast rows found for leaderboards.")
+    elif batter_board_days > 2:
+        warnings.append(f"Batter leaderboard source rows are stale by {batter_board_days} days.")
+    if pitch_arsenal_count == 0:
+        warnings.append("No current-season PitchArsenal rows found.")
+
+    if latest_statcast is None and latest_pitcher_agg is None:
+        status = "empty"
+    elif any(days is not None and days > 2 for days in (statcast_days, pitcher_days, batter_board_days)):
+        status = "stale"
+    else:
+        status = "fresh"
+
+    return {
+        "status": status,
+        "as_of_date": as_of.isoformat(),
+        "season": season,
+        "database_url_type": _db_type(database_url),
+        "latest_statcast_event_date": _iso(latest_statcast),
+        "statcast_days_stale": statcast_days,
+        "pitcher_aggregate_latest_end_date": _iso(latest_pitcher_agg),
+        "pitcher_aggregate_days_stale": pitcher_days,
+        "batter_aggregate_latest_end_date": _iso(latest_batter_agg),
+        "batter_aggregate_days_stale": batter_agg_days,
+        "batter_leaderboard_latest_event_date": _iso(latest_batter_board),
+        "batter_leaderboard_days_stale": batter_board_days,
+        "pitch_arsenal_current_season_count": int(pitch_arsenal_count),
+        "current_season_batter_terminal_rows": int(batter_terminal_rows),
+        "current_season_statcast_rows": int(statcast_rows),
+        "warnings": warnings,
+    }
+
+
+__all__ = ["build_data_freshness_payload"]

--- a/scripts/nightly_statcast_refresh.py
+++ b/scripts/nightly_statcast_refresh.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
+
+try:
+    from dotenv import load_dotenv
+except Exception:
+    load_dotenv = None
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if load_dotenv is not None:
+    load_dotenv(ROOT / ".env")
+
+from sqlalchemy import func
+
+from mlb_app.data_freshness import build_data_freshness_payload
+from mlb_app.database import PitchArsenal, PitcherAggregate, StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.db_utils import TERMINAL_EVENTS
+from mlb_app.etl import run_etl_for_date
+
+MLB_TZ = ZoneInfo("America/New_York")
+
+
+def _today_mlb() -> dt.date:
+    return dt.datetime.now(MLB_TZ).date()
+
+
+def resolve_target_dates(date_arg: Optional[str], days: int, include_today: bool) -> List[str]:
+    if date_arg:
+        dt.date.fromisoformat(date_arg)
+        return [date_arg]
+
+    today = _today_mlb()
+    dates: List[dt.date] = []
+
+    if days <= 0:
+        dates.append(today - dt.timedelta(days=1))
+    else:
+        end_offset = 0 if include_today else 1
+        for offset in range(days - 1 + end_offset, end_offset - 1, -1):
+            dates.append(today - dt.timedelta(days=offset))
+
+    if include_today and today not in dates:
+        dates.append(today)
+
+    deduped = []
+    for value in dates:
+        iso = value.isoformat()
+        if iso not in deduped:
+            deduped.append(iso)
+    return deduped
+
+
+def _database_url(allow_sqlite_local: bool) -> str:
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    if allow_sqlite_local:
+        return "sqlite:///mlb.db"
+    raise RuntimeError("DATABASE_URL is required for nightly Statcast refresh. Use --allow-sqlite-local only for local validation.")
+
+
+def _rows_for_date(session, date_str: str) -> int:
+    target = dt.date.fromisoformat(date_str)
+    return session.query(func.count(StatcastEvent.id)).filter(StatcastEvent.game_date == target).scalar() or 0
+
+
+def _validation_summary(database_url: str, dates: List[str]) -> Dict[str, Any]:
+    engine = get_engine(database_url)
+    create_tables(engine)
+    Session = get_session(engine)
+    season = _today_mlb().year
+    recent_cutoff = _today_mlb() - dt.timedelta(days=7)
+
+    with Session() as session:
+        freshness = build_data_freshness_payload(session, database_url=database_url, as_of=_today_mlb())
+        statcast_rows_by_date = {date_str: _rows_for_date(session, date_str) for date_str in dates}
+        recent_pitcher_aggregate_count = (
+            session.query(func.count(PitcherAggregate.id))
+            .filter(PitcherAggregate.end_date >= recent_cutoff)
+            .scalar()
+            or 0
+        )
+        current_season_pitch_arsenal_count = (
+            session.query(func.count(PitchArsenal.id)).filter(PitchArsenal.season == season).scalar() or 0
+        )
+        current_season_batter_terminal_rows = (
+            session.query(func.count(StatcastEvent.id))
+            .filter(
+                StatcastEvent.game_date >= dt.date(season, 1, 1),
+                StatcastEvent.game_date <= dt.date(season, 12, 31),
+                StatcastEvent.batter_id.isnot(None),
+                StatcastEvent.events.in_(list(TERMINAL_EVENTS)),
+            )
+            .scalar()
+            or 0
+        )
+
+    return {
+        "freshness": freshness,
+        "latest_statcast_event_date": freshness.get("latest_statcast_event_date"),
+        "statcast_rows_by_date": statcast_rows_by_date,
+        "recent_pitcher_aggregate_count": int(recent_pitcher_aggregate_count),
+        "current_season_pitch_arsenal_count": int(current_season_pitch_arsenal_count),
+        "current_season_batter_terminal_rows": int(current_season_batter_terminal_rows),
+    }
+
+
+def run_refresh(date_arg: Optional[str], days: int, include_today: bool, allow_sqlite_local: bool, validate_only: bool = False) -> Dict[str, Any]:
+    database_url = _database_url(allow_sqlite_local)
+    os.environ["DATABASE_URL"] = database_url
+    dates = resolve_target_dates(date_arg, days, include_today)
+
+    errors: List[Dict[str, str]] = []
+    refreshed: List[str] = []
+
+    if not validate_only:
+        for date_str in dates:
+            try:
+                run_etl_for_date(date_str)
+                refreshed.append(date_str)
+            except Exception as exc:
+                errors.append({"date": date_str, "type": exc.__class__.__name__, "message": str(exc)})
+
+    validation = _validation_summary(database_url, dates)
+    warnings = list((validation.get("freshness") or {}).get("warnings") or [])
+    if validate_only:
+        warnings.append("validate_only=true; no ETL refresh was executed.")
+
+    status = "ok"
+    if errors and not refreshed and not validate_only:
+        status = "error"
+    elif errors:
+        status = "partial"
+    elif (validation.get("freshness") or {}).get("status") in {"stale", "empty"}:
+        status = "warning"
+
+    return {
+        "status": status,
+        "validate_only": validate_only,
+        "dates_requested": dates,
+        "dates_refreshed": refreshed,
+        "latest_statcast_event_date": validation.get("latest_statcast_event_date"),
+        "statcast_rows_by_date": validation.get("statcast_rows_by_date"),
+        "recent_pitcher_aggregate_count": validation.get("recent_pitcher_aggregate_count"),
+        "current_season_pitch_arsenal_count": validation.get("current_season_pitch_arsenal_count"),
+        "current_season_batter_terminal_rows": validation.get("current_season_batter_terminal_rows"),
+        "freshness": validation.get("freshness"),
+        "warnings": warnings,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Refresh Statcast-backed MLB data for production UI surfaces.")
+    parser.add_argument("--date", help="Refresh one date in YYYY-MM-DD format")
+    parser.add_argument("--days", type=int, default=2, help="Number of recent MLB dates to refresh when --date is omitted")
+    parser.add_argument("--include-today", action="store_true", help="Include the current MLB Eastern date")
+    parser.add_argument("--allow-sqlite-local", action="store_true", help="Allow sqlite:///mlb.db fallback for local validation")
+    parser.add_argument("--validate-only", action="store_true", help="Only inspect DB freshness without running ETL")
+    args = parser.parse_args()
+
+    try:
+        result = run_refresh(
+            date_arg=args.date,
+            days=args.days,
+            include_today=args.include_today,
+            allow_sqlite_local=args.allow_sqlite_local,
+            validate_only=args.validate_only,
+        )
+    except Exception as exc:
+        result = {
+            "status": "error",
+            "errors": [{"type": exc.__class__.__name__, "message": str(exc)}],
+            "warnings": [],
+        }
+        print(json.dumps(result, indent=2, sort_keys=True, default=str))
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True, default=str))
+    return 1 if result.get("status") == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nightly_statcast_refresh.py
+++ b/tests/test_nightly_statcast_refresh.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "nightly_statcast_refresh.py"
+spec = importlib.util.spec_from_file_location("nightly_statcast_refresh", MODULE_PATH)
+nightly = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(nightly)
+
+
+def test_resolve_target_dates_single_date():
+    assert nightly.resolve_target_dates("2026-05-19", days=2, include_today=True) == ["2026-05-19"]
+
+
+def test_resolve_target_dates_rejects_bad_date():
+    try:
+        nightly.resolve_target_dates("2026-99-99", days=2, include_today=True)
+    except ValueError:
+        return
+    raise AssertionError("Expected invalid date to raise ValueError")
+
+
+def test_database_url_requires_explicit_local_fallback(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    try:
+        nightly._database_url(allow_sqlite_local=False)
+    except RuntimeError as exc:
+        assert "DATABASE_URL is required" in str(exc)
+        return
+    raise AssertionError("Expected missing DATABASE_URL to raise RuntimeError")
+
+
+def test_database_url_allows_sqlite_for_local_validation(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert nightly._database_url(allow_sqlite_local=True) == "sqlite:///mlb.db"


### PR DESCRIPTION
## Summary

This PR productionizes the missing Statcast refresh path without changing the canonical matchup model or rebuilding the matchup detail page.

It adds a nightly DB refresh job for the Statcast-backed data surfaces that already power:

- Daily Matchups pitcher overview
- Matchup detail pitcher overview/profile data
- Pitcher aggregates
- Pitch arsenal cards
- Batter leaderboard source rows

The key distinction: PR #330 is preserved as a DB-first display/enrichment layer. This PR does not change `mlb_app/canonical_matchup_probability.py`, `home_win_prob`, `away_win_prob`, or canonical probability behavior.

## What changed

### New nightly refresh script

Added:

```text
scripts/nightly_statcast_refresh.py
```

The script:

- loads `.env` when present
- requires `DATABASE_URL` by default
- only allows SQLite fallback with `--allow-sqlite-local`
- resolves MLB Eastern target dates
- supports `--date`, `--days`, `--include-today`, and `--validate-only`
- calls existing `run_etl_for_date(...)`
- validates DB state after refresh
- prints JSON summary including row counts, latest event dates, warnings, and errors

### New scheduled GitHub Actions workflow

Added:

```text
.github/workflows/nightly-statcast-refresh.yml
```

It runs nightly at 08:15 UTC and supports manual dispatch. It installs dependencies, compiles `mlb_app` and `scripts`, then runs:

```text
python scripts/nightly_statcast_refresh.py --days 2 --include-today
```

It requires `DATABASE_URL` in GitHub Actions secrets and uploads the JSON refresh summary as an artifact.

### New read-only freshness diagnostics

Added:

```text
mlb_app/data_freshness.py
GET /data/freshness
```

This endpoint is exposed through the existing included batter router, so `mlb_app/app.py` remains untouched.

It reports:

- latest Statcast event date
- Statcast days stale
- latest pitcher aggregate date
- pitcher aggregate days stale
- latest batter leaderboard source date
- batter leaderboard days stale
- current-season pitch arsenal count
- current-season batter terminal row count
- database URL type without secrets
- status: `fresh`, `stale`, or `empty`
- warnings

It never triggers ETL or external network calls.

### Docs and tests

Added:

```text
docs/statcast_refresh.md
tests/test_nightly_statcast_refresh.py
```

The docs explain that `/batters/leaderboards` is read-only and that stale leaderboard/pitcher overview data should be fixed through the nightly refresh job, not request-time scraping.

## Files changed

- `.github/workflows/nightly-statcast-refresh.yml`
- `docs/statcast_refresh.md`
- `mlb_app/batter_routes.py`
- `mlb_app/data_freshness.py`
- `scripts/nightly_statcast_refresh.py`
- `tests/test_nightly_statcast_refresh.py`

## Safety notes

Preserved:

- existing `/matchup/{game_pk}` route
- existing `/matchups` contract
- `home_win_prob` and `away_win_prob`
- PR #330 DB-first starter overview enrichment
- null handling for FIP, xFIP, SIERA, and xSIERA
- request-time read-only behavior for leaderboards

Not changed:

- `mlb_app/app.py`
- `mlb_app/canonical_matchup_probability.py`
- frontend matchup detail page layout
- canonical probability blend

## Validation performed

- Compared branch against `main`: 6 files changed, 6 commits ahead, 0 behind.
- Added compile step to the new workflow: `python -m compileall mlb_app scripts`.
- Added tests for target date resolution and safe DATABASE_URL behavior.

## Manual validation after merge

1. Confirm GitHub Actions secret `DATABASE_URL` exists.
2. Manually run `Nightly Statcast Refresh` from Actions.
3. Inspect the uploaded `nightly-statcast-refresh-summary` artifact.
4. Hit production:

```text
/data/freshness
```

5. Confirm `latest_statcast_event_date`, `pitcher_aggregate_latest_end_date`, and `batter_leaderboard_latest_event_date` are current.
6. Open Daily Matchups and click into a game. Confirm matchup detail pitcher overview/profile sections show populated data when valid DB/API data exists and clean diagnostics when missing.

## Note

A full README replacement was blocked by the connector safety layer during implementation, so the refresh contract is documented in `docs/statcast_refresh.md` instead. The README can be linked to this doc in a follow-up if needed.