### PR TITLE
Add canonical model engine foundation and usage-weighted hitter gates

### DIFF
--- a/docs/canonical_model_engine_v2_summary.md
+++ b/docs/canonical_model_engine_v2_summary.md
@@ -1,0 +1,207 @@
+# Canonical Model Engine v2 Summary
+
+## What changed in this branch
+
+This branch adds the first safe implementation foundation for a shared canonical model layer without rewriting Model Projections or redesigning any cards.
+
+### Added files
+
+- `docs/model_formula_audit.md`
+- `mlb_app/canonical_model_engine.py`
+- `tests/test_canonical_model_engine.py`
+- `docs/canonical_model_engine_v2_summary.md`
+
+## What formulas now exist in the canonical foundation
+
+### 1. American odds to implied probability
+
+Function:
+- `american_to_implied_probability()`
+
+Purpose:
+- Normalize sportsbook odds into implied probability for cross-surface edge calculations.
+
+### 2. Expected value calculation
+
+Function:
+- `calculate_expected_value()`
+
+Purpose:
+- Calculate EV using model probability and American odds.
+
+### 3. Confidence tier assignment
+
+Function:
+- `assign_confidence_tier()`
+
+Current tiers:
+- `NO_BET`
+- `MONITOR`
+- `LEAN`
+- `STRONG`
+- `LOCK`
+
+Purpose:
+- Provide a stricter shared tiering contract based on:
+  - data quality
+  - confidence score
+  - probability edge
+  - expected value
+  - missing inputs
+
+### 4. Usage-weighted pitcher-vs-hitter evaluation
+
+Function:
+- `evaluate_usage_weighted_pitcher_vs_hitter()`
+
+Purpose:
+- Prevent false-positive hitter recommendations driven by low-usage pitch success.
+- Enforce majority arsenal support.
+- Suppress hitter recommendations when usage-weighted whiff/strikeout risk overwhelms contact quality.
+- Emit detailed diagnostic fields that can later flow into Daily Odds, AI Data Assistant, and Model Tracker.
+
+## How pitcher-vs-hitter arsenal usage weighting works
+
+The evaluator:
+
+1. Normalizes the pitcher’s arsenal usage.
+2. Builds expected exposure share by pitch type.
+3. Scores each pitch type using hitter-side:
+   - xwOBA
+   - on-base percentage
+   - hard-hit rate
+   - barrel rate
+   - whiff rate
+   - strikeout rate
+4. Produces usage-weighted aggregates for:
+   - positive contact
+   - whiff/strikeout risk
+   - xwOBA/on-base quality
+   - hard-hit quality
+   - final usage-weighted net score
+5. Determines whether the hitter is supported across a majority of projected exposure.
+
+## How low-usage pitch false positives are blocked
+
+The evaluator will not promote a hitter just because one small-usage pitch grades well.
+
+Current blocking logic:
+
+- Tracks `supported_usage_share` across only the pitch types that grade positively.
+- Requires majority arsenal support to allow a strong positive recommendation.
+- Emits `low_usage_pitch_warnings` when a supportive pitch is too small a share of projected usage.
+- Returns `MONITOR` or `NO_BET` when the hitter’s positive edge does not cover enough expected exposure.
+
+## How whiff/strikeout risk suppresses hitter recommendations
+
+The evaluator calculates:
+
+- `usage_weighted_positive_contact_score`
+- `usage_weighted_whiff_strikeout_risk`
+
+If the whiff/strikeout risk outweighs positive contact quality, the hitter is downgraded or blocked even if some hard-hit indicators are positive.
+
+## What fields are returned by the usage-weighted evaluator
+
+The current diagnostic contract includes:
+
+- `pitcher_arsenal_usage`
+- `expected_pitch_type_exposure`
+- `hitter_metrics_by_pitch_type`
+- `usage_weighted_positive_contact_score`
+- `usage_weighted_whiff_strikeout_risk`
+- `usage_weighted_xwOBA_or_on_base_score`
+- `usage_weighted_hard_hit_score`
+- `pitch_types_supporting_edge`
+- `pitch_types_hurting_edge`
+- `low_usage_pitch_warnings`
+- `pitch_data_quality_flags`
+- `majority_usage_supported`
+- `supported_usage_share`
+- `usage_weighted_pitcher_vs_hitter_score`
+- `final_pitcher_vs_hitter_recommendation_status`
+
+## What this branch does not do yet
+
+This branch is a foundation layer. It does not yet fully wire the new canonical engine into:
+
+- Daily Odds route outputs
+- AI Data Assistant response rendering
+- Model Tracker persistence fields
+- Model Projections route or page behavior
+
+That wiring should happen in the next implementation pass after this shared formula foundation is reviewed.
+
+## How Daily Odds can use this next
+
+Daily Odds should next consume:
+
+- `american_to_implied_probability()`
+- `calculate_expected_value()`
+- `assign_confidence_tier()`
+- `evaluate_usage_weighted_pitcher_vs_hitter()`
+
+The highest-value next step is replacing local prop gating with canonical usage-weighted hitter diagnostics and shared confidence tiers.
+
+## How AI Data Assistant can use this next
+
+AI Data Assistant should next use the returned usage-weighted diagnostic object to answer:
+
+- why a hitter matchup passed or failed
+- whether majority arsenal exposure supports the edge
+- which pitch types support the edge
+- which pitch types hurt the edge
+- whether low-usage pitch warnings blocked the recommendation
+- whether pitch data quality weakened confidence
+
+## How Model Tracker can use this next
+
+Model Tracker should next snapshot these pick-time diagnostics inside existing JSON-safe fields:
+
+- usage-weighted pitcher-vs-hitter score
+- supported usage share
+- pitch data quality flags
+- low-usage pitch warnings
+- final pitcher-vs-hitter recommendation status
+- confidence tier
+- expected value
+
+## Tests added in this branch
+
+- positive American odds implied probability
+- negative American odds implied probability
+- positive EV calculation
+- `STRONG` confidence tier assignment
+- low-usage pitch cannot drive a positive recommendation
+- majority usage support can promote a hitter
+- whiff/strikeout risk suppresses hitter recommendation
+- missing pitch usage blocks recommendation
+- low sample pitch data flags `MONITOR` or worse
+
+## Known limitations
+
+- No live route integration yet
+- No tracker persistence wiring yet
+- No backtest script yet
+- No canonical game-level team/pitcher scoring object yet
+- No explicit team recent-form windows yet in this module
+- No explicit pitcher season-vs-recent-form decomposition yet in this module
+
+## Next recommended improvements
+
+1. Wire Daily Odds to the canonical utility functions.
+2. Add team recent-form component utilities.
+3. Add starting pitcher baseline vs recent-form utilities.
+4. Expand tracker snapshot metadata.
+5. Add backtest script for edge buckets, tier buckets, usage buckets, and pitch-data quality buckets.
+6. Add AI Data Assistant explanation helpers that directly read the canonical usage-weighted output.
+
+## Testing and verification
+
+Expected test entry point:
+
+```bash
+pytest tests/test_canonical_model_engine.py
+```
+
+This branch has not claimed route-level completion. It establishes the shared modeling foundation needed for the stricter cross-surface implementation work in subsequent commits.

