### PR TITLE
Add shared canonical game context across Daily Odds and Model Projections

### DIFF
--- a/mlb_app/ai_data_assistant_performance.py
+++ b/mlb_app/ai_data_assistant_performance.py
@@ -112,6 +112,7 @@ def _canonical_games_from_projection_payload(payload: Dict[str, Any], game_pk: O
         if game_pk is not None and str(game.get("game_pk")) != str(game_pk):
             continue
         probs = game.get("main_matchup_probabilities") or {}
+        context = game.get("canonical_game_context") or (game.get("workspace") or {}).get("canonicalGameContext") or {}
         home_team = (game.get("home_team") or {}).get("name") if isinstance(game.get("home_team"), dict) else game.get("home_team")
         away_team = (game.get("away_team") or {}).get("name") if isinstance(game.get("away_team"), dict) else game.get("away_team")
         home_prob = _safe_float(probs.get("home_win_prob") or game.get("home_win_prob"))
@@ -136,6 +137,7 @@ def _canonical_games_from_projection_payload(payload: Dict[str, Any], game_pk: O
             "probability_component_keys": sorted((probs.get("probability_components") or game.get("probability_components") or {}).keys()),
             "simulation_role": simulation_diag.get("status") or "diagnostic_only_not_final_probability",
             "simulation_is_final_probability": False,
+            "canonical_game_context": context,
         })
         if len(rows) >= limit and game_pk is None:
             break
