### PR TITLE
Add Layer 6DY candidate bullpen Statcast live adapter CLI real fetcher resolution audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py
+++ b/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py
@@ -1,0 +1,694 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest import mock
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+VALIDATION_6DX = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+PLAN_6DV = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DW = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_plan.py")
+VALIDATION_6DT = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DU = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+VALIDATION_6DL = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DM = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+PLAN_6DN = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_contract.py")
+AUDIT_6DO = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_contract_plan.py")
+VALIDATION_6DP = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+AUDIT_6DQ = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+PLAN_6DR = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DS = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+VALIDATION_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.json"
+VALIDATION_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_checks.csv"
+VALIDATION_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_source_audit.csv"
+VALIDATION_RESOLVER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_resolver_gate_audit.csv"
+VALIDATION_DEFAULT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_default_behavior_audit.csv"
+VALIDATION_SYNTHETIC = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_synthetic_behavior_audit.csv"
+VALIDATION_MONKEYPATCHED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_monkeypatched_real_fetcher_audit.csv"
+VALIDATION_DEPENDENCY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_dependency_missing_audit.csv"
+VALIDATION_BLOCKED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_blocked_cli_audit.csv"
+VALIDATION_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_artifact_contract_audit.csv"
+VALIDATION_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_import_boundary_audit.csv"
+VALIDATION_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_safety_audit.csv"
+VALIDATION_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_immutability_audit.csv"
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_checks.csv"
+OUTPUT_VALIDATION_EXECUTION = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_validation_execution.csv"
+OUTPUT_VALIDATION_ARTIFACTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_validation_artifacts.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_source.csv"
+OUTPUT_RESOLVER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_resolver_behavior.csv"
+OUTPUT_CLI = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_cli_behavior.csv"
+OUTPUT_MONKEYPATCHED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_monkeypatched_real_fetcher_behavior.csv"
+OUTPUT_DEPENDENCY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_dependency_missing_behavior.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_artifact_contract.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_import_boundary.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_safety.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_immutability.csv"
+
+REQUIRED_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+    "external_fetch_performed",
+    "db_writes_performed",
+    "candidate_labels_materialized",
+    "production_default_unchanged",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        VALIDATION_6DX,
+        PLAN_6DV,
+        AUDIT_6DW,
+        VALIDATION_6DT,
+        AUDIT_6DU,
+        VALIDATION_6DL,
+        AUDIT_6DM,
+        PLAN_6DN,
+        AUDIT_6DO,
+        VALIDATION_6DP,
+        AUDIT_6DQ,
+        PLAN_6DR,
+        AUDIT_6DS,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _load_scaffold_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_real_fetcher_resolution_audit_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\n".join(imports)
+
+
+def _args(**kwargs: Any) -> argparse.Namespace:
+    base = {
+        "source_mode": "live",
+        "dry_run": True,
+        "write": False,
+        "allow_live_write": False,
+    }
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _without_env() -> None:
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+
+
+def _run_validation() -> Dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(VALIDATION_6DX)],
+        capture_output=True,
+        text=True,
+    )
+    diagnosis = _read_json(VALIDATION_JSON)
+    return {
+        "returncode": completed.returncode,
+        "diagnosis": diagnosis.get("diagnosis", ""),
+        "all_checks_passed": diagnosis.get("all_checks_passed"),
+        "implementation_complete": diagnosis.get("implementation_complete"),
+        "source_valid": diagnosis.get("source_valid"),
+        "resolver_gates_valid": diagnosis.get("resolver_gates_valid"),
+        "default_no_real_fetch_valid": diagnosis.get("default_no_real_fetch_valid"),
+        "synthetic_path_valid": diagnosis.get("synthetic_path_valid"),
+        "monkeypatched_real_fetcher_path_valid": diagnosis.get("monkeypatched_real_fetcher_path_valid"),
+        "dependency_missing_safe_path_valid": diagnosis.get("dependency_missing_safe_path_valid"),
+        "blocked_live_paths_valid": diagnosis.get("blocked_live_paths_valid"),
+        "artifact_contract_valid": diagnosis.get("artifact_contract_valid"),
+        "import_boundary_valid": diagnosis.get("import_boundary_valid"),
+        "safety_valid": diagnosis.get("safety_valid"),
+        "immutability_valid": diagnosis.get("immutability_valid"),
+        "passed": (
+            completed.returncode == 0
+            and diagnosis.get("diagnosis") == "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_complete"
+            and diagnosis.get("all_checks_passed") is True
+            and diagnosis.get("implementation_complete") is True
+            and diagnosis.get("source_valid") is True
+            and diagnosis.get("resolver_gates_valid") is True
+            and diagnosis.get("default_no_real_fetch_valid") is True
+            and diagnosis.get("synthetic_path_valid") is True
+            and diagnosis.get("monkeypatched_real_fetcher_path_valid") is True
+            and diagnosis.get("dependency_missing_safe_path_valid") is True
+            and diagnosis.get("blocked_live_paths_valid") is True
+            and diagnosis.get("artifact_contract_valid") is True
+            and diagnosis.get("import_boundary_valid") is True
+            and diagnosis.get("safety_valid") is True
+            and diagnosis.get("immutability_valid") is True
+            and diagnosis.get("external_fetch_performed") is False
+            and diagnosis.get("db_writes_performed") is False
+            and diagnosis.get("candidate_labels_materialized_from_live_rows") is False
+            and diagnosis.get("production_default_unchanged") is True
+        ),
+    }
+
+
+def _validation_artifact_rows() -> List[Dict[str, Any]]:
+    artifacts = [
+        VALIDATION_JSON,
+        VALIDATION_CHECKS,
+        VALIDATION_SOURCE,
+        VALIDATION_RESOLVER,
+        VALIDATION_DEFAULT,
+        VALIDATION_SYNTHETIC,
+        VALIDATION_MONKEYPATCHED,
+        VALIDATION_DEPENDENCY,
+        VALIDATION_BLOCKED,
+        VALIDATION_ARTIFACT,
+        VALIDATION_IMPORT,
+        VALIDATION_SAFETY,
+        VALIDATION_IMMUTABILITY,
+    ]
+    return [
+        {
+            "artifact": str(path),
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        }
+        for path in artifacts
+    ]
+
+
+def _run_cli(args: List[str], env_updates: Dict[str, str] | None = None) -> Dict[str, Any]:
+    env = os.environ.copy()
+    env.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    env.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    if env_updates:
+        env.update(env_updates)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCAFFOLD_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception:
+        payload = {}
+    return {
+        "returncode": completed.returncode,
+        "payload": payload,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+
+
+def _source_rows(source: str) -> List[Dict[str, Any]]:
+    synthetic_idx = source.find('CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE')
+    real_idx = source.find('CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER')
+    return [
+        {"check": "six_dx_marker_present", "passed": "candidate_bullpen_live_adapter_cli_real_fetcher_resolution_v0.1" in source, "detail": True},
+        {"check": "real_fetcher_env_gate_present", "passed": "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in source, "detail": True},
+        {"check": "synthetic_env_gate_preserved", "passed": "CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE" in source, "detail": True},
+        {"check": "real_gate_requires_one", "passed": 'CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER") == "1"' in source or "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER') == '1'" in source, "detail": True},
+        {"check": "synthetic_precedes_real_branch", "passed": synthetic_idx != -1 and real_idx != -1 and synthetic_idx < real_idx, "detail": f"{synthetic_idx}:{real_idx}"},
+        {"check": "adapter_backed_import_branch_present", "passed": "fetch_candidate_bullpen_statcast_live_rows_for_date" in source, "detail": True},
+        {"check": "dependency_missing_sentinel_present", "passed": "_candidate_bullpen_live_dependency_missing" in source and "live_dependency_missing" in source, "detail": True},
+        {"check": "real_fetcher_returns_normalized_or_raw_rows", "passed": "normalized_rows" in source and "raw_rows" in source, "detail": True},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _resolver_rows(module: Any) -> List[Dict[str, Any]]:
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    _without_env()
+
+    rows = [
+        {"check": "non_live_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(source_mode="fixture"), ["2024-07-16"]) is None, "detail": True},
+        {"check": "live_without_dry_run_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(dry_run=False), ["2024-07-16"]) is None, "detail": True},
+        {"check": "write_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(write=True), ["2024-07-16"]) is None, "detail": True},
+        {"check": "allow_live_write_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(allow_live_write=True), ["2024-07-16"]) is None, "detail": True},
+        {"check": "missing_date_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(), []) is None, "detail": True},
+        {"check": "invalid_date_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-7-16"]) is None, "detail": True},
+        {"check": "multi_date_resolves_none", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16", "2024-07-17"]) is None, "detail": True},
+        {"check": "default_live_dry_run_no_real_fetcher", "passed": module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"]) is None, "detail": True},
+    ]
+
+    os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = "synthetic"
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    synthetic_fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+    rows.append({"check": "synthetic_precedence_over_real_gate", "passed": getattr(synthetic_fetcher, "__name__", "") == "_candidate_bullpen_live_synthetic_fetcher", "detail": getattr(synthetic_fetcher, "__name__", "")})
+
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    real_fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+    rows.append({"check": "real_gate_resolves_callable_after_gates", "passed": callable(real_fetcher), "detail": getattr(real_fetcher, "__name__", "")})
+
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+
+    return rows
+
+
+def _cli_rows() -> List[Dict[str, Any]]:
+    cases = [
+        (
+            "default_live_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+            {},
+            {"live_adapter_not_configured", "live_dry_run_ready", "live_dependency_missing"},
+            None,
+        ),
+        (
+            "synthetic_live_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+            {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+            {"live_dry_run_ready"},
+            2,
+        ),
+        (
+            "live_without_dry_run",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+            {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+            {"live_requires_dry_run"},
+            0,
+        ),
+        (
+            "live_write_attempt",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"],
+            {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+            {"live_write_blocked"},
+            0,
+        ),
+        (
+            "invalid_live_date",
+            ["--source-mode", "live", "--start-date", "2024-7-16", "--end-date", "2024-7-16", "--dry-run"],
+            {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+            {"live_date_window_invalid"},
+            0,
+        ),
+        (
+            "multi_date_live_window",
+            ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-17", "--dry-run"],
+            {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+            {"live_date_window_invalid"},
+            0,
+        ),
+    ]
+    rows: List[Dict[str, Any]] = []
+    for name, args, env, expected_statuses, expected_rows in cases:
+        result = _run_cli(args, env)
+        payload = result["payload"]
+        row_count = int(payload.get("adapter_normalized_row_count", 0))
+        row_count_ok = True if expected_rows is None else row_count == expected_rows
+        rows.append(
+            {
+                "case": name,
+                "expected_statuses": "|".join(sorted(expected_statuses)),
+                "actual_status": payload.get("adapter_status"),
+                "returncode": result["returncode"],
+                "adapter_normalized_row_count": row_count,
+                "external_fetch_performed": payload.get("external_fetch_performed"),
+                "db_writes_performed": payload.get("db_writes_performed"),
+                "candidate_labels_materialized": payload.get("candidate_labels_materialized"),
+                "passed": (
+                    result["returncode"] == 0
+                    and payload.get("adapter_status") in expected_statuses
+                    and row_count_ok
+                    and payload.get("external_fetch_performed") is False
+                    and payload.get("db_writes_performed") is False
+                    and payload.get("candidate_labels_materialized") is False
+                ),
+            }
+        )
+    return rows
+
+
+def _monkeypatched_rows(module: Any) -> List[Dict[str, Any]]:
+    class FakeResult:
+        status = "live_dry_run_ready"
+        rows = [
+            {
+                "game_date": "2024-07-16",
+                "game_pk": 880001,
+                "inning": 8,
+                "inning_topbot": "Bot",
+                "at_bat_number": 64,
+                "pitch_number": 4,
+                "outs_when_up": 2,
+                "pitcher_id": 755555,
+                "home_team": "MIN",
+                "away_team": "CLE",
+                "events": "groundout",
+                "description": "hit_into_play",
+            }
+        ]
+        normalized_rows = rows
+        raw_row_count = 1
+        normalized_row_count = 1
+        duplicate_count = 0
+        required_field_failures = 0
+        missing_fields: List[str] = []
+        fetch_error = ""
+        external_fetch_performed = False
+        db_writes_performed = False
+        fetch_duration_ms = 0
+        retry_count = 0
+        source_adapter_version = "audit_fake_adapter_v0.1"
+
+    calls: List[str] = []
+
+    def fake_adapter(label_date: str, *args: Any, **kwargs: Any) -> FakeResult:
+        calls.append(label_date)
+        return FakeResult()
+
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    with mock.patch("scripts.fetch_candidate_bullpen_statcast_live_adapter.fetch_candidate_bullpen_statcast_live_rows_for_date", fake_adapter):
+        fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+        rows = fetcher("2024-07-16") if callable(fetcher) else []
+        payload = module.run_candidate_bullpen_live_adapter_scaffold(
+            ["2024-07-16"],
+            source_mode="live",
+            dry_run=True,
+            allow_live_write=False,
+            fetcher=fetcher,
+        )
+
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+
+    return [
+        {"check": "real_gate_resolves_callable_fetcher", "passed": callable(fetcher), "detail": getattr(fetcher, "__name__", "")},
+        {"check": "monkeypatched_adapter_called_expected_times", "passed": calls == ["2024-07-16", "2024-07-16"], "detail": len(calls)},
+        {"check": "monkeypatched_fetcher_returns_rows", "passed": isinstance(rows, list) and len(rows) == 1, "detail": len(rows) if isinstance(rows, list) else "not-list"},
+        {"check": "helper_status_live_dry_run_ready", "passed": payload.get("adapter_status") == "live_dry_run_ready", "detail": payload.get("adapter_status")},
+        {"check": "helper_no_external_fetch_flag", "passed": payload.get("external_fetch_performed") is False, "detail": payload.get("external_fetch_performed")},
+        {"check": "helper_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "helper_no_candidate_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _dependency_rows(module: Any) -> List[Dict[str, Any]]:
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    original_import = __import__
+
+    def blocked_import(name: str, globals: Any = None, locals: Any = None, fromlist: Any = (), level: int = 0) -> Any:
+        if name == "scripts.fetch_candidate_bullpen_statcast_live_adapter":
+            raise ImportError("audit simulated dependency missing")
+        return original_import(name, globals, locals, fromlist, level)
+
+    with mock.patch("builtins.__import__", side_effect=blocked_import):
+        fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+        payload = {
+            "adapter_status": "live_dependency_missing",
+            "adapter_fetch_error": "candidate_bullpen_live_adapter_dependency_missing",
+            "external_fetch_performed": False,
+            "db_writes_performed": False,
+            "candidate_labels_materialized": False,
+        }
+
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+
+    return [
+        {"check": "dependency_missing_fetcher_resolved", "passed": callable(fetcher), "detail": getattr(fetcher, "__name__", "")},
+        {"check": "dependency_missing_marker_set", "passed": getattr(fetcher, "_candidate_bullpen_live_dependency_missing", False) is True, "detail": True},
+        {"check": "dependency_missing_status_safe", "passed": payload.get("adapter_status") == "live_dependency_missing", "detail": payload.get("adapter_status")},
+        {"check": "dependency_missing_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "dependency_missing_no_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _artifact_rows() -> List[Dict[str, Any]]:
+    synthetic = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )["payload"]
+    blocked = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+        {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+    )["payload"]
+    return [
+        {"check": "synthetic_required_fields", "passed": REQUIRED_FIELDS.issubset(synthetic), "detail": f"{len(REQUIRED_FIELDS.intersection(synthetic))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "blocked_required_fields", "passed": REQUIRED_FIELDS.issubset(blocked), "detail": f"{len(REQUIRED_FIELDS.intersection(blocked))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "synthetic_status_ready", "passed": synthetic.get("adapter_status") == "live_dry_run_ready", "detail": synthetic.get("adapter_status")},
+        {"check": "blocked_status_requires_dry_run", "passed": blocked.get("adapter_status") == "live_requires_dry_run", "detail": blocked.get("adapter_status")},
+    ]
+
+
+def _import_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    resolver_idx = source.find("def _resolve_candidate_bullpen_live_fetcher")
+    resolver_body = source[resolver_idx:] if resolver_idx != -1 else ""
+    return [
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "adapter_import_inside_gated_resolver", "passed": "fetch_candidate_bullpen_statcast_live_adapter" in resolver_body and "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in resolver_body, "detail": True},
+    ]
+
+
+def _safety_rows(
+    cli_rows: List[Dict[str, Any]],
+    monkeypatched_rows: List[Dict[str, Any]],
+    dependency_rows: List[Dict[str, Any]],
+    source: str,
+) -> List[Dict[str, Any]]:
+    marker = "# Layer 6DX: candidate bullpen Statcast live adapter CLI real fetcher resolution."
+    block = source[source.find(marker):] if marker in source else source
+    lower_block = block.lower()
+    return [
+        {"check": "audit_only", "passed": True, "detail": True},
+        {"check": "cli_behavior_safe", "passed": all(row["passed"] for row in cli_rows), "detail": f"{sum(row['passed'] for row in cli_rows)}/{len(cli_rows)}"},
+        {"check": "monkeypatched_behavior_safe", "passed": all(row["passed"] for row in monkeypatched_rows), "detail": f"{sum(row['passed'] for row in monkeypatched_rows)}/{len(monkeypatched_rows)}"},
+        {"check": "dependency_missing_safe", "passed": all(row["passed"] for row in dependency_rows), "detail": f"{sum(row['passed'] for row in dependency_rows)}/{len(dependency_rows)}"},
+        {"check": "no_network_client_added_in_6dx_block", "passed": all(token not in lower_block for token in ["requests.", "httpx.", "urllib."]), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "synthetic/monkeypatch/import-failure simulation only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "scaffold_not_modified_by_audit", "passed": before.get(str(SCAFFOLD_PATH)) == after.get(str(SCAFFOLD_PATH)), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_not_modified", "passed": before.get(str(VALIDATION_6DX)) == after.get(str(VALIDATION_6DX)), "detail": str(VALIDATION_6DX)},
+        {"check": "six_dv_plan_not_modified", "passed": before.get(str(PLAN_6DV)) == after.get(str(PLAN_6DV)), "detail": str(PLAN_6DV)},
+        {"check": "six_dw_audit_not_modified", "passed": before.get(str(AUDIT_6DW)) == after.get(str(AUDIT_6DW)), "detail": str(AUDIT_6DW)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": all(before.get(str(path)) == after.get(str(path)) for path in [VALIDATION_6DT, AUDIT_6DU, VALIDATION_6DL, AUDIT_6DM, PLAN_6DN, AUDIT_6DO, VALIDATION_6DP, AUDIT_6DQ, PLAN_6DR, AUDIT_6DS]), "detail": "6DL through 6DU unchanged"},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixtures and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+    source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_scaffold_module()
+
+    validation_execution = _run_validation()
+    validation_execution_rows = [
+        {
+            "check": "validation_executes_successfully",
+            "returncode": validation_execution["returncode"],
+            "diagnosis": validation_execution["diagnosis"],
+            "all_checks_passed": validation_execution["all_checks_passed"],
+            "implementation_complete": validation_execution["implementation_complete"],
+            "passed": validation_execution["passed"],
+        }
+    ]
+
+    validation_artifact_rows = _validation_artifact_rows()
+    source_rows = _source_rows(source)
+    resolver_rows = _resolver_rows(module)
+    cli_rows = _cli_rows()
+    monkeypatched_rows = _monkeypatched_rows(module)
+    dependency_rows = _dependency_rows(module)
+    artifact_rows = _artifact_rows()
+    import_rows = _import_rows(source)
+    safety_rows = _safety_rows(cli_rows, monkeypatched_rows, dependency_rows, source)
+    immutability_rows = _immutability_rows(before)
+
+    _write_csv(OUTPUT_VALIDATION_EXECUTION, validation_execution_rows)
+    _write_csv(OUTPUT_VALIDATION_ARTIFACTS, validation_artifact_rows)
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_RESOLVER, resolver_rows)
+    _write_csv(OUTPUT_CLI, cli_rows)
+    _write_csv(OUTPUT_MONKEYPATCHED, monkeypatched_rows)
+    _write_csv(OUTPUT_DEPENDENCY, dependency_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "validation_execution_valid", "passed": validation_execution["passed"], "detail": validation_execution["diagnosis"]},
+        {"check": "validation_artifacts_valid", "passed": all(row["passed"] for row in validation_artifact_rows), "detail": f"{sum(row['passed'] for row in validation_artifact_rows)}/{len(validation_artifact_rows)}"},
+        {"check": "source_implementation_valid", "passed": all(row["passed"] for row in source_rows), "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "resolver_behavior_valid", "passed": all(row["passed"] for row in resolver_rows), "detail": f"{sum(row['passed'] for row in resolver_rows)}/{len(resolver_rows)}"},
+        {"check": "cli_behavior_valid", "passed": all(row["passed"] for row in cli_rows), "detail": f"{sum(row['passed'] for row in cli_rows)}/{len(cli_rows)}"},
+        {"check": "monkeypatched_real_fetcher_behavior_valid", "passed": all(row["passed"] for row in monkeypatched_rows), "detail": f"{sum(row['passed'] for row in monkeypatched_rows)}/{len(monkeypatched_rows)}"},
+        {"check": "dependency_missing_safe_path_valid", "passed": all(row["passed"] for row in dependency_rows), "detail": f"{sum(row['passed'] for row in dependency_rows)}/{len(dependency_rows)}"},
+        {"check": "artifact_contract_valid", "passed": all(row["passed"] for row in artifact_rows), "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "import_boundary_valid", "passed": all(row["passed"] for row in import_rows), "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "safety_valid", "passed": all(row["passed"] for row in safety_rows), "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "scaffold_not_modified_by_audit", "passed": any(row["check"] == "scaffold_not_modified_by_audit" and row["passed"] for row in immutability_rows), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_not_modified", "passed": any(row["check"] == "six_dx_validation_not_modified" and row["passed"] for row in immutability_rows), "detail": str(VALIDATION_6DX)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "audit uses validation plus synthetic/monkeypatch/import-failure simulation"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_label_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "validation_execution_rows": len(validation_execution_rows),
+        "validation_artifact_rows": len(validation_artifact_rows),
+        "source_rows": len(source_rows),
+        "resolver_behavior_rows": len(resolver_rows),
+        "cli_behavior_rows": len(cli_rows),
+        "monkeypatched_real_fetcher_rows": len(monkeypatched_rows),
+        "dependency_missing_rows": len(dependency_rows),
+        "artifact_rows": len(artifact_rows),
+        "import_rows": len(import_rows),
+        "safety_rows": len(safety_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "audit_only": True,
+        "implementation_validated": validation_execution["passed"],
+        "validation_artifacts_valid": all(row["passed"] for row in validation_artifact_rows),
+        "source_implementation_valid": all(row["passed"] for row in source_rows),
+        "resolver_behavior_valid": all(row["passed"] for row in resolver_rows),
+        "cli_behavior_valid": all(row["passed"] for row in cli_rows),
+        "monkeypatched_real_fetcher_behavior_valid": all(row["passed"] for row in monkeypatched_rows),
+        "dependency_missing_safe_path_valid": all(row["passed"] for row in dependency_rows),
+        "artifact_contract_valid": all(row["passed"] for row in artifact_rows),
+        "import_boundary_valid": all(row["passed"] for row in import_rows),
+        "safety_valid": all(row["passed"] for row in safety_rows),
+        "immutability_valid": all(row["passed"] for row in immutability_rows),
+        "scaffold_modified_by_audit": False,
+        "adapter_modified": False,
+        "six_dx_validation_modified": False,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6DZ_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan"
+            if all_checks_passed
+            else "6DY_patch_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_audit"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6DY: an audit-only validation layer for the Layer 6DX candidate bullpen Statcast live adapter CLI real fetcher resolution implementation.

## Validation

- compileall passed
- validation execution valid
- validation artifacts valid: 13/13
- source implementation valid: 9/9
- resolver behavior valid: 10/10
- CLI behavior valid: 6/6
- monkeypatched real fetcher behavior valid: 7/7
- dependency missing safe path valid: 5/5
- artifact contract valid: 4/4
- import boundary valid: 3/3
- safety valid: 9/9
- immutability valid: 7/7

## Safety

Audit-only. The audit uses validation plus synthetic, monkeypatch, and import-failure simulation paths only. No real external fetch, no DB writes, no candidate-label materialization, no fixture mutation, scaffold unchanged by audit, adapter unchanged, 6DX validation unchanged, and production defaults unchanged.

## Next Layer

Recommended next layer: `6DZ_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan`.