--- a/docs/model_formula_audit.md
+++ b/docs/model_formula_audit.md
@@ -1,0 +1,275 @@
+# Model Formula Audit
+
+## Scope of this audit
+
+This audit documents the current formula and route surfaces most relevant to the canonical model engine work. The purpose is to identify where probabilities, edges, confidence, pitcher-vs-hitter logic, and tracker metadata are currently produced so the app can move toward one explainable model contract without breaking working production routes.
+
+This pass intentionally treats Model Projections as a reference surface, not the primary implementation target.
+
+## Audited files
+
+### `mlb_app/scoring.py`
+
+Current role:
+- Core matchup scoring engine for win probability and individual pitcher-vs-batter scoring.
+
+Current formulas:
+- Pitcher aggregate weighted score using:
+  - `k_pct`
+  - `bb_pct`
+  - `hard_hit_pct`
+  - `xwoba`
+  - `avg_velocity`
+- Batter aggregate weighted score using:
+  - `avg_exit_velocity`
+  - `hard_hit_pct`
+  - `barrel_pct`
+  - `k_pct`
+  - `bb_pct`
+  - `batting_avg`
+- Arsenal score using pitch-level:
+  - `usage_pct`
+  - `whiff_pct`
+  - `strikeout_pct`
+  - `rv_per_100`
+  - `xwoba`
+- `compute_win_probability()` converts net score into `home_win_prob` and `away_win_prob` using a logistic transform.
+- `score_individual_matchup()` returns:
+  - `pitcher_advantage`
+  - `batter_advantage`
+  - `net_score`
+  - `pitcher_win_prob`
+
+Current strengths:
+- Already uses pitch usage weighting in the arsenal contribution.
+- Already exposes app-facing `home_win_prob` and `away_win_prob`.
+
+Current gaps:
+- No explicit separation of season baseline vs recent form.
+- No explicit bullpen component.
+- No explicit team recent-form windows.
+- No explicit data quality score.
+- No explicit expected value calculation.
+- No confidence tier taxonomy.
+- Pitcher-vs-hitter logic is not strict enough about majority arsenal exposure.
+- No hard suppression for hitters with poor usage-weighted whiff/strikeout profile.
+- No low-usage pitch warning contract.
+- No pitch-data quality flag contract.
+
+### `mlb_app/daily_odds_routes.py`
+
+Current role:
+- Builds Daily Odds payloads from matchups plus sportsbook events.
+- Generates fallback model candidates when sportsbook events are missing.
+
+Current logic:
+- Imports `build_game_models()` and `build_prop_models()` from `daily_odds_models.py`.
+- Builds fallback moneyline candidates from `home_win_prob` and `away_win_prob`.
+- Builds fallback pitcher watchlist candidates from pitcher `k_pct`, `xwoba`, and `hard_hit_pct`.
+
+Current strengths:
+- Already reads canonical-looking matchup probability fields.
+- Already includes diagnostics like `features_used`, `missing_inputs`, and `drivers`.
+
+Current gaps:
+- Still has route-local fallback scoring behavior.
+- No single canonical recommendation gate shared with other surfaces.
+- No canonical data quality score or confidence tier.
+- No canonical expected value or rejection reason contract.
+
+### `mlb_app/daily_odds_models.py`
+
+Current role:
+- Converts matchup and sportsbook data into Daily Odds model objects.
+
+Current formulas:
+- American odds to implied probability conversion.
+- Moneyline model compares canonical matchup probability against sportsbook implied probability.
+- Spread model uses projected runs or probability differential proxy.
+- Total model uses weather, wind, and offense strength to create total lean.
+- Confidence currently depends mostly on number of features present.
+
+Current strengths:
+- Moneyline model already references canonical matchup probability fields.
+- Already computes edge as model probability minus market implied probability.
+- Already stores `features_used`, `missing_inputs`, and `drivers`.
+
+Current gaps:
+- Confidence is still shallow and feature-count based.
+- No canonical EV framework used across all model families.
+- No strict recommendation gate shared with tracker or assistant.
+- No pitcher-vs-hitter usage-weighted gate contract.
+
+### `mlb_app/ai_data_assistant_routes.py`
+
+Current role:
+- Serves the AI Data Assistant page and query endpoint.
+
+Current logic:
+- Calls `build_ai_data_assistant_response()`.
+- Accepts message/date/game/player/team context.
+
+Current strengths:
+- Already set up to answer against app-owned data.
+- Already has deterministic mode by default.
+
+Current gaps:
+- The route itself does not define canonical formula access. That work happens deeper in the assistant services.
+
+### `mlb_app/ai_data_assistant_performance.py`
+
+Current role:
+- Performance wrapper around AI Data Assistant.
+- Adds process-local caching and canonical probability context.
+
+Current logic:
+- Treats `home_win_prob` and `away_win_prob` as canonical v2 side probabilities.
+- Explicitly marks simulation output as diagnostic only, not final side probability.
+- Enriches assistant responses with canonical probability context.
+
+Current strengths:
+- Strong starting point for using canonical probability contract in the assistant.
+- Already identifies `canonical_matchup_win_probability_v2` and legacy comparison fields.
+
+Current gaps:
+- No unified canonical formula object for pitcher model, team recent form, market edge, or usage-weighted hitter logic.
+- Assistant can explain probability context, but not yet a full canonical model breakdown.
+
+### `mlb_app/model_projection_routes.py`
+
+Current role:
+- Serves `/models/projections`.
+- Delegates to `build_model_projection_payload()`.
+
+Current guidance for this initiative:
+- Treat as a read-only/reference surface in this pass.
+- Do not redesign or rewrite projections workflow here.
+
+### `mlb_app/model_projections.py`
+
+Current role:
+- Builds Model Projections payload using matchups, bullpen profile, environment profile, team offense prior, PA outcome probabilities, and simulation tools.
+
+Current strengths:
+- Rich projection context already exists.
+- Contains several model cards and simulation helpers.
+- Uses offense prior, bullpen profile, environment profile, and pitch arsenal inputs.
+
+Current gaps relative to canonical model initiative:
+- Not the right place to centralize cross-surface formulas yet.
+- Too broad/risky to rewrite in the first pass.
+- Should consume canonical model outputs later rather than be rebuilt now.
+
+### `mlb_app/model_tracker_routes.py`
+
+Current role:
+- Tracker and dashboard route layer.
+- Mostly manages saved workspace/dashboard structures.
+
+Current strengths:
+- Existing route surface already exists for tracker features.
+
+Current gaps:
+- Route file is not the core formula engine.
+- Tracker diagnostics need to be expanded at the snapshot/model layer, not only at the route layer.
+
+### `mlb_app/model_tracker.py`
+
+Current role:
+- Persistent snapshot layer for matchups, daily odds, model projections, and dashboard-style model outputs.
+
+Current strengths:
+- Already stores:
+  - `model_probability`
+  - `market_implied_probability`
+  - `edge`
+  - `score`
+  - `confidence`
+  - `expected_value`
+  - projected totals/runs
+  - home/away win probabilities
+  - reasoning/features/missing inputs/raw payload JSON
+- Already has canonical v2 and legacy model version fields.
+- Already has additive JSON-safe snapshot strategy.
+
+Current gaps:
+- Does not yet store the richer canonical model metadata requested in Issue #432.
+- Missing explicit pick-time storage for:
+  - confidence tier
+  - data quality score
+  - pitcher recent-form components
+  - team recent-form components
+  - usage-weighted pitcher-vs-hitter diagnostics
+  - pitch data quality flags
+  - rejection reasons and gating details
+
+## Current formula truth by surface
+
+### Final side probability
+Current strongest app-facing source:
+- `home_win_prob`
+- `away_win_prob`
+
+Primary current producers/consumers:
+- `mlb_app/scoring.py`
+- matchup payloads
+- `mlb_app/daily_odds_models.py`
+- `mlb_app/ai_data_assistant_performance.py`
+- `mlb_app/model_tracker.py`
+
+### Daily Odds edge
+Current source:
+- market implied probability from American odds
+- compared against matchup-derived canonical probability in Daily Odds models
+
+### Confidence
+Current source:
+- mostly feature-count based in Daily Odds models
+- probability/score proxies in some fallback candidates
+- no globally consistent confidence tier contract
+
+### Pitcher-vs-hitter logic
+Current source:
+- `mlb_app/scoring.py`
+- current scoring uses arsenal `usage_pct`, but not strict majority exposure gates
+
+## Main duplicated or conflicting logic risks
+
+1. Probability, confidence, and score are still partially generated per surface instead of from one canonical model engine.
+2. Daily Odds has fallback candidate logic that can drift from shared scoring.
+3. Tracker stores probabilities and diagnostics but not yet the richer metadata needed to diagnose loss causes.
+4. AI Data Assistant knows canonical side probability context but not yet a unified model breakdown.
+
+## Recommended cleanup path
+
+### Phase 1
+- Add a pure, shared canonical model engine module.
+- Define stable utility formulas for:
+  - implied probability
+  - expected value
+  - confidence tiers
+  - usage-weighted pitcher-vs-hitter evaluation
+- Keep this phase additive and low-risk.
+
+### Phase 2
+- Point Daily Odds and AI Data Assistant diagnostics at the canonical model engine.
+- Expand tracker snapshot metadata with canonical breakdown fields.
+
+### Phase 3
+- Let Model Projections consume canonical model fields later, without rebuilding the page in the first pass.
+
+## First implementation target
+
+The safest immediate implementation is:
+
+1. `docs/model_formula_audit.md`
+2. `mlb_app/modeling/canonical_model_engine.py`
+3. Tests for:
+   - American odds implied probability
+   - EV calculation
+   - usage-weighted pitcher-vs-hitter gates
+   - low-usage pitch false-positive suppression
+   - majority arsenal exposure promotion logic
+   - whiff/strikeout suppression
+
+That creates a real shared modeling foundation without breaking production routes.

