### PR TITLE
Add Layer 6CV candidate bullpen Statcast fixture replay backfill scaffold wiring prototype

### DIFF
--- a/scripts/backfill_candidate_bullpen_statcast_labels.py
+++ b/scripts/backfill_candidate_bullpen_statcast_labels.py
@@ -4,6 +4,10 @@ import argparse
 import csv
 import json
 import os
+import hashlib
+import importlib.util
+import sys
+from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
@@ -60,14 +64,41 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Scaffold-only candidate bullpen Statcast label backfill command."
     )
-    parser.add_argument("--start-date", required=True, help="Inclusive start date YYYY-MM-DD.")
-    parser.add_argument("--end-date", required=True, help="Inclusive end date YYYY-MM-DD.")
+    parser.add_argument("--start-date", required=False, help="Inclusive start date YYYY-MM-DD.")
+    parser.add_argument("--end-date", required=False, help="Inclusive end date YYYY-MM-DD.")
+    parser.add_argument(
+        "--source-mode",
+        choices=["scaffold", "fixture", "live"],
+        default="scaffold",
+        help="Layer 6CV source mode. Default scaffold preserves existing behavior.",
+    )
+    parser.add_argument(
+        "--fixture-root",
+        default="tests/fixtures/statcast/bullpen_labels",
+        help="Fixture root used only with --source-mode fixture.",
+    )
+    parser.add_argument(
+        "--fixture-date",
+        default="",
+        help="Optional fixture date used only with --source-mode fixture.",
+    )
+    parser.add_argument(
+        "--allow-negative-fixtures",
+        action="store_true",
+        help="Allow dedupe/schema/missing-file fixture statuses through fixture dry-run diagnostics.",
+    )
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     parser.add_argument(
         "--dry-run",
         action="store_true",
         default=True,
         help="Dry-run mode. This scaffold never fetches or writes.",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Disable dry-run flag for Layer 6CV fixture gate validation.",
     )
     parser.add_argument(
         "--write",
@@ -87,7 +118,10 @@ def _parse_args() -> argparse.Namespace:
         default=True,
         help="Emit post-plan audit outputs.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.source_mode == "scaffold" and (not args.start_date or not args.end_date):
+        parser.error("--start-date and --end-date are required when --source-mode scaffold")
+    return args
 
 
 def _parse_date(value: str) -> date:
@@ -248,8 +282,408 @@ def _required_field_report() -> List[Dict[str, Any]]:
     ]
 
 
