### PR TITLE
Fix date-wide Statcast refresh and idempotent event upserts

### DIFF
--- a/docs/statcast_refresh.md
+++ b/docs/statcast_refresh.md
@@ -1,18 +1,22 @@
 # Statcast Refresh and Data Freshness
 
-This app does not refresh Statcast data during normal user requests. The leaderboard, pitcher overview, and matchup detail pitcher sections are read paths over stored database rows.
+This app does not refresh Statcast data during normal user requests. The leaderboard, pitcher overview, pitcher recent-outing, rolling-stat, and matchup detail sections are read paths over stored database rows.
 
 ## Why this exists
 
 Pitcher overview and batter leaderboard cards can look empty or stale when the production database has not been refreshed. PR #330 enriched the starter overview payload, but that change does not fetch Statcast rows or create database aggregates by itself. It reads existing DB-backed fields first, uses MLB Stats API fallback for standard season pitching stats, and intentionally keeps FIP, xFIP, SIERA, and xSIERA null unless trusted inputs exist.
+
+The shared root table for Batter leaderboards, Batter data-quality latest event dates, Pitcher Recent Outings, pitcher rolling stats, batter rolling stats, and Statcast fallback context is `statcast_events`. Refreshing only the day's probable starters is not enough because it misses relievers, actual non-probable starters, all hitters, and any game rows not represented by probable-pitcher schedule metadata.
 
 ## Nightly command
 
 The production refresh command is:
 
 ```bash
-python scripts/nightly_statcast_refresh.py --days 2 --include-today
+python scripts/nightly_statcast_refresh.py --days 10 --include-today
 ```
+
+The script defaults to a 10-day rolling overlap when `--days` is omitted. The overlap is intentional: it handles late Statcast availability, late-night games, missed cron windows, doubleheaders, and rows that become complete after the first ingest.
 
 This command should run as a Railway cron job or Railway scheduled service so it executes inside the Railway environment that already has the production `DATABASE_URL`. Do not use GitHub Actions for this job unless a separate GitHub Actions database secret is intentionally created.
 
@@ -23,7 +27,7 @@ Create a Railway cron or scheduled job attached to the same project/environment 
 Command:
 
 ```bash
-python scripts/nightly_statcast_refresh.py --days 2 --include-today
+python scripts/nightly_statcast_refresh.py --days 10 --include-today
 ```
 
 Required environment:
@@ -34,14 +38,28 @@ DATABASE_URL
 
 Railway already provides `DATABASE_URL` to services in the environment when the database is attached. The refresh script refuses to silently use local SQLite unless `--allow-sqlite-local` is passed explicitly for local validation.
 
+## Refresh behavior
+
+The refresh job now uses date-wide Statcast ingestion for each target date. It fetches all pitch-level Statcast rows for the date, not just the probable pitchers from the schedule.
+
+`statcast_events` is updated idempotently:
+
+- primary pitch identity: `game_pk + at_bat_number + pitch_number + pitcher_id + batter_id`
+- fallback identity for incomplete rows: `game_date + pitcher_id + batter_id + pitch_type + events + release_speed + launch_speed + launch_angle + balls + strikes + inning + inning_topbot + outs_when_up`
+- existing rows are updated with better non-null values
+- rerunning the same date should be mostly no-op/update, not duplicate inserts
+- the refresh does not delete or rebuild the full season
+
 ## Tables refreshed
 
-The refresh job uses the existing ETL logic in `mlb_app/etl.py` and updates the surfaces the app already reads:
+The refresh job uses the ETL logic in `mlb_app/etl.py` and updates the surfaces the app already reads:
 
-- `statcast_events` for pitch-level Statcast rows used by pitcher/batter rolling views and batter leaderboards.
-- `pitcher_aggregates` for DB-first pitcher overview and matchup detail pitcher cards.
+- `statcast_events` for pitch-level Statcast rows used by pitcher/batter rolling views, Batter leaderboards, Pitcher Recent Outings, ordered at-bats, and H2H fallback.
+- `pitcher_aggregates` for DB-first pitcher overview, matchup detail pitcher cards, model projections, and starter overview.
+- `batter_aggregates` for Batter profile aggregate cards and multi-season Batter views.
 - `pitch_arsenal` for current-season pitch mix, usage, whiff, xwOBA, and hard-hit context.
 - `team_splits` for matchup offense inputs and split fallback context.
+- `batter_pitch_type_matchups` remains the Stored 365 / Batter vs Arsenal table and should be refreshed after base `statcast_events` is current.
 
 ## Read-only surfaces
 
@@ -50,8 +68,11 @@ These endpoints should not run live Statcast pulls:
 - `/batters/leaderboards`
 - `/batter/{id}/profile`
 - `/batter/{id}/rolling/*`
+- `/pitcher/{id}`
+- `/pitcher/{id}/rolling`
 - `/matchups`
 - `/matchup/{game_pk}`
+- `/matchup/{game_pk}/competitive`
 
 The right fix for stale data is the scheduled refresh job, not request-time scraping.
 
@@ -66,13 +87,18 @@ GET /data/freshness
 It returns:
 
 - latest Statcast event date
-- Statcast days stale
+- latest pitcher event date
+- latest batter event date
+- Statcast, pitcher-event, and batter-event days stale
 - latest pitcher aggregate date
-- pitcher aggregate days stale
+- latest batter aggregate date
 - latest batter leaderboard source date
-- batter leaderboard days stale
 - current-season pitch arsenal count
 - current-season batter terminal row count
+- current-season Statcast row count
+- distinct pitchers with rows in the last 7 days
+- distinct batters with rows in the last 7 days
+- latest Stored 365 / BatterPitchTypeMatchup refresh timestamp
 - database URL type without exposing secrets
 - status: `fresh`, `stale`, or `empty`
 - warnings

--- a/mlb_app/data_freshness.py
+++ b/mlb_app/data_freshness.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from .database import BatterAggregate, PitchArsenal, PitcherAggregate, StatcastEvent
+from .database import BatterAggregate, BatterPitchTypeMatchup, PitchArsenal, PitcherAggregate, StatcastEvent
 from .db_utils import TERMINAL_EVENTS
 
 
@@ -42,10 +42,22 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
     season = as_of.year
     season_start = dt.date(season, 1, 1)
     season_end = dt.date(season, 12, 31)
