### PR TITLE
Add Layer 6AT candidate bullpen dataset schema audit

### DIFF
--- a/scripts/audit_candidate_bullpen_dataset_schema.py
+++ b/scripts/audit_candidate_bullpen_dataset_schema.py
@@ -1,0 +1,592 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "candidate_bullpen_dataset_schema.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "candidate_bullpen_dataset_schema_checks.csv"
+)
+
+OUTPUT_CSV = (
+    TMP_DIR
+    / "candidate_bullpen_dataset_schema.csv"
+)
+
+
+INSPECTION_TARGETS = [
+    "scripts/audit_candidate_bullpen_data_requirements.py",
+    "scripts/audit_candidate_bullpen_calibration_feasibility.py",
+    "mlb_app/simulation/bullpen_state.py",
+    "mlb_app/simulation/bullpen_initializer.py",
+    "mlb_app/simulation/bullpen_selection.py",
+    "mlb_app/simulation/bullpen_usage.py",
+    "mlb_app/simulation/bullpen_chain.py",
+    "mlb_app/simulation/bullpen_shadow_simulation.py",
+]
+
+
+REQUIRED_COLUMNS = [
+    "game_id",
+    "team_id",
+    "pitcher_id",
+    "appearance_order",
+    "inning",
+    "score_margin",
+    "outs",
+    "base_state",
+    "leverage_bucket",
+    "days_rest",
+    "back_to_back_flag",
+    "recent_pitch_count",
+    "role_label",
+    "manager_team_profile_id",
+    "availability_status",
+    "shadow_delta_detected",
+]
+
+
+def build_rows():
+
+    return [
+        {
+            "table_name": (
+                "bullpen_reliever_appearance_sequences"
+            ),
+            "primary_key": (
+                "game_id,team_id,appearance_order"
+            ),
+            "join_keys": (
+                "game_id,team_id,pitcher_id"
+            ),
+            "required_columns": (
+                "game_id,team_id,pitcher_id,"
+                "appearance_order,inning"
+            ),
+            "derived_feature_columns": (
+                "leverage_bucket,role_label,"
+                "score_margin"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "historical_game_logs"
+            ),
+            "readiness_status": (
+                "schema_defined"
+            ),
+            "blocking_issue": (
+                "etl_not_implemented"
+            ),
+            "recommended_action": (
+                "build_sequence_materialization_etl"
+            ),
+            "notes": (
+                "Core historical reliever sequence table."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_reliever_entry_states"
+            ),
+            "primary_key": (
+                "game_id,team_id,pitcher_id,"
+                "appearance_order"
+            ),
+            "join_keys": (
+                "game_id,team_id,pitcher_id"
+            ),
+            "required_columns": (
+                "inning,outs,base_state,"
+                "score_margin"
+            ),
+            "derived_feature_columns": (
+                "leverage_bucket"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "play_by_play"
+            ),
+            "readiness_status": (
+                "schema_defined"
+            ),
+            "blocking_issue": (
+                "entry_state_etl_missing"
+            ),
+            "recommended_action": (
+                "derive_entry_game_state_features"
+            ),
+            "notes": (
+                "Supports leverage and role calibration."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_recent_workload_features"
+            ),
+            "primary_key": (
+                "game_id,team_id,pitcher_id"
+            ),
+            "join_keys": (
+                "pitcher_id,game_id"
+            ),
+            "required_columns": (
+                "days_rest,recent_pitch_count,"
+                "back_to_back_flag"
+            ),
+            "derived_feature_columns": (
+                "rolling_3_day_pitch_count,"
+                "rolling_7_day_appearances"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "appearance_logs"
+            ),
+            "readiness_status": (
+                "schema_partial"
+            ),
+            "blocking_issue": (
+                "recent_workload_history_not_materialized"
+            ),
+            "recommended_action": (
+                "construct_recent_workload_aggregations"
+            ),
+            "notes": (
+                "Workload schema exists conceptually but "
+                "persistent aggregation layer is missing."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_role_identity_profiles"
+            ),
+            "primary_key": (
+                "team_id,season"
+            ),
+            "join_keys": (
+                "team_id,pitcher_id"
+            ),
+            "required_columns": (
+                "role_label,leverage_bucket"
+            ),
+            "derived_feature_columns": (
+                "closer_usage_rate,"
+                "setup_usage_rate"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "derived_historical_usage"
+            ),
+            "readiness_status": (
+                "schema_defined"
+            ),
+            "blocking_issue": "",
+            "recommended_action": (
+                "derive_team_role_profiles"
+            ),
+            "notes": (
+                "Supports bullpen role identity modeling."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_manager_team_tendency_profiles"
+            ),
+            "primary_key": (
+                "manager_team_profile_id"
+            ),
+            "join_keys": (
+                "team_id,season"
+            ),
+            "required_columns": (
+                "manager_team_profile_id,"
+                "role_label"
+            ),
+            "derived_feature_columns": (
+                "aggressive_closer_usage_rate,"
+                "high_leverage_hook_rate"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "longitudinal_usage_profiles"
+            ),
+            "readiness_status": (
+                "schema_partial"
+            ),
+            "blocking_issue": (
+                "manager_metadata_and_history_missing"
+            ),
+            "recommended_action": (
+                "build_manager_team_tendency_profiles"
+            ),
+            "notes": (
+                "Requires longitudinal manager/team tracking."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_multi_game_availability_memory"
+            ),
+            "primary_key": (
+                "pitcher_id,game_id"
+            ),
+            "join_keys": (
+                "pitcher_id"
+            ),
+            "required_columns": (
+                "availability_status,"
+                "days_rest"
+            ),
+            "derived_feature_columns": (
+                "fatigue_carryover_score"
+            ),
+            "label_columns": "",
+            "source_dependency": (
+                "persistent_workload_history"
+            ),
+            "readiness_status": (
+                "schema_partial"
+            ),
+            "blocking_issue": (
+                "cross_game_memory_not_implemented"
+            ),
+            "recommended_action": (
+                "design_persistent_availability_state"
+            ),
+            "notes": (
+                "Current candidate architecture remains "
+                "single-game scoped."
+            ),
+        },
+        {
+            "table_name": (
+                "bullpen_shadow_backtest_labels"
+            ),
+            "primary_key": (
+                "game_id,team_id,pitcher_id"
+            ),
+            "join_keys": (
+                "game_id,team_id,pitcher_id"
+            ),
+            "required_columns": (
+                "shadow_delta_detected"
+            ),
+            "derived_feature_columns": (
+                "candidate_selection_count,"
+                "fallback_count"
+            ),
+            "label_columns": (
+                "shadow_delta_detected"
+            ),
+            "source_dependency": (
+                "layer_6_shadow_outputs"
+            ),
+            "readiness_status": (
+                "schema_defined"
+            ),
+            "blocking_issue": "",
+            "recommended_action": (
+                "reuse_existing_shadow_outputs"
+            ),
+            "notes": (
+                "Shadow labels are already available from "
+                "prior candidate bullpen layers."
+            ),
+        },
+    ]
+
+
+def main():
+
+    rows = build_rows()
+
+    df = pd.DataFrame(rows)[
+        [
+            "table_name",
+            "primary_key",
+            "join_keys",
+            "required_columns",
+            "derived_feature_columns",
+            "label_columns",
+            "source_dependency",
+            "readiness_status",
+            "blocking_issue",
+            "recommended_action",
+            "notes",
+        ]
+    ]
+
+    df.to_csv(
+        OUTPUT_CSV,
+        index=False,
+    )
+
+    inspection_targets_present = all(
+        Path(path).exists()
+        for path in INSPECTION_TARGETS
+    )
+
+    required_tables_defined = (
+        len(df) == 7
+    )
+
+    primary_keys_defined = all(
+        df["primary_key"].astype(str).str.len() > 0
+    )
+
+    join_keys_defined = all(
+        df["join_keys"].astype(str).str.len() > 0
+    )
+
+    entry_state_columns_present = all(
+        column in ",".join(
+            df["required_columns"]
+        )
+        for column in [
+            "inning",
+            "score_margin",
+            "outs",
+            "base_state",
+            "leverage_bucket",
+        ]
+    )
+
+    workload_columns_present = all(
+        column in (
+            ",".join(df["required_columns"])
+            + ","
+            + ",".join(
+                df["derived_feature_columns"]
+            )
+        )
+        for column in [
+            "days_rest",
+            "back_to_back_flag",
+            "recent_pitch_count",
+        ]
+    )
+
+    role_columns_present = (
+        "role_label"
+        in (
+            ",".join(df["required_columns"])
+            + ","
+            + ",".join(
+                df["derived_feature_columns"]
+            )
+        )
+    )
+
+    tendency_columns_present = (
+        "manager_team_profile_id"
+        in (
+            ",".join(df["required_columns"])
+            + ","
+            + ",".join(
+                df["derived_feature_columns"]
+            )
+        )
+    )
+
+    availability_columns_present = (
+        "availability_status"
+        in (
+            ",".join(df["required_columns"])
+            + ","
+            + ",".join(
+                df["derived_feature_columns"]
+            )
+        )
+    )
+
+    shadow_label_columns_present = (
+        "shadow_delta_detected"
+        in (
+            ",".join(df["required_columns"])
+            + ","
+            + ",".join(
+                df["label_columns"]
+            )
+        )
+    )
+
+    checks = [
+        {
+            "check": "inspection_targets_present",
+            "passed": inspection_targets_present,
+            "detail": ",".join(
+                INSPECTION_TARGETS
+            ),
+        },
+        {
+            "check": "required_tables_defined",
+            "passed": required_tables_defined,
+            "detail": len(df),
+        },
+        {
+            "check": "primary_keys_defined",
+            "passed": primary_keys_defined,
+            "detail": primary_keys_defined,
+        },
+        {
+            "check": "join_keys_defined",
+            "passed": join_keys_defined,
+            "detail": join_keys_defined,
+        },
+        {
+            "check": "entry_state_columns_present",
+            "passed": entry_state_columns_present,
+            "detail": entry_state_columns_present,
+        },
+        {
+            "check": "workload_columns_present",
+            "passed": workload_columns_present,
+            "detail": workload_columns_present,
+        },
+        {
+            "check": "role_columns_present",
+            "passed": role_columns_present,
+            "detail": role_columns_present,
+        },
+        {
+            "check": "tendency_columns_present",
+            "passed": tendency_columns_present,
+            "detail": tendency_columns_present,
+        },
+        {
+            "check": "availability_columns_present",
+            "passed": availability_columns_present,
+            "detail": availability_columns_present,
+        },
+        {
+            "check": "shadow_label_columns_present",
+            "passed": shadow_label_columns_present,
+            "detail": shadow_label_columns_present,
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_transition_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    checks_df = pd.DataFrame(checks)
+
+    checks_df.to_csv(
+        OUTPUT_CHECKS,
+        index=False,
+    )
+
+    schema_defined_tables = int(
+        (
+            df["readiness_status"]
+            == "schema_defined"
+        ).sum()
+    )
+
+    schema_partial_tables = int(
+        (
+            df["readiness_status"]
+            == "schema_partial"
+        ).sum()
+    )
+
+    schema_blocked_tables = int(
+        (
+            df["readiness_status"]
+            == "schema_blocked"
+        ).sum()
+    )
+
+    schema_ready_for_etl_planning = bool(
+        schema_blocked_tables == 0
+        and schema_defined_tables >= 4
+    )
+
+    if (
+        schema_blocked_tables == 0
+        and schema_partial_tables == 0
+    ):
+        diagnosis = (
+            "candidate_bullpen_dataset_schema_ready"
+        )
+
+    elif schema_ready_for_etl_planning:
+        diagnosis = (
+            "candidate_bullpen_dataset_schema_partial"
+        )
+
+    else:
+        diagnosis = (
+            "candidate_bullpen_dataset_schema_blocked"
+        )
+
+    payload = {
+        "diagnosis": diagnosis,
+        "tables_defined": len(df),
+        "schema_defined_tables": (
+            schema_defined_tables
+        ),
+        "schema_partial_tables": (
+            schema_partial_tables
+        ),
+        "schema_blocked_tables": (
+            schema_blocked_tables
+        ),
+        "top_blocker": (
+            "etl_not_implemented_for_sequence_and_workload_tables"
+        ),
+        "schema_ready_for_etl_planning": (
+            schema_ready_for_etl_planning
+        ),
+        "production_default_unchanged": True,
+        "recommended_next_step": (
+            "layer_6au_candidate_bullpen_etl_plan"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6AT candidate bullpen dataset schema audit.

## What this adds

- `scripts/audit_candidate_bullpen_dataset_schema.py`

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/audit_candidate_bullpen_dataset_schema.py
cat tmp/candidate_bullpen_dataset_schema_checks.csv
cat tmp/candidate_bullpen_dataset_schema.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_dataset_schema_partial",
  "tables_defined": 7,
  "schema_defined_tables": 4,
  "schema_partial_tables": 3,
  "schema_blocked_tables": 0,
  "top_blocker": "etl_not_implemented_for_sequence_and_workload_tables",
  "schema_ready_for_etl_planning": true,
  "production_default_unchanged": true,
  "recommended_next_step": "layer_6au_candidate_bullpen_etl_plan"
}
```

## Safety

The audit is schema-only. It does not create database tables, ingest data, run ETL, mutate game engine, alter inning simulation, alter transitions/scoring, or change production defaults.

## Recommended next step

Layer 6AU — Candidate Bullpen ETL Plan