@@ -170,6 +172,7 @@ def _build_canonical_probability_context(session, context: Dict[str, Any], game_
 
 
 def _compact_daily_odds_game_model(model: Dict[str, Any], label: str, game_pk: Optional[int]) -> Dict[str, Any]:
+    diagnostics = model.get("diagnostics") or {}
     return {
         "game_pk": game_pk,
         "label": label,
@@ -183,6 +186,7 @@ def _compact_daily_odds_game_model(model: Dict[str, Any], label: str, game_pk: O
         "recommendation_status": model.get("recommendation_status"),
         "rejection_reason": model.get("rejection_reason"),
         "drivers": model.get("drivers") or [],
+        "canonical_game_context": diagnostics.get("canonical_game_context") or model.get("canonical_game_context"),
     }
 
 
@@ -204,6 +208,7 @@ def _compact_daily_odds_prop_candidate(candidate: Dict[str, Any]) -> Dict[str, A
         "rejection_reason": candidate.get("rejection_reason"),
         "usage_weighted_gate": diagnostics.get("usage_weighted_gate"),
         "drivers": candidate.get("drivers") or [],
+        "canonical_game_context": diagnostics.get("canonical_game_context") or candidate.get("canonical_game_context"),
     }
 
 
@@ -269,11 +274,15 @@ def _canonical_answer_prefix(canonical_context: Dict[str, Any]) -> str:
     confidence = best.get("data_confidence") or "unknown"
     lineup = best.get("lineup_status") or "unknown"
     components = ", ".join(best.get("probability_component_keys") or []) or "component diagnostics missing"
+    game_context = best.get("canonical_game_context") or {}
+    total_runs = game_context.get("projected_total_runs")
     return (
         "Canonical probability note\n"
         f"Final side probability comes from canonical v2 `home_win_prob` and `away_win_prob`, not the simulation diagnostic. "
         f"Top loaded game: {best.get('label') or 'unknown game'}; side lean {favorite} at {favorite_prob}; confidence {confidence}; lineup status {lineup}. "
-        f"Components available: {components}.\n"
+        f"Components available: {components}."
+        + (f" Shared game context projected total: {total_runs}." if total_runs is not None else "")
+        + "\n"
     )
 
 
@@ -289,10 +298,14 @@ def _daily_odds_answer_prefix(daily_odds_context: Dict[str, Any]) -> str:
     lead_prop = prop_candidates[0] if prop_candidates else {}
     game_line = ""
     if lead_game:
+        context = lead_game.get("canonical_game_context") or {}
+        context_prob_gap = context.get("probability_gap")
         game_line = (
             f"Top game model: {lead_game.get('label')} | {lead_game.get('market')} | {lead_game.get('pick')} | "
             f"edge {_pct(lead_game.get('edge')) or lead_game.get('edge')} | EV {lead_game.get('expected_value')} | "
-            f"tier {lead_game.get('confidence_tier') or 'unknown'} | status {lead_game.get('recommendation_status') or 'unknown'}. "
+            f"tier {lead_game.get('confidence_tier') or 'unknown'} | status {lead_game.get('recommendation_status') or 'unknown'}."
+            + (f" Shared game context gap: {context_prob_gap}." if context_prob_gap is not None else "")
+            + " "
         )
     prop_line = ""
     if lead_prop:
@@ -312,7 +325,7 @@ def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_cont
     enriched["canonical_probability_context"] = canonical_context
     enriched["daily_odds_diagnostics_context"] = daily_odds_context
     sources = list(enriched.get("sources_used") or [])
-    for source in ["canonical_matchup_probability_v2", "matchups.home_win_prob_and_away_win_prob", "daily_odds_models"]:
+    for source in ["canonical_matchup_probability_v2", "matchups.home_win_prob_and_away_win_prob", "daily_odds_models", "canonical_game_context_v1"]:
         if source not in sources:
             sources.append(source)
     enriched["sources_used"] = sources
@@ -334,7 +347,7 @@ def _enrich_result_with_canonical_context(result: Dict[str, Any], canonical_cont
     if "Canonical probability note" not in answer:
         enriched["answer"] = note + "\n" + answer
     confidence_note = enriched.get("confidence_note") or ""
-    canonical_note = " Canonical v2 is the final side probability; simulations are diagnostic/run-distribution context only. Daily Odds diagnostics include EV, confidence tier, recommendation status, and optional hitter-usage gate output."
+    canonical_note = " Canonical v2 is the final side probability; simulations are diagnostic/run-distribution context only. Daily Odds diagnostics include EV, confidence tier, recommendation status, optional hitter-usage gate output, and shared game context."
     if canonical_note.strip() not in confidence_note:
         enriched["confidence_note"] = confidence_note + canonical_note
     return enriched

--- a/mlb_app/canonical_game_context.py
+++ b/mlb_app/canonical_game_context.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .canonical_model_engine import build_starting_pitcher_component, build_team_recent_form_component, clamp, safe_float
+
+GAME_CONTEXT_VERSION = "canonical_game_context_v1"
+
+
+def _offense_signal(inputs: Optional[Dict[str, Any]]) -> Optional[float]:
+    inputs = inputs or {}
+    obp = safe_float(inputs.get("on_base_pct"))
+    slg = safe_float(inputs.get("slugging_pct"))
+    iso = safe_float(inputs.get("iso") or inputs.get("stored_iso"))
+    bb = safe_float(inputs.get("bb_pct"))
+    k = safe_float(inputs.get("k_pct"))
+    values: List[float] = []
+    if obp is not None:
+        values.append(0.5 + ((obp - 0.320) * 2.5))
+    if slg is not None:
+        values.append(0.5 + ((slg - 0.410) * 1.6))
+    if iso is not None:
+        values.append(0.5 + ((iso - 0.160) * 1.8))
+    if bb is not None and k is not None:
+        values.append(0.5 + ((bb - k + 0.140) * 1.0))
+    return round(clamp(sum(values) / len(values), 0.0, 1.0), 4) if values else None
+
+
+def _pitcher_scores(overview: Optional[Dict[str, Any]], features: Optional[Dict[str, Any]]) -> Dict[str, Optional[float]]:
+    overview = overview or {}
+    features = features or {}
+    era = safe_float(overview.get("era"))
+    kbb = safe_float(overview.get("k_minus_bb_pct"))
+    xwoba = safe_float(overview.get("xwoba_allowed"))
+    hard_hit = safe_float(overview.get("hard_hit_rate_allowed"))
+    season_parts: List[float] = []
+    if era is not None:
+        season_parts.append(0.5 + ((4.00 - era) * 0.06))
+    if kbb is not None:
+        season_parts.append(0.5 + ((kbb - 0.14) * 1.8))
+    if xwoba is not None:
+        season_parts.append(0.5 + ((0.320 - xwoba) * 2.6))
+    if hard_hit is not None:
+        season_parts.append(0.5 + ((0.38 - hard_hit) * 1.6))
+    season_score = round(clamp(sum(season_parts) / len(season_parts), 0.0, 1.0), 4) if season_parts else None
+    feat_k = safe_float(features.get("k_pct"))
+    feat_bb = safe_float(features.get("bb_pct"))
+    feat_xwoba = safe_float(features.get("xwoba"))
+    feat_hard_hit = safe_float(features.get("hard_hit_pct"))
+    feat_velocity = safe_float(features.get("avg_velocity"))
+    recent_parts: List[float] = []
+    if feat_k is not None and feat_bb is not None:
+        recent_parts.append(0.5 + (((feat_k - feat_bb) - 0.14) * 1.5))
+    if feat_xwoba is not None:
+        recent_parts.append(0.5 + ((0.320 - feat_xwoba) * 2.4))
+    if feat_hard_hit is not None:
+        recent_parts.append(0.5 + ((0.38 - feat_hard_hit) * 1.5))
+    if feat_velocity is not None:
+        recent_parts.append(0.5 + ((feat_velocity - 93.0) * 0.025))
+    recent_score = round(clamp(sum(recent_parts) / len(recent_parts), 0.0, 1.0), 4) if recent_parts else season_score
+    return {
+        "season_baseline_score": season_score,
+        "recent_form_score": recent_score,
+        "k_bb_score": round(clamp(0.5 + (((feat_k or 0.20) - (feat_bb or 0.08) - 0.12) * 1.8), 0.0, 1.0), 4) if feat_k is not None or feat_bb is not None else None,
+        "contact_quality_allowed_score": round(clamp(0.5 + ((0.320 - (feat_xwoba if feat_xwoba is not None else xwoba if xwoba is not None else 0.320)) * 2.6), 0.0, 1.0), 4) if (feat_xwoba is not None or xwoba is not None) else None,
+        "arsenal_quality_score": round(clamp(0.5 + ((feat_velocity - 93.0) * 0.025), 0.0, 1.0), 4) if feat_velocity is not None else None,
+        "platoon_risk_score": round(clamp((xwoba - 0.300) * 2.0, 0.0, 1.0), 4) if xwoba is not None else None,
+        "expected_workload_score": round(clamp((safe_float(overview.get("innings_pitched")) or 0.0) / 180.0, 0.0, 1.0), 4) if safe_float(overview.get("innings_pitched")) is not None else None,
+        "velocity_or_stuff_trend": round((feat_velocity - 93.0) / 10.0, 4) if feat_velocity is not None else None,
+        "command_trend": round((0.08 - feat_bb) * 2.0, 4) if feat_bb is not None else None,
+    }
+
+
+def build_canonical_game_context(matchup_like: Dict[str, Any], projection_sim: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    home_team = matchup_like.get("home_team_name") or matchup_like.get("home_team") or ((matchup_like.get("home_team") or {}).get("name") if isinstance(matchup_like.get("home_team"), dict) else None)
+    away_team = matchup_like.get("away_team_name") or matchup_like.get("away_team") or ((matchup_like.get("away_team") or {}).get("name") if isinstance(matchup_like.get("away_team"), dict) else None)
+    home_prob = safe_float(matchup_like.get("home_win_prob") or matchup_like.get("home_win_probability"))
+    away_prob = safe_float(matchup_like.get("away_win_prob") or matchup_like.get("away_win_probability"))
+    probability_components = matchup_like.get("probability_components") or ((matchup_like.get("main_matchup_probabilities") or {}).get("probability_components")) or {}
+    pitcher_overview = matchup_like.get("pitcher_overview") or ((matchup_like.get("main_matchup_probabilities") or {}).get("pitcher_overview")) or {}
+    home_overview = pitcher_overview.get("home") if isinstance(pitcher_overview, dict) else {}
+    away_overview = pitcher_overview.get("away") if isinstance(pitcher_overview, dict) else {}
+    home_features = matchup_like.get("home_pitcher_features") or ((matchup_like.get("teams") or {}).get("home") or {}).get("pitcher_features") or {}
+    away_features = matchup_like.get("away_pitcher_features") or ((matchup_like.get("teams") or {}).get("away") or {}).get("pitcher_features") or {}
+    home_offense_inputs = matchup_like.get("home_offense_inputs") or ((matchup_like.get("teams") or {}).get("home") or {}).get("offense_inputs") or {}
+    away_offense_inputs = matchup_like.get("away_offense_inputs") or ((matchup_like.get("teams") or {}).get("away") or {}).get("offense_inputs") or {}
+    home_pitcher_component = build_starting_pitcher_component(**_pitcher_scores(home_overview, home_features))
+    away_pitcher_component = build_starting_pitcher_component(**_pitcher_scores(away_overview, away_features))
+    home_signal = _offense_signal(home_offense_inputs)
+    away_signal = _offense_signal(away_offense_inputs)
+    home_team_component = build_team_recent_form_component(home_signal, home_signal, home_signal, home_signal)
+    away_team_component = build_team_recent_form_component(away_signal, away_signal, away_signal, away_signal)
+    sim_diag = ((probability_components or {}).get("simulation") or {}).get("diagnostics") or {}
+    projection_sim = projection_sim or {}
+    home_runs = safe_float(projection_sim.get("home_expected_runs") or sim_diag.get("home_expected_runs"))
+    away_runs = safe_float(projection_sim.get("away_expected_runs") or sim_diag.get("away_expected_runs"))
+    total_runs = safe_float(projection_sim.get("total_expected_runs") or sim_diag.get("total_expected_runs"))
+    probability_gap = round(abs((home_prob or 0.5) - (away_prob or 0.5)), 4) if home_prob is not None and away_prob is not None else None
+    favorite_side = "home" if home_prob is not None and away_prob is not None and home_prob >= away_prob else "away" if home_prob is not None and away_prob is not None else None
+    return {
+        "object_version": GAME_CONTEXT_VERSION,
+        "game_pk": matchup_like.get("game_pk"),
+        "game_date": matchup_like.get("game_date"),
+        "away_team": away_team,
+        "home_team": home_team,
+        "home_win_prob": round(home_prob, 4) if home_prob is not None else None,
+        "away_win_prob": round(away_prob, 4) if away_prob is not None else None,
+        "projected_home_runs": round(home_runs, 3) if home_runs is not None else None,
+        "projected_away_runs": round(away_runs, 3) if away_runs is not None else None,
+        "projected_total_runs": round(total_runs, 3) if total_runs is not None else None,
+        "starting_pitcher_component": {"home": home_pitcher_component, "away": away_pitcher_component},
+        "team_recent_form_component": {"home": home_team_component, "away": away_team_component},
+        "bullpen_component": ((probability_components or {}).get("bullpen") or {}),
+        "lineup_status": matchup_like.get("lineup_status"),
+        "data_confidence": matchup_like.get("data_confidence"),
+        "probability_gap": probability_gap,
+        "favorite_side": favorite_side,
+        "missing_inputs": matchup_like.get("missing_inputs") or [],
+    }

--- a/mlb_app/daily_odds_models.py
+++ b/mlb_app/daily_odds_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from .canonical_game_context import build_canonical_game_context
 from .canonical_model_engine import (
     american_to_implied_probability,
     assign_confidence_tier,
@@ -61,6 +62,7 @@ def _data_quality_score(used: int, expected: int, diagnostics: Optional[Dict[str
     diagnostics = diagnostics or {}
     lineup_status = str(diagnostics.get("lineup_status") or "").lower()
     data_confidence = str(diagnostics.get("data_confidence") or "").lower()
+    canonical_game_context = diagnostics.get("canonical_game_context") or {}
 
     if data_confidence == "high":
         base += 0.12
@@ -75,6 +77,10 @@ def _data_quality_score(used: int, expected: int, diagnostics: Optional[Dict[str
         base -= 0.05
     elif lineup_status == "projected":
         base += 0.02
+
+    context_quality = _safe_float(canonical_game_context.get("data_quality_score"))
+    if context_quality is not None:
+        base = (base * 0.55) + (context_quality * 0.45)
 
     return round(_clamp(base, 0.0, 1.0), 3)
 
@@ -135,6 +141,13 @@ def _extract_batter_gate(matchup: Dict[str, Any], player_name: Optional[str]) ->
         if "final_pitcher_vs_hitter_recommendation_status" in value:
             return value
     return None
+
+
+def _game_context_object(matchup: Dict[str, Any]) -> Dict[str, Any]:
+    existing = matchup.get("canonical_game_context")
+    if isinstance(existing, dict) and existing:
+        return existing
+    return build_canonical_game_context(matchup)
 
 
 def _model_output(
@@ -219,12 +232,14 @@ def _game_context(matchup: Dict[str, Any]) -> Dict[str, Any]:
 
 def build_game_models(matchup: Dict[str, Any], event: Dict[str, Any]) -> Dict[str, Any]:
     ctx = _game_context(matchup)
+    canonical_game_context = _game_context_object(matchup)
     moneyline = _find_market(event, ["h2h"])
     spread = _find_market(event, ["spreads"])
     total = _find_market(event, ["totals"])
     return {
         "game_pk": ctx.get("game_pk"),
         "event_id": event.get("event_id"),
+        "canonical_game_context": canonical_game_context,
         "moneyline": build_moneyline_model(matchup, moneyline, ctx),
         "spread": build_spread_model(matchup, spread, ctx),
         "total": build_total_model(matchup, total, ctx),
@@ -235,11 +250,14 @@ def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, An
     features: List[Dict[str, Any]] = []
     missing: List[str] = []
     drivers: List[str] = []
+    canonical_game_context = _game_context_object(matchup)
 
     home_prob_raw, home_prob_src = _get(matchup, ["home_win_prob", "home_win_probability", "probabilities.home", "prediction.home_win_probability"])
     away_prob_raw, away_prob_src = _get(matchup, ["away_win_prob", "away_win_probability", "probabilities.away", "prediction.away_win_probability"])
     home_prob = _feature(features, "home_canonical_win_probability", home_prob_raw, home_prob_src or "home_win_prob", "canonical_v2")
     away_prob = _feature(features, "away_canonical_win_probability", away_prob_raw, away_prob_src or "away_win_prob", "canonical_v2")
+    context_gap = _feature(features, "canonical_game_probability_gap", canonical_game_context.get("probability_gap"), "canonical_game_context", "raw")
+    context_quality = _feature(features, "canonical_game_data_quality_score", canonical_game_context.get("data_quality_score"), "canonical_game_context", "raw")
     if home_prob is None:
         missing.append("home_canonical_win_probability")
     if away_prob is None:
@@ -251,6 +269,8 @@ def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, An
         drivers.append(f"canonical model version: {model_version}")
     if probability_components:
         drivers.append("canonical probability component diagnostics available")
+    if canonical_game_context:
+        drivers.append("shared canonical game context available for side, projected runs, and pitcher/team decomposition")
 
     home_sel = _pick_selection_by_team(market, ctx.get("home_team") or "")
     away_sel = _pick_selection_by_team(market, ctx.get("away_team") or "")
@@ -268,7 +288,7 @@ def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, An
         missing.append("away_market_implied_probability")
 
     if home_prob is None or away_prob is None:
-        return _model_output("moneyline_canonical_v2", "moneyline", "No pick", 0.0, None, None, None, features, missing, drivers, {"model_version": model_version})
+        return _model_output("moneyline_canonical_v2", "moneyline", "No pick", 0.0, None, None, None, features, missing, drivers, {"model_version": model_version, "canonical_game_context": canonical_game_context})
 
     pick_home = home_prob >= away_prob
     pick = ctx.get("home_team") if pick_home else ctx.get("away_team")
@@ -276,6 +296,8 @@ def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, An
     market_prob = home_market if pick_home else away_market
     market_price = home_price if pick_home else away_price
     drivers.append("final side probability comes from canonical matchup home_win_prob/away_win_prob")
+    if context_gap is not None:
+        drivers.append("shared canonical game context probability gap informs confidence and diagnostics")
     if market_prob is not None:
         drivers.append("edge equals canonical probability minus sportsbook implied probability")
 
@@ -298,6 +320,7 @@ def build_moneyline_model(matchup: Dict[str, Any], market: Optional[Dict[str, An
             "legacy_home_win_prob": matchup.get("legacy_home_win_prob"),
             "legacy_away_win_prob": matchup.get("legacy_away_win_prob"),
             "market_context_note": "Odds compare against canonical probability; odds do not define the model.",
+            "canonical_game_context": canonical_game_context,
         },
     )
 
@@ -306,10 +329,15 @@ def build_spread_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]]
     features: List[Dict[str, Any]] = []
     missing: List[str] = []
     drivers: List[str] = []
-    home_runs_raw, home_runs_src = _get(matchup, ["home_projected_runs", "home_runs_projected", "projection.home_runs", "home_score_projection"])
-    away_runs_raw, away_runs_src = _get(matchup, ["away_projected_runs", "away_runs_projected", "projection.away_runs", "away_score_projection"])
-    home_runs = _feature(features, "home_projected_runs", home_runs_raw, home_runs_src)
-    away_runs = _feature(features, "away_projected_runs", away_runs_raw, away_runs_src)
+    canonical_game_context = _game_context_object(matchup)
+    home_runs_raw, home_runs_src = _get(matchup, ["home_projected_runs", "home_runs_projected", "projection.home_runs", "home_score_projection", "canonical_game_context.projected_home_runs"])
+    away_runs_raw, away_runs_src = _get(matchup, ["away_projected_runs", "away_runs_projected", "projection.away_runs", "away_score_projection", "canonical_game_context.projected_away_runs"])
+    if home_runs_raw is None:
+        home_runs_raw = canonical_game_context.get("projected_home_runs")
+    if away_runs_raw is None:
+        away_runs_raw = canonical_game_context.get("projected_away_runs")
+    home_runs = _feature(features, "home_projected_runs", home_runs_raw, home_runs_src or "canonical_game_context.projected_home_runs")
+    away_runs = _feature(features, "away_projected_runs", away_runs_raw, away_runs_src or "canonical_game_context.projected_away_runs")
     if home_runs is None:
         missing.append("home_projected_runs")
     if away_runs is None:
@@ -320,6 +348,8 @@ def build_spread_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]]
     if home_prob is not None and away_prob is not None:
         features.append({"name": "canonical_home_win_probability", "value": home_prob, "source": "home_win_prob", "transform": "canonical_v2"})
         features.append({"name": "canonical_away_win_probability", "value": away_prob, "source": "away_win_prob", "transform": "canonical_v2"})
+    if canonical_game_context:
+        drivers.append("shared canonical game context available for projected runs and side decomposition")
 
     if home_runs is not None and away_runs is not None:
         run_diff = home_runs - away_runs
@@ -370,6 +400,7 @@ def build_spread_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]]
         {
             "lineup_status": matchup.get("lineup_status"),
             "data_confidence": matchup.get("data_confidence"),
+            "canonical_game_context": canonical_game_context,
         },
     )
 
@@ -378,6 +409,7 @@ def build_total_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]],
     features: List[Dict[str, Any]] = []
     missing: List[str] = []
     drivers: List[str] = []
+    canonical_game_context = _game_context_object(matchup)
     temp_raw, temp_src = _get(matchup, ["weather.temp_f", "weather.temp", "temp_f"])
     temp = _feature(features, "temperature_f", temp_raw, temp_src)
     if temp is None:
@@ -386,10 +418,14 @@ def build_total_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]],
     wind = _feature(features, "wind_speed", wind_raw, wind_src)
     if wind is None:
         missing.append("wind_speed")
-    home_off_raw, home_off_src = _get(matchup, ["home_offense_score", "home_team_strength", "home_hitting_score", "home_team_stats.ops"])
-    away_off_raw, away_off_src = _get(matchup, ["away_offense_score", "away_team_strength", "away_hitting_score", "away_team_stats.ops"])
-    home_off = _feature(features, "home_offense_strength", home_off_raw, home_off_src)
-    away_off = _feature(features, "away_offense_strength", away_off_raw, away_off_src)
+    home_off_raw, home_off_src = _get(matchup, ["home_offense_score", "home_team_strength", "home_hitting_score", "away_offense_inputs.on_base_pct", "canonical_game_context.team_recent_form_component.home.team_recent_form_score"])
+    away_off_raw, away_off_src = _get(matchup, ["away_offense_score", "away_team_strength", "away_hitting_score", "home_offense_inputs.on_base_pct", "canonical_game_context.team_recent_form_component.away.team_recent_form_score"])
+    if home_off_raw is None:
+        home_off_raw = ((canonical_game_context.get("team_recent_form_component") or {}).get("home") or {}).get("team_recent_form_score")
+    if away_off_raw is None:
+        away_off_raw = ((canonical_game_context.get("team_recent_form_component") or {}).get("away") or {}).get("team_recent_form_score")
+    home_off = _feature(features, "home_offense_strength", home_off_raw, home_off_src or "canonical_game_context.team_recent_form_component.home.team_recent_form_score")
+    away_off = _feature(features, "away_offense_strength", away_off_raw, away_off_src or "canonical_game_context.team_recent_form_component.away.team_recent_form_score")
     if home_off is None:
         missing.append("home_offense_strength")
     if away_off is None:
@@ -433,8 +469,9 @@ def build_total_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]],
         drivers.append("wind run environment")
     if home_off is not None and away_off is not None:
         env += (home_off + away_off - 1.0)
-        drivers.append("combined offense")
-    projected_total = (market_total if market_total is not None else 8.5) + env
+        drivers.append("combined offense or recent-form context")
+    context_total = _safe_float(canonical_game_context.get("projected_total_runs"))
+    projected_total = context_total if context_total is not None else (market_total if market_total is not None else 8.5) + env
     pick_over = projected_total >= (market_total if market_total is not None else 8.5)
     pick = f"Over {market_total}" if pick_over else f"Under {market_total}"
     model_prob = canonical_clamp(0.5 + abs(projected_total - (market_total or 8.5)) / 5.0)
@@ -454,6 +491,7 @@ def build_total_model(matchup: Dict[str, Any], market: Optional[Dict[str, Any]],
         {
             "lineup_status": matchup.get("lineup_status"),
             "data_confidence": matchup.get("data_confidence"),
+            "canonical_game_context": canonical_game_context,
         },
     )
 
@@ -558,6 +596,7 @@ def _prop_model_probability(
 
 def build_prop_models(matchup: Dict[str, Any], prop_markets: List[Dict[str, Any]], market_filter: Optional[str] = None, limit: int = 20) -> Dict[str, Any]:
     candidates: List[Dict[str, Any]] = []
+    canonical_game_context = _game_context_object(matchup)
     for market in prop_markets or []:
         market_name = str(market.get("market_name") or market.get("market_key") or "prop")
         market_key = str(market.get("market_key") or market.get("market_type") or market_name)
@@ -581,6 +620,7 @@ def build_prop_models(matchup: Dict[str, Any], prop_markets: List[Dict[str, Any]
                 "data_confidence": matchup.get("data_confidence"),
                 "model_version": matchup.get("model_version"),
                 "usage_weighted_gate": gate,
+                "canonical_game_context": canonical_game_context,
             }
             output = _model_output(
                 "prop_pregame_candidates_v2",
@@ -603,7 +643,8 @@ def build_prop_models(matchup: Dict[str, Any], prop_markets: List[Dict[str, Any]
                     "player_name": player_name,
                     "selection": sel.get("name"),
                     "line": line,
+                    "canonical_game_context": canonical_game_context,
                 }
             )
     candidates.sort(key=lambda row: ((abs(row.get("edge") or 0.0) * 10.0) + (row.get("confidence") or 0.0) + (row.get("score") or 0.0)), reverse=True)
-    return {"top_candidates": candidates[:limit], "candidate_count": len(candidates)}
+    return {"top_candidates": candidates[:limit], "candidate_count": len(candidates), "canonical_game_context": canonical_game_context}

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
 
+from .canonical_game_context import build_canonical_game_context
 from .db_utils import get_pitch_arsenal_with_fallback, get_team_split
 from .matchup_generator import generate_matchups_for_date
 from .model_projection_formulas import bullpen_collapse_index, offensive_firepower_score, pitch_identity_disruption_score, pitching_volatility_score, safe_float
@@ -99,15 +100,7 @@ def _bullpen_inputs(session: Session, team_id: Optional[int], team_name: Optiona
         return {"source_table": table, "error": str(exc)}
 
 
-def _probability_model_card(
-    model_name: str,
-    score: Optional[float],
-    inputs: Dict[str, Any],
-    formula: str,
-    steps: List[str],
-    notes: List[str],
-    confidence: str = "low",
-) -> Dict[str, Any]:
+def _probability_model_card(model_name: str, score: Optional[float], inputs: Dict[str, Any], formula: str, steps: List[str], notes: List[str], confidence: str = "low") -> Dict[str, Any]:
     missing = [key for key, value in inputs.items() if value is None]
     return {
         "model_name": model_name,
@@ -122,13 +115,7 @@ def _probability_model_card(
     }
 
 
-def _team_offense_prior_pa_model(
-    team_id: Optional[int],
-    team_name: Optional[str],
-    opposing_pitcher_profile: Optional[Dict[str, Any]],
-    environment_profile: Dict[str, Any],
-    offense_profile: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+def _team_offense_prior_pa_model(team_id: Optional[int], team_name: Optional[str], opposing_pitcher_profile: Optional[Dict[str, Any]], environment_profile: Dict[str, Any], offense_profile: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if not offense_profile:
         offense_profile = build_team_offense_prior(team_id=team_id, team_name=team_name)
 
@@ -164,13 +151,7 @@ def _rate_from_count(numerator: Any, denominator: Any) -> Optional[float]:
     return round(num / den, 4)
 
 
-def _choose_count_derived_rate(
-    raw_rate: Any,
-    numerator: Any,
-    denominator: Any,
-    plausible_low: float,
-    plausible_high: float,
-) -> tuple[Optional[float], str]:
+def _choose_count_derived_rate(raw_rate: Any, numerator: Any, denominator: Any, plausible_low: float, plausible_high: float) -> tuple[Optional[float], str]:
     normalized = _normalize_rate(raw_rate)
     derived = _rate_from_count(numerator, denominator)
 
@@ -186,26 +167,12 @@ def _choose_count_derived_rate(
     return None, "missing_rate"
 
 
-
-
 def _pitcher_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
     features = team.get("pitcher_features") or {}
     arsenal = team.get("pitch_arsenal") or {}
 
-    k_rate, k_rate_source = _choose_count_derived_rate(
-        features.get("k_pct"),
-        features.get("strikeouts"),
-        features.get("pa"),
-        plausible_low=0.08,
-        plausible_high=0.45,
-    )
-    bb_rate, bb_rate_source = _choose_count_derived_rate(
-        features.get("bb_pct"),
-        features.get("walks"),
-        features.get("pa"),
-        plausible_low=0.015,
-        plausible_high=0.20,
-    )
+    k_rate, k_rate_source = _choose_count_derived_rate(features.get("k_pct"), features.get("strikeouts"), features.get("pa"), plausible_low=0.08, plausible_high=0.45)
+    bb_rate, bb_rate_source = _choose_count_derived_rate(features.get("bb_pct"), features.get("walks"), features.get("pa"), plausible_low=0.015, plausible_high=0.20)
     hard_hit = _normalize_rate(features.get("hard_hit_pct"))
     xwoba = safe_float(features.get("xwoba"))
     xba = safe_float(features.get("xba"))
@@ -248,20 +215,8 @@ def _pitcher_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
 def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
     inputs = team.get("offense_inputs") or {}
 
-    k_rate, k_rate_source = _choose_count_derived_rate(
-        inputs.get("k_pct"),
-        inputs.get("strikeouts"),
-        inputs.get("pa"),
-        plausible_low=0.10,
-        plausible_high=0.40,
-    )
-    bb_rate, bb_rate_source = _choose_count_derived_rate(
-        inputs.get("bb_pct"),
-        inputs.get("walks"),
-        inputs.get("pa"),
-        plausible_low=0.03,
-        plausible_high=0.18,
-    )
+    k_rate, k_rate_source = _choose_count_derived_rate(inputs.get("k_pct"), inputs.get("strikeouts"), inputs.get("pa"), plausible_low=0.10, plausible_high=0.40)
+    bb_rate, bb_rate_source = _choose_count_derived_rate(inputs.get("bb_pct"), inputs.get("walks"), inputs.get("pa"), plausible_low=0.03, plausible_high=0.18)
 
     profile = {
         "metadata": {
@@ -285,13 +240,7 @@ def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
         },
         "contact_skill": {"k_rate": k_rate, "batting_avg": safe_float(inputs.get("batting_avg")), "contact_rate": None},
         "plate_discipline": {"bb_rate": bb_rate, "on_base_pct": safe_float(inputs.get("on_base_pct"))},
-        "power": {
-            "iso": safe_float(inputs.get("iso")),
-            "slugging_pct": safe_float(inputs.get("slugging_pct")),
-            "home_runs": safe_float(inputs.get("home_runs")),
-            "doubles": safe_float(inputs.get("doubles")),
-            "triples": safe_float(inputs.get("triples")),
-        },
+        "power": {"iso": safe_float(inputs.get("iso")), "slugging_pct": safe_float(inputs.get("slugging_pct")), "home_runs": safe_float(inputs.get("home_runs")), "doubles": safe_float(inputs.get("doubles")), "triples": safe_float(inputs.get("triples"))},
         "run_creation": {"pa": safe_float(inputs.get("pa")), "hits": safe_float(inputs.get("hits")), "walks": safe_float(inputs.get("walks")), "strikeouts": safe_float(inputs.get("strikeouts"))},
     }
 
@@ -314,34 +263,10 @@ def _matchup_workspace_analysis(offense_team: Dict[str, Any], opposing_pitcher: 
     pitcher_features = opposing_pitcher.get("pitcher_features") or {}
     arsenal = opposing_pitcher.get("pitch_arsenal") or {}
 
-    offense_k, _ = _choose_count_derived_rate(
-        offense_inputs.get("k_pct"),
-        offense_inputs.get("strikeouts"),
-        offense_inputs.get("pa"),
-        plausible_low=0.10,
-        plausible_high=0.40,
-    )
-    offense_bb, _ = _choose_count_derived_rate(
-        offense_inputs.get("bb_pct"),
-        offense_inputs.get("walks"),
-        offense_inputs.get("pa"),
-        plausible_low=0.03,
-        plausible_high=0.18,
-    )
-    pitcher_k, _ = _choose_count_derived_rate(
-        pitcher_features.get("k_pct"),
-        pitcher_features.get("strikeouts"),
-        pitcher_features.get("pa"),
-        plausible_low=0.08,
-        plausible_high=0.45,
-    )
-    pitcher_bb, _ = _choose_count_derived_rate(
-        pitcher_features.get("bb_pct"),
-        pitcher_features.get("walks"),
-        pitcher_features.get("pa"),
-        plausible_low=0.015,
-        plausible_high=0.20,
-    )
+    offense_k, _ = _choose_count_derived_rate(offense_inputs.get("k_pct"), offense_inputs.get("strikeouts"), offense_inputs.get("pa"), plausible_low=0.10, plausible_high=0.40)
+    offense_bb, _ = _choose_count_derived_rate(offense_inputs.get("bb_pct"), offense_inputs.get("walks"), offense_inputs.get("pa"), plausible_low=0.03, plausible_high=0.18)
+    pitcher_k, _ = _choose_count_derived_rate(pitcher_features.get("k_pct"), pitcher_features.get("strikeouts"), pitcher_features.get("pa"), plausible_low=0.08, plausible_high=0.45)
+    pitcher_bb, _ = _choose_count_derived_rate(pitcher_features.get("bb_pct"), pitcher_features.get("walks"), pitcher_features.get("pa"), plausible_low=0.015, plausible_high=0.20)
 
     pitch_edges = []
     for pitch_type, row in (arsenal or {}).items():
@@ -669,7 +594,9 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             shared_bullpen_sim = shared_outputs.get("bullpen_adjusted_game_simulation", {}) or {}
             projection_sim = shared_bullpen_sim or shared_game_sim
             canonical_probabilities = _canonical_probability_payload(matchup, projection_sim=projection_sim)
+            canonical_game_context = build_canonical_game_context(matchup, projection_sim=projection_sim)
             workspace["canonicalMatchupProbability"] = canonical_probabilities
+            workspace["canonicalGameContext"] = canonical_game_context
             workspace["sharedSimulationDiagnostics"] = {
                 "status": "diagnostic_only_not_final_probability",
                 "source": "sharedSimulation.derived_outputs",
@@ -705,6 +632,7 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "pitcher_overview": canonical_probabilities.get("pitcher_overview"),
                 "batter_vs_arsenal_summary": canonical_probabilities.get("batter_vs_arsenal_summary"),
                 "main_matchup_probabilities": canonical_probabilities,
+                "canonical_game_context": canonical_game_context,
                 "teams": {"away": away, "home": home},
                 "workspace": workspace,
             })
@@ -720,5 +648,6 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             "home_win_prob and away_win_prob are canonical v2 from /matchups.",
             "Simulation outputs remain available as diagnostics and do not define final side probability.",
             "Missing inputs are returned explicitly and are not fabricated.",
+            "canonical_game_context is the shared game-level object for side, projected runs, pitcher/team components, and data-quality context.",
         ],
     }

--- a/tests/test_canonical_game_context.py
+++ b/tests/test_canonical_game_context.py
@@ -1,0 +1,48 @@
+from mlb_app.canonical_game_context import build_canonical_game_context
+
+
+def test_build_canonical_game_context_returns_shared_game_object():
+    matchup = {
+        "game_pk": 123,
+        "game_date": "2026-05-24",
+        "away_team_name": "Brewers",
+        "home_team_name": "Cubs",
+        "home_win_prob": 0.61,
+        "away_win_prob": 0.39,
+        "lineup_status": "confirmed",
+        "data_confidence": "high",
+        "missing_inputs": [],
+        "probability_components": {
+            "bullpen": {
+                "source": "build_bullpen_profile",
+                "available": True,
+                "score": 0.53,
+                "diagnostics": {
+                    "home_bullpen_quality_score": 0.62,
+                    "away_bullpen_quality_score": 0.55,
+                },
+            },
+            "simulation": {
+                "diagnostics": {
+                    "home_expected_runs": 4.8,
+                    "away_expected_runs": 3.9,
+                    "total_expected_runs": 8.7,
+                }
+            },
+        },
+        "pitcher_overview": {
+            "home": {"era": 3.20, "k_minus_bb_pct": 0.19, "xwoba_allowed": 0.298, "hard_hit_rate_allowed": 0.34, "innings_pitched": 72},
+            "away": {"era": 4.10, "k_minus_bb_pct": 0.12, "xwoba_allowed": 0.325, "hard_hit_rate_allowed": 0.39, "innings_pitched": 68},
+        },
+        "home_pitcher_features": {"k_pct": 0.28, "bb_pct": 0.07, "xwoba": 0.301, "hard_hit_pct": 0.33, "avg_velocity": 94.1},
+        "away_pitcher_features": {"k_pct": 0.22, "bb_pct": 0.09, "xwoba": 0.327, "hard_hit_pct": 0.40, "avg_velocity": 92.4},
+        "home_offense_inputs": {"on_base_pct": 0.336, "slugging_pct": 0.431, "iso": 0.176, "bb_pct": 0.087, "k_pct": 0.221},
+        "away_offense_inputs": {"on_base_pct": 0.317, "slugging_pct": 0.401, "iso": 0.154, "bb_pct": 0.073, "k_pct": 0.244},
+    }
+    game_context = build_canonical_game_context(matchup)
+    assert game_context["game_pk"] == 123
+    assert game_context["home_win_prob"] == 0.61
+    assert game_context["projected_total_runs"] == 8.7
+    assert game_context["starting_pitcher_component"]["home"]["pitcher_component_score"] is not None
+    assert game_context["team_recent_form_component"]["home"]["team_recent_form_score"] is not None
+    assert game_context["bullpen_component"]["bullpen_edge"] == 0.07

--- a/tests/test_canonical_game_context_consumers.py
+++ b/tests/test_canonical_game_context_consumers.py
@@ -1,0 +1,51 @@
+from mlb_app.ai_data_assistant_performance import _compact_daily_odds_game_model
+from mlb_app.daily_odds_models import build_game_models
+
+
+def test_build_game_models_returns_canonical_game_context():
+    matchup = {
+        "game_pk": 123,
+        "away_team_name": "Brewers",
+        "home_team_name": "Cubs",
+        "home_win_prob": 0.61,
+        "away_win_prob": 0.39,
+        "lineup_status": "confirmed",
+        "data_confidence": "high",
+        "missing_inputs": [],
+        "probability_components": {
+            "bullpen": {"source": "build_bullpen_profile", "available": True, "score": 0.53, "diagnostics": {"home_bullpen_quality_score": 0.62, "away_bullpen_quality_score": 0.55}},
+            "simulation": {"diagnostics": {"home_expected_runs": 4.8, "away_expected_runs": 3.9, "total_expected_runs": 8.7}},
+        },
+        "pitcher_overview": {"home": {}, "away": {}},
+        "home_pitcher_features": {},
+        "away_pitcher_features": {},
+        "home_offense_inputs": {"on_base_pct": 0.336, "slugging_pct": 0.431, "iso": 0.176, "bb_pct": 0.087, "k_pct": 0.221},
+        "away_offense_inputs": {"on_base_pct": 0.317, "slugging_pct": 0.401, "iso": 0.154, "bb_pct": 0.073, "k_pct": 0.244},
+    }
+    event = {
+        "event_id": "evt1",
+        "markets": [
+            {"market_key": "h2h", "selections": [{"name": "Cubs", "price": -120}, {"name": "Brewers", "price": +105}]},
+            {"market_key": "spreads", "selections": [{"name": "Cubs", "line": -1.5, "price": +120}, {"name": "Brewers", "line": 1.5, "price": -140}]},
+            {"market_key": "totals", "selections": [{"name": "Over", "line": 8.5, "price": -110}, {"name": "Under", "line": 8.5, "price": -110}]},
+        ],
+    }
+    models = build_game_models(matchup, event)
+    assert "canonical_game_context" in models
+    assert models["canonical_game_context"]["projected_total_runs"] == 8.7
+
+
+def test_ai_compact_daily_odds_game_model_preserves_canonical_game_context():
+    model = {
+        "market": "moneyline",
+        "pick": "Cubs",
+        "model_probability": 0.61,
+        "market_implied_probability": 0.5455,
+        "edge": 0.0645,
+        "expected_value": 0.118,
+        "confidence_tier": "STRONG",
+        "recommendation_status": "recommended",
+        "diagnostics": {"canonical_game_context": {"projected_total_runs": 8.7, "favorite_side": "home"}},
+    }
+    compact = _compact_daily_odds_game_model(model, "Brewers @ Cubs", 123)
+    assert compact["canonical_game_context"]["projected_total_runs"] == 8.7


### PR DESCRIPTION
## What this PR does

This PR adds the next layer the app was missing: one shared game-level canonical object that can be reused across surfaces without rebuilding Model Projections.

The implementation is intentionally additive.

## Included

### 1. Shared game-level object

Adds a new shared builder:

- `mlb_app/canonical_game_context.py`

It produces a reusable game-level object with:

- game id / teams / date
- home and away canonical win probabilities
- projected runs / total
- starting pitcher component
- team recent-form component
- bullpen component
- lineup/data confidence context
- probability gap / favorite side
- missing inputs

This is the first explicit cross-surface object for game-level reasoning.

### 2. Daily Odds now reads the shared object

`mlb_app/daily_odds_models.py` now:

- builds or consumes `canonical_game_context`
- returns it from `build_game_models()`
- uses it in moneyline diagnostics
- uses it in spread projected-run context
- uses it in total projected-total / recent-form context
- carries it through prop diagnostics as additive context

### 3. Model Projections now consumes the same object without being rebuilt

`mlb_app/model_projections.py` now attaches the same shared object to:

- top-level game payload as `canonical_game_context`
- workspace payload as `workspace.canonicalGameContext`

This keeps Model Projections structurally intact while giving it the same shared game-level context as the other surfaces.

### 4. AI assistant explainability now preserves the object in Daily Odds diagnostics compaction

`mlb_app/ai_data_assistant_performance.py` now preserves `canonical_game_context` when compacting Daily Odds game-model diagnostics for assistant responses.

## Files changed

### Added

- `mlb_app/canonical_game_context.py`
- `tests/test_canonical_game_context.py`
- `tests/test_canonical_game_context_consumers.py`

### Updated

- `mlb_app/daily_odds_models.py`
- `mlb_app/model_projections.py`
- `mlb_app/ai_data_assistant_performance.py`

## What is intentionally not claimed in this PR

I am **not** claiming a full tracker extraction layer for `canonical_game_context` yet.

The tracker already captures a lot of downstream raw payload JSON, and this PR makes the shared object available in the consumer payloads that tracker ingests. But the dedicated tracker-side extraction/normalization pass for this new object still needs a cleaner follow-up change.

I am also **not** rebuilding Model Projections UI or card structure.

## Why this approach is safe

- shared object is additive
- Daily Odds uses it as extra context, not a route rewrite
- Model Projections consumes it without page rebuild
- AI assistant compaction preserves it without changing the core assistant contract

## Tests added

- shared game-context builder returns the expected object shape
- Daily Odds `build_game_models()` returns `canonical_game_context`
- AI assistant Daily Odds compaction preserves `canonical_game_context`

## Next recommended follow-up

1. Explicit tracker extraction/normalization of `canonical_game_context`
2. Promote shared object usage more deeply into assistant explanations
3. Expand the game-level object with stronger no-bet / recommendation fields once the tracker extraction is in place

## Issue linkage

Continues #432 by creating the explicit shared game-level object and wiring it into Daily Odds and Model Projections without a UI rebuild.