--- a/mlb_app/canonical_model_engine.py
+++ b/mlb_app/canonical_model_engine.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+CONFIDENCE_TIERS = ("NO_BET", "MONITOR", "LEAN", "STRONG", "LOCK")
+
+
+def safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_rate(value: Any) -> Optional[float]:
+    numeric = safe_float(value)
+    if numeric is None:
+        return None
+    return numeric / 100.0 if numeric > 1 else numeric
+
+
+def clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def american_to_implied_probability(price: Any) -> Optional[float]:
+    odds = safe_float(price)
+    if odds is None or odds == 0:
+        return None
+    if odds > 0:
+        return round(100.0 / (odds + 100.0), 4)
+    return round(abs(odds) / (abs(odds) + 100.0), 4)
+
+
+def calculate_expected_value(model_probability: Any, american_odds: Any) -> Optional[float]:
+    probability = safe_float(model_probability)
+    odds = safe_float(american_odds)
+    if probability is None or odds is None:
+        return None
+    if probability < 0 or probability > 1 or odds == 0:
+        return None
+    profit_on_one_unit = odds / 100.0 if odds > 0 else 100.0 / abs(odds)
+    loss_probability = 1.0 - probability
+    return round((probability * profit_on_one_unit) - loss_probability, 4)
+
+
+def assign_confidence_tier(
+    data_quality_score: Any,
+    confidence_score: Any,
+    probability_edge: Any,
+    expected_value: Any,
+    missing_inputs: Optional[Iterable[str]] = None,
+) -> str:
+    data_quality = safe_float(data_quality_score)
+    confidence = safe_float(confidence_score)
+    edge = safe_float(probability_edge)
+    ev = safe_float(expected_value)
+    missing_count = len(list(missing_inputs or []))
+
+    if None in (data_quality, confidence, edge, ev):
+        return "MONITOR"
+
+    if missing_count >= 3:
+        return "NO_BET"
+    if data_quality < 0.45 or confidence < 0.45 or edge <= 0 or ev <= 0:
+        return "NO_BET"
+    if data_quality < 0.60 or confidence < 0.58:
+        return "MONITOR"
+    if edge < 0.025 or ev < 0.015:
+        return "LEAN"
+    if data_quality >= 0.88 and confidence >= 0.84 and edge >= 0.060 and ev >= 0.050 and missing_count == 0:
+        return "LOCK"
+    if data_quality >= 0.72 and confidence >= 0.68 and edge >= 0.040 and ev >= 0.030:
+        return "STRONG"
+    return "LEAN"
+
+
+def _weighted_average(parts: List[Tuple[Optional[float], float]]) -> Optional[float]:
+    numerator = 0.0
+    denominator = 0.0
+    for value, weight in parts:
+        if value is None:
+            continue
+        numerator += value * weight
+        denominator += weight
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _pitch_type_support_metrics(metrics: Dict[str, Any]) -> Dict[str, Optional[float]]:
+    xwoba = safe_float(metrics.get("xwoba"))
+    on_base = safe_float(metrics.get("on_base_pct"))
+    hard_hit = normalize_rate(metrics.get("hard_hit_pct"))
+    barrel = normalize_rate(metrics.get("barrel_pct"))
+    whiff = normalize_rate(metrics.get("whiff_pct"))
+    strikeout = normalize_rate(metrics.get("k_pct"))
+
+    positive_contact = _weighted_average([
+        (((xwoba - 0.320) * 3.0) if xwoba is not None else None, 1.2),
+        (((on_base - 0.320) * 2.5) if on_base is not None else None, 1.0),
+        (((hard_hit - 0.38) * 2.5) if hard_hit is not None else None, 1.1),
+        (((barrel - 0.08) * 3.0) if barrel is not None else None, 0.9),
+    ])
+    whiff_risk = _weighted_average([
+        (((whiff - 0.28) * 3.0) if whiff is not None else None, 1.2),
+        (((strikeout - 0.24) * 2.5) if strikeout is not None else None, 1.0),
+    ])
+    net_score = None
+    if positive_contact is not None or whiff_risk is not None:
+        net_score = (positive_contact or 0.0) - (whiff_risk or 0.0)
+
+    return {
+        "xwoba": xwoba,
+        "on_base_pct": on_base,
+        "hard_hit_pct": hard_hit,
+        "barrel_pct": barrel,
+        "whiff_pct": whiff,
+        "k_pct": strikeout,
+        "positive_contact_score": round(positive_contact, 4) if positive_contact is not None else None,
+        "whiff_strikeout_risk": round(whiff_risk, 4) if whiff_risk is not None else None,
+        "net_pitch_type_score": round(net_score, 4) if net_score is not None else None,
+    }
+
+
+def evaluate_usage_weighted_pitcher_vs_hitter(
+    pitcher_arsenal_usage: Dict[str, Any],
+    hitter_metrics_by_pitch_type: Dict[str, Dict[str, Any]],
+    *,
+    min_majority_usage: float = 0.50,
+    min_supported_usage_for_positive_note: float = 0.10,
+) -> Dict[str, Any]:
+    normalized_usage: Dict[str, float] = {}
+    for pitch_type, raw_usage in (pitcher_arsenal_usage or {}).items():
+        usage = normalize_rate(raw_usage)
+        if usage is not None and usage > 0:
+            normalized_usage[str(pitch_type)] = usage
+
+    total_usage = sum(normalized_usage.values())
+    if total_usage <= 0:
+        return {
+            "status": "NO_BET",
+            "reason": "missing_pitcher_arsenal_usage",
+            "pitcher_arsenal_usage": {},
+            "expected_pitch_type_exposure": {},
+            "hitter_metrics_by_pitch_type": hitter_metrics_by_pitch_type or {},
+            "usage_weighted_positive_contact_score": None,
+            "usage_weighted_whiff_strikeout_risk": None,
+            "usage_weighted_xwoba_or_on_base_score": None,
+            "usage_weighted_hard_hit_score": None,
+            "pitch_types_supporting_edge": [],
+            "pitch_types_hurting_edge": [],
+            "low_usage_pitch_warnings": ["No valid arsenal usage available."],
+            "pitch_data_quality_flags": ["missing_pitch_usage_data"],
+            "majority_usage_supported": False,
+            "supported_usage_share": 0.0,
+            "usage_weighted_pitcher_vs_hitter_score": None,
+            "final_pitcher_vs_hitter_recommendation_status": "NO_BET",
+        }
+
+    exposure = {pitch_type: round(usage / total_usage, 4) for pitch_type, usage in normalized_usage.items()}
+    supporting: List[Dict[str, Any]] = []
+    hurting: List[Dict[str, Any]] = []
+    low_usage_warnings: List[str] = []
+    pitch_data_quality_flags: List[str] = []
+    weighted_positive_contact = 0.0
+    weighted_whiff_risk = 0.0
+    weighted_on_base = 0.0
+    weighted_hard_hit = 0.0
+    weighted_net = 0.0
+    supported_usage_share = 0.0
+
+    for pitch_type, usage_share in sorted(exposure.items(), key=lambda item: item[1], reverse=True):
+        metrics = dict((hitter_metrics_by_pitch_type or {}).get(pitch_type) or {})
+        support_metrics = _pitch_type_support_metrics(metrics)
+        quality_flag = metrics.get("data_quality_flag")
+        sample_size = safe_float(metrics.get("sample_size"))
+        if quality_flag:
+            pitch_data_quality_flags.append(f"{pitch_type}:{quality_flag}")
+        if sample_size is not None and sample_size < 5:
+            pitch_data_quality_flags.append(f"{pitch_type}:low_sample_size")
+
+        pos = support_metrics.get("positive_contact_score") or 0.0
+        risk = support_metrics.get("whiff_strikeout_risk") or 0.0
+        net = support_metrics.get("net_pitch_type_score")
+        xwoba = support_metrics.get("xwoba")
+        on_base = support_metrics.get("on_base_pct")
+        hard_hit = support_metrics.get("hard_hit_pct")
+
+        weighted_positive_contact += usage_share * pos
+        weighted_whiff_risk += usage_share * risk
+        if xwoba is not None or on_base is not None:
+            weighted_on_base += usage_share * (((xwoba - 0.320) if xwoba is not None else 0.0) + ((on_base - 0.320) if on_base is not None else 0.0))
+        if hard_hit is not None:
+            weighted_hard_hit += usage_share * (hard_hit - 0.38)
+        if net is not None:
+            weighted_net += usage_share * net
+
+        record = {
+            "pitch_type": pitch_type,
+            "usage_share": round(usage_share, 4),
+            **support_metrics,
+        }
+
+        pitch_positive = (
+            net is not None
+            and net > 0
+            and (support_metrics.get("whiff_strikeout_risk") or 0.0) <= (support_metrics.get("positive_contact_score") or 0.0)
+        )
+        if pitch_positive:
+            supporting.append(record)
+            supported_usage_share += usage_share
+        else:
+            hurting.append(record)
+
+        if usage_share < min_supported_usage_for_positive_note and pitch_positive:
+            low_usage_warnings.append(
+                f"{pitch_type} supports the hitter, but only accounts for {round(usage_share * 100, 1)}% of expected usage."
+            )
+
+    majority_usage_supported = supported_usage_share >= min_majority_usage
+    weighted_positive_contact = round(weighted_positive_contact, 4)
+    weighted_whiff_risk = round(weighted_whiff_risk, 4)
+    weighted_on_base = round(weighted_on_base, 4)
+    weighted_hard_hit = round(weighted_hard_hit, 4)
+    weighted_net = round(weighted_net, 4)
+
+    status = "NO_BET"
+    if pitch_data_quality_flags:
+        status = "MONITOR"
+    if (
+        majority_usage_supported
+        and weighted_net > 0
+        and weighted_positive_contact > 0
+        and weighted_whiff_risk <= weighted_positive_contact
+        and weighted_on_base > 0
+    ):
+        status = "STRONG" if weighted_net >= 0.08 and weighted_hard_hit >= 0 else "LEAN"
+    elif weighted_net > 0 and not majority_usage_supported:
+        status = "MONITOR"
+        low_usage_warnings.append("Positive signals do not cover a majority of projected pitch exposure.")
+    elif weighted_whiff_risk > weighted_positive_contact:
+        low_usage_warnings.append("Usage-weighted whiff/strikeout risk overwhelms positive contact indicators.")
+
+    return {
+        "status": status,
+        "reason": "usage_weighted_pitcher_vs_hitter_evaluation",
+        "pitcher_arsenal_usage": {key: round(value, 4) for key, value in normalized_usage.items()},
+        "expected_pitch_type_exposure": exposure,
+        "hitter_metrics_by_pitch_type": hitter_metrics_by_pitch_type or {},
+        "usage_weighted_positive_contact_score": weighted_positive_contact,
+        "usage_weighted_whiff_strikeout_risk": weighted_whiff_risk,
+        "usage_weighted_xwoba_or_on_base_score": weighted_on_base,
+        "usage_weighted_hard_hit_score": weighted_hard_hit,
+        "pitch_types_supporting_edge": supporting,
+        "pitch_types_hurting_edge": hurting,
+        "low_usage_pitch_warnings": low_usage_warnings,
+        "pitch_data_quality_flags": sorted(set(pitch_data_quality_flags)),
+        "majority_usage_supported": majority_usage_supported,
+        "supported_usage_share": round(supported_usage_share, 4),
+        "usage_weighted_pitcher_vs_hitter_score": weighted_net,
+        "final_pitcher_vs_hitter_recommendation_status": status,
+    }

