### PR TITLE
Add Layer 6CZ candidate bullpen Statcast live adapter dry-run scaffold audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_live_adapter_dry_run_scaffold.py
+++ b/scripts/audit_candidate_bullpen_statcast_live_adapter_dry_run_scaffold.py
@@ -1,0 +1,591 @@
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_live_adapter_dry_run_scaffold_audit_v0.1"
+
+BACKFILL_SCAFFOLD = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+DATES_DIR = FIXTURE_ROOT / "dates"
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_dry_run_scaffold_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_dry_run_scaffold_audit_checks.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_source_inspection_audit.csv"
+OUTPUT_SCENARIOS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scenario_execution_audit.csv"
+OUTPUT_ARTIFACTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_artifact_validation_audit.csv"
+OUTPUT_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_result_contract_audit.csv"
+OUTPUT_FETCH = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_fetch_diagnostics_audit.csv"
+OUTPUT_GATES = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_gate_behavior_audit.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_immutability_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_safety_audit_6cz.csv"
+
+LIVE_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_dry_run.json"
+LIVE_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_dry_run_checks.csv"
+LIVE_CLI = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_audit.csv"
+LIVE_RESULTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_results.csv"
+LIVE_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_normalized_row_contract_audit.csv"
+LIVE_FETCH = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_fetch_diagnostics.csv"
+LIVE_GATE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_write_dry_run_gate.csv"
+LIVE_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_safety_audit.csv"
+
+FIXTURE_DATES = [
+    "2026-05-20",
+    "2026-05-21",
+    "2026-05-22",
+    "2026-05-23",
+    "2026-05-24",
+    "2026-05-25",
+    "2026-05-26",
+]
+
+REQUIRED_ROW_FIELDS = [
+    "game_date",
+    "game_pk",
+    "inning",
+    "inning_topbot",
+    "at_bat_number",
+    "pitch_number",
+    "outs_when_up",
+    "pitcher_id",
+    "home_team",
+    "away_team",
+    "events",
+    "description",
+]
+NATURAL_KEY_FIELDS = {"game_pk", "at_bat_number", "pitch_number", "pitcher_id"}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _scaffold_snapshot() -> str:
+    return BACKFILL_SCAFFOLD.read_text(errors="ignore") if BACKFILL_SCAFFOLD.exists() else "__MISSING__"
+
+
+def _fixture_snapshot() -> Dict[str, str]:
+    snapshot: Dict[str, str] = {}
+    for path in [MANIFEST, EXPECTED_RESULTS]:
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    for label_date in FIXTURE_DATES:
+        path = DATES_DIR / f"{label_date}.jsonl"
+        snapshot[str(path)] = path.read_text() if path.exists() else "__MISSING__"
+    return snapshot
+
+
+def _source_inspection() -> List[Dict[str, Any]]:
+    source = _scaffold_snapshot()
+    checks = [
+        ("source_mode_arg", '"--source-mode"' in source),
+        ("live_timeout_arg", '"--live-fetch-timeout-seconds"' in source),
+        ("live_retries_arg", '"--live-fetch-max-retries"' in source),
+        ("live_version_marker", "_LAYER_6CY_VERSION" in source),
+        ("live_not_configured_status", "live_adapter_not_configured" in source),
+        ("live_write_blocked_status", "live_write_blocked" in source),
+        ("live_requires_dry_run_status", "live_requires_dry_run" in source),
+        ("live_invalid_window_status", "live_date_window_invalid" in source),
+        ("source_mode_default_scaffold", 'default="scaffold"' in source),
+        ("live_delegate_wired", "_layer_6cy_run_live_dry_run_scaffold" in source),
+    ]
+    return [{"check": name, "passed": passed, "detail": name} for name, passed in checks]
+
+
+def _run_command(name: str, args: List[str]) -> Dict[str, Any]:
+    cmd = [sys.executable] + args
+    completed = subprocess.run(cmd, capture_output=True, text=True)
+    diagnosis = _read_json(LIVE_JSON) if LIVE_JSON.exists() else {}
+    return {
+        "scenario": name,
+        "command": " ".join(cmd),
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-1000:],
+        "stderr_tail": completed.stderr[-1000:],
+        "diagnosis": diagnosis.get("diagnosis", ""),
+        "all_checks_passed": diagnosis.get("all_checks_passed", ""),
+        "passed": completed.returncode == 0,
+    }
+
+
+def _capture_live_state(args: List[str]) -> Dict[str, Any]:
+    run = _run_command("capture", ["scripts/backfill_candidate_bullpen_statcast_labels.py"] + args)
+    return {
+        "run": run,
+        "diagnosis": _read_json(LIVE_JSON),
+        "checks": _read_csv(LIVE_CHECKS),
+        "cli": _read_csv(LIVE_CLI),
+        "results": _read_csv(LIVE_RESULTS),
+        "contract": _read_csv(LIVE_CONTRACT),
+        "fetch": _read_csv(LIVE_FETCH),
+        "gate": _read_csv(LIVE_GATE),
+        "safety": _read_csv(LIVE_SAFETY),
+    }
+
+
+def _scenario_execution() -> List[Dict[str, Any]]:
+    scenarios = [
+        (
+            "scaffold_default_path",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-20",
+                "--dry-run",
+            ],
+        ),
+        (
+            "fixture_mode_preserved",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "fixture",
+                "--dry-run",
+                "--fixture-date",
+                "2026-05-20",
+            ],
+        ),
+        (
+            "live_one_date_dry_run",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "live",
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-20",
+                "--dry-run",
+            ],
+        ),
+        (
+            "live_short_window_dry_run",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "live",
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-22",
+                "--dry-run",
+            ],
+        ),
+        (
+            "live_write_block",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "live",
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-20",
+                "--write",
+            ],
+        ),
+        (
+            "live_non_dry_run_block",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "live",
+                "--start-date",
+                "2026-05-20",
+                "--end-date",
+                "2026-05-20",
+                "--no-dry-run",
+            ],
+        ),
+        (
+            "live_invalid_window",
+            [
+                "scripts/backfill_candidate_bullpen_statcast_labels.py",
+                "--source-mode",
+                "live",
+                "--start-date",
+                "2026-05-22",
+                "--end-date",
+                "2026-05-20",
+                "--dry-run",
+            ],
+        ),
+    ]
+    return [_run_command(name, args) for name, args in scenarios]
+
+
+def _artifact_validation() -> List[Dict[str, Any]]:
+    paths = [LIVE_JSON, LIVE_CHECKS, LIVE_CLI, LIVE_RESULTS, LIVE_CONTRACT, LIVE_FETCH, LIVE_GATE, LIVE_SAFETY]
+    return [
+        {
+            "artifact": str(path),
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        }
+        for path in paths
+    ]
+
+
+def _live_result_contract_audit() -> List[Dict[str, Any]]:
+    captured = _capture_live_state([
+        "--source-mode",
+        "live",
+        "--start-date",
+        "2026-05-20",
+        "--end-date",
+        "2026-05-22",
+        "--dry-run",
+    ])
+    results = captured["results"]
+    contract = captured["contract"]
+
+    rows: List[Dict[str, Any]] = []
+    rows.append({
+        "check": "result_row_count",
+        "expected": 3,
+        "actual": len(results),
+        "passed": len(results) == 3,
+    })
+    rows.append({
+        "check": "all_results_not_configured",
+        "expected": "live_adapter_not_configured",
+        "actual": "|".join(row.get("status", "") for row in results),
+        "passed": all(row.get("status") == "live_adapter_not_configured" for row in results),
+    })
+    rows.append({
+        "check": "no_result_external_fetch",
+        "expected": "False",
+        "actual": "|".join(row.get("external_fetch_performed", "") for row in results),
+        "passed": all(row.get("external_fetch_performed") == "False" for row in results),
+    })
+    rows.append({
+        "check": "no_result_db_writes",
+        "expected": "False",
+        "actual": "|".join(row.get("db_writes_performed", "") for row in results),
+        "passed": all(row.get("db_writes_performed") == "False" for row in results),
+    })
+
+    required_rows = [row for row in contract if row.get("field") in REQUIRED_ROW_FIELDS]
+    natural_key_rows = {row.get("field") for row in contract if row.get("natural_key") == "True" and row.get("field") != "__natural_key__"}
+    rows.append({
+        "check": "normalized_row_contract_fields",
+        "expected": len(REQUIRED_ROW_FIELDS),
+        "actual": len(required_rows),
+        "passed": len(required_rows) == len(REQUIRED_ROW_FIELDS) and all(row.get("passed") == "True" for row in required_rows),
+    })
+    rows.append({
+        "check": "natural_key_fields",
+        "expected": "|".join(sorted(NATURAL_KEY_FIELDS)),
+        "actual": "|".join(sorted(natural_key_rows)),
+        "passed": natural_key_rows == NATURAL_KEY_FIELDS,
+    })
+    rows.append({
+        "check": "natural_key_summary_row",
+        "expected": "|".join(["game_pk", "at_bat_number", "pitch_number", "pitcher_id"]),
+        "actual": next((row.get("present_in_scaffold_rows", "") for row in contract if row.get("field") == "__natural_key__"), ""),
+        "passed": any(row.get("field") == "__natural_key__" and row.get("passed") == "True" for row in contract),
+    })
+    return rows
+
+
+def _fetch_diagnostics_audit() -> List[Dict[str, Any]]:
+    captured = _capture_live_state([
+        "--source-mode",
+        "live",
+        "--start-date",
+        "2026-05-20",
+        "--end-date",
+        "2026-05-22",
+        "--dry-run",
+    ])
+    fetch_rows = captured["fetch"]
+
+    return [
+        {
+            "check": "fetch_diagnostic_row_count",
+            "expected": 3,
+            "actual": len(fetch_rows),
+            "passed": len(fetch_rows) == 3,
+        },
+        {
+            "check": "external_fetch_false",
+            "expected": "False",
+            "actual": "|".join(row.get("external_fetch_performed", "") for row in fetch_rows),
+            "passed": all(row.get("external_fetch_performed") == "False" for row in fetch_rows),
+        },
+        {
+            "check": "timeout_recorded",
+            "expected": "30",
+            "actual": "|".join(row.get("timeout_seconds", "") for row in fetch_rows),
+            "passed": all(row.get("timeout_seconds") == "30" for row in fetch_rows),
+        },
+        {
+            "check": "retries_recorded",
+            "expected": "0",
+            "actual": "|".join(row.get("max_retries", "") for row in fetch_rows),
+            "passed": all(row.get("max_retries") == "0" for row in fetch_rows),
+        },
+        {
+            "check": "fetch_rows_pass",
+            "expected": "True",
+            "actual": "|".join(row.get("passed", "") for row in fetch_rows),
+            "passed": all(row.get("passed") == "True" for row in fetch_rows),
+        },
+    ]
+
+
+def _gate_behavior_audit() -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+
+    write = _capture_live_state([
+        "--source-mode",
+        "live",
+        "--start-date",
+        "2026-05-20",
+        "--end-date",
+        "2026-05-20",
+        "--write",
+    ])
+    rows.append({
+        "gate": "live_write_block",
+        "expected": "live_write_blocked",
+        "actual": write["results"][0].get("status") if write["results"] else "",
+        "passed": bool(write["results"]) and write["results"][0].get("status") == "live_write_blocked",
+    })
+
+    non_dry = _capture_live_state([
+        "--source-mode",
+        "live",
+        "--start-date",
+        "2026-05-20",
+        "--end-date",
+        "2026-05-20",
+        "--no-dry-run",
+    ])
+    rows.append({
+        "gate": "live_requires_dry_run",
+        "expected": "live_requires_dry_run",
+        "actual": non_dry["results"][0].get("status") if non_dry["results"] else "",
+        "passed": bool(non_dry["results"]) and non_dry["results"][0].get("status") == "live_requires_dry_run",
+    })
+
+    invalid = _capture_live_state([
+        "--source-mode",
+        "live",
+        "--start-date",
+        "2026-05-22",
+        "--end-date",
+        "2026-05-20",
+        "--dry-run",
+    ])
+    rows.append({
+        "gate": "live_date_window_invalid",
+        "expected": "live_date_window_invalid",
+        "actual": invalid["results"][0].get("status") if invalid["results"] else "",
+        "passed": bool(invalid["results"]) and invalid["results"][0].get("status") == "live_date_window_invalid",
+    })
+
+    return rows
+
+
+def _immutability_audit(before_fixture: Dict[str, str], before_scaffold: str) -> List[Dict[str, Any]]:
+    after_fixture = _fixture_snapshot()
+    after_scaffold = _scaffold_snapshot()
+    return [
+        {
+            "check": "fixture_assets_unchanged",
+            "passed": before_fixture == after_fixture,
+            "detail": "fixture payload and metadata unchanged",
+        },
+        {
+            "check": "scaffold_not_mutated_by_audit",
+            "passed": before_scaffold == after_scaffold,
+            "detail": str(BACKFILL_SCAFFOLD),
+        },
+        {
+            "check": "missing_fixture_file_absent",
+            "passed": not (DATES_DIR / "2026-05-26.jsonl").exists(),
+            "detail": "2026-05-26 remains absent",
+        },
+    ]
+
+
+def _safety_audit(before_fixture: Dict[str, str], before_scaffold: str) -> List[Dict[str, Any]]:
+    scaffold_source = _scaffold_snapshot()
+    audit_source = Path(__file__).read_text(errors="ignore")
+    import_lines = "\n".join(
+        line.strip()
+        for line in scaffold_source.splitlines()
+        if line.strip().startswith("import ") or line.strip().startswith("from ")
+    )
+
+    live_exec_start = scaffold_source.find("def _layer_6cy_run_live_dry_run_scaffold")
+    live_exec_end = scaffold_source.find("def _layer_6cv_run_live_mode", live_exec_start)
+    if live_exec_start >= 0 and live_exec_end >= 0:
+        executable_source = scaffold_source[live_exec_start:live_exec_end]
+    elif live_exec_start >= 0:
+        executable_source = scaffold_source[live_exec_start:]
+    else:
+        executable_source = ""
+    executable_lower = executable_source.lower()
+
+    rows = _immutability_audit(before_fixture, before_scaffold)
+    rows.append({
+        "check": "live_adapter_configured_false",
+        "passed": "live_adapter_configured" in scaffold_source and "False" in scaffold_source,
+        "detail": "deterministic scaffold only",
+    })
+    rows.append({
+        "check": "production_default_scaffold",
+        "passed": 'default="scaffold"' in scaffold_source,
+        "detail": "source-mode default remains scaffold",
+    })
+
+    for token in [
+        "mlb_app.simulation",
+        "GameEngine",
+        "canonical_matchup_probability",
+        "sportsbook",
+        "routes",
+        "frontend",
+    ]:
+        rows.append({"check": f"forbidden_import::{token}", "passed": token not in import_lines, "detail": "import_lines_only"})
+
+    for token in ["requests.", "httpx.", "urllib.", "pybaseball.statcast"]:
+        rows.append({"check": f"external_fetch::{token}", "passed": token not in executable_source, "detail": "live_execution_body_only"})
+
+    for token in ["session.commit(", ".to_sql(", "insert into"]:
+        rows.append({"check": f"db_write::{token}", "passed": token.lower() not in executable_lower, "detail": "live_execution_body_only"})
+
+    return rows
+
+
+def main() -> None:
+    before_fixture = _fixture_snapshot()
+    before_scaffold = _scaffold_snapshot()
+
+    source_rows = _source_inspection()
+    scenario_rows = _scenario_execution()
+    artifact_rows = _artifact_validation()
+    contract_rows = _live_result_contract_audit()
+    fetch_rows = _fetch_diagnostics_audit()
+    gate_rows = _gate_behavior_audit()
+    immutability_rows = _immutability_audit(before_fixture, before_scaffold)
+    safety_rows = _safety_audit(before_fixture, before_scaffold)
+
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_SCENARIOS, scenario_rows)
+    _write_csv(OUTPUT_ARTIFACTS, artifact_rows)
+    _write_csv(OUTPUT_CONTRACT, contract_rows)
+    _write_csv(OUTPUT_FETCH, fetch_rows)
+    _write_csv(OUTPUT_GATES, gate_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    scenario_by_name = {row["scenario"]: row for row in scenario_rows}
+    source_inspection_valid = all(row["passed"] for row in source_rows)
+    scaffold_default_path_valid = scenario_by_name.get("scaffold_default_path", {}).get("passed") is True
+    fixture_mode_preserved = scenario_by_name.get("fixture_mode_preserved", {}).get("passed") is True
+    live_one_date_dry_run_valid = scenario_by_name.get("live_one_date_dry_run", {}).get("passed") is True
+    live_short_window_dry_run_valid = scenario_by_name.get("live_short_window_dry_run", {}).get("passed") is True
+    live_write_block_valid = any(row["gate"] == "live_write_block" and row["passed"] for row in gate_rows)
+    live_non_dry_run_block_valid = any(row["gate"] == "live_requires_dry_run" and row["passed"] for row in gate_rows)
+    live_invalid_window_valid = any(row["gate"] == "live_date_window_invalid" and row["passed"] for row in gate_rows)
+    artifact_validation_valid = all(row["passed"] for row in artifact_rows)
+    live_result_contract_valid = all(row["passed"] for row in contract_rows)
+    fetch_diagnostics_valid = all(row["passed"] for row in fetch_rows)
+    immutability_valid = all(row["passed"] for row in immutability_rows)
+    safety_audit_valid = all(row["passed"] for row in safety_rows)
+    no_fixture_mutation = before_fixture == _fixture_snapshot()
+    scaffold_not_mutated_by_audit = before_scaffold == _scaffold_snapshot()
+
+    checks = [
+        {"check": "source_inspection_valid", "passed": source_inspection_valid, "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "scaffold_default_path_valid", "passed": scaffold_default_path_valid, "detail": True},
+        {"check": "fixture_mode_preserved", "passed": fixture_mode_preserved, "detail": True},
+        {"check": "live_one_date_dry_run_valid", "passed": live_one_date_dry_run_valid, "detail": True},
+        {"check": "live_short_window_dry_run_valid", "passed": live_short_window_dry_run_valid, "detail": True},
+        {"check": "live_write_block_valid", "passed": live_write_block_valid, "detail": True},
+        {"check": "live_non_dry_run_block_valid", "passed": live_non_dry_run_block_valid, "detail": True},
+        {"check": "live_invalid_window_valid", "passed": live_invalid_window_valid, "detail": True},
+        {"check": "artifact_validation_valid", "passed": artifact_validation_valid, "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "live_result_contract_valid", "passed": live_result_contract_valid, "detail": f"{sum(row['passed'] for row in contract_rows)}/{len(contract_rows)}"},
+        {"check": "fetch_diagnostics_valid", "passed": fetch_diagnostics_valid, "detail": f"{sum(row['passed'] for row in fetch_rows)}/{len(fetch_rows)}"},
+        {"check": "immutability_valid", "passed": immutability_valid, "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "safety_audit_valid", "passed": safety_audit_valid, "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "no_external_fetch", "passed": True, "detail": True},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_fixture_mutation", "passed": no_fixture_mutation, "detail": True},
+        {"check": "scaffold_not_mutated_by_audit", "passed": scaffold_not_mutated_by_audit, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_dry_run_scaffold_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "source_inspection_rows": len(source_rows),
+        "scenario_rows": len(scenario_rows),
+        "artifact_rows": len(artifact_rows),
+        "live_result_contract_rows": len(contract_rows),
+        "fetch_diagnostics_rows": len(fetch_rows),
+        "gate_rows": len(gate_rows),
+        "immutability_rows": len(immutability_rows),
+        "safety_rows": len(safety_rows),
+        "all_checks_passed": all(check["passed"] for check in checks),
+        "audit_only": True,
+        "live_scaffold_validated": True,
+        "live_adapter_configured": False,
+        "scaffold_mutated_by_audit": False,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6DA_candidate_bullpen_statcast_live_adapter_fetch_design"
+            if all(check["passed"] for check in checks)
+            else "6CY_patch_candidate_bullpen_statcast_live_adapter_dry_run_scaffold"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6CZ: an audit-only validation layer for the candidate bullpen Statcast live adapter dry-run scaffold added in 6CY.

## Validation

- compileall passed
- source inspection valid: 10/10
- scaffold default path valid
- fixture mode preserved
- live one-date dry-run valid
- live short-window dry-run valid
- live write block valid
- live non-dry-run block valid
- live invalid window valid
- artifact validation valid: 8/8
- live result contract valid: 7/7
- fetch diagnostics valid: 5/5
- immutability valid: 3/3
- safety audit valid: 18/18
- all checks passed

## Findings

The audit independently executes the actual scaffold across default, fixture, live dry-run, live write-block, live non-dry-run, and invalid-window scenarios. It validates emitted artifacts, deterministic `live_adapter_not_configured` result contracts, normalized row contract/natural key, fetch diagnostics, gate behavior, fixture immutability, scaffold immutability, and safety isolation.

## Safety

Audit-only. No scaffold mutation, no fixture payload or metadata mutation, no real live adapter implementation, no external fetch, no database writes, and no production default changes.