+    recent_cutoff = as_of - dt.timedelta(days=7)
 
     latest_statcast = session.query(func.max(StatcastEvent.game_date)).scalar()
+    latest_pitcher_event = (
+        session.query(func.max(StatcastEvent.game_date))
+        .filter(StatcastEvent.pitcher_id.isnot(None), StatcastEvent.pitcher_id != 0)
+        .scalar()
+    )
+    latest_batter_event = (
+        session.query(func.max(StatcastEvent.game_date))
+        .filter(StatcastEvent.batter_id.isnot(None), StatcastEvent.batter_id != 0)
+        .scalar()
+    )
     latest_pitcher_agg = session.query(func.max(PitcherAggregate.end_date)).scalar()
     latest_batter_agg = session.query(func.max(BatterAggregate.end_date)).scalar()
+    latest_stored_365_refresh = session.query(func.max(BatterPitchTypeMatchup.refreshed_at)).scalar()
     latest_batter_board = (
         session.query(func.max(StatcastEvent.game_date))
         .filter(
@@ -77,8 +89,30 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
         .scalar()
         or 0
     )
+    recent_distinct_pitcher_count_7d = (
+        session.query(func.count(func.distinct(StatcastEvent.pitcher_id)))
+        .filter(
+            StatcastEvent.game_date >= recent_cutoff,
+            StatcastEvent.pitcher_id.isnot(None),
+            StatcastEvent.pitcher_id != 0,
+        )
+        .scalar()
+        or 0
+    )
+    recent_distinct_batter_count_7d = (
+        session.query(func.count(func.distinct(StatcastEvent.batter_id)))
+        .filter(
+            StatcastEvent.game_date >= recent_cutoff,
+            StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.batter_id != 0,
+        )
+        .scalar()
+        or 0
+    )
 
     statcast_days = _days_stale(latest_statcast, as_of)
+    pitcher_event_days = _days_stale(latest_pitcher_event, as_of)
+    batter_event_days = _days_stale(latest_batter_event, as_of)
     pitcher_days = _days_stale(latest_pitcher_agg, as_of)
     batter_board_days = _days_stale(latest_batter_board, as_of)
     batter_agg_days = _days_stale(latest_batter_agg, as_of)
@@ -88,6 +122,14 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
         warnings.append("No StatcastEvent rows found.")
     elif statcast_days > 2:
         warnings.append(f"StatcastEvent data is stale by {statcast_days} days.")
+    if pitcher_event_days is None:
+        warnings.append("No pitcher StatcastEvent rows found.")
+    elif pitcher_event_days > 2:
+        warnings.append(f"Pitcher StatcastEvent rows are stale by {pitcher_event_days} days.")
+    if batter_event_days is None:
+        warnings.append("No batter StatcastEvent rows found.")
+    elif batter_event_days > 2:
+        warnings.append(f"Batter StatcastEvent rows are stale by {batter_event_days} days.")
     if pitcher_days is None:
         warnings.append("No PitcherAggregate rows found.")
     elif pitcher_days > 2:
@@ -101,7 +143,10 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
 
     if latest_statcast is None and latest_pitcher_agg is None:
         status = "empty"
-    elif any(days is not None and days > 2 for days in (statcast_days, pitcher_days, batter_board_days)):
+    elif any(
+        days is not None and days > 2
+        for days in (statcast_days, pitcher_event_days, batter_event_days, pitcher_days, batter_board_days)
+    ):
         status = "stale"
     else:
         status = "fresh"
@@ -113,6 +158,10 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
         "database_url_type": _db_type(database_url),
         "latest_statcast_event_date": _iso(latest_statcast),
         "statcast_days_stale": statcast_days,
+        "latest_pitcher_event_date": _iso(latest_pitcher_event),
+        "pitcher_event_days_stale": pitcher_event_days,
+        "latest_batter_event_date": _iso(latest_batter_event),
+        "batter_event_days_stale": batter_event_days,
         "pitcher_aggregate_latest_end_date": _iso(latest_pitcher_agg),
         "pitcher_aggregate_days_stale": pitcher_days,
         "batter_aggregate_latest_end_date": _iso(latest_batter_agg),
@@ -122,6 +171,9 @@ def build_data_freshness_payload(session: Session, database_url: Optional[str] =
         "pitch_arsenal_current_season_count": int(pitch_arsenal_count),
         "current_season_batter_terminal_rows": int(batter_terminal_rows),
         "current_season_statcast_rows": int(statcast_rows),
+        "recent_distinct_pitcher_count_7d": int(recent_distinct_pitcher_count_7d),
+        "recent_distinct_batter_count_7d": int(recent_distinct_batter_count_7d),
+        "latest_batter_pitch_type_matchup_refresh": _iso(latest_stored_365_refresh),
         "warnings": warnings,
     }
 

--- a/mlb_app/etl.py
+++ b/mlb_app/etl.py
@@ -15,11 +15,12 @@ import argparse
 import logging
 import os
 from datetime import date, datetime, timedelta
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import requests
 from dotenv import load_dotenv
+from sqlalchemy import and_, func, or_
 
 from .database import (
     get_engine,
@@ -36,6 +37,7 @@ from .statsapi_cache import fetch_json_with_cache, make_cache_key
 from .statcast_utils import (
     fetch_statcast_pitcher_data,
     fetch_statcast_batter_data,
+    fetch_statcast_all_events,
     fetch_pitch_arsenal_leaderboard,
     calculate_pitcher_aggregates,
     calculate_batter_aggregates,
@@ -169,6 +171,201 @@ def _safe_str(val, max_len: int) -> Optional[str]:
     return text[:max_len] if text else None
 
 
+def _clean_short_text(value: Any, max_len: int) -> Optional[str]:
+    if value is None or pd.isna(value):
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"nan", "none", "null", "na", "n/a"}:
+        return None
+    return text[:max_len]
+
+
+def _row_game_date(row: pd.Series) -> Optional[date]:
+    value = row.get("game_date")
+    if value is None or pd.isna(value):
+        return None
+    try:
+        return pd.to_datetime(value).date()
+    except Exception:
+        return None
+
+
+def _row_pitcher_id(row: pd.Series, fallback_pitcher_id: Optional[int] = None) -> int:
+    for key in ("pitcher", "pitcher_id", "player_id"):
+        value = _safe_int(row.get(key))
+        if value:
+            return value
+    return int(fallback_pitcher_id or 0)
+
+
+def _row_batter_id(row: pd.Series) -> int:
+    for key in ("batter", "batter_id"):
+        value = _safe_int(row.get(key))
+        if value:
+            return value
+    return 0
+
+
+def _event_values_from_row(row: pd.Series, fallback_pitcher_id: Optional[int] = None) -> Dict[str, Any]:
+    return {
+        "game_date": _row_game_date(row),
+        "game_pk": _safe_int(row.get("game_pk")),
+        "at_bat_number": _safe_int(row.get("at_bat_number")),
+        "pitch_number": _safe_int(row.get("pitch_number")),
+        "inning": _safe_int(row.get("inning")),
+        "inning_topbot": _safe_str(row.get("inning_topbot"), 10),
+        "outs_when_up": _safe_int(row.get("outs_when_up")),
+        "home_team": _safe_str(row.get("home_team"), 10),
+        "away_team": _safe_str(row.get("away_team"), 10),
+        "pitcher_id": _row_pitcher_id(row, fallback_pitcher_id),
+        "batter_id": _row_batter_id(row),
+        "pitch_type": _clean_short_text(row.get("pitch_type"), 5),
+        "release_speed": _safe_float(row.get("release_speed")),
+        "release_spin_rate": _safe_float(row.get("release_spin_rate")),
+        "pfx_x": _safe_float(row.get("pfx_x")),
+        "pfx_z": _safe_float(row.get("pfx_z")),
+        "plate_x": _safe_float(row.get("plate_x")),
+        "plate_z": _safe_float(row.get("plate_z")),
+        "balls": _safe_int(row.get("balls")),
+        "strikes": _safe_int(row.get("strikes")),
+        "events": _clean_short_text(row.get("events"), 50),
+        "description": _safe_str(row.get("description"), 60),
+        "launch_speed": _safe_float(row.get("launch_speed")),
+        "launch_angle": _safe_float(row.get("launch_angle")),
+        "estimated_woba_using_speedangle": _safe_float(row.get("estimated_woba_using_speedangle")),
+        "estimated_ba_using_speedangle": _safe_float(row.get("estimated_ba_using_speedangle")),
+        "stand": _clean_short_text(row.get("stand"), 1),
+        "p_throws": _clean_short_text(row.get("p_throws"), 1),
+    }
+
+
+def _primary_pitch_identity(values: Dict[str, Any]) -> Optional[Tuple[Any, ...]]:
+    required = (
+        values.get("game_pk"),
+        values.get("at_bat_number"),
+        values.get("pitch_number"),
+        values.get("pitcher_id"),
+        values.get("batter_id"),
+    )
+    if all(value is not None for value in required):
+        return required
+    return None
+
+
+def _find_existing_statcast_event(session, values: Dict[str, Any]) -> Optional[StatcastEvent]:
+    primary = _primary_pitch_identity(values)
+    if primary is not None:
+        game_pk, at_bat_number, pitch_number, pitcher_id, batter_id = primary
+        return (
+            session.query(StatcastEvent)
+            .filter(
+                StatcastEvent.game_pk == game_pk,
+                StatcastEvent.at_bat_number == at_bat_number,
+                StatcastEvent.pitch_number == pitch_number,
+                StatcastEvent.pitcher_id == pitcher_id,
+                StatcastEvent.batter_id == batter_id,
+            )
+            .first()
+        )
+
+    filters = [
+        StatcastEvent.game_date == values.get("game_date"),
+        StatcastEvent.pitcher_id == values.get("pitcher_id"),
+        StatcastEvent.batter_id == values.get("batter_id"),
+        StatcastEvent.pitch_type == values.get("pitch_type"),
+        StatcastEvent.events == values.get("events"),
+        StatcastEvent.release_speed == values.get("release_speed"),
+        StatcastEvent.launch_speed == values.get("launch_speed"),
+        StatcastEvent.launch_angle == values.get("launch_angle"),
+        StatcastEvent.balls == values.get("balls"),
+        StatcastEvent.strikes == values.get("strikes"),
+        StatcastEvent.inning == values.get("inning"),
+        StatcastEvent.inning_topbot == values.get("inning_topbot"),
+        StatcastEvent.outs_when_up == values.get("outs_when_up"),
+    ]
+    return session.query(StatcastEvent).filter(and_(*filters)).first()
+
+
+def _upsert_statcast_event(session, values: Dict[str, Any]) -> str:
+    if values.get("game_date") is None or not values.get("pitcher_id"):
+        return "skipped"
+
+    existing = _find_existing_statcast_event(session, values)
+    if existing is None:
+        session.add(StatcastEvent(**values))
+        return "inserted"
+
+    changed = False
+    for key, value in values.items():
+        if value is None:
+            continue
+        if getattr(existing, key, None) != value:
+            setattr(existing, key, value)
+            changed = True
+    return "updated" if changed else "noop"
+
+
+def _upsert_statcast_dataframe(
+    session,
+    df: pd.DataFrame,
+    fallback_pitcher_id: Optional[int] = None,
+    commit_every: int = 1000,
+) -> Dict[str, int]:
+    stats = {"inserted": 0, "updated": 0, "noop": 0, "skipped": 0}
+    if df is None or df.empty:
+        return stats
+
+    for idx, (_, row) in enumerate(df.iterrows(), start=1):
+        try:
+            status = _upsert_statcast_event(session, _event_values_from_row(row, fallback_pitcher_id))
+            stats[status] = stats.get(status, 0) + 1
+        except Exception as exc:
+            log.debug("Statcast row upsert skipped: %s", exc)
+            stats["skipped"] += 1
+        if idx % commit_every == 0:
+            session.commit()
+    session.commit()
+    return stats
+
+
+def _events_to_statcast_dataframe(events: List[StatcastEvent]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "game_date": e.game_date,
+                "game_pk": e.game_pk,
+                "at_bat_number": e.at_bat_number,
+                "pitch_number": e.pitch_number,
+                "inning": e.inning,
+                "inning_topbot": e.inning_topbot,
+                "outs_when_up": e.outs_when_up,
+                "home_team": e.home_team,
+                "away_team": e.away_team,
+                "pitcher": e.pitcher_id,
+                "batter": e.batter_id,
+                "pitch_type": e.pitch_type,
+                "release_speed": e.release_speed,
+                "release_spin_rate": e.release_spin_rate,
+                "pfx_x": e.pfx_x,
+                "pfx_z": e.pfx_z,
+                "plate_x": e.plate_x,
+                "plate_z": e.plate_z,
+                "balls": e.balls,
+                "strikes": e.strikes,
+                "events": e.events,
+                "description": e.description,
+                "launch_speed": e.launch_speed,
+                "launch_angle": e.launch_angle,
+                "estimated_woba_using_speedangle": e.estimated_woba_using_speedangle,
+                "estimated_ba_using_speedangle": e.estimated_ba_using_speedangle,
+                "stand": e.stand,
+                "p_throws": e.p_throws,
+            }
+            for e in events
+        ]
+    )
+
+
 def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -> pd.DataFrame:
     try:
         df = fetch_statcast_pitcher_data(pitcher_id, start, end)
