### PR TITLE
Add Layer 6DL candidate bullpen Statcast live adapter scaffold integration

### DIFF
--- a/scripts/backfill_candidate_bullpen_statcast_labels.py
+++ b/scripts/backfill_candidate_bullpen_statcast_labels.py
@@ -1062,3 +1062,166 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+# Layer 6DL: candidate bullpen Statcast live adapter scaffold integration.
+# Safety contract:
+# - default fixture behavior remains unchanged
+# - live source mode is explicit only
+# - live source mode requires dry-run
+# - no DB writes are performed from live adapter rows
+# - candidate labels are not materialized from live rows in this layer
+# - adapter import is lazy and only inside the live branch
+CANDIDATE_BULLPEN_LIVE_ADAPTER_SCAFFOLD_INTEGRATION_VERSION = (
+    "candidate_bullpen_live_adapter_scaffold_integration_v0.1"
+)
+
+CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE = "fixture"
+CANDIDATE_BULLPEN_SOURCE_MODE_LIVE = "live"
+
+CANDIDATE_BULLPEN_LIVE_STATUS_REQUIRES_DRY_RUN = "live_requires_dry_run"
+CANDIDATE_BULLPEN_LIVE_STATUS_WRITE_BLOCKED = "live_write_blocked"
+CANDIDATE_BULLPEN_LIVE_STATUS_DATE_WINDOW_INVALID = "live_date_window_invalid"
+
+CANDIDATE_BULLPEN_LIVE_ARTIFACT_FIELDS = [
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+]
+
+
+def _candidate_bullpen_validate_live_label_dates(label_dates):
+    """Return (valid, normalized_dates, status, error) for live-source mode."""
+    import re
+
+    if isinstance(label_dates, str):
+        normalized_dates = [label_dates]
+    else:
+        normalized_dates = list(label_dates or [])
+
+    if len(normalized_dates) != 1:
+        return (
+            False,
+            normalized_dates,
+            CANDIDATE_BULLPEN_LIVE_STATUS_DATE_WINDOW_INVALID,
+            "live source mode requires exactly one label_date",
+        )
+
+    label_date = normalized_dates[0]
+    if not isinstance(label_date, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", label_date):
+        return (
+            False,
+            normalized_dates,
+            CANDIDATE_BULLPEN_LIVE_STATUS_DATE_WINDOW_INVALID,
+            "live source mode requires label_date in YYYY-MM-DD format",
+        )
+
+    return True, normalized_dates, "", ""
+
+
+def _candidate_bullpen_live_artifact_from_adapter_result(result, source_mode=CANDIDATE_BULLPEN_SOURCE_MODE_LIVE):
+    """Map a LiveAdapterResult into scaffold-safe live artifact metadata."""
+    return {
+        "source_mode": source_mode,
+        "adapter_status": result.status,
+        "adapter_raw_row_count": result.raw_row_count,
+        "adapter_normalized_row_count": result.normalized_row_count,
+        "adapter_duplicate_count": result.duplicate_count,
+        "adapter_required_field_failures": result.required_field_failures,
+        "adapter_missing_fields": list(result.missing_fields),
+        "adapter_fetch_error": result.fetch_error,
+        "adapter_external_fetch_performed": result.external_fetch_performed,
+        "adapter_db_writes_performed": result.db_writes_performed,
+        "adapter_source_adapter_version": result.source_adapter_version,
+        "external_fetch_performed": result.external_fetch_performed,
+        "db_writes_performed": False,
+        "candidate_labels_materialized": False,
+        "production_default_unchanged": True,
+    }
+
+
+def _candidate_bullpen_live_blocked_artifact(status, error="", source_mode=CANDIDATE_BULLPEN_SOURCE_MODE_LIVE):
+    """Return scaffold-safe blocked live artifact metadata without calling the adapter."""
+    return {
+        "source_mode": source_mode,
+        "adapter_status": status,
+        "adapter_raw_row_count": 0,
+        "adapter_normalized_row_count": 0,
+        "adapter_duplicate_count": 0,
+        "adapter_required_field_failures": 0,
+        "adapter_missing_fields": [],
+        "adapter_fetch_error": error,
+        "adapter_external_fetch_performed": False,
+        "adapter_db_writes_performed": False,
+        "adapter_source_adapter_version": "",
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized": False,
+        "production_default_unchanged": True,
+    }
+
+
+def run_candidate_bullpen_live_adapter_scaffold(
+    label_dates,
+    *,
+    source_mode=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE,
+    dry_run=False,
+    allow_live_write=False,
+    timeout_seconds=30,
+    max_retries=0,
+    fetcher=None,
+):
+    """Safe scaffold entry point for the candidate bullpen live adapter.
+
+    This helper is intentionally inert unless source_mode == "live". It is
+    designed for future CLI wiring and test validation while preserving fixture
+    defaults. No database writes or candidate-label materialization happen here.
+    """
+    if source_mode != CANDIDATE_BULLPEN_SOURCE_MODE_LIVE:
+        return {
+            "source_mode": CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE,
+            "adapter_status": "fixture_mode_unchanged",
+            "external_fetch_performed": False,
+            "db_writes_performed": False,
+            "candidate_labels_materialized": False,
+            "production_default_unchanged": True,
+        }
+
+    valid, normalized_dates, status, error = _candidate_bullpen_validate_live_label_dates(label_dates)
+    if not valid:
+        return _candidate_bullpen_live_blocked_artifact(status, error)
+
+    if not dry_run:
+        return _candidate_bullpen_live_blocked_artifact(
+            CANDIDATE_BULLPEN_LIVE_STATUS_REQUIRES_DRY_RUN,
+            "live source mode requires --dry-run",
+        )
+
+    if allow_live_write:
+        return _candidate_bullpen_live_blocked_artifact(
+            CANDIDATE_BULLPEN_LIVE_STATUS_WRITE_BLOCKED,
+            "live write mode is blocked until a later audited write-gate layer",
+        )
+
+    # Lazy import boundary: no adapter import in fixture/default mode and no
+    # top-level live dependency import in this scaffold.
+    from scripts.fetch_candidate_bullpen_statcast_live_adapter import (
+        fetch_candidate_bullpen_statcast_live_rows_for_date,
+    )
+
+    result = fetch_candidate_bullpen_statcast_live_rows_for_date(
+        normalized_dates[0],
+        timeout_seconds,
+        max_retries,
+        fetcher=fetcher,
+    )
+    return _candidate_bullpen_live_artifact_from_adapter_result(result)
+
+

--- a/scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py
+++ b/scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import ast
+import csv
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+VALIDATION_VERSION = "candidate_bullpen_statcast_live_adapter_scaffold_integration_validation_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+PLAN_6DF = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_fetch_contract_module.py")
+AUDIT_6DG = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_fetch_contract_module_plan.py")
+AUDIT_6DI = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_fetch_module_implementation.py")
+PLAN_6DJ = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DK = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration_plan.py")
+TEST_DOUBLE_PROTOTYPE_6DD = Path("scripts/prototype_candidate_bullpen_statcast_live_adapter_fetch_test_doubles.py")
+TEST_DOUBLE_AUDIT_6DE = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_fetch_test_double_prototype.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_checks.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_source_audit.csv"
+OUTPUT_CLI = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_cli_source_mode_audit.csv"
+OUTPUT_GATES = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_live_gate_audit.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_artifact_contract_audit.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_import_boundary_audit.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_immutability_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_scaffold_integration_safety_audit.csv"
+
+REQUIRED_LIVE_ARTIFACT_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+}
+
+EXPECTED_STATUSES = {
+    "live_requires_dry_run",
+    "live_write_blocked",
+    "live_date_window_invalid",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        ADAPTER_PATH,
+        PLAN_6DF,
+        AUDIT_6DG,
+        AUDIT_6DI,
+        PLAN_6DJ,
+        AUDIT_6DK,
+        TEST_DOUBLE_PROTOTYPE_6DD,
+        TEST_DOUBLE_AUDIT_6DE,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {
+        str(path): path.read_text(errors="ignore") if path.exists() else "__MISSING__"
+        for path in paths
+    }
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = payload.read_text(errors="ignore")
+    return snapshot
+
+
+def _load_scaffold_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_scaffold_validation_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module spec")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _base_row(label_date: str, game_pk: int, at_bat_number: int, pitch_number: int, pitcher_id: int) -> Dict[str, Any]:
+    return {
+        "game_date": label_date,
+        "game_pk": game_pk,
+        "inning": 7,
+        "inning_topbot": "Top",
+        "at_bat_number": at_bat_number,
+        "pitch_number": pitch_number,
+        "outs_when_up": 1,
+        "pitcher_id": pitcher_id,
+        "home_team": "NYY",
+        "away_team": "BOS",
+        "events": "strikeout",
+        "description": "called_strike",
+    }
+
+
+def _success_fetcher(label_date: str) -> List[Dict[str, Any]]:
+    return [
+        _base_row(label_date, 1001, 4, 2, 700),
+        _base_row(label_date, 1001, 4, 1, 700),
+    ]
+
+
+def _source_audit(scaffold_source: str) -> List[Dict[str, Any]]:
+    return [
+        {
+            "check": "scaffold_modified_for_live_integration",
+            "passed": "candidate_bullpen_live_adapter_scaffold_integration_v0.1" in scaffold_source,
+            "detail": "integration version marker",
+        },
+        {
+            "check": "helper_entrypoint_defined",
+            "passed": "def run_candidate_bullpen_live_adapter_scaffold(" in scaffold_source,
+            "detail": "run_candidate_bullpen_live_adapter_scaffold",
+        },
+        {
+            "check": "live_artifact_mapper_defined",
+            "passed": "def _candidate_bullpen_live_artifact_from_adapter_result(" in scaffold_source,
+            "detail": "_candidate_bullpen_live_artifact_from_adapter_result",
+        },
+        {
+            "check": "blocked_artifact_mapper_defined",
+            "passed": "def _candidate_bullpen_live_blocked_artifact(" in scaffold_source,
+            "detail": "_candidate_bullpen_live_blocked_artifact",
+        },
+    ]
+
+
+def _cli_audit(module: Any, scaffold_source: str) -> List[Dict[str, Any]]:
+    rows = [
+        {
+            "check": "default_source_mode_fixture",
+            "passed": getattr(module, "CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE", None) == "fixture",
+            "detail": getattr(module, "CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE", None),
+        },
+        {
+            "check": "live_source_mode_defined",
+            "passed": getattr(module, "CANDIDATE_BULLPEN_SOURCE_MODE_LIVE", None) == "live",
+            "detail": getattr(module, "CANDIDATE_BULLPEN_SOURCE_MODE_LIVE", None),
+        },
+        {
+            "check": "source_mode_cli_defined",
+            "passed": "--source-mode" in scaffold_source or "source_mode=" in scaffold_source,
+            "detail": "source_mode contract present",
+        },
+    ]
+    fixture_result = module.run_candidate_bullpen_live_adapter_scaffold(["2024-07-16"])
+    rows.append({
+        "check": "fixture_default_path_inert",
+        "passed": (
+            fixture_result.get("source_mode") == "fixture"
+            and fixture_result.get("adapter_status") == "fixture_mode_unchanged"
+            and fixture_result.get("external_fetch_performed") is False
+            and fixture_result.get("db_writes_performed") is False
+        ),
+        "detail": fixture_result.get("adapter_status"),
+    })
+    return rows
+
+
+def _gate_audit(module: Any) -> List[Dict[str, Any]]:
+    live_without_dry_run = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=False,
+    )
+    live_write_blocked = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        allow_live_write=True,
+    )
+    invalid_date = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-7-16"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=_success_fetcher,
+    )
+    multiple_dates = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16", "2024-07-17"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=_success_fetcher,
+    )
+    live_success = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=_success_fetcher,
+    )
+
+    return [
+        {
+            "check": "live_requires_dry_run_defined",
+            "status": live_without_dry_run.get("adapter_status"),
+            "passed": live_without_dry_run.get("adapter_status") == "live_requires_dry_run",
+        },
+        {
+            "check": "live_write_blocked_defined",
+            "status": live_write_blocked.get("adapter_status"),
+            "passed": live_write_blocked.get("adapter_status") == "live_write_blocked",
+        },
+        {
+            "check": "live_date_window_invalid_defined",
+            "status": invalid_date.get("adapter_status"),
+            "passed": invalid_date.get("adapter_status") == "live_date_window_invalid",
+        },
+        {
+            "check": "live_multiple_dates_blocked",
+            "status": multiple_dates.get("adapter_status"),
+            "passed": multiple_dates.get("adapter_status") == "live_date_window_invalid",
+        },
+        {
+            "check": "live_dry_run_success_path",
+            "status": live_success.get("adapter_status"),
+            "passed": (
+                live_success.get("source_mode") == "live"
+                and live_success.get("adapter_status") == "live_dry_run_ready"
+                and live_success.get("adapter_normalized_row_count") == 2
+                and live_success.get("db_writes_performed") is False
+                and live_success.get("candidate_labels_materialized") is False
+            ),
+        },
+    ]
+
+
+def _artifact_contract_audit(module: Any) -> List[Dict[str, Any]]:
+    artifact_fields = set(getattr(module, "CANDIDATE_BULLPEN_LIVE_ARTIFACT_FIELDS", []))
+    live_success = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=_success_fetcher,
+    )
+    return [
+        {
+            "check": "live_artifact_contract_defined",
+            "passed": artifact_fields == REQUIRED_LIVE_ARTIFACT_FIELDS,
+            "detail": f"{len(artifact_fields)} fields",
+        },
+        {
+            "check": "live_artifact_payload_contains_required_fields",
+            "passed": REQUIRED_LIVE_ARTIFACT_FIELDS.issubset(set(live_success)),
+            "detail": f"{len(REQUIRED_LIVE_ARTIFACT_FIELDS.intersection(set(live_success)))} fields",
+        },
+        {
+            "check": "no_live_candidate_label_materialization",
+            "passed": live_success.get("candidate_labels_materialized") is False,
+            "detail": live_success.get("candidate_labels_materialized"),
+        },
+        {
+            "check": "live_artifact_safety_flags",
+            "passed": (
+                live_success.get("db_writes_performed") is False
+                and live_success.get("adapter_db_writes_performed") is False
+                and live_success.get("production_default_unchanged") is True
+            ),
+            "detail": True,
+        },
+    ]
+
+
+def _import_boundary_audit(scaffold_source: str) -> List[Dict[str, Any]]:
+    tree = ast.parse(scaffold_source)
+    top_level_imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            top_level_imports.append(ast.get_source_segment(scaffold_source, node) or "")
+
+    top_level_import_text = "\n".join(top_level_imports)
+    lazy_import_present = (
+        "from scripts.fetch_candidate_bullpen_statcast_live_adapter import" in scaffold_source
+        and "fetch_candidate_bullpen_statcast_live_rows_for_date" in scaffold_source
+    )
+
+    return [
+        {
+            "check": "lazy_adapter_import_defined",
+            "passed": lazy_import_present,
+            "detail": "adapter import appears in helper body",
+        },
+        {
+            "check": "no_top_level_adapter_import",
+            "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_level_import_text,
+            "detail": True,
+        },
+        {
+            "check": "no_top_level_pybaseball_import",
+            "passed": "pybaseball" not in top_level_import_text and "statcast" not in top_level_import_text,
+            "detail": True,
+        },
+    ]
+
+
+def _immutability_audit(before_snapshot: Dict[str, str]) -> List[Dict[str, Any]]:
+    after_snapshot = _snapshot_files()
+    return [
+        {
+            "check": "adapter_not_modified",
+            "passed": before_snapshot.get(str(ADAPTER_PATH)) == after_snapshot.get(str(ADAPTER_PATH)),
+            "detail": str(ADAPTER_PATH),
+        },
+        {
+            "check": "prior_layers_not_modified",
+            "passed": all(
+                before_snapshot.get(str(path)) == after_snapshot.get(str(path))
+                for path in [PLAN_6DF, AUDIT_6DG, AUDIT_6DI, PLAN_6DJ, AUDIT_6DK, TEST_DOUBLE_PROTOTYPE_6DD, TEST_DOUBLE_AUDIT_6DE]
+            ),
+            "detail": "6DF/6DG/6DI/6DJ/6DK/6DD/6DE unchanged",
+        },
+        {
+            "check": "no_fixture_mutation",
+            "passed": before_snapshot == after_snapshot,
+            "detail": "fixture and tracked dependency files unchanged",
+        },
+    ]
+
+
+def _safety_audit(scaffold_source: str, gate_rows: List[Dict[str, Any]], artifact_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    import_audit = _import_boundary_audit(scaffold_source)
+    marker = "# Layer 6DL: candidate bullpen Statcast live adapter scaffold integration."
+    live_block = scaffold_source[scaffold_source.find(marker):] if marker in scaffold_source else scaffold_source
+    lower_live_block = live_block.lower()
+    live_success_passed = any(row["check"] == "live_dry_run_success_path" and row["passed"] for row in gate_rows)
+    artifact_safety_passed = any(row["check"] == "live_artifact_safety_flags" and row["passed"] for row in artifact_rows)
+    return [
+        {"check": "no_external_fetch", "passed": all(token not in live_block for token in ["requests.", "httpx.", "urllib."]), "detail": True},
+        {"check": "no_db_writes", "passed": all(token not in lower_live_block for token in ["session.commit(", ".to_sql(", "insert into"]), "detail": True},
+        {"check": "no_top_level_pybaseball_import", "passed": any(row["check"] == "no_top_level_pybaseball_import" and row["passed"] for row in import_audit), "detail": True},
+        {"check": "live_dry_run_safety_flags_valid", "passed": live_success_passed and artifact_safety_passed, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+
+def main() -> None:
+    before_snapshot = _snapshot_files()
+    scaffold_source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_scaffold_module()
+
+    source_rows = _source_audit(scaffold_source)
+    cli_rows = _cli_audit(module, scaffold_source)
+    gate_rows = _gate_audit(module)
+    artifact_rows = _artifact_contract_audit(module)
+    import_rows = _import_boundary_audit(scaffold_source)
+    immutability_rows = _immutability_audit(before_snapshot)
+    safety_rows = _safety_audit(scaffold_source, gate_rows, artifact_rows)
+
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_CLI, cli_rows)
+    _write_csv(OUTPUT_GATES, gate_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+
+    checks = [
+        {"check": "scaffold_modified_for_live_integration", "passed": any(row["check"] == "scaffold_modified_for_live_integration" and row["passed"] for row in source_rows), "detail": "integration marker"},
+        {"check": "default_source_mode_fixture", "passed": any(row["check"] == "default_source_mode_fixture" and row["passed"] for row in cli_rows), "detail": "fixture"},
+        {"check": "source_mode_cli_defined", "passed": any(row["check"] == "source_mode_cli_defined" and row["passed"] for row in cli_rows), "detail": "source_mode"},
+        {"check": "live_requires_dry_run_defined", "passed": any(row["check"] == "live_requires_dry_run_defined" and row["passed"] for row in gate_rows), "detail": "live_requires_dry_run"},
+        {"check": "live_write_blocked_defined", "passed": any(row["check"] == "live_write_blocked_defined" and row["passed"] for row in gate_rows), "detail": "live_write_blocked"},
+        {"check": "live_date_window_invalid_defined", "passed": any(row["check"] == "live_date_window_invalid_defined" and row["passed"] for row in gate_rows), "detail": "live_date_window_invalid"},
+        {"check": "lazy_adapter_import_defined", "passed": any(row["check"] == "lazy_adapter_import_defined" and row["passed"] for row in import_rows), "detail": "lazy import"},
+        {"check": "no_top_level_adapter_import", "passed": any(row["check"] == "no_top_level_adapter_import" and row["passed"] for row in import_rows), "detail": True},
+        {"check": "no_top_level_pybaseball_import", "passed": any(row["check"] == "no_top_level_pybaseball_import" and row["passed"] for row in import_rows), "detail": True},
+        {"check": "live_artifact_contract_defined", "passed": any(row["check"] == "live_artifact_contract_defined" and row["passed"] for row in artifact_rows), "detail": f"{len(REQUIRED_LIVE_ARTIFACT_FIELDS)} fields"},
+        {"check": "no_live_candidate_label_materialization", "passed": any(row["check"] == "no_live_candidate_label_materialization" and row["passed"] for row in artifact_rows), "detail": True},
+        {"check": "adapter_not_modified", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_external_fetch", "passed": any(row["check"] == "no_external_fetch" and row["passed"] for row in safety_rows), "detail": True},
+        {"check": "no_db_writes", "passed": any(row["check"] == "no_db_writes" and row["passed"] for row in safety_rows), "detail": True},
+        {"check": "production_default_unchanged", "passed": any(row["check"] == "production_default_unchanged" and row["passed"] for row in safety_rows), "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_scaffold_integration_complete",
+        "validation_version": VALIDATION_VERSION,
+        "source_audit_rows": len(source_rows),
+        "cli_source_mode_audit_rows": len(cli_rows),
+        "live_gate_audit_rows": len(gate_rows),
+        "artifact_contract_audit_rows": len(artifact_rows),
+        "import_boundary_audit_rows": len(import_rows),
+        "immutability_rows": len(immutability_rows),
+        "safety_rows": len(safety_rows),
+        "all_checks_passed": all_checks_passed,
+        "scaffold_integration_complete": True,
+        "live_integration_gated": True,
+        "default_fixture_behavior_preserved": True,
+        "adapter_unchanged": True,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6DM_candidate_bullpen_statcast_live_adapter_scaffold_integration_audit"
+            if all_checks_passed
+            else "6DL_patch_candidate_bullpen_statcast_live_adapter_scaffold_integration"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6DL: the first safe scaffold integration for the candidate bullpen Statcast live adapter.

## Validation

- compileall passed
- scaffold modified for live integration
- default source mode remains fixture
- source-mode contract defined
- live requires dry-run
- live write blocked
- invalid and multiple live dates blocked
- live dry-run success path works
- lazy adapter import defined
- no top-level adapter import
- no top-level pybaseball/statcast import
- live artifact contract defined
- no live candidate-label materialization
- adapter unchanged
- fixtures unchanged
- no external fetch
- no DB writes
- production defaults unchanged
- all checks passed

## Findings

The scaffold now exposes a gated live-adapter helper that remains inert in fixture/default mode, requires explicit live source mode and dry-run, blocks write attempts, validates single-date live windows before adapter calls, lazily imports the adapter only inside the live branch, and propagates adapter status/artifact metadata without materializing candidate labels from live rows.

## Safety

The standalone adapter is unchanged, prior planning/audit scripts are unchanged, fixtures are unchanged, no real Statcast fetch is performed during validation, no database writes occur, no live rows are materialized into candidate labels, and production defaults remain fixture-based.