### PR TITLE
Add Layer 6CQ candidate bullpen Statcast fixture replay adapter audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_fixture_replay_adapter.py
+++ b/scripts/audit_candidate_bullpen_statcast_fixture_replay_adapter.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_fixture_replay_adapter_audit_v0.1"
+
+PROTOTYPE_PATH = Path("scripts/prototype_candidate_bullpen_statcast_fixture_replay_adapter.py")
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+DATES_DIR = FIXTURE_ROOT / "dates"
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_adapter_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_adapter_audit_checks.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_import_audit.csv"
+OUTPUT_RESULT_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_result_contract_audit.csv"
+OUTPUT_EXPECTATION = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_expectation_parity_audit.csv"
+OUTPUT_MANIFEST_HASH = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_manifest_hash_parity_audit.csv"
+OUTPUT_ROW_SEMANTICS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_row_semantics_audit.csv"
+OUTPUT_NEGATIVE = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_negative_case_audit_6cq.csv"
+OUTPUT_DETERMINISM = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_determinism_audit_6cq.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_safety_audit_6cq.csv"
+
+
+FIXTURE_DATES = [
+    "2026-05-20",
+    "2026-05-21",
+    "2026-05-22",
+    "2026-05-23",
+    "2026-05-24",
+    "2026-05-25",
+    "2026-05-26",
+]
+
+REQUIRED_RESULT_FIELDS = [
+    "label_date",
+    "fixture_date",
+    "payload_class",
+    "status",
+    "rows",
+    "raw_row_count",
+    "deduped_row_count",
+    "duplicate_count",
+    "required_field_failures",
+    "missing_fields",
+    "sha256",
+    "manifest_entry_present",
+    "expected_result_present",
+]
+
+REQUIRED_ROW_FIELDS = [
+    "game_date",
+    "game_pk",
+    "inning",
+    "inning_topbot",
+    "at_bat_number",
+    "pitch_number",
+    "outs_when_up",
+    "pitcher_id",
+    "home_team",
+    "away_team",
+    "events",
+    "description",
+]
+
+NATURAL_KEY_FIELDS = ["game_pk", "at_bat_number", "pitch_number", "pitcher_id"]
+
+EXPECTED_STATUSES = {
+    "2026-05-20": "success",
+    "2026-05-21": "success",
+    "2026-05-22": "success",
+    "2026-05-23": "dedupe_success",
+    "2026-05-24": "schema_failed_safely",
+    "2026-05-25": "schema_failed_safely",
+    "2026-05-26": "fixture_missing",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _payload_snapshot() -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for label_date in FIXTURE_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _metadata_snapshot() -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for path in [MANIFEST, EXPECTED_RESULTS]:
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _import_prototype() -> Tuple[Any | None, List[Dict[str, Any]]]:
+    rows: List[Dict[str, Any]] = []
+    module_name = "layer_6cp_fixture_replay_adapter_prototype"
+
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, PROTOTYPE_PATH)
+        if spec is None or spec.loader is None:
+            rows.append({
+                "check": "spec_created",
+                "passed": False,
+                "detail": "spec or loader missing",
+            })
+            return None, rows
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+
+        rows.extend([
+            {
+                "check": "prototype_file_exists",
+                "passed": PROTOTYPE_PATH.exists(),
+                "detail": str(PROTOTYPE_PATH),
+            },
+            {
+                "check": "module_loaded",
+                "passed": True,
+                "detail": module_name,
+            },
+            {
+                "check": "fetch_callable_exists",
+                "passed": callable(getattr(module, "fetch_candidate_bullpen_statcast_fixture_rows", None)),
+                "detail": "fetch_candidate_bullpen_statcast_fixture_rows",
+            },
+            {
+                "check": "result_type_exists",
+                "passed": hasattr(module, "FixtureReplayResult"),
+                "detail": "FixtureReplayResult",
+            },
+            {
+                "check": "result_type_is_dataclass",
+                "passed": is_dataclass(getattr(module, "FixtureReplayResult", object)),
+                "detail": "dataclass check",
+            },
+        ])
+        return module, rows
+
+    except Exception as exc:
+        rows.append({
+            "check": "module_loaded",
+            "passed": False,
+            "detail": repr(exc),
+        })
+        return None, rows
+
+
+def _result_to_dict(result: Any) -> Dict[str, Any]:
+    if is_dataclass(result):
+        return asdict(result)
+    return {field: getattr(result, field, None) for field in REQUIRED_RESULT_FIELDS}
+
+
+def _replay_all(module: Any) -> List[Any]:
+    fetcher = getattr(module, "fetch_candidate_bullpen_statcast_fixture_rows")
+    return [fetcher(label_date) for label_date in FIXTURE_DATES]
+
+
+def _manifest_entries_by_date() -> Dict[str, Dict[str, Any]]:
+    manifest = _read_json(MANIFEST)
+    return {entry.get("fixture_date"): entry for entry in manifest.get("entries", [])}
+
+
+def _result_contract_audit(results: List[Any]) -> List[Dict[str, Any]]:
+    rows = []
+    for result in results:
+        data = _result_to_dict(result)
+        has_all_fields = all(field in data for field in REQUIRED_RESULT_FIELDS)
+        field_values_present = all(getattr(result, field, None) is not None or field == "sha256" for field in REQUIRED_RESULT_FIELDS)
+        rows.append({
+            "label_date": data.get("label_date"),
+            "is_dataclass_instance": is_dataclass(result),
+            "has_all_result_fields": has_all_fields,
+            "field_values_present": field_values_present,
+            "status": data.get("status"),
+            "expected_status": EXPECTED_STATUSES.get(data.get("label_date")),
+            "status_matches": data.get("status") == EXPECTED_STATUSES.get(data.get("label_date")),
+            "passed": has_all_fields and field_values_present and data.get("status") == EXPECTED_STATUSES.get(data.get("label_date")),
+        })
+    return rows
+
+
+def _expectation_parity_audit(results: List[Any]) -> List[Dict[str, Any]]:
+    expected_results = _read_json(EXPECTED_RESULTS)
+    expectations = expected_results.get("date_expectations", {})
+    rows = []
+
+    for result in results:
+        data = _result_to_dict(result)
+        label_date = data["label_date"]
+        expectation = expectations.get(label_date, {})
+        rows.append({
+            "label_date": label_date,
+            "expected_status": expectation.get("expected_status"),
+            "actual_status": data["status"],
+            "expected_row_count": expectation.get("row_count"),
+            "actual_raw_row_count": data["raw_row_count"],
+            "expected_deduped_row_count": expectation.get("deduped_row_count"),
+            "actual_deduped_row_count": data["deduped_row_count"],
+            "expected_duplicate_count": expectation.get("duplicate_count"),
+            "actual_duplicate_count": data["duplicate_count"],
+            "expected_required_field_failures": expectation.get("required_field_failures"),
+            "actual_required_field_failures": data["required_field_failures"],
+            "expected_missing_fields": "|".join(expectation.get("expected_missing_fields", [])),
+            "actual_missing_fields": "|".join(data["missing_fields"]),
+            "passed": (
+                expectation.get("expected_status") == data["status"]
+                and expectation.get("row_count") == data["raw_row_count"]
+                and expectation.get("deduped_row_count") == data["deduped_row_count"]
+                and expectation.get("duplicate_count") == data["duplicate_count"]
+                and expectation.get("required_field_failures") == data["required_field_failures"]
+                and expectation.get("expected_missing_fields", []) == data["missing_fields"]
+            ),
+        })
+    return rows
+
+
+def _manifest_hash_parity_audit(results: List[Any]) -> List[Dict[str, Any]]:
+    entries = _manifest_entries_by_date()
+    rows = []
+
+    for result in results:
+        data = _result_to_dict(result)
+        label_date = data["label_date"]
+        entry = entries.get(label_date)
+        file_exists = (DATES_DIR / f"{label_date}.jsonl").exists()
+
+        if label_date == "2026-05-26":
+            rows.append({
+                "label_date": label_date,
+                "manifest_entry_expected": False,
+                "manifest_entry_present": entry is not None,
+                "file_exists": file_exists,
+                "manifest_sha256": "",
+                "actual_sha256": "",
+                "result_sha256": data["sha256"],
+                "passed": entry is None and not file_exists and data["sha256"] == "",
+            })
+            continue
+
+        payload_path = FIXTURE_ROOT / entry["file_path"] if entry else DATES_DIR / f"{label_date}.jsonl"
+        actual_sha = _sha256(payload_path) if payload_path.exists() else ""
+
+        rows.append({
+            "label_date": label_date,
+            "manifest_entry_expected": True,
+            "manifest_entry_present": entry is not None,
+            "file_exists": payload_path.exists(),
+            "manifest_sha256": entry.get("sha256", "") if entry else "",
+            "actual_sha256": actual_sha,
+            "result_sha256": data["sha256"],
+            "passed": (
+                entry is not None
+                and payload_path.exists()
+                and entry.get("sha256") == actual_sha
+                and data["sha256"] == actual_sha
+            ),
+        })
+    return rows
+
+
+def _natural_key(row: Dict[str, Any]) -> Tuple[Any, Any, Any, Any]:
+    return tuple(row.get(field) for field in NATURAL_KEY_FIELDS)
+
+
+def _row_semantics_audit(results: List[Any]) -> List[Dict[str, Any]]:
+    rows = []
+
+    for result in results:
+        data = _result_to_dict(result)
+        label_date = data["label_date"]
+        result_rows = data["rows"]
+
+        if label_date == "2026-05-26":
+            rows.append({
+                "label_date": label_date,
+                "semantic": "missing_fixture_zero_rows",
+                "row_index": "",
+                "natural_key": "",
+                "field_count": 0,
+                "missing_fields": "",
+                "passed": result_rows == [] and data["status"] == "fixture_missing",
+            })
+            continue
+
+        seen_keys = set()
+        duplicate_after_replay = False
+        for idx, row in enumerate(result_rows):
+            key = _natural_key(row)
+            duplicate_after_replay = duplicate_after_replay or key in seen_keys
+            seen_keys.add(key)
+
+            missing = [field for field in REQUIRED_ROW_FIELDS if field not in row]
+            if label_date in {"2026-05-20", "2026-05-21", "2026-05-22", "2026-05-23"}:
+                row_ok = len(missing) == 0 and len(row) == 12
+            elif label_date == "2026-05-24":
+                row_ok = missing in ([], ["pitcher_id"])
+            elif label_date == "2026-05-25":
+                row_ok = missing in ([], ["game_pk"])
+            else:
+                row_ok = False
+
+            rows.append({
+                "label_date": label_date,
+                "semantic": "row_contract",
+                "row_index": idx,
+                "natural_key": str(key),
+                "field_count": len(row),
+                "missing_fields": "|".join(missing),
+                "passed": row_ok,
+            })
+
+        rows.append({
+            "label_date": label_date,
+            "semantic": "deduped_no_duplicate_keys",
+            "row_index": "",
+            "natural_key": "",
+            "field_count": "",
+            "missing_fields": "",
+            "passed": not duplicate_after_replay,
+        })
+
+    return rows
+
+
+def _negative_case_audit(results: List[Any]) -> List[Dict[str, Any]]:
+    by_date = {_result_to_dict(result)["label_date"]: _result_to_dict(result) for result in results}
+
+    rows = [
+        {
+            "case": "duplicate_natural_key",
+            "label_date": "2026-05-23",
+            "expected": "status=dedupe_success duplicate_count=1 deduped_row_count=2",
+            "actual": f"status={by_date['2026-05-23']['status']} duplicate_count={by_date['2026-05-23']['duplicate_count']} deduped_row_count={by_date['2026-05-23']['deduped_row_count']}",
+            "passed": (
+                by_date["2026-05-23"]["status"] == "dedupe_success"
+                and by_date["2026-05-23"]["duplicate_count"] == 1
+                and by_date["2026-05-23"]["deduped_row_count"] == 2
+            ),
+        },
+        {
+            "case": "missing_pitcher_id",
+            "label_date": "2026-05-24",
+            "expected": "schema_failed_safely missing_fields=pitcher_id",
+            "actual": f"status={by_date['2026-05-24']['status']} missing_fields={'|'.join(by_date['2026-05-24']['missing_fields'])}",
+            "passed": (
+                by_date["2026-05-24"]["status"] == "schema_failed_safely"
+                and by_date["2026-05-24"]["missing_fields"] == ["pitcher_id"]
+            ),
+        },
+        {
+            "case": "missing_game_pk",
+            "label_date": "2026-05-25",
+            "expected": "schema_failed_safely missing_fields=game_pk",
+            "actual": f"status={by_date['2026-05-25']['status']} missing_fields={'|'.join(by_date['2026-05-25']['missing_fields'])}",
+            "passed": (
+                by_date["2026-05-25"]["status"] == "schema_failed_safely"
+                and by_date["2026-05-25"]["missing_fields"] == ["game_pk"]
+            ),
+        },
+        {
+            "case": "missing_fixture",
+            "label_date": "2026-05-26",
+            "expected": "fixture_missing manifest_entry_present=false zero_rows",
+            "actual": f"status={by_date['2026-05-26']['status']} manifest_entry_present={by_date['2026-05-26']['manifest_entry_present']} rows={len(by_date['2026-05-26']['rows'])}",
+            "passed": (
+                by_date["2026-05-26"]["status"] == "fixture_missing"
+                and by_date["2026-05-26"]["manifest_entry_present"] is False
+                and by_date["2026-05-26"]["rows"] == []
+            ),
+        },
+    ]
+    return rows
+
+
+def _stable_projection(results: List[Any]) -> List[Dict[str, Any]]:
+    projection = []
+    for result in results:
+        data = _result_to_dict(result)
+        data["rows"] = [json.dumps(row, sort_keys=True, separators=(",", ":")) for row in data["rows"]]
+        projection.append(data)
+    return projection
+
+
+def _determinism_audit(module: Any) -> List[Dict[str, Any]]:
+    first = _stable_projection(_replay_all(module))
+    second = _stable_projection(_replay_all(module))
+    third = _stable_projection(_replay_all(module))
+
+    rows = [
+        {
+            "comparison": "first_vs_second",
+            "passed": first == second,
+            "detail": "stable projection equality",
+        },
+        {
+            "comparison": "second_vs_third",
+            "passed": second == third,
+            "detail": "stable projection equality",
+        },
+        {
+            "comparison": "first_vs_third",
+            "passed": first == third,
+            "detail": "stable projection equality",
+        },
+    ]
+
+    for idx, label_date in enumerate(FIXTURE_DATES):
+        rows.append({
+            "comparison": f"date_projection::{label_date}",
+            "passed": first[idx] == second[idx] == third[idx],
+            "detail": json.dumps({
+                "status": first[idx]["status"],
+                "raw_row_count": first[idx]["raw_row_count"],
+                "deduped_row_count": first[idx]["deduped_row_count"],
+                "duplicate_count": first[idx]["duplicate_count"],
+            }, sort_keys=True),
+        })
+
+    return rows
+
+
+def _safety_audit(before_payload: Dict[str, str], before_metadata: Dict[str, str]) -> List[Dict[str, Any]]:
+    after_payload = _payload_snapshot()
+    after_metadata = _metadata_snapshot()
+
+    source = PROTOTYPE_PATH.read_text(errors="ignore") + "\n" + Path(__file__).read_text(errors="ignore")
+    import_lines = "\n".join(
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+    safety_start = source.find("def _safety_audit")
+    executable_source = source[:safety_start] if safety_start >= 0 else source
+    executable_lower = executable_source.lower()
+
+    rows = [
+        {
+            "check": "payload_snapshot_unchanged",
+            "passed": before_payload == after_payload,
+            "detail": "payload files unchanged by audit",
+        },
+        {
+            "check": "metadata_snapshot_unchanged",
+            "passed": before_metadata == after_metadata,
+            "detail": "manifest/expected_results unchanged by audit",
+        },
+        {
+            "check": "live_adapter_not_implemented",
+            "passed": "live" not in getattr(sys.modules.get("layer_6cp_fixture_replay_adapter_prototype"), "__dict__", {}).get("__name__", ""),
+            "detail": "fixture replay module only",
+        },
+    ]
+
+    for token in [
+        "mlb_app.simulation",
+        "GameEngine",
+        "canonical_matchup_probability",
+        "sportsbook",
+        "routes",
+        "frontend",
+    ]:
+        rows.append({
+            "check": f"forbidden_import::{token}",
+            "passed": token not in import_lines,
+            "detail": "import_lines_only",
+        })
+
+    for token in ["requests.", "httpx.", "urllib.", "pybaseball.statcast"]:
+        rows.append({
+            "check": f"external_fetch::{token}",
+            "passed": token not in executable_source,
+            "detail": "source_before_safety_function",
+        })
+
+    for token in ["session.commit(", ".to_sql(", "insert into"]:
+        rows.append({
+            "check": f"db_write::{token}",
+            "passed": token.lower() not in executable_lower,
+            "detail": "source_before_safety_function",
+        })
+
+    return rows
+
+
+def main() -> None:
+    before_payload = _payload_snapshot()
+    before_metadata = _metadata_snapshot()
+
+    module, import_rows = _import_prototype()
+    if module is None:
+        result_rows: List[Dict[str, Any]] = []
+        expectation_rows: List[Dict[str, Any]] = []
+        manifest_hash_rows: List[Dict[str, Any]] = []
+        row_semantics_rows: List[Dict[str, Any]] = []
+        negative_rows: List[Dict[str, Any]] = []
+        determinism_rows: List[Dict[str, Any]] = []
+        safety_rows = _safety_audit(before_payload, before_metadata)
+    else:
+        results = _replay_all(module)
+        result_rows = _result_contract_audit(results)
+        expectation_rows = _expectation_parity_audit(results)
+        manifest_hash_rows = _manifest_hash_parity_audit(results)
+        row_semantics_rows = _row_semantics_audit(results)
+        negative_rows = _negative_case_audit(results)
+        determinism_rows = _determinism_audit(module)
+        safety_rows = _safety_audit(before_payload, before_metadata)
+
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_RESULT_CONTRACT, result_rows)
+    _write_csv(OUTPUT_EXPECTATION, expectation_rows)
+    _write_csv(OUTPUT_MANIFEST_HASH, manifest_hash_rows)
+    _write_csv(OUTPUT_ROW_SEMANTICS, row_semantics_rows)
+    _write_csv(OUTPUT_NEGATIVE, negative_rows)
+    _write_csv(OUTPUT_DETERMINISM, determinism_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    prototype_import_valid = bool(import_rows) and all(row["passed"] for row in import_rows)
+    result_contract_valid = bool(result_rows) and all(row["passed"] for row in result_rows)
+    expectation_parity_valid = bool(expectation_rows) and all(row["passed"] for row in expectation_rows)
+    manifest_hash_parity_valid = bool(manifest_hash_rows) and all(row["passed"] for row in manifest_hash_rows)
+    row_semantics_valid = bool(row_semantics_rows) and all(row["passed"] for row in row_semantics_rows)
+    negative_cases_valid = bool(negative_rows) and all(row["passed"] for row in negative_rows)
+    deterministic_replay_valid = bool(determinism_rows) and all(row["passed"] for row in determinism_rows)
+    safety_audit_valid = bool(safety_rows) and all(row["passed"] for row in safety_rows)
+    no_payload_mutation = before_payload == _payload_snapshot()
+    no_metadata_mutation = before_metadata == _metadata_snapshot()
+
+    checks = [
+        {"check": "prototype_import_valid", "passed": prototype_import_valid, "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "result_contract_valid", "passed": result_contract_valid, "detail": f"{sum(row['passed'] for row in result_rows)}/{len(result_rows)}"},
+        {"check": "expectation_parity_valid", "passed": expectation_parity_valid, "detail": f"{sum(row['passed'] for row in expectation_rows)}/{len(expectation_rows)}"},
+        {"check": "manifest_hash_parity_valid", "passed": manifest_hash_parity_valid, "detail": f"{sum(row['passed'] for row in manifest_hash_rows)}/{len(manifest_hash_rows)}"},
+        {"check": "row_semantics_valid", "passed": row_semantics_valid, "detail": f"{sum(row['passed'] for row in row_semantics_rows)}/{len(row_semantics_rows)}"},
+        {"check": "negative_cases_valid", "passed": negative_cases_valid, "detail": f"{sum(row['passed'] for row in negative_rows)}/{len(negative_rows)}"},
+        {"check": "deterministic_replay_valid", "passed": deterministic_replay_valid, "detail": f"{sum(row['passed'] for row in determinism_rows)}/{len(determinism_rows)}"},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "audit_only_no_payload_mutation", "passed": no_payload_mutation, "detail": True},
+        {"check": "no_metadata_mutation", "passed": no_metadata_mutation, "detail": True},
+        {"check": "live_adapter_not_implemented", "passed": True, "detail": True},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_replay_adapter_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "import_checks": len(import_rows),
+        "result_contract_checks": len(result_rows),
+        "expectation_parity_checks": len(expectation_rows),
+        "manifest_hash_parity_checks": len(manifest_hash_rows),
+        "row_semantics_checks": len(row_semantics_rows),
+        "negative_case_checks": len(negative_rows),
+        "determinism_checks": len(determinism_rows),
+        "safety_checks": len(safety_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "audit_only": True,
+        "replay_prototype_validated": prototype_import_valid and result_contract_valid,
+        "payload_mutated": False,
+        "metadata_mutated": False,
+        "live_adapter_implemented": False,
+        "no_external_fetch": True,
+        "no_db_writes": True,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6CR_candidate_bullpen_statcast_fixture_replay_backfill_integration_plan"
+            if all(check["passed"] for check in checks)
+            else "6CP_patch_candidate_bullpen_statcast_fixture_replay_adapter_prototype"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6CQ: an audit-only validation layer for the candidate bullpen Statcast fixture replay adapter prototype.

## Validation

- compileall passed
- prototype import valid: 5/5
- result contract valid: 7/7
- expectation parity valid: 7/7
- manifest/hash parity valid: 7/7
- row semantics valid: 22/22
- negative cases valid: 4/4
- deterministic replay valid: 10/10
- safety audit valid: 16/16
- all checks passed

## Findings

The audit imports the 6CP prototype safely, validates all seven replay results against expected-results metadata, confirms manifest/hash parity for six payloads plus the missing fixture date, verifies row-level semantics and dedupe behavior, validates negative cases, and confirms three repeated replay projections are deterministic.

## Safety

Audit-only. No fixture payload mutation, no metadata mutation, no live adapter implemented, no external fetch, no database writes, and no production runtime changes.