@@ -178,44 +375,75 @@ def _load_statcast_for_pitcher(session, pitcher_id: int, start: str, end: str) -
     if df is None or df.empty:
         return pd.DataFrame()
 
-    for _, row in df.iterrows():
-        try:
-            ev = StatcastEvent(
-                game_date=pd.to_datetime(row.get("game_date")).date() if row.get("game_date") else None,
-                game_pk=_safe_int(row.get("game_pk")),
-                at_bat_number=_safe_int(row.get("at_bat_number")),
-                pitch_number=_safe_int(row.get("pitch_number")),
-                inning=_safe_int(row.get("inning")),
-                inning_topbot=_safe_str(row.get("inning_topbot"), 10),
-                outs_when_up=_safe_int(row.get("outs_when_up")),
-                home_team=_safe_str(row.get("home_team"), 10),
-                away_team=_safe_str(row.get("away_team"), 10),
-                pitcher_id=pitcher_id,
-                batter_id=int(row["batter"]) if pd.notna(row.get("batter")) else 0,
-                pitch_type=str(row.get("pitch_type", "") or "")[:5] or None,
-                release_speed=_safe_float(row.get("release_speed")),
-                release_spin_rate=_safe_float(row.get("release_spin_rate")),
-                pfx_x=_safe_float(row.get("pfx_x")),
-                pfx_z=_safe_float(row.get("pfx_z")),
-                plate_x=_safe_float(row.get("plate_x")),
-                plate_z=_safe_float(row.get("plate_z")),
-                balls=int(row["balls"]) if pd.notna(row.get("balls")) else None,
-                strikes=int(row["strikes"]) if pd.notna(row.get("strikes")) else None,
-                events=str(row.get("events", "") or "")[:50] or None,
-                description=_safe_str(row.get("description"), 60),
-                launch_speed=_safe_float(row.get("launch_speed")),
-                launch_angle=_safe_float(row.get("launch_angle")),
-                estimated_woba_using_speedangle=_safe_float(row.get("estimated_woba_using_speedangle")),
-                estimated_ba_using_speedangle=_safe_float(row.get("estimated_ba_using_speedangle")),
-                stand=str(row.get("stand", "") or "")[:1] or None,
-                p_throws=str(row.get("p_throws", "") or "")[:1] or None,
-            )
-            session.add(ev)
-        except Exception:
-            continue
-    session.commit()
-    log.info("Statcast events loaded pitcher=%s rows=%d", pitcher_id, len(df))
+    stats = _upsert_statcast_dataframe(session, df, fallback_pitcher_id=pitcher_id)
+    log.info(
+        "Statcast events loaded pitcher=%s rows=%d inserted=%d updated=%d noop=%d skipped=%d",
+        pitcher_id,
+        len(df),
+        stats.get("inserted", 0),
+        stats.get("updated", 0),
+        stats.get("noop", 0),
+        stats.get("skipped", 0),
+    )
     return df
