### PR TITLE
Add Layer 6EA live fetcher observability plan audit

### DIFF
--- a/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan.py
+++ b/scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import ast
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+AUDIT_VERSION = "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+PLAN_6DZ = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py")
+VALIDATION_6DX = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DY = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+PLAN_6DV = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DW = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_plan.py")
+VALIDATION_6DT = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DU = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+VALIDATION_6DL = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DM = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+PLAN_6DN = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_contract.py")
+AUDIT_6DO = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_contract_plan.py")
+VALIDATION_6DP = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+AUDIT_6DQ = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+PLAN_6DR = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DS = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+PLAN_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan.json"
+PLAN_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_checks.csv"
+PLAN_CURRENT_STATE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_current_state.csv"
+PLAN_FIELD_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_field_contract.csv"
+PLAN_STATUS_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_status_value_contract.csv"
+PLAN_ARTIFACT_COMPAT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_artifact_compatibility_contract.csv"
+PLAN_VALIDATION_STRATEGY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_validation_strategy.csv"
+PLAN_SAFETY_NON_GOALS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_safety_non_goals.csv"
+PLAN_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_immutability.csv"
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_checks.csv"
+OUTPUT_PLAN_EXECUTION = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_execution.csv"
+OUTPUT_PLAN_ARTIFACTS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_artifacts.csv"
+OUTPUT_CURRENT_STATE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_current_state.csv"
+OUTPUT_FIELD_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_field_contract.csv"
+OUTPUT_STATUS_CONTRACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_status_value_contract.csv"
+OUTPUT_ARTIFACT_COMPAT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_artifact_compatibility_contract.csv"
+OUTPUT_VALIDATION_STRATEGY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_validation_strategy.csv"
+OUTPUT_SAFETY_NON_GOALS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_safety_non_goals.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_immutability.csv"
+
+OBSERVABILITY_FIELDS = [
+    "live_fetcher_resolution_source",
+    "live_fetcher_resolution_status",
+    "live_fetcher_resolution_gate",
+    "live_fetcher_resolution_reason",
+    "live_fetcher_resolution_dependency_error",
+    "live_fetcher_resolution_external_fetch_enabled",
+    "live_fetcher_resolution_synthetic_enabled",
+    "live_fetcher_resolution_real_enabled",
+]
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _contains(rows: List[Dict[str, Any]], *needles: str) -> bool:
+    haystack = json.dumps(rows, sort_keys=True).lower()
+    return all(needle.lower() in haystack for needle in needles)
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        PLAN_6DZ,
+        VALIDATION_6DX,
+        AUDIT_6DY,
+        PLAN_6DV,
+        AUDIT_6DW,
+        VALIDATION_6DT,
+        AUDIT_6DU,
+        VALIDATION_6DL,
+        AUDIT_6DM,
+        PLAN_6DN,
+        AUDIT_6DO,
+        VALIDATION_6DP,
+        AUDIT_6DQ,
+        PLAN_6DR,
+        AUDIT_6DS,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\n".join(imports)
+
+
+def _run_plan() -> Dict[str, Any]:
+    completed = subprocess.run(
+        [sys.executable, str(PLAN_6DZ)],
+        capture_output=True,
+        text=True,
+    )
+    diagnosis = _read_json(PLAN_JSON)
+    return {
+        "returncode": completed.returncode,
+        "diagnosis": diagnosis.get("diagnosis", ""),
+        "all_checks_passed": diagnosis.get("all_checks_passed"),
+        "planning_only": diagnosis.get("planning_only"),
+        "current_state_valid": diagnosis.get("current_state_valid"),
+        "observability_field_contract_defined": diagnosis.get("observability_field_contract_defined"),
+        "status_value_contract_defined": diagnosis.get("status_value_contract_defined"),
+        "artifact_compatibility_contract_defined": diagnosis.get("artifact_compatibility_contract_defined"),
+        "validation_strategy_defined": diagnosis.get("validation_strategy_defined"),
+        "safety_non_goals_defined": diagnosis.get("safety_non_goals_defined"),
+        "immutability_valid": diagnosis.get("immutability_valid"),
+        "passed": (
+            completed.returncode == 0
+            and diagnosis.get("diagnosis") == "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_complete"
+            and diagnosis.get("all_checks_passed") is True
+            and diagnosis.get("planning_only") is True
+            and diagnosis.get("current_state_valid") is True
+            and diagnosis.get("observability_field_contract_defined") is True
+            and diagnosis.get("status_value_contract_defined") is True
+            and diagnosis.get("artifact_compatibility_contract_defined") is True
+            and diagnosis.get("validation_strategy_defined") is True
+            and diagnosis.get("safety_non_goals_defined") is True
+            and diagnosis.get("immutability_valid") is True
+            and diagnosis.get("scaffold_unchanged") is True
+            and diagnosis.get("adapter_unchanged") is True
+            and diagnosis.get("six_dx_validation_unchanged") is True
+            and diagnosis.get("six_dy_audit_unchanged") is True
+            and diagnosis.get("fixture_assets_mutated") is False
+            and diagnosis.get("external_fetch_performed") is False
+            and diagnosis.get("db_writes_performed") is False
+            and diagnosis.get("candidate_labels_materialized_from_live_rows") is False
+            and diagnosis.get("production_default_unchanged") is True
+        ),
+    }
+
+
+def _plan_artifact_rows() -> List[Dict[str, Any]]:
+    artifacts = [
+        PLAN_JSON,
+        PLAN_CHECKS,
+        PLAN_CURRENT_STATE,
+        PLAN_FIELD_CONTRACT,
+        PLAN_STATUS_CONTRACT,
+        PLAN_ARTIFACT_COMPAT,
+        PLAN_VALIDATION_STRATEGY,
+        PLAN_SAFETY_NON_GOALS,
+        PLAN_IMMUTABILITY,
+    ]
+    return [
+        {
+            "artifact": str(path),
+            "exists": path.exists(),
+            "size_bytes": path.stat().st_size if path.exists() else 0,
+            "passed": path.exists() and path.stat().st_size > 0,
+        }
+        for path in artifacts
+    ]
+
+
+def _current_state_rows(scaffold_source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(scaffold_source)
+    return [
+        {"check": "scaffold_exists", "passed": SCAFFOLD_PATH.exists(), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_exists", "passed": ADAPTER_PATH.exists(), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_exists", "passed": VALIDATION_6DX.exists(), "detail": str(VALIDATION_6DX)},
+        {"check": "six_dy_audit_exists", "passed": AUDIT_6DY.exists(), "detail": str(AUDIT_6DY)},
+        {"check": "six_dz_plan_exists", "passed": PLAN_6DZ.exists(), "detail": str(PLAN_6DZ)},
+        {"check": "six_dx_marker_present", "passed": "candidate_bullpen_live_adapter_cli_real_fetcher_resolution_v0.1" in scaffold_source, "detail": True},
+        {"check": "real_fetcher_env_gate_present", "passed": "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in scaffold_source, "detail": True},
+        {"check": "synthetic_env_gate_preserved", "passed": "CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE" in scaffold_source, "detail": True},
+        {"check": "resolver_present", "passed": "def _resolve_candidate_bullpen_live_fetcher" in scaffold_source, "detail": True},
+        {"check": "adapter_backed_import_branch_present", "passed": "fetch_candidate_bullpen_statcast_live_rows_for_date" in scaffold_source, "detail": True},
+        {"check": "dependency_missing_status_present", "passed": "live_dependency_missing" in scaffold_source, "detail": True},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in scaffold_source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in scaffold_source, "detail": True},
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+    ]
+
+
+def _field_contract_rows() -> List[Dict[str, Any]]:
+    rows = _read_csv(PLAN_FIELD_CONTRACT)
+    return [
+        {
+            "check": f"{field}_planned",
+            "passed": _contains(rows, field, "additive", "diagnostic-only"),
+            "detail": field,
+        }
+        for field in OBSERVABILITY_FIELDS
+    ] + [
+        {"check": "fields_do_not_affect_writes", "passed": _contains(rows, "must not affect writes"), "detail": True},
+        {"check": "fields_do_not_affect_materialization", "passed": _contains(rows, "materialization"), "detail": True},
+        {"check": "fields_do_not_affect_resolver_gates", "passed": _contains(rows, "resolver gate decisions"), "detail": True},
+    ]
+
+
+def _status_contract_rows() -> List[Dict[str, Any]]:
+    rows = _read_csv(PLAN_STATUS_CONTRACT)
+    return [
+        {"check": "default_no_gate_planned", "passed": _contains(rows, "default_no_gate", "safe no-real-fetcher status"), "detail": True},
+        {"check": "synthetic_gate_planned", "passed": _contains(rows, "synthetic_gate", "live_dry_run_ready", "synthetic_test_double"), "detail": True},
+        {"check": "real_gate_planned", "passed": _contains(rows, "real_gate", "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER=1", "real_adapter"), "detail": True},
+        {"check": "dependency_missing_planned", "passed": _contains(rows, "dependency_missing", "live_dependency_missing"), "detail": True},
+        {"check": "live_without_dry_run_blocked_planned", "passed": _contains(rows, "live_without_dry_run", "live_requires_dry_run"), "detail": True},
+        {"check": "live_write_blocked_planned", "passed": _contains(rows, "live_write_attempt", "live_write_blocked"), "detail": True},
+        {"check": "invalid_multi_date_blocked_planned", "passed": _contains(rows, "invalid_or_multi_date", "live_date_window_invalid"), "detail": True},
+    ]
+
+
+def _artifact_compat_rows() -> List[Dict[str, Any]]:
+    rows = _read_csv(PLAN_ARTIFACT_COMPAT)
+    return [
+        {"check": "existing_required_fields_preserved", "passed": _contains(rows, "Existing 15 adapter/safety fields"), "detail": True},
+        {"check": "observability_fields_additive", "passed": _contains(rows, "additive only"), "detail": True},
+        {"check": "fixture_scaffold_behavior_unchanged", "passed": _contains(rows, "Fixture/scaffold behavior remains unchanged"), "detail": True},
+        {"check": "downstream_json_consumers_safe", "passed": _contains(rows, "downstream JSON consumers", "optional/additive"), "detail": True},
+        {"check": "diagnostic_only", "passed": _contains(rows, "diagnostic-only", "DB writes", "materialization"), "detail": True},
+    ]
+
+
+def _validation_strategy_rows() -> List[Dict[str, Any]]:
+    rows = _read_csv(PLAN_VALIDATION_STRATEGY)
+    return [
+        {"check": "compileall_planned", "passed": _contains(rows, "compileall", "python -m compileall mlb_app scripts"), "detail": True},
+        {"check": "source_audit_planned", "passed": _contains(rows, "source_audit", "observability fields"), "detail": True},
+        {"check": "default_no_real_fetch_observability_audit_planned", "passed": _contains(rows, "default_no_real_fetch_observability_audit"), "detail": True},
+        {"check": "synthetic_observability_audit_planned", "passed": _contains(rows, "synthetic_observability_audit"), "detail": True},
+        {"check": "monkeypatched_real_fetcher_observability_audit_planned", "passed": _contains(rows, "monkeypatched_real_fetcher_observability_audit", "no network"), "detail": True},
+        {"check": "dependency_missing_observability_audit_planned", "passed": _contains(rows, "dependency_missing_observability_audit", "live_dependency_missing"), "detail": True},
+        {"check": "blocked_path_observability_audit_planned", "passed": _contains(rows, "blocked_path_observability_audit"), "detail": True},
+        {"check": "artifact_compatibility_audit_planned", "passed": _contains(rows, "artifact_compatibility_audit", "existing 15 fields"), "detail": True},
+        {"check": "import_boundary_audit_planned", "passed": _contains(rows, "import_boundary_audit"), "detail": True},
+        {"check": "immutability_audit_planned", "passed": _contains(rows, "immutability_audit"), "detail": True},
+        {"check": "safety_audit_planned", "passed": _contains(rows, "safety_audit", "no real fetch", "no DB writes"), "detail": True},
+    ]
+
+
+def _safety_non_goal_rows() -> List[Dict[str, Any]]:
+    rows = _read_csv(PLAN_SAFETY_NON_GOALS)
+    return [
+        {"check": "planning_only", "passed": _contains(rows, "planning_only", "plan only"), "detail": True},
+        {"check": "no_real_fetch", "passed": _contains(rows, "no_real_fetch", "No real Statcast/pybaseball fetch"), "detail": True},
+        {"check": "no_real_fetch_in_validation_ci", "passed": _contains(rows, "no_real_fetch_in_validation_ci", "network fetches"), "detail": True},
+        {"check": "no_db_writes", "passed": _contains(rows, "no_db_writes", "No DB writes"), "detail": True},
+        {"check": "no_candidate_materialization", "passed": _contains(rows, "no_candidate_materialization", "No candidate labels"), "detail": True},
+        {"check": "no_fixture_mutation", "passed": _contains(rows, "no_fixture_mutation", "Fixture assets remain unchanged"), "detail": True},
+        {"check": "no_adapter_modification", "passed": _contains(rows, "no_adapter_modification", "Adapter source remains unchanged"), "detail": True},
+        {"check": "no_production_default_change", "passed": _contains(rows, "no_production_default_change", "Production defaults remain unchanged"), "detail": True},
+        {"check": "no_resolver_gate_change", "passed": _contains(rows, "no_resolver_gate_change", "Resolver gates remain unchanged"), "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "scaffold_not_modified_by_audit", "passed": before.get(str(SCAFFOLD_PATH)) == after.get(str(SCAFFOLD_PATH)), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_not_modified", "passed": before.get(str(VALIDATION_6DX)) == after.get(str(VALIDATION_6DX)), "detail": str(VALIDATION_6DX)},
+        {"check": "six_dy_audit_not_modified", "passed": before.get(str(AUDIT_6DY)) == after.get(str(AUDIT_6DY)), "detail": str(AUDIT_6DY)},
+        {"check": "six_dz_plan_not_modified", "passed": before.get(str(PLAN_6DZ)) == after.get(str(PLAN_6DZ)), "detail": str(PLAN_6DZ)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": all(before.get(str(path)) == after.get(str(path)) for path in [PLAN_6DV, AUDIT_6DW, VALIDATION_6DT, AUDIT_6DU, VALIDATION_6DL, AUDIT_6DM, PLAN_6DN, AUDIT_6DO, VALIDATION_6DP, AUDIT_6DQ, PLAN_6DR, AUDIT_6DS]), "detail": "6DL through 6DW unchanged"},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixtures and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+    scaffold_source = SCAFFOLD_PATH.read_text(errors="ignore")
+
+    plan_execution = _run_plan()
+    plan_execution_rows = [
+        {
+            "check": "plan_executes_successfully",
+            "returncode": plan_execution["returncode"],
+            "diagnosis": plan_execution["diagnosis"],
+            "all_checks_passed": plan_execution["all_checks_passed"],
+            "planning_only": plan_execution["planning_only"],
+            "current_state_valid": plan_execution["current_state_valid"],
+            "observability_field_contract_defined": plan_execution["observability_field_contract_defined"],
+            "status_value_contract_defined": plan_execution["status_value_contract_defined"],
+            "artifact_compatibility_contract_defined": plan_execution["artifact_compatibility_contract_defined"],
+            "validation_strategy_defined": plan_execution["validation_strategy_defined"],
+            "safety_non_goals_defined": plan_execution["safety_non_goals_defined"],
+            "immutability_valid": plan_execution["immutability_valid"],
+            "passed": plan_execution["passed"],
+        }
+    ]
+
+    plan_artifact_rows = _plan_artifact_rows()
+    current_state_rows = _current_state_rows(scaffold_source)
+    field_contract_rows = _field_contract_rows()
+    status_contract_rows = _status_contract_rows()
+    artifact_compat_rows = _artifact_compat_rows()
+    validation_strategy_rows = _validation_strategy_rows()
+    safety_non_goal_rows = _safety_non_goal_rows()
+    immutability_rows = _immutability_rows(before)
+
+    _write_csv(OUTPUT_PLAN_EXECUTION, plan_execution_rows)
+    _write_csv(OUTPUT_PLAN_ARTIFACTS, plan_artifact_rows)
+    _write_csv(OUTPUT_CURRENT_STATE, current_state_rows)
+    _write_csv(OUTPUT_FIELD_CONTRACT, field_contract_rows)
+    _write_csv(OUTPUT_STATUS_CONTRACT, status_contract_rows)
+    _write_csv(OUTPUT_ARTIFACT_COMPAT, artifact_compat_rows)
+    _write_csv(OUTPUT_VALIDATION_STRATEGY, validation_strategy_rows)
+    _write_csv(OUTPUT_SAFETY_NON_GOALS, safety_non_goal_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "plan_execution_valid", "passed": plan_execution["passed"], "detail": plan_execution["diagnosis"]},
+        {"check": "plan_artifacts_valid", "passed": all(row["passed"] for row in plan_artifact_rows), "detail": f"{sum(row['passed'] for row in plan_artifact_rows)}/{len(plan_artifact_rows)}"},
+        {"check": "current_state_valid", "passed": all(row["passed"] for row in current_state_rows), "detail": f"{sum(row['passed'] for row in current_state_rows)}/{len(current_state_rows)}"},
+        {"check": "observability_field_contract_valid", "passed": all(row["passed"] for row in field_contract_rows), "detail": f"{sum(row['passed'] for row in field_contract_rows)}/{len(field_contract_rows)}"},
+        {"check": "status_value_contract_valid", "passed": all(row["passed"] for row in status_contract_rows), "detail": f"{sum(row['passed'] for row in status_contract_rows)}/{len(status_contract_rows)}"},
+        {"check": "artifact_compatibility_contract_valid", "passed": all(row["passed"] for row in artifact_compat_rows), "detail": f"{sum(row['passed'] for row in artifact_compat_rows)}/{len(artifact_compat_rows)}"},
+        {"check": "validation_strategy_valid", "passed": all(row["passed"] for row in validation_strategy_rows), "detail": f"{sum(row['passed'] for row in validation_strategy_rows)}/{len(validation_strategy_rows)}"},
+        {"check": "safety_non_goals_valid", "passed": all(row["passed"] for row in safety_non_goal_rows), "detail": f"{sum(row['passed'] for row in safety_non_goal_rows)}/{len(safety_non_goal_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "scaffold_not_modified_by_audit", "passed": any(row["check"] == "scaffold_not_modified_by_audit" and row["passed"] for row in immutability_rows), "detail": str(SCAFFOLD_PATH)},
+        {"check": "adapter_not_modified", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_not_modified", "passed": any(row["check"] == "six_dx_validation_not_modified" and row["passed"] for row in immutability_rows), "detail": str(VALIDATION_6DX)},
+        {"check": "six_dy_audit_not_modified", "passed": any(row["check"] == "six_dy_audit_not_modified" and row["passed"] for row in immutability_rows), "detail": str(AUDIT_6DY)},
+        {"check": "six_dz_plan_not_modified", "passed": any(row["check"] == "six_dz_plan_not_modified" and row["passed"] for row in immutability_rows), "detail": str(PLAN_6DZ)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "audit-only plan validation"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_label_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit_complete",
+        "audit_version": AUDIT_VERSION,
+        "plan_execution_rows": len(plan_execution_rows),
+        "plan_artifact_rows": len(plan_artifact_rows),
+        "current_state_rows": len(current_state_rows),
+        "observability_field_contract_rows": len(field_contract_rows),
+        "status_value_contract_rows": len(status_contract_rows),
+        "artifact_compatibility_rows": len(artifact_compat_rows),
+        "validation_strategy_rows": len(validation_strategy_rows),
+        "safety_non_goal_rows": len(safety_non_goal_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "audit_only": True,
+        "plan_validated": plan_execution["passed"],
+        "plan_artifacts_valid": all(row["passed"] for row in plan_artifact_rows),
+        "current_state_valid": all(row["passed"] for row in current_state_rows),
+        "observability_field_contract_valid": all(row["passed"] for row in field_contract_rows),
+        "status_value_contract_valid": all(row["passed"] for row in status_contract_rows),
+        "artifact_compatibility_contract_valid": all(row["passed"] for row in artifact_compat_rows),
+        "validation_strategy_valid": all(row["passed"] for row in validation_strategy_rows),
+        "safety_non_goals_valid": all(row["passed"] for row in safety_non_goal_rows),
+        "immutability_valid": all(row["passed"] for row in immutability_rows),
+        "scaffold_modified_by_audit": False,
+        "adapter_modified": False,
+        "six_dx_validation_modified": False,
+        "six_dy_audit_modified": False,
+        "six_dz_plan_modified": False,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6EB_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability"
+            if all_checks_passed
+            else "6EA_patch_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan_audit"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6EA: an audit-only validation layer for the Layer 6DZ candidate bullpen Statcast live adapter CLI live fetcher observability plan.

## Validation

- compileall passed
- plan execution valid
- plan artifacts valid: 9/9
- current state valid: 14/14
- observability field contract valid: 11/11
- status/value contract valid: 7/7
- artifact compatibility contract valid: 5/5
- validation strategy valid: 11/11
- safety/non-goals valid: 9/9
- immutability valid: 7/7

## Safety

Audit-only. No runtime behavior change. Scaffold unchanged by audit, adapter unchanged, 6DX validation unchanged, 6DY audit unchanged, 6DZ plan unchanged, fixtures unchanged, no external fetch, no DB writes, no live-row materialization, and production default unchanged.

## Next Layer

Recommended next layer: 6EB_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.