### PR TITLE
Add tracker and AI assistant support for canonical Daily Odds diagnostics

### DIFF
--- a/mlb_app/ai_data_assistant_performance.py
+++ b/mlb_app/ai_data_assistant_performance.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import copy
 import time
 from contextvars import ContextVar
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from . import ai_data_assistant as core
+from .daily_odds_models import build_game_models
+from .daily_odds_routes import _build_global_prop_candidates, _build_matchup_index, _load_matchups
 from .model_projections import build_model_projection_payload as uncached_build_model_projection_payload
+from .odds_provider import fetch_draftkings_events
 from .shared_payload_cache import clear_shared_payload_cache, env_ttl, get_cache, get_or_set, make_cache_key, set_cache, stable_hash
 
 AI_RESPONSE_TTL_SECONDS = 180
@@ -36,12 +39,6 @@ def _add_timing(name: str, elapsed_ms: int) -> None:
 
 
 def cached_build_model_projection_payload(session, target_date: str) -> Dict[str, Any]:
-    """Shared TTL cache for the expensive model projection payload.
-
-    This monkey-patches the imported symbol inside `mlb_app.ai_data_assistant`, so
-    all existing v2 builders keep their current code path while sharing the same
-    process-local projection cache contract as `/models/projections`.
-    """
     cache_key = make_cache_key("model_projection", "full", target_date)
     ttl_seconds = env_ttl("MODEL_PROJECTION_CACHE_TTL_SECONDS")
 
