### PR TITLE
Add Layer 6CN candidate bullpen Statcast fixture payload scaffold audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_fixture_payload_scaffold.py
+++ b/scripts/audit_candidate_bullpen_statcast_fixture_payload_scaffold.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_fixture_payload_scaffold_audit_v0.1"
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+DATES_DIR = FIXTURE_ROOT / "dates"
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+SCHEMA = FIXTURE_ROOT / "schema.json"
+PROVENANCE = FIXTURE_ROOT / "provenance.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_scaffold_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_scaffold_audit_checks.csv"
+OUTPUT_FILE_PRESENCE = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_file_presence_audit.csv"
+OUTPUT_JSONL = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_jsonl_parse_audit.csv"
+OUTPUT_MANIFEST = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_manifest_audit.csv"
+OUTPUT_EXPECTED = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_expected_results_audit.csv"
+OUTPUT_ROWS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_row_contract_audit_6cn.csv"
+OUTPUT_NEGATIVE = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_negative_case_audit.csv"
+OUTPUT_DETERMINISM = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_determinism_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_payload_safety_audit_6cn.csv"
+
+
+REQUIRED_FIELDS = [
+    "game_date",
+    "game_pk",
+    "inning",
+    "inning_topbot",
+    "at_bat_number",
+    "pitch_number",
+    "outs_when_up",
+    "pitcher_id",
+    "home_team",
+    "away_team",
+    "events",
+    "description",
+]
+
+NATURAL_KEY_FIELDS = ["game_pk", "at_bat_number", "pitch_number", "pitcher_id"]
+
+REQUIRED_MANIFEST_FIELDS = [
+    "fixture_version",
+    "fixture_date",
+    "file_path",
+    "row_count",
+    "sha256",
+    "source_label",
+    "generation_method",
+    "known_limitations",
+    "expected_duplicate_count",
+    "expected_required_field_failures",
+]
+
+EXPECTED_CREATED_DATES = [
+    "2026-05-20",
+    "2026-05-21",
+    "2026-05-22",
+    "2026-05-23",
+    "2026-05-24",
+    "2026-05-25",
+]
+MISSING_DATE = "2026-05-26"
+
+EXPECTED_STATUSES = {
+    "2026-05-20": "success",
+    "2026-05-21": "success",
+    "2026-05-22": "success",
+    "2026-05-23": "dedupe_success",
+    "2026-05-24": "schema_failed_safely",
+    "2026-05-25": "schema_failed_safely",
+    "2026-05-26": "fixture_missing",
+}
+
+EXPECTED_MISSING_FIELDS = {
+    "2026-05-24": "pitcher_id",
+    "2026-05-25": "game_pk",
+}
+
+EXPECTED_DUPLICATE_COUNTS = {
+    "2026-05-23": 1,
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        row["__line_number__"] = line_number
+        rows.append(row)
+    return rows
+
+
+def _payload_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in row.items() if not key.startswith("__")}
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _natural_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any, Any]:
+    clean = _payload_row(row)
+    return tuple(clean.get(field) for field in NATURAL_KEY_FIELDS)
+
+
+def _sort_value(value: Any) -> Tuple[int, str]:
+    if value is None:
+        return (1, "")
+    return (0, str(value))
+
+
+def _sorted_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted(rows, key=lambda row: tuple(_sort_value(item) for item in _natural_key(row)))
+
+
+def _dedupe_rows(rows: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], int]:
+    seen = set()
+    deduped = []
+    duplicates = 0
+    for row in rows:
+        key = _natural_key(row)
+        if key in seen:
+            duplicates += 1
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped, duplicates
+
+
+def _required_field_failures(rows: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
+    failures = 0
+    missing_fields: List[str] = []
+    for row in rows:
+        clean = _payload_row(row)
+        missing = [field for field in REQUIRED_FIELDS if field not in clean]
+        if missing:
+            failures += 1
+            missing_fields.extend(missing)
+    return failures, sorted(set(missing_fields))
+
+
+def _metadata_snapshot() -> Dict[str, str]:
+    snapshot = {}
+    for path in [MANIFEST, SCHEMA, PROVENANCE, EXPECTED_RESULTS]:
+        snapshot[str(path)] = path.read_text() if path.exists() else ""
+    return snapshot
+
+
+def _payload_snapshot() -> Dict[str, str]:
+    snapshot = {}
+    for label_date in EXPECTED_CREATED_DATES + [MISSING_DATE]:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _file_presence_audit() -> List[Dict[str, Any]]:
+    rows = []
+    for label_date in EXPECTED_CREATED_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        rows.append({
+            "fixture_date": label_date,
+            "path": str(path),
+            "expected_exists": True,
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        })
+
+    missing_path = DATES_DIR / f"{MISSING_DATE}.jsonl"
+    rows.append({
+        "fixture_date": MISSING_DATE,
+        "path": str(missing_path),
+        "expected_exists": False,
+        "exists": missing_path.exists(),
+        "size_bytes": missing_path.stat().st_size if missing_path.exists() else 0,
+        "passed": not missing_path.exists(),
+    })
+
+    for path in [MANIFEST, SCHEMA, PROVENANCE, EXPECTED_RESULTS]:
+        rows.append({
+            "fixture_date": "__metadata__",
+            "path": str(path),
+            "expected_exists": True,
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        })
+
+    return rows
+
+
+def _jsonl_parse_audit() -> List[Dict[str, Any]]:
+    rows = []
+    schema = _read_json(SCHEMA)
+    schema_fields = schema.get("required_normalized_fields", REQUIRED_FIELDS)
+
+    for label_date in EXPECTED_CREATED_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        parsed_rows = []
+        parse_error = ""
+        try:
+            parsed_rows = _read_jsonl(path)
+        except Exception as exc:
+            parse_error = repr(exc)
+
+        for row in parsed_rows:
+            clean = _payload_row(row)
+            missing = [field for field in REQUIRED_FIELDS if field not in clean]
+            extra = [field for field in clean if field not in schema_fields]
+            intended_missing = EXPECTED_MISSING_FIELDS.get(label_date)
+            expected_missing = [intended_missing] if intended_missing else []
+
+            if intended_missing:
+                missing_ok = missing in ([], expected_missing)
+            else:
+                missing_ok = missing == []
+
+            rows.append({
+                "fixture_date": label_date,
+                "path": str(path),
+                "line_number": row.get("__line_number__"),
+                "parse_ok": parse_error == "",
+                "field_count": len(clean),
+                "missing_fields": "|".join(missing),
+                "extra_fields": "|".join(extra),
+                "expected_missing_fields": "|".join(expected_missing),
+                "passed": (
+                    parse_error == ""
+                    and missing_ok
+                    and extra == []
+                ),
+            })
+
+        if parse_error:
+            rows.append({
+                "fixture_date": label_date,
+                "path": str(path),
+                "line_number": "",
+                "parse_ok": False,
+                "field_count": 0,
+                "missing_fields": "",
+                "extra_fields": "",
+                "expected_missing_fields": "",
+                "passed": False,
+                "error": parse_error,
+            })
+
+    return rows
+
+
+def _manifest_audit() -> List[Dict[str, Any]]:
+    manifest = _read_json(MANIFEST)
+    entries = manifest.get("entries", [])
+    by_date = {entry.get("fixture_date"): entry for entry in entries}
+    rows = []
+
+    for label_date in EXPECTED_CREATED_DATES:
+        entry = by_date.get(label_date, {})
+        path = FIXTURE_ROOT / entry.get("file_path", "")
+        required_present = all(field in entry for field in REQUIRED_MANIFEST_FIELDS)
+        generation_ok = entry.get("generation_method") in {"hand_curated", "synthetic_negative_case"}
+        sha_ok = path.exists() and entry.get("sha256") == _sha256(path)
+
+        rows.append({
+            "fixture_date": label_date,
+            "has_entry": bool(entry),
+            "required_fields_present": required_present,
+            "generation_method": entry.get("generation_method", ""),
+            "generation_method_ok": generation_ok,
+            "sha256_matches": sha_ok,
+            "passed": bool(entry) and required_present and generation_ok and sha_ok,
+        })
+
+    rows.append({
+        "fixture_date": MISSING_DATE,
+        "has_entry": MISSING_DATE in by_date,
+        "required_fields_present": "",
+        "generation_method": "",
+        "generation_method_ok": "",
+        "sha256_matches": "",
+        "passed": MISSING_DATE not in by_date,
+    })
+
+    rows.append({
+        "fixture_date": "__entry_count__",
+        "has_entry": len(entries),
+        "required_fields_present": "",
+        "generation_method": "",
+        "generation_method_ok": "",
+        "sha256_matches": "",
+        "passed": len(entries) == 6,
+    })
+
+    return rows
+
+
+def _expected_results_audit() -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+    rows = []
+
+    for label_date, expected_status in EXPECTED_STATUSES.items():
+        item = expectations.get(label_date, {})
+        rows.append({
+            "fixture_date": label_date,
+            "has_expectation": label_date in expectations,
+            "expected_status": expected_status,
+            "actual_status": item.get("expected_status"),
+            "file_created": item.get("file_created"),
+            "passed": label_date in expectations and item.get("expected_status") == expected_status,
+        })
+
+    rows.append({
+        "fixture_date": "__expectation_count__",
+        "has_expectation": len(expectations),
+        "expected_status": "7",
+        "actual_status": str(len(expectations)),
+        "file_created": "",
+        "passed": len(expectations) == 7,
+    })
+
+    return rows
+
+
+def _row_contract_audit() -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+    rows = []
+
+    for label_date in EXPECTED_CREATED_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        rows_for_date = _read_jsonl(path)
+        sorted_rows = _sorted_rows(rows_for_date)
+        deduped, duplicate_count = _dedupe_rows(sorted_rows)
+        required_failures, missing_fields = _required_field_failures(deduped)
+        expectation = expectations.get(label_date, {})
+
+        rows.append({
+            "fixture_date": label_date,
+            "row_count": len(rows_for_date),
+            "expected_row_count": expectation.get("row_count"),
+            "deduped_row_count": len(deduped),
+            "expected_deduped_row_count": expectation.get("deduped_row_count"),
+            "duplicate_count": duplicate_count,
+            "expected_duplicate_count": expectation.get("duplicate_count"),
+            "required_field_failures": required_failures,
+            "expected_required_field_failures": expectation.get("required_field_failures"),
+            "missing_fields": "|".join(missing_fields),
+            "expected_missing_fields": "|".join(expectation.get("expected_missing_fields", [])),
+            "sorted_by_natural_key": rows_for_date == sorted_rows,
+            "passed": (
+                len(rows_for_date) == expectation.get("row_count")
+                and len(deduped) == expectation.get("deduped_row_count")
+                and duplicate_count == expectation.get("duplicate_count")
+                and required_failures == expectation.get("required_field_failures")
+                and missing_fields == expectation.get("expected_missing_fields", [])
+                and rows_for_date == sorted_rows
+            ),
+        })
+
+    missing_expectation = expectations.get(MISSING_DATE, {})
+    rows.append({
+        "fixture_date": MISSING_DATE,
+        "row_count": 0,
+        "expected_row_count": missing_expectation.get("row_count"),
+        "deduped_row_count": 0,
+        "expected_deduped_row_count": missing_expectation.get("deduped_row_count"),
+        "duplicate_count": 0,
+        "expected_duplicate_count": missing_expectation.get("duplicate_count"),
+        "required_field_failures": 0,
+        "expected_required_field_failures": missing_expectation.get("required_field_failures"),
+        "missing_fields": "",
+        "expected_missing_fields": "|".join(missing_expectation.get("expected_missing_fields", [])),
+        "sorted_by_natural_key": True,
+        "passed": (
+            not (DATES_DIR / f"{MISSING_DATE}.jsonl").exists()
+            and missing_expectation.get("expected_status") == "fixture_missing"
+        ),
+    })
+
+    return rows
+
+
+def _negative_case_audit() -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+
+    checks = [
+        {
+            "case": "duplicate_natural_key",
+            "fixture_date": "2026-05-23",
+            "expected": "duplicate_count=1",
+            "actual": f"duplicate_count={expectations.get('2026-05-23', {}).get('duplicate_count')}",
+            "passed": expectations.get("2026-05-23", {}).get("duplicate_count") == 1,
+        },
+        {
+            "case": "missing_pitcher_id",
+            "fixture_date": "2026-05-24",
+            "expected": "pitcher_id",
+            "actual": "|".join(expectations.get("2026-05-24", {}).get("expected_missing_fields", [])),
+            "passed": expectations.get("2026-05-24", {}).get("expected_missing_fields") == ["pitcher_id"],
+        },
+        {
+            "case": "missing_game_pk",
+            "fixture_date": "2026-05-25",
+            "expected": "game_pk",
+            "actual": "|".join(expectations.get("2026-05-25", {}).get("expected_missing_fields", [])),
+            "passed": expectations.get("2026-05-25", {}).get("expected_missing_fields") == ["game_pk"],
+        },
+        {
+            "case": "missing_fixture_file",
+            "fixture_date": MISSING_DATE,
+            "expected": "fixture_missing and file absent",
+            "actual": f"status={expectations.get(MISSING_DATE, {}).get('expected_status')} exists={(DATES_DIR / f'{MISSING_DATE}.jsonl').exists()}",
+            "passed": (
+                expectations.get(MISSING_DATE, {}).get("expected_status") == "fixture_missing"
+                and not (DATES_DIR / f"{MISSING_DATE}.jsonl").exists()
+            ),
+        },
+    ]
+
+    return checks
+
+
+def _stable_projection() -> Dict[str, Any]:
+    manifest = _read_json(MANIFEST)
+    expected_results = _read_json(EXPECTED_RESULTS)
+    payloads = {}
+
+    for label_date in EXPECTED_CREATED_DATES + [MISSING_DATE]:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        payloads[label_date] = {
+            "exists": path.exists(),
+            "sha256": _sha256(path) if path.exists() else "",
+            "content": path.read_text() if path.exists() else "",
+        }
+
+    return {
+        "manifest_entries": manifest.get("entries", []),
+        "date_expectations": expected_results.get("date_expectations", {}),
+        "payloads": payloads,
+    }
+
+
+def _determinism_audit() -> List[Dict[str, Any]]:
+    first = _stable_projection()
+    second = _stable_projection()
+
+    rows = []
+    for key in ["manifest_entries", "date_expectations", "payloads"]:
+        rows.append({
+            "comparison": key,
+            "first": json.dumps(first[key], sort_keys=True),
+            "second": json.dumps(second[key], sort_keys=True),
+            "passed": first[key] == second[key],
+        })
+
+    for label_date in EXPECTED_CREATED_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        first_sha = _sha256(path)
+        second_sha = _sha256(path)
+        rows.append({
+            "comparison": f"sha256::{label_date}",
+            "first": first_sha,
+            "second": second_sha,
+            "passed": first_sha == second_sha,
+        })
+
+    return rows
+
+
+def _safety_audit(before_payload: Dict[str, str], before_metadata: Dict[str, str]) -> List[Dict[str, Any]]:
+    after_payload = _payload_snapshot()
+    after_metadata = _metadata_snapshot()
+
+    source = Path(__file__).read_text(errors="ignore")
+    import_lines = "\n".join(
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+    safety_start = source.find("def _safety_audit")
+    executable_source = source[:safety_start] if safety_start >= 0 else source
+    executable_lower = executable_source.lower()
+
+    rows = [
+        {
+            "check": "payload_snapshot_unchanged",
+            "passed": before_payload == after_payload,
+            "detail": "payload files unchanged by audit",
+        },
+        {
+            "check": "metadata_snapshot_unchanged",
+            "passed": before_metadata == after_metadata,
+            "detail": "manifest/schema/provenance/expected_results unchanged by audit",
+        },
+    ]
+
+    for token in [
+        "mlb_app.simulation",
+        "GameEngine",
+        "canonical_matchup_probability",
+        "sportsbook",
+        "routes",
+        "frontend",
+    ]:
+        rows.append({
+            "check": f"forbidden_import::{token}",
+            "passed": token not in import_lines,
+            "detail": "import_lines_only",
+        })
+
+    for token in ["requests.", "httpx.", "urllib.", "pybaseball.statcast"]:
+        rows.append({
+            "check": f"external_fetch::{token}",
+            "passed": token not in executable_source,
+            "detail": "source_before_safety_function",
+        })
+
+    for token in ["session.commit(", ".to_sql(", "insert into"]:
+        rows.append({
+            "check": f"db_write::{token}",
+            "passed": token.lower() not in executable_lower,
+            "detail": "source_before_safety_function",
+        })
+
+    return rows
+
+
+def main() -> None:
+    before_payload = _payload_snapshot()
+    before_metadata = _metadata_snapshot()
+
+    file_rows = _file_presence_audit()
+    jsonl_rows = _jsonl_parse_audit()
+    manifest_rows = _manifest_audit()
+    expected_rows = _expected_results_audit()
+    row_contract_rows = _row_contract_audit()
+    negative_rows = _negative_case_audit()
+    determinism_rows = _determinism_audit()
+    safety_rows = _safety_audit(before_payload, before_metadata)
+
+    _write_csv(OUTPUT_FILE_PRESENCE, file_rows)
+    _write_csv(OUTPUT_JSONL, jsonl_rows)
+    _write_csv(OUTPUT_MANIFEST, manifest_rows)
+    _write_csv(OUTPUT_EXPECTED, expected_rows)
+    _write_csv(OUTPUT_ROWS, row_contract_rows)
+    _write_csv(OUTPUT_NEGATIVE, negative_rows)
+    _write_csv(OUTPUT_DETERMINISM, determinism_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    file_presence_valid = all(row["passed"] for row in file_rows)
+    jsonl_parse_valid = all(row["passed"] for row in jsonl_rows)
+    manifest_valid = all(row["passed"] for row in manifest_rows)
+    expected_results_valid = all(row["passed"] for row in expected_rows)
+    row_contract_valid = all(row["passed"] for row in row_contract_rows)
+    negative_cases_valid = all(row["passed"] for row in negative_rows)
+    determinism_valid = all(row["passed"] for row in determinism_rows)
+    safety_audit_valid = all(row["passed"] for row in safety_rows)
+    no_metadata_mutation = before_metadata == _metadata_snapshot()
+    no_payload_mutation = before_payload == _payload_snapshot()
+
+    checks = [
+        {"check": "file_presence_valid", "passed": file_presence_valid, "detail": f"{sum(row['passed'] for row in file_rows)}/{len(file_rows)}"},
+        {"check": "jsonl_parse_valid", "passed": jsonl_parse_valid, "detail": f"{sum(row['passed'] for row in jsonl_rows)}/{len(jsonl_rows)}"},
+        {"check": "manifest_valid", "passed": manifest_valid, "detail": f"{sum(row['passed'] for row in manifest_rows)}/{len(manifest_rows)}"},
+        {"check": "expected_results_valid", "passed": expected_results_valid, "detail": f"{sum(row['passed'] for row in expected_rows)}/{len(expected_rows)}"},
+        {"check": "row_contract_valid", "passed": row_contract_valid, "detail": f"{sum(row['passed'] for row in row_contract_rows)}/{len(row_contract_rows)}"},
+        {"check": "negative_cases_valid", "passed": negative_cases_valid, "detail": f"{sum(row['passed'] for row in negative_rows)}/{len(negative_rows)}"},
+        {"check": "determinism_valid", "passed": determinism_valid, "detail": f"{sum(row['passed'] for row in determinism_rows)}/{len(determinism_rows)}"},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "audit_only_no_payload_mutation", "passed": no_payload_mutation, "detail": True},
+        {"check": "no_metadata_mutation", "passed": no_metadata_mutation, "detail": True},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_payload_scaffold_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "file_presence_checks": len(file_rows),
+        "jsonl_parse_checks": len(jsonl_rows),
+        "manifest_checks": len(manifest_rows),
+        "expected_result_checks": len(expected_rows),
+        "row_contract_checks": len(row_contract_rows),
+        "negative_case_checks": len(negative_rows),
+        "determinism_checks": len(determinism_rows),
+        "safety_checks": len(safety_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "audit_only": True,
+        "payload_mutated": False,
+        "metadata_mutated": False,
+        "fixture_adapter_implemented": False,
+        "no_external_fetch": True,
+        "no_db_writes": True,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6CO_candidate_bullpen_statcast_fixture_replay_adapter_plan"
+            if all(check["passed"] for check in checks)
+            else "6CM_patch_candidate_bullpen_statcast_fixture_payload_scaffold"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6CN: an audit-only validation layer for the candidate bullpen Statcast fixture payload scaffold.

## Validation

- compileall passed
- file presence valid: 11/11
- JSONL parse valid: 16/16
- manifest valid: 8/8
- expected results valid: 8/8
- row contract valid: 7/7
- negative cases valid: 4/4
- determinism valid: 9/9
- safety audit valid: 15/15
- all checks passed

## Findings

The audit validates the synthetic fixture payload corpus without mutating payload or metadata files. It confirms created and missing fixture file expectations, JSONL parse validity, manifest/hash consistency, expected-results coverage, row-count/dedupe/required-field contracts, negative-case behavior, deterministic rereads, and safety boundaries.

## Safety

Audit-only. No payload mutation, no metadata mutation, no fixture adapter implemented, no external fetch, database write, production engine, inning simulation, route, sportsbook, frontend, or canonical probability changes.