### PR TITLE
Add Layer 6DU candidate bullpen Statcast live adapter CLI live dry-run fetcher injection audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py
+++ b/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py
@@ -1,0 +1,622 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+VALIDATION_6DT = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+VALIDATION_6DL = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DM = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+PLAN_6DN = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_contract.py")
+AUDIT_6DO = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_contract_plan.py")
+VALIDATION_6DP = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+AUDIT_6DQ = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+PLAN_6DR = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DS = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+VALIDATION_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.json"
+VALIDATION_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_checks.csv"
+VALIDATION_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_source_audit.csv"
+VALIDATION_RESOLVER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_resolver_audit.csv"
+VALIDATION_BLOCKED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_blocked_cli_audit.csv"
+VALIDATION_SYNTHETIC = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_synthetic_cli_audit.csv"
+VALIDATION_HELPER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_helper_audit.csv"
+VALIDATION_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_artifact_contract_audit.csv"
+VALIDATION_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_import_boundary_audit.csv"
+VALIDATION_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_safety_audit.csv"
+VALIDATION_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_immutability_audit.csv"
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_checks.csv"
+OUTPUT_VALIDATION_EXECUTION = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_validation_execution.csv"
+OUTPUT_VALIDATION_ARTIFACTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_validation_artifacts.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_source.csv"
+OUTPUT_RESOLVER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_resolver_behavior.csv"
+OUTPUT_CLI = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_cli_behavior.csv"
+OUTPUT_HELPER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_helper_behavior.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_artifact_contract.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_import_boundary.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_safety.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_immutability.csv"
+
+REQUIRED_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+    "external_fetch_performed",
+    "db_writes_performed",
+    "candidate_labels_materialized",
+    "production_default_unchanged",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        VALIDATION_6DT,
+        VALIDATION_6DL,
+        AUDIT_6DM,
+        PLAN_6DN,
+        AUDIT_6DO,
+        VALIDATION_6DP,
+        AUDIT_6DQ,
+        PLAN_6DR,
+        AUDIT_6DS,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _load_scaffold_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_fetcher_injection_audit_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\n".join(imports)
+
+
+def _run_validation() -> Dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(VALIDATION_6DT)],
+        capture_output=True,
+        text=True,
+    )
+    diagnosis = _read_json(VALIDATION_JSON)
+    return {
+        "returncode": completed.returncode,
+        "diagnosis": diagnosis.get("diagnosis", ""),
+        "all_checks_passed": diagnosis.get("all_checks_passed"),
+        "implementation_complete": diagnosis.get("implementation_complete"),
+        "cli_synthetic_live_dry_run_ready": diagnosis.get("cli_synthetic_live_dry_run_ready"),
+        "blocked_live_paths_valid": diagnosis.get("blocked_live_paths_valid"),
+        "stdout_tail": completed.stdout[-1000:],
+        "stderr_tail": completed.stderr[-1000:],
+        "passed": (
+            completed.returncode == 0
+            and diagnosis.get("diagnosis") == "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_complete"
+            and diagnosis.get("all_checks_passed") is True
+            and diagnosis.get("implementation_complete") is True
+            and diagnosis.get("cli_synthetic_live_dry_run_ready") is True
+            and diagnosis.get("blocked_live_paths_valid") is True
+            and diagnosis.get("adapter_unchanged") is True
+            and diagnosis.get("prior_validation_audit_plan_scripts_unchanged") is True
+            and diagnosis.get("fixture_assets_mutated") is False
+            and diagnosis.get("external_fetch_performed") is False
+            and diagnosis.get("db_writes_performed") is False
+            and diagnosis.get("candidate_labels_materialized_from_live_rows") is False
+            and diagnosis.get("production_default_unchanged") is True
+        ),
+    }
+
+
+def _validation_artifact_rows() -> List[Dict[str, Any]]:
+    artifacts = [
+        VALIDATION_JSON,
+        VALIDATION_CHECKS,
+        VALIDATION_SOURCE,
+        VALIDATION_RESOLVER,
+        VALIDATION_BLOCKED,
+        VALIDATION_SYNTHETIC,
+        VALIDATION_HELPER,
+        VALIDATION_ARTIFACT,
+        VALIDATION_IMPORT,
+        VALIDATION_SAFETY,
+        VALIDATION_IMMUTABILITY,
+    ]
+    return [
+        {
+            "artifact": str(path),
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        }
+        for path in artifacts
+    ]
+
+
+def _run_cli(args: List[str], synthetic: bool = False) -> Dict[str, Any]:
+    env = os.environ.copy()
+    if synthetic:
+        env["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = "synthetic"
+    else:
+        env.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCAFFOLD_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception:
+        payload = {}
+    return {
+        "returncode": completed.returncode,
+        "payload": payload,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+
+
+def _source_rows(source: str) -> List[Dict[str, Any]]:
+    return [
+        {"check": "six_dt_marker_present", "passed": "candidate_bullpen_live_adapter_cli_live_dry_run_fetcher_injection_v0.1" in source, "detail": True},
+        {"check": "synthetic_fetcher_present", "passed": "def _candidate_bullpen_live_synthetic_fetcher" in source, "detail": True},
+        {"check": "resolver_present", "passed": "def _resolve_candidate_bullpen_live_fetcher" in source, "detail": True},
+        {"check": "env_gate_present", "passed": "CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE" in source, "detail": True},
+        {"check": "live_route_passes_resolved_fetcher", "passed": "fetcher=resolved_fetcher" in source, "detail": True},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _resolver_behavior_rows(module: Any) -> List[Dict[str, Any]]:
+    old_env = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    def args(**kwargs: Any) -> argparse.Namespace:
+        base = {
+            "source_mode": "live",
+            "dry_run": True,
+            "write": False,
+            "allow_live_write": False,
+        }
+        base.update(kwargs)
+        return argparse.Namespace(**base)
+
+    rows: List[Dict[str, Any]] = []
+    rows.append(
+        {
+            "check": "non_live_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(source_mode="fixture"), ["2024-07-16"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "live_without_dry_run_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(dry_run=False), ["2024-07-16"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "write_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(write=True), ["2024-07-16"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "allow_live_write_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(allow_live_write=True), ["2024-07-16"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "missing_date_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(), []) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "invalid_date_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(), ["2024-7-16"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "multi_date_resolves_none",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(), ["2024-07-16", "2024-07-17"]) is None,
+            "detail": True,
+        }
+    )
+    rows.append(
+        {
+            "check": "default_live_dry_run_no_real_fetcher",
+            "passed": module._resolve_candidate_bullpen_live_fetcher(args(), ["2024-07-16"]) is None,
+            "detail": True,
+        }
+    )
+
+    os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = "synthetic"
+    fetcher = module._resolve_candidate_bullpen_live_fetcher(args(), ["2024-07-16"])
+    rows.append(
+        {
+            "check": "synthetic_env_resolves_fetcher",
+            "passed": callable(fetcher),
+            "detail": str(fetcher),
+        }
+    )
+    sample_rows = fetcher("2024-07-16") if callable(fetcher) else []
+    rows.append(
+        {
+            "check": "synthetic_fetcher_deterministic_valid_rows",
+            "passed": (
+                isinstance(sample_rows, list)
+                and len(sample_rows) == 2
+                and all(row.get("game_date") == "2024-07-16" for row in sample_rows)
+                and all("pitcher_id" in row for row in sample_rows)
+            ),
+            "detail": len(sample_rows) if isinstance(sample_rows, list) else "not-list",
+        }
+    )
+
+    if old_env is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_env
+
+    return rows
+
+
+def _cli_behavior_rows() -> List[Dict[str, Any]]:
+    cases = [
+        (
+            "live_without_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+            True,
+            "live_requires_dry_run",
+        ),
+        (
+            "live_write_attempt",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"],
+            True,
+            "live_write_blocked",
+        ),
+        (
+            "invalid_live_date",
+            ["--source-mode", "live", "--start-date", "2024-7-16", "--end-date", "2024-7-16", "--dry-run"],
+            True,
+            "live_date_window_invalid",
+        ),
+        (
+            "multi_date_live_window",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-17", "--dry-run"],
+            True,
+            "live_date_window_invalid",
+        ),
+        (
+            "synthetic_live_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+            True,
+            "live_dry_run_ready",
+        ),
+    ]
+    rows: List[Dict[str, Any]] = []
+    for name, args, synthetic, expected_status in cases:
+        result = _run_cli(args, synthetic=synthetic)
+        payload = result["payload"]
+        expected_rows = 2 if name == "synthetic_live_dry_run" else 0
+        rows.append(
+            {
+                "case": name,
+                "expected_status": expected_status,
+                "actual_status": payload.get("adapter_status"),
+                "returncode": result["returncode"],
+                "adapter_normalized_row_count": payload.get("adapter_normalized_row_count"),
+                "external_fetch_performed": payload.get("external_fetch_performed"),
+                "db_writes_performed": payload.get("db_writes_performed"),
+                "candidate_labels_materialized": payload.get("candidate_labels_materialized"),
+                "passed": (
+                    result["returncode"] == 0
+                    and payload.get("adapter_status") == expected_status
+                    and int(payload.get("adapter_normalized_row_count", 0)) == expected_rows
+                    and payload.get("external_fetch_performed") is False
+                    and payload.get("db_writes_performed") is False
+                    and payload.get("candidate_labels_materialized") is False
+                ),
+            }
+        )
+    return rows
+
+
+def _helper_behavior_rows(module: Any) -> List[Dict[str, Any]]:
+    calls: List[str] = []
+
+    def fetcher(label_date: str) -> List[Dict[str, Any]]:
+        calls.append(label_date)
+        return [
+            {
+                "game_date": label_date,
+                "game_pk": 991001,
+                "inning": 8,
+                "inning_topbot": "Top",
+                "at_bat_number": 55,
+                "pitch_number": 1,
+                "outs_when_up": 1,
+                "pitcher_id": 733333,
+                "home_team": "BOS",
+                "away_team": "NYY",
+                "events": "single",
+                "description": "hit_into_play",
+            }
+        ]
+
+    payload = module.run_candidate_bullpen_live_adapter_scaffold(
+        ["2024-07-16"],
+        source_mode="live",
+        dry_run=True,
+        allow_live_write=False,
+        fetcher=fetcher,
+    )
+
+    return [
+        {"check": "helper_status_live_dry_run_ready", "passed": payload.get("adapter_status") == "live_dry_run_ready", "detail": payload.get("adapter_status")},
+        {"check": "helper_fetcher_called_once", "passed": calls == ["2024-07-16"], "detail": len(calls)},
+        {"check": "helper_no_external_fetch", "passed": payload.get("external_fetch_performed") is False, "detail": payload.get("external_fetch_performed")},
+        {"check": "helper_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "helper_no_candidate_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _artifact_contract_rows() -> List[Dict[str, Any]]:
+    success = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        synthetic=True,
+    )["payload"]
+    blocked = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+        synthetic=True,
+    )["payload"]
+    write_blocked = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"],
+        synthetic=True,
+    )["payload"]
+
+    return [
+        {"check": "success_required_fields", "passed": REQUIRED_FIELDS.issubset(success), "detail": f"{len(REQUIRED_FIELDS.intersection(success))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "blocked_required_fields", "passed": REQUIRED_FIELDS.issubset(blocked), "detail": f"{len(REQUIRED_FIELDS.intersection(blocked))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "write_blocked_required_fields", "passed": REQUIRED_FIELDS.issubset(write_blocked), "detail": f"{len(REQUIRED_FIELDS.intersection(write_blocked))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "success_status", "passed": success.get("adapter_status") == "live_dry_run_ready", "detail": success.get("adapter_status")},
+        {"check": "requires_dry_run_status", "passed": blocked.get("adapter_status") == "live_requires_dry_run", "detail": blocked.get("adapter_status")},
+        {"check": "write_blocked_status", "passed": write_blocked.get("adapter_status") == "live_write_blocked", "detail": write_blocked.get("adapter_status")},
+    ]
+
+
+def _import_boundary_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    helper_idx = source.find("def run_candidate_bullpen_live_adapter_scaffold(")
+    helper_body = source[helper_idx:] if helper_idx != -1 else ""
+    return [
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_or_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "adapter_import_inside_helper_boundary", "passed": "fetch_candidate_bullpen_statcast_live_adapter" in helper_body, "detail": True},
+    ]
+
+
+def _safety_rows(
+    source: str,
+    cli_rows: List[Dict[str, Any]],
+    helper_rows: List[Dict[str, Any]],
+    resolver_rows: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    marker = "# Layer 6DT: candidate bullpen Statcast live adapter CLI live dry-run fetcher injection."
+    live_block = source[source.find(marker):] if marker in source else source
+    lower_live_block = live_block.lower()
+    return [
+        {"check": "audit_only", "passed": True, "detail": True},
+        {"check": "resolver_no_real_fetch_default", "passed": any(row["check"] == "default_live_dry_run_no_real_fetcher" and row["passed"] for row in resolver_rows), "detail": True},
+        {"check": "cli_no_real_external_fetch", "passed": all(row.get("external_fetch_performed") is False for row in cli_rows), "detail": True},
+        {"check": "cli_no_db_writes", "passed": all(row.get("db_writes_performed") is False for row in cli_rows), "detail": True},
+        {"check": "cli_no_candidate_materialization", "passed": all(row.get("candidate_labels_materialized") is False for row in cli_rows), "detail": True},
+        {"check": "helper_safe", "passed": all(row["passed"] for row in helper_rows), "detail": True},
+        {"check": "no_network_client_added_in_6dt_block", "passed": all(token not in lower_live_block for token in ["requests.", "httpx.", "urllib."]), "detail": True},
+        {"check": "production_default_unchanged", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "scaffold_not_modified_by_audit", "passed": before.get(str(SCAFFOLD_PATH)) == after.get(str(SCAFFOLD_PATH)), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dt_validation_not_modified", "passed": before.get(str(VALIDATION_6DT)) == after.get(str(VALIDATION_6DT)), "detail": str(VALIDATION_6DT)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": all(before.get(str(path)) == after.get(str(path)) for path in [VALIDATION_6DL, AUDIT_6DM, PLAN_6DN, AUDIT_6DO, VALIDATION_6DP, AUDIT_6DQ, PLAN_6DR, AUDIT_6DS]), "detail": "6DL through 6DS unchanged"},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixtures and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+    source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_scaffold_module()
+
+    validation_execution = _run_validation()
+    validation_execution_rows = [
+        {
+            "check": "validation_executes_successfully",
+            "returncode": validation_execution["returncode"],
+            "diagnosis": validation_execution["diagnosis"],
+            "all_checks_passed": validation_execution["all_checks_passed"],
+            "implementation_complete": validation_execution["implementation_complete"],
+            "cli_synthetic_live_dry_run_ready": validation_execution["cli_synthetic_live_dry_run_ready"],
+            "blocked_live_paths_valid": validation_execution["blocked_live_paths_valid"],
+            "passed": validation_execution["passed"],
+        }
+    ]
+
+    validation_artifact_rows = _validation_artifact_rows()
+    source_rows = _source_rows(source)
+    resolver_rows = _resolver_behavior_rows(module)
+    cli_rows = _cli_behavior_rows()
+    helper_rows = _helper_behavior_rows(module)
+    artifact_rows = _artifact_contract_rows()
+    import_rows = _import_boundary_rows(source)
+    safety_rows = _safety_rows(source, cli_rows, helper_rows, resolver_rows)
+    immutability_rows = _immutability_rows(before)
+
+    _write_csv(OUTPUT_VALIDATION_EXECUTION, validation_execution_rows)
+    _write_csv(OUTPUT_VALIDATION_ARTIFACTS, validation_artifact_rows)
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_RESOLVER, resolver_rows)
+    _write_csv(OUTPUT_CLI, cli_rows)
+    _write_csv(OUTPUT_HELPER, helper_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "validation_execution_valid", "passed": validation_execution["passed"], "detail": validation_execution["diagnosis"]},
+        {"check": "validation_artifacts_valid", "passed": all(row["passed"] for row in validation_artifact_rows), "detail": f"{sum(row['passed'] for row in validation_artifact_rows)}/{len(validation_artifact_rows)}"},
+        {"check": "source_implementation_valid", "passed": all(row["passed"] for row in source_rows), "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "resolver_behavior_valid", "passed": all(row["passed"] for row in resolver_rows), "detail": f"{sum(row['passed'] for row in resolver_rows)}/{len(resolver_rows)}"},
+        {"check": "cli_behavior_valid", "passed": all(row["passed"] for row in cli_rows), "detail": f"{sum(row['passed'] for row in cli_rows)}/{len(cli_rows)}"},
+        {"check": "helper_behavior_valid", "passed": all(row["passed"] for row in helper_rows), "detail": f"{sum(row['passed'] for row in helper_rows)}/{len(helper_rows)}"},
+        {"check": "artifact_contract_valid", "passed": all(row["passed"] for row in artifact_rows), "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "import_boundary_valid", "passed": all(row["passed"] for row in import_rows), "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "safety_valid", "passed": all(row["passed"] for row in safety_rows), "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "scaffold_not_modified_by_audit", "passed": any(row["check"] == "scaffold_not_modified_by_audit" and row["passed"] for row in immutability_rows), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dt_validation_not_modified", "passed": any(row["check"] == "six_dt_validation_not_modified" and row["passed"] for row in immutability_rows), "detail": str(VALIDATION_6DT)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": any(row["check"] == "prior_validation_audit_plan_scripts_not_modified" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "audit uses env-gated synthetic test double only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_label_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "validation_execution_rows": len(validation_execution_rows),
+        "validation_artifact_rows": len(validation_artifact_rows),
+        "source_rows": len(source_rows),
+        "resolver_behavior_rows": len(resolver_rows),
+        "cli_behavior_rows": len(cli_rows),
+        "helper_behavior_rows": len(helper_rows),
+        "artifact_contract_rows": len(artifact_rows),
+        "import_boundary_rows": len(import_rows),
+        "safety_rows": len(safety_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "audit_only": True,
+        "implementation_validated": True,
+        "validation_artifacts_valid": True,
+        "source_implementation_valid": True,
+        "resolver_behavior_valid": True,
+        "cli_behavior_valid": True,
+        "helper_behavior_valid": True,
+        "artifact_contract_valid": True,
+        "import_boundary_valid": True,
+        "scaffold_modified_by_audit": False,
+        "adapter_modified": False,
+        "six_dt_validation_modified": False,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6DV_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_plan"
+            if all_checks_passed
+            else "6DU_patch_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_audit"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6DU: an audit-only validation layer for the Layer 6DT candidate bullpen Statcast live adapter CLI live dry-run fetcher injection implementation.

## Validation

- compileall passed
- validation execution valid
- validation artifacts valid: 11/11
- source implementation valid: 6/6
- resolver behavior valid: 10/10
- CLI behavior valid: 5/5
- helper behavior valid: 5/5
- artifact contract valid: 6/6
- import boundary valid: 3/3
- safety valid: 8/8
- immutability valid: 5/5

## Findings

The audit independently validates the env-gated synthetic live dry-run path, blocked live statuses, direct helper fetcher injection, artifact/status contracts, lazy import boundary, and safety controls.

## Safety

Audit-only. No scaffold modification by the audit, adapter unchanged, 6DT validation unchanged, prior validation/audit/plan scripts unchanged, fixtures unchanged, no real external fetch, no DB writes, no live-row materialization, and production defaults unchanged.

## Next Layer

Recommended next layer: `6DV_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_plan`.