@@ -73,11 +70,6 @@ def cached_build_model_projection_payload(session, target_date: str) -> Dict[str
 
 
 def apply_performance_patch() -> None:
-    """Patch the existing v1/v2 service path once per process.
-
-    No new route, page, or duplicate assistant service is created. The existing
-    `ai_data_assistant.py` functions still do the product logic.
-    """
     global _patch_applied
     if _patch_applied:
         return
@@ -177,6 +169,92 @@ def _build_canonical_probability_context(session, context: Dict[str, Any], game_
     }
 
 
+def _compact_daily_odds_game_model(model: Dict[str, Any], label: str, game_pk: Optional[int]) -> Dict[str, Any]:
+    return {
+        "game_pk": game_pk,
+        "label": label,
+        "market": model.get("market"),
+        "pick": model.get("pick"),
+        "model_probability": _safe_float(model.get("model_probability")),
+        "market_implied_probability": _safe_float(model.get("market_implied_probability")),
+        "edge": _safe_float(model.get("edge")),
+        "expected_value": _safe_float(model.get("expected_value")),
+        "confidence_tier": model.get("confidence_tier"),
+        "recommendation_status": model.get("recommendation_status"),
+        "rejection_reason": model.get("rejection_reason"),
+        "drivers": model.get("drivers") or [],
+    }
+
+
+def _compact_daily_odds_prop_candidate(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    diagnostics = candidate.get("diagnostics") or {}
+    return {
+        "game_pk": candidate.get("game_pk"),
+        "label": f"{candidate.get('away_team') or 'Away'} @ {candidate.get('home_team') or 'Home'}",
+        "market": candidate.get("market"),
+        "pick": candidate.get("pick"),
+        "player_name": candidate.get("player_name"),
+        "model_probability": _safe_float(candidate.get("model_probability")),
+        "market_implied_probability": _safe_float(candidate.get("market_implied_probability")),
+        "edge": _safe_float(candidate.get("edge")),
+        "expected_value": _safe_float(candidate.get("expected_value")),
+        "confidence_tier": candidate.get("confidence_tier"),
+        "data_quality_score": _safe_float(candidate.get("data_quality_score")),
+        "recommendation_status": candidate.get("recommendation_status"),
+        "rejection_reason": candidate.get("rejection_reason"),
+        "usage_weighted_gate": diagnostics.get("usage_weighted_gate"),
+        "drivers": candidate.get("drivers") or [],
+    }
+
+
+def _build_daily_odds_diagnostics_context(session, context: Dict[str, Any], game_pk: Optional[int] = None) -> Dict[str, Any]:
+    date = context.get("date") or core.today()
+    start = _now()
+    try:
+        matchups, matchup_errors = _load_matchups(date)
+        if game_pk is not None:
+            matchups = [m for m in matchups if str(m.get("game_pk")) == str(game_pk)]
+        matchup_index = _build_matchup_index(matchups)
+        events = fetch_draftkings_events(date) or []
+        game_models: List[Dict[str, Any]] = []
+        for event in events:
+            key = f"{(event.get('away_team') or {}).get('name','').lower()}@{(event.get('home_team') or {}).get('name','').lower()}"
+            matchup = matchup_index.get(key)
+            if not matchup:
+                continue
+            if game_pk is not None and str(matchup.get("game_pk")) != str(game_pk):
+                continue
+            models = build_game_models(matchup, event)
+            label = f"{matchup.get('away_team_name') or matchup.get('away_team')} @ {matchup.get('home_team_name') or matchup.get('home_team')}"
+            for market_name in ("moneyline", "spread", "total"):
+                model = models.get(market_name)
+                if isinstance(model, dict):
+                    game_models.append(_compact_daily_odds_game_model(model, label, matchup.get("game_pk")))
+        game_models.sort(key=lambda row: abs(row.get("edge") or 0.0), reverse=True)
+        prop_candidates = _build_global_prop_candidates(events, matchup_index, matchups, limit=12)
+        if game_pk is not None:
+            prop_candidates = [c for c in prop_candidates if str(c.get("game_pk")) == str(game_pk)]
+        top_prop_candidates = [_compact_daily_odds_prop_candidate(c) for c in prop_candidates[:6]]
+        _add_timing("daily_odds_diagnostics_context_ms", _ms(start))
+        return {
+            "available": bool(game_models or top_prop_candidates),
+            "date": date,
+            "top_game_models": game_models[:6],
+            "top_prop_candidates": top_prop_candidates,
+            "matchup_errors": matchup_errors,
+            "event_count": len(events),
+            "source_note": "Daily Odds diagnostics include EV, confidence tier, data quality, recommendation status, and optional usage-weighted hitter gate output.",
+        }
+    except Exception as exc:
+        return {
+            "available": False,
+            "date": date,
+            "error": str(exc),
+            "top_game_models": [],
+            "top_prop_candidates": [],
+        }
+
+
 def _canonical_answer_prefix(canonical_context: Dict[str, Any]) -> str:
     if not canonical_context.get("available"):
         return (
@@ -199,11 +277,42 @@ def _canonical_answer_prefix(canonical_context: Dict[str, Any]) -> str:
     )
 
 
-def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_context: Dict[str, Any]) -> Dict[str, Any]:
+def _daily_odds_answer_prefix(daily_odds_context: Dict[str, Any]) -> str:
+    if not daily_odds_context.get("available"):
+        return (
+            "Daily Odds note\n"
+            "Daily Odds diagnostics were not available for this query.\n"
+        )
+    game_models = daily_odds_context.get("top_game_models") or []
+    prop_candidates = daily_odds_context.get("top_prop_candidates") or []
+    lead_game = game_models[0] if game_models else {}
+    lead_prop = prop_candidates[0] if prop_candidates else {}
+    game_line = ""
+    if lead_game:
+        game_line = (
+            f"Top game model: {lead_game.get('label')} | {lead_game.get('market')} | {lead_game.get('pick')} | "
+            f"edge {_pct(lead_game.get('edge')) or lead_game.get('edge')} | EV {lead_game.get('expected_value')} | "
+            f"tier {lead_game.get('confidence_tier') or 'unknown'} | status {lead_game.get('recommendation_status') or 'unknown'}. "
+        )
+    prop_line = ""
+    if lead_prop:
+        gate = lead_prop.get("usage_weighted_gate") or {}
+        gate_status = gate.get("final_pitcher_vs_hitter_recommendation_status") or gate.get("status")
+        prop_line = (
+            f"Top prop candidate: {lead_prop.get('player_name') or 'unknown player'} | {lead_prop.get('market')} | {lead_prop.get('pick')} | "
+            f"EV {lead_prop.get('expected_value')} | tier {lead_prop.get('confidence_tier') or 'unknown'} | "
+            f"status {lead_prop.get('recommendation_status') or 'unknown'}"
+            + (f" | usage gate {gate_status}." if gate_status else ".")
+        )
+    return "Daily Odds note\n" + game_line + prop_line + "\n"
+
+
+def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_context: Dict[str, Any], daily_odds_context: Dict[str, Any]) -> Dict[str, Any]:
     enriched = copy.deepcopy(result)
     enriched["canonical_probability_context"] = canonical_context
+    enriched["daily_odds_diagnostics_context"] = daily_odds_context
     sources = list(enriched.get("sources_used") or [])
-    for source in ["canonical_matchup_probability_v2", "matchups.home_win_prob_and_away_win_prob"]:
+    for source in ["canonical_matchup_probability_v2", "matchups.home_win_prob_and_away_win_prob", "daily_odds_models"]:
         if source not in sources:
             sources.append(source)
     enriched["sources_used"] = sources
