### PR TITLE
Add Layer 6EB live fetcher observability

### DIFF
--- a/scripts/backfill_candidate_bullpen_statcast_labels.py
+++ b/scripts/backfill_candidate_bullpen_statcast_labels.py
@@ -946,6 +946,30 @@ def _layer_6cy_run_live_dry_run_scaffold(args: argparse.Namespace) -> int:
 
 
 
+def _candidate_bullpen_live_fetcher_observability(
+    *,
+    source: str,
+    status: str,
+    gate: str,
+    reason: str,
+    dependency_error: str = "",
+    external_fetch_enabled: bool = False,
+    synthetic_enabled: bool = False,
+    real_enabled: bool = False,
+) -> Dict[str, Any]:
+    """Build additive diagnostic-only live fetcher observability fields."""
+    return {
+        "live_fetcher_resolution_source": source,
+        "live_fetcher_resolution_status": status,
+        "live_fetcher_resolution_gate": gate,
+        "live_fetcher_resolution_reason": reason,
+        "live_fetcher_resolution_dependency_error": dependency_error,
+        "live_fetcher_resolution_external_fetch_enabled": bool(external_fetch_enabled),
+        "live_fetcher_resolution_synthetic_enabled": bool(synthetic_enabled),
+        "live_fetcher_resolution_real_enabled": bool(real_enabled),
+    }
+
+
 def _candidate_bullpen_live_synthetic_fetcher(label_date: str) -> List[Dict[str, Any]]:
     """Validation-only deterministic live fetcher test double.
 
@@ -1041,6 +1065,15 @@ def _resolve_candidate_bullpen_live_fetcher(args: argparse.Namespace, label_date
     return None
 
 
+def _candidate_bullpen_apply_live_fetcher_observability(
+    artifact: Dict[str, Any],
+    observability: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Attach additive diagnostic-only observability fields to a live artifact."""
+    artifact.update(observability)
+    return artifact
+
+
 def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
     import re
 
@@ -1064,7 +1097,52 @@ def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
     elif args.end_date:
         label_dates = [str(args.end_date)]
 
+    synthetic_enabled = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE") == "synthetic"
+    real_enabled = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER") == "1"
     resolved_fetcher = _resolve_candidate_bullpen_live_fetcher(args, label_dates)
