### PR TITLE
Add Layer 6BE candidate bullpen role segmentation analysis

### DIFF
--- a/scripts/analyze_candidate_bullpen_role_segmentation.py
+++ b/scripts/analyze_candidate_bullpen_role_segmentation.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.model_projections import build_model_projection_payload
+
+
+TARGET_DATE = "2026-05-20"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_role_segmentation_analysis.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_role_segmentation_analysis_checks.csv"
+OUTPUT_ROLE_ANALYSIS = OUTPUT_DIR / "candidate_bullpen_role_segmentation_analysis_roles.csv"
+OUTPUT_TEAM_SPREAD = OUTPUT_DIR / "candidate_bullpen_role_segmentation_analysis_team_spread.csv"
+
+
+ROLE_TEMPLATES = [
+    {
+        "role_name": "closer",
+        "role_priority": 1,
+        "leverage_bucket": "save_highest_leverage",
+        "expected_usage_inning_min": 8,
+        "expected_usage_inning_max": 9,
+        "inherited_runner_exposure": "low",
+        "k_delta": 0.018,
+        "bb_delta": -0.008,
+        "whiff_delta": 0.015,
+        "csw_delta": 0.010,
+        "hard_hit_delta": -0.012,
+        "xwoba_delta": -0.010,
+        "quality_delta": 0.030,
+    },
+    {
+        "role_name": "setup",
+        "role_priority": 2,
+        "leverage_bucket": "late_high_leverage",
+        "expected_usage_inning_min": 7,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.012,
+        "bb_delta": -0.005,
+        "whiff_delta": 0.010,
+        "csw_delta": 0.007,
+        "hard_hit_delta": -0.008,
+        "xwoba_delta": -0.007,
+        "quality_delta": 0.020,
+    },
+    {
+        "role_name": "high_leverage",
+        "role_priority": 3,
+        "leverage_bucket": "matchup_high_leverage",
+        "expected_usage_inning_min": 6,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "high",
+        "k_delta": 0.006,
+        "bb_delta": -0.002,
+        "whiff_delta": 0.006,
+        "csw_delta": 0.004,
+        "hard_hit_delta": -0.004,
+        "xwoba_delta": -0.004,
+        "quality_delta": 0.010,
+    },
+    {
+        "role_name": "middle_relief",
+        "role_priority": 4,
+        "leverage_bucket": "middle_neutral",
+        "expected_usage_inning_min": 4,
+        "expected_usage_inning_max": 7,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.000,
+        "bb_delta": 0.000,
+        "whiff_delta": 0.000,
+        "csw_delta": 0.000,
+        "hard_hit_delta": 0.000,
+        "xwoba_delta": 0.000,
+        "quality_delta": 0.000,
+    },
+    {
+        "role_name": "long_relief",
+        "role_priority": 5,
+        "leverage_bucket": "length_low_leverage",
+        "expected_usage_inning_min": 2,
+        "expected_usage_inning_max": 6,
+        "inherited_runner_exposure": "low",
+        "k_delta": -0.012,
+        "bb_delta": 0.006,
+        "whiff_delta": -0.010,
+        "csw_delta": -0.006,
+        "hard_hit_delta": 0.010,
+        "xwoba_delta": 0.010,
+        "quality_delta": -0.020,
+    },
+]
+
+
+EXPECTED_ROLE_ORDER = ["closer", "setup", "high_leverage", "middle_relief", "long_relief"]
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _clamp(value: Optional[float], lower: float, upper: float) -> Optional[float]:
+    if value is None:
+        return None
+    return round(max(lower, min(upper, value)), 4)
+
+
+def _profile_value(profile: Dict[str, Any], section: str, key: str) -> Optional[float]:
+    return _safe_float((profile.get(section) or {}).get(key))
+
+
+def _role_value(base: Optional[float], delta: float, lower: float, upper: float) -> Optional[float]:
+    if base is None:
+        return None
+    return _clamp(base + delta, lower, upper)
+
+
+def _extract_profiles(game: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    direct_inputs = ((game.get("sharedSimulation") or {}).get("direct_inputs") or {})
+    workspace = game.get("workspace") or {}
+
+    return {
+        "away": direct_inputs.get("away_bullpen_profile") or workspace.get("awayBullpenProfile") or {},
+        "home": direct_inputs.get("home_bullpen_profile") or workspace.get("homeBullpenProfile") or {},
+    }
+
+
+def _build_role_rows(game: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    profiles = _extract_profiles(game)
+    teams = game.get("teams") or {}
+
+    for side, profile in profiles.items():
+        metadata = profile.get("metadata") or {}
+        team_payload = teams.get(side) or {}
+
+        team_name = metadata.get("team_name") or team_payload.get("team_name") or team_payload.get("name")
+        team_id = metadata.get("team_id") or team_payload.get("team_id")
+
+        base_k = _profile_value(profile, "bat_missing", "k_rate")
+        base_whiff = _profile_value(profile, "bat_missing", "whiff_rate")
+        base_csw = _profile_value(profile, "bat_missing", "csw_rate")
+        base_bb = _profile_value(profile, "command_control", "bb_rate")
+        base_hard_hit = _profile_value(profile, "contact_management", "hard_hit_rate_allowed")
+        base_xwoba = _profile_value(profile, "contact_management", "xwoba_allowed")
+        base_quality = _safe_float(metadata.get("bullpen_quality_score")) or 0.0
+
+        for template in ROLE_TEMPLATES:
+            rows.append(
+                {
+                    "game_pk": game.get("game_pk"),
+                    "game_date": game.get("game_date"),
+                    "side": side,
+                    "team_id": team_id,
+                    "team_name": team_name,
+                    "base_source_type": metadata.get("source_type"),
+                    "base_confidence": metadata.get("data_confidence"),
+                    "base_profile_version": metadata.get("bullpen_profile_version"),
+                    "base_quality_label": metadata.get("bullpen_quality_label"),
+                    "base_quality_score": base_quality,
+                    "role_name": template["role_name"],
+                    "role_priority": template["role_priority"],
+                    "leverage_bucket": template["leverage_bucket"],
+                    "role_k_rate": _role_value(base_k, template["k_delta"], 0.14, 0.36),
+                    "role_bb_rate": _role_value(base_bb, template["bb_delta"], 0.045, 0.15),
+                    "role_whiff_rate": _role_value(base_whiff, template["whiff_delta"], 0.16, 0.38),
+                    "role_csw_rate": _role_value(base_csw, template["csw_delta"], 0.21, 0.36),
+                    "role_hard_hit_rate_allowed": _role_value(base_hard_hit, template["hard_hit_delta"], 0.28, 0.50),
+                    "role_xwoba_allowed": _role_value(base_xwoba, template["xwoba_delta"], 0.265, 0.380),
+                    "role_quality_score": _clamp(base_quality + template["quality_delta"], -0.18, 0.18),
+                    "source_type": "candidate_bullpen_role_segmentation_v1",
+                    "source_confidence": "prototype",
+                    "candidate_only": True,
+                }
+            )
+
+    return rows
+
+
+def _team_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    return (row.get("game_pk"), row.get("side"), row.get("team_id"))
+
+
+def _roles_by_team(rows: List[Dict[str, Any]]) -> Dict[Tuple[Any, Any, Any], Dict[str, Dict[str, Any]]]:
+    grouped: Dict[Tuple[Any, Any, Any], Dict[str, Dict[str, Any]]] = defaultdict(dict)
+    for row in rows:
+        grouped[_team_key(row)][row["role_name"]] = row
+    return grouped
+
+
+def _priority_order_valid(grouped: Dict[Tuple[Any, Any, Any], Dict[str, Dict[str, Any]]]) -> bool:
+    for role_map in grouped.values():
+        priorities = [
+            role_map.get(role, {}).get("role_priority")
+            for role in EXPECTED_ROLE_ORDER
+        ]
+        if priorities != [1, 2, 3, 4, 5]:
+            return False
+    return True
+
+
+def _nonincreasing(values: List[Optional[float]]) -> bool:
+    numeric = [v for v in values if v is not None]
+    return len(numeric) == len(values) and all(a >= b for a, b in zip(numeric, numeric[1:]))
+
+
+def _nondecreasing(values: List[Optional[float]]) -> bool:
+    numeric = [v for v in values if v is not None]
+    return len(numeric) == len(values) and all(a <= b for a, b in zip(numeric, numeric[1:]))
+
+
+def _monotonic_valid(grouped: Dict[Tuple[Any, Any, Any], Dict[str, Dict[str, Any]]]) -> bool:
+    for role_map in grouped.values():
+        ordered = [role_map.get(role, {}) for role in EXPECTED_ROLE_ORDER]
+
+        quality = [row.get("role_quality_score") for row in ordered]
+        k_rate = [row.get("role_k_rate") for row in ordered]
+        bb_rate = [row.get("role_bb_rate") for row in ordered]
+        hard_hit = [row.get("role_hard_hit_rate_allowed") for row in ordered]
+        xwoba = [row.get("role_xwoba_allowed") for row in ordered]
+
+        if not _nonincreasing(quality):
+            return False
+        if not _nonincreasing(k_rate):
+            return False
+        if not _nondecreasing(bb_rate):
+            return False
+        if not _nondecreasing(hard_hit):
+            return False
+        if not _nondecreasing(xwoba):
+            return False
+
+    return True
+
+
+def _mean(values: List[float]) -> Optional[float]:
+    if not values:
+        return None
+    return round(sum(values) / len(values), 4)
+
+
+def _analyze_spreads(grouped: Dict[Tuple[Any, Any, Any], Dict[str, Dict[str, Any]]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    spreads: List[Dict[str, Any]] = []
+
+    k_deltas: List[float] = []
+    bb_deltas: List[float] = []
+    xwoba_deltas: List[float] = []
+    quality_deltas: List[float] = []
+
+    all_quality_scores: List[float] = []
+
+    for role_map in grouped.values():
+        closer = role_map.get("closer") or {}
+        long_relief = role_map.get("long_relief") or {}
+
+        row = {
+            "game_pk": closer.get("game_pk"),
+            "side": closer.get("side"),
+            "team_id": closer.get("team_id"),
+            "team_name": closer.get("team_name"),
+            "closer_k_rate": closer.get("role_k_rate"),
+            "long_relief_k_rate": long_relief.get("role_k_rate"),
+            "closer_vs_long_k_rate_delta": round((closer.get("role_k_rate") or 0) - (long_relief.get("role_k_rate") or 0), 4),
+            "closer_bb_rate": closer.get("role_bb_rate"),
+            "long_relief_bb_rate": long_relief.get("role_bb_rate"),
+            "closer_vs_long_bb_rate_delta": round((long_relief.get("role_bb_rate") or 0) - (closer.get("role_bb_rate") or 0), 4),
+            "closer_xwoba_allowed": closer.get("role_xwoba_allowed"),
+            "long_relief_xwoba_allowed": long_relief.get("role_xwoba_allowed"),
+            "closer_vs_long_xwoba_delta": round((long_relief.get("role_xwoba_allowed") or 0) - (closer.get("role_xwoba_allowed") or 0), 4),
+            "closer_quality_score": closer.get("role_quality_score"),
+            "long_relief_quality_score": long_relief.get("role_quality_score"),
+            "closer_vs_long_quality_delta": round((closer.get("role_quality_score") or 0) - (long_relief.get("role_quality_score") or 0), 4),
+        }
+
+        spreads.append(row)
+
+        k_deltas.append(row["closer_vs_long_k_rate_delta"])
+        bb_deltas.append(row["closer_vs_long_bb_rate_delta"])
+        xwoba_deltas.append(row["closer_vs_long_xwoba_delta"])
+        quality_deltas.append(row["closer_vs_long_quality_delta"])
+
+        for role in EXPECTED_ROLE_ORDER:
+            q = role_map.get(role, {}).get("role_quality_score")
+            if q is not None:
+                all_quality_scores.append(float(q))
+
+    metrics = {
+        "average_closer_vs_long_k_rate_delta": _mean(k_deltas),
+        "average_closer_vs_long_bb_rate_delta": _mean(bb_deltas),
+        "average_closer_vs_long_xwoba_delta": _mean(xwoba_deltas),
+        "average_closer_vs_long_quality_delta": _mean(quality_deltas),
+        "min_role_quality_score": round(min(all_quality_scores), 4) if all_quality_scores else None,
+        "max_role_quality_score": round(max(all_quality_scores), 4) if all_quality_scores else None,
+        "team_sides_analyzed": len(spreads),
+    }
+
+    return spreads, metrics
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionFactory = get_session(engine)
+
+    session: Session = SessionFactory()
+    try:
+        payload = build_model_projection_payload(session, TARGET_DATE)
+        games = payload.get("games") or []
+    finally:
+        session.close()
+
+    role_rows: List[Dict[str, Any]] = []
+    for game in games:
+        role_rows.extend(_build_role_rows(game))
+
+    _write_csv(OUTPUT_ROLE_ANALYSIS, role_rows)
+
+    grouped = _roles_by_team(role_rows)
+    spreads, metrics = _analyze_spreads(grouped)
+    _write_csv(OUTPUT_TEAM_SPREAD, spreads)
+
+    expected_team_sides = len(games) * 2
+    expected_rows = expected_team_sides * len(ROLE_TEMPLATES)
+
+    role_names = {row.get("role_name") for row in role_rows}
+    expected_roles = set(EXPECTED_ROLE_ORDER)
+
+    prototype_rows_available = len(role_rows) > 0
+    expected_role_count = len(role_rows) == expected_rows and all(len(role_map) == 5 for role_map in grouped.values())
+    role_priority_order_valid = _priority_order_valid(grouped)
+    monotonic_quality_valid = _monotonic_valid(grouped)
+    role_separation_present = all(
+        spread["closer_vs_long_k_rate_delta"] > 0
+        and spread["closer_vs_long_bb_rate_delta"] > 0
+        and spread["closer_vs_long_xwoba_delta"] > 0
+        and spread["closer_vs_long_quality_delta"] > 0
+        for spread in spreads
+    )
+    candidate_mode_only = all(row.get("candidate_only") is True for row in role_rows)
+
+    checks = [
+        {
+            "check": "prototype_rows_available",
+            "passed": prototype_rows_available,
+            "detail": len(role_rows),
+        },
+        {
+            "check": "expected_role_count",
+            "passed": expected_role_count,
+            "detail": f"{len(role_rows)}/{expected_rows}",
+        },
+        {
+            "check": "all_expected_roles_present",
+            "passed": role_names == expected_roles,
+            "detail": sorted(role_names),
+        },
+        {
+            "check": "role_priority_order_valid",
+            "passed": role_priority_order_valid,
+            "detail": role_priority_order_valid,
+        },
+        {
+            "check": "monotonic_quality_valid",
+            "passed": monotonic_quality_valid,
+            "detail": monotonic_quality_valid,
+        },
+        {
+            "check": "role_separation_present",
+            "passed": role_separation_present,
+            "detail": metrics,
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": candidate_mode_only,
+            "detail": candidate_mode_only,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    with OUTPUT_CHECKS.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["check", "passed", "detail"])
+        writer.writeheader()
+        writer.writerows(checks)
+
+    passed = all(check["passed"] for check in checks)
+    next_layer = (
+        "6BF_candidate_bullpen_fatigue_availability_prototype"
+        if passed
+        else "6BD_patch_candidate_bullpen_role_segmentation_prototype"
+    )
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_role_segmentation_analysis_complete",
+        "games_processed": len(games),
+        "team_sides_analyzed": expected_team_sides,
+        "role_rows_analyzed": len(role_rows),
+        "expected_role_rows": expected_rows,
+        "all_checks_passed": passed,
+        "metrics": metrics,
+        "risks": [
+            "Role segmentation is deterministic prior only.",
+            "No active reliever IDs are assigned.",
+            "No fatigue, days-rest, or recent workload adjustment is present.",
+            "No handedness-specific role deployment is present.",
+            "No inherited-runner performance logic is present.",
+            "No manager tendency logic is present.",
+        ],
+        "production_default_unchanged": True,
+        "recommended_next_layer": next_layer,
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6BE: an analysis layer for the Layer 6BD candidate bullpen role segmentation prototype.

## Purpose

Layer 6BD created deterministic candidate bullpen roles for each team-side. Layer 6BE analyzes whether those generated role profiles are coherent, ordered by leverage, and safe enough to serve as the foundation for the next fatigue and availability prototype layer.

## What the analysis does

- Rebuilds the candidate role rows from the Model Projections bullpen profile input contract.
- Verifies expected coverage: 15 games, 30 team-sides, 150 role rows, 5 roles per team-side.
- Verifies role priority order: closer, setup, high leverage, middle relief, long relief.
- Verifies monotonic quality separation across roles.
- Computes closer-vs-long-relief separation metrics.
- Writes JSON and CSV outputs under `tmp/`.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/analyze_candidate_bullpen_role_segmentation.py
cat tmp/candidate_bullpen_role_segmentation_analysis_checks.csv
cat tmp/candidate_bullpen_role_segmentation_analysis.json
head -20 tmp/candidate_bullpen_role_segmentation_analysis_team_spread.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_role_segmentation_analysis_complete",
  "games_processed": 15,
  "team_sides_analyzed": 30,
  "role_rows_analyzed": 150,
  "expected_role_rows": 150,
  "all_checks_passed": true,
  "metrics": {
    "average_closer_vs_long_k_rate_delta": 0.03,
    "average_closer_vs_long_bb_rate_delta": 0.014,
    "average_closer_vs_long_xwoba_delta": 0.02,
    "average_closer_vs_long_quality_delta": 0.05,
    "min_role_quality_score": -0.07,
    "max_role_quality_score": 0.11,
    "team_sides_analyzed": 30
  },
  "production_default_unchanged": true,
  "recommended_next_layer": "6BF_candidate_bullpen_fatigue_availability_prototype"
}
```

## Findings

The candidate role scaffold is coherent and monotonic. Closer roles separate cleanly from long-relief roles in expected directions: higher K rate, lower BB rate, lower xwOBA allowed, and higher quality score.

Remaining risks are intentionally deferred to the next layer:

- Role segmentation is deterministic prior only.
- No active reliever IDs are assigned.
- No recent workload adjustment is present.
- No handedness-specific role deployment is present.
- No inherited-runner performance logic is present.
- No manager tendency logic is present.

## Safety

Analysis-only. This does not change bullpen profile construction, game engine logic, inning simulation logic, database writes, production defaults, route behavior, sportsbook outputs, or frontend rendering.