@@ -215,12 +324,17 @@ def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_cont
             "simulation_role": canonical_context.get("simulation_role"),
             "games_loaded": len(canonical_context.get("games") or []),
         }
-    note = _canonical_answer_prefix(canonical_context)
+        enriched["data_quality"]["daily_odds_diagnostics"] = {
+            "available": daily_odds_context.get("available"),
+            "game_model_count": len(daily_odds_context.get("top_game_models") or []),
+            "prop_candidate_count": len(daily_odds_context.get("top_prop_candidates") or []),
+        }
+    note = _canonical_answer_prefix(canonical_context) + _daily_odds_answer_prefix(daily_odds_context)
     answer = enriched.get("answer") or ""
     if "Canonical probability note" not in answer:
         enriched["answer"] = note + "\n" + answer
     confidence_note = enriched.get("confidence_note") or ""
-    canonical_note = " Canonical v2 is the final side probability; simulations are diagnostic/run-distribution context only."
+    canonical_note = " Canonical v2 is the final side probability; simulations are diagnostic/run-distribution context only. Daily Odds diagnostics include EV, confidence tier, recommendation status, and optional hitter-usage gate output."
     if canonical_note.strip() not in confidence_note:
         enriched["confidence_note"] = confidence_note + canonical_note
     return enriched
