### PR TITLE
Add backend route visibility diagnostics

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -32,6 +32,7 @@ import datetime
 import os
 import re
 import time
+import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests as _req
@@ -1517,6 +1518,38 @@ def create_app():
             live_only=live_only,
             state=state,
         )
+
+
+    @app.get("/debug/routes")
+    def debug_routes() -> Dict[str, Any]:
+        """Return mounted route visibility for deployment diagnostics."""
+        route_paths = sorted(
+            {
+                getattr(route, "path", "")
+                for route in app.routes
+                if getattr(route, "path", "")
+            }
+        )
+
+        try:
+            git_sha = subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except Exception:
+            git_sha = os.getenv("RAILWAY_GIT_COMMIT_SHA") or os.getenv("GIT_SHA")
+
+        return {
+            "status": "ok",
+            "version": "0.5.2",
+            "git_sha": git_sha,
+            "route_count": len(route_paths),
+            "has_models_projections": "/models/projections" in route_paths,
+            "has_matchups": "/matchups" in route_paths,
+            "has_daily_odds": any(route.startswith("/daily-odds") for route in route_paths),
+            "routes": route_paths,
+        }
 
     @app.get("/matchups")
     def list_matchups(date: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/scripts/audit_backend_route_visibility.py
+++ b/scripts/audit_backend_route_visibility.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import json
+
+APP = Path("mlb_app/app.py")
+ROUTES = Path("mlb_app/model_projection_routes.py")
+OUT = Path("tmp/backend_route_visibility_audit.json")
+OUT.parent.mkdir(exist_ok=True)
+
+app_text = APP.read_text()
+routes_text = ROUTES.read_text()
+
+checks = {
+    "model_projection_router_imported": "model_projection_router" in app_text,
+    "model_projection_router_included": "include_router(model_projection_router)" in app_text,
+    "models_projections_route_defined": '@router.get("/models/projections")' in routes_text,
+    "app_factory_present": "def create_app" in app_text,
+    "app_object_created": "app = create_app()" in app_text,
+}
+
+payload = {
+    "diagnosis": "backend_route_visibility_expected_present" if all(checks.values()) else "backend_route_visibility_missing",
+    **checks,
+    "recommended_runtime_check": "/debug/routes",
+    "production_default_unchanged": True,
+}
+
+OUT.write_text(json.dumps(payload, indent=2))
+print(json.dumps(payload, indent=2))


### PR DESCRIPTION
## Summary

Adds a lightweight backend route visibility diagnostic endpoint and audit script to help determine whether Railway is running the expected backend code and whether `/models/projections` is mounted in production.

## What this adds

- `GET /debug/routes`
  - reports mounted route paths
  - reports whether `/models/projections`, `/matchups`, and `/daily-odds` are present
  - reports route count and deployment git SHA when available
- `scripts/audit_backend_route_visibility.py`
  - verifies local source wiring for model projection route registration

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/audit_backend_route_visibility.py
```

Result:

```json
{
  "diagnosis": "backend_route_visibility_expected_present",
  "model_projection_router_imported": true,
  "model_projection_router_included": true,
  "models_projections_route_defined": true,
  "app_factory_present": true,
  "app_object_created": true,
  "recommended_runtime_check": "/debug/routes",
  "production_default_unchanged": true
}
```

## Context

The live Backend Sandbox currently returns 404 for `/models/projections`, while merged `main` includes and registers the route. This diagnostic endpoint will distinguish between a stale/wrong Railway deployment and an app route-registration/runtime issue.

## Safety

This does not alter model logic, matchup generation, database writes, scoring, simulations, routes used by frontend pages, or production defaults.