### PR TITLE
Add Layer 6CM candidate bullpen Statcast fixture payload scaffold

### DIFF
--- a/scripts/scaffold_candidate_bullpen_statcast_fixture_payloads.py
+++ b/scripts/scaffold_candidate_bullpen_statcast_fixture_payloads.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+SCAFFOLD_VERSION = "candidate_bullpen_statcast_fixture_payload_scaffold_v0.1"
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+DATES_DIR = FIXTURE_ROOT / "dates"
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+SCHEMA = FIXTURE_ROOT / "schema.json"
+PROVENANCE = FIXTURE_ROOT / "provenance.json"
+README = FIXTURE_ROOT / "README.md"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_scaffold.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_scaffold_checks.csv"
+OUTPUT_INVENTORY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_file_inventory.csv"
+OUTPUT_MANIFEST_AUDIT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_manifest_entry_audit.csv"
+OUTPUT_EXPECTED_AUDIT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_expected_result_audit.csv"
+OUTPUT_HASH_AUDIT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_hash_audit.csv"
+OUTPUT_ROW_AUDIT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_row_contract_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_safety_audit.csv"
+
+
+REQUIRED_FIELDS = [
+    "game_date",
+    "game_pk",
+    "inning",
+    "inning_topbot",
+    "at_bat_number",
+    "pitch_number",
+    "outs_when_up",
+    "pitcher_id",
+    "home_team",
+    "away_team",
+    "events",
+    "description",
+]
+
+NATURAL_KEY_FIELDS = ["game_pk", "at_bat_number", "pitch_number", "pitcher_id"]
+
+PAYLOAD_CLASSES = {
+    "2026-05-20": {
+        "payload_class": "positive_minimal_valid_date",
+        "case_type": "positive",
+        "expected_status": "success",
+        "generation_method": "hand_curated",
+        "create_file": True,
+    },
+    "2026-05-21": {
+        "payload_class": "positive_multi_pitcher_date",
+        "case_type": "positive",
+        "expected_status": "success",
+        "generation_method": "hand_curated",
+        "create_file": True,
+    },
+    "2026-05-22": {
+        "payload_class": "positive_multi_game_date",
+        "case_type": "positive",
+        "expected_status": "success",
+        "generation_method": "hand_curated",
+        "create_file": True,
+    },
+    "2026-05-23": {
+        "payload_class": "negative_duplicate_natural_key_date",
+        "case_type": "negative",
+        "expected_status": "dedupe_success",
+        "generation_method": "synthetic_negative_case",
+        "create_file": True,
+    },
+    "2026-05-24": {
+        "payload_class": "negative_missing_pitcher_id_date",
+        "case_type": "negative",
+        "expected_status": "schema_failed_safely",
+        "generation_method": "synthetic_negative_case",
+        "create_file": True,
+    },
+    "2026-05-25": {
+        "payload_class": "negative_missing_game_pk_date",
+        "case_type": "negative",
+        "expected_status": "schema_failed_safely",
+        "generation_method": "synthetic_negative_case",
+        "create_file": True,
+    },
+    "2026-05-26": {
+        "payload_class": "negative_missing_fixture_date",
+        "case_type": "negative_missing_file",
+        "expected_status": "fixture_missing",
+        "generation_method": "synthetic_negative_case",
+        "create_file": False,
+    },
+}
+
+
+def _base_row(
+    *,
+    game_date: str,
+    game_pk: int,
+    at_bat_number: int,
+    pitch_number: int,
+    pitcher_id: int,
+    inning: int = 7,
+    inning_topbot: str = "Top",
+    outs_when_up: int | None = 1,
+    home_team: str = "HOM",
+    away_team: str = "AWY",
+    events: str | None = "strikeout",
+    description: str | None = "called_strike",
+) -> Dict[str, Any]:
+    return {
+        "game_date": game_date,
+        "game_pk": game_pk,
+        "inning": inning,
+        "inning_topbot": inning_topbot,
+        "at_bat_number": at_bat_number,
+        "pitch_number": pitch_number,
+        "outs_when_up": outs_when_up,
+        "pitcher_id": pitcher_id,
+        "home_team": home_team,
+        "away_team": away_team,
+        "events": events,
+        "description": description,
+    }
+
+
+def _payload_rows() -> Dict[str, List[Dict[str, Any]]]:
+    return {
+        "2026-05-20": [
+            _base_row(game_date="2026-05-20", game_pk=777001, at_bat_number=42, pitch_number=1, pitcher_id=123456),
+            _base_row(game_date="2026-05-20", game_pk=777001, at_bat_number=42, pitch_number=2, pitcher_id=123456, description="swinging_strike"),
+            _base_row(game_date="2026-05-20", game_pk=777001, at_bat_number=42, pitch_number=3, pitcher_id=123456, description="in_play"),
+        ],
+        "2026-05-21": [
+            _base_row(game_date="2026-05-21", game_pk=777002, at_bat_number=10, pitch_number=1, pitcher_id=223456, home_team="AAA", away_team="BBB"),
+            _base_row(game_date="2026-05-21", game_pk=777002, at_bat_number=11, pitch_number=1, pitcher_id=323456, home_team="AAA", away_team="BBB", events="walk", description="ball"),
+            _base_row(game_date="2026-05-21", game_pk=777002, at_bat_number=12, pitch_number=1, pitcher_id=223456, home_team="AAA", away_team="BBB", events="single", description="hit_into_play"),
+        ],
+        "2026-05-22": [
+            _base_row(game_date="2026-05-22", game_pk=777003, at_bat_number=5, pitch_number=1, pitcher_id=423456, home_team="CCC", away_team="DDD"),
+            _base_row(game_date="2026-05-22", game_pk=777004, at_bat_number=5, pitch_number=1, pitcher_id=523456, home_team="EEE", away_team="FFF", events="double", description="hit_into_play"),
+            _base_row(game_date="2026-05-22", game_pk=777004, at_bat_number=6, pitch_number=1, pitcher_id=523456, home_team="EEE", away_team="FFF", events=None, description="foul"),
+        ],
+        "2026-05-23": [
+            _base_row(game_date="2026-05-23", game_pk=777005, at_bat_number=20, pitch_number=1, pitcher_id=623456),
+            _base_row(game_date="2026-05-23", game_pk=777005, at_bat_number=20, pitch_number=1, pitcher_id=623456, description="duplicate_called_strike"),
+            _base_row(game_date="2026-05-23", game_pk=777005, at_bat_number=20, pitch_number=2, pitcher_id=623456, description="swinging_strike"),
+        ],
+        "2026-05-24": [
+            _without_key(_base_row(game_date="2026-05-24", game_pk=777006, at_bat_number=30, pitch_number=1, pitcher_id=723456), "pitcher_id"),
+            _base_row(game_date="2026-05-24", game_pk=777006, at_bat_number=30, pitch_number=2, pitcher_id=723456),
+        ],
+        "2026-05-25": [
+            _without_key(_base_row(game_date="2026-05-25", game_pk=777007, at_bat_number=40, pitch_number=1, pitcher_id=823456), "game_pk"),
+            _base_row(game_date="2026-05-25", game_pk=777007, at_bat_number=40, pitch_number=2, pitcher_id=823456),
+        ],
+    }
+
+
+def _without_key(row: Dict[str, Any], key: str) -> Dict[str, Any]:
+    out = dict(row)
+    out.pop(key, None)
+    return out
+
+
+def _natural_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any, Any]:
+    return tuple(row.get(field) for field in NATURAL_KEY_FIELDS)
+
+
+def _sort_value(value: Any) -> Tuple[int, str]:
+    if value is None:
+        return (1, "")
+    return (0, str(value))
+
+
+def _sort_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted(rows, key=lambda row: tuple(_sort_value(item) for item in _natural_key(row)))
+
+
+def _dedupe_rows(rows: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], int]:
+    seen = set()
+    deduped = []
+    duplicates = 0
+    for row in rows:
+        key = _natural_key(row)
+        if key in seen:
+            duplicates += 1
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped, duplicates
+
+
+def _required_field_failures(rows: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
+    failures = 0
+    missing_fields: List[str] = []
+    for row in rows:
+        missing = [field for field in REQUIRED_FIELDS if field not in row]
+        if missing:
+            failures += 1
+            missing_fields.extend(missing)
+    return failures, sorted(set(missing_fields))
+
+
+def _stable_json(row: Dict[str, Any]) -> str:
+    return json.dumps(row, sort_keys=True, separators=(",", ":"))
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(_stable_json(row) for row in rows) + "\n"
+    path.write_text(content)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _expected_for_date(label_date: str, rows: List[Dict[str, Any]] | None) -> Dict[str, Any]:
+    meta = PAYLOAD_CLASSES[label_date]
+    if rows is None:
+        return {
+            "fixture_date": label_date,
+            "payload_class": meta["payload_class"],
+            "file_path": f"dates/{label_date}.jsonl",
+            "row_count": 0,
+            "deduped_row_count": 0,
+            "duplicate_count": 0,
+            "required_field_failures": 0,
+            "expected_status": "fixture_missing",
+            "expected_missing_fields": [],
+            "expected_natural_keys": [],
+            "expected_sha256": "",
+            "file_created": False,
+        }
+
+    sorted_rows = _sort_rows(rows)
+    deduped, duplicate_count = _dedupe_rows(sorted_rows)
+    required_failures, missing_fields = _required_field_failures(deduped)
+    file_path = DATES_DIR / f"{label_date}.jsonl"
+    return {
+        "fixture_date": label_date,
+        "payload_class": meta["payload_class"],
+        "file_path": f"dates/{label_date}.jsonl",
+        "row_count": len(sorted_rows),
+        "deduped_row_count": len(deduped),
+        "duplicate_count": duplicate_count,
+        "required_field_failures": required_failures,
+        "expected_status": meta["expected_status"],
+        "expected_missing_fields": missing_fields,
+        "expected_natural_keys": [str(_natural_key(row)) for row in deduped],
+        "expected_sha256": _sha256(file_path) if file_path.exists() else "",
+        "file_created": True,
+    }
+
+
+def _update_manifest_and_expected(payloads: Dict[str, List[Dict[str, Any]]]) -> None:
+    manifest = _read_json(MANIFEST)
+    expected_results = _read_json(EXPECTED_RESULTS)
+
+    entries = []
+    date_expectations: Dict[str, Any] = {}
+
+    for label_date in sorted(PAYLOAD_CLASSES):
+        meta = PAYLOAD_CLASSES[label_date]
+        if meta["create_file"]:
+            rows = _sort_rows(payloads[label_date])
+            file_path = DATES_DIR / f"{label_date}.jsonl"
+            sha = _sha256(file_path)
+            expectation = _expected_for_date(label_date, rows)
+            expectation["expected_sha256"] = sha
+            date_expectations[label_date] = expectation
+
+            entries.append({
+                "fixture_version": manifest.get("fixture_version", "bullpen_statcast_fixture_v0.1"),
+                "fixture_date": label_date,
+                "file_path": f"dates/{label_date}.jsonl",
+                "row_count": len(rows),
+                "sha256": sha,
+                "source_label": f"{meta['case_type']}::{meta['payload_class']}",
+                "generation_method": meta["generation_method"],
+                "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+                "expected_duplicate_count": expectation["duplicate_count"],
+                "expected_required_field_failures": expectation["required_field_failures"],
+            })
+        else:
+            date_expectations[label_date] = _expected_for_date(label_date, None)
+
+    manifest["entries"] = entries
+    expected_results["date_expectations"] = date_expectations
+    expected_results["negative_fixture_expectations"] = {
+        label_date: expectation
+        for label_date, expectation in date_expectations.items()
+        if PAYLOAD_CLASSES[label_date]["case_type"].startswith("negative")
+    }
+
+    _write_json(MANIFEST, manifest)
+    _write_json(EXPECTED_RESULTS, expected_results)
+
+
+def _payload_inventory() -> List[Dict[str, Any]]:
+    rows = []
+    for label_date in sorted(PAYLOAD_CLASSES):
+        path = DATES_DIR / f"{label_date}.jsonl"
+        expected_created = PAYLOAD_CLASSES[label_date]["create_file"]
+        rows.append({
+            "fixture_date": label_date,
+            "payload_class": PAYLOAD_CLASSES[label_date]["payload_class"],
+            "file_path": str(path),
+            "expected_created": expected_created,
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() == expected_created,
+        })
+    return rows
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _manifest_audit() -> List[Dict[str, Any]]:
+    manifest = _read_json(MANIFEST)
+    entries = manifest.get("entries", [])
+    by_date = {entry["fixture_date"]: entry for entry in entries}
+    rows = []
+
+    for label_date, meta in sorted(PAYLOAD_CLASSES.items()):
+        should_have_entry = meta["create_file"]
+        entry = by_date.get(label_date)
+        rows.append({
+            "fixture_date": label_date,
+            "payload_class": meta["payload_class"],
+            "should_have_entry": should_have_entry,
+            "has_entry": entry is not None,
+            "row_count": entry.get("row_count") if entry else "",
+            "sha256_present": bool(entry.get("sha256")) if entry else False,
+            "generation_method": entry.get("generation_method") if entry else "",
+            "passed": (entry is not None) == should_have_entry and (not entry or bool(entry.get("sha256"))),
+        })
+
+    return rows
+
+
+def _expected_audit() -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+    rows = []
+
+    for label_date, meta in sorted(PAYLOAD_CLASSES.items()):
+        item = expectations.get(label_date, {})
+        rows.append({
+            "fixture_date": label_date,
+            "payload_class": meta["payload_class"],
+            "has_expectation": label_date in expectations,
+            "expected_status": item.get("expected_status"),
+            "file_created": item.get("file_created"),
+            "row_count": item.get("row_count"),
+            "duplicate_count": item.get("duplicate_count"),
+            "required_field_failures": item.get("required_field_failures"),
+            "passed": label_date in expectations and item.get("expected_status") == meta["expected_status"],
+        })
+
+    return rows
+
+
+def _hash_audit() -> List[Dict[str, Any]]:
+    manifest = _read_json(MANIFEST)
+    rows = []
+
+    for entry in manifest.get("entries", []):
+        path = FIXTURE_ROOT / entry["file_path"]
+        actual_sha = _sha256(path)
+        rows.append({
+            "fixture_date": entry["fixture_date"],
+            "file_path": str(path),
+            "manifest_sha256": entry["sha256"],
+            "actual_sha256": actual_sha,
+            "passed": actual_sha == entry["sha256"],
+        })
+
+    return rows
+
+
+def _row_contract_audit() -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+    rows = []
+
+    for label_date, meta in sorted(PAYLOAD_CLASSES.items()):
+        path = DATES_DIR / f"{label_date}.jsonl"
+        if not path.exists():
+            rows.append({
+                "fixture_date": label_date,
+                "payload_class": meta["payload_class"],
+                "row_count": 0,
+                "deduped_row_count": 0,
+                "duplicate_count": 0,
+                "required_field_failures": 0,
+                "missing_fields": "",
+                "sorted_by_natural_key": True,
+                "passed": meta["create_file"] is False,
+            })
+            continue
+
+        rows_for_date = _read_jsonl(path)
+        sorted_rows = _sort_rows(rows_for_date)
+        deduped, duplicate_count = _dedupe_rows(sorted_rows)
+        required_failures, missing_fields = _required_field_failures(deduped)
+        expectation = expectations[label_date]
+
+        rows.append({
+            "fixture_date": label_date,
+            "payload_class": meta["payload_class"],
+            "row_count": len(rows_for_date),
+            "deduped_row_count": len(deduped),
+            "duplicate_count": duplicate_count,
+            "required_field_failures": required_failures,
+            "missing_fields": "|".join(missing_fields),
+            "sorted_by_natural_key": rows_for_date == sorted_rows,
+            "passed": (
+                len(rows_for_date) == expectation["row_count"]
+                and len(deduped) == expectation["deduped_row_count"]
+                and duplicate_count == expectation["duplicate_count"]
+                and required_failures == expectation["required_field_failures"]
+                and rows_for_date == sorted_rows
+            ),
+        })
+
+    return rows
+
+
+def _safety_audit() -> List[Dict[str, Any]]:
+    source = Path(__file__).read_text(errors="ignore")
+    import_lines = "\n".join(
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+
+    safety_function_start = source.find("def _safety_audit")
+    executable_source = source[:safety_function_start] if safety_function_start >= 0 else source
+
+    forbidden_import_tokens = [
+        "mlb_app.simulation",
+        "GameEngine",
+        "canonical_matchup_probability",
+        "sportsbook",
+        "routes",
+        "frontend",
+    ]
+    external_fetch_tokens = [
+        "requests.",
+        "httpx.",
+        "urllib.",
+        "pybaseball.statcast",
+    ]
+    db_write_tokens = [
+        "session.commit(",
+        ".to_sql(",
+        "insert into",
+    ]
+
+    rows = []
+    for token in forbidden_import_tokens:
+        rows.append({
+            "check_type": "forbidden_import",
+            "token": token,
+            "present": token in import_lines,
+            "passed": token not in import_lines,
+            "scan_scope": "import_lines_only",
+        })
+
+    for token in external_fetch_tokens:
+        rows.append({
+            "check_type": "external_fetch",
+            "token": token,
+            "present": token in executable_source,
+            "passed": token not in executable_source,
+            "scan_scope": "source_before_safety_function",
+        })
+
+    executable_lower = executable_source.lower()
+    for token in db_write_tokens:
+        rows.append({
+            "check_type": "db_write",
+            "token": token,
+            "present": token.lower() in executable_lower,
+            "passed": token.lower() not in executable_lower,
+            "scan_scope": "source_before_safety_function",
+        })
+
+    return rows
+
+
+def main() -> None:
+    DATES_DIR.mkdir(parents=True, exist_ok=True)
+    payloads = _payload_rows()
+
+    for label_date, meta in sorted(PAYLOAD_CLASSES.items()):
+        path = DATES_DIR / f"{label_date}.jsonl"
+        if meta["create_file"]:
+            _write_jsonl(path, _sort_rows(payloads[label_date]))
+        elif path.exists():
+            path.unlink()
+
+    _update_manifest_and_expected(payloads)
+
+    inventory_rows = _payload_inventory()
+    manifest_rows = _manifest_audit()
+    expected_rows = _expected_audit()
+    hash_rows = _hash_audit()
+    row_rows = _row_contract_audit()
+    safety_rows = _safety_audit()
+
+    _write_csv(OUTPUT_INVENTORY, inventory_rows)
+    _write_csv(OUTPUT_MANIFEST_AUDIT, manifest_rows)
+    _write_csv(OUTPUT_EXPECTED_AUDIT, expected_rows)
+    _write_csv(OUTPUT_HASH_AUDIT, hash_rows)
+    _write_csv(OUTPUT_ROW_AUDIT, row_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    payload_files_created = sum(1 for row in inventory_rows if row["exists"]) == 6 and all(row["passed"] for row in inventory_rows)
+    missing_fixture_file_absent = not (DATES_DIR / "2026-05-26.jsonl").exists()
+    manifest_entries_valid = len(_read_json(MANIFEST).get("entries", [])) == 6 and all(row["passed"] for row in manifest_rows)
+    expected_results_valid = len(_read_json(EXPECTED_RESULTS).get("date_expectations", {})) == 7 and all(row["passed"] for row in expected_rows)
+    hash_audit_valid = len(hash_rows) == 6 and all(row["passed"] for row in hash_rows)
+    row_contract_valid = all(row["passed"] for row in row_rows)
+    duplicate_expectations_valid = any(row["fixture_date"] == "2026-05-23" and row["duplicate_count"] == 1 for row in row_rows)
+    required_field_expectations_valid = (
+        any(row["fixture_date"] == "2026-05-24" and row["required_field_failures"] == 1 and row["missing_fields"] == "pitcher_id" for row in row_rows)
+        and any(row["fixture_date"] == "2026-05-25" and row["required_field_failures"] == 1 and row["missing_fields"] == "game_pk" for row in row_rows)
+    )
+    safety_audit_valid = all(row["passed"] for row in safety_rows)
+
+    checks = [
+        {"check": "payload_files_created", "passed": payload_files_created, "detail": "6 created, 1 intentionally missing"},
+        {"check": "missing_fixture_file_absent", "passed": missing_fixture_file_absent, "detail": "2026-05-26.jsonl absent"},
+        {"check": "manifest_entries_valid", "passed": manifest_entries_valid, "detail": f"{len(_read_json(MANIFEST).get('entries', []))} entries"},
+        {"check": "expected_results_valid", "passed": expected_results_valid, "detail": f"{len(_read_json(EXPECTED_RESULTS).get('date_expectations', {}))} expectations"},
+        {"check": "hash_audit_valid", "passed": hash_audit_valid, "detail": f"{sum(row['passed'] for row in hash_rows)}/{len(hash_rows)}"},
+        {"check": "row_contract_valid", "passed": row_contract_valid, "detail": f"{sum(row['passed'] for row in row_rows)}/{len(row_rows)}"},
+        {"check": "duplicate_expectations_valid", "passed": duplicate_expectations_valid, "detail": "2026-05-23 duplicate_count=1"},
+        {"check": "required_field_expectations_valid", "passed": required_field_expectations_valid, "detail": "2026-05-24 pitcher_id, 2026-05-25 game_pk"},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_payload_scaffold_complete",
+        "scaffold_version": SCAFFOLD_VERSION,
+        "payload_files_created": 6,
+        "missing_fixture_files": ["tests/fixtures/statcast/bullpen_labels/dates/2026-05-26.jsonl"],
+        "manifest_entries": len(_read_json(MANIFEST).get("entries", [])),
+        "date_expectations": len(_read_json(EXPECTED_RESULTS).get("date_expectations", {})),
+        "hash_audit_rows": len(hash_rows),
+        "row_contract_rows": len(row_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "synthetic_fixture_payloads_only": True,
+        "fixture_adapter_implemented": False,
+        "backfill_scaffold_modified": False,
+        "test_double_prototype_modified": False,
+        "no_external_fetch": True,
+        "no_db_writes": True,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6CN_candidate_bullpen_statcast_fixture_payload_scaffold_audit"
+            if all(check["passed"] for check in checks)
+            else "6CM_patch_candidate_bullpen_statcast_fixture_payload_scaffold"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-20.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-20.jsonl
@@ -1,0 +1,3 @@
+{"at_bat_number":42,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-20","game_pk":777001,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":123456}
+{"at_bat_number":42,"away_team":"AWY","description":"swinging_strike","events":"strikeout","game_date":"2026-05-20","game_pk":777001,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":2,"pitcher_id":123456}
+{"at_bat_number":42,"away_team":"AWY","description":"in_play","events":"strikeout","game_date":"2026-05-20","game_pk":777001,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":3,"pitcher_id":123456}

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-21.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-21.jsonl
@@ -1,0 +1,3 @@
+{"at_bat_number":10,"away_team":"BBB","description":"called_strike","events":"strikeout","game_date":"2026-05-21","game_pk":777002,"home_team":"AAA","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":223456}
+{"at_bat_number":11,"away_team":"BBB","description":"ball","events":"walk","game_date":"2026-05-21","game_pk":777002,"home_team":"AAA","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":323456}
+{"at_bat_number":12,"away_team":"BBB","description":"hit_into_play","events":"single","game_date":"2026-05-21","game_pk":777002,"home_team":"AAA","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":223456}

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-22.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-22.jsonl
@@ -1,0 +1,3 @@
+{"at_bat_number":5,"away_team":"DDD","description":"called_strike","events":"strikeout","game_date":"2026-05-22","game_pk":777003,"home_team":"CCC","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":423456}
+{"at_bat_number":5,"away_team":"FFF","description":"hit_into_play","events":"double","game_date":"2026-05-22","game_pk":777004,"home_team":"EEE","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":523456}
+{"at_bat_number":6,"away_team":"FFF","description":"foul","events":null,"game_date":"2026-05-22","game_pk":777004,"home_team":"EEE","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":523456}

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-23.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-23.jsonl
@@ -1,0 +1,3 @@
+{"at_bat_number":20,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-23","game_pk":777005,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":623456}
+{"at_bat_number":20,"away_team":"AWY","description":"duplicate_called_strike","events":"strikeout","game_date":"2026-05-23","game_pk":777005,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":623456}
+{"at_bat_number":20,"away_team":"AWY","description":"swinging_strike","events":"strikeout","game_date":"2026-05-23","game_pk":777005,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":2,"pitcher_id":623456}

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-24.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-24.jsonl
@@ -1,0 +1,2 @@
+{"at_bat_number":30,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-24","game_pk":777006,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1}
+{"at_bat_number":30,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-24","game_pk":777006,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":2,"pitcher_id":723456}

--- a/tests/fixtures/statcast/bullpen_labels/dates/2026-05-25.jsonl
+++ b/tests/fixtures/statcast/bullpen_labels/dates/2026-05-25.jsonl
@@ -1,0 +1,2 @@
+{"at_bat_number":40,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-25","game_pk":777007,"home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":2,"pitcher_id":823456}
+{"at_bat_number":40,"away_team":"AWY","description":"called_strike","events":"strikeout","game_date":"2026-05-25","home_team":"HOM","inning":7,"inning_topbot":"Top","outs_when_up":1,"pitch_number":1,"pitcher_id":823456}

--- a/tests/fixtures/statcast/bullpen_labels/expected_results.json
+++ b/tests/fixtures/statcast/bullpen_labels/expected_results.json
@@ -1,14 +1,208 @@
 {
-  "expected_results_version": "bullpen_statcast_fixture_expected_results_v0.1",
-  "default_expectations": {
-    "row_format": "jsonl",
-    "expected_duplicate_count": 0,
-    "expected_required_field_failures": 0,
-    "expected_replay_deterministic": true,
-    "expected_no_external_fetch": true,
-    "expected_no_db_writes": true
+  "created_as_scaffold": true,
+  "date_expectations": {
+    "2026-05-20": {
+      "deduped_row_count": 3,
+      "duplicate_count": 0,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [
+        "(777001, 42, 1, 123456)",
+        "(777001, 42, 2, 123456)",
+        "(777001, 42, 3, 123456)"
+      ],
+      "expected_sha256": "8320ce2f8516043911693a604fd999200c75db24c4fe98f06f356f30a81a4c9a",
+      "expected_status": "success",
+      "file_created": true,
+      "file_path": "dates/2026-05-20.jsonl",
+      "fixture_date": "2026-05-20",
+      "payload_class": "positive_minimal_valid_date",
+      "required_field_failures": 0,
+      "row_count": 3
+    },
+    "2026-05-21": {
+      "deduped_row_count": 3,
+      "duplicate_count": 0,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [
+        "(777002, 10, 1, 223456)",
+        "(777002, 11, 1, 323456)",
+        "(777002, 12, 1, 223456)"
+      ],
+      "expected_sha256": "e975ad0336368239d593149c2d94d634cd3faac5d63ca574c55f7a98da5fbae2",
+      "expected_status": "success",
+      "file_created": true,
+      "file_path": "dates/2026-05-21.jsonl",
+      "fixture_date": "2026-05-21",
+      "payload_class": "positive_multi_pitcher_date",
+      "required_field_failures": 0,
+      "row_count": 3
+    },
+    "2026-05-22": {
+      "deduped_row_count": 3,
+      "duplicate_count": 0,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [
+        "(777003, 5, 1, 423456)",
+        "(777004, 5, 1, 523456)",
+        "(777004, 6, 1, 523456)"
+      ],
+      "expected_sha256": "bef4ef1b43c42a288a1a0685429b790e877efeb4a31e50f6e372483a19e195b1",
+      "expected_status": "success",
+      "file_created": true,
+      "file_path": "dates/2026-05-22.jsonl",
+      "fixture_date": "2026-05-22",
+      "payload_class": "positive_multi_game_date",
+      "required_field_failures": 0,
+      "row_count": 3
+    },
+    "2026-05-23": {
+      "deduped_row_count": 2,
+      "duplicate_count": 1,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [
+        "(777005, 20, 1, 623456)",
+        "(777005, 20, 2, 623456)"
+      ],
+      "expected_sha256": "d13630f7bbc2cad031274ea1113e4bca49ddf5992f0c28d654706c270f6caa42",
+      "expected_status": "dedupe_success",
+      "file_created": true,
+      "file_path": "dates/2026-05-23.jsonl",
+      "fixture_date": "2026-05-23",
+      "payload_class": "negative_duplicate_natural_key_date",
+      "required_field_failures": 0,
+      "row_count": 3
+    },
+    "2026-05-24": {
+      "deduped_row_count": 2,
+      "duplicate_count": 0,
+      "expected_missing_fields": [
+        "pitcher_id"
+      ],
+      "expected_natural_keys": [
+        "(777006, 30, 1, None)",
+        "(777006, 30, 2, 723456)"
+      ],
+      "expected_sha256": "c06adf77a3c85b4f48ce4e0a1484a2150e482b50d9994ad5f2fb04b01eaa647e",
+      "expected_status": "schema_failed_safely",
+      "file_created": true,
+      "file_path": "dates/2026-05-24.jsonl",
+      "fixture_date": "2026-05-24",
+      "payload_class": "negative_missing_pitcher_id_date",
+      "required_field_failures": 1,
+      "row_count": 2
+    },
+    "2026-05-25": {
+      "deduped_row_count": 2,
+      "duplicate_count": 0,
+      "expected_missing_fields": [
+        "game_pk"
+      ],
+      "expected_natural_keys": [
+        "(777007, 40, 2, 823456)",
+        "(None, 40, 1, 823456)"
+      ],
+      "expected_sha256": "d554f7c7e90cc107960de0ffeb5514d752ddb97dc8c97e9876ab862bd097aabc",
+      "expected_status": "schema_failed_safely",
+      "file_created": true,
+      "file_path": "dates/2026-05-25.jsonl",
+      "fixture_date": "2026-05-25",
+      "payload_class": "negative_missing_game_pk_date",
+      "required_field_failures": 1,
+      "row_count": 2
+    },
+    "2026-05-26": {
+      "deduped_row_count": 0,
+      "duplicate_count": 0,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [],
+      "expected_sha256": "",
+      "expected_status": "fixture_missing",
+      "file_created": false,
+      "file_path": "dates/2026-05-26.jsonl",
+      "fixture_date": "2026-05-26",
+      "payload_class": "negative_missing_fixture_date",
+      "required_field_failures": 0,
+      "row_count": 0
+    }
   },
-  "date_expectations": {},
-  "negative_fixture_expectations": {},
-  "created_as_scaffold": true
+  "default_expectations": {
+    "expected_duplicate_count": 0,
+    "expected_no_db_writes": true,
+    "expected_no_external_fetch": true,
+    "expected_replay_deterministic": true,
+    "expected_required_field_failures": 0,
+    "row_format": "jsonl"
+  },
+  "expected_results_version": "bullpen_statcast_fixture_expected_results_v0.1",
+  "negative_fixture_expectations": {
+    "2026-05-23": {
+      "deduped_row_count": 2,
+      "duplicate_count": 1,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [
+        "(777005, 20, 1, 623456)",
+        "(777005, 20, 2, 623456)"
+      ],
+      "expected_sha256": "d13630f7bbc2cad031274ea1113e4bca49ddf5992f0c28d654706c270f6caa42",
+      "expected_status": "dedupe_success",
+      "file_created": true,
+      "file_path": "dates/2026-05-23.jsonl",
+      "fixture_date": "2026-05-23",
+      "payload_class": "negative_duplicate_natural_key_date",
+      "required_field_failures": 0,
+      "row_count": 3
+    },
+    "2026-05-24": {
+      "deduped_row_count": 2,
+      "duplicate_count": 0,
+      "expected_missing_fields": [
+        "pitcher_id"
+      ],
+      "expected_natural_keys": [
+        "(777006, 30, 1, None)",
+        "(777006, 30, 2, 723456)"
+      ],
+      "expected_sha256": "c06adf77a3c85b4f48ce4e0a1484a2150e482b50d9994ad5f2fb04b01eaa647e",
+      "expected_status": "schema_failed_safely",
+      "file_created": true,
+      "file_path": "dates/2026-05-24.jsonl",
+      "fixture_date": "2026-05-24",
+      "payload_class": "negative_missing_pitcher_id_date",
+      "required_field_failures": 1,
+      "row_count": 2
+    },
+    "2026-05-25": {
+      "deduped_row_count": 2,
+      "duplicate_count": 0,
+      "expected_missing_fields": [
+        "game_pk"
+      ],
+      "expected_natural_keys": [
+        "(777007, 40, 2, 823456)",
+        "(None, 40, 1, 823456)"
+      ],
+      "expected_sha256": "d554f7c7e90cc107960de0ffeb5514d752ddb97dc8c97e9876ab862bd097aabc",
+      "expected_status": "schema_failed_safely",
+      "file_created": true,
+      "file_path": "dates/2026-05-25.jsonl",
+      "fixture_date": "2026-05-25",
+      "payload_class": "negative_missing_game_pk_date",
+      "required_field_failures": 1,
+      "row_count": 2
+    },
+    "2026-05-26": {
+      "deduped_row_count": 0,
+      "duplicate_count": 0,
+      "expected_missing_fields": [],
+      "expected_natural_keys": [],
+      "expected_sha256": "",
+      "expected_status": "fixture_missing",
+      "file_created": false,
+      "file_path": "dates/2026-05-26.jsonl",
+      "fixture_date": "2026-05-26",
+      "payload_class": "negative_missing_fixture_date",
+      "required_field_failures": 0,
+      "row_count": 0
+    }
+  }
 }

--- a/tests/fixtures/statcast/bullpen_labels/manifest.json
+++ b/tests/fixtures/statcast/bullpen_labels/manifest.json
@@ -1,9 +1,88 @@
 {
-  "fixture_version": "bullpen_statcast_fixture_v0.1",
-  "fixture_type": "candidate_bullpen_statcast_label_rows",
-  "root": "tests/fixtures/statcast/bullpen_labels",
+  "created_as_scaffold": true,
   "dates_directory": "tests/fixtures/statcast/bullpen_labels/dates",
-  "entries": [],
+  "entries": [
+    {
+      "expected_duplicate_count": 0,
+      "expected_required_field_failures": 0,
+      "file_path": "dates/2026-05-20.jsonl",
+      "fixture_date": "2026-05-20",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "hand_curated",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 3,
+      "sha256": "8320ce2f8516043911693a604fd999200c75db24c4fe98f06f356f30a81a4c9a",
+      "source_label": "positive::positive_minimal_valid_date"
+    },
+    {
+      "expected_duplicate_count": 0,
+      "expected_required_field_failures": 0,
+      "file_path": "dates/2026-05-21.jsonl",
+      "fixture_date": "2026-05-21",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "hand_curated",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 3,
+      "sha256": "e975ad0336368239d593149c2d94d634cd3faac5d63ca574c55f7a98da5fbae2",
+      "source_label": "positive::positive_multi_pitcher_date"
+    },
+    {
+      "expected_duplicate_count": 0,
+      "expected_required_field_failures": 0,
+      "file_path": "dates/2026-05-22.jsonl",
+      "fixture_date": "2026-05-22",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "hand_curated",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 3,
+      "sha256": "bef4ef1b43c42a288a1a0685429b790e877efeb4a31e50f6e372483a19e195b1",
+      "source_label": "positive::positive_multi_game_date"
+    },
+    {
+      "expected_duplicate_count": 1,
+      "expected_required_field_failures": 0,
+      "file_path": "dates/2026-05-23.jsonl",
+      "fixture_date": "2026-05-23",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "synthetic_negative_case",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 3,
+      "sha256": "d13630f7bbc2cad031274ea1113e4bca49ddf5992f0c28d654706c270f6caa42",
+      "source_label": "negative::negative_duplicate_natural_key_date"
+    },
+    {
+      "expected_duplicate_count": 0,
+      "expected_required_field_failures": 1,
+      "file_path": "dates/2026-05-24.jsonl",
+      "fixture_date": "2026-05-24",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "synthetic_negative_case",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 2,
+      "sha256": "c06adf77a3c85b4f48ce4e0a1484a2150e482b50d9994ad5f2fb04b01eaa647e",
+      "source_label": "negative::negative_missing_pitcher_id_date"
+    },
+    {
+      "expected_duplicate_count": 0,
+      "expected_required_field_failures": 1,
+      "file_path": "dates/2026-05-25.jsonl",
+      "fixture_date": "2026-05-25",
+      "fixture_version": "bullpen_statcast_fixture_v0.1",
+      "generation_method": "synthetic_negative_case",
+      "known_limitations": "Small synthetic normalized fixture payload for adapter replay validation; not a full slate.",
+      "row_count": 2,
+      "sha256": "d554f7c7e90cc107960de0ffeb5514d752ddb97dc8c97e9876ab862bd097aabc",
+      "source_label": "negative::negative_missing_game_pk_date"
+    }
+  ],
+  "fixture_type": "candidate_bullpen_statcast_label_rows",
+  "fixture_version": "bullpen_statcast_fixture_v0.1",
+  "natural_key_fields": [
+    "game_pk",
+    "at_bat_number",
+    "pitch_number",
+    "pitcher_id"
+  ],
   "required_manifest_fields": [
     "fixture_version",
     "fixture_date",
@@ -30,11 +109,5 @@
     "events",
     "description"
   ],
-  "natural_key_fields": [
-    "game_pk",
-    "at_bat_number",
-    "pitch_number",
-    "pitcher_id"
-  ],
-  "created_as_scaffold": true
+  "root": "tests/fixtures/statcast/bullpen_labels"
 }


### PR DESCRIPTION
## Summary

Adds Layer 6CM: deterministic synthetic JSONL fixture payloads for the candidate bullpen Statcast fixture corpus.

## Validation

- compileall passed
- payload files created: 6
- missing fixture file absent: 2026-05-26.jsonl
- manifest entries valid: 6
- expected results valid: 7 expectations
- hash audit valid: 6/6
- row contract valid: 7/7
- duplicate expectation valid: 2026-05-23 duplicate_count=1
- required-field expectations valid: 2026-05-24 missing pitcher_id, 2026-05-25 missing game_pk
- safety audit valid: 13/13
- all checks passed

## Findings

The scaffold creates six small synthetic normalized JSONL fixture payloads, intentionally leaves the missing fixture date absent, updates manifest entries with SHA256 hashes and expectations, and updates expected-results metadata for all seven reserved dates. Positive, duplicate-key, required-field failure, and missing-file cases are now represented deterministically.

## Safety

Synthetic fixture payloads only. No fixture adapter implemented, no backfill scaffold modification, no external fetch, database write, production engine, inning simulation, route, sportsbook, frontend, or canonical probability changes.