### PR TITLE
Add Postgres-backed My Dashboard MVP with lightweight profiles and daily folders

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,7 @@ import LiveGamePageRestored from './pages/LiveGamePageRestored'
 import DailyOddsPage from './pages/DailyOddsPage'
 import ModelProjectionsPage from './pages/ModelProjectionsPage'
 import NewsPage from './pages/NewsPage'
-import MyDashboardPage from './pages/MyDashboardPage'
+import MyDashboardWorkspacePage from './pages/MyDashboardWorkspacePage'
 import ModelTrackerPage from './pages/ModelTrackerPage'
 
 // Set VITE_ENABLE_BATTER_PAGE=true in Railway env vars to re-enable the Batter routes.
@@ -68,7 +68,7 @@ export default function App() {
             <Route path="/news" element={<NewsPage />} />
             <Route path="/models/projections" element={<ModelProjectionsPage />} />
             <Route path="/model-tracker" element={<ModelTrackerPage />} />
-            <Route path="/my-dashboard" element={<MyDashboardPage />} />
+            <Route path="/my-dashboard" element={<MyDashboardWorkspacePage />} />
             <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
             <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />
             <Route path="/standings" element={<StandingsPage />} />

--- a/frontend/src/pages/MyDashboardWorkspacePage.jsx
+++ b/frontend/src/pages/MyDashboardWorkspacePage.jsx
@@ -1,0 +1,503 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+const API = import.meta.env.VITE_API_BASE_URL || ''
+
+const COMPONENTS = [
+  { key: 'hitters', title: 'My Top Hitters Today', description: 'Unique hitter board from Batter vs Arsenal, pitch usage, damage quality, and model context.' },
+  { key: 'pitchers', title: 'My Top Pitchers Today', description: 'Pitcher lean board using K profile, contact suppression, opponent offense, and arsenal context.' },
+  { key: 'teams', title: 'My Top Teams Today', description: 'Team board from model side edge, expected runs, offense profile, and opponent weaknesses.' },
+  { key: 'totals', title: 'My Top Totals Today', description: 'Game total watchlist from projected runs, run environment, and simulation context.' },
+  { key: 'overall_players', title: 'My Top Overall Players Today', description: 'Combined unique player board blending hitter and pitcher model-solver scores.' },
+]
+
+const FEATURE_CHOICES = ['Matchups', 'Daily Odds', 'Model Projections', 'News', 'Props', 'Pitchers', 'Batters']
+
+const BASE_FILTERS = {
+  search_text: '',
+  team: '',
+  opponent: '',
+  min_score: '',
+  min_confidence: '',
+}
+
+function cleanFilters(filters) {
+  return Object.fromEntries(
+    Object.entries(filters || {}).filter(([, value]) => value !== '' && value !== null && value !== undefined)
+  )
+}
+
+function formatDateTime(value) {
+  if (!value) return '—'
+  try {
+    return new Date(value).toLocaleString()
+  } catch {
+    return value
+  }
+}
+
+function formatNumber(value) {
+  const num = Number(value)
+  if (!Number.isFinite(num)) return '—'
+  return Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(3)
+}
+
+export default function MyDashboardWorkspacePage() {
+  const today = new Date().toISOString().slice(0, 10)
+  const [authChecked, setAuthChecked] = useState(false)
+  const [profile, setProfile] = useState(null)
+  const [workspace, setWorkspace] = useState(null)
+  const [authError, setAuthError] = useState(null)
+  const [savingProfile, setSavingProfile] = useState(false)
+  const [results, setResults] = useState({})
+  const [runErrors, setRunErrors] = useState({})
+  const [loading, setLoading] = useState({})
+  const [saveMessage, setSaveMessage] = useState(null)
+  const [form, setForm] = useState({
+    email: '',
+    username: '',
+    password: '',
+    feature_interests: ['Matchups', 'Model Projections'],
+    wants_newsletter: false,
+    plan_type: 'free',
+  })
+  const [filters, setFilters] = useState(
+    Object.fromEntries(COMPONENTS.map(component => [component.key, { ...BASE_FILTERS }]))
+  )
+
+  useEffect(() => {
+    async function bootstrap() {
+      try {
+        const res = await fetch(`${API}/my-dashboard/profile`, { credentials: 'include' })
+        const json = await res.json()
+        if (json.authenticated) {
+          setProfile(json.user)
+          await loadWorkspace()
+        }
+      } catch (err) {
+        console.error('My Dashboard bootstrap failed', err)
+      } finally {
+        setAuthChecked(true)
+      }
+    }
+    bootstrap()
+  }, [])
+
+  async function loadWorkspace() {
+    const res = await fetch(`${API}/my-dashboard/workspace`, { credentials: 'include' })
+    const json = await res.json()
+    if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+    setWorkspace(json)
+    return json
+  }
+
+  async function handleProfileSubmit(event) {
+    event.preventDefault()
+    setSavingProfile(true)
+    setAuthError(null)
+    try {
+      const res = await fetch(`${API}/my-dashboard/profile`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      setProfile(json.user)
+      await loadWorkspace()
+    } catch (err) {
+      setAuthError(err.message || 'Failed to create dashboard profile')
+    } finally {
+      setSavingProfile(false)
+      setAuthChecked(true)
+    }
+  }
+
+  function toggleInterest(choice) {
+    setForm(prev => ({
+      ...prev,
+      feature_interests: prev.feature_interests.includes(choice)
+        ? prev.feature_interests.filter(item => item !== choice)
+        : [...prev.feature_interests, choice],
+    }))
+  }
+
+  async function runBoard(componentKey) {
+    setLoading(prev => ({ ...prev, [componentKey]: true }))
+    setRunErrors(prev => ({ ...prev, [componentKey]: null }))
+    try {
+      const res = await fetch(`${API}/my-dashboard/solver`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          date: today,
+          component: componentKey,
+          filters: cleanFilters(filters[componentKey] || {}),
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      setResults(prev => ({ ...prev, [componentKey]: json }))
+    } catch (err) {
+      setRunErrors(prev => ({ ...prev, [componentKey]: err.message || 'Board run failed' }))
+    } finally {
+      setLoading(prev => ({ ...prev, [componentKey]: false }))
+    }
+  }
+
+  async function runAllBoards() {
+    const keys = COMPONENTS.map(component => component.key)
+    setLoading(prev => ({ ...prev, ...Object.fromEntries(keys.map(key => [key, true])) }))
+    setRunErrors({})
+    try {
+      const res = await fetch(`${API}/my-dashboard/solver/batch`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          date: today,
+          components: keys,
+          filters_by_component: Object.fromEntries(keys.map(key => [key, cleanFilters(filters[key] || {})])),
+          active_lineups: false,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      setResults(prev => ({ ...prev, ...(json.results || {}) }))
+    } catch (err) {
+      setRunErrors(prev => ({ ...prev, _all: err.message || 'Populate all failed' }))
+    } finally {
+      setLoading(prev => ({ ...prev, ...Object.fromEntries(keys.map(key => [key, false])) }))
+    }
+  }
+
+  async function saveItemToToday(component, item) {
+    if (!workspace?.today_folder_id) return
+    setSaveMessage(null)
+    try {
+      const res = await fetch(`${API}/my-dashboard/items`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          folder_id: workspace.today_folder_id,
+          source_tab: 'my-dashboard',
+          source_type: 'solver_result',
+          title: `${component.title} | ${item.entity_name || item.title || 'Saved item'}`,
+          subtitle: item.primary_reason || component.description,
+          payload_json: {
+            saved_from_component: component.key,
+            saved_on_date: today,
+            entity_name: item.entity_name,
+            entity_id: item.entity_id,
+            entity_type: item.entity_type,
+            game_pk: item.game_pk,
+            score: item.score,
+            confidence: item.confidence,
+            metrics: item.metrics || {},
+            reasoning: item.reasoning || [],
+            available_fields: Object.keys(item.metrics || {}),
+            conditions: ['equals', 'contains', 'min', 'max', 'in'],
+            max_filters: 5,
+            logic_mode: 'AND',
+          },
+          filter_json: cleanFilters(filters[component.key] || {}),
+          sort_json: { by: 'score', direction: 'desc' },
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      await loadWorkspace()
+      setSaveMessage(`Saved ${item.entity_name || item.title || 'item'} to today's folder.`)
+    } catch (err) {
+      setSaveMessage(err.message || 'Failed to save item')
+    }
+  }
+
+  const folders = workspace?.folders || []
+  const defaultFolder = useMemo(() => folders.find(folder => folder.is_default), [folders])
+  const todayFolder = useMemo(() => folders.find(folder => folder.id === workspace?.today_folder_id), [folders, workspace])
+
+  if (!authChecked) {
+    return <div style={stateStyle}>Loading dashboard workspace…</div>
+  }
+
+  if (!profile) {
+    return (
+      <div style={pageStyle}>
+        <section style={heroStyle}>
+          <div>
+            <div style={eyebrowStyle}>My Dashboard MVP</div>
+            <h1 style={titleStyle}>Create your analyst profile</h1>
+            <p style={subtitleStyle}>Store daily dashboards, keep folders by date, and prepare for future click-to-save discovery from Matchups, Daily Odds, Model Projections, News, and every endpoint across the app.</p>
+          </div>
+        </section>
+
+        <section style={layoutStyle}>
+          <div style={railStyle}>
+            <InfoCard title="Daily folders" body="Every user gets a Default Dashboard plus today’s dated folder so discoveries stay organized and easy to review later." />
+            <InfoCard title="Free seeded board" body="Your default dashboard is automatically seeded from the current My Dashboard experience that exists in the app today." />
+            <InfoCard title="Future save-anything path" body="The backend item schema is already structured so later we can save discoveries from Matchups, Odds, Models, News, Pitchers, Batters, Teams, and more." />
+          </div>
+
+          <form onSubmit={handleProfileSubmit} style={formCardStyle}>
+            <div>
+              <h2 style={cardTitleStyle}>Sign in or create profile</h2>
+              <p style={cardSubtitleStyle}>Required: email and username. Password is optional for this MVP.</p>
+            </div>
+
+            <label style={labelStyle}>Email</label>
+            <input style={inputStyle} value={form.email} onChange={e => setForm(prev => ({ ...prev, email: e.target.value }))} placeholder="you@example.com" />
+
+            <label style={labelStyle}>Username</label>
+            <input style={inputStyle} value={form.username} onChange={e => setForm(prev => ({ ...prev, username: e.target.value }))} placeholder="SharpBettorMike" />
+
+            <label style={labelStyle}>Password (optional)</label>
+            <input style={inputStyle} type="password" value={form.password} onChange={e => setForm(prev => ({ ...prev, password: e.target.value }))} placeholder="Optional password" />
+
+            <label style={labelStyle}>Feature interests</label>
+            <div style={pillWrapStyle}>
+              {FEATURE_CHOICES.map(choice => (
+                <button key={choice} type="button" onClick={() => toggleInterest(choice)} style={form.feature_interests.includes(choice) ? activePillStyle : pillStyle}>
+                  {choice}
+                </button>
+              ))}
+            </div>
+
+            <label style={checkLabelStyle}><input type="checkbox" checked={form.wants_newsletter} onChange={e => setForm(prev => ({ ...prev, wants_newsletter: e.target.checked }))} /> Interested in newsletter updates</label>
+            <label style={checkLabelStyle}><input type="radio" name="plan_type" checked={form.plan_type === 'free'} onChange={() => setForm(prev => ({ ...prev, plan_type: 'free' }))} /> Free dashboard</label>
+            <label style={checkLabelStyle}><input type="radio" name="plan_type" checked={form.plan_type === 'newsletter_10_day_trial'} onChange={() => setForm(prev => ({ ...prev, plan_type: 'newsletter_10_day_trial' }))} /> 10 days of picks for $5 interest</label>
+
+            {authError && <div style={errorStyle}>{authError}</div>}
+            <button type="submit" style={primaryButtonStyle} disabled={savingProfile}>{savingProfile ? 'Creating profile…' : 'Enter My Dashboard'}</button>
+          </form>
+        </section>
+      </div>
+    )
+  }
+
+  return (
+    <div style={pageStyle}>
+      <section style={heroStyle}>
+        <div>
+          <div style={eyebrowStyle}>My Dashboard</div>
+          <h1 style={titleStyle}>Welcome back, {profile.username}</h1>
+          <p style={subtitleStyle}>Your signed-in workspace now persists in the app database. Save today’s discovery into folders, keep a seeded default board, and continue using the existing free solver boards below.</p>
+        </div>
+        <div style={summaryCardStyle}>
+          <div style={summaryRowStyle}><span>Email</span><strong>{profile.email}</strong></div>
+          <div style={summaryRowStyle}><span>Plan</span><strong>{profile.preferences?.plan_type || 'free'}</strong></div>
+          <div style={summaryRowStyle}><span>Newsletter</span><strong>{profile.preferences?.wants_newsletter ? 'Interested' : 'No'}</strong></div>
+          <div style={summaryRowStyle}><span>Interests</span><strong>{(profile.preferences?.feature_interests || []).join(', ') || 'None selected'}</strong></div>
+        </div>
+      </section>
+
+      <section style={layoutStyle}>
+        <section style={panelStyle}>
+          <div style={panelHeaderStyle}>
+            <div>
+              <h2 style={cardTitleStyle}>Folders</h2>
+              <p style={cardSubtitleStyle}>Project-style cards for your default board and daily saved dashboards.</p>
+            </div>
+            <button onClick={loadWorkspace} style={secondaryButtonStyle}>Refresh</button>
+          </div>
+          <div style={folderGridStyle}>
+            {folders.map(folder => (
+              <div key={folder.id} style={folderCardStyle}>
+                <div style={folderBadgeStyle}>{folder.is_default ? 'Default' : 'Daily Folder'}</div>
+                <div style={folderNameStyle}>{folder.folder_name}</div>
+                <div style={metaStyle}>{folder.folder_date || 'Reusable board'}</div>
+                <div style={metaStyle}>{folder.item_count} item{folder.item_count === 1 ? '' : 's'}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section style={panelStyle}>
+          <div style={panelHeaderStyle}>
+            <div>
+              <h2 style={cardTitleStyle}>Seeded default dashboard</h2>
+              <p style={cardSubtitleStyle}>Built from the current My Dashboard concepts so every signed-in user starts with a familiar free board.</p>
+            </div>
+          </div>
+          <div style={seedGridStyle}>
+            {(defaultFolder?.items || []).map(item => (
+              <div key={item.id} style={seedCardStyle}>
+                <div style={seedTitleStyle}>{item.title}</div>
+                <div style={seedBodyStyle}>{item.subtitle}</div>
+                <div style={metaStyle}>Max filters: {item.payload_json?.save_ready?.max_filters || 5}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </section>
+
+      <section style={panelStyle}>
+        <div style={panelHeaderStyle}>
+          <div>
+            <h2 style={cardTitleStyle}>Today’s folder</h2>
+            <p style={cardSubtitleStyle}>Saved discoveries from the boards below land here first. Later this same schema can accept saved insights from every app tab.</p>
+          </div>
+        </div>
+        <div style={todayShellStyle}>
+          <div style={folderCardStyle}>
+            <div style={folderBadgeStyle}>Today</div>
+            <div style={folderNameStyle}>{todayFolder?.folder_name || today}</div>
+            <div style={metaStyle}>{todayFolder?.item_count || 0} item{todayFolder?.item_count === 1 ? '' : 's'}</div>
+          </div>
+          <div style={savedListStyle}>
+            {(todayFolder?.items || []).length === 0 ? (
+              <div style={emptyStyle}>No saved discoveries yet. Run a board and use “Save to Today”.</div>
+            ) : (
+              todayFolder.items.map(item => (
+                <div key={item.id} style={savedItemStyle}>
+                  <div style={savedTitleStyle}>{item.title}</div>
+                  <div style={savedBodyStyle}>{item.subtitle || 'Saved dashboard item'}</div>
+                  <div style={metaStyle}>Source: {item.source_tab} • {item.source_type}</div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+        {saveMessage && <div style={successStyle}>{saveMessage}</div>}
+      </section>
+
+      <section style={panelStyle}>
+        <div style={panelHeaderStyle}>
+          <div>
+            <h2 style={cardTitleStyle}>Free daily boards</h2>
+            <p style={cardSubtitleStyle}>These still run through the current free solver endpoints. The difference now is that signed-in users can save the discoveries they care about.</p>
+          </div>
+          <button onClick={runAllBoards} style={primaryButtonStyle}>Populate all</button>
+        </div>
+        {runErrors._all && <div style={errorStyle}>{runErrors._all}</div>}
+        <div style={boardGridStyle}>
+          {COMPONENTS.map(component => {
+            const result = results[component.key]
+            const items = result?.items || []
+            return (
+              <div key={component.key} style={boardCardStyle}>
+                <div style={boardHeaderStyle}>
+                  <div>
+                    <div style={boardTitleStyle}>{component.title}</div>
+                    <div style={boardDescriptionStyle}>{component.description}</div>
+                  </div>
+                  <div style={countBadgeStyle}>{items.length || 0}/10</div>
+                </div>
+
+                <div style={filterGridStyle}>
+                  <input style={smallInputStyle} placeholder="Search" value={filters[component.key]?.search_text || ''} onChange={e => setFilters(prev => ({ ...prev, [component.key]: { ...prev[component.key], search_text: e.target.value } }))} />
+                  <input style={smallInputStyle} placeholder="Team" value={filters[component.key]?.team || ''} onChange={e => setFilters(prev => ({ ...prev, [component.key]: { ...prev[component.key], team: e.target.value } }))} />
+                  <input style={smallInputStyle} placeholder="Opponent" value={filters[component.key]?.opponent || ''} onChange={e => setFilters(prev => ({ ...prev, [component.key]: { ...prev[component.key], opponent: e.target.value } }))} />
+                  <input style={smallInputStyle} placeholder="Min score" value={filters[component.key]?.min_score || ''} onChange={e => setFilters(prev => ({ ...prev, [component.key]: { ...prev[component.key], min_score: e.target.value } }))} />
+                  <select style={smallInputStyle} value={filters[component.key]?.min_confidence || ''} onChange={e => setFilters(prev => ({ ...prev, [component.key]: { ...prev[component.key], min_confidence: e.target.value } }))}>
+                    <option value="">Any confidence</option>
+                    <option value="low">Low+</option>
+                    <option value="medium">Medium+</option>
+                    <option value="high">High only</option>
+                  </select>
+                </div>
+
+                <button onClick={() => runBoard(component.key)} style={secondaryButtonStyle} disabled={loading[component.key]}>{loading[component.key] ? 'Running…' : 'Run board'}</button>
+                {runErrors[component.key] && <div style={errorStyle}>{runErrors[component.key]}</div>}
+
+                <div style={resultGridStyle}>
+                  {items.length === 0 ? (
+                    <div style={emptyStyle}>No results yet. Run this board to populate fresh discovery for today.</div>
+                  ) : (
+                    items.slice(0, 5).map((item, idx) => (
+                      <div key={`${component.key}-${idx}-${item.entity_id || item.entity_name || idx}`} style={resultCardStyle}>
+                        <div style={resultHeaderStyle}>
+                          <div>
+                            <div style={resultTitleStyle}>{item.entity_name || item.title || 'Ranked item'}</div>
+                            <div style={metaStyle}>{item.team || 'Team unavailable'} {item.opponent ? `vs ${item.opponent}` : ''}</div>
+                          </div>
+                          <div style={scorePillStyle}>{formatNumber(item.score)}</div>
+                        </div>
+                        <div style={resultBodyStyle}>{item.primary_reason || 'Model solver ranked this item from app-owned data.'}</div>
+                        <div style={metaStyle}>Confidence: {item.confidence || 'low'}</div>
+                        <div style={resultActionsStyle}>
+                          <button onClick={() => saveItemToToday(component, item)} style={miniPrimaryStyle}>Save to Today</button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function InfoCard({ title, body }) {
+  return (
+    <div style={infoCardStyle}>
+      <div style={infoTitleStyle}>{title}</div>
+      <div style={infoBodyStyle}>{body}</div>
+    </div>
+  )
+}
+
+const pageStyle = { display: 'grid', gap: '18px' }
+const heroStyle = { display: 'flex', justifyContent: 'space-between', gap: '18px', flexWrap: 'wrap', background: 'linear-gradient(135deg, #141925, #0d1117)', border: '1px solid #2a3243', borderRadius: '18px', padding: '24px' }
+const eyebrowStyle = { color: '#8ab4ff', fontSize: '12px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }
+const titleStyle = { margin: 0, fontSize: '34px', color: '#e6edf3' }
+const subtitleStyle = { margin: '10px 0 0', color: '#97a3b6', maxWidth: '760px', lineHeight: 1.6 }
+const layoutStyle = { display: 'grid', gridTemplateColumns: 'minmax(260px, 0.9fr) minmax(320px, 1.1fr)', gap: '18px' }
+const railStyle = { display: 'grid', gap: '14px' }
+const infoCardStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: '16px', padding: '18px' }
+const infoTitleStyle = { color: '#e6edf3', fontWeight: 700, marginBottom: '8px' }
+const infoBodyStyle = { color: '#97a3b6', lineHeight: 1.55 }
+const formCardStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: '18px', padding: '22px', display: 'grid', gap: '12px' }
+const panelStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: '18px', padding: '20px', display: 'grid', gap: '14px' }
+const panelHeaderStyle = { display: 'flex', justifyContent: 'space-between', gap: '16px', flexWrap: 'wrap', alignItems: 'flex-start' }
+const cardTitleStyle = { margin: 0, color: '#e6edf3', fontSize: '24px' }
+const cardSubtitleStyle = { margin: '8px 0 0', color: '#97a3b6', lineHeight: 1.5 }
+const labelStyle = { color: '#c9d1d9', fontSize: '13px', fontWeight: 600 }
+const inputStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '10px', padding: '10px 12px' }
+const smallInputStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '8px', padding: '8px 10px', fontSize: '12px' }
+const pillWrapStyle = { display: 'flex', flexWrap: 'wrap', gap: '8px' }
+const pillStyle = { background: '#0d1117', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: '999px', padding: '8px 12px', cursor: 'pointer' }
+const activePillStyle = { ...pillStyle, background: '#1c365d', borderColor: '#3b82f6' }
+const checkLabelStyle = { display: 'flex', gap: '8px', alignItems: 'center', color: '#c9d1d9', fontSize: '13px' }
+const primaryButtonStyle = { background: '#7c3aed', color: '#fff', border: 0, borderRadius: '10px', padding: '12px 14px', fontWeight: 700, cursor: 'pointer' }
+const secondaryButtonStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: '10px', padding: '10px 12px', cursor: 'pointer' }
+const miniPrimaryStyle = { background: '#2563eb', color: '#fff', border: 0, borderRadius: '8px', padding: '8px 10px', cursor: 'pointer', fontSize: '12px', fontWeight: 700 }
+const summaryCardStyle = { minWidth: '320px', background: '#0d1117', border: '1px solid #273042', borderRadius: '14px', padding: '16px', display: 'grid', gap: '10px' }
+const summaryRowStyle = { display: 'flex', justifyContent: 'space-between', gap: '10px', color: '#97a3b6', fontSize: '13px' }
+const folderGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: '14px' }
+const folderCardStyle = { background: 'linear-gradient(180deg, #141b2b, #111827)', border: '1px solid #293246', borderRadius: '16px', padding: '18px', display: 'grid', gap: '8px', minHeight: '120px' }
+const folderBadgeStyle = { color: '#a78bfa', fontSize: '11px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em' }
+const folderNameStyle = { color: '#e6edf3', fontSize: '20px', fontWeight: 700 }
+const metaStyle = { color: '#8b949e', fontSize: '12px', lineHeight: 1.45 }
+const seedGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '14px' }
+const seedCardStyle = { background: '#0d1117', border: '1px solid #263042', borderRadius: '14px', padding: '16px', display: 'grid', gap: '8px' }
+const seedTitleStyle = { color: '#e6edf3', fontWeight: 700 }
+const seedBodyStyle = { color: '#97a3b6', fontSize: '13px', lineHeight: 1.5 }
+const todayShellStyle = { display: 'grid', gap: '14px' }
+const savedListStyle = { display: 'grid', gap: '10px' }
+const savedItemStyle = { background: '#0d1117', border: '1px solid #263042', borderRadius: '12px', padding: '12px' }
+const savedTitleStyle = { color: '#e6edf3', fontWeight: 700, marginBottom: '4px' }
+const savedBodyStyle = { color: '#97a3b6', fontSize: '13px', lineHeight: 1.45, marginBottom: '6px' }
+const boardGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '16px' }
+const boardCardStyle = { background: '#0d1117', border: '1px solid #263042', borderRadius: '16px', padding: '16px', display: 'grid', gap: '12px' }
+const boardHeaderStyle = { display: 'flex', justifyContent: 'space-between', gap: '12px', alignItems: 'flex-start' }
+const boardTitleStyle = { color: '#e6edf3', fontWeight: 700 }
+const boardDescriptionStyle = { color: '#97a3b6', fontSize: '13px', lineHeight: 1.45, marginTop: '6px' }
+const countBadgeStyle = { background: '#1f2937', border: '1px solid #374151', borderRadius: '999px', color: '#e6edf3', padding: '6px 10px', fontSize: '12px', fontWeight: 700 }
+const filterGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '8px' }
+const resultGridStyle = { display: 'grid', gap: '10px' }
+const resultCardStyle = { background: '#111827', border: '1px solid #273042', borderRadius: '12px', padding: '12px', display: 'grid', gap: '8px' }
+const resultHeaderStyle = { display: 'flex', justifyContent: 'space-between', gap: '10px' }
+const resultTitleStyle = { color: '#e6edf3', fontWeight: 700 }
+const resultBodyStyle = { color: '#97a3b6', fontSize: '13px', lineHeight: 1.45 }
+const resultActionsStyle = { display: 'flex', justifyContent: 'flex-end' }
+const scorePillStyle = { background: '#1d4ed8', color: '#fff', borderRadius: '999px', padding: '6px 10px', fontSize: '12px', fontWeight: 700, height: 'fit-content' }
+const emptyStyle = { color: '#8b949e', fontSize: '13px', lineHeight: 1.5, padding: '8px 0' }
+const successStyle = { background: '#10261a', border: '1px solid #1f6f43', color: '#7ee787', borderRadius: '10px', padding: '12px' }
+const errorStyle = { background: '#2b1014', border: '1px solid #8b1e2d', color: '#ffb4be', borderRadius: '10px', padding: '12px' }
+const stateStyle = { color: '#9aa4b2', padding: '36px', textAlign: 'center' }

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -3,7 +3,7 @@ Database models and utilities for the MLB prediction app.
 
 This module defines the SQLAlchemy ORM models used to store raw Statcast
 events, aggregated pitch-arsenal statistics, platoon splits, rolling/seasonal
-metrics and game-level matchups.  It also provides helper functions to
+metrics and game-level matchups. It also provides helper functions to
 instantiate a database engine and session maker based on a connection URL.
 """
 
@@ -13,12 +13,15 @@ from datetime import date, datetime
 from typing import Optional
 
 from sqlalchemy import (
+    JSON,
+    Boolean,
     Column,
     Date,
     DateTime,
     Float,
     Integer,
     String,
+    Text,
     create_engine,
     Index,
     inspect,
@@ -255,6 +258,81 @@ class Matchup(Base):
     prediction: Optional[float] = Column(Float, nullable=True)
 
     __table_args__ = (Index("ix_matchups_date_home_away", "game_date", "home_team_id", "away_team_id"),)
+
+
+class AppUser(Base):
+    __tablename__ = "app_users"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    email: str = Column(String(255), nullable=False, unique=True, index=True)
+    username: str = Column(String(80), nullable=False, index=True)
+    password_hash: Optional[str] = Column(String(255), nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AppUserPreference(Base):
+    __tablename__ = "app_user_preferences"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, unique=True, index=True)
+    wants_newsletter: bool = Column(Boolean, nullable=False, default=False)
+    feature_interests_json = Column(JSON, nullable=True)
+    plan_type: Optional[str] = Column(String(64), nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AppDashboardFolder(Base):
+    __tablename__ = "app_dashboard_folders"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, index=True)
+    folder_name: str = Column(String(255), nullable=False)
+    folder_date: Optional[date] = Column(Date, nullable=True, index=True)
+    is_default: bool = Column(Boolean, nullable=False, default=False)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("ix_app_dashboard_folders_user_default", "user_id", "is_default"),
+        Index("ix_app_dashboard_folders_user_date", "user_id", "folder_date"),
+    )
+
+
+class AppDashboardItem(Base):
+    __tablename__ = "app_dashboard_items"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, index=True)
+    folder_id: int = Column(Integer, nullable=False, index=True)
+    source_tab: str = Column(String(100), nullable=False, index=True)
+    source_type: str = Column(String(100), nullable=False, index=True)
+    title: str = Column(String(255), nullable=False)
+    subtitle: Optional[str] = Column(String(255), nullable=True)
+    payload_json = Column(JSON, nullable=False)
+    filter_json = Column(JSON, nullable=True)
+    sort_json = Column(JSON, nullable=True)
+    pin_order: Optional[int] = Column(Integer, nullable=True)
+    notes: Optional[str] = Column(Text, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("ix_app_dashboard_items_user_folder", "user_id", "folder_id"),
+        Index("ix_app_dashboard_items_source", "source_tab", "source_type"),
+    )
+
+
+class AppSession(Base):
+    __tablename__ = "app_sessions"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, index=True)
+    session_token: str = Column(String(128), nullable=False, unique=True, index=True)
+    expires_at: datetime = Column(DateTime, nullable=False, index=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    last_seen_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
 STATCAST_EVENT_SAFE_COLUMNS = {

--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -1,26 +1,116 @@
 from __future__ import annotations
 
+import base64
 import datetime as dt
+import hashlib
+import hmac
+import json
 import os
-from typing import Any, Dict, Optional
+import secrets
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Cookie, HTTPException, Query, Response
+from pydantic import BaseModel, Field
 
-from .database import create_tables, get_engine, get_session
+from .database import (
+    AppDashboardFolder,
+    AppDashboardItem,
+    AppSession,
+    AppUser,
+    AppUserPreference,
+    create_tables,
+    get_engine,
+    get_session,
+)
 from .model_tracker import (
     list_tracker_rows,
     refresh_tracker_results,
 )
 from .model_tracker_safe_snapshot import build_tracker_snapshot_safe
 
-router = APIRouter(prefix="/model-tracker", tags=["model-tracker"])
+router = APIRouter(tags=["model-tracker", "my-dashboard"])
+
+DASHBOARD_SESSION_COOKIE = "mlb_dashboard_session"
+DASHBOARD_SESSION_DAYS = 30
+FEATURE_CHOICES = [
+    "Matchups",
+    "Daily Odds",
+    "Model Projections",
+    "News",
+    "Props",
+    "Pitchers",
+    "Batters",
+]
+DEFAULT_COMPONENTS = [
+    {
+        "key": "hitters",
+        "title": "My Top Hitters Today",
+        "description": "Unique hitter board from Batter vs Arsenal, pitch usage, damage quality, and model context.",
+        "source_type": "seeded_component",
+    },
+    {
+        "key": "pitchers",
+        "title": "My Top Pitchers Today",
+        "description": "Pitcher lean board using K profile, contact suppression, opponent offense, and arsenal context.",
+        "source_type": "seeded_component",
+    },
+    {
+        "key": "teams",
+        "title": "My Top Teams Today",
+        "description": "Team board from model side edge, expected runs, offense profile, and opponent weaknesses.",
+        "source_type": "seeded_component",
+    },
+    {
+        "key": "totals",
+        "title": "My Top Totals Today",
+        "description": "Game total watchlist from projected runs, run environment, and simulation context.",
+        "source_type": "seeded_component",
+    },
+    {
+        "key": "overall_players",
+        "title": "My Top Overall Players Today",
+        "description": "Combined unique player board blending hitter and pitcher model-solver scores.",
+        "source_type": "seeded_component",
+    },
+]
+DEFAULT_FILTER_FIELDS = ["search_text", "team", "opponent", "min_score", "min_confidence"]
+
+
+class DashboardProfileRequest(BaseModel):
+    email: str
+    username: str
+    password: Optional[str] = None
+    feature_interests: List[str] = Field(default_factory=list)
+    wants_newsletter: bool = False
+    plan_type: Optional[str] = "free"
+
+
+class DashboardItemCreateRequest(BaseModel):
+    folder_id: int
+    source_tab: str
+    source_type: str
+    title: str
+    subtitle: Optional[str] = None
+    payload_json: Dict[str, Any]
+    filter_json: Optional[Dict[str, Any]] = None
+    sort_json: Optional[Dict[str, Any]] = None
+    pin_order: Optional[int] = None
+    notes: Optional[str] = None
+
+
+class DashboardFolderCreateRequest(BaseModel):
+    folder_name: str
+    folder_date: Optional[str] = None
+    is_default: bool = False
+
 
 
 def _session_factory():
-    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    database_url = os.getenv("DATABASE_URL") or os.getenv("SQLALCHEMY_DATABASE_URL") or os.getenv("POSTGRES_URL") or "sqlite:///mlb.db"
     engine = get_engine(database_url)
     create_tables(engine)
     return get_session(engine)
+
 
 
 def _target_date(value: Optional[str]) -> str:
@@ -32,7 +122,294 @@ def _target_date(value: Optional[str]) -> str:
     return target
 
 
-@router.get("/health")
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.utcnow()
+
+
+
+def _normalize_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+
+def _normalize_username(username: str) -> str:
+    return (username or "").strip()
+
+
+
+def _hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 310000)
+    return f"pbkdf2_sha256${base64.b64encode(salt).decode()}${base64.b64encode(derived).decode()}"
+
+
+
+def _verify_password(password: str, stored: Optional[str]) -> bool:
+    if not stored or "$" not in stored:
+        return False
+    try:
+        _, salt_b64, hash_b64 = stored.split("$", 2)
+        salt = base64.b64decode(salt_b64.encode())
+        expected = base64.b64decode(hash_b64.encode())
+        candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 310000)
+        return hmac.compare_digest(candidate, expected)
+    except Exception:
+        return False
+
+
+
+def _serialize_user(user: AppUser, prefs: Optional[AppUserPreference]) -> Dict[str, Any]:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "username": user.username,
+        "created_at": user.created_at.isoformat() if user.created_at else None,
+        "updated_at": user.updated_at.isoformat() if user.updated_at else None,
+        "preferences": {
+            "wants_newsletter": prefs.wants_newsletter if prefs else False,
+            "feature_interests": prefs.feature_interests_json or [],
+            "plan_type": prefs.plan_type if prefs else "free",
+        },
+    }
+
+
+
+def _serialize_folder(folder: AppDashboardFolder, items: List[AppDashboardItem]) -> Dict[str, Any]:
+    return {
+        "id": folder.id,
+        "folder_name": folder.folder_name,
+        "folder_date": folder.folder_date.isoformat() if folder.folder_date else None,
+        "is_default": folder.is_default,
+        "created_at": folder.created_at.isoformat() if folder.created_at else None,
+        "updated_at": folder.updated_at.isoformat() if folder.updated_at else None,
+        "item_count": len(items),
+        "items": [_serialize_item(item) for item in items],
+    }
+
+
+
+def _serialize_item(item: AppDashboardItem) -> Dict[str, Any]:
+    return {
+        "id": item.id,
+        "user_id": item.user_id,
+        "folder_id": item.folder_id,
+        "source_tab": item.source_tab,
+        "source_type": item.source_type,
+        "title": item.title,
+        "subtitle": item.subtitle,
+        "payload_json": item.payload_json,
+        "filter_json": item.filter_json,
+        "sort_json": item.sort_json,
+        "pin_order": item.pin_order,
+        "notes": item.notes,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+        "updated_at": item.updated_at.isoformat() if item.updated_at else None,
+    }
+
+
+
+def _build_seed_payload(component: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "component_key": component["key"],
+        "title": component["title"],
+        "description": component["description"],
+        "seeded_from": "current_my_dashboard_page",
+        "save_ready": {
+            "source_tabs_supported": [
+                "Matchups",
+                "Daily Odds",
+                "Model Projections",
+                "News",
+                "My Dashboard",
+                "Pitcher",
+                "Batter",
+                "Team",
+                "Model Tracker",
+            ],
+            "available_fields": ["title", "subtitle", "metrics", "reasoning", "game_pk", "entity_id", "entity_type"],
+            "conditions": ["equals", "contains", "min", "max", "in"],
+            "max_filters": 5,
+            "default_filter_fields": DEFAULT_FILTER_FIELDS,
+            "logic_mode": "AND",
+        },
+    }
+
+
+
+def _get_or_create_today_folder(session, user_id: int) -> AppDashboardFolder:
+    today = dt.date.today()
+    folder = (
+        session.query(AppDashboardFolder)
+        .filter(AppDashboardFolder.user_id == user_id, AppDashboardFolder.folder_date == today)
+        .order_by(AppDashboardFolder.id.asc())
+        .first()
+    )
+    if folder:
+        return folder
+    now = _utcnow()
+    folder = AppDashboardFolder(
+        user_id=user_id,
+        folder_name=today.isoformat(),
+        folder_date=today,
+        is_default=False,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(folder)
+    session.flush()
+    return folder
+
+
+
+def _get_or_create_default_folder(session, user_id: int) -> AppDashboardFolder:
+    folder = (
+        session.query(AppDashboardFolder)
+        .filter(AppDashboardFolder.user_id == user_id, AppDashboardFolder.is_default.is_(True))
+        .order_by(AppDashboardFolder.id.asc())
+        .first()
+    )
+    if folder:
+        return folder
+    now = _utcnow()
+    folder = AppDashboardFolder(
+        user_id=user_id,
+        folder_name="Default Dashboard",
+        folder_date=None,
+        is_default=True,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(folder)
+    session.flush()
+    return folder
+
+
+
+def _seed_default_dashboard(session, user_id: int, folder_id: int) -> None:
+    existing = (
+        session.query(AppDashboardItem)
+        .filter(AppDashboardItem.user_id == user_id, AppDashboardItem.folder_id == folder_id)
+        .count()
+    )
+    if existing:
+        return
+    now = _utcnow()
+    for index, component in enumerate(DEFAULT_COMPONENTS, start=1):
+        session.add(
+            AppDashboardItem(
+                user_id=user_id,
+                folder_id=folder_id,
+                source_tab="my-dashboard",
+                source_type=component["source_type"],
+                title=component["title"],
+                subtitle=component["description"],
+                payload_json=_build_seed_payload(component),
+                filter_json={
+                    "default_filter_fields": DEFAULT_FILTER_FIELDS,
+                    "max_filters": 5,
+                },
+                sort_json={"mode": "manual_seed_order", "position": index},
+                pin_order=index,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+
+
+def _upsert_preferences(session, user_id: int, request: DashboardProfileRequest) -> AppUserPreference:
+    prefs = session.query(AppUserPreference).filter(AppUserPreference.user_id == user_id).first()
+    now = _utcnow()
+    feature_interests = [choice for choice in request.feature_interests if choice in FEATURE_CHOICES]
+    if prefs is None:
+        prefs = AppUserPreference(
+            user_id=user_id,
+            wants_newsletter=request.wants_newsletter,
+            feature_interests_json=feature_interests,
+            plan_type=request.plan_type or "free",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(prefs)
+    else:
+        prefs.wants_newsletter = request.wants_newsletter
+        prefs.feature_interests_json = feature_interests
+        prefs.plan_type = request.plan_type or prefs.plan_type or "free"
+        prefs.updated_at = now
+    return prefs
+
+
+
+def _create_session(session, user_id: int) -> AppSession:
+    now = _utcnow()
+    expires_at = now + dt.timedelta(days=DASHBOARD_SESSION_DAYS)
+    token = secrets.token_urlsafe(32)
+    db_session = AppSession(
+        user_id=user_id,
+        session_token=token,
+        expires_at=expires_at,
+        created_at=now,
+        last_seen_at=now,
+    )
+    session.add(db_session)
+    session.flush()
+    return db_session
+
+
+
+def _get_active_user(session, token: Optional[str]) -> Optional[AppUser]:
+    if not token:
+        return None
+    now = _utcnow()
+    db_session = (
+        session.query(AppSession)
+        .filter(AppSession.session_token == token, AppSession.expires_at > now)
+        .order_by(AppSession.id.desc())
+        .first()
+    )
+    if not db_session:
+        return None
+    db_session.last_seen_at = now
+    user = session.query(AppUser).filter(AppUser.id == db_session.user_id).first()
+    return user
+
+
+
+def _get_workspace_payload(session, user: AppUser) -> Dict[str, Any]:
+    prefs = session.query(AppUserPreference).filter(AppUserPreference.user_id == user.id).first()
+    default_folder = _get_or_create_default_folder(session, user.id)
+    today_folder = _get_or_create_today_folder(session, user.id)
+    _seed_default_dashboard(session, user.id, default_folder.id)
+    session.flush()
+
+    folders = (
+        session.query(AppDashboardFolder)
+        .filter(AppDashboardFolder.user_id == user.id)
+        .order_by(AppDashboardFolder.is_default.desc(), AppDashboardFolder.folder_date.desc().nullslast(), AppDashboardFolder.id.desc())
+        .all()
+    )
+    items = (
+        session.query(AppDashboardItem)
+        .filter(AppDashboardItem.user_id == user.id)
+        .order_by(AppDashboardItem.folder_id.asc(), AppDashboardItem.pin_order.asc().nullslast(), AppDashboardItem.id.asc())
+        .all()
+    )
+    items_by_folder: Dict[int, List[AppDashboardItem]] = {}
+    for item in items:
+        items_by_folder.setdefault(item.folder_id, []).append(item)
+
+    return {
+        "user": _serialize_user(user, prefs),
+        "folders": [_serialize_folder(folder, items_by_folder.get(folder.id, [])) for folder in folders],
+        "default_folder_id": default_folder.id,
+        "today_folder_id": today_folder.id,
+        "feature_choices": FEATURE_CHOICES,
+        "seeded_components": [component["key"] for component in DEFAULT_COMPONENTS],
+    }
+
+
+@router.get("/model-tracker/health")
 def model_tracker_health() -> Dict[str, Any]:
     return {
         "status": "ok",
@@ -42,7 +419,7 @@ def model_tracker_health() -> Dict[str, Any]:
     }
 
 
-@router.post("/snapshot")
+@router.post("/model-tracker/snapshot")
 def model_tracker_snapshot(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
     target = _target_date(date)
     try:
@@ -55,7 +432,7 @@ def model_tracker_snapshot(date: Optional[str] = Query(default=None)) -> Dict[st
         raise HTTPException(status_code=500, detail={"message": "Model Tracker snapshot failed", "error": str(exc)}) from exc
 
 
-@router.get("")
+@router.get("/model-tracker")
 def model_tracker_list(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
     target = _target_date(date)
     try:
@@ -68,7 +445,7 @@ def model_tracker_list(date: Optional[str] = Query(default=None)) -> Dict[str, A
         raise HTTPException(status_code=500, detail={"message": "Model Tracker list failed", "error": str(exc)}) from exc
 
 
-@router.get("/game/{game_pk}")
+@router.get("/model-tracker/game/{game_pk}")
 def model_tracker_game(game_pk: int, date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
     target = _target_date(date)
     try:
@@ -83,7 +460,7 @@ def model_tracker_game(game_pk: int, date: Optional[str] = Query(default=None)) 
         raise HTTPException(status_code=500, detail={"message": "Model Tracker game lookup failed", "error": str(exc)}) from exc
 
 
-@router.post("/results/refresh")
+@router.post("/model-tracker/results/refresh")
 def model_tracker_results_refresh(date: Optional[str] = Query(default=None)) -> Dict[str, Any]:
     target = _target_date(date)
     try:
@@ -94,3 +471,169 @@ def model_tracker_results_refresh(date: Optional[str] = Query(default=None)) -> 
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "Model Tracker result refresh failed", "error": str(exc)}) from exc
+
+
+@router.post("/my-dashboard/profile")
+def my_dashboard_profile_create(request: DashboardProfileRequest, response: Response) -> Dict[str, Any]:
+    email = _normalize_email(request.email)
+    username = _normalize_username(request.username)
+    if not email or "@" not in email:
+        raise HTTPException(status_code=400, detail="A valid email is required")
+    if not username:
+        raise HTTPException(status_code=400, detail="Username is required")
+
+    Session = _session_factory()
+    with Session() as session:
+        user = session.query(AppUser).filter(AppUser.email == email).first()
+        now = _utcnow()
+        if user is None:
+            user = AppUser(
+                email=email,
+                username=username,
+                password_hash=_hash_password(request.password) if request.password else None,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(user)
+            session.flush()
+        else:
+            if user.password_hash and request.password and not _verify_password(request.password, user.password_hash):
+                raise HTTPException(status_code=403, detail="Password does not match existing account")
+            user.username = username or user.username
+            if request.password and not user.password_hash:
+                user.password_hash = _hash_password(request.password)
+            user.updated_at = now
+
+        prefs = _upsert_preferences(session, user.id, request)
+        default_folder = _get_or_create_default_folder(session, user.id)
+        _seed_default_dashboard(session, user.id, default_folder.id)
+        _get_or_create_today_folder(session, user.id)
+        db_session = _create_session(session, user.id)
+        session.commit()
+
+        response.set_cookie(
+            key=DASHBOARD_SESSION_COOKIE,
+            value=db_session.session_token,
+            httponly=True,
+            samesite="lax",
+            secure=False,
+            max_age=DASHBOARD_SESSION_DAYS * 24 * 60 * 60,
+            path="/",
+        )
+        return {
+            "ok": True,
+            "user": _serialize_user(user, prefs),
+            "default_folder_id": default_folder.id,
+            "session_expires_at": db_session.expires_at.isoformat(),
+        }
+
+
+@router.get("/my-dashboard/profile")
+def my_dashboard_profile_get(mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            return {"authenticated": False}
+        prefs = session.query(AppUserPreference).filter(AppUserPreference.user_id == user.id).first()
+        session.commit()
+        return {
+            "authenticated": True,
+            "user": _serialize_user(user, prefs),
+            "feature_choices": FEATURE_CHOICES,
+        }
+
+
+@router.get("/my-dashboard/workspace")
+def my_dashboard_workspace(mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            raise HTTPException(status_code=401, detail="Dashboard sign-in required")
+        payload = _get_workspace_payload(session, user)
+        session.commit()
+        return payload
+
+
+@router.post("/my-dashboard/folders/today/ensure")
+def my_dashboard_ensure_today_folder(mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            raise HTTPException(status_code=401, detail="Dashboard sign-in required")
+        folder = _get_or_create_today_folder(session, user.id)
+        session.commit()
+        return {
+            "ok": True,
+            "folder": _serialize_folder(folder, []),
+        }
+
+
+@router.post("/my-dashboard/folders")
+def my_dashboard_create_folder(request: DashboardFolderCreateRequest, mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            raise HTTPException(status_code=401, detail="Dashboard sign-in required")
+        now = _utcnow()
+        folder_date = dt.date.fromisoformat(request.folder_date) if request.folder_date else None
+        folder = AppDashboardFolder(
+            user_id=user.id,
+            folder_name=request.folder_name.strip(),
+            folder_date=folder_date,
+            is_default=bool(request.is_default),
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(folder)
+        session.commit()
+        return {"ok": True, "folder": _serialize_folder(folder, [])}
+
+
+@router.get("/my-dashboard/items")
+def my_dashboard_items(folder_id: Optional[int] = Query(default=None), mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            raise HTTPException(status_code=401, detail="Dashboard sign-in required")
+        query = session.query(AppDashboardItem).filter(AppDashboardItem.user_id == user.id)
+        if folder_id is not None:
+            query = query.filter(AppDashboardItem.folder_id == folder_id)
+        items = query.order_by(AppDashboardItem.pin_order.asc().nullslast(), AppDashboardItem.id.asc()).all()
+        session.commit()
+        return {"items": [_serialize_item(item) for item in items]}
+
+
+@router.post("/my-dashboard/items")
+def my_dashboard_create_item(request: DashboardItemCreateRequest, mlb_dashboard_session: Optional[str] = Cookie(default=None)) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = _get_active_user(session, mlb_dashboard_session)
+        if not user:
+            raise HTTPException(status_code=401, detail="Dashboard sign-in required")
+        folder = session.query(AppDashboardFolder).filter(AppDashboardFolder.id == request.folder_id, AppDashboardFolder.user_id == user.id).first()
+        if not folder:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        now = _utcnow()
+        item = AppDashboardItem(
+            user_id=user.id,
+            folder_id=folder.id,
+            source_tab=request.source_tab,
+            source_type=request.source_type,
+            title=request.title,
+            subtitle=request.subtitle,
+            payload_json=request.payload_json,
+            filter_json=request.filter_json,
+            sort_json=request.sort_json,
+            pin_order=request.pin_order,
+            notes=request.notes,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(item)
+        session.commit()
+        return {"ok": True, "item": _serialize_item(item)}


### PR DESCRIPTION
This PR builds a low-risk MVP for `My Dashboard` on top of the existing app architecture. It replaces the browser-local prototype with a Postgres-backed profile and folder system while preserving the existing free board concept and solver endpoints.

Included
- New Postgres-backed dashboard models in `mlb_app/database.py`
  - `app_users`
  - `app_user_preferences`
  - `app_dashboard_folders`
  - `app_dashboard_items`
  - `app_sessions`
- New `/my-dashboard/...` API endpoints added through the existing mounted router file `mlb_app/model_tracker_routes.py`
  - profile create/load
  - workspace load
  - today folder ensure
  - create folder
  - list items
  - create item
- New frontend page `frontend/src/pages/MyDashboardWorkspacePage.jsx`
  - lightweight sign-in/profile creation
  - folder grid and seeded default dashboard
  - today folder view
  - free daily boards using current solver endpoints
  - save-to-today flow for discoveries
- Route switch in `frontend/src/App.jsx`
  - `/my-dashboard` now points to the new Postgres-backed workspace page

Important implementation notes
- Kept current architecture low-risk by avoiding `app.py` edits.
- Reused the already-mounted router module pattern instead of adding another monolith route block.
- The default dashboard is seeded from the current My Dashboard concept using the same existing free board components:
  - hitters
  - pitchers
  - teams
  - totals
  - overall_players
- `dashboard_items.payload_json` is future-ready for saved discoveries from Matchups, Daily Odds, Model Projections, News, Pitcher, Batter, Team, Model Tracker, and My Dashboard.
- The frontend still relies on the existing solver endpoints for the free boards; this PR adds persistence and user/folder structure around them.

Still to do later
- production-secure cookie policy/env handling
- real sign-out flow
- richer filter builder UI beyond the initial 5 filters
- save from every tab directly in the UI
- plan/payment flow for newsletter offers

This PR is intentionally MVP-scoped and additive.