+
+
+def refresh_statcast_events_for_date(session, date_str: str) -> Dict[str, Any]:
+    """Fetch all pitch-level Statcast rows for one MLB date and upsert them.
+
+    This is the production freshness path. It is intentionally date-wide rather
+    than probable-pitcher-only so Batter leaderboards, pitcher game logs,
+    relievers, non-probable starters, and H2H fallbacks all see the same base
+    event table.
+    """
+    try:
+        df = fetch_statcast_all_events(date_str, date_str)
+    except Exception as exc:
+        log.warning("Date-wide Statcast fetch failed date=%s: %s", date_str, exc)
+        return {
+            "date": date_str,
+            "source": "datewide_statcast",
+            "rows_returned": 0,
+            "inserted": 0,
+            "updated": 0,
+            "noop": 0,
+            "skipped": 0,
+            "error": str(exc),
+        }
+
+    if df is None or df.empty:
+        return {
+            "date": date_str,
+            "source": "datewide_statcast",
+            "rows_returned": 0,
+            "inserted": 0,
+            "updated": 0,
+            "noop": 0,
+            "skipped": 0,
+        }
+
+    stats = _upsert_statcast_dataframe(session, df)
+    stats.update({"date": date_str, "source": "datewide_statcast", "rows_returned": int(len(df))})
+    return stats
+
+
+def _query_statcast_events_for_window(
+    session,
+    *,
+    start_date: date,
+    end_date: date,
+    pitcher_id: Optional[int] = None,
+    batter_id: Optional[int] = None,
+) -> List[StatcastEvent]:
+    query = session.query(StatcastEvent).filter(
+        StatcastEvent.game_date >= start_date,
+        StatcastEvent.game_date <= end_date,
+    )
+    if pitcher_id is not None:
+        query = query.filter(StatcastEvent.pitcher_id == pitcher_id)
+    if batter_id is not None:
+        query = query.filter(StatcastEvent.batter_id == batter_id)
+    return query.all()
 
 
 def _load_pitcher_aggregate(session, pitcher_id: int, df: pd.DataFrame, end_date: date) -> None:
@@ -238,6 +466,108 @@ def _load_pitcher_aggregate(session, pitcher_id: int, df: pd.DataFrame, end_date
         )
         session.add(record)
     session.commit()