+
+    if resolved_fetcher is None:
+        observability = _candidate_bullpen_live_fetcher_observability(
+            source="none",
+            status="not_configured",
+            gate="none",
+            reason="no live fetcher resolution gate enabled",
+            external_fetch_enabled=False,
+            synthetic_enabled=synthetic_enabled,
+            real_enabled=real_enabled,
+        )
+    elif getattr(resolved_fetcher, "_candidate_bullpen_live_dependency_missing", False):
+        observability = _candidate_bullpen_live_fetcher_observability(
+            source="dependency_missing",
+            status="live_dependency_missing",
+            gate="real",
+            reason="real adapter dependency missing",
+            dependency_error="candidate_bullpen_live_adapter_dependency_missing",
+            external_fetch_enabled=False,
+            synthetic_enabled=synthetic_enabled,
+            real_enabled=real_enabled,
+        )
+    elif getattr(resolved_fetcher, "__name__", "") == "_candidate_bullpen_live_synthetic_fetcher":
+        observability = _candidate_bullpen_live_fetcher_observability(
+            source="synthetic_test_double",
+            status="resolved",
+            gate="synthetic",
+            reason="validation synthetic fetcher gate enabled",
+            external_fetch_enabled=False,
+            synthetic_enabled=synthetic_enabled,
+            real_enabled=real_enabled,
+        )
+    else:
+        observability = _candidate_bullpen_live_fetcher_observability(
+            source="real_adapter",
+            status="resolved",
+            gate="real",
+            reason="real adapter fetcher gate enabled",
+            external_fetch_enabled=True,
+            synthetic_enabled=synthetic_enabled,
+            real_enabled=real_enabled,
+        )
+
     live_artifact = run_candidate_bullpen_live_adapter_scaffold(
         label_dates,
         source_mode=CANDIDATE_BULLPEN_SOURCE_MODE_LIVE,
@@ -1075,6 +1153,8 @@ def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
     if getattr(resolved_fetcher, "_candidate_bullpen_live_dependency_missing", False):
         live_artifact["adapter_status"] = "live_dependency_missing"
         live_artifact["adapter_fetch_error"] = "candidate_bullpen_live_adapter_dependency_missing"
+
+    _candidate_bullpen_apply_live_fetcher_observability(live_artifact, observability)
     print(json.dumps(live_artifact, indent=2, sort_keys=True))
     return 0
 
@@ -1194,6 +1274,12 @@ def main() -> None:
     OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
     print(json.dumps(diagnosis, indent=2))
 
+
+# Layer 6EB: candidate bullpen Statcast live adapter CLI live fetcher observability.
+# Live fetcher observability version: candidate_bullpen_live_adapter_cli_live_fetcher_observability_v0.1
+# Adds additive diagnostic-only live_fetcher_resolution_* fields. These fields
+# must not affect resolver gates, writes, materialization, fixture behavior, or
+# production defaults.
 
 # Layer 6DX: candidate bullpen Statcast live adapter CLI real fetcher resolution.
 # Real fetcher resolution version: candidate_bullpen_live_adapter_cli_real_fetcher_resolution_v0.1

--- a/scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py
+++ b/scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest import mock
+
+
+VALIDATION_VERSION = "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_validation_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+VALIDATION_6DX = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DY = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+PLAN_6DZ = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py")
+AUDIT_6EA = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan.py")
+PLAN_6DV = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DW = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution_plan.py")
+VALIDATION_6DT = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DU = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+VALIDATION_6DL = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+AUDIT_6DM = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_scaffold_integration.py")
+PLAN_6DN = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_contract.py")
+AUDIT_6DO = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_contract_plan.py")
+VALIDATION_6DP = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+AUDIT_6DQ = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_scaffold_integration.py")
+PLAN_6DR = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection.py")
+AUDIT_6DS = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_dry_run_fetcher_injection_plan.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_checks.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_source_audit.csv"
+OUTPUT_FIELDS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_fields_audit.csv"
+OUTPUT_DEFAULT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_default_audit.csv"
+OUTPUT_SYNTHETIC = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_synthetic_audit.csv"
+OUTPUT_MONKEYPATCHED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_monkeypatched_real_audit.csv"
+OUTPUT_DEPENDENCY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_dependency_missing_audit.csv"
+OUTPUT_BLOCKED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_blocked_path_audit.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_artifact_compatibility_audit.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_import_boundary_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_safety_audit.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_immutability_audit.csv"
+
+OBSERVABILITY_FIELDS = {
+    "live_fetcher_resolution_source",
+    "live_fetcher_resolution_status",
+    "live_fetcher_resolution_gate",
+    "live_fetcher_resolution_reason",
+    "live_fetcher_resolution_dependency_error",
+    "live_fetcher_resolution_external_fetch_enabled",
+    "live_fetcher_resolution_synthetic_enabled",
+    "live_fetcher_resolution_real_enabled",
+}
+
+REQUIRED_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+    "external_fetch_performed",
+    "db_writes_performed",
+    "candidate_labels_materialized",
+    "production_default_unchanged",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        VALIDATION_6DX,
+        AUDIT_6DY,
+        PLAN_6DZ,
+        AUDIT_6EA,
+        PLAN_6DV,
+        AUDIT_6DW,
+        VALIDATION_6DT,
+        AUDIT_6DU,
+        VALIDATION_6DL,
+        AUDIT_6DM,
+        PLAN_6DN,
+        AUDIT_6DO,
+        VALIDATION_6DP,
+        AUDIT_6DQ,
+        PLAN_6DR,
+        AUDIT_6DS,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _load_scaffold_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_live_fetcher_observability_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\n".join(imports)
+
+
+def _run_cli(args: List[str], env_updates: Dict[str, str] | None = None) -> Dict[str, Any]:
+    env = os.environ.copy()
+    env.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    env.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    if env_updates:
+        env.update(env_updates)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCAFFOLD_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception:
+        payload = {}
+    return {"returncode": completed.returncode, "payload": payload, "stdout": completed.stdout, "stderr": completed.stderr}
+
+
+def _args(**kwargs: Any) -> argparse.Namespace:
+    base = {"source_mode": "live", "dry_run": True, "write": False, "allow_live_write": False}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _source_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    return [
+        {"check": "six_eb_marker_present", "passed": "candidate_bullpen_live_adapter_cli_live_fetcher_observability_v0.1" in source, "detail": True},
+        {"check": "observability_builder_defined", "passed": "def _candidate_bullpen_live_fetcher_observability" in source, "detail": True},
+        {"check": "observability_apply_defined", "passed": "def _candidate_bullpen_apply_live_fetcher_observability" in source, "detail": True},
+        {"check": "all_observability_fields_present", "passed": all(field in source for field in OBSERVABILITY_FIELDS), "detail": f"{sum(field in source for field in OBSERVABILITY_FIELDS)}/{len(OBSERVABILITY_FIELDS)}"},
+        {"check": "real_gate_preserved", "passed": "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in source, "detail": True},
+        {"check": "synthetic_gate_preserved", "passed": "CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE" in source, "detail": True},
+        {"check": "dependency_missing_preserved", "passed": "live_dependency_missing" in source, "detail": True},
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _field_rows(payload: Dict[str, Any], case: str) -> List[Dict[str, Any]]:
+    return [
+        {
+            "case": case,
+            "field": field,
+            "present": field in payload,
+            "value": payload.get(field),
+            "passed": field in payload,
+        }
+        for field in sorted(OBSERVABILITY_FIELDS)
+    ]
+
+
+def _default_rows() -> List[Dict[str, Any]]:
+    result = _run_cli(["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"])
+    payload = result["payload"]
+    return [
+        {"check": "default_returncode_zero", "passed": result["returncode"] == 0, "detail": result["returncode"]},
+        {"check": "default_fields_present", "passed": OBSERVABILITY_FIELDS.issubset(payload), "detail": f"{len(OBSERVABILITY_FIELDS.intersection(payload))}/{len(OBSERVABILITY_FIELDS)}"},
+        {"check": "default_source_safe", "passed": payload.get("live_fetcher_resolution_source") in {"none", "dependency_missing"}, "detail": payload.get("live_fetcher_resolution_source")},
+        {"check": "default_no_external_fetch", "passed": payload.get("external_fetch_performed") is False and payload.get("live_fetcher_resolution_external_fetch_enabled") in {False, True}, "detail": payload.get("external_fetch_performed")},
+        {"check": "default_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "default_no_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _synthetic_rows() -> List[Dict[str, Any]]:
+    result = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )
+    payload = result["payload"]
+    return [
+        {"check": "synthetic_returncode_zero", "passed": result["returncode"] == 0, "detail": result["returncode"]},
+        {"check": "synthetic_status_ready", "passed": payload.get("adapter_status") == "live_dry_run_ready", "detail": payload.get("adapter_status")},
+        {"check": "synthetic_source", "passed": payload.get("live_fetcher_resolution_source") == "synthetic_test_double", "detail": payload.get("live_fetcher_resolution_source")},
+        {"check": "synthetic_gate", "passed": payload.get("live_fetcher_resolution_gate") == "synthetic", "detail": payload.get("live_fetcher_resolution_gate")},
+        {"check": "synthetic_enabled_true", "passed": payload.get("live_fetcher_resolution_synthetic_enabled") is True, "detail": payload.get("live_fetcher_resolution_synthetic_enabled")},
+        {"check": "synthetic_real_enabled_false", "passed": payload.get("live_fetcher_resolution_real_enabled") is False, "detail": payload.get("live_fetcher_resolution_real_enabled")},
+        {"check": "synthetic_no_external_fetch", "passed": payload.get("external_fetch_performed") is False, "detail": payload.get("external_fetch_performed")},
+        {"check": "synthetic_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+    ]
+
+
+def _monkeypatched_rows(module: Any) -> List[Dict[str, Any]]:
+    class FakeResult:
+        status = "live_dry_run_ready"
+        rows = [
+            {
+                "game_date": "2024-07-16",
+                "game_pk": 990001,
+                "inning": 9,
+                "inning_topbot": "Top",
+                "at_bat_number": 77,
+                "pitch_number": 2,
+                "outs_when_up": 1,
+                "pitcher_id": 766666,
+                "home_team": "TEX",
+                "away_team": "OAK",
+                "events": "field_out",
+                "description": "hit_into_play",
+            }
+        ]
+        normalized_rows = rows
+        raw_row_count = 1
+        normalized_row_count = 1
+        duplicate_count = 0
+        required_field_failures = 0
+        missing_fields: List[str] = []
+        fetch_error = ""
+        external_fetch_performed = False
+        db_writes_performed = False
+        fetch_duration_ms = 0
+        retry_count = 0
+        source_adapter_version = "observability_fake_adapter_v0.1"
+
+    calls: List[str] = []
+
+    def fake_adapter(label_date: str, *args: Any, **kwargs: Any) -> FakeResult:
+        calls.append(label_date)
+        return FakeResult()
+
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    with mock.patch("scripts.fetch_candidate_bullpen_statcast_live_adapter.fetch_candidate_bullpen_statcast_live_rows_for_date", fake_adapter):
+        fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+        observability = module._candidate_bullpen_live_fetcher_observability(
+            source="real_adapter",
+            status="resolved",
+            gate="real",
+            reason="real adapter fetcher gate enabled",
+            external_fetch_enabled=True,
+            synthetic_enabled=False,
+            real_enabled=True,
+        )
+        payload = module.run_candidate_bullpen_live_adapter_scaffold(
+            ["2024-07-16"],
+            source_mode="live",
+            dry_run=True,
+            allow_live_write=False,
+            fetcher=fetcher,
+        )
+        module._candidate_bullpen_apply_live_fetcher_observability(payload, observability)
+
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+
+    return [
+        {"check": "real_fetcher_callable", "passed": callable(fetcher), "detail": getattr(fetcher, "__name__", "")},
+        {"check": "real_adapter_called_once_by_helper", "passed": calls == ["2024-07-16"], "detail": len(calls)},
+        {"check": "real_status_ready", "passed": payload.get("adapter_status") == "live_dry_run_ready", "detail": payload.get("adapter_status")},
+        {"check": "real_observability_source", "passed": payload.get("live_fetcher_resolution_source") == "real_adapter", "detail": payload.get("live_fetcher_resolution_source")},
+        {"check": "real_observability_gate", "passed": payload.get("live_fetcher_resolution_gate") == "real", "detail": payload.get("live_fetcher_resolution_gate")},
+        {"check": "real_enabled_true", "passed": payload.get("live_fetcher_resolution_real_enabled") is True, "detail": payload.get("live_fetcher_resolution_real_enabled")},
+        {"check": "real_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "real_no_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _dependency_rows(module: Any) -> List[Dict[str, Any]]:
+    observability = module._candidate_bullpen_live_fetcher_observability(
+        source="dependency_missing",
+        status="live_dependency_missing",
+        gate="real",
+        reason="real adapter dependency missing",
+        dependency_error="candidate_bullpen_live_adapter_dependency_missing",
+        external_fetch_enabled=False,
+        synthetic_enabled=False,
+        real_enabled=True,
+    )
+    payload = {
+        "adapter_status": "live_dependency_missing",
+        "adapter_fetch_error": "candidate_bullpen_live_adapter_dependency_missing",
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized": False,
+    }
+    module._candidate_bullpen_apply_live_fetcher_observability(payload, observability)
+    return [
+        {"check": "dependency_source", "passed": payload.get("live_fetcher_resolution_source") == "dependency_missing", "detail": payload.get("live_fetcher_resolution_source")},
+        {"check": "dependency_status", "passed": payload.get("live_fetcher_resolution_status") == "live_dependency_missing", "detail": payload.get("live_fetcher_resolution_status")},
+        {"check": "dependency_error", "passed": payload.get("live_fetcher_resolution_dependency_error") == "candidate_bullpen_live_adapter_dependency_missing", "detail": payload.get("live_fetcher_resolution_dependency_error")},
+        {"check": "dependency_no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"check": "dependency_no_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+
+
+def _blocked_rows() -> List[Dict[str, Any]]:
+    cases = [
+        ("live_without_dry_run", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"], "live_requires_dry_run"),
+        ("live_write_attempt", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"], "live_write_blocked"),
+        ("invalid_live_date", ["--source-mode", "live", "--start-date", "2024-7-16", "--end-date", "2024-7-16", "--dry-run"], "live_date_window_invalid"),
+        ("multi_date_live_window", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-17", "--dry-run"], "live_date_window_invalid"),
+    ]
+    rows: List[Dict[str, Any]] = []
+    for case, args, expected in cases:
+        result = _run_cli(args, {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"})
+        payload = result["payload"]
+        rows.append(
+            {
+                "case": case,
+                "expected_status": expected,
+                "actual_status": payload.get("adapter_status"),
+                "observability_fields_present": OBSERVABILITY_FIELDS.issubset(payload),
+                "external_fetch_performed": payload.get("external_fetch_performed"),
+                "db_writes_performed": payload.get("db_writes_performed"),
+                "candidate_labels_materialized": payload.get("candidate_labels_materialized"),
+                "passed": (
+                    result["returncode"] == 0
+                    and payload.get("adapter_status") == expected
+                    and payload.get("external_fetch_performed") is False
+                    and payload.get("db_writes_performed") is False
+                    and payload.get("candidate_labels_materialized") is False
+                ),
+            }
+        )
+    return rows
+
+
+def _artifact_rows() -> List[Dict[str, Any]]:
+    synthetic = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )["payload"]
+    blocked = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"],
+        {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"},
+    )["payload"]
+    return [
+        {"check": "synthetic_existing_fields_preserved", "passed": REQUIRED_FIELDS.issubset(synthetic), "detail": f"{len(REQUIRED_FIELDS.intersection(synthetic))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "synthetic_observability_fields_present", "passed": OBSERVABILITY_FIELDS.issubset(synthetic), "detail": f"{len(OBSERVABILITY_FIELDS.intersection(synthetic))}/{len(OBSERVABILITY_FIELDS)}"},
+        {"check": "blocked_existing_fields_preserved", "passed": REQUIRED_FIELDS.issubset(blocked), "detail": f"{len(REQUIRED_FIELDS.intersection(blocked))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "observability_additive_total_fields", "passed": len(synthetic.keys()) >= len(REQUIRED_FIELDS) + len(OBSERVABILITY_FIELDS), "detail": len(synthetic.keys())},
+    ]
+
+
+def _import_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    resolver_idx = source.find("def _resolve_candidate_bullpen_live_fetcher")
+    resolver_body = source[resolver_idx:] if resolver_idx != -1 else ""
+    return [
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "adapter_import_inside_gated_resolver", "passed": "fetch_candidate_bullpen_statcast_live_adapter" in resolver_body and "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in resolver_body, "detail": True},
+    ]
+
+
+def _safety_rows(
+    default_rows: List[Dict[str, Any]],
+    synthetic_rows: List[Dict[str, Any]],
+    monkeypatched_rows: List[Dict[str, Any]],
+    dependency_rows: List[Dict[str, Any]],
+    blocked_rows: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    return [
+        {"check": "default_safe", "passed": all(row["passed"] for row in default_rows), "detail": True},
+        {"check": "synthetic_safe", "passed": all(row["passed"] for row in synthetic_rows), "detail": True},
+        {"check": "monkeypatched_safe", "passed": all(row["passed"] for row in monkeypatched_rows), "detail": True},
+        {"check": "dependency_safe", "passed": all(row["passed"] for row in dependency_rows), "detail": True},
+        {"check": "blocked_safe", "passed": all(row["passed"] for row in blocked_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "subprocess synthetic plus monkeypatch only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "six_dx_validation_not_modified", "passed": before.get(str(VALIDATION_6DX)) == after.get(str(VALIDATION_6DX)), "detail": str(VALIDATION_6DX)},
+        {"check": "six_dy_audit_not_modified", "passed": before.get(str(AUDIT_6DY)) == after.get(str(AUDIT_6DY)), "detail": str(AUDIT_6DY)},
+        {"check": "six_dz_plan_not_modified", "passed": before.get(str(PLAN_6DZ)) == after.get(str(PLAN_6DZ)), "detail": str(PLAN_6DZ)},
+        {"check": "six_ea_audit_not_modified", "passed": before.get(str(AUDIT_6EA)) == after.get(str(AUDIT_6EA)), "detail": str(AUDIT_6EA)},
+        {"check": "prior_validation_audit_plan_scripts_not_modified", "passed": all(before.get(str(path)) == after.get(str(path)) for path in [PLAN_6DV, AUDIT_6DW, VALIDATION_6DT, AUDIT_6DU, VALIDATION_6DL, AUDIT_6DM, PLAN_6DN, AUDIT_6DO, VALIDATION_6DP, AUDIT_6DQ, PLAN_6DR, AUDIT_6DS]), "detail": "6DL through 6DW unchanged"},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixtures and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+    source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_scaffold_module()
+
+    source_rows = _source_rows(source)
+    default_rows = _default_rows()
+    synthetic_rows = _synthetic_rows()
+    monkeypatched_rows = _monkeypatched_rows(module)
+    dependency_rows = _dependency_rows(module)
+    blocked_rows = _blocked_rows()
+    artifact_rows = _artifact_rows()
+    import_rows = _import_rows(source)
+    safety_rows = _safety_rows(default_rows, synthetic_rows, monkeypatched_rows, dependency_rows, blocked_rows)
+    immutability_rows = _immutability_rows(before)
+
+    default_payload = _run_cli(["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"])["payload"]
+    synthetic_payload = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )["payload"]
+    field_rows = _field_rows(default_payload, "default") + _field_rows(synthetic_payload, "synthetic")
+
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_FIELDS, field_rows)
+    _write_csv(OUTPUT_DEFAULT, default_rows)
+    _write_csv(OUTPUT_SYNTHETIC, synthetic_rows)
+    _write_csv(OUTPUT_MONKEYPATCHED, monkeypatched_rows)
+    _write_csv(OUTPUT_DEPENDENCY, dependency_rows)
+    _write_csv(OUTPUT_BLOCKED, blocked_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "source_valid", "passed": all(row["passed"] for row in source_rows), "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "observability_fields_valid", "passed": all(row["passed"] for row in field_rows), "detail": f"{sum(row['passed'] for row in field_rows)}/{len(field_rows)}"},
+        {"check": "default_observability_valid", "passed": all(row["passed"] for row in default_rows), "detail": f"{sum(row['passed'] for row in default_rows)}/{len(default_rows)}"},
+        {"check": "synthetic_observability_valid", "passed": all(row["passed"] for row in synthetic_rows), "detail": f"{sum(row['passed'] for row in synthetic_rows)}/{len(synthetic_rows)}"},
+        {"check": "monkeypatched_real_fetcher_observability_valid", "passed": all(row["passed"] for row in monkeypatched_rows), "detail": f"{sum(row['passed'] for row in monkeypatched_rows)}/{len(monkeypatched_rows)}"},
+        {"check": "dependency_missing_observability_valid", "passed": all(row["passed"] for row in dependency_rows), "detail": f"{sum(row['passed'] for row in dependency_rows)}/{len(dependency_rows)}"},
+        {"check": "blocked_path_observability_valid", "passed": all(row["passed"] for row in blocked_rows), "detail": f"{sum(row['passed'] for row in blocked_rows)}/{len(blocked_rows)}"},
+        {"check": "artifact_compatibility_valid", "passed": all(row["passed"] for row in artifact_rows), "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "import_boundary_valid", "passed": all(row["passed"] for row in import_rows), "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "safety_valid", "passed": all(row["passed"] for row in safety_rows), "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "adapter_unchanged", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "validation uses synthetic/monkeypatch only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_label_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_complete",
+        "validation_version": VALIDATION_VERSION,
+        "source_rows": len(source_rows),
+        "observability_field_rows": len(field_rows),
+        "default_observability_rows": len(default_rows),
+        "synthetic_observability_rows": len(synthetic_rows),
+        "monkeypatched_real_fetcher_rows": len(monkeypatched_rows),
+        "dependency_missing_rows": len(dependency_rows),
+        "blocked_path_rows": len(blocked_rows),
+        "artifact_rows": len(artifact_rows),
+        "import_rows": len(import_rows),
+        "safety_rows": len(safety_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "implementation_complete": all_checks_passed,
+        "source_valid": all(row["passed"] for row in source_rows),
+        "observability_fields_valid": all(row["passed"] for row in field_rows),
+        "default_observability_valid": all(row["passed"] for row in default_rows),
+        "synthetic_observability_valid": all(row["passed"] for row in synthetic_rows),
+        "monkeypatched_real_fetcher_observability_valid": all(row["passed"] for row in monkeypatched_rows),
+        "dependency_missing_observability_valid": all(row["passed"] for row in dependency_rows),
+        "blocked_path_observability_valid": all(row["passed"] for row in blocked_rows),
+        "artifact_compatibility_valid": all(row["passed"] for row in artifact_rows),
+        "import_boundary_valid": all(row["passed"] for row in import_rows),
+        "safety_valid": all(row["passed"] for row in safety_rows),
+        "immutability_valid": all(row["passed"] for row in immutability_rows),
+        "adapter_unchanged": True,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6EC_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_audit"
+            if all_checks_passed
+            else "6EB_patch_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6EB: additive diagnostic-only live fetcher resolution observability fields for the candidate bullpen Statcast live adapter CLI live path.

## Validation

- compileall passed
- source valid: 10/10
- observability fields valid: 16/16
- default observability valid: 6/6
- synthetic observability valid: 8/8
- monkeypatched real fetcher observability valid: 8/8
- dependency missing observability valid: 5/5
- blocked path observability valid: 4/4
- artifact compatibility valid: 4/4
- import boundary valid: 3/3
- safety valid: 9/9
- immutability valid: 7/7

## Safety

No resolver gate changes. No top-level adapter, pybaseball, or statcast import. Adapter unchanged, fixtures unchanged, no external fetch in validation, no DB writes, no candidate-label materialization from live rows, and production default unchanged.

## Next Layer

Recommended next layer: 6EC_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_audit.