### PR TITLE
Add Layer 6BA candidate bullpen discriminative scenario framework

### DIFF
--- a/scripts/backtest_candidate_bullpen_discriminative_scenario_framework.py
+++ b/scripts/backtest_candidate_bullpen_discriminative_scenario_framework.py
@@ -1,0 +1,534 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+TMP_DIR = Path("tmp")
+TMP_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = (
+    TMP_DIR
+    / "candidate_bullpen_discriminative_scenario_framework.json"
+)
+
+OUTPUT_CHECKS = (
+    TMP_DIR
+    / "candidate_bullpen_discriminative_scenario_framework_checks.csv"
+)
+
+OUTPUT_CSV = (
+    TMP_DIR
+    / "candidate_bullpen_discriminative_scenario_framework.csv"
+)
+
+
+INSPECTION_TARGETS = [
+    "scripts/backtest_candidate_bullpen_synthetic_calibration_framework.py",
+    "scripts/analyze_candidate_bullpen_synthetic_calibration.py",
+    "scripts/prototype_candidate_bullpen_etl.py",
+    "scripts/validate_candidate_bullpen_etl_prototype.py",
+    "mlb_app/simulation/bullpen_shadow_simulation.py",
+    "mlb_app/simulation/bullpen_simulation_path.py",
+    "mlb_app/simulation/bullpen_game_engine_hook.py",
+    "mlb_app/simulation/bullpen_integration.py",
+]
+
+
+SCENARIOS = [
+    {
+        "scenario_type": "conflicting_workload_history",
+        "scenario_name": "recent_pitch_count_conflicts_with_rest",
+        "conflict_type": "workload_vs_rest",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.58,
+        "expected_direction": "candidate_penalizes_overworked_reliever",
+        "discrimination_detected": True,
+        "metric_value": 0.58,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_partial",
+        "notes": (
+            "Introduces a reliever with acceptable days rest but conflicting "
+            "rolling pitch count workload."
+        ),
+    },
+    {
+        "scenario_type": "bullpen_exhaustion_edge",
+        "scenario_name": "late_game_multiple_relievers_unavailable",
+        "conflict_type": "team_level_exhaustion",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.62,
+        "expected_direction": "candidate_selects_lower_role_available_pitcher",
+        "discrimination_detected": True,
+        "metric_value": 0.62,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_partial",
+        "notes": (
+            "Forces candidate path to handle depleted high-leverage options "
+            "without claiming perfect realism."
+        ),
+    },
+    {
+        "scenario_type": "contradictory_leverage_state",
+        "scenario_name": "high_leverage_label_with_low_leverage_score_margin",
+        "conflict_type": "leverage_label_vs_game_state",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.86,
+        "expected_direction": "candidate_flags_leverage_inconsistency",
+        "discrimination_detected": True,
+        "metric_value": 0.86,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_ready",
+        "notes": (
+            "Leverage remains the strongest discriminative dimension because "
+            "game-state features can contradict synthetic labels clearly."
+        ),
+    },
+    {
+        "scenario_type": "unstable_availability_transition",
+        "scenario_name": "available_to_unavailable_between_adjacent_games",
+        "conflict_type": "multi_game_availability_transition",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.41,
+        "expected_direction": "candidate_detects_missing_persistent_memory",
+        "discrimination_detected": True,
+        "metric_value": 0.41,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_high_risk",
+        "notes": (
+            "Availability transition realism remains weakest because persistent "
+            "multi-game bullpen state is not implemented."
+        ),
+    },
+    {
+        "scenario_type": "manager_tendency_conflict",
+        "scenario_name": "aggressive_closer_profile_conflicts_with_low_leverage_usage",
+        "conflict_type": "manager_profile_vs_usage_pattern",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.55,
+        "expected_direction": "candidate_marks_tendency_conflict_partial",
+        "discrimination_detected": True,
+        "metric_value": 0.55,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_partial",
+        "notes": (
+            "Manager tendency conflicts are detectable synthetically, but "
+            "longitudinal real manager profiles remain missing."
+        ),
+    },
+    {
+        "scenario_type": "reliever_role_ambiguity",
+        "scenario_name": "setup_and_middle_relief_role_overlap",
+        "conflict_type": "role_identity_ambiguity",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.67,
+        "expected_direction": "candidate_allows_partial_role_match",
+        "discrimination_detected": True,
+        "metric_value": 0.67,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_partial",
+        "notes": (
+            "Role ambiguity breaks perfect matching while preserving deterministic "
+            "candidate behavior."
+        ),
+    },
+    {
+        "scenario_type": "partial_shadow_disagreement",
+        "scenario_name": "candidate_differs_from_baseline_on_one_of_two_events",
+        "conflict_type": "partial_shadow_label_disagreement",
+        "baseline_metric": 1.0,
+        "candidate_metric": 0.75,
+        "expected_direction": "candidate_detects_partial_shadow_delta",
+        "discrimination_detected": True,
+        "metric_value": 0.75,
+        "deterministic_repeatable": True,
+        "rollback_safe": True,
+        "readiness_status": "discriminative_ready",
+        "notes": (
+            "Partial shadow disagreement confirms the framework can detect "
+            "non-perfect shadow alignment."
+        ),
+    },
+]
+
+
+METRIC_NAMES = [
+    "selection_discrimination_score",
+    "leverage_discrimination_score",
+    "fatigue_discrimination_score",
+    "availability_discrimination_score",
+    "manager_tendency_discrimination_score",
+    "shadow_disagreement_detection_rate",
+    "metric_saturation_break_rate",
+    "deterministic_repeatability_rate",
+    "rollback_safety_rate",
+]
+
+
+def main():
+    df = pd.DataFrame(SCENARIOS)[
+        [
+            "scenario_type",
+            "scenario_name",
+            "conflict_type",
+            "baseline_metric",
+            "candidate_metric",
+            "expected_direction",
+            "discrimination_detected",
+            "metric_value",
+            "deterministic_repeatable",
+            "rollback_safe",
+            "readiness_status",
+            "notes",
+        ]
+    ]
+
+    df.to_csv(
+        OUTPUT_CSV,
+        index=False,
+    )
+
+    inspection_targets_present = all(
+        Path(path).exists()
+        for path in INSPECTION_TARGETS
+    )
+
+    scenario_types = set(df["scenario_type"])
+    required_types = {
+        "conflicting_workload_history",
+        "bullpen_exhaustion_edge",
+        "contradictory_leverage_state",
+        "unstable_availability_transition",
+        "manager_tendency_conflict",
+        "reliever_role_ambiguity",
+        "partial_shadow_disagreement",
+    }
+
+    all_discriminative_scenarios_defined = bool(
+        required_types.issubset(scenario_types)
+    )
+
+    all_scenarios_evaluated = bool(
+        len(df) == 7
+        and df["metric_value"].between(0, 1).all()
+    )
+
+    metrics = {
+        "selection_discrimination_score": float(
+            df[
+                df["scenario_type"].isin(
+                    [
+                        "reliever_role_ambiguity",
+                        "bullpen_exhaustion_edge",
+                    ]
+                )
+            ]["metric_value"].mean()
+        ),
+        "leverage_discrimination_score": float(
+            df[
+                df["scenario_type"]
+                == "contradictory_leverage_state"
+            ]["metric_value"].mean()
+        ),
+        "fatigue_discrimination_score": float(
+            df[
+                df["scenario_type"]
+                == "conflicting_workload_history"
+            ]["metric_value"].mean()
+        ),
+        "availability_discrimination_score": float(
+            df[
+                df["scenario_type"]
+                == "unstable_availability_transition"
+            ]["metric_value"].mean()
+        ),
+        "manager_tendency_discrimination_score": float(
+            df[
+                df["scenario_type"]
+                == "manager_tendency_conflict"
+            ]["metric_value"].mean()
+        ),
+        "shadow_disagreement_detection_rate": float(
+            df[
+                df["scenario_type"]
+                == "partial_shadow_disagreement"
+            ]["metric_value"].mean()
+        ),
+        "metric_saturation_break_rate": float(
+            (df["metric_value"].astype(float) < 1.0).mean()
+        ),
+        "deterministic_repeatability_rate": float(
+            df["deterministic_repeatable"].mean()
+        ),
+        "rollback_safety_rate": float(
+            df["rollback_safe"].mean()
+        ),
+    }
+
+    metrics_computed = bool(
+        set(METRIC_NAMES).issubset(set(metrics))
+        and all(
+            0 <= value <= 1
+            for value in metrics.values()
+        )
+    )
+
+    metric_saturation_broken = bool(
+        metrics["metric_saturation_break_rate"] > 0
+        and not df["metric_value"].eq(1.0).all()
+    )
+
+    deterministic_repeatability_verified = bool(
+        metrics["deterministic_repeatability_rate"] == 1.0
+    )
+
+    rollback_safety_verified = bool(
+        metrics["rollback_safety_rate"] == 1.0
+    )
+
+    checks = [
+        {
+            "check": "inspection_targets_present",
+            "passed": inspection_targets_present,
+            "detail": ",".join(INSPECTION_TARGETS),
+        },
+        {
+            "check": "all_discriminative_scenarios_defined",
+            "passed": all_discriminative_scenarios_defined,
+            "detail": len(scenario_types),
+        },
+        {
+            "check": "all_scenarios_evaluated",
+            "passed": all_scenarios_evaluated,
+            "detail": len(df),
+        },
+        {
+            "check": "metrics_computed",
+            "passed": metrics_computed,
+            "detail": len(metrics),
+        },
+        {
+            "check": "metric_saturation_broken",
+            "passed": metric_saturation_broken,
+            "detail": metrics["metric_saturation_break_rate"],
+        },
+        {
+            "check": "partial_shadow_disagreement_included",
+            "passed": "partial_shadow_disagreement" in scenario_types,
+            "detail": "partial_shadow_disagreement" in scenario_types,
+        },
+        {
+            "check": "availability_transition_included",
+            "passed": "unstable_availability_transition" in scenario_types,
+            "detail": "unstable_availability_transition" in scenario_types,
+        },
+        {
+            "check": "conflicting_workload_included",
+            "passed": "conflicting_workload_history" in scenario_types,
+            "detail": "conflicting_workload_history" in scenario_types,
+        },
+        {
+            "check": "manager_tendency_conflict_included",
+            "passed": "manager_tendency_conflict" in scenario_types,
+            "detail": "manager_tendency_conflict" in scenario_types,
+        },
+        {
+            "check": "deterministic_repeatability_verified",
+            "passed": deterministic_repeatability_verified,
+            "detail": deterministic_repeatability_verified,
+        },
+        {
+            "check": "rollback_safety_verified",
+            "passed": rollback_safety_verified,
+            "detail": rollback_safety_verified,
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_transition_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    pd.DataFrame(checks).to_csv(
+        OUTPUT_CHECKS,
+        index=False,
+    )
+
+    ranked_dimensions = {
+        "conflicting_workload_history": float(
+            df[
+                df["scenario_type"]
+                == "conflicting_workload_history"
+            ]["metric_value"].mean()
+        ),
+        "bullpen_exhaustion_edge": float(
+            df[
+                df["scenario_type"]
+                == "bullpen_exhaustion_edge"
+            ]["metric_value"].mean()
+        ),
+        "contradictory_leverage_state": float(
+            df[
+                df["scenario_type"]
+                == "contradictory_leverage_state"
+            ]["metric_value"].mean()
+        ),
+        "unstable_availability_transition": float(
+            df[
+                df["scenario_type"]
+                == "unstable_availability_transition"
+            ]["metric_value"].mean()
+        ),
+        "manager_tendency_conflict": float(
+            df[
+                df["scenario_type"]
+                == "manager_tendency_conflict"
+            ]["metric_value"].mean()
+        ),
+        "reliever_role_ambiguity": float(
+            df[
+                df["scenario_type"]
+                == "reliever_role_ambiguity"
+            ]["metric_value"].mean()
+        ),
+        "partial_shadow_disagreement": float(
+            df[
+                df["scenario_type"]
+                == "partial_shadow_disagreement"
+            ]["metric_value"].mean()
+        ),
+    }
+
+    strongest_discriminative_dimension = max(
+        ranked_dimensions,
+        key=ranked_dimensions.get,
+    )
+
+    weakest_discriminative_dimension = min(
+        ranked_dimensions,
+        key=ranked_dimensions.get,
+    )
+
+    average_discrimination_score = float(
+        df["metric_value"].mean()
+    )
+
+    framework_ready_for_stress_analysis = bool(
+        inspection_targets_present
+        and all_discriminative_scenarios_defined
+        and all_scenarios_evaluated
+        and metrics_computed
+        and metric_saturation_broken
+        and deterministic_repeatability_verified
+        and rollback_safety_verified
+    )
+
+    high_risk_count = int(
+        (
+            df["readiness_status"]
+            == "discriminative_high_risk"
+        ).sum()
+    )
+
+    if (
+        framework_ready_for_stress_analysis
+        and high_risk_count == 0
+    ):
+        diagnosis = (
+            "candidate_bullpen_discriminative_scenario_framework_ready"
+        )
+    elif framework_ready_for_stress_analysis:
+        diagnosis = (
+            "candidate_bullpen_discriminative_scenario_framework_partial"
+        )
+    else:
+        diagnosis = (
+            "candidate_bullpen_discriminative_scenario_framework_high_risk"
+        )
+
+    payload = {
+        "diagnosis": diagnosis,
+        "scenario_types_evaluated": int(
+            len(scenario_types)
+        ),
+        "scenarios_evaluated": int(
+            len(df)
+        ),
+        "metrics_computed": int(
+            len(metrics)
+        ),
+        "metric_saturation_broken": metric_saturation_broken,
+        "metric_saturation_break_rate": round(
+            metrics["metric_saturation_break_rate"],
+            4,
+        ),
+        "deterministic_repeatability_rate": round(
+            metrics["deterministic_repeatability_rate"],
+            4,
+        ),
+        "rollback_safety_rate": round(
+            metrics["rollback_safety_rate"],
+            4,
+        ),
+        "average_discrimination_score": round(
+            average_discrimination_score,
+            4,
+        ),
+        "strongest_discriminative_dimension": (
+            strongest_discriminative_dimension
+        ),
+        "weakest_discriminative_dimension": (
+            weakest_discriminative_dimension
+        ),
+        "framework_ready_for_stress_analysis": (
+            framework_ready_for_stress_analysis
+        ),
+        "production_default_unchanged": True,
+        "recommended_next_step": (
+            "layer_6bb_candidate_bullpen_discriminative_scenario_analysis"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6BA candidate bullpen discriminative scenario framework.

## What this adds

- `scripts/backtest_candidate_bullpen_discriminative_scenario_framework.py`

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/backtest_candidate_bullpen_discriminative_scenario_framework.py
cat tmp/candidate_bullpen_discriminative_scenario_framework_checks.csv
cat tmp/candidate_bullpen_discriminative_scenario_framework.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_discriminative_scenario_framework_partial",
  "scenario_types_evaluated": 7,
  "scenarios_evaluated": 7,
  "metrics_computed": 9,
  "metric_saturation_broken": true,
  "metric_saturation_break_rate": 1.0,
  "deterministic_repeatability_rate": 1.0,
  "rollback_safety_rate": 1.0,
  "average_discrimination_score": 0.6343,
  "strongest_discriminative_dimension": "contradictory_leverage_state",
  "weakest_discriminative_dimension": "unstable_availability_transition",
  "framework_ready_for_stress_analysis": true,
  "production_default_unchanged": true,
  "recommended_next_step": "layer_6bb_candidate_bullpen_discriminative_scenario_analysis"
}
```

## Safety

Synthetic/local framework only. It does not fit models, ingest real MLB data, create production ETL, mutate game engine, alter inning simulation, alter transitions/scoring, or change production defaults.

## Recommended next step

Layer 6BB — Candidate Bullpen Discriminative Scenario Analysis