+
+
+def _load_batter_aggregate(session, batter_id: int, df: pd.DataFrame, end_date: date) -> None:
+    metrics = calculate_batter_aggregates(df)
+    if not metrics:
+        return
+    existing = session.query(BatterAggregate).filter_by(
+        batter_id=batter_id, window="90d", end_date=end_date
+    ).first()
+    if existing:
+        for k, v in metrics.items():
+            if hasattr(existing, k):
+                setattr(existing, k, v)
+    else:
+        record = BatterAggregate(
+            batter_id=batter_id,
+            window="90d",
+            end_date=end_date,
+            **{k: v for k, v in metrics.items() if hasattr(BatterAggregate, k)},
+        )
+        session.add(record)
+    session.commit()
+
+
+def recompute_recent_aggregates_from_events(
+    session,
+    *,
+    end_date: date,
+    window_days: int = 90,
+    pitcher_ids: Optional[List[int]] = None,
+    batter_ids: Optional[List[int]] = None,
+    refresh_pitch_arsenal: bool = True,
+) -> Dict[str, int]:
+    start_date = end_date - timedelta(days=window_days)
+
+    if pitcher_ids is None:
+        pitcher_rows = (
+            session.query(StatcastEvent.pitcher_id)
+            .filter(
+                StatcastEvent.game_date >= start_date,
+                StatcastEvent.game_date <= end_date,
+                StatcastEvent.pitcher_id.isnot(None),
+                StatcastEvent.pitcher_id != 0,
+            )
+            .distinct()
+            .all()
+        )
+        pitcher_ids = [int(row[0]) for row in pitcher_rows if row[0]]
+
+    if batter_ids is None:
+        batter_rows = (
+            session.query(StatcastEvent.batter_id)
+            .filter(
+                StatcastEvent.game_date >= start_date,
+                StatcastEvent.game_date <= end_date,
+                StatcastEvent.batter_id.isnot(None),
+                StatcastEvent.batter_id != 0,
+            )
+            .distinct()
+            .all()
+        )
+        batter_ids = [int(row[0]) for row in batter_rows if row[0]]
+
+    season = end_date.year
+    pitcher_count = 0
+    batter_count = 0
+    arsenal_count = 0
+
+    for pitcher_id in sorted(set(pitcher_ids)):
+        events = _query_statcast_events_for_window(
+            session,
+            start_date=start_date,
+            end_date=end_date,
+            pitcher_id=pitcher_id,
+        )
+        if not events:
+            continue
+        df = _events_to_statcast_dataframe(events)
+        _load_pitcher_aggregate(session, pitcher_id, df, end_date)
+        pitcher_count += 1
+        if refresh_pitch_arsenal:
+            _load_pitch_arsenal_from_df(session, pitcher_id, df, season)
+            arsenal_count += 1
+
+    for batter_id in sorted(set(batter_ids)):
+        events = _query_statcast_events_for_window(
+            session,
+            start_date=start_date,
+            end_date=end_date,
+            batter_id=batter_id,
+        )
+        if not events:
+            continue
+        df = _events_to_statcast_dataframe(events)
+        _load_batter_aggregate(session, batter_id, df, end_date)
+        batter_count += 1
+
+    return {
+        "pitcher_aggregates_refreshed": pitcher_count,
+        "batter_aggregates_refreshed": batter_count,
+        "pitch_arsenal_pitchers_refreshed": arsenal_count,
+    }
 
 
 def _load_pitch_arsenal_from_df(session, pitcher_id: int, df: pd.DataFrame, season: int) -> None:
@@ -287,6 +617,9 @@ def _try_load_arsenal_leaderboard(session, season: int) -> bool:
                 pitcher_id=pitcher_id, season=season, pitch_type=pitch_type
             ).first()
             if existing:
