### PR TITLE
Add Layer 6CT candidate bullpen Statcast fixture replay backfill integration audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_fixture_replay_backfill_integration.py
+++ b/scripts/audit_candidate_bullpen_statcast_fixture_replay_backfill_integration.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_fixture_replay_backfill_integration_audit_v0.1"
+
+PROTOTYPE_PATH = Path("scripts/prototype_candidate_bullpen_statcast_fixture_replay_backfill_integration.py")
+REPLAY_ADAPTER_PATH = Path("scripts/prototype_candidate_bullpen_statcast_fixture_replay_adapter.py")
+BACKFILL_SCAFFOLD = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_integration_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_integration_audit_checks.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_import_audit.csv"
+OUTPUT_SCENARIOS = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_scenario_matrix_audit.csv"
+OUTPUT_ADAPTER = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_adapter_selection_audit_6ct.csv"
+OUTPUT_EXPECTATION = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_expectation_parity_audit_6ct.csv"
+OUTPUT_NEGATIVE = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_negative_gate_audit_6ct.csv"
+OUTPUT_WRITE_DRY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_write_dry_run_gate_audit.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_immutability_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_fixture_replay_backfill_safety_audit_6ct.csv"
+
+
+POSITIVE_DATES = ["2026-05-20", "2026-05-21", "2026-05-22"]
+NEGATIVE_DATES = ["2026-05-23", "2026-05-24", "2026-05-25", "2026-05-26"]
+ALL_DATES = POSITIVE_DATES + NEGATIVE_DATES
+NEGATIVE_STATUSES = {"dedupe_success", "schema_failed_safely", "fixture_missing"}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _file_sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else "__MISSING__"
+
+
+def _payload_snapshot() -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for label_date in ALL_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _metadata_snapshot() -> Dict[str, str]:
+    return {
+        str(path): path.read_text() if path.exists() else "__MISSING__"
+        for path in [MANIFEST, EXPECTED_RESULTS]
+    }
+
+
+def _code_snapshot() -> Dict[str, str]:
+    return {
+        str(path): path.read_text() if path.exists() else "__MISSING__"
+        for path in [PROTOTYPE_PATH, BACKFILL_SCAFFOLD]
+    }
+
+
+def _import_module_from_path(path: Path, module_name: str) -> Tuple[Any | None, List[Dict[str, Any]]]:
+    rows: List[Dict[str, Any]] = []
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            rows.append({"check": f"{module_name}_spec_created", "passed": False, "detail": "spec or loader missing"})
+            return None, rows
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+
+        rows.append({"check": f"{module_name}_file_exists", "passed": path.exists(), "detail": str(path)})
+        rows.append({"check": f"{module_name}_module_loaded", "passed": True, "detail": module_name})
+        return module, rows
+
+    except Exception as exc:
+        rows.append({"check": f"{module_name}_module_loaded", "passed": False, "detail": repr(exc)})
+        return None, rows
+
+
+def _import_prototype() -> Tuple[Any | None, Any | None, List[Dict[str, Any]]]:
+    prototype, rows = _import_module_from_path(
+        PROTOTYPE_PATH,
+        "layer_6cs_fixture_replay_backfill_integration_prototype_audit",
+    )
+
+    replay_adapter, replay_rows = _import_module_from_path(
+        REPLAY_ADAPTER_PATH,
+        "layer_6cp_fixture_replay_adapter_for_6ct_audit",
+    )
+    rows.extend(replay_rows)
+
+    if prototype is not None:
+        rows.extend([
+            {
+                "check": "integration_runner_exists",
+                "passed": callable(getattr(prototype, "run_fixture_replay_backfill_dry_run", None)),
+                "detail": "run_fixture_replay_backfill_dry_run",
+            },
+            {
+                "check": "backfill_result_type_exists",
+                "passed": hasattr(prototype, "BackfillIntegrationResult"),
+                "detail": "BackfillIntegrationResult",
+            },
+            {
+                "check": "backfill_result_type_is_dataclass",
+                "passed": is_dataclass(getattr(prototype, "BackfillIntegrationResult", object)),
+                "detail": "dataclass check",
+            },
+        ])
+
+    if replay_adapter is not None:
+        rows.extend([
+            {
+                "check": "replay_fetch_callable_exists",
+                "passed": callable(getattr(replay_adapter, "fetch_candidate_bullpen_statcast_fixture_rows", None)),
+                "detail": "fetch_candidate_bullpen_statcast_fixture_rows",
+            },
+            {
+                "check": "replay_result_type_exists",
+                "passed": hasattr(replay_adapter, "FixtureReplayResult"),
+                "detail": "FixtureReplayResult",
+            },
+        ])
+
+    return prototype, replay_adapter, rows
+
+
+def _result_to_dict(result: Any) -> Dict[str, Any]:
+    if is_dataclass(result):
+        return asdict(result)
+    return dict(result)
+
+
+def _run_case(
+    prototype: Any,
+    replay_adapter: Any,
+    *,
+    scenario: str,
+    source_mode: str,
+    fixture_date: str | None,
+    allow_negative_fixtures: bool,
+    dry_run: bool,
+    write: bool,
+) -> List[Dict[str, Any]]:
+    runner = getattr(prototype, "run_fixture_replay_backfill_dry_run")
+    results = runner(
+        replay_module=replay_adapter,
+        source_mode=source_mode,
+        fixture_root=FIXTURE_ROOT,
+        fixture_date=fixture_date,
+        allow_negative_fixtures=allow_negative_fixtures,
+        dry_run=dry_run,
+        write=write,
+        scenario=scenario,
+    )
+    return [_result_to_dict(result) for result in results]
+
+
+def _scenario_matrix(prototype: Any, replay_adapter: Any) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+
+    cases = [
+        {
+            "scenario": "positive_only_without_negative_allowance",
+            "dates": POSITIVE_DATES,
+            "source_mode": "fixture",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": False,
+        },
+        {
+            "scenario": "all_dates_without_negative_allowance",
+            "dates": [None],
+            "source_mode": "fixture",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": False,
+        },
+        {
+            "scenario": "all_dates_with_negative_allowance",
+            "dates": [None],
+            "source_mode": "fixture",
+            "allow_negative_fixtures": True,
+            "dry_run": True,
+            "write": False,
+        },
+    ]
+
+    for label_date in NEGATIVE_DATES:
+        cases.append({
+            "scenario": f"negative_without_allowance::{label_date}",
+            "dates": [label_date],
+            "source_mode": "fixture",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": False,
+        })
+
+    cases.extend([
+        {
+            "scenario": "fixture_write_rejected",
+            "dates": ["2026-05-20"],
+            "source_mode": "fixture",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": True,
+        },
+        {
+            "scenario": "fixture_non_dry_run_rejected",
+            "dates": ["2026-05-20"],
+            "source_mode": "fixture",
+            "allow_negative_fixtures": False,
+            "dry_run": False,
+            "write": False,
+        },
+        {
+            "scenario": "live_mode_rejected",
+            "dates": ["2026-05-20"],
+            "source_mode": "live",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": False,
+        },
+        {
+            "scenario": "invalid_source_mode_rejected",
+            "dates": ["2026-05-20"],
+            "source_mode": "invalid_mode",
+            "allow_negative_fixtures": False,
+            "dry_run": True,
+            "write": False,
+        },
+    ])
+
+    for case in cases:
+        for date_value in case["dates"]:
+            rows.extend(_run_case(
+                prototype,
+                replay_adapter,
+                scenario=case["scenario"],
+                source_mode=case["source_mode"],
+                fixture_date=date_value,
+                allow_negative_fixtures=case["allow_negative_fixtures"],
+                dry_run=case["dry_run"],
+                write=case["write"],
+            ))
+
+    return rows
+
+
+def _expected_status_for_row(row: Dict[str, Any]) -> str:
+    if row["source_mode"] == "live":
+        return "live_adapter_not_implemented"
+    if row["source_mode"] not in {"fixture", "live"}:
+        return "invalid_source_mode"
+    if row["write_requested"]:
+        return "fixture_write_blocked"
+    if not row["dry_run"]:
+        return "fixture_requires_dry_run"
+    if row["replay_status"] in NEGATIVE_STATUSES and not row["allow_negative_fixtures"]:
+        return "negative_fixture_blocked"
+    return "fixture_dry_run_ready"
+
+
+def _adapter_selection_audit(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    audit_rows = []
+    for row in rows:
+        expected_status = _expected_status_for_row(row)
+        audit_rows.append({
+            "scenario": row["scenario"],
+            "source_mode": row["source_mode"],
+            "fixture_date": row["fixture_date"],
+            "actual_status": row["status"],
+            "expected_status": expected_status,
+            "passed": row["status"] == expected_status,
+        })
+    return audit_rows
+
+
+def _expectation_parity_audit(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    expectations = _read_json(EXPECTED_RESULTS).get("date_expectations", {})
+    audit_rows = []
+
+    for row in rows:
+        if row["status"] != "fixture_dry_run_ready":
+            continue
+
+        expectation = expectations.get(row["fixture_date"], {})
+        audit_rows.append({
+            "scenario": row["scenario"],
+            "fixture_date": row["fixture_date"],
+            "expected_status": expectation.get("expected_status"),
+            "actual_replay_status": row["replay_status"],
+            "expected_row_count": expectation.get("row_count"),
+            "actual_raw_row_count": row["raw_row_count"],
+            "expected_deduped_row_count": expectation.get("deduped_row_count"),
+            "actual_deduped_row_count": row["deduped_row_count"],
+            "expected_duplicate_count": expectation.get("duplicate_count"),
+            "actual_duplicate_count": row["duplicate_count"],
+            "expected_required_field_failures": expectation.get("required_field_failures"),
+            "actual_required_field_failures": row["required_field_failures"],
+            "expected_missing_fields": "|".join(expectation.get("expected_missing_fields", [])),
+            "actual_missing_fields": "|".join(row["missing_fields"]),
+            "passed": (
+                expectation.get("expected_status") == row["replay_status"]
+                and expectation.get("row_count") == row["raw_row_count"]
+                and expectation.get("deduped_row_count") == row["deduped_row_count"]
+                and expectation.get("duplicate_count") == row["duplicate_count"]
+                and expectation.get("required_field_failures") == row["required_field_failures"]
+                and expectation.get("expected_missing_fields", []) == row["missing_fields"]
+            ),
+        })
+
+    return audit_rows
+
+
+def _negative_gate_audit(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    audit_rows = []
+    for label_date in NEGATIVE_DATES:
+        blocked = [
+            row for row in rows
+            if row["fixture_date"] == label_date
+            and row["allow_negative_fixtures"] is False
+            and row["replay_status"] in NEGATIVE_STATUSES
+        ]
+        allowed = [
+            row for row in rows
+            if row["fixture_date"] == label_date
+            and row["allow_negative_fixtures"] is True
+            and row["status"] == "fixture_dry_run_ready"
+        ]
+
+        audit_rows.append({
+            "fixture_date": label_date,
+            "blocked_without_allowance": any(row["status"] == "negative_fixture_blocked" for row in blocked),
+            "allowed_with_allowance": any(row["status"] == "fixture_dry_run_ready" for row in allowed),
+            "passed": (
+                any(row["status"] == "negative_fixture_blocked" for row in blocked)
+                and any(row["status"] == "fixture_dry_run_ready" for row in allowed)
+            ),
+        })
+    return audit_rows
+
+
+def _write_dry_run_gate_audit(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    audit_rows = []
+
+    write_rows = [row for row in rows if row["write_requested"]]
+    dry_run_gate_rows = [row for row in rows if row["source_mode"] == "fixture" and row["dry_run"] is False]
+
+    for row in write_rows:
+        audit_rows.append({
+            "scenario": row["scenario"],
+            "gate": "fixture_write_block",
+            "fixture_date": row["fixture_date"],
+            "status": row["status"],
+            "passed": row["status"] == "fixture_write_blocked",
+        })
+
+    for row in dry_run_gate_rows:
+        audit_rows.append({
+            "scenario": row["scenario"],
+            "gate": "fixture_requires_dry_run",
+            "fixture_date": row["fixture_date"],
+            "status": row["status"],
+            "passed": row["status"] == "fixture_requires_dry_run",
+        })
+
+    return audit_rows
+
+
+def _positive_behavior_valid(rows: List[Dict[str, Any]]) -> bool:
+    for label_date in POSITIVE_DATES:
+        matches = [
+            row for row in rows
+            if row["fixture_date"] == label_date
+            and row["allow_negative_fixtures"] is False
+            and row["status"] == "fixture_dry_run_ready"
+            and row["replay_status"] == "success"
+        ]
+        if not matches:
+            return False
+    return True
+
+
+def _immutability_audit(before_payload: Dict[str, str], before_metadata: Dict[str, str], before_code: Dict[str, str]) -> List[Dict[str, Any]]:
+    after_payload = _payload_snapshot()
+    after_metadata = _metadata_snapshot()
+    after_code = _code_snapshot()
+
+    return [
+        {
+            "check": "payload_snapshot_unchanged",
+            "passed": before_payload == after_payload,
+            "detail": "fixture payloads unchanged",
+        },
+        {
+            "check": "metadata_snapshot_unchanged",
+            "passed": before_metadata == after_metadata,
+            "detail": "manifest/expected_results unchanged",
+        },
+        {
+            "check": "prototype_not_modified",
+            "passed": before_code.get(str(PROTOTYPE_PATH)) == after_code.get(str(PROTOTYPE_PATH)),
+            "detail": str(PROTOTYPE_PATH),
+        },
+        {
+            "check": "backfill_scaffold_not_modified",
+            "passed": before_code.get(str(BACKFILL_SCAFFOLD)) == after_code.get(str(BACKFILL_SCAFFOLD)),
+            "detail": str(BACKFILL_SCAFFOLD),
+        },
+        {
+            "check": "missing_fixture_file_absent",
+            "passed": not (DATES_DIR / "2026-05-26.jsonl").exists(),
+            "detail": "2026-05-26 remains absent",
+        },
+    ]
+
+
+def _safety_audit(before_payload: Dict[str, str], before_metadata: Dict[str, str], before_code: Dict[str, str]) -> List[Dict[str, Any]]:
+    source = (
+        Path(__file__).read_text(errors="ignore")
+        + "\n"
+        + PROTOTYPE_PATH.read_text(errors="ignore")
+    )
+    import_lines = "\n".join(
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+    safety_start = source.find("def _safety_audit")
+    executable_source = source[:safety_start] if safety_start >= 0 else source
+    executable_lower = executable_source.lower()
+
+    rows = _immutability_audit(before_payload, before_metadata, before_code)
+    rows.append({
+        "check": "live_adapter_not_implemented",
+        "passed": "live_adapter_not_implemented" in source and "source_mode == \"live\"" in source,
+        "detail": "live source mode returns not implemented",
+    })
+
+    for token in [
+        "mlb_app.simulation",
+        "GameEngine",
+        "canonical_matchup_probability",
+        "sportsbook",
+        "routes",
+        "frontend",
+    ]:
+        rows.append({
+            "check": f"forbidden_import::{token}",
+            "passed": token not in import_lines,
+            "detail": "import_lines_only",
+        })
+
+    for token in ["requests.", "httpx.", "urllib.", "pybaseball.statcast"]:
+        rows.append({
+            "check": f"external_fetch::{token}",
+            "passed": token not in executable_source,
+            "detail": "source_before_safety_function",
+        })
+
+    for token in ["session.commit(", ".to_sql(", "insert into"]:
+        rows.append({
+            "check": f"db_write::{token}",
+            "passed": token.lower() not in executable_lower,
+            "detail": "source_before_safety_function",
+        })
+
+    return rows
+
+
+def main() -> None:
+    before_payload = _payload_snapshot()
+    before_metadata = _metadata_snapshot()
+    before_code = _code_snapshot()
+
+    prototype, replay_adapter, import_rows = _import_prototype()
+    scenario_rows: List[Dict[str, Any]] = []
+    if prototype is not None and replay_adapter is not None:
+        scenario_rows = _scenario_matrix(prototype, replay_adapter)
+
+    adapter_rows = _adapter_selection_audit(scenario_rows)
+    expectation_rows = _expectation_parity_audit(scenario_rows)
+    negative_rows = _negative_gate_audit(scenario_rows)
+    write_dry_rows = _write_dry_run_gate_audit(scenario_rows)
+    immutability_rows = _immutability_audit(before_payload, before_metadata, before_code)
+    safety_rows = _safety_audit(before_payload, before_metadata, before_code)
+
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SCENARIOS, scenario_rows)
+    _write_csv(OUTPUT_ADAPTER, adapter_rows)
+    _write_csv(OUTPUT_EXPECTATION, expectation_rows)
+    _write_csv(OUTPUT_NEGATIVE, negative_rows)
+    _write_csv(OUTPUT_WRITE_DRY, write_dry_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    prototype_import_valid = bool(import_rows) and all(row["passed"] for row in import_rows)
+    scenario_matrix_valid = bool(scenario_rows) and len(scenario_rows) >= 25
+    adapter_selection_valid = bool(adapter_rows) and all(row["passed"] for row in adapter_rows)
+    positive_fixture_behavior_valid = _positive_behavior_valid(scenario_rows)
+    negative_fixture_gate_valid = bool(negative_rows) and all(row["blocked_without_allowance"] for row in negative_rows)
+    negative_fixture_allowed_valid = bool(negative_rows) and all(row["allowed_with_allowance"] for row in negative_rows)
+    fixture_write_block_valid = any(row["gate"] == "fixture_write_block" and row["passed"] for row in write_dry_rows)
+    fixture_dry_run_gate_valid = any(row["gate"] == "fixture_requires_dry_run" and row["passed"] for row in write_dry_rows)
+    live_mode_not_implemented = any(row["status"] == "live_adapter_not_implemented" for row in scenario_rows)
+    invalid_source_mode_rejected = any(row["status"] == "invalid_source_mode" for row in scenario_rows)
+    expectation_parity_valid = bool(expectation_rows) and all(row["passed"] for row in expectation_rows)
+    immutability_valid = bool(immutability_rows) and all(row["passed"] for row in immutability_rows)
+    safety_audit_valid = bool(safety_rows) and all(row["passed"] for row in safety_rows)
+    no_payload_mutation = before_payload == _payload_snapshot()
+    no_metadata_mutation = before_metadata == _metadata_snapshot()
+    prototype_not_modified = before_code.get(str(PROTOTYPE_PATH)) == _code_snapshot().get(str(PROTOTYPE_PATH))
+    backfill_scaffold_not_modified = before_code.get(str(BACKFILL_SCAFFOLD)) == _code_snapshot().get(str(BACKFILL_SCAFFOLD))
+
+    checks = [
+        {"check": "prototype_import_valid", "passed": prototype_import_valid, "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "scenario_matrix_valid", "passed": scenario_matrix_valid, "detail": f"{len(scenario_rows)} scenario rows"},
+        {"check": "adapter_selection_valid", "passed": adapter_selection_valid, "detail": f"{sum(row['passed'] for row in adapter_rows)}/{len(adapter_rows)}"},
+        {"check": "positive_fixture_behavior_valid", "passed": positive_fixture_behavior_valid, "detail": "2026-05-20/21/22 success without negative allowance"},
+        {"check": "negative_fixture_gate_valid", "passed": negative_fixture_gate_valid, "detail": f"{sum(row['blocked_without_allowance'] for row in negative_rows)}/{len(negative_rows)} blocked"},
+        {"check": "negative_fixture_allowed_valid", "passed": negative_fixture_allowed_valid, "detail": f"{sum(row['allowed_with_allowance'] for row in negative_rows)}/{len(negative_rows)} allowed"},
+        {"check": "fixture_write_block_valid", "passed": fixture_write_block_valid, "detail": "fixture write rejected"},
+        {"check": "fixture_dry_run_gate_valid", "passed": fixture_dry_run_gate_valid, "detail": "fixture non-dry-run rejected"},
+        {"check": "live_mode_not_implemented", "passed": live_mode_not_implemented, "detail": True},
+        {"check": "invalid_source_mode_rejected", "passed": invalid_source_mode_rejected, "detail": True},
+        {"check": "expectation_parity_valid", "passed": expectation_parity_valid, "detail": f"{sum(row['passed'] for row in expectation_rows)}/{len(expectation_rows)}"},
+        {"check": "immutability_valid", "passed": immutability_valid, "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "no_payload_mutation", "passed": no_payload_mutation, "detail": True},
+        {"check": "no_metadata_mutation", "passed": no_metadata_mutation, "detail": True},
+        {"check": "prototype_not_modified", "passed": prototype_not_modified, "detail": True},
+        {"check": "backfill_scaffold_not_modified", "passed": backfill_scaffold_not_modified, "detail": True},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_replay_backfill_integration_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "import_checks": len(import_rows),
+        "scenario_rows": len(scenario_rows),
+        "adapter_selection_rows": len(adapter_rows),
+        "expectation_parity_rows": len(expectation_rows),
+        "negative_gate_rows": len(negative_rows),
+        "write_dry_run_gate_rows": len(write_dry_rows),
+        "immutability_rows": len(immutability_rows),
+        "safety_rows": len(safety_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "audit_only": True,
+        "integration_prototype_validated": True,
+        "prototype_mutated": False,
+        "backfill_scaffold_mutated": False,
+        "payload_mutated": False,
+        "metadata_mutated": False,
+        "live_adapter_implemented": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "missing_fixture_file_created": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6CU_candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_plan"
+            if all(check["passed"] for check in checks)
+            else "6CS_patch_candidate_bullpen_statcast_fixture_replay_backfill_integration_prototype"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6CT: an audit-only validation layer for the candidate bullpen Statcast fixture replay/backfill integration prototype.

## Validation

- compileall passed
- prototype import valid: 9/9
- scenario matrix valid: 25 rows
- adapter selection valid: 25/25
- positive fixture behavior valid
- negative fixture gate valid: 4/4 blocked without allowance
- negative fixture allowed valid: 4/4 allowed with explicit allowance
- fixture write block valid
- fixture non-dry-run gate valid
- live mode not implemented
- invalid source mode rejected
- expectation parity valid: 13/13
- immutability valid: 5/5
- safety audit valid: 19/19
- all checks passed

## Findings

The audit independently imports and executes the 6CS prototype scenario matrix, verifies source-mode selection, positive fixture dry-run behavior, negative fixture gating and allowance, fixture write and dry-run gates, live-mode rejection, invalid source-mode rejection, expected-results parity, and immutability of fixture payloads, metadata, prototype code, and the backfill scaffold.

## Safety

Audit-only. No prototype mutation, no backfill scaffold mutation, no fixture payload or metadata mutation, no live adapter implemented, no external fetch, no database writes, and no production default changes.