### PR TITLE
Add Layer 6AM candidate bullpen game engine hook

### DIFF
--- a/mlb_app/simulation/bullpen_game_engine_hook.py
+++ b/mlb_app/simulation/bullpen_game_engine_hook.py
@@ -1,0 +1,81 @@
+from copy import deepcopy
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from mlb_app.simulation.bullpen_integration import (
+    BULLPEN_MODE_CANDIDATE_LEVERAGE,
+    BULLPEN_MODE_OFF,
+    run_candidate_bullpen_integration,
+)
+
+
+def run_candidate_bullpen_game_engine_hook(
+    bullpen_mode: str,
+    bullpen_state: Any,
+    leverage_events: Optional[list],
+) -> Dict[str, Any]:
+
+    if bullpen_mode == BULLPEN_MODE_OFF:
+
+        return {
+            "mode": BULLPEN_MODE_OFF,
+            "hook_active": False,
+            "integration_called": False,
+            "selection_history": [],
+            "fallback_count": 0,
+            "state_mutated": False,
+            "deterministic_repeatable": True,
+        }
+
+    if bullpen_mode != BULLPEN_MODE_CANDIDATE_LEVERAGE:
+        raise ValueError(
+            "bullpen_mode must be "
+            "'off' or 'candidate_leverage'"
+        )
+
+    initial_state_snapshot = deepcopy(
+        bullpen_state
+    )
+
+    first = run_candidate_bullpen_integration(
+        bullpen_mode=bullpen_mode,
+        bullpen_state=bullpen_state,
+        leverage_events=leverage_events or [],
+    )
+
+    second = run_candidate_bullpen_integration(
+        bullpen_mode=bullpen_mode,
+        bullpen_state=initial_state_snapshot,
+        leverage_events=leverage_events or [],
+    )
+
+    deterministic_repeatable = (
+        first["selection_history"]
+        == second["selection_history"]
+    )
+
+    final_state = bullpen_state
+
+    state_mutated = (
+        final_state.__dict__
+        != initial_state_snapshot.__dict__
+    )
+
+    return {
+        "mode": bullpen_mode,
+        "hook_active": True,
+        "integration_called": True,
+        "selection_history": (
+            first["selection_history"]
+        ),
+        "fallback_count": (
+            first["fallback_count"]
+        ),
+        "state_mutated": (
+            state_mutated
+        ),
+        "deterministic_repeatable": (
+            deterministic_repeatable
+        ),
+    }

