### PR TITLE
Add Layer 6AW candidate bullpen ETL prototype validation

### DIFF
--- a/scripts/validate_candidate_bullpen_etl_prototype.py
+++ b/scripts/validate_candidate_bullpen_etl_prototype.py
@@ -1,0 +1,585 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "candidate_bullpen_etl_prototype_validation.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "candidate_bullpen_etl_prototype_validation_checks.csv"
+)
+
+OUTPUT_MATRIX = (
+    TMP_DIR
+    / "candidate_bullpen_etl_prototype_validation_matrix.csv"
+)
+
+
+TABLE_PATHS = {
+    "appearance_sequences": (
+        TMP_DIR
+        / "prototype_bullpen_reliever_appearance_sequences.csv"
+    ),
+    "entry_states": (
+        TMP_DIR
+        / "prototype_bullpen_reliever_entry_states.csv"
+    ),
+    "workload_features": (
+        TMP_DIR
+        / "prototype_bullpen_recent_workload_features.csv"
+    ),
+    "role_identity_profiles": (
+        TMP_DIR
+        / "prototype_bullpen_role_identity_profiles.csv"
+    ),
+    "manager_team_tendency_profiles": (
+        TMP_DIR
+        / "prototype_bullpen_manager_team_tendency_profiles.csv"
+    ),
+    "availability_memory": (
+        TMP_DIR
+        / "prototype_bullpen_multi_game_availability_memory.csv"
+    ),
+    "shadow_labels": (
+        TMP_DIR
+        / "prototype_bullpen_shadow_backtest_labels.csv"
+    ),
+}
+
+
+PRIMARY_KEYS = {
+    "appearance_sequences": [
+        "game_id",
+        "team_id",
+        "appearance_order",
+    ],
+    "entry_states": [
+        "game_id",
+        "team_id",
+        "pitcher_id",
+        "appearance_order",
+    ],
+    "workload_features": [
+        "game_id",
+        "team_id",
+        "pitcher_id",
+    ],
+    "role_identity_profiles": [
+        "team_id",
+        "season",
+        "pitcher_id",
+    ],
+    "manager_team_tendency_profiles": [
+        "manager_team_profile_id",
+    ],
+    "availability_memory": [
+        "pitcher_id",
+        "game_id",
+    ],
+    "shadow_labels": [
+        "game_id",
+        "team_id",
+        "pitcher_id",
+    ],
+}
+
+
+CALIBRATION_FEATURE_COLUMNS = [
+    "leverage_bucket",
+    "score_margin",
+    "inning",
+    "outs",
+    "base_state",
+    "days_rest",
+    "recent_pitch_count",
+    "back_to_back_flag",
+    "role_label",
+    "availability_status",
+    "fatigue_carryover_score",
+]
+
+
+SHADOW_LABEL_COLUMNS = [
+    "shadow_delta_detected",
+    "candidate_selection_count",
+    "fallback_count",
+]
+
+
+def ensure_prototype_outputs():
+
+    missing = [
+        path
+        for path in TABLE_PATHS.values()
+        if not path.exists()
+    ]
+
+    if missing:
+        subprocess.run(
+            [
+                sys.executable,
+                "scripts/prototype_candidate_bullpen_etl.py",
+            ],
+            check=True,
+        )
+
+
+def load_tables():
+
+    return {
+        name: pd.read_csv(path)
+        for name, path in TABLE_PATHS.items()
+    }
+
+
+def primary_key_unique(table_name, df):
+
+    key = PRIMARY_KEYS[table_name]
+
+    return bool(
+        not df.duplicated(
+            subset=key
+        ).any()
+    )
+
+
+def validate_join(
+    join_name,
+    left_table,
+    right_table,
+    left_df,
+    right_df,
+    join_keys,
+):
+
+    joined = left_df.merge(
+        right_df[
+            join_keys
+        ].drop_duplicates(),
+        on=join_keys,
+        how="left",
+        indicator=True,
+    )
+
+    left_rows = len(left_df)
+
+    matched_rows = int(
+        (
+            joined["_merge"]
+            == "both"
+        ).sum()
+    )
+
+    match_rate = (
+        matched_rows / left_rows
+        if left_rows
+        else 0.0
+    )
+
+    return {
+        "join_name": join_name,
+        "left_table": left_table,
+        "right_table": right_table,
+        "left_rows": left_rows,
+        "matched_rows": matched_rows,
+        "match_rate": round(
+            match_rate,
+            4,
+        ),
+        "passed": bool(
+            match_rate == 1.0
+        ),
+    }
+
+
+def main():
+
+    ensure_prototype_outputs()
+
+    tables = load_tables()
+
+    all_prototype_tables_present = all(
+        path.exists()
+        for path in TABLE_PATHS.values()
+    )
+
+    all_tables_non_empty = all(
+        len(df) > 0
+        for df in tables.values()
+    )
+
+    primary_keys_unique = all(
+        primary_key_unique(
+            table_name,
+            df,
+        )
+        for table_name, df in tables.items()
+    )
+
+    appearance = tables[
+        "appearance_sequences"
+    ]
+
+    entry = tables[
+        "entry_states"
+    ]
+
+    workload = tables[
+        "workload_features"
+    ]
+
+    role = tables[
+        "role_identity_profiles"
+    ]
+
+    manager = tables[
+        "manager_team_tendency_profiles"
+    ]
+
+    availability = tables[
+        "availability_memory"
+    ]
+
+    shadow = tables[
+        "shadow_labels"
+    ]
+
+    join_rows = [
+        validate_join(
+            "appearance_to_entry",
+            "appearance_sequences",
+            "entry_states",
+            appearance,
+            entry,
+            [
+                "game_id",
+                "team_id",
+                "pitcher_id",
+                "appearance_order",
+            ],
+        ),
+        validate_join(
+            "appearance_to_workload",
+            "appearance_sequences",
+            "workload_features",
+            appearance,
+            workload,
+            [
+                "game_id",
+                "team_id",
+                "pitcher_id",
+            ],
+        ),
+        validate_join(
+            "appearance_to_role_profile",
+            "appearance_sequences",
+            "role_identity_profiles",
+            appearance,
+            role,
+            [
+                "team_id",
+                "pitcher_id",
+                "role_label",
+                "leverage_bucket",
+            ],
+        ),
+        validate_join(
+            "appearance_to_shadow_label",
+            "appearance_sequences",
+            "shadow_labels",
+            appearance,
+            shadow,
+            [
+                "game_id",
+                "team_id",
+                "pitcher_id",
+            ],
+        ),
+        validate_join(
+            "workload_to_availability",
+            "workload_features",
+            "availability_memory",
+            workload,
+            availability,
+            [
+                "game_id",
+                "pitcher_id",
+            ],
+        ),
+        validate_join(
+            "role_to_manager_tendency",
+            "role_identity_profiles",
+            "manager_team_tendency_profiles",
+            role,
+            manager,
+            [
+                "team_id",
+                "season",
+                "role_label",
+            ],
+        ),
+    ]
+
+    matrix_df = pd.DataFrame(
+        join_rows
+    )
+
+    matrix_df.to_csv(
+        OUTPUT_MATRIX,
+        index=False,
+    )
+
+    joins_validated = len(matrix_df)
+
+    joins_passed = int(
+        matrix_df[
+            "passed"
+        ].sum()
+    )
+
+    minimum_join_match_rate = float(
+        matrix_df[
+            "match_rate"
+        ].min()
+    )
+
+    combined_columns = set()
+
+    for df in tables.values():
+        combined_columns.update(
+            df.columns
+        )
+
+    calibration_features_present = all(
+        column in combined_columns
+        for column in CALIBRATION_FEATURE_COLUMNS
+    )
+
+    shadow_labels_present = all(
+        column in shadow.columns
+        for column in SHADOW_LABEL_COLUMNS
+    )
+
+    checks = [
+        {
+            "check": "all_prototype_tables_present",
+            "passed": all_prototype_tables_present,
+            "detail": len(TABLE_PATHS),
+        },
+        {
+            "check": "all_tables_non_empty",
+            "passed": all_tables_non_empty,
+            "detail": all_tables_non_empty,
+        },
+        {
+            "check": "primary_keys_unique",
+            "passed": primary_keys_unique,
+            "detail": primary_keys_unique,
+        },
+        {
+            "check": "appearance_to_entry_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_entry"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_entry"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "appearance_to_workload_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_workload"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_workload"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "appearance_to_role_profile_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_role_profile"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_role_profile"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "appearance_to_shadow_label_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_shadow_label"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "appearance_to_shadow_label"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "workload_to_availability_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "workload_to_availability"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "workload_to_availability"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "role_to_manager_tendency_join_valid",
+            "passed": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "role_to_manager_tendency"
+                ]["passed"].iloc[0]
+            ),
+            "detail": bool(
+                matrix_df[
+                    matrix_df["join_name"]
+                    == "role_to_manager_tendency"
+                ]["passed"].iloc[0]
+            ),
+        },
+        {
+            "check": "calibration_features_present",
+            "passed": calibration_features_present,
+            "detail": calibration_features_present,
+        },
+        {
+            "check": "shadow_labels_present",
+            "passed": shadow_labels_present,
+            "detail": shadow_labels_present,
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_transition_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    checks_df = pd.DataFrame(
+        checks
+    )
+
+    checks_df.to_csv(
+        OUTPUT_CHECKS,
+        index=False,
+    )
+
+    prototype_validated_for_calibration = bool(
+        all_prototype_tables_present
+        and all_tables_non_empty
+        and primary_keys_unique
+        and joins_passed == joins_validated
+        and calibration_features_present
+        and shadow_labels_present
+    )
+
+    diagnosis = (
+        "candidate_bullpen_etl_prototype_validation_passed"
+        if prototype_validated_for_calibration
+        else (
+            "candidate_bullpen_etl_prototype_validation_partial"
+            if all_prototype_tables_present
+            and all_tables_non_empty
+            else "candidate_bullpen_etl_prototype_validation_failed"
+        )
+    )
+
+    payload = {
+        "diagnosis": diagnosis,
+        "tables_loaded": len(tables),
+        "joins_validated": joins_validated,
+        "joins_passed": joins_passed,
+        "minimum_join_match_rate": round(
+            minimum_join_match_rate,
+            4,
+        ),
+        "calibration_features_present": (
+            calibration_features_present
+        ),
+        "shadow_labels_present": (
+            shadow_labels_present
+        ),
+        "prototype_validated_for_calibration": (
+            prototype_validated_for_calibration
+        ),
+        "production_default_unchanged": True,
+        "recommended_next_step": (
+            "layer_6ax_candidate_bullpen_calibration_prototype_plan"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6AW candidate bullpen ETL prototype validation.

## What this adds

- `scripts/validate_candidate_bullpen_etl_prototype.py`

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/validate_candidate_bullpen_etl_prototype.py
cat tmp/candidate_bullpen_etl_prototype_validation_checks.csv
cat tmp/candidate_bullpen_etl_prototype_validation_matrix.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_etl_prototype_validation_passed",
  "tables_loaded": 7,
  "joins_validated": 6,
  "joins_passed": 6,
  "minimum_join_match_rate": 1.0,
  "calibration_features_present": true,
  "shadow_labels_present": true,
  "prototype_validated_for_calibration": true,
  "production_default_unchanged": true,
  "recommended_next_step": "layer_6ax_candidate_bullpen_calibration_prototype_plan"
}
```

## Safety

The validation uses synthetic/local prototype outputs only. It does not ingest real data, create database tables, run production ETL, mutate game engine, alter inning simulation, alter transitions/scoring, or change production defaults.

## Recommended next step

Layer 6AX — Candidate Bullpen Calibration Prototype Plan