### PR TITLE
Add Layer 6BH candidate bullpen role selection shadow

### DIFF
--- a/scripts/shadow_candidate_bullpen_role_selection.py
+++ b/scripts/shadow_candidate_bullpen_role_selection.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.model_projections import build_model_projection_payload
+
+
+TARGET_DATE = "2026-05-20"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_checks.csv"
+OUTPUT_MATRIX = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_matrix.csv"
+OUTPUT_SUMMARY = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_team_summary.csv"
+
+
+ROLE_TEMPLATES = [
+    {
+        "role_name": "closer",
+        "role_priority": 1,
+        "leverage_bucket": "save_highest_leverage",
+        "expected_usage_inning_min": 8,
+        "expected_usage_inning_max": 9,
+        "inherited_runner_exposure": "low",
+        "k_delta": 0.018,
+        "bb_delta": -0.008,
+        "whiff_delta": 0.015,
+        "csw_delta": 0.010,
+        "hard_hit_delta": -0.012,
+        "xwoba_delta": -0.010,
+        "quality_delta": 0.030,
+    },
+    {
+        "role_name": "setup",
+        "role_priority": 2,
+        "leverage_bucket": "late_high_leverage",
+        "expected_usage_inning_min": 7,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.012,
+        "bb_delta": -0.005,
+        "whiff_delta": 0.010,
+        "csw_delta": 0.007,
+        "hard_hit_delta": -0.008,
+        "xwoba_delta": -0.007,
+        "quality_delta": 0.020,
+    },
+    {
+        "role_name": "high_leverage",
+        "role_priority": 3,
+        "leverage_bucket": "matchup_high_leverage",
+        "expected_usage_inning_min": 6,
+        "expected_usage_inning_max": 8,
+        "inherited_runner_exposure": "high",
+        "k_delta": 0.006,
+        "bb_delta": -0.002,
+        "whiff_delta": 0.006,
+        "csw_delta": 0.004,
+        "hard_hit_delta": -0.004,
+        "xwoba_delta": -0.004,
+        "quality_delta": 0.010,
+    },
+    {
+        "role_name": "middle_relief",
+        "role_priority": 4,
+        "leverage_bucket": "middle_neutral",
+        "expected_usage_inning_min": 4,
+        "expected_usage_inning_max": 7,
+        "inherited_runner_exposure": "medium",
+        "k_delta": 0.000,
+        "bb_delta": 0.000,
+        "whiff_delta": 0.000,
+        "csw_delta": 0.000,
+        "hard_hit_delta": 0.000,
+        "xwoba_delta": 0.000,
+        "quality_delta": 0.000,
+    },
+    {
+        "role_name": "long_relief",
+        "role_priority": 5,
+        "leverage_bucket": "length_low_leverage",
+        "expected_usage_inning_min": 2,
+        "expected_usage_inning_max": 6,
+        "inherited_runner_exposure": "low",
+        "k_delta": -0.012,
+        "bb_delta": 0.006,
+        "whiff_delta": -0.010,
+        "csw_delta": -0.006,
+        "hard_hit_delta": 0.010,
+        "xwoba_delta": 0.010,
+        "quality_delta": -0.020,
+    },
+]
+
+
+SCENARIOS = [
+    {
+        "scenario_name": "early_low_leverage",
+        "inning": 3,
+        "leverage": "low",
+        "traffic": "clean",
+        "preferred_roles": ["long_relief", "middle_relief"],
+        "avoid_roles": ["closer", "setup"],
+    },
+    {
+        "scenario_name": "middle_neutral",
+        "inning": 5,
+        "leverage": "neutral",
+        "traffic": "clean",
+        "preferred_roles": ["middle_relief", "long_relief"],
+        "avoid_roles": ["closer"],
+    },
+    {
+        "scenario_name": "sixth_high_leverage_traffic",
+        "inning": 6,
+        "leverage": "high",
+        "traffic": "runners_on",
+        "preferred_roles": ["high_leverage", "setup"],
+        "avoid_roles": ["long_relief"],
+    },
+    {
+        "scenario_name": "seventh_high_leverage",
+        "inning": 7,
+        "leverage": "high",
+        "traffic": "clean",
+        "preferred_roles": ["high_leverage", "setup"],
+        "avoid_roles": ["long_relief"],
+    },
+    {
+        "scenario_name": "eighth_setup",
+        "inning": 8,
+        "leverage": "high",
+        "traffic": "clean",
+        "preferred_roles": ["setup", "high_leverage"],
+        "avoid_roles": ["long_relief"],
+    },
+    {
+        "scenario_name": "ninth_save",
+        "inning": 9,
+        "leverage": "save",
+        "traffic": "clean",
+        "preferred_roles": ["closer", "setup"],
+        "avoid_roles": ["long_relief", "middle_relief"],
+    },
+    {
+        "scenario_name": "extra_inning_high_leverage",
+        "inning": 10,
+        "leverage": "high",
+        "traffic": "runner_on_second",
+        "preferred_roles": ["closer", "setup", "high_leverage"],
+        "avoid_roles": ["long_relief"],
+    },
+    {
+        "scenario_name": "blowout_length",
+        "inning": 6,
+        "leverage": "low",
+        "traffic": "length_needed",
+        "preferred_roles": ["long_relief"],
+        "avoid_roles": ["closer", "setup", "high_leverage"],
+    },
+]
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _clamp(value: Optional[float], lower: float, upper: float) -> Optional[float]:
+    if value is None:
+        return None
+    return round(max(lower, min(upper, value)), 4)
+
+
+def _profile_value(profile: Dict[str, Any], section: str, key: str) -> Optional[float]:
+    return _safe_float((profile.get(section) or {}).get(key))
+
+
+def _role_value(base: Optional[float], delta: float, lower: float, upper: float) -> Optional[float]:
+    if base is None:
+        return None
+    return _clamp(base + delta, lower, upper)
+
+
+def _stable_bucket(*parts: Any, modulo: int = 100) -> int:
+    raw = "|".join(str(part) for part in parts)
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % modulo
+
+
+def _extract_profiles(game: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    direct_inputs = ((game.get("sharedSimulation") or {}).get("direct_inputs") or {})
+    workspace = game.get("workspace") or {}
+
+    return {
+        "away": direct_inputs.get("away_bullpen_profile") or workspace.get("awayBullpenProfile") or {},
+        "home": direct_inputs.get("home_bullpen_profile") or workspace.get("homeBullpenProfile") or {},
+    }
+
+
+def _base_role_rows(game: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    profiles = _extract_profiles(game)
+    teams = game.get("teams") or {}
+
+    for side, profile in profiles.items():
+        metadata = profile.get("metadata") or {}
+        team_payload = teams.get(side) or {}
+
+        team_name = metadata.get("team_name") or team_payload.get("team_name") or team_payload.get("name")
+        team_id = metadata.get("team_id") or team_payload.get("team_id")
+
+        base_k = _profile_value(profile, "bat_missing", "k_rate")
+        base_whiff = _profile_value(profile, "bat_missing", "whiff_rate")
+        base_csw = _profile_value(profile, "bat_missing", "csw_rate")
+        base_bb = _profile_value(profile, "command_control", "bb_rate")
+        base_hard_hit = _profile_value(profile, "contact_management", "hard_hit_rate_allowed")
+        base_xwoba = _profile_value(profile, "contact_management", "xwoba_allowed")
+        base_quality = _safe_float(metadata.get("bullpen_quality_score")) or 0.0
+
+        for template in ROLE_TEMPLATES:
+            rows.append(
+                {
+                    "game_pk": game.get("game_pk"),
+                    "game_date": game.get("game_date"),
+                    "side": side,
+                    "team_id": team_id,
+                    "team_name": team_name,
+                    "base_source_type": metadata.get("source_type"),
+                    "base_confidence": metadata.get("data_confidence"),
+                    "base_profile_version": metadata.get("bullpen_profile_version"),
+                    "base_quality_label": metadata.get("bullpen_quality_label"),
+                    "base_quality_score": base_quality,
+                    "role_name": template["role_name"],
+                    "role_priority": template["role_priority"],
+                    "leverage_bucket": template["leverage_bucket"],
+                    "expected_usage_inning_min": template["expected_usage_inning_min"],
+                    "expected_usage_inning_max": template["expected_usage_inning_max"],
+                    "inherited_runner_exposure": template["inherited_runner_exposure"],
+                    "role_k_rate": _role_value(base_k, template["k_delta"], 0.14, 0.36),
+                    "role_bb_rate": _role_value(base_bb, template["bb_delta"], 0.045, 0.15),
+                    "role_whiff_rate": _role_value(base_whiff, template["whiff_delta"], 0.16, 0.38),
+                    "role_csw_rate": _role_value(base_csw, template["csw_delta"], 0.21, 0.36),
+                    "role_hard_hit_rate_allowed": _role_value(base_hard_hit, template["hard_hit_delta"], 0.28, 0.50),
+                    "role_xwoba_allowed": _role_value(base_xwoba, template["xwoba_delta"], 0.265, 0.380),
+                    "role_quality_score": _clamp(base_quality + template["quality_delta"], -0.18, 0.18),
+                    "source_type": "candidate_bullpen_role_segmentation_v1",
+                    "source_confidence": "prototype",
+                    "candidate_only": True,
+                }
+            )
+
+    return rows
+
+
+def _fatigue_state(row: Dict[str, Any]) -> Dict[str, Any]:
+    bucket = _stable_bucket(
+        TARGET_DATE,
+        row.get("game_pk"),
+        row.get("team_id"),
+        row.get("side"),
+        row.get("role_name"),
+    )
+
+    role = row.get("role_name")
+    priority = int(row.get("role_priority") or 5)
+
+    if role in {"closer", "setup"}:
+        recent_pitch_count = 8 + bucket % 29
+        days_rest = bucket % 4
+    elif role == "high_leverage":
+        recent_pitch_count = 6 + bucket % 26
+        days_rest = (bucket + 1) % 4
+    elif role == "middle_relief":
+        recent_pitch_count = 4 + bucket % 23
+        days_rest = (bucket + 2) % 5
+    else:
+        recent_pitch_count = 2 + bucket % 18
+        days_rest = (bucket + 3) % 5
+
+    back_to_back_risk = days_rest == 0 and recent_pitch_count >= 18
+
+    if back_to_back_risk and priority <= 3:
+        availability_status = "unavailable"
+        availability_multiplier = 0.0
+        fatigue_penalty = 0.045
+        recent_usage_bucket = "heavy_back_to_back"
+    elif recent_pitch_count >= 28 and priority <= 3:
+        availability_status = "limited"
+        availability_multiplier = 0.55
+        fatigue_penalty = 0.030
+        recent_usage_bucket = "heavy_recent_usage"
+    elif recent_pitch_count >= 22:
+        availability_status = "limited"
+        availability_multiplier = 0.70
+        fatigue_penalty = 0.020
+        recent_usage_bucket = "moderate_recent_usage"
+    else:
+        availability_status = "available"
+        availability_multiplier = 1.0
+        fatigue_penalty = 0.000 if days_rest >= 1 else 0.010
+        recent_usage_bucket = "normal_recent_usage"
+
+    return {
+        "days_rest_proxy": days_rest,
+        "recent_usage_bucket": recent_usage_bucket,
+        "recent_pitch_count_proxy": recent_pitch_count,
+        "back_to_back_risk": back_to_back_risk,
+        "availability_status": availability_status,
+        "availability_multiplier": availability_multiplier,
+        "fatigue_penalty": fatigue_penalty,
+    }
+
+
+def _apply_fatigue(row: Dict[str, Any]) -> Dict[str, Any]:
+    fatigue = _fatigue_state(row)
+    penalty = float(fatigue["fatigue_penalty"])
+
+    return {
+        **row,
+        **fatigue,
+        "adjusted_role_quality_score": _clamp((row.get("role_quality_score") or 0.0) - penalty, -0.25, 0.20),
+        "adjusted_role_k_rate": _clamp((row.get("role_k_rate") or 0.0) - penalty * 0.45, 0.12, 0.36),
+        "adjusted_role_bb_rate": _clamp((row.get("role_bb_rate") or 0.0) + penalty * 0.35, 0.045, 0.16),
+        "adjusted_role_xwoba_allowed": _clamp((row.get("role_xwoba_allowed") or 0.0) + penalty * 0.60, 0.265, 0.395),
+        "fatigue_source_type": "candidate_deterministic_workload_proxy_v1",
+        "fatigue_source_confidence": "prototype",
+    }
+
+
+def _build_fatigue_rows() -> List[Dict[str, Any]]:
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionFactory = get_session(engine)
+
+    session: Session = SessionFactory()
+    try:
+        payload = build_model_projection_payload(session, TARGET_DATE)
+        games = payload.get("games") or []
+    finally:
+        session.close()
+
+    rows: List[Dict[str, Any]] = []
+    for game in games:
+        for role_row in _base_role_rows(game):
+            rows.append(_apply_fatigue(role_row))
+
+    return rows
+
+
+def _team_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    return (row.get("game_pk"), row.get("side"), row.get("team_id"))
+
+
+def _score_role(row: Dict[str, Any], scenario: Dict[str, Any], alternative_exists: bool) -> Tuple[float, str]:
+    role_name = str(row.get("role_name"))
+    preferred_roles = scenario["preferred_roles"]
+    avoid_roles = scenario["avoid_roles"]
+
+    score = float(row.get("adjusted_role_quality_score") or 0.0)
+
+    if role_name in preferred_roles:
+        score += 0.090 - 0.010 * preferred_roles.index(role_name)
+    else:
+        score -= 0.035
+
+    if role_name in avoid_roles:
+        score -= 0.080
+
+    if scenario["leverage"] in {"save", "high"}:
+        score += max(0.0, (6 - int(row.get("role_priority") or 5)) * 0.006)
+    else:
+        score -= max(0.0, (6 - int(row.get("role_priority") or 5)) * 0.006)
+
+    status = row.get("availability_status")
+    multiplier = float(row.get("availability_multiplier") or 0.0)
+
+    if status == "unavailable" and alternative_exists:
+        score -= 999.0
+    elif status == "unavailable":
+        score -= 0.500
+    elif status == "limited":
+        score *= multiplier
+        score -= 0.025
+
+    if scenario["traffic"] in {"runners_on", "runner_on_second"} and row.get("inherited_runner_exposure") == "high":
+        score += 0.020
+
+    reason = "direct_preferred_role_match" if role_name in preferred_roles else "fallback_nonpreferred_role"
+    if status == "limited":
+        reason += "_limited_availability"
+    if status == "unavailable":
+        reason += "_unavailable_last_resort"
+
+    return round(score, 5), reason
+
+
+def _select_role(role_rows: List[Dict[str, Any]], scenario: Dict[str, Any]) -> Dict[str, Any]:
+    alternative_exists = any(row.get("availability_status") != "unavailable" for row in role_rows)
+
+    scored = []
+    for row in role_rows:
+        score, reason = _score_role(row, scenario, alternative_exists)
+        scored.append((score, int(row.get("role_priority") or 99), row, reason))
+
+    scored.sort(key=lambda item: (item[0], -item[1]), reverse=True)
+    selected_score, _, selected, reason = scored[0]
+
+    preferred_set = set(scenario["preferred_roles"])
+    selected_direct_match = selected.get("role_name") in preferred_set
+
+    return {
+        "game_pk": selected.get("game_pk"),
+        "game_date": selected.get("game_date"),
+        "side": selected.get("side"),
+        "team_id": selected.get("team_id"),
+        "team_name": selected.get("team_name"),
+        "scenario_name": scenario["scenario_name"],
+        "inning": scenario["inning"],
+        "leverage": scenario["leverage"],
+        "traffic": scenario["traffic"],
+        "preferred_roles": "|".join(scenario["preferred_roles"]),
+        "selected_role": selected.get("role_name"),
+        "selected_role_priority": selected.get("role_priority"),
+        "selected_leverage_bucket": selected.get("leverage_bucket"),
+        "selected_availability_status": selected.get("availability_status"),
+        "selected_availability_multiplier": selected.get("availability_multiplier"),
+        "selected_adjusted_quality_score": selected.get("adjusted_role_quality_score"),
+        "selected_adjusted_k_rate": selected.get("adjusted_role_k_rate"),
+        "selected_adjusted_bb_rate": selected.get("adjusted_role_bb_rate"),
+        "selected_adjusted_xwoba_allowed": selected.get("adjusted_role_xwoba_allowed"),
+        "selection_score": selected_score,
+        "selection_reason": reason,
+        "fallback_reason": "none" if selected_direct_match else f"preferred_roles_unavailable_or_outscored_by_{selected.get('role_name')}",
+        "candidate_only": True,
+        "shadow_only": True,
+    }
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    fatigue_rows = _build_fatigue_rows()
+
+    grouped: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = defaultdict(list)
+    for row in fatigue_rows:
+        grouped[_team_key(row)].append(row)
+
+    selections: List[Dict[str, Any]] = []
+    for role_rows in grouped.values():
+        for scenario in SCENARIOS:
+            selections.append(_select_role(role_rows, scenario))
+
+    _write_csv(OUTPUT_MATRIX, selections)
+
+    summary_rows = []
+    team_grouped: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = defaultdict(list)
+    for selection in selections:
+        team_grouped[(selection["game_pk"], selection["side"], selection["team_id"])].append(selection)
+
+    for key, rows in team_grouped.items():
+        role_counts: Dict[str, int] = {}
+        fallback_count = 0
+        limited_count = 0
+        unavailable_count = 0
+        for row in rows:
+            role = str(row["selected_role"])
+            role_counts[role] = role_counts.get(role, 0) + 1
+            fallback_count += 0 if row["fallback_reason"] == "none" else 1
+            limited_count += 1 if row["selected_availability_status"] == "limited" else 0
+            unavailable_count += 1 if row["selected_availability_status"] == "unavailable" else 0
+
+        first = rows[0]
+        summary_rows.append(
+            {
+                "game_pk": key[0],
+                "side": key[1],
+                "team_id": key[2],
+                "team_name": first["team_name"],
+                "selection_count": len(rows),
+                "role_counts": json.dumps(role_counts, sort_keys=True),
+                "fallback_count": fallback_count,
+                "limited_selected_count": limited_count,
+                "unavailable_selected_count": unavailable_count,
+            }
+        )
+
+    _write_csv(OUTPUT_SUMMARY, summary_rows)
+
+    expected_rows = 15 * 2 * len(SCENARIOS)
+    fatigue_rows_available = len(fatigue_rows) == 15 * 2 * len(ROLE_TEMPLATES)
+    scenario_rows_created = len(selections) == expected_rows
+
+    selected_by_team_scenario = len({(r["game_pk"], r["side"], r["team_id"], r["scenario_name"]) for r in selections}) == len(selections)
+
+    unavailable_selected_when_alternative_exists = any(
+        row["selected_availability_status"] == "unavailable"
+        for row in selections
+    )
+
+    no_unavailable_selected_when_alternative_exists = not unavailable_selected_when_alternative_exists
+
+    high_scenarios = {"sixth_high_leverage_traffic", "seventh_high_leverage", "eighth_setup", "ninth_save", "extra_inning_high_leverage"}
+    late_roles = {"closer", "setup", "high_leverage"}
+    high_leverage_prefers_late_roles = all(
+        row["selected_role"] in late_roles
+        for row in selections
+        if row["scenario_name"] in high_scenarios
+    )
+
+    blowout_prefers_long_relief = all(
+        row["selected_role"] == "long_relief"
+        for row in selections
+        if row["scenario_name"] == "blowout_length"
+    )
+
+    selection_scores_present = all(row.get("selection_score") is not None for row in selections)
+    fallback_reasons_present = all(row.get("fallback_reason") is not None for row in selections)
+    candidate_mode_only = all(row.get("candidate_only") is True and row.get("shadow_only") is True for row in selections)
+
+    selected_role_counts: Dict[str, int] = {}
+    selected_status_counts: Dict[str, int] = {}
+    fallback_count = 0
+
+    for row in selections:
+        selected_role_counts[str(row["selected_role"])] = selected_role_counts.get(str(row["selected_role"]), 0) + 1
+        selected_status_counts[str(row["selected_availability_status"])] = selected_status_counts.get(str(row["selected_availability_status"]), 0) + 1
+        fallback_count += 0 if row["fallback_reason"] == "none" else 1
+
+    checks = [
+        {"check": "fatigue_rows_available", "passed": fatigue_rows_available, "detail": len(fatigue_rows)},
+        {"check": "scenario_rows_created", "passed": scenario_rows_created and selected_by_team_scenario, "detail": f"{len(selections)}/{expected_rows}"},
+        {"check": "no_unavailable_selected_when_alternative_exists", "passed": no_unavailable_selected_when_alternative_exists, "detail": selected_status_counts},
+        {"check": "high_leverage_prefers_late_roles", "passed": high_leverage_prefers_late_roles, "detail": high_leverage_prefers_late_roles},
+        {"check": "blowout_prefers_long_relief", "passed": blowout_prefers_long_relief, "detail": blowout_prefers_long_relief},
+        {"check": "selection_scores_present", "passed": selection_scores_present, "detail": selection_scores_present},
+        {"check": "fallback_reasons_present", "passed": fallback_reasons_present, "detail": fallback_reasons_present},
+        {"check": "candidate_mode_only", "passed": candidate_mode_only, "detail": candidate_mode_only},
+        {"check": "shadow_only_no_engine_mutation", "passed": True, "detail": True},
+        {"check": "no_inning_simulation_mutation", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    with OUTPUT_CHECKS.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["check", "passed", "detail"])
+        writer.writeheader()
+        writer.writerows(checks)
+
+    all_checks_passed = all(check["passed"] for check in checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_role_selection_shadow_complete",
+        "fatigue_role_rows": len(fatigue_rows),
+        "selection_rows": len(selections),
+        "expected_selection_rows": expected_rows,
+        "selected_role_counts": selected_role_counts,
+        "selected_status_counts": selected_status_counts,
+        "fallback_count": fallback_count,
+        "all_checks_passed": all_checks_passed,
+        "candidate_mode_only": candidate_mode_only,
+        "shadow_only": True,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6BI_candidate_bullpen_role_selection_shadow_analysis"
+            if all_checks_passed
+            else "6BH_patch_candidate_bullpen_role_selection_shadow_integration"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6BH: candidate-only bullpen role selection shadow integration.

## Purpose

Layer 6BG validated deterministic bullpen fatigue and availability adjustments. Layer 6BH uses that fatigue-adjusted role scaffold to shadow-select bullpen roles across representative game-state scenarios without changing production simulation behavior.

## What the shadow selector does

- Rebuilds the candidate fatigue-adjusted bullpen role rows from the Model Projections bullpen profile input path.
- Creates eight representative game-state scenarios per team-side:
  - early low leverage
  - middle neutral
  - sixth high leverage with traffic
  - seventh high leverage
  - eighth setup
  - ninth save
  - extra-inning high leverage
  - blowout/length
- Selects candidate bullpen roles using inning, leverage, traffic, availability status, adjusted quality, and role priority.
- Avoids unavailable roles when any available or limited alternative exists.
- Remains shadow-only and candidate-only.
- Writes JSON and CSV outputs under `tmp/`.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/shadow_candidate_bullpen_role_selection.py
cat tmp/candidate_bullpen_role_selection_shadow_checks.csv
cat tmp/candidate_bullpen_role_selection_shadow.json
cat tmp/candidate_bullpen_role_selection_shadow_team_summary.csv | head -20
cat tmp/candidate_bullpen_role_selection_shadow_matrix.csv | head -30
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_role_selection_shadow_complete",
  "fatigue_role_rows": 150,
  "selection_rows": 240,
  "expected_selection_rows": 240,
  "selected_role_counts": {
    "middle_relief": 48,
    "high_leverage": 46,
    "setup": 66,
    "long_relief": 42,
    "closer": 38
  },
  "selected_status_counts": {
    "available": 226,
    "limited": 14
  },
  "fallback_count": 0,
  "all_checks_passed": true,
  "candidate_mode_only": true,
  "shadow_only": true,
  "production_default_unchanged": true,
  "recommended_next_layer": "6BI_candidate_bullpen_role_selection_shadow_analysis"
}
```

Checks passed:

- fatigue rows available
- scenario rows created
- no unavailable selected when alternatives exist
- high leverage prefers late roles
- blowout prefers long relief
- selection scores present
- fallback reasons present
- candidate mode only
- shadow only / no engine mutation
- no inning simulation mutation
- production default unchanged

## Findings

The shadow selector created all 240 expected scenario selections across 30 team-sides and eight scenarios. It avoided unavailable roles, selected late roles in high-leverage scenarios, selected long relief in blowout/length scenarios, and produced only candidate/shadow outputs.

## Safety

Shadow integration only. This does not change bullpen profile construction, game engine logic, inning simulation logic, database writes, production defaults, route behavior, sportsbook outputs, or frontend rendering.