+                for field in ("pitch_name", "pitch_count", "usage_pct", "whiff_pct", "strikeout_pct", "rv_per_100", "xwoba", "hard_hit_pct"):
+                    if hasattr(existing, field):
+                        setattr(existing, field, _pitch_arsenal_value_from_row(row, field))
                 continue
             session.add(PitchArsenal(
                 season=season,
@@ -309,12 +642,20 @@ def _try_load_arsenal_leaderboard(session, season: int) -> bool:
         return False
 
 
+def _pitch_arsenal_value_from_row(row: pd.Series, field: str) -> Any:
+    if field == "pitch_name":
+        return str(row.get("pitch_name", "") or "")
+    if field == "pitch_count":
+        return int(row["pitch_count"]) if pd.notna(row.get("pitch_count")) else None
+    return _safe_float(row.get(field))
+
+
 # ---------------------------------------------------------------------------
 # Main ETL orchestration
 # ---------------------------------------------------------------------------
 
-def run_etl_for_date(date_str: str) -> None:
-    engine = get_engine(DATABASE_URL)
+def run_etl_for_date(date_str: str, *, datewide_statcast: bool = True) -> Dict[str, Any]:
+    engine = get_engine(os.getenv("DATABASE_URL", DATABASE_URL))
     create_tables(engine)
     Session = get_session(engine)
 
@@ -323,7 +664,7 @@ def run_etl_for_date(date_str: str) -> None:
         games = fetch_schedule(date_str)
         if not games:
             log.info("No games found for %s", date_str)
-            return
+            return {"date": date_str, "status": "no_games", "statcast_refresh": None}
 
         pitcher_ids = _extract_pitcher_ids(games)
         team_ids = _extract_team_ids(games)
@@ -331,21 +672,74 @@ def run_etl_for_date(date_str: str) -> None:
         end_dt = datetime.strptime(date_str, "%Y-%m-%d").date()
         start_dt = (end_dt - timedelta(days=90)).isoformat()
 
-        log.info("Found %d pitchers, %d teams", len(pitcher_ids), len(team_ids))
+        log.info("Found %d probable pitchers, %d teams", len(pitcher_ids), len(team_ids))
 
         _load_team_splits(session, team_ids, season)
 
+        statcast_refresh = None
+        if datewide_statcast:
+            statcast_refresh = refresh_statcast_events_for_date(session, date_str)
+            log.info("Date-wide Statcast refresh %s", statcast_refresh)
+
         arsenal_loaded = _try_load_arsenal_leaderboard(session, season)
 
-        for pitcher_id in pitcher_ids:
-            df = _load_statcast_for_pitcher(session, pitcher_id, start_dt, date_str)
-            _load_pitcher_aggregate(session, pitcher_id, df, end_dt)
-            if not arsenal_loaded:
-                _load_pitch_arsenal_from_df(session, pitcher_id, df, season)
-            if df.empty:
-                _ensure_historical_aggregate(session, pitcher_id, season)
+        aggregate_summary: Dict[str, int] = {
+            "pitcher_aggregates_refreshed": 0,
+            "batter_aggregates_refreshed": 0,
+            "pitch_arsenal_pitchers_refreshed": 0,
+        }
+
+        if datewide_statcast:
+            date_pitcher_rows = (
+                session.query(StatcastEvent.pitcher_id)
+                .filter(
+                    StatcastEvent.game_date == end_dt,
+                    StatcastEvent.pitcher_id.isnot(None),
+                    StatcastEvent.pitcher_id != 0,
+                )
+                .distinct()
+                .all()
+            )
+            date_batter_rows = (
+                session.query(StatcastEvent.batter_id)
+                .filter(
+                    StatcastEvent.game_date == end_dt,
+                    StatcastEvent.batter_id.isnot(None),
+                    StatcastEvent.batter_id != 0,
+                )
+                .distinct()
+                .all()
+            )
+            affected_pitcher_ids = [int(row[0]) for row in date_pitcher_rows if row[0]]
+            affected_batter_ids = [int(row[0]) for row in date_batter_rows if row[0]]
+            aggregate_summary = recompute_recent_aggregates_from_events(
+                session,
+                end_date=end_dt,
+                pitcher_ids=affected_pitcher_ids,
+                batter_ids=affected_batter_ids,
+                refresh_pitch_arsenal=not arsenal_loaded,
+            )
+        else:
+            for pitcher_id in pitcher_ids:
+                df = _load_statcast_for_pitcher(session, pitcher_id, start_dt, date_str)
+                _load_pitcher_aggregate(session, pitcher_id, df, end_dt)
+                aggregate_summary["pitcher_aggregates_refreshed"] += 1
+                if not arsenal_loaded:
+                    _load_pitch_arsenal_from_df(session, pitcher_id, df, season)
+                    aggregate_summary["pitch_arsenal_pitchers_refreshed"] += 1
+                if df.empty:
+                    _ensure_historical_aggregate(session, pitcher_id, season)
 
         log.info("ETL complete for %s", date_str)
+        return {
+            "date": date_str,
+            "status": "ok",
+            "probable_pitcher_count": len(pitcher_ids),
+            "team_count": len(team_ids),
+            "statcast_refresh": statcast_refresh,
+            "aggregate_summary": aggregate_summary,
+            "arsenal_leaderboard_loaded": arsenal_loaded,
+        }
 
 
 def _ensure_historical_aggregate(session, pitcher_id: int, current_season: int) -> None:
@@ -414,9 +808,11 @@ if __name__ == "__main__":
     parser.add_argument("--date", default=date.today().isoformat(), help="YYYY-MM-DD")
     parser.add_argument("--backfill-days", type=int, default=0,
                         help="Backfill this many days before today")
+    parser.add_argument("--pitcher-only", action="store_true",
+                        help="Use legacy probable-pitcher Statcast pulls instead of date-wide refresh")
     args = parser.parse_args()
 
     if args.backfill_days > 0:
         run_backfill(args.backfill_days)
     else:
-        run_etl_for_date(args.date)
+        run_etl_for_date(args.date, datewide_statcast=not args.pitcher_only)

--- a/scripts/nightly_statcast_refresh.py
+++ b/scripts/nightly_statcast_refresh.py
@@ -25,7 +25,16 @@ if load_dotenv is not None:
 from sqlalchemy import func
 
 from mlb_app.data_freshness import build_data_freshness_payload
-from mlb_app.database import PitchArsenal, PitcherAggregate, StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.database import (
+    BatterAggregate,
+    BatterPitchTypeMatchup,
+    PitchArsenal,
+    PitcherAggregate,
+    StatcastEvent,
+    create_tables,
+    get_engine,
+    get_session,
+)
 from mlb_app.db_utils import TERMINAL_EVENTS
 from mlb_app.etl import run_etl_for_date
 
@@ -80,15 +89,22 @@ def _validation_summary(database_url: str, dates: List[str]) -> Dict[str, Any]:
     engine = get_engine(database_url)
     create_tables(engine)
     Session = get_session(engine)
-    season = _today_mlb().year
-    recent_cutoff = _today_mlb() - dt.timedelta(days=7)
+    as_of = _today_mlb()
+    season = as_of.year
+    recent_cutoff = as_of - dt.timedelta(days=7)
 
     with Session() as session:
-        freshness = build_data_freshness_payload(session, database_url=database_url, as_of=_today_mlb())
+        freshness = build_data_freshness_payload(session, database_url=database_url, as_of=as_of)
         statcast_rows_by_date = {date_str: _rows_for_date(session, date_str) for date_str in dates}
         recent_pitcher_aggregate_count = (
             session.query(func.count(PitcherAggregate.id))
             .filter(PitcherAggregate.end_date >= recent_cutoff)
+            .scalar()
+            or 0
+        )
+        recent_batter_aggregate_count = (
+            session.query(func.count(BatterAggregate.id))
+            .filter(BatterAggregate.end_date >= recent_cutoff)
             .scalar()
             or 0
         )
@@ -106,29 +122,62 @@ def _validation_summary(database_url: str, dates: List[str]) -> Dict[str, Any]:
             .scalar()
             or 0
         )
+        recent_distinct_pitcher_count_7d = (
+            session.query(func.count(func.distinct(StatcastEvent.pitcher_id)))
+            .filter(
+                StatcastEvent.game_date >= recent_cutoff,
+                StatcastEvent.pitcher_id.isnot(None),
+                StatcastEvent.pitcher_id != 0,
+            )
+            .scalar()
+            or 0
+        )
+        recent_distinct_batter_count_7d = (
+            session.query(func.count(func.distinct(StatcastEvent.batter_id)))
+            .filter(
+                StatcastEvent.game_date >= recent_cutoff,
+                StatcastEvent.batter_id.isnot(None),
+                StatcastEvent.batter_id != 0,
+            )
+            .scalar()
+            or 0
+        )
+        latest_stored_365_refresh = session.query(func.max(BatterPitchTypeMatchup.refreshed_at)).scalar()
 
     return {
         "freshness": freshness,
         "latest_statcast_event_date": freshness.get("latest_statcast_event_date"),
         "statcast_rows_by_date": statcast_rows_by_date,
         "recent_pitcher_aggregate_count": int(recent_pitcher_aggregate_count),
+        "recent_batter_aggregate_count": int(recent_batter_aggregate_count),
         "current_season_pitch_arsenal_count": int(current_season_pitch_arsenal_count),
         "current_season_batter_terminal_rows": int(current_season_batter_terminal_rows),
+        "recent_distinct_pitcher_count_7d": int(recent_distinct_pitcher_count_7d),
+        "recent_distinct_batter_count_7d": int(recent_distinct_batter_count_7d),
+        "latest_batter_pitch_type_matchup_refresh": latest_stored_365_refresh.isoformat() if latest_stored_365_refresh else None,
     }
 
 
-def run_refresh(date_arg: Optional[str], days: int, include_today: bool, allow_sqlite_local: bool, validate_only: bool = False) -> Dict[str, Any]:
+def run_refresh(
+    date_arg: Optional[str],
+    days: int,
+    include_today: bool,
+    allow_sqlite_local: bool,
+    validate_only: bool = False,
+) -> Dict[str, Any]:
     database_url = _database_url(allow_sqlite_local)
     os.environ["DATABASE_URL"] = database_url
     dates = resolve_target_dates(date_arg, days, include_today)
 
     errors: List[Dict[str, str]] = []
     refreshed: List[str] = []
+    refresh_results: List[Dict[str, Any]] = []
 
     if not validate_only:
         for date_str in dates:
             try:
-                run_etl_for_date(date_str)
+                result = run_etl_for_date(date_str, datewide_statcast=True)
+                refresh_results.append(result if isinstance(result, dict) else {"date": date_str, "status": "ok"})
                 refreshed.append(date_str)
             except Exception as exc:
                 errors.append({"date": date_str, "type": exc.__class__.__name__, "message": str(exc)})
@@ -151,11 +200,16 @@ def run_refresh(date_arg: Optional[str], days: int, include_today: bool, allow_s
         "validate_only": validate_only,
         "dates_requested": dates,
         "dates_refreshed": refreshed,
+        "refresh_results": refresh_results,
         "latest_statcast_event_date": validation.get("latest_statcast_event_date"),
         "statcast_rows_by_date": validation.get("statcast_rows_by_date"),
         "recent_pitcher_aggregate_count": validation.get("recent_pitcher_aggregate_count"),
+        "recent_batter_aggregate_count": validation.get("recent_batter_aggregate_count"),
         "current_season_pitch_arsenal_count": validation.get("current_season_pitch_arsenal_count"),
         "current_season_batter_terminal_rows": validation.get("current_season_batter_terminal_rows"),
+        "recent_distinct_pitcher_count_7d": validation.get("recent_distinct_pitcher_count_7d"),
+        "recent_distinct_batter_count_7d": validation.get("recent_distinct_batter_count_7d"),
+        "latest_batter_pitch_type_matchup_refresh": validation.get("latest_batter_pitch_type_matchup_refresh"),
         "freshness": validation.get("freshness"),
         "warnings": warnings,
         "errors": errors,
@@ -165,7 +219,12 @@ def run_refresh(date_arg: Optional[str], days: int, include_today: bool, allow_s
 def main() -> int:
     parser = argparse.ArgumentParser(description="Refresh Statcast-backed MLB data for production UI surfaces.")
     parser.add_argument("--date", help="Refresh one date in YYYY-MM-DD format")
-    parser.add_argument("--days", type=int, default=2, help="Number of recent MLB dates to refresh when --date is omitted")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=10,
+        help="Number of recent MLB dates to refresh when --date is omitted. Default is 10 for overlap and late Statcast availability.",
+    )
     parser.add_argument("--include-today", action="store_true", help="Include the current MLB Eastern date")
     parser.add_argument("--allow-sqlite-local", action="store_true", help="Allow sqlite:///mlb.db fallback for local validation")
     parser.add_argument("--validate-only", action="store_true", help="Only inspect DB freshness without running ETL")

--- a/tests/test_datewide_statcast_refresh.py
+++ b/tests/test_datewide_statcast_refresh.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pandas as pd
+
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app import etl
+
+
+def _session_factory(tmp_path):
+    db_path = tmp_path / "statcast_refresh_test.db"
+    engine = get_engine(f"sqlite:///{db_path}")
+    create_tables(engine)
+    return get_session(engine)
+
+
+def _sample_statcast_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "game_date": "2026-05-18",
+                "game_pk": 777001,
+                "at_bat_number": 1,
+                "pitch_number": 1,
+                "inning": 1,
+                "inning_topbot": "Top",
+                "outs_when_up": 0,
+                "home_team": "CHC",
+                "away_team": "STL",
+                "pitcher": 1001,
+                "batter": 2001,
+                "pitch_type": "FF",
+                "release_speed": 95.4,
+                "release_spin_rate": 2300,
+                "pfx_x": -0.4,
+                "pfx_z": 1.3,
+                "plate_x": 0.2,
+                "plate_z": 2.4,
+                "balls": 0,
+                "strikes": 0,
+                "events": None,
+                "description": "called_strike",
+                "launch_speed": None,
+                "launch_angle": None,
+                "estimated_woba_using_speedangle": None,
+                "estimated_ba_using_speedangle": None,
+                "stand": "R",
+                "p_throws": "R",
+            },
+            {
+                "game_date": "2026-05-18",
+                "game_pk": 777001,
+                "at_bat_number": 1,
+                "pitch_number": 2,
+                "inning": 1,
+                "inning_topbot": "Top",
+                "outs_when_up": 0,
+                "home_team": "CHC",
+                "away_team": "STL",
+                "pitcher": 1001,
+                "batter": 2001,
+                "pitch_type": "SL",
+                "release_speed": 86.2,
+                "release_spin_rate": 2550,
+                "pfx_x": 0.7,
+                "pfx_z": 0.2,
+                "plate_x": -0.1,
+                "plate_z": 1.9,
+                "balls": 0,
+                "strikes": 1,
+                "events": "single",
+                "description": "hit_into_play",
+                "launch_speed": 101.0,
+                "launch_angle": 14.0,
+                "estimated_woba_using_speedangle": 0.72,
+                "estimated_ba_using_speedangle": 0.68,
+                "stand": "R",
+                "p_throws": "R",
+            },
+        ]
+    )
+
+
+def test_refresh_statcast_events_for_date_is_idempotent(monkeypatch, tmp_path):
+    Session = _session_factory(tmp_path)
+    monkeypatch.setattr(etl, "fetch_statcast_all_events", lambda start, end: _sample_statcast_df())
+
+    with Session() as session:
+        first = etl.refresh_statcast_events_for_date(session, "2026-05-18")
+        assert first["rows_returned"] == 2
+        assert first["inserted"] == 2
+        assert first["updated"] == 0
+        assert first["noop"] == 0
+        assert session.query(StatcastEvent).count() == 2
+
+        second = etl.refresh_statcast_events_for_date(session, "2026-05-18")
+        assert second["rows_returned"] == 2
+        assert second["inserted"] == 0
+        assert second["updated"] == 0
+        assert second["noop"] == 2
+        assert session.query(StatcastEvent).count() == 2
+
+
+def test_refresh_statcast_events_for_date_updates_existing_non_null_values(monkeypatch, tmp_path):
+    Session = _session_factory(tmp_path)
+    base_df = _sample_statcast_df()
+    updated_df = _sample_statcast_df()
+    updated_df.loc[0, "release_speed"] = 96.1
+    updated_df.loc[0, "events"] = "strikeout"
+
+    responses = iter([base_df, updated_df])
+    monkeypatch.setattr(etl, "fetch_statcast_all_events", lambda start, end: next(responses))
+
+    with Session() as session:
+        first = etl.refresh_statcast_events_for_date(session, "2026-05-18")
+        second = etl.refresh_statcast_events_for_date(session, "2026-05-18")
+
+        assert first["inserted"] == 2
+        assert second["inserted"] == 0
+        assert second["updated"] == 1
+        assert session.query(StatcastEvent).count() == 2
+
+        row = (
+            session.query(StatcastEvent)
+            .filter(
+                StatcastEvent.game_pk == 777001,
+                StatcastEvent.at_bat_number == 1,
+                StatcastEvent.pitch_number == 1,
+                StatcastEvent.pitcher_id == 1001,
+                StatcastEvent.batter_id == 2001,
+            )
+            .first()
+        )
+        assert row is not None
+        assert row.release_speed == 96.1
+        assert row.events == "strikeout"
+
+
+def test_recompute_recent_aggregates_from_events_creates_pitcher_and_batter_90d_rows(monkeypatch, tmp_path):
+    Session = _session_factory(tmp_path)
+    monkeypatch.setattr(etl, "fetch_statcast_all_events", lambda start, end: _sample_statcast_df())
+
+    with Session() as session:
+        etl.refresh_statcast_events_for_date(session, "2026-05-18")
+        summary = etl.recompute_recent_aggregates_from_events(
+            session,
+            end_date=dt.date(2026, 5, 18),
+            pitcher_ids=[1001],
+            batter_ids=[2001],
+            refresh_pitch_arsenal=False,
+        )
+
+        assert summary["pitcher_aggregates_refreshed"] == 1
+        assert summary["batter_aggregates_refreshed"] == 1
+        assert summary["pitch_arsenal_pitchers_refreshed"] == 0