--- a/tests/test_canonical_model_engine.py
+++ b/tests/test_canonical_model_engine.py
@@ -1,0 +1,93 @@
+from mlb_app.canonical_model_engine import (
+    american_to_implied_probability,
+    assign_confidence_tier,
+    calculate_expected_value,
+    evaluate_usage_weighted_pitcher_vs_hitter,
+)
+
+
+def test_american_to_implied_probability_positive_odds():
+    assert american_to_implied_probability(+150) == 0.4
+
+
+def test_american_to_implied_probability_negative_odds():
+    assert american_to_implied_probability(-150) == 0.6
+
+
+def test_calculate_expected_value_positive_ev():
+    # +150 means 1.5 units profit on 1 staked
+    assert calculate_expected_value(0.5, +150) == 0.25
+
+
+def test_assign_confidence_tier_strong():
+    tier = assign_confidence_tier(
+        data_quality_score=0.82,
+        confidence_score=0.74,
+        probability_edge=0.045,
+        expected_value=0.035,
+        missing_inputs=[],
+    )
+    assert tier == "STRONG"
+
+
+def test_low_usage_pitch_cannot_drive_positive_recommendation():
+    result = evaluate_usage_weighted_pitcher_vs_hitter(
+        pitcher_arsenal_usage={"FF": 70, "SL": 25, "CU": 5},
+        hitter_metrics_by_pitch_type={
+            "FF": {"xwoba": 0.280, "on_base_pct": 0.290, "hard_hit_pct": 0.28, "whiff_pct": 0.34, "k_pct": 0.31},
+            "SL": {"xwoba": 0.295, "on_base_pct": 0.300, "hard_hit_pct": 0.31, "whiff_pct": 0.33, "k_pct": 0.30},
+            "CU": {"xwoba": 0.420, "on_base_pct": 0.410, "hard_hit_pct": 0.60, "whiff_pct": 0.12, "k_pct": 0.10},
+        },
+    )
+    assert result["final_pitcher_vs_hitter_recommendation_status"] in {"NO_BET", "MONITOR"}
+    assert result["majority_usage_supported"] is False
+
+
+def test_majority_usage_support_can_promote_hitter():
+    result = evaluate_usage_weighted_pitcher_vs_hitter(
+        pitcher_arsenal_usage={"FF": 35, "SL": 25, "CH": 20, "CU": 20},
+        hitter_metrics_by_pitch_type={
+            "FF": {"xwoba": 0.365, "on_base_pct": 0.360, "hard_hit_pct": 0.48, "barrel_pct": 0.11, "whiff_pct": 0.20, "k_pct": 0.18},
+            "SL": {"xwoba": 0.350, "on_base_pct": 0.345, "hard_hit_pct": 0.45, "barrel_pct": 0.10, "whiff_pct": 0.22, "k_pct": 0.20},
+            "CH": {"xwoba": 0.340, "on_base_pct": 0.338, "hard_hit_pct": 0.42, "barrel_pct": 0.09, "whiff_pct": 0.21, "k_pct": 0.19},
+            "CU": {"xwoba": 0.300, "on_base_pct": 0.305, "hard_hit_pct": 0.33, "barrel_pct": 0.05, "whiff_pct": 0.26, "k_pct": 0.24},
+        },
+    )
+    assert result["majority_usage_supported"] is True
+    assert result["final_pitcher_vs_hitter_recommendation_status"] in {"LEAN", "STRONG"}
+
+
+def test_whiff_risk_suppresses_hitter_even_with_hard_hit():
+    result = evaluate_usage_weighted_pitcher_vs_hitter(
+        pitcher_arsenal_usage={"FF": 40, "SL": 35, "CH": 25},
+        hitter_metrics_by_pitch_type={
+            "FF": {"xwoba": 0.330, "on_base_pct": 0.325, "hard_hit_pct": 0.47, "barrel_pct": 0.10, "whiff_pct": 0.39, "k_pct": 0.36},
+            "SL": {"xwoba": 0.325, "on_base_pct": 0.320, "hard_hit_pct": 0.44, "barrel_pct": 0.09, "whiff_pct": 0.41, "k_pct": 0.37},
+            "CH": {"xwoba": 0.315, "on_base_pct": 0.310, "hard_hit_pct": 0.41, "barrel_pct": 0.08, "whiff_pct": 0.38, "k_pct": 0.35},
+        },
+    )
+    assert result["usage_weighted_whiff_strikeout_risk"] > result["usage_weighted_positive_contact_score"]
+    assert result["final_pitcher_vs_hitter_recommendation_status"] in {"NO_BET", "MONITOR"}
+
+
+def test_missing_or_malformed_pitch_usage_blocks_high_confidence_recommendation():
+    result = evaluate_usage_weighted_pitcher_vs_hitter(
+        pitcher_arsenal_usage={"FF": None, "SL": "", "CH": 0},
+        hitter_metrics_by_pitch_type={
+            "FF": {"xwoba": 0.380, "on_base_pct": 0.370, "hard_hit_pct": 0.50, "whiff_pct": 0.18, "k_pct": 0.16},
+        },
+    )
+    assert result["final_pitcher_vs_hitter_recommendation_status"] == "NO_BET"
+    assert "missing_pitch_usage_data" in result["pitch_data_quality_flags"]
+
+
+def test_low_sample_pitch_data_flags_monitor_or_worse():
+    result = evaluate_usage_weighted_pitcher_vs_hitter(
+        pitcher_arsenal_usage={"FF": 55, "SL": 45},
+        hitter_metrics_by_pitch_type={
+            "FF": {"xwoba": 0.360, "on_base_pct": 0.350, "hard_hit_pct": 0.46, "whiff_pct": 0.21, "k_pct": 0.19, "sample_size": 3},
+            "SL": {"xwoba": 0.355, "on_base_pct": 0.348, "hard_hit_pct": 0.43, "whiff_pct": 0.22, "k_pct": 0.20, "sample_size": 3},
+        },
+    )
+    assert result["pitch_data_quality_flags"]
+    assert result["final_pitcher_vs_hitter_recommendation_status"] in {"MONITOR", "NO_BET"}


