### PR TITLE
Fix Model Tracker filter targets, visible summaries, and game labels

### DIFF
--- a/frontend/src/pages/ModelTrackerPage.jsx
+++ b/frontend/src/pages/ModelTrackerPage.jsx
@@ -125,6 +125,18 @@ function summarySentence(row) {
   return text.length > 620 ? `${text.slice(0, 617).trim()}...` : text
 }
 
+function gameFilterValue(value) {
+  return String(value || 'ungrouped')
+}
+
+function gameLabel(rowOrGame) {
+  const away = rowOrGame?.away_team || 'Away'
+  const home = rowOrGame?.home_team || 'Home'
+  if (rowOrGame?.away_team || rowOrGame?.home_team) return `${away} @ ${home}`
+  if (rowOrGame?.game_pk) return `Game ${rowOrGame.game_pk}`
+  return 'Ungrouped'
+}
+
 function TrackerRowCard({ row }) {
   const [flipped, setFlipped] = useState(false)
   const metrics = metricList(row)
@@ -137,7 +149,7 @@ function TrackerRowCard({ row }) {
       <div>
         <div style={s.rowTitle}>{title}</div>
         <div style={s.rowMeta}>{row.source} / {row.source_component} · {row.market_type || row.pick_type || 'model'} · {gradeLabel(row)}</div>
-        <div style={s.rowMeta}>{row.away_team || 'Away'} @ {row.home_team || 'Home'} · Game PK {row.game_pk || 'N/A'}{row.player_name ? ` · Player ${row.player_name}` : ''}</div>
+        <div style={s.rowMeta}>{gameLabel(row)} · Game PK {row.game_pk || 'N/A'}{row.player_name ? ` · Player ${row.player_name}` : ''}</div>
       </div>
       <div style={s.chipRail}>
         {row.model_name && <span style={s.chip}>Model: {row.model_name}</span>}
@@ -171,8 +183,8 @@ function TrackerRowCard({ row }) {
 }
 
 function GameTrackerCard({ game }) {
-  const title = game.game_pk ? `${game.away_team || 'Away'} @ ${game.home_team || 'Home'}` : 'Ungrouped model outputs'
-  const rows = (game.rows || []).filter(Boolean).sort((a, b) => {
+  const title = gameLabel(game)
+  const rows = safeArray(game.rows).slice().sort((a, b) => {
     const weight = row => {
       if (['won', 'lost', 'push', 'partial'].includes(row.grade)) return 5
       if (row.result_status === 'live') return 4
@@ -269,29 +281,86 @@ export default function ModelTrackerPage() {
   })), [payload])
 
   const games = payload?.games || []
-  const sources = useMemo(() => ['all', ...Array.from(new Set(rows.map(r => r.source).filter(Boolean))).sort()], [rows])
-  const grades = useMemo(() => ['all', ...Array.from(new Set(rows.map(r => r.grade).filter(Boolean))).sort()], [rows])
-  const gameOptions = useMemo(() => ['all', ...games.map(g => String(g.game_pk || 'ungrouped'))], [games])
+  const q = search.trim().toLowerCase()
+
+  const searchMatches = row => {
+    if (!q) return true
+    return [row.pick_label, row.player_name, row.team_name, row.away_team, row.home_team, row.model_name, textValue(row.primary_reason), textValue(row.grade_reason)]
+      .some(value => String(value || '').toLowerCase().includes(q))
+  }
+
+  const rowsForSourceOptions = useMemo(() => rows.filter(row => {
+    if (gradeFilter !== 'all' && row.grade !== gradeFilter) return false
+    if (gameFilter !== 'all' && gameFilterValue(row.game_pk) !== gameFilter) return false
+    return true
+  }), [rows, gradeFilter, gameFilter])
+
+  const rowsForGradeOptions = useMemo(() => rows.filter(row => {
+    if (sourceFilter !== 'all' && row.source !== sourceFilter) return false
+    if (gameFilter !== 'all' && gameFilterValue(row.game_pk) !== gameFilter) return false
+    return true
+  }), [rows, sourceFilter, gameFilter])
+
+  const rowsForGameOptions = useMemo(() => rows.filter(row => {
+    if (sourceFilter !== 'all' && row.source !== sourceFilter) return false
+    if (gradeFilter !== 'all' && row.grade !== gradeFilter) return false
+    return true
+  }), [rows, sourceFilter, gradeFilter])
+
+  const sourceOptions = useMemo(() => ['all', ...Array.from(new Set(rowsForSourceOptions.map(r => r.source).filter(Boolean))).sort()], [rowsForSourceOptions])
+  const gradeOptions = useMemo(() => ['all', ...Array.from(new Set(rowsForGradeOptions.map(r => r.grade).filter(Boolean))).sort()], [rowsForGradeOptions])
+  const gameOptions = useMemo(() => {
+    const gameMap = new Map()
+    safeArray(games).forEach(game => {
+      const value = gameFilterValue(game.game_pk)
+      gameMap.set(value, { value, label: gameLabel(game) })
+    })
+    rowsForGameOptions.forEach(row => {
+      const value = gameFilterValue(row.game_pk)
+      if (!gameMap.has(value)) gameMap.set(value, { value, label: gameLabel(row) })
+    })
+    return [{ value: 'all', label: 'all' }, ...Array.from(gameMap.values()).sort((a, b) => a.label.localeCompare(b.label))]
+  }, [games, rowsForGameOptions])
+
+  useEffect(() => {
+    if (!sourceOptions.includes(sourceFilter)) setSourceFilter('all')
+  }, [sourceOptions, sourceFilter])
+
+  useEffect(() => {
+    if (!gradeOptions.includes(gradeFilter)) setGradeFilter('all')
+  }, [gradeOptions, gradeFilter])
+
+  useEffect(() => {
+    if (!gameOptions.some(option => option.value === gameFilter)) setGameFilter('all')
+  }, [gameOptions, gameFilter])
 
   const filteredRows = useMemo(() => {
-    const q = search.trim().toLowerCase()
     return rows.filter(row => {
       if (sourceFilter !== 'all' && row.source !== sourceFilter) return false
       if (gradeFilter !== 'all' && row.grade !== gradeFilter) return false
-      if (gameFilter !== 'all' && String(row.game_pk || 'ungrouped') !== gameFilter) return false
-      if (!q) return true
-      return [row.pick_label, row.player_name, row.team_name, row.away_team, row.home_team, row.model_name, textValue(row.primary_reason), textValue(row.grade_reason)]
-        .some(value => String(value || '').toLowerCase().includes(q))
+      if (gameFilter !== 'all' && gameFilterValue(row.game_pk) !== gameFilter) return false
+      return searchMatches(row)
     })
   }, [rows, sourceFilter, gradeFilter, gameFilter, search])
 
   const filteredGames = useMemo(() => {
-    const allowedIds = new Set(filteredRows.map(row => String(row.game_pk || 'ungrouped')))
+    const allowedIds = new Set(filteredRows.map(row => gameFilterValue(row.game_pk)))
     const filteredRowKeys = new Set(filteredRows.map(row => row.id || row.tracker_key).filter(Boolean))
-    return games.map(game => ({ ...game, rows: (game.rows || []).filter(row => filteredRowKeys.has(row.id || row.tracker_key)) })).filter(game => allowedIds.has(String(game.game_pk || 'ungrouped')))
+    return games
+      .map(game => ({ ...game, rows: safeArray(game.rows).filter(row => filteredRowKeys.has(row.id || row.tracker_key)) }))
+      .filter(game => allowedIds.has(gameFilterValue(game.game_pk)))
   }, [games, filteredRows])
 
-  const summary = payload?.summary || {}
+  const filteredSummary = useMemo(() => ({
+    total_rows: filteredRows.length,
+    games_tracked: filteredGames.length,
+    pending_rows: filteredRows.filter(r => r.grade === 'pending').length,
+    live_rows: filteredRows.filter(r => r.result_status === 'live').length,
+    graded_rows: filteredRows.filter(r => ['won', 'lost', 'push', 'partial'].includes(r.grade)).length,
+    won: filteredRows.filter(r => r.grade === 'won').length,
+    lost: filteredRows.filter(r => r.grade === 'lost').length,
+    ungraded_rows: filteredRows.filter(r => ['ungraded', 'watchlist_only'].includes(r.grade)).length,
+  }), [filteredRows, filteredGames])
 
   return <div style={s.page}>
     <section style={s.hero}>
@@ -312,14 +381,14 @@ export default function ModelTrackerPage() {
     {error && <div className="state-panel error">{error}</div>}
     {loading && <div className="state-panel">Loading tracker rows...</div>}
 
-    <section style={s.statsScroller} aria-label="Model Tracker summary cards"><div style={s.statRail}><StatCard label="Tracked Rows" value={summary.total_rows || filteredRows.length} /><StatCard label="Games Tracked" value={summary.games_tracked} /><StatCard label="Pending" value={summary.pending_rows} /><StatCard label="Live" value={summary.live_rows} /><StatCard label="Graded" value={summary.graded_rows} /><StatCard label="Won" value={summary.won} /><StatCard label="Lost" value={summary.lost} /><StatCard label="Ungraded" value={summary.ungraded_rows} /></div></section>
+    <section style={s.statsScroller} aria-label="Model Tracker summary cards"><div style={s.statRail}><StatCard label="Visible Rows" value={filteredSummary.total_rows} /><StatCard label="Visible Games" value={filteredSummary.games_tracked} /><StatCard label="Pending" value={filteredSummary.pending_rows} /><StatCard label="Live" value={filteredSummary.live_rows} /><StatCard label="Graded" value={filteredSummary.graded_rows} /><StatCard label="Won" value={filteredSummary.won} /><StatCard label="Lost" value={filteredSummary.lost} /><StatCard label="Ungraded" value={filteredSummary.ungraded_rows} /></div></section>
 
     <section style={s.section}>
       <div style={s.sectionHeader}><div style={s.sectionTitle}>Filters</div><span className="status-badge">{filteredRows.length} visible rows · {cacheByDate[date] ? 'cached date loaded' : 'fresh request'}</span></div>
       <div style={s.filters}>
-        <label><div style={s.label}>Source</div><select className="input-control" style={s.input} value={sourceFilter} onChange={e => setSourceFilter(e.target.value)}>{sources.map(source => <option key={source} value={source}>{source}</option>)}</select></label>
-        <label><div style={s.label}>Grade</div><select className="input-control" style={s.input} value={gradeFilter} onChange={e => setGradeFilter(e.target.value)}>{grades.map(grade => <option key={grade} value={grade}>{grade}</option>)}</select></label>
-        <label><div style={s.label}>Game</div><select className="input-control" style={s.input} value={gameFilter} onChange={e => setGameFilter(e.target.value)}>{gameOptions.map(game => <option key={game} value={game}>{game}</option>)}</select></label>
+        <label><div style={s.label}>Source</div><select className="input-control" style={s.input} value={sourceFilter} onChange={e => setSourceFilter(e.target.value)}>{sourceOptions.map(source => <option key={source} value={source}>{source}</option>)}</select></label>
+        <label><div style={s.label}>Grade</div><select className="input-control" style={s.input} value={gradeFilter} onChange={e => setGradeFilter(e.target.value)}>{gradeOptions.map(grade => <option key={grade} value={grade}>{grade}</option>)}</select></label>
+        <label><div style={s.label}>Game</div><select className="input-control" style={s.input} value={gameFilter} onChange={e => setGameFilter(e.target.value)}>{gameOptions.map(game => <option key={game.value} value={game.value}>{game.label}</option>)}</select></label>
         <label><div style={s.label}>Search</div><input className="input-control" style={s.input} value={search} onChange={e => setSearch(e.target.value)} placeholder="player, team, pick, reason" /></label>
       </div>
     </section>
@@ -327,12 +396,12 @@ export default function ModelTrackerPage() {
     <section style={s.section}>
       <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Game Grouped Tracker</div><div style={s.rowMeta}>The front of each card shows formulas, metrics, features, and missing inputs. Flip the card for a concise analyst readout tied to the same stored row.</div></div></div>
       {filteredGames.length === 0 && <div className="state-panel">No tracker rows found. Click Refresh Snapshot to save today's model outputs.</div>}
-      {filteredGames.map(game => <GameTrackerCard key={String(game.game_pk || 'ungrouped')} game={game} />)}
+      {filteredGames.map(game => <GameTrackerCard key={gameFilterValue(game.game_pk)} game={game} />)}
     </section>
 
     <section style={s.section}>
       <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Table View</div><div style={s.rowMeta}>Every stored model output, including ungraded watchlist rows and final comparison state. Scroll horizontally to inspect every column.</div></div></div>
-      <div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>Date</th><th style={s.th}>Source</th><th style={s.th}>Game</th><th style={s.th}>Type</th><th style={s.th}>Pick</th><th style={s.th}>Player/Team</th><th style={s.th}>Model</th><th style={s.th}>Score</th><th style={s.th}>Confidence</th><th style={s.th}>Line</th><th style={s.th}>Price</th><th style={s.th}>Status</th><th style={s.th}>Grade</th><th style={s.th}>Reason</th></tr></thead><tbody>{filteredRows.map(row => <tr key={row.id || row.tracker_key}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{row.source}</td><td style={s.td}>{row.away_team || 'Away'} @ {row.home_team || 'Home'}</td><td style={s.td}>{row.market_type || row.pick_type}</td><td style={s.td}>{row.pick_label || 'N/A'}</td><td style={s.td}>{row.player_name || row.team_name || 'N/A'}</td><td style={s.td}>{row.model_name || 'N/A'}</td><td style={s.td}>{fmt(row.score)}</td><td style={s.td}>{fmt(row.confidence)}</td><td style={s.td}>{fmt(row.line)}</td><td style={s.td}>{fmt(row.price, 0)}</td><td style={s.td}>{row.result_status}</td><td style={s.td}>{row.grade}</td><td style={{ ...s.td, whiteSpace: 'pre-wrap', minWidth: 300, maxWidth: 520 }}>{textValue(row.grade_reason || row.primary_reason || 'N/A')}</td></tr>)}</tbody></table></div>
+      <div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>Date</th><th style={s.th}>Source</th><th style={s.th}>Game</th><th style={s.th}>Type</th><th style={s.th}>Pick</th><th style={s.th}>Player/Team</th><th style={s.th}>Model</th><th style={s.th}>Score</th><th style={s.th}>Confidence</th><th style={s.th}>Line</th><th style={s.th}>Price</th><th style={s.th}>Status</th><th style={s.th}>Grade</th><th style={s.th}>Reason</th></tr></thead><tbody>{filteredRows.map(row => <tr key={row.id || row.tracker_key}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{row.source}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{row.market_type || row.pick_type}</td><td style={s.td}>{row.pick_label || 'N/A'}</td><td style={s.td}>{row.player_name || row.team_name || 'N/A'}</td><td style={s.td}>{row.model_name || 'N/A'}</td><td style={s.td}>{fmt(row.score)}</td><td style={s.td}>{fmt(row.confidence)}</td><td style={s.td}>{fmt(row.line)}</td><td style={s.td}>{fmt(row.price, 0)}</td><td style={s.td}>{row.result_status}</td><td style={s.td}>{row.grade}</td><td style={{ ...s.td, whiteSpace: 'pre-wrap', minWidth: 300, maxWidth: 520 }}>{textValue(row.grade_reason || row.primary_reason || 'N/A')}</td></tr>)}</tbody></table></div>
     </section>
   </div>
 }


### PR DESCRIPTION
Audit and fix the Model Tracker execution path with minimal UI-risk changes.

What this PR changes:
- keeps the existing search behavior intact
- fixes Game filter labels to use real matchup text instead of raw game PK display values
- makes Source, Grade, and Game option targets update from the current filter context instead of the full unfiltered payload
- resets invalid filter values when option sets shrink after another filter changes
- updates visible summary cards to reflect the filtered row set instead of the unfiltered payload summary
- keeps row filtering client-side on the existing `/model-tracker?date=...` response contract

What the audit found:
- frontend page: `frontend/src/pages/ModelTrackerPage.jsx`
- backend routes: `/model-tracker`, `/model-tracker/snapshot`, `/model-tracker/results/refresh`
- current implementation loads one date-scoped payload and applies Source, Grade, Game, and Search entirely client-side
- Source options, Grade options, and Game options were previously built from the full payload instead of the currently constrained filter context
- Game filter display values were raw `game_pk` strings
- pending rows are still expected for some sources by design because several snapshot builders intentionally store outputs as `pending`, `ungraded`, or watchlist rows until final result mapping is safe

This PR does not redesign the page or change the search semantics. It focuses on deterministic filter behavior and clearer game targeting.