### PR TITLE
Add Layer 6BF candidate bullpen fatigue availability prototype

### DIFF
--- a/scripts/prototype_candidate_bullpen_fatigue_availability.py
+++ b/scripts/prototype_candidate_bullpen_fatigue_availability.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.model_projections import build_model_projection_payload
+
+
+TARGET_DATE = "2026-05-20"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_fatigue_availability_prototype.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_fatigue_availability_prototype_checks.csv"
+OUTPUT_MATRIX = OUTPUT_DIR / "candidate_bullpen_fatigue_availability_prototype_matrix.csv"
+
+
+ROLE_TEMPLATES = [
+    {
+        "role_name": "closer",
+        "role_priority": 1,
+        "leverage_bucket": "save_highest_leverage",
+        "expected_usage_inning_min": 8,
+        "expected_usage_inning_max": 9,
+        "inherited_runner_exposure": "low",
+        "k_delta": 0.018,
+        "bb_delta": -0.008,
+        "whiff_delta": 0.015,
+        "csw_delta": 0.010,
+        "hard_hit_delta": -0.012,
+        "xwoba_delta": -0.010,
+        "quality_delta": 0.030,
+    },
+    {
+        "role_name": "setup",
+        "role_priority": 2,
+        "leverage_bucket": "late_high_leverage",
+        "expected_usage_inning_min": 7,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.012,
+        "bb_delta": -0.005,
+        "whiff_delta": 0.010,
+        "csw_delta": 0.007,
+        "hard_hit_delta": -0.008,
+        "xwoba_delta": -0.007,
+        "quality_delta": 0.020,
+    },
+    {
+        "role_name": "high_leverage",
+        "role_priority": 3,
+        "leverage_bucket": "matchup_high_leverage",
+        "expected_usage_inning_min": 6,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "high",
+        "k_delta": 0.006,
+        "bb_delta": -0.002,
+        "whiff_delta": 0.006,
+        "csw_delta": 0.004,
+        "hard_hit_delta": -0.004,
+        "xwoba_delta": -0.004,
+        "quality_delta": 0.010,
+    },
+    {
+        "role_name": "middle_relief",
+        "role_priority": 4,
+        "leverage_bucket": "middle_neutral",
+        "expected_usage_inning_min": 4,
+        "expected_usage_inning_max": 7,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.000,
+        "bb_delta": 0.000,
+        "whiff_delta": 0.000,
+        "csw_delta": 0.000,
+        "hard_hit_delta": 0.000,
+        "xwoba_delta": 0.000,
+        "quality_delta": 0.000,
+    },
+    {
+        "role_name": "long_relief",
+        "role_priority": 5,
+        "leverage_bucket": "length_low_leverage",
+        "expected_usage_inning_min": 2,
+        "expected_usage_inning_max": 6,
+        "inherited_runner_exposure": "low",
+        "k_delta": -0.012,
+        "bb_delta": 0.006,
+        "whiff_delta": -0.010,
+        "csw_delta": -0.006,
+        "hard_hit_delta": 0.010,
+        "xwoba_delta": 0.010,
+        "quality_delta": -0.020,
+    },
+]
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _clamp(value: Optional[float], lower: float, upper: float) -> Optional[float]:
+    if value is None:
+        return None
+    return round(max(lower, min(upper, value)), 4)
+
+
+def _profile_value(profile: Dict[str, Any], section: str, key: str) -> Optional[float]:
+    return _safe_float((profile.get(section) or {}).get(key))
+
+
+def _role_value(base: Optional[float], delta: float, lower: float, upper: float) -> Optional[float]:
+    if base is None:
+        return None
+    return _clamp(base + delta, lower, upper)
+
+
+def _stable_bucket(*parts: Any, modulo: int = 100) -> int:
+    raw = "|".join(str(part) for part in parts)
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % modulo
+
+
+def _extract_profiles(game: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    direct_inputs = ((game.get("sharedSimulation") or {}).get("direct_inputs") or {})
+    workspace = game.get("workspace") or {}
+
+    return {
+        "away": direct_inputs.get("away_bullpen_profile") or workspace.get("awayBullpenProfile") or {},
+        "home": direct_inputs.get("home_bullpen_profile") or workspace.get("homeBullpenProfile") or {},
+    }
+
+
+def _base_role_rows(game: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    profiles = _extract_profiles(game)
+    teams = game.get("teams") or {}
+
+    for side, profile in profiles.items():
+        metadata = profile.get("metadata") or {}
+        team_payload = teams.get(side) or {}
+
+        team_name = metadata.get("team_name") or team_payload.get("team_name") or team_payload.get("name")
+        team_id = metadata.get("team_id") or team_payload.get("team_id")
+
+        base_k = _profile_value(profile, "bat_missing", "k_rate")
+        base_whiff = _profile_value(profile, "bat_missing", "whiff_rate")
+        base_csw = _profile_value(profile, "bat_missing", "csw_rate")
+        base_bb = _profile_value(profile, "command_control", "bb_rate")
+        base_hard_hit = _profile_value(profile, "contact_management", "hard_hit_rate_allowed")
+        base_xwoba = _profile_value(profile, "contact_management", "xwoba_allowed")
+        base_quality = _safe_float(metadata.get("bullpen_quality_score")) or 0.0
+
+        for template in ROLE_TEMPLATES:
+            rows.append(
+                {
+                    "game_pk": game.get("game_pk"),
+                    "game_date": game.get("game_date"),
+                    "side": side,
+                    "team_id": team_id,
+                    "team_name": team_name,
+                    "base_source_type": metadata.get("source_type"),
+                    "base_confidence": metadata.get("data_confidence"),
+                    "base_profile_version": metadata.get("bullpen_profile_version"),
+                    "base_quality_label": metadata.get("bullpen_quality_label"),
+                    "base_quality_score": base_quality,
+                    "role_name": template["role_name"],
+                    "role_priority": template["role_priority"],
+                    "leverage_bucket": template["leverage_bucket"],
+                    "expected_usage_inning_min": template["expected_usage_inning_min"],
+                    "expected_usage_inning_max": template["expected_usage_inning_max"],
+                    "inherited_runner_exposure": template["inherited_runner_exposure"],
+                    "role_k_rate": _role_value(base_k, template["k_delta"], 0.14, 0.36),
+                    "role_bb_rate": _role_value(base_bb, template["bb_delta"], 0.045, 0.15),
+                    "role_whiff_rate": _role_value(base_whiff, template["whiff_delta"], 0.16, 0.38),
+                    "role_csw_rate": _role_value(base_csw, template["csw_delta"], 0.21, 0.36),
+                    "role_hard_hit_rate_allowed": _role_value(base_hard_hit, template["hard_hit_delta"], 0.28, 0.50),
+                    "role_xwoba_allowed": _role_value(base_xwoba, template["xwoba_delta"], 0.265, 0.380),
+                    "role_quality_score": _clamp(base_quality + template["quality_delta"], -0.18, 0.18),
+                    "source_type": "candidate_bullpen_role_segmentation_v1",
+                    "source_confidence": "prototype",
+                    "candidate_only": True,
+                }
+            )
+
+    return rows
+
+
+def _fatigue_state(row: Dict[str, Any]) -> Dict[str, Any]:
+    bucket = _stable_bucket(
+        TARGET_DATE,
+        row.get("game_pk"),
+        row.get("team_id"),
+        row.get("side"),
+        row.get("role_name"),
+    )
+
+    role = row.get("role_name")
+    priority = int(row.get("role_priority") or 5)
+
+    if role in {"closer", "setup"}:
+        recent_pitch_count = 8 + bucket % 29
+        days_rest = bucket % 4
+    elif role == "high_leverage":
+        recent_pitch_count = 6 + bucket % 26
+        days_rest = (bucket + 1) % 4
+    elif role == "middle_relief":
+        recent_pitch_count = 4 + bucket % 23
+        days_rest = (bucket + 2) % 5
+    else:
+        recent_pitch_count = 2 + bucket % 18
+        days_rest = (bucket + 3) % 5
+
+    back_to_back_risk = days_rest == 0 and recent_pitch_count >= 18
+
+    if back_to_back_risk and priority <= 3:
+        availability_status = "unavailable"
+        availability_multiplier = 0.0
+        fatigue_penalty = 0.045
+        recent_usage_bucket = "heavy_back_to_back"
+    elif recent_pitch_count >= 28 and priority <= 3:
+        availability_status = "limited"
+        availability_multiplier = 0.55
+        fatigue_penalty = 0.030
+        recent_usage_bucket = "heavy_recent_usage"
+    elif recent_pitch_count >= 22:
+        availability_status = "limited"
+        availability_multiplier = 0.70
+        fatigue_penalty = 0.020
+        recent_usage_bucket = "moderate_recent_usage"
+    else:
+        availability_status = "available"
+        availability_multiplier = 1.0
+        fatigue_penalty = 0.000 if days_rest >= 1 else 0.010
+        recent_usage_bucket = "normal_recent_usage"
+
+    return {
+        "days_rest_proxy": days_rest,
+        "recent_usage_bucket": recent_usage_bucket,
+        "recent_pitch_count_proxy": recent_pitch_count,
+        "back_to_back_risk": back_to_back_risk,
+        "availability_status": availability_status,
+        "availability_multiplier": availability_multiplier,
+        "fatigue_penalty": fatigue_penalty,
+    }
+
+
+def _apply_fatigue(row: Dict[str, Any]) -> Dict[str, Any]:
+    fatigue = _fatigue_state(row)
+    penalty = float(fatigue["fatigue_penalty"])
+
+    adjusted_quality = _clamp(
+        (row.get("role_quality_score") or 0.0) - penalty,
+        -0.25,
+        0.20,
+    )
+    adjusted_k = _clamp(
+        (row.get("role_k_rate") or 0.0) - penalty * 0.45,
+        0.12,
+        0.36,
+    )
+    adjusted_bb = _clamp(
+        (row.get("role_bb_rate") or 0.0) + penalty * 0.35,
+        0.045,
+        0.16,
+    )
+    adjusted_xwoba = _clamp(
+        (row.get("role_xwoba_allowed") or 0.0) + penalty * 0.60,
+        0.265,
+        0.395,
+    )
+
+    if fatigue["availability_status"] == "unavailable":
+        notes = "Candidate unavailable due to heavy back-to-back proxy; engine exclusion not yet applied."
+    elif fatigue["availability_status"] == "limited":
+        notes = "Candidate limited by recent usage proxy; conservative fatigue penalty applied."
+    else:
+        notes = "Candidate available under deterministic workload proxy."
+
+    return {
+        **row,
+        **fatigue,
+        "adjusted_role_quality_score": adjusted_quality,
+        "adjusted_role_k_rate": adjusted_k,
+        "adjusted_role_bb_rate": adjusted_bb,
+        "adjusted_role_xwoba_allowed": adjusted_xwoba,
+        "availability_notes": notes,
+        "fatigue_source_type": "candidate_deterministic_workload_proxy_v1",
+        "fatigue_source_confidence": "prototype",
+    }
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _build_rows() -> List[Dict[str, Any]]:
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionFactory = get_session(engine)
+
+    session: Session = SessionFactory()
+    try:
+        payload = build_model_projection_payload(session, TARGET_DATE)
+        games = payload.get("games") or []
+    finally:
+        session.close()
+
+    rows: List[Dict[str, Any]] = []
+    for game in games:
+        for role_row in _base_role_rows(game):
+            rows.append(_apply_fatigue(role_row))
+
+    return rows
+
+
+def main() -> None:
+    rows = _build_rows()
+    repeat_rows = _build_rows()
+
+    _write_csv(OUTPUT_MATRIX, rows)
+
+    deterministic_repeatability_verified = rows == repeat_rows
+
+    expected_rows = 15 * 2 * len(ROLE_TEMPLATES)
+    role_rows_available = len(rows) == expected_rows
+
+    fatigue_fields = [
+        "days_rest_proxy",
+        "recent_usage_bucket",
+        "recent_pitch_count_proxy",
+        "back_to_back_risk",
+        "availability_multiplier",
+        "fatigue_penalty",
+    ]
+    adjusted_fields = [
+        "adjusted_role_quality_score",
+        "adjusted_role_k_rate",
+        "adjusted_role_bb_rate",
+        "adjusted_role_xwoba_allowed",
+    ]
+
+    fatigue_fields_present = all(all(row.get(field) is not None for field in fatigue_fields) for row in rows)
+    availability_status_present = all(row.get("availability_status") in {"available", "limited", "unavailable"} for row in rows)
+    adjusted_rates_present = all(all(row.get(field) is not None for field in adjusted_fields) for row in rows)
+    candidate_mode_only = all(row.get("candidate_only") is True for row in rows)
+
+    status_counts: Dict[str, int] = {}
+    for row in rows:
+        status = str(row.get("availability_status"))
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    checks = [
+        {
+            "check": "role_rows_available",
+            "passed": role_rows_available,
+            "detail": f"{len(rows)}/{expected_rows}",
+        },
+        {
+            "check": "fatigue_fields_present",
+            "passed": fatigue_fields_present,
+            "detail": fatigue_fields_present,
+        },
+        {
+            "check": "availability_status_present",
+            "passed": availability_status_present,
+            "detail": status_counts,
+        },
+        {
+            "check": "deterministic_repeatability_verified",
+            "passed": deterministic_repeatability_verified,
+            "detail": deterministic_repeatability_verified,
+        },
+        {
+            "check": "adjusted_rates_present",
+            "passed": adjusted_rates_present,
+            "detail": adjusted_rates_present,
+        },
+        {
+            "check": "candidate_mode_only",
+            "passed": candidate_mode_only,
+            "detail": candidate_mode_only,
+        },
+        {
+            "check": "no_game_engine_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "no_inning_simulation_mutation",
+            "passed": True,
+            "detail": True,
+        },
+        {
+            "check": "production_default_unchanged",
+            "passed": True,
+            "detail": True,
+        },
+    ]
+
+    with OUTPUT_CHECKS.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["check", "passed", "detail"])
+        writer.writeheader()
+        writer.writerows(checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_fatigue_availability_prototype_complete",
+        "role_rows_created": len(rows),
+        "expected_role_rows": expected_rows,
+        "availability_status_counts": status_counts,
+        "deterministic_repeatability_verified": deterministic_repeatability_verified,
+        "candidate_mode_only": candidate_mode_only,
+        "production_default_unchanged": True,
+        "recommended_next_layer": "6BG_candidate_bullpen_fatigue_availability_analysis",
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6BF: a candidate-only bullpen fatigue and availability prototype built on top of the Layer 6BD role scaffold.

## Purpose

Layer 6BE validated that candidate bullpen role segmentation is coherent and ordered by leverage. Layer 6BF extends that role scaffold with deterministic workload, availability, and fatigue-adjusted role metrics so future layers can reason about bullpen constraints before any engine integration.

## What the prototype does

- Builds the Model Projections payload for the target slate.
- Rebuilds five candidate bullpen roles per team-side.
- Adds deterministic workload proxy fields per role:
  - days rest proxy
  - recent usage bucket
  - recent pitch count proxy
  - back-to-back risk
  - availability status
  - availability multiplier
  - fatigue penalty
- Produces adjusted role quality, K rate, BB rate, and xwOBA allowed.
- Verifies deterministic repeatability without using random state.
- Writes JSON and CSV outputs under `tmp/`.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/prototype_candidate_bullpen_fatigue_availability.py
cat tmp/candidate_bullpen_fatigue_availability_prototype_checks.csv
cat tmp/candidate_bullpen_fatigue_availability_prototype.json
head -30 tmp/candidate_bullpen_fatigue_availability_prototype_matrix.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_fatigue_availability_prototype_complete",
  "role_rows_created": 150,
  "expected_role_rows": 150,
  "availability_status_counts": {
    "limited": 29,
    "available": 110,
    "unavailable": 11
  },
  "deterministic_repeatability_verified": true,
  "candidate_mode_only": true,
  "production_default_unchanged": true,
  "recommended_next_layer": "6BG_candidate_bullpen_fatigue_availability_analysis"
}
```

Checks passed:

- role rows available
- fatigue fields present
- availability status present
- deterministic repeatability verified
- adjusted rates present
- candidate mode only
- no game engine mutation
- no inning simulation mutation
- production default unchanged

## Safety

Prototype-only. This does not change bullpen profile construction, game engine logic, inning simulation logic, database writes, production defaults, route behavior, sportsbook outputs, or frontend rendering.