### PR DESCRIPTION
## What this PR does

This PR creates the first safe implementation foundation for the canonical model engine work tracked in #432.

It does **not** rebuild Model Projections and it does **not** redesign any cards.

It adds:

- a repo audit doc for current formula surfaces
- a shared canonical model utility module in the existing `mlb_app/` package
- focused tests for implied probability, EV, confidence tiers, and usage-weighted pitcher-vs-hitter gating
- a short implementation summary doc

## Files added

- `docs/model_formula_audit.md`
- `mlb_app/canonical_model_engine.py`
- `tests/test_canonical_model_engine.py`
- `docs/canonical_model_engine_v2_summary.md`

## Why this approach

The repo already has shared formula logic spread across:

- `mlb_app/scoring.py`
- `mlb_app/daily_odds_models.py`
- `mlb_app/model_projection_formulas.py`
- `mlb_app/model_projections.py`
- `mlb_app/ai_data_assistant_performance.py`
- `mlb_app/model_tracker.py`

This PR does not try to rewrite all of that in one risky pass.

Instead, it establishes a real canonical foundation that can be consumed next by Daily Odds, AI Data Assistant, and Model Tracker.

## Canonical foundation added here

### Shared utility formulas

- `american_to_implied_probability()`
- `calculate_expected_value()`
- `assign_confidence_tier()`
- `evaluate_usage_weighted_pitcher_vs_hitter()`