### PR DESCRIPTION
## Summary

Fixes the Statcast freshness architecture so production refresh is date-wide instead of probable-pitcher-only.

This addresses the stale Batter page and missing pitcher Recent Outings symptoms by making `statcast_events` the complete, idempotent base layer for recent MLB dates.

## What changed

- Adds date-wide Statcast fetch through existing `fetch_statcast_all_events()`.
- Adds idempotent `statcast_events` upsert logic using pitch identity:
  - `game_pk + at_bat_number + pitch_number + pitcher_id + batter_id` when available.
  - fallback identity for rows missing full pitch ordering fields.
- Preserves legacy probable-pitcher flow behind `--pitcher-only` fallback.
- Recomputes affected 90-day pitcher and batter aggregates from stored event rows.
- Refreshes pitch arsenal from refreshed rows when Savant arsenal leaderboard is unavailable.
- Updates nightly refresh default to a 10-day rolling overlap window.
- Expands `/data/freshness` diagnostics for batter/pitcher event freshness, aggregate freshness, recent distinct player counts, and Stored 365 refresh timestamp.
- Adds idempotency tests proving reruns do not duplicate `statcast_events`.

## Why this is needed

Current production symptoms:

- Batter landing page shows `Latest event: 2026-05-03`.
- Pitcher profile Recent Outings is missing roughly a week.