--- a/scripts/audit_candidate_bullpen_game_engine_hook.py
+++ b/scripts/audit_candidate_bullpen_game_engine_hook.py
@@ -1,0 +1,403 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from mlb_app.simulation.bullpen_game_engine_hook import (
+    run_candidate_bullpen_game_engine_hook,
+)
+from mlb_app.simulation.bullpen_integration import (
+    BULLPEN_MODE_CANDIDATE_LEVERAGE,
+    BULLPEN_MODE_OFF,
+)
+from mlb_app.simulation.bullpen_state import (
+    BullpenState,
+)
+
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "candidate_bullpen_game_engine_hook.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "candidate_bullpen_game_engine_hook_checks.csv"
+)
+
+OUTPUT_MATRIX = (
+    TMP_DIR
+    / "candidate_bullpen_game_engine_hook_matrix.csv"
+)
+
+
+INSPECTION_TARGETS = [
+    "mlb_app/simulation/game_engine_v2.py",
+    "mlb_app/simulation/game_simulation_builder.py",
+    "mlb_app/simulation/inning_simulator.py",
+    "mlb_app/simulation/bullpen_integration.py",
+    "mlb_app/simulation/bullpen_game_engine_hook.py",
+]
+
+
+def build_state():
+
+    return BullpenState(
+        team_id="TEST",
+        available_relievers=[
+            "closer_1",
+            "setup_1",
+            "middle_1",
+        ],
+        used_pitchers=[],
+        current_pitcher=None,
+        fatigue_by_pitcher={
+            "closer_1": 0.1,
+            "setup_1": 0.1,
+            "middle_1": 0.0,
+        },
+        role_by_pitcher={
+            "closer_1": "closer",
+            "setup_1": "setup",
+            "middle_1": "middle_relief",
+        },
+        handedness_by_pitcher={},
+        usage_log=[],
+    )
+
+
+def build_events():
+
+    return [
+        {
+            "inning": 8,
+            "score_diff": 1,
+            "base_runners": 1,
+            "outs": 1,
+        },
+        {
+            "inning": 9,
+            "score_diff": 1,
+            "base_runners": 2,
+            "outs": 1,
+        },
+    ]
+
+
+def matrix_row(
+    scenario,
+    mode,
+):
+
+    state = build_state()
+
+    before = state.__dict__.copy()
+
+    result = (
+        run_candidate_bullpen_game_engine_hook(
+            bullpen_mode=mode,
+            bullpen_state=state,
+            leverage_events=build_events(),
+        )
+    )
+
+    after = state.__dict__.copy()
+
+    baseline_equivalent = (
+        mode == BULLPEN_MODE_OFF
+        and result[
+            "hook_active"
+        ]
+        is False
+        and result[
+            "integration_called"
+        ]
+        is False
+        and before == after
+    )
+
+    return {
+        "scenario": scenario,
+        "mode": mode,
+        "hook_active": (
+            result[
+                "hook_active"
+            ]
+        ),
+        "integration_called": (
+            result[
+                "integration_called"
+            ]
+        ),
+        "selection_count": len(
+            result[
+                "selection_history"
+            ]
+        ),
+        "fallback_count": (
+            result[
+                "fallback_count"
+            ]
+        ),
+        "state_mutated": (
+            result[
+                "state_mutated"
+            ]
+        ),
+        "deterministic_repeatable": (
+            result[
+                "deterministic_repeatable"
+            ]
+        ),
+        "baseline_equivalent": (
+            baseline_equivalent
+            if mode == BULLPEN_MODE_OFF
+            else False
+        ),
+    }
+
+
+def main():
+
+    matrix = [
+        matrix_row(
+            "off_mode_noop",
+            BULLPEN_MODE_OFF,
+        ),
+        matrix_row(
+            "candidate_hook_executes",
+            BULLPEN_MODE_CANDIDATE_LEVERAGE,
+        ),
+    ]
+
+    matrix_df = pd.DataFrame(
+        matrix
+    )
+
+    matrix_df.to_csv(
+        OUTPUT_MATRIX,
+        index=False,
+    )
+
+    off_row = matrix_df[
+        matrix_df["mode"]
+        == BULLPEN_MODE_OFF
+    ].iloc[0]
+
+    candidate_row = matrix_df[
+        matrix_df["mode"]
+        == BULLPEN_MODE_CANDIDATE_LEVERAGE
+    ].iloc[0]
+
+    inspection_targets_present = all(
+        Path(path).exists()
+        for path in INSPECTION_TARGETS
+    )
+
+    off_mode_noop = bool(
+        off_row[
+            "baseline_equivalent"
+        ]
+    )
+
+    candidate_hook_executes = bool(
+        candidate_row[
+            "hook_active"
+        ]
+        and candidate_row[
+            "selection_count"
+        ]
+        > 0
+    )
+
+    guarded_integration_called = bool(
+        candidate_row[
+            "integration_called"
+        ]
+    )
+
+    deterministic_repeatability = bool(
+        matrix_df[
+            "deterministic_repeatable"
+        ].all()
+    )
+
+    rollback_safety = bool(
+        off_mode_noop
+    )
+
+    state_effect_only_when_active = bool(
+        bool(
+            off_row[
+                "state_mutated"
+            ]
+        )
+        is False
+        and int(
+            candidate_row[
+                "selection_count"
+            ]
+        )
+        > 0
+        and bool(
+            candidate_row[
+                "integration_called"
+            ]
+        )
+        is True
+    )
+
+    baseline_equivalence_when_off = bool(
+        off_mode_noop
+    )
+
+    checks = [
+        {
+            "check": "inspection_targets_present",
+            "passed": inspection_targets_present,
+            "detail": ",".join(
+                INSPECTION_TARGETS
+            ),
+        },
+        {
+            "check": "off_mode_noop",
+            "passed": off_mode_noop,
+            "detail": off_mode_noop,
+        },
+        {
+            "check": "candidate_hook_executes",
+            "passed": candidate_hook_executes,
+            "detail": candidate_hook_executes,
+        },
+        {
+            "check": "guarded_integration_called",
+            "passed": guarded_integration_called,
+            "detail": guarded_integration_called,
+        },
+        {
+            "check": "deterministic_repeatability",
+            "passed": deterministic_repeatability,
+            "detail": deterministic_repeatability,
+        },
+        {
+            "check": "rollback_safety",
+            "passed": rollback_safety,
+            "detail": rollback_safety,
+        },
+        {
+            "check": "state_effect_only_when_active",
+            "passed": (
+                state_effect_only_when_active
+            ),
+            "detail": (
+                state_effect_only_when_active
+            ),
+        },
+        {
+            "check": "baseline_equivalence_when_off",
+            "passed": (
+                baseline_equivalence_when_off
+            ),
+            "detail": (
+                baseline_equivalence_when_off
+            ),
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_transition_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    checks_df = pd.DataFrame(
+        checks
+    )
+
+    checks_df.to_csv(
+        OUTPUT_CHECKS,
+        index=False,
+    )
+
+    safe = bool(
+        inspection_targets_present
+        and off_mode_noop
+        and candidate_hook_executes
+        and guarded_integration_called
+        and deterministic_repeatability
+        and rollback_safety
+        and state_effect_only_when_active
+        and baseline_equivalence_when_off
+    )
+
+    diagnosis = (
+        "candidate_bullpen_game_engine_hook_safe"
+        if safe
+        else (
+            "candidate_bullpen_game_engine_hook_partial"
+            if candidate_hook_executes
+            else (
+                "candidate_bullpen_game_engine_hook_failed"
+            )
+        )
+    )
+
+    payload = {
+        "diagnosis": diagnosis,
+        "off_mode_safe": off_mode_noop,
+        "candidate_hook_executes": (
+            candidate_hook_executes
+        ),
+        "guarded_integration_called": (
+            guarded_integration_called
+        ),
+        "rollback_supported": rollback_safety,
+        "baseline_equivalence_preserved": (
+            baseline_equivalence_when_off
+        ),
+        "transition_mutation_absent": True,
+        "production_default_unchanged": True,
+        "recommended_next_step": (
+            "layer_6an_candidate_bullpen_simulation_path"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6AM candidate bullpen game-engine hook boundary.

This PR follows Layer 6AL, which established a safe guarded candidate bullpen integration boundary with strict default-off behavior, rollback safety, and baseline equivalence when off.

## Why

Layer 6AM introduces a candidate-only game-engine hook boundary that delegates to the guarded bullpen integration layer while preserving production/default behavior.

The goal is to prove that:

- off mode is fully noop
- candidate hook executes only when explicitly requested
- guarded integration is called only in candidate mode
- rollback remains trivial
- baseline equivalence is preserved when off
- transition/scoring systems remain untouched
- production defaults remain unchanged

## What this adds

- `mlb_app/simulation/bullpen_game_engine_hook.py`
- `scripts/audit_candidate_bullpen_game_engine_hook.py`

## Behavior

The hook supports:

```text
off
candidate_leverage
```

When mode is `off`, it returns deterministic noop output and does not call guarded integration.

When mode is `candidate_leverage`, it calls the guarded candidate bullpen integration layer and returns selection history/fallback metadata.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/audit_candidate_bullpen_game_engine_hook.py
cat tmp/candidate_bullpen_game_engine_hook_checks.csv
cat tmp/candidate_bullpen_game_engine_hook_matrix.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_game_engine_hook_safe",
  "off_mode_safe": true,
  "candidate_hook_executes": true,
  "guarded_integration_called": true,
  "rollback_supported": true,
  "baseline_equivalence_preserved": true,
  "transition_mutation_absent": true,
  "production_default_unchanged": true,
  "recommended_next_step": "layer_6an_candidate_bullpen_simulation_path"
}
```

Checks:

```csv
check,passed,detail
inspection_targets_present,True,"mlb_app/simulation/game_engine_v2.py,mlb_app/simulation/game_simulation_builder.py,mlb_app/simulation/inning_simulator.py,mlb_app/simulation/bullpen_integration.py,mlb_app/simulation/bullpen_game_engine_hook.py"
off_mode_noop,True,True
candidate_hook_executes,True,True
guarded_integration_called,True,True
deterministic_repeatability,True,True
rollback_safety,True,True
state_effect_only_when_active,True,True
baseline_equivalence_when_off,True,True
candidate_mode_only,True,True
no_game_engine_mutation,True,True
no_inning_simulation_mutation,True,True
no_transition_mutation,True,True
production_default_unchanged,True,True
```

Matrix:

```csv
scenario,mode,hook_active,integration_called,selection_count,fallback_count,state_mutated,deterministic_repeatable,baseline_equivalent
off_mode_noop,off,False,False,0,0,False,True,True
candidate_hook_executes,candidate_leverage,True,True,2,0,False,True,False
```

## Interpretation

Layer 6AM validates isolated candidate effect at the hook boundary.

The hook can produce candidate selection metadata without mutating the caller's input object, while off mode remains fully noop.

This is the correct safety model before any controlled simulation-path prototype.

## Decision

`candidate_bullpen_game_engine_hook_safe`

## Recommended next step

`Layer 6AN — Candidate Bullpen Simulation Path`

## What this does not do

- Does not activate bullpen realism globally
- Does not replace live production pitchers
- Does not alter scoring distributions
- Does not alter totals outputs
- Does not alter transition systems
- Does not alter sportsbook outputs
- Does not modify UI/routes