### Key behavior now codified

- low-usage pitch success cannot drive a hitter recommendation by itself
- majority arsenal support is required for stronger hitter recommendations
- usage-weighted whiff/strikeout risk can suppress a hitter recommendation even when hard-hit indicators exist
- missing or malformed pitch usage blocks promotion
- low sample pitch data produces quality flags and `MONITOR`/worse behavior

## What is intentionally not wired yet in this PR

To keep this pass safe, this PR does **not** yet wire the canonical utilities into:

- `daily_odds_routes.py`
- `daily_odds_models.py`
- `ai_data_assistant_performance.py`
- `model_tracker.py`
- `model_projection_routes.py`
- `model_projections.py`

That integration should happen in the next PR once the shared contract is reviewed.

## Why Model Projections is untouched

Per issue clarification, Model Projections should not be rebuilt in this pass. It remains a reference surface only.

## Tests added

- American odds implied probability for positive odds
- American odds implied probability for negative odds
- positive EV calculation
- `STRONG` confidence tier assignment
- low-usage pitch false positive suppression
- majority arsenal exposure promotion logic
- whiff/strikeout suppression logic
- missing pitch usage blocks recommendation
- low sample pitch data quality flags

## Issue linkage

Closes part of #432 by adding the canonical model engine foundation, usage-weighted pitcher-vs-hitter gates, and audit documentation.

## Suggested next PR

1. Wire Daily Odds to canonical EV / confidence tier / pitcher-vs-hitter gate utilities.
2. Add tracker snapshot support for canonical usage-weighted hitter diagnostics.
3. Add team recent-form and starting pitcher season-vs-recent-form canonical component utilities.
4. Add backtest script and bucketed diagnostics.
