### PR TITLE
Render model projections from shared simulation payload

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -804,7 +804,11 @@ function GameProjectionCard({ game }) {
         ))}
       </div>
 
-      {!awayRunModel || !homeRunModel || !totalModel ? (
+      {(
+        !awayRunModel ||
+        !homeRunModel ||
+        !totalModel
+      ) && !Object.keys(getSharedDerivedSimulation(game) || {}).length ? (
         <div style={s.noData}>Simulation projections are not available for this game yet.</div>
       ) : renderTab()}
     </article>


### PR DESCRIPTION
## Summary

Updates the Model Projections page so it renders when the backend provides the newer sharedSimulation payload, even if the legacy Simulation model rows are absent.

## Problem

The page was reaching the production models projections endpoint and rendering game cards, but each card still showed that simulation projections were not available.

The card gate required all three legacy model records: awayRunModel, homeRunModel, and totalModel.

The production backend now provides simulation data through sharedSimulation.derived_outputs, so missing legacy model rows should not block rendering when shared simulation data is present.

## What changed

The availability gate now allows rendering when getSharedDerivedSimulation(game) has content.

## Validation

Production backend was confirmed healthy:

- backend health returns 0.5.2
- debug routes include models projections
- models projections for 2026-05-20 returns count 15
- payload includes sharedSimulation status ok and derived simulation outputs

## Safety

Frontend-only rendering gate fix. No backend logic, database writes, model logic, simulations, scoring, or production defaults are changed.