Root cause from code audit:

- `/batters/leaderboards` computes latest event from `max(StatcastEvent.game_date)`.
- Pitcher Recent Outings are built directly from `StatcastEvent` grouped by game/date.
- Existing `run_etl_for_date()` only refreshed probable pitchers from the schedule, which misses relievers, actual pitchers not listed as probable, and complete batter coverage.

## Preservation rules followed

- No frontend page changes.
- No `/matchups` contract changes.
- No changes to `home_win_prob` or `away_win_prob`.
- No canonical matchup probability changes.
- No request-time Statcast scraping inside user-facing endpoints.
- No fabricated FIP/xFIP/SIERA/xSIERA.

## Test coverage added

New file:

- `tests/test_datewide_statcast_refresh.py`

Covers:

- First refresh inserts rows.
- Second refresh of same date produces no duplicate rows.
- Existing rows are updated when incoming Statcast rows contain better values.
- Recompute path creates pitcher and batter 90-day aggregate rows.

## Manual production validation after merge

Run Railway refresh:

```bash
python scripts/nightly_statcast_refresh.py --days 10 --include-today
```

Then verify:

```text
GET /data/freshness
GET /batters/leaderboards
GET /pitcher/{id}
GET /pitcher/{id}/rolling
GET /matchups?date=YYYY-MM-DD
GET /matchup/{game_pk}/competitive
```

Expected:

- Batter leaderboard latest event is no longer stuck at 2026-05-03 when later games exist.
- Pitcher Recent Outings includes the missing week.
- Re-running the refresh does not inflate `statcast_events` row counts.
