### PR TITLE
Add Layer 6DQ candidate bullpen Statcast live adapter CLI scaffold integration audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py
+++ b/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import ast
+import csv
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+VALIDATION_6DL = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DM = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+PLAN_6DN = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_contract.py")
+AUDIT_6DO = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_contract_plan.py")
+VALIDATION_6DP = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+VALIDATION_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.json"
+VALIDATION_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_checks.csv"
+VALIDATION_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_source_audit.csv"
+VALIDATION_CLI_ARGS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_cli_argument_audit.csv"
+VALIDATION_SUBPROCESS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_subprocess_blocked_live_audit.csv"
+VALIDATION_HELPER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_helper_runtime_audit.csv"
+VALIDATION_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_artifact_contract_audit.csv"
+VALIDATION_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_import_boundary_audit.csv"
+VALIDATION_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_safety_audit.csv"
+VALIDATION_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_immutability_audit.csv"
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_checks.csv"
+OUTPUT_VALIDATION_ARTIFACTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_validation_artifacts.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_source.csv"
+OUTPUT_CLI_BLOCKED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_cli_blocked_behavior.csv"
+OUTPUT_HELPER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_helper_runtime.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_artifact_contract.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_import_boundary.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_safety.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_immutability.csv"
+
+REQUIRED_ADAPTER_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+}
+
+REQUIRED_SAFETY_FIELDS = {
+    "external_fetch_performed",
+    "db_writes_performed",
+    "candidate_labels_materialized",
+    "production_default_unchanged",
+}
+
+
+class FetchProbe:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def __call__(self, label_date: str) -> List[Dict[str, Any]]:
+        self.calls.append(label_date)
+        return [
+            {
+                "game_date": label_date,
+                "game_pk": 9201,
+                "inning": 8,
+                "inning_topbot": "Bot",
+                "at_bat_number": 4,
+                "pitch_number": 1,
+                "outs_when_up": 2,
+                "pitcher_id": 700777,
+                "home_team": "NYM",
+                "away_team": "ATL",
+                "events": "field_out",
+                "description": "hit_into_play",
+            }
+        ]
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        VALIDATION_6DL,
+        AUDIT_6DM,
+        PLAN_6DN,
+        AUDIT_6DO,
+        VALIDATION_6DP,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _load_scaffold_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_cli_scaffold_audit_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\n".join(imports)
+
+
+def _run_validation_script() -> Dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(VALIDATION_6DP)],
+        capture_output=True,
+        text=True,
+    )
+    diagnosis = _read_json(VALIDATION_JSON)
+    return {
+        "returncode": completed.returncode,
+        "diagnosis": diagnosis.get("diagnosis", ""),
+        "all_checks_passed": diagnosis.get("all_checks_passed"),
+        "stdout_tail": completed.stdout[-1000:],
+        "stderr_tail": completed.stderr[-1000:],
+        "passed": (
+            completed.returncode == 0
+            and diagnosis.get("diagnosis") == "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_complete"
+            and diagnosis.get("all_checks_passed") is True
+            and diagnosis.get("cli_scaffold_integration_complete") is True
+            and diagnosis.get("live_cli_gated") is True
+            and diagnosis.get("adapter_unchanged") is True
+            and diagnosis.get("external_fetch_performed") is False
+            and diagnosis.get("db_writes_performed") is False
+            and diagnosis.get("candidate_labels_materialized_from_live_rows") is False
+            and diagnosis.get("production_default_unchanged") is True
+        ),
+    }
+
+
+def _validation_artifact_rows() -> List[Dict[str, Any]]:
+    artifacts = [
+        VALIDATION_JSON,
+        VALIDATION_CHECKS,
+        VALIDATION_SOURCE,
+        VALIDATION_CLI_ARGS,
+        VALIDATION_SUBPROCESS,
+        VALIDATION_HELPER,
+        VALIDATION_ARTIFACT,
+        VALIDATION_IMPORT,
+        VALIDATION_SAFETY,
+        VALIDATION_IMMUTABILITY,
+    ]
+    return [
+        {
+            "artifact": str(path),
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        }
+        for path in artifacts
+    ]
+
+
+def _scaffold_source_rows(source: str) -> List[Dict[str, Any]]:
+    helper_idx = source.find("def run_candidate_bullpen_live_adapter_scaffold(")
+    main_idx = source.rfind('if __name__ == "__main__":')
+    return [
+        {"check": "cli_integration_marker_exists", "passed": "candidate_bullpen_live_adapter_cli_scaffold_integration_v0.1" in source, "detail": True},
+        {"check": "allow_live_write_arg_exists", "passed": '"--allow-live-write"' in source, "detail": True},
+        {"check": "explicit_live_route_exists", "passed": 'if args.source_mode == "live":' in source, "detail": True},
+        {"check": "live_route_calls_helper", "passed": "run_candidate_bullpen_live_adapter_scaffold(" in source, "detail": True},
+        {"check": "live_route_prints_json", "passed": "print(json.dumps(live_artifact" in source, "detail": True},
+        {"check": "main_call_after_helper_definition", "passed": helper_idx != -1 and main_idx != -1 and main_idx > helper_idx, "detail": {"helper_idx": helper_idx, "main_idx": main_idx}},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _run_cli(args: List[str]) -> Dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(SCAFFOLD_PATH), *args],
+        capture_output=True,
+        text=True,
+    )
+    payload: Dict[str, Any] = {}
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception:
+        payload = {}
+    return {
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "payload": payload,
+    }
+
+
+def _cli_blocked_rows() -> List[Dict[str, Any]]:
+    cases = [
+        (
+            "live_without_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+            "live_requires_dry_run",
+        ),
+        (
+            "live_write_attempt",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"],
+            "live_write_blocked",
+        ),
+        (
+            "invalid_live_date",
+            ["--source-mode", "live", "--start-date", "2024-7-16", "--end-date", "2024-7-16", "--dry-run"],
+            "live_date_window_invalid",
+        ),
+    ]
+
+    rows: List[Dict[str, Any]] = []
+    for name, args, expected_status in cases:
+        result = _run_cli(args)
+        payload = result["payload"]
+        rows.append(
+            {
+                "case": name,
+                "expected_status": expected_status,
+                "actual_status": payload.get("adapter_status"),
+                "returncode": result["returncode"],
+                "json_payload": bool(payload),
+                "external_fetch_performed": payload.get("external_fetch_performed"),
+                "db_writes_performed": payload.get("db_writes_performed"),
+                "candidate_labels_materialized": payload.get("candidate_labels_materialized"),
+                "passed": (
+                    result["returncode"] == 0
+                    and bool(payload)
+                    and payload.get("adapter_status") == expected_status
+                    and payload.get("external_fetch_performed") is False
+                    and payload.get("db_writes_performed") is False
+                    and payload.get("candidate_labels_materialized") is False
+                ),
+            }
+        )
+    return rows
+
+
+def _helper_runtime_rows(module: Any) -> List[Dict[str, Any]]:
+    probe = FetchProbe()
+    success = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        allow_live_write=False,
+        fetcher=probe,
+    )
+
+    invalid_probe = FetchProbe()
+    invalid = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["bad-date"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=invalid_probe,
+    )
+
+    multi_probe = FetchProbe()
+    multi = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16", "2024-07-17"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=multi_probe,
+    )
+
+    fixture_probe = FetchProbe()
+    fixture = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="fixture",
+        dry_run=False,
+        fetcher=fixture_probe,
+    )
+
+    return [
+        {"check": "synthetic_live_dry_run_ready", "passed": success.get("adapter_status") == "live_dry_run_ready", "status": success.get("adapter_status")},
+        {"check": "synthetic_fetcher_called_once", "passed": probe.calls == ["2024-07-16"], "calls": len(probe.calls)},
+        {"check": "invalid_date_blocks_before_fetcher", "passed": invalid.get("adapter_status") == "live_date_window_invalid" and not invalid_probe.calls, "status": invalid.get("adapter_status"), "calls": len(invalid_probe.calls)},
+        {"check": "multiple_dates_block_before_fetcher", "passed": multi.get("adapter_status") == "live_date_window_invalid" and not multi_probe.calls, "status": multi.get("adapter_status"), "calls": len(multi_probe.calls)},
+        {"check": "fixture_helper_branch_inert", "passed": fixture.get("adapter_status") == "fixture_mode_unchanged" and not fixture_probe.calls, "status": fixture.get("adapter_status"), "calls": len(fixture_probe.calls)},
+        {"check": "helper_no_db_writes", "passed": success.get("db_writes_performed") is False, "value": success.get("db_writes_performed")},
+        {"check": "helper_no_candidate_materialization", "passed": success.get("candidate_labels_materialized") is False, "value": success.get("candidate_labels_materialized")},
+    ]
+
+
+def _artifact_contract_rows(module: Any) -> List[Dict[str, Any]]:
+    probe = FetchProbe()
+    success = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        fetcher=probe,
+    )
+    blocked = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=False,
+    )
+    invalid = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["bad-date"],
+        source_mode="live",
+        dry_run=True,
+    )
+
+    required = REQUIRED_ADAPTER_FIELDS | REQUIRED_SAFETY_FIELDS
+    return [
+        {"check": "success_required_fields_present", "passed": required.issubset(success), "detail": f"{len(required.intersection(success))}/{len(required)}"},
+        {"check": "blocked_required_fields_present", "passed": required.issubset(blocked), "detail": f"{len(required.intersection(blocked))}/{len(required)}"},
+        {"check": "invalid_required_fields_present", "passed": required.issubset(invalid), "detail": f"{len(required.intersection(invalid))}/{len(required)}"},
+        {"check": "blocked_status_error_metadata_present", "passed": blocked.get("adapter_status") == "live_requires_dry_run" and bool(blocked.get("adapter_fetch_error")), "detail": blocked.get("adapter_fetch_error")},
+        {"check": "invalid_status_error_metadata_present", "passed": invalid.get("adapter_status") == "live_date_window_invalid" and bool(invalid.get("adapter_fetch_error")), "detail": invalid.get("adapter_fetch_error")},
+    ]
+
+
+def _import_boundary_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    helper_idx = source.find("def run_candidate_bullpen_live_adapter_scaffold(")
+    helper_body = source[helper_idx:] if helper_idx != -1 else ""
+    return [
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "adapter_import_inside_helper_boundary", "passed": "fetch_candidate_bullpen_statcast_live_adapter" in helper_body, "detail": True},
+    ]
+
+
+def _safety_rows(source: str, cli_rows: List[Dict[str, Any]], helper_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    marker = "# Layer 6DP: candidate bullpen Statcast live adapter CLI scaffold integration."
+    live_block = source[source.find(marker):] if marker in source else source
+    lower_live_block = live_block.lower()
+    return [
+        {"check": "no_external_fetch", "passed": all(row["passed"] for row in cli_rows) and all(row["passed"] for row in helper_rows), "detail": "blocked CLI plus synthetic helper only"},
+        {"check": "no_network_client_added", "passed": all(token not in lower_live_block for token in ["requests.", "httpx.", "urllib."]), "detail": "6DP/6DL live integration block only"},
+        {"check": "no_db_writes", "passed": all(row.get("db_writes_performed") is False for row in cli_rows), "detail": True},
+        {"check": "no_candidate_materialization", "passed": all(row.get("candidate_labels_materialized") is False for row in cli_rows), "detail": True},
+        {"check": "production_default_unchanged", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "scaffold_not_modified_by_audit", "passed": before.get(str(SCAFFOLD_PATH)) == after.get(str(SCAFFOLD_PATH)), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "validation_script_not_modified", "passed": before.get(str(VALIDATION_6DP)) == after.get(str(VALIDATION_6DP)), "detail": str(VALIDATION_6DP)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": all(before.get(str(path)) == after.get(str(path)) for path in [VALIDATION_6DL, AUDIT_6DM, PLAN_6DN, AUDIT_6DO]), "detail": "6DL/6DM/6DN/6DO unchanged"},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixture and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+
+    validation_execution = _run_validation_script()
+    validation_artifacts = _validation_artifact_rows()
+
+    source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_scaffold_module()
+
+    source_rows = _scaffold_source_rows(source)
+    cli_rows = _cli_blocked_rows()
+    helper_rows = _helper_runtime_rows(module)
+    artifact_rows = _artifact_contract_rows(module)
+    import_rows = _import_boundary_rows(source)
+    safety_rows = _safety_rows(source, cli_rows, helper_rows)
+    immutability_rows = _immutability_rows(before)
+
+    _write_csv(OUTPUT_VALIDATION_ARTIFACTS, validation_artifacts)
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_CLI_BLOCKED, cli_rows)
+    _write_csv(OUTPUT_HELPER, helper_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "validation_script_execution_valid", "passed": validation_execution["passed"], "detail": validation_execution["diagnosis"]},
+        {"check": "validation_artifacts_valid", "passed": all(row["passed"] for row in validation_artifacts), "detail": f"{sum(row['passed'] for row in validation_artifacts)}/{len(validation_artifacts)}"},
+        {"check": "scaffold_source_valid", "passed": all(row["passed"] for row in source_rows), "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "cli_blocked_behavior_valid", "passed": all(row["passed"] for row in cli_rows), "detail": f"{sum(row['passed'] for row in cli_rows)}/{len(cli_rows)}"},
+        {"check": "helper_runtime_valid", "passed": all(row["passed"] for row in helper_rows), "detail": f"{sum(row['passed'] for row in helper_rows)}/{len(helper_rows)}"},
+        {"check": "artifact_contract_valid", "passed": all(row["passed"] for row in artifact_rows), "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "import_boundary_valid", "passed": all(row["passed"] for row in import_rows), "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "safety_valid", "passed": all(row["passed"] for row in safety_rows), "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "scaffold_not_modified_by_audit", "passed": any(row["check"] == "scaffold_not_modified_by_audit" and row["passed"] for row in immutability_rows), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "validation_script_not_modified", "passed": any(row["check"] == "validation_script_not_modified" and row["passed"] for row in immutability_rows), "detail": str(VALIDATION_6DP)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_external_fetch", "passed": True, "detail": "blocked CLI subprocesses plus synthetic helper only"},
+        {"check": "no_db_writes", "passed": True, "detail": "audit-only; no DB writes"},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "validation_artifact_rows": len(validation_artifacts),
+        "scaffold_source_rows": len(source_rows),
+        "cli_blocked_behavior_rows": len(cli_rows),
+        "helper_runtime_rows": len(helper_rows),
+        "artifact_contract_rows": len(artifact_rows),
+        "import_boundary_rows": len(import_rows),
+        "safety_rows": len(safety_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "audit_only": True,
+        "cli_scaffold_integration_validated": True,
+        "scaffold_modified_by_audit": False,
+        "adapter_modified": False,
+        "validation_script_modified": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "fixture_assets_mutated": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6DR_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan"
+            if all_checks_passed
+            else "6DQ_patch_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration_audit"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6DQ: an audit-only validation layer for the candidate bullpen Statcast live adapter CLI scaffold integration from 6DP.

## Validation

- compileall passed
- 6DP validation script execution valid
- validation artifacts valid: 10/10
- scaffold source valid: 7/7
- CLI blocked behavior valid: 3/3
- helper runtime valid: 7/7
- artifact contract valid: 5/5
- import boundary valid: 3/3
- safety valid: 5/5
- immutability valid: 5/5

## Findings

The audit confirms the explicit live CLI scaffold path remains gated and validates the expected blocked statuses: `live_requires_dry_run`, `live_write_blocked`, and `live_date_window_invalid`. The direct helper runtime validates synthetic live dry-run behavior and fixture branch inertness.

## Safety

Audit-only. No scaffold modification by the audit, adapter unchanged, 6DP validation unchanged, no fixture mutation, no external fetch, no DB writes, no candidate-label materialization from live rows, and production default unchanged.

## Next Layer

Recommended next layer: `6DR_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan`.