@@ -249,6 +363,7 @@ def _build_ai_data_assistant_response_uncached(
         timing["context_build_ms"] = _ms(context_start)
 
     canonical_context = _build_canonical_probability_context(session, context, game_pk=game_pk)
+    daily_odds_context = _build_daily_odds_diagnostics_context(session, context, game_pk=game_pk)
 
     answer_start = _now()
     result = core.answer_with_optional_llm(message, context, use_llm=use_llm)
@@ -256,7 +371,7 @@ def _build_ai_data_assistant_response_uncached(
         timing["answer_render_ms"] = _ms(answer_start)
         timing["llm_requested"] = 1 if use_llm else 0
 
-    result = _enrich_result_with_canonical_context(result, canonical_context)
+    result = _enrich_result_with_canonical_context(result, canonical_context, daily_odds_context)
     return result
 
 
@@ -269,15 +384,6 @@ def build_ai_data_assistant_response(
     team_id: Optional[int] = None,
     use_llm: bool = False,
 ) -> Dict[str, Any]:
-    """Fast wrapper for the existing AI Data Assistant service.
-
-    Adds:
-    - shared process-local TTL response cache for repeated chip clicks
-    - shared process-local TTL Model Projection cache by date
-    - deterministic answers by default
-    - canonical probability context on every response
-    - timing metadata on every response
-    """
     apply_performance_patch()
     total_start = _now()
     timing: Dict[str, float] = {}

--- a/mlb_app/canonical_model_engine.py
+++ b/mlb_app/canonical_model_engine.py
@@ -264,3 +264,141 @@ def evaluate_usage_weighted_pitcher_vs_hitter(
         "usage_weighted_pitcher_vs_hitter_score": weighted_net,
         "final_pitcher_vs_hitter_recommendation_status": status,
     }
+
+
+def build_team_recent_form_component(
+    season_score: Any,
+    l30_score: Any,
+    l15_score: Any,
+    l7_score: Any = None,
+    *,
+    home_away_context: Any = None,
+    vs_handedness_context: Any = None,
+) -> Dict[str, Any]:
+    season = safe_float(season_score)
+    l30 = safe_float(l30_score)
+    l15 = safe_float(l15_score)
+    l7 = safe_float(l7_score)
+    home_away = safe_float(home_away_context)
+    handedness = safe_float(vs_handedness_context)
+
+    weighted_score = _weighted_average([
+        (season, 0.40),
+        (l30, 0.25),
+        (l15, 0.20),
+        (l7, 0.10),
+        (home_away, 0.03),
+        (handedness, 0.02),
+    ])
+    current = _weighted_average([
+        (l30, 0.45),
+        (l15, 0.35),
+        (l7, 0.20),
+    ])
+    recent_form_delta = None
+    if current is not None and season is not None:
+        recent_form_delta = round(current - season, 4)
+    trend = "stable"
+    if recent_form_delta is not None:
+        if recent_form_delta >= 0.03:
+            trend = "improving"
+        elif recent_form_delta <= -0.03:
+            trend = "declining"
+    missing_inputs = [
+        name for name, value in {
+            "season_score": season,
+            "l30_score": l30,
+            "l15_score": l15,
+            "l7_score": l7,
+            "home_away_context": home_away,
+            "vs_handedness_context": handedness,
+        }.items() if value is None
+    ]
+    data_quality = round(clamp(1.0 - (len(missing_inputs) * 0.12), 0.25, 1.0), 3)
+    return {
+        "team_offense_season_score": round(season, 4) if season is not None else None,
+        "team_offense_l30_score": round(l30, 4) if l30 is not None else None,
+        "team_offense_l15_score": round(l15, 4) if l15 is not None else None,
+        "team_offense_l7_score": round(l7, 4) if l7 is not None else None,
+        "team_home_away_context": round(home_away, 4) if home_away is not None else None,
+        "team_vs_handedness_context": round(handedness, 4) if handedness is not None else None,
+        "team_recent_form_score": round(weighted_score, 4) if weighted_score is not None else None,
+        "team_recent_form_delta": recent_form_delta,
+        "team_recent_form_trend": trend,
+        "team_recent_form_data_quality": data_quality,
+        "missing_inputs": missing_inputs,
+    }
+
+
+def build_starting_pitcher_component(
+    season_baseline_score: Any,
+    recent_form_score: Any,
+    k_bb_score: Any,
+    contact_quality_allowed_score: Any,
+    arsenal_quality_score: Any,
+    platoon_risk_score: Any,
+    expected_workload_score: Any,
+    *,
+    velocity_or_stuff_trend: Any = None,
+    command_trend: Any = None,
+) -> Dict[str, Any]:
+    season = safe_float(season_baseline_score)
+    recent = safe_float(recent_form_score)
+    kbb = safe_float(k_bb_score)
+    contact = safe_float(contact_quality_allowed_score)
+    arsenal = safe_float(arsenal_quality_score)
+    platoon = safe_float(platoon_risk_score)
+    workload = safe_float(expected_workload_score)
+    velocity = safe_float(velocity_or_stuff_trend)
+    command = safe_float(command_trend)
+
+    weighted_score = _weighted_average([
+        (season, 0.24),
+        (recent, 0.20),
+        (kbb, 0.16),
+        (contact, 0.16),
+        (arsenal, 0.10),
+        (-platoon if platoon is not None else None, 0.06),
+        (workload, 0.04),
+        (velocity, 0.02),
+        (command, 0.02),
+    ])
+    recent_delta = None
+    if recent is not None and season is not None:
+        recent_delta = round(recent - season, 4)
+    trend = "stable"
+    if recent_delta is not None:
+        if recent_delta >= 0.03 or (velocity is not None and velocity >= 0.03) or (command is not None and command >= 0.03):
+            trend = "improving"
+        elif recent_delta <= -0.03 or (velocity is not None and velocity <= -0.03) or (command is not None and command <= -0.03):
+            trend = "declining"
+    missing_inputs = [
+        name for name, value in {
+            "season_baseline_score": season,
+            "recent_form_score": recent,
+            "k_bb_score": kbb,
+            "contact_quality_allowed_score": contact,
+            "arsenal_quality_score": arsenal,
+            "platoon_risk_score": platoon,
+            "expected_workload_score": workload,
+            "velocity_or_stuff_trend": velocity,
+            "command_trend": command,
+        }.items() if value is None
+    ]
+    data_quality = round(clamp(1.0 - (len(missing_inputs) * 0.10), 0.25, 1.0), 3)
+    return {
+        "pitcher_season_baseline_score": round(season, 4) if season is not None else None,
+        "pitcher_recent_form_score": round(recent, 4) if recent is not None else None,
+        "pitcher_k_bb_score": round(kbb, 4) if kbb is not None else None,
+        "pitcher_contact_quality_allowed_score": round(contact, 4) if contact is not None else None,
+        "pitcher_arsenal_quality_score": round(arsenal, 4) if arsenal is not None else None,
+        "pitcher_platoon_risk_score": round(platoon, 4) if platoon is not None else None,
+        "pitcher_expected_workload_score": round(workload, 4) if workload is not None else None,
+        "pitcher_velocity_or_stuff_trend": round(velocity, 4) if velocity is not None else None,
+        "pitcher_command_trend": round(command, 4) if command is not None else None,
+        "pitcher_component_score": round(weighted_score, 4) if weighted_score is not None else None,
+        "pitcher_recent_form_delta": recent_delta,
+        "pitcher_trend": trend,
+        "pitcher_data_quality_flags": missing_inputs,
+        "pitcher_data_quality_score": data_quality,
+    }

--- a/mlb_app/model_tracker.py
+++ b/mlb_app/model_tracker.py
@@ -216,11 +216,6 @@ def _team_name(value: Any) -> Optional[str]:
 
 
 def _canonical_probability_bundle(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract canonical v2 diagnostics from any matchup/projection-shaped payload.
-
-    This intentionally returns a JSON-safe bundle that can be stored in the
-    existing text columns. No schema migration is required.
-    """
     probs = payload.get("main_matchup_probabilities") if isinstance(payload.get("main_matchup_probabilities"), dict) else payload
     workspace = payload.get("workspace") or {}
     canonical_workspace = workspace.get("canonicalMatchupProbability") or {}
@@ -276,6 +271,20 @@ def _canonical_reasoning(bundle: Dict[str, Any], extra: Optional[Dict[str, Any]]
         },
         "extra": extra or {},
     }
+
+
+def _daily_odds_tracker_extra(model: Dict[str, Any], bundle: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    extra = {
+        "confidence_tier": model.get("confidence_tier"),
+        "data_quality_score": model.get("data_quality_score"),
+        "recommendation_status": model.get("recommendation_status"),
+        "rejection_reason": model.get("rejection_reason"),
+        "expected_value": model.get("expected_value"),
+        "usage_weighted_gate": (model.get("diagnostics") or {}).get("usage_weighted_gate"),
+    }
+    if bundle is not None:
+        extra["canonical_probability"] = bundle
+    return extra
 
 
 def _team_pick_from_canonical(bundle: Dict[str, Any], home_team: Any, away_team: Any) -> tuple[Optional[str], Optional[float]]:
@@ -363,6 +372,7 @@ def normalize_daily_odds_rows(payload: Dict[str, Any], target_date: str) -> List
             reasoning = {
                 "drivers": model.get("drivers") or model.get("reasoning") or [],
                 "canonical_probability": bundle,
+                "daily_odds_diagnostics": _daily_odds_tracker_extra(model, bundle),
                 "market_context_note": "Daily Odds compares sportsbook implied probability against canonical probability; odds do not define canonical probability.",
             }
             rows.append(_base_row(
@@ -390,15 +400,23 @@ def normalize_daily_odds_rows(payload: Dict[str, Any], target_date: str) -> List
                 away_win_probability=bundle.get("canonical_away_win_prob"),
                 primary_reason=_short_reason(model.get("drivers") or model.get("reasoning") or model.get("primary_reason"), "Daily Odds model output."),
                 reasoning_json=_json(reasoning),
-                features_used_json=_json(model_features),
+                features_used_json=_json(model_features + [
+                    {"name": "confidence_tier", "value": model.get("confidence_tier"), "source": "daily_odds_models"},
+                    {"name": "data_quality_score", "value": model.get("data_quality_score"), "source": "daily_odds_models"},
+                    {"name": "recommendation_status", "value": model.get("recommendation_status"), "source": "daily_odds_models"},
+                ]),
                 missing_inputs_json=_json((model.get("missing_inputs") or []) + (bundle.get("missing_inputs") or [])),
-                raw_payload_json=_json({"game": game, "model": model, "canonical_probability": bundle}),
+                raw_payload_json=_json({"game": game, "model": model, "canonical_probability": bundle, "daily_odds_tracker_diagnostics": _daily_odds_tracker_extra(model, bundle)}),
                 grade="pending" if model.get("pick") else "ungraded",
                 result_status="pending",
             ))
     for candidate in payload.get("top_prop_model_candidates") or []:
         if not isinstance(candidate, dict):
             continue
+        reasoning = {
+            "drivers": candidate.get("drivers") or candidate.get("reasoning") or [],
+            "daily_odds_diagnostics": _daily_odds_tracker_extra(candidate),
+        }
         rows.append(_base_row(
             "daily_odds", target_date,
             source_endpoint="/daily-odds/models",
@@ -422,10 +440,14 @@ def normalize_daily_odds_rows(payload: Dict[str, Any], target_date: str) -> List
             price=_safe_float(candidate.get("price")),
             expected_value=_safe_float(candidate.get("expected_value")),
             primary_reason=_short_reason(candidate.get("drivers") or candidate.get("reasoning") or candidate.get("primary_reason"), "Daily Odds prop/watchlist candidate."),
-            reasoning_json=_json(candidate.get("drivers") or candidate.get("reasoning") or []),
-            features_used_json=_json(candidate.get("features_used") or []),
+            reasoning_json=_json(reasoning),
+            features_used_json=_json((candidate.get("features_used") or []) + [
+                {"name": "confidence_tier", "value": candidate.get("confidence_tier"), "source": "daily_odds_models"},
+                {"name": "data_quality_score", "value": candidate.get("data_quality_score"), "source": "daily_odds_models"},
+                {"name": "recommendation_status", "value": candidate.get("recommendation_status"), "source": "daily_odds_models"},
+            ]),
             missing_inputs_json=_json(candidate.get("missing_inputs") or []),
-            raw_payload_json=_json(candidate),
+            raw_payload_json=_json({**candidate, "daily_odds_tracker_diagnostics": _daily_odds_tracker_extra(candidate)}),
             grade="ungraded",
             grade_reason="Stored as watchlist output until explicit player-stat result mapping is available.",
             result_status="pending",
@@ -556,6 +578,7 @@ def normalize_dashboard_rows(component: str, payload: Dict[str, Any], target_dat
 
 def normalize_ai_data_assistant_rows(payload: Dict[str, Any], target_date: str, prompt: str) -> List[Dict[str, Any]]:
     canonical_context = payload.get("canonical_probability_context") or {}
+    daily_odds_context = payload.get("daily_odds_diagnostics_context") or {}
     return [_base_row(
         "ai_data_assistant", target_date,
         source_endpoint="/ai-data-assistant",
@@ -567,7 +590,7 @@ def normalize_ai_data_assistant_rows(payload: Dict[str, Any], target_date: str, 
         model_name="ai_data_assistant_deterministic",
         model_version=canonical_context.get("model_version") or CANONICAL_MODEL_VERSION,
         primary_reason=_short_reason(payload.get("answer"), "AI Data Assistant deterministic answer captured."),
-        reasoning_json=_json({"canonical_probability_context": canonical_context, "sections": payload.get("sections") or []}),
+        reasoning_json=_json({"canonical_probability_context": canonical_context, "daily_odds_diagnostics_context": daily_odds_context, "sections": payload.get("sections") or []}),
         features_used_json=_json(payload.get("sources_used") or []),
         missing_inputs_json=_json(payload.get("missing_data") or []),
         raw_payload_json=_json(payload),
@@ -662,8 +685,10 @@ def _row_payload(row: ModelTrackerSnapshot) -> Dict[str, Any]:
     features = _loads(row.features_used_json) or []
     raw_payload = _loads(row.raw_payload_json)
     canonical_diagnostics = None
+    daily_odds_diagnostics = None
     if isinstance(reasoning, dict):
         canonical_diagnostics = reasoning.get("canonical_probability") or reasoning.get("canonical_probability_context")
+        daily_odds_diagnostics = reasoning.get("daily_odds_diagnostics") or reasoning.get("daily_odds_diagnostics_context")
     return {
         "id": row.id,
         "tracker_key": row.tracker_key,
@@ -705,6 +730,7 @@ def _row_payload(row: ModelTrackerSnapshot) -> Dict[str, Any]:
         "features_used": features,
         "missing_inputs": _loads(row.missing_inputs_json) or [],
         "canonical_diagnostics": canonical_diagnostics,
+        "daily_odds_diagnostics": daily_odds_diagnostics,
         "raw_payload": raw_payload,
         "game_status_at_snapshot": row.game_status_at_snapshot,
         "result_status": row.result_status,

--- a/tests/test_ai_data_assistant_performance.py
+++ b/tests/test_ai_data_assistant_performance.py
@@ -1,0 +1,34 @@
+from mlb_app.ai_data_assistant_performance import _daily_odds_answer_prefix
+
+
+def test_daily_odds_answer_prefix_includes_new_fields():
+    context = {
+        "available": True,
+        "top_game_models": [
+            {
+                "label": "Brewers @ Cubs",
+                "market": "moneyline",
+                "pick": "Cubs",
+                "edge": 0.0645,
+                "expected_value": 0.1183,
+                "confidence_tier": "STRONG",
+                "recommendation_status": "recommended",
+            }
+        ],
+        "top_prop_candidates": [
+            {
+                "player_name": "Mookie Betts",
+                "market": "batter_hits",
+                "pick": "Mookie Betts 1.5",
+                "expected_value": -0.07,
+                "confidence_tier": "NO_BET",
+                "recommendation_status": "no_bet",
+                "usage_weighted_gate": {"final_pitcher_vs_hitter_recommendation_status": "NO_BET"},
+            }
+        ],
+    }
+    note = _daily_odds_answer_prefix(context)
+    assert "Daily Odds note" in note
+    assert "moneyline" in note
+    assert "EV" in note
+    assert "usage gate NO_BET" in note

--- a/tests/test_canonical_model_engine.py
+++ b/tests/test_canonical_model_engine.py
@@ -1,6 +1,8 @@
 from mlb_app.canonical_model_engine import (
     american_to_implied_probability,
     assign_confidence_tier,
+    build_starting_pitcher_component,
+    build_team_recent_form_component,
     calculate_expected_value,
     evaluate_usage_weighted_pitcher_vs_hitter,
 )
@@ -15,7 +17,6 @@ def test_american_to_implied_probability_negative_odds():
 
 
 def test_calculate_expected_value_positive_ev():
-    # +150 means 1.5 units profit on 1 staked
     assert calculate_expected_value(0.5, +150) == 0.25
 
 
@@ -91,3 +92,34 @@ def test_low_sample_pitch_data_flags_monitor_or_worse():
     )
     assert result["pitch_data_quality_flags"]
     assert result["final_pitcher_vs_hitter_recommendation_status"] in {"MONITOR", "NO_BET"}
+
+
+def test_team_recent_form_component_identifies_improving_trend():
+    result = build_team_recent_form_component(
+        season_score=0.51,
+        l30_score=0.55,
+        l15_score=0.59,
+        l7_score=0.62,
+        home_away_context=0.57,
+        vs_handedness_context=0.58,
+    )
+    assert result["team_recent_form_trend"] == "improving"
+    assert result["team_recent_form_score"] is not None
+    assert result["team_recent_form_delta"] > 0
+
+
+def test_starting_pitcher_component_identifies_declining_trend():
+    result = build_starting_pitcher_component(
+        season_baseline_score=0.64,
+        recent_form_score=0.57,
+        k_bb_score=0.61,
+        contact_quality_allowed_score=0.52,
+        arsenal_quality_score=0.58,
+        platoon_risk_score=0.14,
+        expected_workload_score=0.55,
+        velocity_or_stuff_trend=-0.05,
+        command_trend=-0.04,
+    )
+    assert result["pitcher_trend"] == "declining"
+    assert result["pitcher_component_score"] is not None
+    assert result["pitcher_recent_form_delta"] < 0

--- a/tests/test_model_tracker_daily_odds.py
+++ b/tests/test_model_tracker_daily_odds.py
@@ -1,0 +1,96 @@
+from mlb_app.model_tracker import normalize_ai_data_assistant_rows, normalize_daily_odds_rows
+
+
+def test_normalize_daily_odds_rows_stores_new_diagnostics_in_json_columns():
+    payload = {
+        "games": [
+            {
+                "game_pk": 123,
+                "event_id": "evt1",
+                "away_team": "Brewers",
+                "home_team": "Cubs",
+                "home_win_prob": 0.61,
+                "away_win_prob": 0.39,
+                "model_version": "canonical_matchup_win_probability_v2",
+                "lineup_status": "confirmed",
+                "data_confidence": "high",
+                "models": {
+                    "moneyline": {
+                        "model": "moneyline_canonical_v2",
+                        "market": "moneyline",
+                        "pick": "Cubs",
+                        "model_probability": 0.61,
+                        "market_implied_probability": 0.5455,
+                        "edge": 0.0645,
+                        "score": 0.61,
+                        "confidence": 0.82,
+                        "price": -120,
+                        "expected_value": 0.1183,
+                        "confidence_tier": "STRONG",
+                        "data_quality_score": 0.94,
+                        "recommendation_status": "recommended",
+                        "rejection_reason": None,
+                        "drivers": ["canonical probability", "positive edge"],
+                        "features_used": [{"name": "home_win_prob", "value": 0.61}],
+                        "missing_inputs": [],
+                        "diagnostics": {"usage_weighted_gate": None},
+                    }
+                },
+            }
+        ],
+        "top_prop_model_candidates": [
+            {
+                "game_pk": 123,
+                "event_id": "evt1",
+                "away_team": "Brewers",
+                "home_team": "Cubs",
+                "player_name": "Mookie Betts",
+                "market": "batter_hits",
+                "pick": "Mookie Betts 1.5",
+                "model_probability": 0.44,
+                "market_implied_probability": 0.48,
+                "edge": -0.04,
+                "score": 0.04,
+                "confidence": 0.66,
+                "price": 110,
+                "expected_value": -0.076,
+                "confidence_tier": "NO_BET",
+                "data_quality_score": 0.71,
+                "recommendation_status": "no_bet",
+                "rejection_reason": "non_positive_edge",
+                "drivers": ["usage-weighted gate suppressed over"],
+                "features_used": [],
+                "missing_inputs": ["pitch_data_quality_review"],
+                "diagnostics": {
+                    "usage_weighted_gate": {
+                        "final_pitcher_vs_hitter_recommendation_status": "NO_BET",
+                        "supported_usage_share": 0.22,
+                    }
+                },
+            }
+        ],
+    }
+
+    rows = normalize_daily_odds_rows(payload, "2026-05-24")
+    assert len(rows) == 2
+    moneyline = rows[0]
+    prop = rows[1]
+    assert "confidence_tier" in (moneyline["reasoning_json"] or "")
+    assert "recommendation_status" in (moneyline["reasoning_json"] or "")
+    assert "daily_odds_tracker_diagnostics" in (prop["raw_payload_json"] or "")
+    assert "NO_BET" in (prop["raw_payload_json"] or "")
+
+
+def test_normalize_ai_data_assistant_rows_preserves_daily_odds_context():
+    payload = {
+        "answer": "Here is the current model view.",
+        "canonical_probability_context": {"model_version": "canonical_matchup_win_probability_v2"},
+        "daily_odds_diagnostics_context": {"available": True, "top_game_models": [{"market": "moneyline"}]},
+        "sources_used": ["canonical_matchup_probability_v2", "daily_odds_models"],
+        "missing_data": [],
+        "sections": [],
+    }
+    rows = normalize_ai_data_assistant_rows(payload, "2026-05-24", "What does Daily Odds tell us?")
+    assert len(rows) == 1
+    row = rows[0]
+    assert "daily_odds_diagnostics_context" in (row["reasoning_json"] or "")


### PR DESCRIPTION
## What this PR does

This PR is the next implementation step after the merged Daily Odds canonical wiring.

It adds three things in the sequence requested:

1. **Model Tracker storage** for the new Daily Odds fields using existing JSON columns, not a risky schema migration.
2. **AI Data Assistant explainability** for those same Daily Odds diagnostics.
3. New shared utilities for:
   - team recent-form decomposition
   - starting pitcher season-vs-recent decomposition

Model Projections are still untouched.

## Included

### 1. Model Tracker capture for Daily Odds diagnostics

`mlb_app/model_tracker.py` now stores additional Daily Odds metadata inside existing JSON-safe tracker payloads, including:

- `confidence_tier`
- `data_quality_score`
- `recommendation_status`
- `rejection_reason`
- `expected_value`
- `usage_weighted_gate` when present for batter props

These are persisted through:

- `reasoning_json`
- `features_used_json`
- `raw_payload_json`

No physical DB migration was introduced.

### 2. AI Data Assistant Daily Odds explainability context

`mlb_app/ai_data_assistant_performance.py` now loads a lightweight Daily Odds diagnostics context and includes it in the assistant response.

It adds:

- `daily_odds_diagnostics_context`
- top game-model diagnostics
- top prop candidate diagnostics
- answer prefix text that can explain:
  - edge
  - EV
  - confidence tier
  - recommendation status
  - optional hitter usage gate status

This is additive and preserves the existing assistant flow.

### 3. New shared recent-form utilities

`mlb_app/canonical_model_engine.py` now includes:

- `build_team_recent_form_component()`
- `build_starting_pitcher_component()`

These utilities provide the first shared decomposition layer for:

- team season vs L30 / L15 / L7 context
- team recent-form delta and trend
- starting pitcher season baseline vs recent form
- pitcher K-BB / contact quality / arsenal / platoon / workload decomposition
- pitcher trend and data-quality flags

## Files changed

### Updated

- `mlb_app/canonical_model_engine.py`
- `mlb_app/model_tracker.py`
- `mlb_app/ai_data_assistant_performance.py`

### Added

- `tests/test_model_tracker_daily_odds.py`
- `tests/test_ai_data_assistant_performance.py`

### Updated tests

- `tests/test_canonical_model_engine.py`

## Why this approach is safe

- no Model Projections rebuild
- no card redesign
- no route contract breakage
- no physical tracker schema migration
- all new tracker diagnostics live in existing JSON columns
- assistant explainability is additive and stays inside the current cached response path

## Tests added

### Canonical utilities

- recent-form trend detection for teams
- season-vs-recent trend detection for pitchers

### Tracker

- Daily Odds rows persist the new diagnostic fields in JSON columns
- AI assistant tracker rows preserve Daily Odds diagnostics context

### AI assistant

- Daily Odds note includes EV, market, and usage-gate explanation text

## What is still not done in this PR

- no backtest script yet
- no full tracker reporting rollup by tier / bucket yet
- no full AI answer routing by these diagnostics yet
- no explicit game-level canonical recommendation object spanning all surfaces yet
- no Model Projections consumer wiring yet

## Next recommended PR

1. Add bucketed tracker summaries by:
   - confidence tier
   - data quality
   - edge bucket
   - pitcher recent-form bucket
   - team recent-form bucket
   - usage-gate bucket
2. Add a backtest script using the tracker snapshots.
3. Expand Daily Odds/AI/Tracker around the new team and pitcher component utilities.

## Issue linkage

Continues #432 by adding the next requested implementation sequence after the Daily Odds wiring merge.
