### PR TITLE
Use shared API base for model projections page

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { API_BASE } from '../lib/api'
 
-const API = import.meta.env.VITE_API_BASE_URL || ''
+const API = API_BASE
 
 const s = {
   page: { color: '#e6edf3' },


### PR DESCRIPTION
## Summary

Updates the Model Projections frontend page to use the shared `API_BASE` helper instead of falling back to an empty API base.

## Problem

`frontend/src/pages/ModelProjectionsPage.jsx` used:

```js
const API = import.meta.env.VITE_API_BASE_URL || ''
```

When `VITE_API_BASE_URL` is missing or stale at frontend build time, the page calls the frontend origin for `/models/projections`, which causes the Model Projections page to show missing simulation projections even though the production backend endpoint is healthy.

## What changed

- Imports `API_BASE` from `frontend/src/lib/api.js`
- Uses the same production backend fallback as the other working frontend pages

## Validation

Direct production backend validation:

```bash
API="https://mlb-prediction-app-production-732c.up.railway.app"

curl -s "$API/health"
curl -s "$API/debug/routes" | python -m json.tool | grep -n "models/projections" -C 3
curl -s "$API/models/projections?date=2026-05-20" | python -m json.tool | head -160
```

Confirmed:

- production backend health returns `0.5.2`
- `/debug/routes` includes `/models/projections`
- `/models/projections?date=2026-05-20` returns `count: 15`

Local frontend build note:

`npm --prefix frontend run build` currently fails because `BatterPage.jsx` imports missing dependency `recharts`. That is unrelated to this one-line API-base fix and should be handled separately if Railway build also fails.

## Safety

Frontend-only API base routing fix. No backend logic, model logic, database writes, simulations, scoring, or production defaults are changed.