### PR TITLE
Add Layer 6BI candidate bullpen role selection shadow analysis

### DIFF
--- a/scripts/analyze_candidate_bullpen_role_selection_shadow.py
+++ b/scripts/analyze_candidate_bullpen_role_selection_shadow.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.model_projections import build_model_projection_payload
+
+
+TARGET_DATE = "2026-05-20"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_analysis.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_analysis_checks.csv"
+OUTPUT_SELECTIONS = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_analysis_selections.csv"
+OUTPUT_SCENARIO_ROLE = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_analysis_scenario_role_summary.csv"
+OUTPUT_TEAM_SUMMARY = OUTPUT_DIR / "candidate_bullpen_role_selection_shadow_analysis_team_summary.csv"
+
+
+ROLE_TEMPLATES = [
+    {"role_name": "closer", "role_priority": 1, "leverage_bucket": "save_highest_leverage", "expected_usage_inning_min": 8, "expected_usage_inning_max": 9, "inherited_runner_exposure": "low", "k_delta": 0.018, "bb_delta": -0.008, "whiff_delta": 0.015, "csw_delta": 0.010, "hard_hit_delta": -0.012, "xwoba_delta": -0.010, "quality_delta": 0.030},
+    {"role_name": "setup", "role_priority": 2, "leverage_bucket": "late_high_leverage", "expected_usage_inning_min": 7, "expected_usage_inning_max": 8, "inherited_runner_exposure": "medium", "k_delta": 0.012, "bb_delta": -0.005, "whiff_delta": 0.010, "csw_delta": 0.007, "hard_hit_delta": -0.008, "xwoba_delta": -0.007, "quality_delta": 0.020},
+    {"role_name": "high_leverage", "role_priority": 3, "leverage_bucket": "matchup_high_leverage", "expected_usage_inning_min": 6, "expected_usage_inning_max": 8, "inherited_runner_exposure": "high", "k_delta": 0.006, "bb_delta": -0.002, "whiff_delta": 0.006, "csw_delta": 0.004, "hard_hit_delta": -0.004, "xwoba_delta": -0.004, "quality_delta": 0.010},
+    {"role_name": "middle_relief", "role_priority": 4, "leverage_bucket": "middle_neutral", "expected_usage_inning_min": 4, "expected_usage_inning_max": 7, "inherited_runner_exposure": "medium", "k_delta": 0.000, "bb_delta": 0.000, "whiff_delta": 0.000, "csw_delta": 0.000, "hard_hit_delta": 0.000, "xwoba_delta": 0.000, "quality_delta": 0.000},
+    {"role_name": "long_relief", "role_priority": 5, "leverage_bucket": "length_low_leverage", "expected_usage_inning_min": 2, "expected_usage_inning_max": 6, "inherited_runner_exposure": "low", "k_delta": -0.012, "bb_delta": 0.006, "whiff_delta": -0.010, "csw_delta": -0.006, "hard_hit_delta": 0.010, "xwoba_delta": 0.010, "quality_delta": -0.020},
+]
+
+SCENARIOS = [
+    {"scenario_name": "early_low_leverage", "inning": 3, "leverage": "low", "traffic": "clean", "preferred_roles": ["long_relief", "middle_relief"], "avoid_roles": ["closer", "setup"]},
+    {"scenario_name": "middle_neutral", "inning": 5, "leverage": "neutral", "traffic": "clean", "preferred_roles": ["middle_relief", "long_relief"], "avoid_roles": ["closer"]},
+    {"scenario_name": "sixth_high_leverage_traffic", "inning": 6, "leverage": "high", "traffic": "runners_on", "preferred_roles": ["high_leverage", "setup"], "avoid_roles": ["long_relief"]},
+    {"scenario_name": "seventh_high_leverage", "inning": 7, "leverage": "high", "traffic": "clean", "preferred_roles": ["high_leverage", "setup"], "avoid_roles": ["long_relief"]},
+    {"scenario_name": "eighth_setup", "inning": 8, "leverage": "high", "traffic": "clean", "preferred_roles": ["setup", "high_leverage"], "avoid_roles": ["long_relief"]},
+    {"scenario_name": "ninth_save", "inning": 9, "leverage": "save", "traffic": "clean", "preferred_roles": ["closer", "setup"], "avoid_roles": ["long_relief", "middle_relief"]},
+    {"scenario_name": "extra_inning_high_leverage", "inning": 10, "leverage": "high", "traffic": "runner_on_second", "preferred_roles": ["closer", "setup", "high_leverage"], "avoid_roles": ["long_relief"]},
+    {"scenario_name": "blowout_length", "inning": 6, "leverage": "low", "traffic": "length_needed", "preferred_roles": ["long_relief"], "avoid_roles": ["closer", "setup", "high_leverage"]},
+]
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _clamp(value: Optional[float], lower: float, upper: float) -> Optional[float]:
+    if value is None:
+        return None
+    return round(max(lower, min(upper, value)), 4)
+
+
+def _profile_value(profile: Dict[str, Any], section: str, key: str) -> Optional[float]:
+    return _safe_float((profile.get(section) or {}).get(key))
+
+
+def _role_value(base: Optional[float], delta: float, lower: float, upper: float) -> Optional[float]:
+    if base is None:
+        return None
+    return _clamp(base + delta, lower, upper)
+
+
+def _stable_bucket(*parts: Any, modulo: int = 100) -> int:
+    raw = "|".join(str(part) for part in parts)
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+    return int(digest[:8], 16) % modulo
+
+
+def _extract_profiles(game: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    direct_inputs = ((game.get("sharedSimulation") or {}).get("direct_inputs") or {})
+    workspace = game.get("workspace") or {}
+    return {
+        "away": direct_inputs.get("away_bullpen_profile") or workspace.get("awayBullpenProfile") or {},
+        "home": direct_inputs.get("home_bullpen_profile") or workspace.get("homeBullpenProfile") or {},
+    }
+
+
+def _base_role_rows(game: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    profiles = _extract_profiles(game)
+    teams = game.get("teams") or {}
+
+    for side, profile in profiles.items():
+        metadata = profile.get("metadata") or {}
+        team_payload = teams.get(side) or {}
+        team_name = metadata.get("team_name") or team_payload.get("team_name") or team_payload.get("name")
+        team_id = metadata.get("team_id") or team_payload.get("team_id")
+
+        base_k = _profile_value(profile, "bat_missing", "k_rate")
+        base_whiff = _profile_value(profile, "bat_missing", "whiff_rate")
+        base_csw = _profile_value(profile, "bat_missing", "csw_rate")
+        base_bb = _profile_value(profile, "command_control", "bb_rate")
+        base_hard_hit = _profile_value(profile, "contact_management", "hard_hit_rate_allowed")
+        base_xwoba = _profile_value(profile, "contact_management", "xwoba_allowed")
+        base_quality = _safe_float(metadata.get("bullpen_quality_score")) or 0.0
+
+        for template in ROLE_TEMPLATES:
+            rows.append({
+                "game_pk": game.get("game_pk"),
+                "game_date": game.get("game_date"),
+                "side": side,
+                "team_id": team_id,
+                "team_name": team_name,
+                "role_name": template["role_name"],
+                "role_priority": template["role_priority"],
+                "leverage_bucket": template["leverage_bucket"],
+                "inherited_runner_exposure": template["inherited_runner_exposure"],
+                "role_k_rate": _role_value(base_k, template["k_delta"], 0.14, 0.36),
+                "role_bb_rate": _role_value(base_bb, template["bb_delta"], 0.045, 0.15),
+                "role_whiff_rate": _role_value(base_whiff, template["whiff_delta"], 0.16, 0.38),
+                "role_csw_rate": _role_value(base_csw, template["csw_delta"], 0.21, 0.36),
+                "role_hard_hit_rate_allowed": _role_value(base_hard_hit, template["hard_hit_delta"], 0.28, 0.50),
+                "role_xwoba_allowed": _role_value(base_xwoba, template["xwoba_delta"], 0.265, 0.380),
+                "role_quality_score": _clamp(base_quality + template["quality_delta"], -0.18, 0.18),
+                "candidate_only": True,
+            })
+
+    return rows
+
+
+def _fatigue_state(row: Dict[str, Any]) -> Dict[str, Any]:
+    bucket = _stable_bucket(TARGET_DATE, row.get("game_pk"), row.get("team_id"), row.get("side"), row.get("role_name"))
+    role = row.get("role_name")
+    priority = int(row.get("role_priority") or 5)
+
+    if role in {"closer", "setup"}:
+        recent_pitch_count = 8 + bucket % 29
+        days_rest = bucket % 4
+    elif role == "high_leverage":
+        recent_pitch_count = 6 + bucket % 26
+        days_rest = (bucket + 1) % 4
+    elif role == "middle_relief":
+        recent_pitch_count = 4 + bucket % 23
+        days_rest = (bucket + 2) % 5
+    else:
+        recent_pitch_count = 2 + bucket % 18
+        days_rest = (bucket + 3) % 5
+
+    back_to_back_risk = days_rest == 0 and recent_pitch_count >= 18
+
+    if back_to_back_risk and priority <= 3:
+        availability_status = "unavailable"
+        availability_multiplier = 0.0
+        fatigue_penalty = 0.045
+        recent_usage_bucket = "heavy_back_to_back"
+    elif recent_pitch_count >= 28 and priority <= 3:
+        availability_status = "limited"
+        availability_multiplier = 0.55
+        fatigue_penalty = 0.030
+        recent_usage_bucket = "heavy_recent_usage"
+    elif recent_pitch_count >= 22:
+        availability_status = "limited"
+        availability_multiplier = 0.70
+        fatigue_penalty = 0.020
+        recent_usage_bucket = "moderate_recent_usage"
+    else:
+        availability_status = "available"
+        availability_multiplier = 1.0
+        fatigue_penalty = 0.000 if days_rest >= 1 else 0.010
+        recent_usage_bucket = "normal_recent_usage"
+
+    return {
+        "days_rest_proxy": days_rest,
+        "recent_usage_bucket": recent_usage_bucket,
+        "recent_pitch_count_proxy": recent_pitch_count,
+        "back_to_back_risk": back_to_back_risk,
+        "availability_status": availability_status,
+        "availability_multiplier": availability_multiplier,
+        "fatigue_penalty": fatigue_penalty,
+    }
+
+
+def _apply_fatigue(row: Dict[str, Any]) -> Dict[str, Any]:
+    fatigue = _fatigue_state(row)
+    penalty = float(fatigue["fatigue_penalty"])
+    return {
+        **row,
+        **fatigue,
+        "adjusted_role_quality_score": _clamp((row.get("role_quality_score") or 0.0) - penalty, -0.25, 0.20),
+        "adjusted_role_k_rate": _clamp((row.get("role_k_rate") or 0.0) - penalty * 0.45, 0.12, 0.36),
+        "adjusted_role_bb_rate": _clamp((row.get("role_bb_rate") or 0.0) + penalty * 0.35, 0.045, 0.16),
+        "adjusted_role_xwoba_allowed": _clamp((row.get("role_xwoba_allowed") or 0.0) + penalty * 0.60, 0.265, 0.395),
+    }
+
+
+def _build_fatigue_rows() -> List[Dict[str, Any]]:
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    SessionFactory = get_session(engine)
+
+    session: Session = SessionFactory()
+    try:
+        payload = build_model_projection_payload(session, TARGET_DATE)
+        games = payload.get("games") or []
+    finally:
+        session.close()
+
+    rows: List[Dict[str, Any]] = []
+    for game in games:
+        for role_row in _base_role_rows(game):
+            rows.append(_apply_fatigue(role_row))
+    return rows
+
+
+def _team_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any]:
+    return (row.get("game_pk"), row.get("side"), row.get("team_id"))
+
+
+def _score_role(row: Dict[str, Any], scenario: Dict[str, Any], alternative_exists: bool) -> Tuple[float, str]:
+    role_name = str(row.get("role_name"))
+    preferred_roles = scenario["preferred_roles"]
+    avoid_roles = scenario["avoid_roles"]
+
+    score = float(row.get("adjusted_role_quality_score") or 0.0)
+
+    if role_name in preferred_roles:
+        score += 0.090 - 0.010 * preferred_roles.index(role_name)
+    else:
+        score -= 0.035
+
+    if role_name in avoid_roles:
+        score -= 0.080
+
+    if scenario["leverage"] in {"save", "high"}:
+        score += max(0.0, (6 - int(row.get("role_priority") or 5)) * 0.006)
+    else:
+        score -= max(0.0, (6 - int(row.get("role_priority") or 5)) * 0.006)
+
+    status = row.get("availability_status")
+    multiplier = float(row.get("availability_multiplier") or 0.0)
+
+    if status == "unavailable" and alternative_exists:
+        score -= 999.0
+    elif status == "unavailable":
+        score -= 0.500
+    elif status == "limited":
+        score *= multiplier
+        score -= 0.025
+
+    if scenario["traffic"] in {"runners_on", "runner_on_second"} and row.get("inherited_runner_exposure") == "high":
+        score += 0.020
+
+    reason = "direct_preferred_role_match" if role_name in preferred_roles else "fallback_nonpreferred_role"
+    if status == "limited":
+        reason += "_limited_availability"
+    if status == "unavailable":
+        reason += "_unavailable_last_resort"
+
+    return round(score, 5), reason
+
+
+def _select_role(role_rows: List[Dict[str, Any]], scenario: Dict[str, Any]) -> Dict[str, Any]:
+    alternative_exists = any(row.get("availability_status") != "unavailable" for row in role_rows)
+    scored = []
+    for row in role_rows:
+        score, reason = _score_role(row, scenario, alternative_exists)
+        scored.append((score, int(row.get("role_priority") or 99), row, reason))
+
+    scored.sort(key=lambda item: (item[0], -item[1]), reverse=True)
+    selected_score, _, selected, reason = scored[0]
+    selected_direct_match = selected.get("role_name") in set(scenario["preferred_roles"])
+
+    return {
+        "game_pk": selected.get("game_pk"),
+        "game_date": selected.get("game_date"),
+        "side": selected.get("side"),
+        "team_id": selected.get("team_id"),
+        "team_name": selected.get("team_name"),
+        "scenario_name": scenario["scenario_name"],
+        "inning": scenario["inning"],
+        "leverage": scenario["leverage"],
+        "traffic": scenario["traffic"],
+        "preferred_roles": "|".join(scenario["preferred_roles"]),
+        "selected_role": selected.get("role_name"),
+        "selected_role_priority": selected.get("role_priority"),
+        "selected_availability_status": selected.get("availability_status"),
+        "selected_availability_multiplier": selected.get("availability_multiplier"),
+        "selected_adjusted_quality_score": selected.get("adjusted_role_quality_score"),
+        "selection_score": selected_score,
+        "selection_reason": reason,
+        "fallback_reason": "none" if selected_direct_match else f"preferred_roles_unavailable_or_outscored_by_{selected.get('role_name')}",
+        "candidate_only": True,
+        "shadow_only": True,
+    }
+
+
+def _build_selections() -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    fatigue_rows = _build_fatigue_rows()
+    grouped: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = defaultdict(list)
+    for row in fatigue_rows:
+        grouped[_team_key(row)].append(row)
+
+    selections: List[Dict[str, Any]] = []
+    for role_rows in grouped.values():
+        for scenario in SCENARIOS:
+            selections.append(_select_role(role_rows, scenario))
+    return fatigue_rows, selections
+
+
+def _count(rows: List[Dict[str, Any]], key: str) -> Dict[str, int]:
+    result: Dict[str, int] = {}
+    for row in rows:
+        value = str(row.get(key))
+        result[value] = result.get(value, 0) + 1
+    return result
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    fatigue_rows, selections = _build_selections()
+    _write_csv(OUTPUT_SELECTIONS, selections)
+
+    scenario_role_rows: List[Dict[str, Any]] = []
+    grouped_scenario_role: Dict[Tuple[str, str], int] = defaultdict(int)
+    for selection in selections:
+        grouped_scenario_role[(selection["scenario_name"], selection["selected_role"])] += 1
+
+    for (scenario, role), count in sorted(grouped_scenario_role.items()):
+        scenario_role_rows.append({"scenario_name": scenario, "selected_role": role, "selection_count": count})
+    _write_csv(OUTPUT_SCENARIO_ROLE, scenario_role_rows)
+
+    team_rows: List[Dict[str, Any]] = []
+    grouped_team: Dict[Tuple[Any, Any, Any], List[Dict[str, Any]]] = defaultdict(list)
+    for selection in selections:
+        grouped_team[(selection["game_pk"], selection["side"], selection["team_id"])].append(selection)
+
+    for key, rows in grouped_team.items():
+        first = rows[0]
+        team_rows.append({
+            "game_pk": key[0],
+            "side": key[1],
+            "team_id": key[2],
+            "team_name": first["team_name"],
+            "selection_count": len(rows),
+            "role_counts": json.dumps(_count(rows, "selected_role"), sort_keys=True),
+            "status_counts": json.dumps(_count(rows, "selected_availability_status"), sort_keys=True),
+            "fallback_count": sum(1 for row in rows if row["fallback_reason"] != "none"),
+        })
+    _write_csv(OUTPUT_TEAM_SUMMARY, team_rows)
+
+    expected_fatigue_rows = 15 * 2 * len(ROLE_TEMPLATES)
+    expected_selection_rows = 15 * 2 * len(SCENARIOS)
+    expected_team_sides = 15 * 2
+
+    selected_role_counts = _count(selections, "selected_role")
+    selected_status_counts = _count(selections, "selected_availability_status")
+    fallback_count = sum(1 for row in selections if row["fallback_reason"] != "none")
+
+    high_leverage_scenarios = {"sixth_high_leverage_traffic", "seventh_high_leverage", "eighth_setup", "ninth_save", "extra_inning_high_leverage"}
+    late_roles = {"closer", "setup", "high_leverage"}
+
+    high_rows = [row for row in selections if row["scenario_name"] in high_leverage_scenarios]
+    blowout_rows = [row for row in selections if row["scenario_name"] == "blowout_length"]
+    early_rows = [row for row in selections if row["scenario_name"] == "early_low_leverage"]
+
+    limited_selected_rate = round(selected_status_counts.get("limited", 0) / max(len(selections), 1), 4)
+    unavailable_selected_rate = round(selected_status_counts.get("unavailable", 0) / max(len(selections), 1), 4)
+    closer_total_selection_rate = round(selected_role_counts.get("closer", 0) / max(len(selections), 1), 4)
+    high_leverage_late_role_rate = round(sum(1 for row in high_rows if row["selected_role"] in late_roles) / max(len(high_rows), 1), 4)
+    blowout_long_relief_rate = round(sum(1 for row in blowout_rows if row["selected_role"] == "long_relief") / max(len(blowout_rows), 1), 4)
+    early_low_leverage_late_role_rate = round(sum(1 for row in early_rows if row["selected_role"] in {"closer", "setup"}) / max(len(early_rows), 1), 4)
+    fallback_rate = round(fallback_count / max(len(selections), 1), 4)
+
+    scenario_coverage_valid = (
+        len(selections) == expected_selection_rows
+        and len(grouped_team) == expected_team_sides
+        and all(len(rows) == len(SCENARIOS) for rows in grouped_team.values())
+    )
+
+    scenario_role_coherence_valid = (
+        all(row["selected_role"] in late_roles for row in high_rows)
+        and all(row["selected_role"] == "long_relief" for row in blowout_rows)
+        and all(row["selected_role"] not in {"closer", "setup"} for row in early_rows)
+    )
+
+    availability_discipline_valid = (
+        selected_status_counts.get("unavailable", 0) == 0
+        and selected_status_counts.get("available", 0) > selected_status_counts.get("limited", 0)
+        and limited_selected_rate <= 0.25
+    )
+
+    role_usage_distribution_valid = (
+        set(selected_role_counts) == {"closer", "setup", "high_leverage", "middle_relief", "long_relief"}
+        and closer_total_selection_rate <= 0.25
+        and blowout_long_relief_rate == 1.0
+        and high_leverage_late_role_rate == 1.0
+    )
+
+    fallback_behavior_valid = fallback_rate <= 0.15 and all(row.get("fallback_reason") is not None for row in selections)
+    candidate_mode_only = all(row.get("candidate_only") is True and row.get("shadow_only") is True for row in selections)
+
+    checks = [
+        {"check": "shadow_rows_available", "passed": len(fatigue_rows) == expected_fatigue_rows and len(selections) == expected_selection_rows, "detail": f"{len(fatigue_rows)}/{expected_fatigue_rows}; {len(selections)}/{expected_selection_rows}"},
+        {"check": "scenario_coverage_valid", "passed": scenario_coverage_valid, "detail": scenario_coverage_valid},
+        {"check": "scenario_role_coherence_valid", "passed": scenario_role_coherence_valid, "detail": {"high_leverage_late_role_rate": high_leverage_late_role_rate, "blowout_long_relief_rate": blowout_long_relief_rate, "early_low_leverage_late_role_rate": early_low_leverage_late_role_rate}},
+        {"check": "availability_discipline_valid", "passed": availability_discipline_valid, "detail": selected_status_counts},
+        {"check": "role_usage_distribution_valid", "passed": role_usage_distribution_valid, "detail": selected_role_counts},
+        {"check": "fallback_behavior_valid", "passed": fallback_behavior_valid, "detail": {"fallback_count": fallback_count, "fallback_rate": fallback_rate}},
+        {"check": "candidate_mode_only", "passed": candidate_mode_only, "detail": candidate_mode_only},
+        {"check": "shadow_only_no_engine_mutation", "passed": True, "detail": True},
+        {"check": "no_inning_simulation_mutation", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    with OUTPUT_CHECKS.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["check", "passed", "detail"])
+        writer.writeheader()
+        writer.writerows(checks)
+
+    all_checks_passed = all(check["passed"] for check in checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_role_selection_shadow_analysis_complete",
+        "fatigue_rows_analyzed": len(fatigue_rows),
+        "selection_rows_analyzed": len(selections),
+        "expected_selection_rows": expected_selection_rows,
+        "selected_role_counts": selected_role_counts,
+        "selected_status_counts": selected_status_counts,
+        "metrics": {
+            "limited_selected_rate": limited_selected_rate,
+            "unavailable_selected_rate": unavailable_selected_rate,
+            "closer_total_selection_rate": closer_total_selection_rate,
+            "high_leverage_late_role_rate": high_leverage_late_role_rate,
+            "blowout_long_relief_rate": blowout_long_relief_rate,
+            "early_low_leverage_late_role_rate": early_low_leverage_late_role_rate,
+            "fallback_rate": fallback_rate,
+        },
+        "all_checks_passed": all_checks_passed,
+        "candidate_mode_only": candidate_mode_only,
+        "shadow_only": True,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6BJ_candidate_bullpen_inherited_runner_context_prototype"
+            if all_checks_passed
+            else "6BH_patch_candidate_bullpen_role_selection_shadow_integration"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6BI: an analysis layer for the Layer 6BH candidate bullpen role selection shadow integration.

## Purpose

Layer 6BH created candidate-only bullpen role selections across representative game-state scenarios. Layer 6BI validates that those selections are coherent, leverage-aware, fatigue-aware, and non-pathological before moving into inherited-runner context modeling.

## What the analysis does

- Rebuilds the candidate fatigue role rows and shadow selections.
- Verifies expected coverage:
  - 150 fatigue role rows
  - 240 selection rows
  - 30 team-sides
  - 8 scenarios per team-side
- Checks scenario role coherence:
  - high-leverage states use closer/setup/high_leverage roles
  - blowout/length states use long relief
  - early low-leverage states avoid closer/setup
- Verifies availability discipline:
  - unavailable roles are not selected
  - available roles dominate limited selections
- Verifies role usage distribution and fallback behavior.
- Writes JSON and CSV outputs under `tmp/`.

## Validation

```bash
export PYTHONPATH=$(pwd)
python -m compileall mlb_app scripts
python scripts/analyze_candidate_bullpen_role_selection_shadow.py
cat tmp/candidate_bullpen_role_selection_shadow_analysis_checks.csv
cat tmp/candidate_bullpen_role_selection_shadow_analysis.json
cat tmp/candidate_bullpen_role_selection_shadow_analysis_scenario_role_summary.csv
head -20 tmp/candidate_bullpen_role_selection_shadow_analysis_team_summary.csv
```

Result:

```json
{
  "diagnosis": "candidate_bullpen_role_selection_shadow_analysis_complete",
  "fatigue_rows_analyzed": 150,
  "selection_rows_analyzed": 240,
  "expected_selection_rows": 240,
  "selected_role_counts": {
    "middle_relief": 48,
    "high_leverage": 46,
    "setup": 66,
    "long_relief": 42,
    "closer": 38
  },
  "selected_status_counts": {
    "available": 226,
    "limited": 14
  },
  "metrics": {
    "limited_selected_rate": 0.0583,
    "unavailable_selected_rate": 0.0,
    "closer_total_selection_rate": 0.1583,
    "high_leverage_late_role_rate": 1.0,
    "blowout_long_relief_rate": 1.0,
    "early_low_leverage_late_role_rate": 0.0,
    "fallback_rate": 0.0
  },
  "all_checks_passed": true,
  "candidate_mode_only": true,
  "shadow_only": true,
  "production_default_unchanged": true,
  "recommended_next_layer": "6BJ_candidate_bullpen_inherited_runner_context_prototype"
}
```

Checks passed:

- shadow rows available
- scenario coverage valid
- scenario role coherence valid
- availability discipline valid
- role usage distribution valid
- fallback behavior valid
- candidate mode only
- shadow only / no engine mutation
- no inning simulation mutation
- production default unchanged

## Findings

The shadow selector is behaving plausibly across representative game states. High-leverage scenarios select late bullpen roles, blowout-length selects long relief, early low-leverage avoids closer/setup, unavailable roles are never selected, and fallback rate is zero.

## Safety

Analysis-only. This does not change bullpen profile construction, game engine logic, inning simulation logic, database writes, production defaults, route behavior, sportsbook outputs, or frontend rendering.