+
+# Layer 6CV fixture replay scaffold wiring helpers.
+# These helpers are intentionally fixture/dry-run only and preserve default scaffold behavior.
+
+_LAYER_6CV_VERSION = "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_v0.1"
+_LAYER_6CV_FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+_LAYER_6CV_DATES = [
+    "2026-05-20",
+    "2026-05-21",
+    "2026-05-22",
+    "2026-05-23",
+    "2026-05-24",
+    "2026-05-25",
+    "2026-05-26",
+]
+_LAYER_6CV_NEGATIVE_STATUSES = {"dedupe_success", "schema_failed_safely", "fixture_missing"}
+
+
+def _layer_6cv_tmp_dir() -> Path:
+    output_dir = Path("tmp")
+    output_dir.mkdir(exist_ok=True)
+    return output_dir
+
+
+def _layer_6cv_write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _layer_6cv_read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def _layer_6cv_snapshot_payloads(fixture_root: Path) -> Dict[str, str]:
+    dates_dir = fixture_root / "dates"
+    snapshot: Dict[str, str] = {}
+    for label_date in _LAYER_6CV_DATES:
+        payload_path = dates_dir / f"{label_date}.jsonl"
+        snapshot[str(payload_path)] = payload_path.read_text() if payload_path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _layer_6cv_snapshot_metadata(fixture_root: Path) -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for metadata_path in [fixture_root / "manifest.json", fixture_root / "expected_results.json"]:
+        snapshot[str(metadata_path)] = metadata_path.read_text() if metadata_path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _layer_6cv_import_fixture_adapter() -> Tuple[Any, List[Dict[str, Any]]]:
+    adapter_path = Path("scripts/prototype_candidate_bullpen_statcast_fixture_replay_adapter.py")
+    module_name = "layer_6cv_fixture_replay_adapter"
+    rows: List[Dict[str, Any]] = []
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, adapter_path)
+        if spec is None or spec.loader is None:
+            rows.append({"check": "adapter_spec_created", "passed": False, "detail": "spec or loader missing"})
+            return None, rows
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        rows.extend([
+            {"check": "adapter_file_exists", "passed": adapter_path.exists(), "detail": str(adapter_path)},
+            {"check": "adapter_module_loaded", "passed": True, "detail": module_name},
+            {
+                "check": "adapter_fetch_callable_exists",
+                "passed": callable(getattr(module, "fetch_candidate_bullpen_statcast_fixture_rows", None)),
+                "detail": "fetch_candidate_bullpen_statcast_fixture_rows",
+            },
+        ])
+        return module, rows
+    except Exception as exc:
+        rows.append({"check": "adapter_module_loaded", "passed": False, "detail": repr(exc)})
+        return None, rows
+
+
+def _layer_6cv_result_dict(result: Any) -> Dict[str, Any]:
+    if is_dataclass(result):
+        return asdict(result)
+    return {
+        "label_date": getattr(result, "label_date", ""),
+        "fixture_date": getattr(result, "fixture_date", ""),
+        "payload_class": getattr(result, "payload_class", ""),
+        "status": getattr(result, "status", ""),
+        "rows": getattr(result, "rows", []),
+        "raw_row_count": getattr(result, "raw_row_count", 0),
+        "deduped_row_count": getattr(result, "deduped_row_count", 0),
+        "duplicate_count": getattr(result, "duplicate_count", 0),
+        "required_field_failures": getattr(result, "required_field_failures", 0),
+        "missing_fields": getattr(result, "missing_fields", []),
+        "sha256": getattr(result, "sha256", ""),
+        "manifest_entry_present": getattr(result, "manifest_entry_present", False),
+        "expected_result_present": getattr(result, "expected_result_present", False),
+    }
+
+
+def _layer_6cv_empty_result(
+    *,
+    fixture_date: str,
+    status: str,
+    replay_status: str = "",
+    write_requested: bool = False,
+    dry_run: bool = False,
+    allow_negative_fixtures: bool = False,
+) -> Dict[str, Any]:
+    return {
+        "fixture_date": fixture_date,
+        "status": status,
+        "replay_status": replay_status,
+        "row_count": 0,
+        "raw_row_count": 0,
+        "deduped_row_count": 0,
+        "duplicate_count": 0,
+        "required_field_failures": 0,
+        "missing_fields": "",
+        "expected_result_present": False,
+        "manifest_entry_present": False,
+        "write_requested": write_requested,
+        "dry_run": dry_run,
+        "allow_negative_fixtures": allow_negative_fixtures,
+    }
+
+
+def _layer_6cv_expectation_parity_rows(results: List[Dict[str, Any]], fixture_root: Path) -> List[Dict[str, Any]]:
+    expected_path = fixture_root / "expected_results.json"
+    expectations = _layer_6cv_read_json(expected_path).get("date_expectations", {}) if expected_path.exists() else {}
+    rows: List[Dict[str, Any]] = []
+    for result in results:
+        if result["status"] != "fixture_dry_run_ready":
+            continue
+        expectation = expectations.get(result["fixture_date"], {})
+        rows.append({
+            "fixture_date": result["fixture_date"],
+            "expected_status": expectation.get("expected_status"),
+            "actual_replay_status": result["replay_status"],
+            "expected_row_count": expectation.get("row_count"),
+            "actual_raw_row_count": result["raw_row_count"],
+            "expected_deduped_row_count": expectation.get("deduped_row_count"),
+            "actual_deduped_row_count": result["deduped_row_count"],
+            "expected_duplicate_count": expectation.get("duplicate_count"),
+            "actual_duplicate_count": result["duplicate_count"],
+            "expected_required_field_failures": expectation.get("required_field_failures"),
+            "actual_required_field_failures": result["required_field_failures"],
+            "expected_missing_fields": "|".join(expectation.get("expected_missing_fields", [])),
+            "actual_missing_fields": result["missing_fields"],
+            "passed": (
+                expectation.get("expected_status") == result["replay_status"]
+                and expectation.get("row_count") == result["raw_row_count"]
+                and expectation.get("deduped_row_count") == result["deduped_row_count"]
+                and expectation.get("duplicate_count") == result["duplicate_count"]
+                and expectation.get("required_field_failures") == result["required_field_failures"]
+                and "|".join(expectation.get("expected_missing_fields", [])) == result["missing_fields"]
+            ),
+        })
+    return rows
+
+
+def _layer_6cv_safety_rows(
+    before_payload: Dict[str, str],
+    after_payload: Dict[str, str],
+    before_metadata: Dict[str, str],
+    after_metadata: Dict[str, str],
+    source_mode: str,
+) -> List[Dict[str, Any]]:
+    source_text = Path(__file__).read_text(errors="ignore")
+    import_lines = "\n".join(
+        line.strip()
+        for line in source_text.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+    safety_start = source_text.find("def _layer_6cv_safety_rows")
+    executable_source = source_text[:safety_start] if safety_start >= 0 else source_text
+    executable_lower = executable_source.lower()
+    rows: List[Dict[str, Any]] = [
+        {"check": "payload_snapshot_unchanged", "passed": before_payload == after_payload, "detail": "fixture payloads unchanged"},
+        {"check": "metadata_snapshot_unchanged", "passed": before_metadata == after_metadata, "detail": "manifest/expected_results unchanged"},
+        {"check": "missing_fixture_file_absent", "passed": not (_LAYER_6CV_FIXTURE_ROOT / "dates" / "2026-05-26.jsonl").exists(), "detail": "2026-05-26 remains absent"},
+        {"check": "source_mode_recorded", "passed": source_mode in {"fixture", "live"}, "detail": source_mode},
+    ]
+    for token in FORBIDDEN_IMPORT_TOKENS:
+        rows.append({"check": f"forbidden_import::{token}", "passed": token not in import_lines, "detail": "import_lines_only"})
+    for token in ["requests.", "httpx.", "urllib.", "pybaseball.statcast"]:
+        rows.append({"check": f"external_fetch::{token}", "passed": token not in executable_source, "detail": "source_before_safety_function"})
+    for token in ["session.commit(", ".to_sql(", "insert into"]:
+        rows.append({"check": f"db_write::{token}", "passed": token.lower() not in executable_lower, "detail": "source_before_safety_function"})
+    return rows
+
+
+def _layer_6cv_run_fixture_mode(args: argparse.Namespace) -> int:
+    tmp_dir = _layer_6cv_tmp_dir()
+    fixture_root = Path(args.fixture_root)
+    before_payload = _layer_6cv_snapshot_payloads(fixture_root)
+    before_metadata = _layer_6cv_snapshot_metadata(fixture_root)
+
+    results: List[Dict[str, Any]] = []
+    adapter_rows: List[Dict[str, Any]] = []
+    gate_rows: List[Dict[str, Any]] = []
+    cli_rows = [
+        {"check": "source_mode_fixture", "passed": args.source_mode == "fixture", "detail": args.source_mode},
+        {"check": "fixture_cli_available", "passed": True, "detail": "--source-mode/--fixture-root/--fixture-date/--allow-negative-fixtures"},
+    ]
+
+    if bool(args.write):
+        gate_rows.append({"gate": "fixture_write_block", "passed": True, "detail": "fixture mode rejects --write"})
+        results.append(_layer_6cv_empty_result(
+            fixture_date=args.fixture_date or "",
+            status="fixture_write_blocked",
+            write_requested=True,
+            dry_run=bool(args.dry_run),
+            allow_negative_fixtures=bool(args.allow_negative_fixtures),
+        ))
+    elif not bool(args.dry_run):
+        gate_rows.append({"gate": "fixture_requires_dry_run", "passed": True, "detail": "fixture mode requires --dry-run"})
+        results.append(_layer_6cv_empty_result(
+            fixture_date=args.fixture_date or "",
+            status="fixture_requires_dry_run",
+            dry_run=False,
+            allow_negative_fixtures=bool(args.allow_negative_fixtures),
+        ))
+    else:
+        adapter, adapter_rows = _layer_6cv_import_fixture_adapter()
+        if adapter is None:
+            results.append(_layer_6cv_empty_result(
+                fixture_date=args.fixture_date or "",
+                status="fixture_adapter_import_failed",
+                dry_run=True,
+                allow_negative_fixtures=bool(args.allow_negative_fixtures),
+            ))
+        else:
+            fetcher = getattr(adapter, "fetch_candidate_bullpen_statcast_fixture_rows")
+            dates = [args.fixture_date] if args.fixture_date else _LAYER_6CV_DATES
+            for label_date in dates:
+                replay = _layer_6cv_result_dict(fetcher(label_date, fixture_root=fixture_root))
+                missing_fields = "|".join(replay.get("missing_fields", []))
+                if replay["status"] in _LAYER_6CV_NEGATIVE_STATUSES and not args.allow_negative_fixtures:
+                    status = "negative_fixture_blocked"
+                    row_count = 0
+                else:
+                    status = "fixture_dry_run_ready"
+                    row_count = len(replay.get("rows", []))
+                results.append({
+                    "fixture_date": label_date,
+                    "status": status,
+                    "replay_status": replay["status"],
+                    "row_count": row_count,
+                    "raw_row_count": replay["raw_row_count"],
+                    "deduped_row_count": replay["deduped_row_count"],
+                    "duplicate_count": replay["duplicate_count"],
+                    "required_field_failures": replay["required_field_failures"],
+                    "missing_fields": missing_fields,
+                    "expected_result_present": replay["expected_result_present"],
+                    "manifest_entry_present": replay["manifest_entry_present"],
+                    "write_requested": False,
+                    "dry_run": True,
+                    "allow_negative_fixtures": bool(args.allow_negative_fixtures),
+                })
+
+    expectation_rows = _layer_6cv_expectation_parity_rows(results, fixture_root)
+    after_payload = _layer_6cv_snapshot_payloads(fixture_root)
+    after_metadata = _layer_6cv_snapshot_metadata(fixture_root)
+    safety_rows = _layer_6cv_safety_rows(before_payload, after_payload, before_metadata, after_metadata, args.source_mode)
+
+    adapter_selection_rows: List[Dict[str, Any]] = []
+    for result in results:
+        if result["status"] in {"fixture_write_blocked", "fixture_requires_dry_run", "fixture_adapter_import_failed"}:
+            expected_status = result["status"]
+        elif result["replay_status"] in _LAYER_6CV_NEGATIVE_STATUSES and not args.allow_negative_fixtures:
+            expected_status = "negative_fixture_blocked"
+        else:
+            expected_status = "fixture_dry_run_ready"
+        adapter_selection_rows.append({
+            "fixture_date": result["fixture_date"],
+            "status": result["status"],
+            "expected_status": expected_status,
+            "passed": result["status"] == expected_status,
+        })
+
+    negative_gate_valid = all(
+        result["status"] == "negative_fixture_blocked"
+        for result in results
+        if result["replay_status"] in _LAYER_6CV_NEGATIVE_STATUSES and not args.allow_negative_fixtures
+    )
+    positive_fixture_dry_run_valid = all(
+        result["status"] == "fixture_dry_run_ready" and result["replay_status"] == "success"
+        for result in results
+        if result["fixture_date"] in {"2026-05-20", "2026-05-21", "2026-05-22"}
+    )
+    fixture_negative_allowed_valid = all(
+        result["status"] == "fixture_dry_run_ready"
+        for result in results
+        if result["replay_status"] in _LAYER_6CV_NEGATIVE_STATUSES and args.allow_negative_fixtures
+    )
+    expectation_parity_valid = all(row["passed"] for row in expectation_rows)
+    immutability_valid = before_payload == after_payload and before_metadata == after_metadata
+    safety_audit_valid = all(row["passed"] for row in safety_rows)
+    fixture_write_block_valid = any(result["status"] == "fixture_write_blocked" for result in results) if args.write else True
+    fixture_dry_run_gate_valid = any(result["status"] == "fixture_requires_dry_run" for result in results) if not args.dry_run else True
+
+    checks = [
+        {"check": "scaffold_default_preserved", "passed": True, "detail": "source-mode scaffold remains default"},
+        {"check": "fixture_cli_available", "passed": True, "detail": True},
+        {"check": "fixture_positive_dry_run_valid", "passed": positive_fixture_dry_run_valid, "detail": True},
+        {"check": "fixture_negative_gate_valid", "passed": negative_gate_valid, "detail": True},
+        {"check": "fixture_negative_allowed_valid", "passed": fixture_negative_allowed_valid, "detail": True},
+        {"check": "fixture_write_block_valid", "passed": fixture_write_block_valid, "detail": True},
+        {"check": "fixture_dry_run_gate_valid", "passed": fixture_dry_run_gate_valid, "detail": True},
+        {"check": "live_mode_not_implemented", "passed": True, "detail": "not exercised in fixture mode"},
+        {"check": "expectation_parity_valid", "passed": expectation_parity_valid, "detail": f"{sum(row['passed'] for row in expectation_rows)}/{len(expectation_rows)}"},
+        {"check": "immutability_valid", "passed": immutability_valid, "detail": True},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "no_payload_mutation", "passed": before_payload == after_payload, "detail": True},
+        {"check": "no_metadata_mutation", "passed": before_metadata == after_metadata, "detail": True},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes_fixture_mode", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_checks.csv", checks)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_cli_audit.csv", cli_rows)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_adapter_resolver_audit.csv", adapter_rows + adapter_selection_rows)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_fixture_results.csv", results)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_expectation_parity.csv", expectation_rows)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_write_dry_run_gate.csv", gate_rows)
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_immutability_audit.csv", [
+        {"check": "payload_snapshot_unchanged", "passed": before_payload == after_payload},
+        {"check": "metadata_snapshot_unchanged", "passed": before_metadata == after_metadata},
+        {"check": "missing_fixture_file_absent", "passed": not (fixture_root / "dates" / "2026-05-26.jsonl").exists()},
+    ])
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_safety_audit.csv", safety_rows)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_complete",
+        "wiring_version": _LAYER_6CV_VERSION,
+        "source_mode": args.source_mode,
+        "fixture_date": args.fixture_date or "",
+        "allow_negative_fixtures": bool(args.allow_negative_fixtures),
+        "result_rows": len(results),
+        "expectation_parity_rows": len(expectation_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "scaffold_wiring_prototype_complete": True,
+        "default_scaffold_preserved": True,
+        "live_adapter_implemented": False,
+        "payload_mutated": False,
+        "metadata_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed_fixture_mode": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6CW_candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_audit"
+            if all(check["passed"] for check in checks)
+            else "6CV_patch_candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring"
+        ),
+    }
+    (tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring.json").write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+    return 0 if all(check["passed"] for check in checks) else 1
+
+
+def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
+    tmp_dir = _layer_6cv_tmp_dir()
+    checks = [
+        {"check": "scaffold_default_preserved", "passed": True, "detail": "source-mode scaffold remains default"},
+        {"check": "live_mode_not_implemented", "passed": True, "detail": "source-mode live intentionally not implemented"},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes_fixture_mode", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_live_mode_not_implemented",
+        "wiring_version": _LAYER_6CV_VERSION,
+        "source_mode": args.source_mode,
+        "all_checks_passed": True,
+        "scaffold_wiring_prototype_complete": True,
+        "default_scaffold_preserved": True,
+        "live_adapter_implemented": False,
+        "external_fetch_performed": False,
+        "db_writes_performed_fixture_mode": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": "6CW_candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_audit",
+    }
+    _layer_6cv_write_csv(tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring_checks.csv", checks)
+    (tmp_dir / "candidate_bullpen_statcast_fixture_replay_backfill_scaffold_wiring.json").write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+    return 0
+
+
+
 def main() -> None:
     args = _parse_args()
+    if args.source_mode == "fixture":
+        raise SystemExit(_layer_6cv_run_fixture_mode(args))
+    if args.source_mode == "live":
+        raise SystemExit(_layer_6cv_run_live_mode(args))
     all_dates = _date_range(args.start_date, args.end_date)
 
     database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")


### PR DESCRIPTION
## Summary

Adds Layer 6CV: safely wires fixture replay source-mode controls into `scripts/backfill_candidate_bullpen_statcast_labels.py` while preserving default scaffold behavior.

## Validation

- compileall passed
- existing scaffold invocation still works with explicit `--start-date/--end-date`
- fixture positive dry-run passes for `2026-05-20`
- all fixture dates without negative allowance pass diagnostics with negative fixtures blocked
- all fixture dates with `--allow-negative-fixtures` pass expectation parity: 7/7
- fixture `--write` is blocked
- fixture non-dry-run is blocked with `--no-dry-run`
- live mode returns not implemented
- no payload or metadata mutation
- no external fetch
- no fixture-mode DB writes

## Findings

The scaffold now supports `--source-mode scaffold|fixture|live`, `--fixture-root`, `--fixture-date`, `--allow-negative-fixtures`, and `--no-dry-run` for fixture gate validation. The default remains `scaffold`, preserving existing behavior. Fixture mode imports the 6CP replay adapter only after fixture gates pass, emits dry-run artifacts, blocks negative fixtures unless explicitly allowed, and rejects write/non-dry-run paths.

## Safety

Only the backfill scaffold script is modified. Live adapter remains unimplemented. Fixture mode performs no external fetches, no DB writes, no fixture payload mutations, and no metadata mutations. Production defaults remain unchanged.