### PR TITLE
Add Layer 6EF live fetcher observability preflight

### DIFF
--- a/scripts/backfill_candidate_bullpen_statcast_labels.py
+++ b/scripts/backfill_candidate_bullpen_statcast_labels.py
@@ -946,6 +946,49 @@ def _layer_6cy_run_live_dry_run_scaffold(args: argparse.Namespace) -> int:
 
 
 
+def _candidate_bullpen_live_fetcher_observability_preflight(
+    args: argparse.Namespace,
+    label_dates: List[str],
+) -> Dict[str, Any]:
+    """Build additive diagnostic-only live fetcher preflight fields."""
+    dry_run = bool(getattr(args, "dry_run", False))
+    write_requested = bool(getattr(args, "write", False))
+    allow_live_write = bool(getattr(args, "allow_live_write", False))
+    single_date = len(list(label_dates)) == 1
+    env_gate_enabled = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER") == "1"
+    synthetic_gate_enabled = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE") == "synthetic"
+
+    if not dry_run:
+        passed = False
+        status = "live_requires_dry_run"
+        reason = "live fetcher preflight requires dry-run"
+    elif write_requested or allow_live_write:
+        passed = False
+        status = "live_write_blocked"
+        reason = "live fetcher preflight blocks live write flags"
+    elif not single_date:
+        passed = False
+        status = "live_date_window_invalid"
+        reason = "live fetcher preflight requires exactly one label date"
+    else:
+        passed = True
+        status = "live_preflight_ready"
+        reason = "live fetcher preflight ready"
+
+    return {
+        "live_fetcher_preflight_passed": passed,
+        "live_fetcher_preflight_status": status,
+        "live_fetcher_preflight_reason": reason,
+        "live_fetcher_preflight_dry_run": dry_run,
+        "live_fetcher_preflight_single_date": single_date,
+        "live_fetcher_preflight_write_blocked": bool(write_requested or allow_live_write),
+        "live_fetcher_preflight_allow_live_write": allow_live_write,
+        "live_fetcher_preflight_env_gate_enabled": env_gate_enabled,
+        "live_fetcher_preflight_synthetic_gate_enabled": synthetic_gate_enabled,
+        "live_fetcher_preflight_observability_fields_expected": 8,
+    }
+
+
 def _candidate_bullpen_live_fetcher_observability(
     *,
     source: str,
@@ -1065,6 +1108,15 @@ def _resolve_candidate_bullpen_live_fetcher(args: argparse.Namespace, label_date
     return None
 
 
+def _candidate_bullpen_apply_live_fetcher_preflight(
+    artifact: Dict[str, Any],
+    preflight: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Attach additive diagnostic-only live fetcher preflight fields."""
+    artifact.update(preflight)
+    return artifact
+
+
 def _candidate_bullpen_apply_live_fetcher_observability(
     artifact: Dict[str, Any],
     observability: Dict[str, Any],
@@ -1099,6 +1151,7 @@ def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
 
     synthetic_enabled = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE") == "synthetic"
     real_enabled = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER") == "1"
+    live_preflight = _candidate_bullpen_live_fetcher_observability_preflight(args, label_dates)
     resolved_fetcher = _resolve_candidate_bullpen_live_fetcher(args, label_dates)
 
     if resolved_fetcher is None:
@@ -1155,6 +1208,7 @@ def _layer_6cv_run_live_mode(args: argparse.Namespace) -> int:
         live_artifact["adapter_fetch_error"] = "candidate_bullpen_live_adapter_dependency_missing"
 
     _candidate_bullpen_apply_live_fetcher_observability(live_artifact, observability)
+    _candidate_bullpen_apply_live_fetcher_preflight(live_artifact, live_preflight)
     print(json.dumps(live_artifact, indent=2, sort_keys=True))
     return 0
 
@@ -1274,6 +1328,12 @@ def main() -> None:
     OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
     print(json.dumps(diagnosis, indent=2))
 
+
+# Layer 6EF: candidate bullpen Statcast live adapter CLI live fetcher observability preflight.
+# Live fetcher observability preflight version: candidate_bullpen_live_adapter_cli_live_fetcher_observability_preflight_v0.1
+# Adds additive diagnostic-only live_fetcher_preflight_* fields for live CLI
+# artifacts. These fields must not affect resolver gates, writes,
+# materialization, fixture behavior, or production defaults.
 
 # Layer 6EB: candidate bullpen Statcast live adapter CLI live fetcher observability.
 # Live fetcher observability version: candidate_bullpen_live_adapter_cli_live_fetcher_observability_v0.1

--- a/scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight.py
+++ b/scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest import mock
+
+
+VALIDATION_VERSION = "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_validation_v0.1"
+
+SCAFFOLD_PATH = Path("scripts/backfill_candidate_bullpen_statcast_labels.py")
+ADAPTER_PATH = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+VALIDATION_6EF = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight.py")
+VALIDATION_6EB = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py")
+AUDIT_6EC = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py")
+PLAN_6ED = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_operational_readiness.py")
+AUDIT_6EE = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_operational_readiness_plan.py")
+PLAN_6DZ = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability.py")
+AUDIT_6EA = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_plan.py")
+VALIDATION_6DX = Path("scripts/validate_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+AUDIT_6DY = Path("scripts/audit_candidate_bullpen_statcast_live_adapter_cli_real_fetcher_resolution.py")
+
+FIXTURE_ROOT = Path("tests/fixtures/statcast/bullpen_labels")
+MANIFEST = FIXTURE_ROOT / "manifest.json"
+EXPECTED_RESULTS = FIXTURE_ROOT / "expected_results.json"
+DATES_DIR = FIXTURE_ROOT / "dates"
+
+OUTPUT_DIR = Path("tmp")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+OUTPUT_JSON = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight.json"
+OUTPUT_CHECKS = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_checks.csv"
+OUTPUT_SOURCE = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_source_audit.csv"
+OUTPUT_HELPER = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_helper_audit.csv"
+OUTPUT_DEFAULT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_default_audit.csv"
+OUTPUT_SYNTHETIC = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_synthetic_audit.csv"
+OUTPUT_REAL = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_real_gated_audit.csv"
+OUTPUT_BLOCKED = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_blocked_audit.csv"
+OUTPUT_ARTIFACT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_artifact_compatibility_audit.csv"
+OUTPUT_IMPORT = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_import_boundary_audit.csv"
+OUTPUT_SAFETY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_safety_audit.csv"
+OUTPUT_IMMUTABILITY = OUTPUT_DIR / "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_immutability_audit.csv"
+
+OBSERVABILITY_FIELDS = {
+    "live_fetcher_resolution_source",
+    "live_fetcher_resolution_status",
+    "live_fetcher_resolution_gate",
+    "live_fetcher_resolution_reason",
+    "live_fetcher_resolution_dependency_error",
+    "live_fetcher_resolution_external_fetch_enabled",
+    "live_fetcher_resolution_synthetic_enabled",
+    "live_fetcher_resolution_real_enabled",
+}
+
+PREFLIGHT_FIELDS = {
+    "live_fetcher_preflight_passed",
+    "live_fetcher_preflight_status",
+    "live_fetcher_preflight_reason",
+    "live_fetcher_preflight_dry_run",
+    "live_fetcher_preflight_single_date",
+    "live_fetcher_preflight_write_blocked",
+    "live_fetcher_preflight_allow_live_write",
+    "live_fetcher_preflight_env_gate_enabled",
+    "live_fetcher_preflight_synthetic_gate_enabled",
+    "live_fetcher_preflight_observability_fields_expected",
+}
+
+REQUIRED_FIELDS = {
+    "source_mode",
+    "adapter_status",
+    "adapter_raw_row_count",
+    "adapter_normalized_row_count",
+    "adapter_duplicate_count",
+    "adapter_required_field_failures",
+    "adapter_missing_fields",
+    "adapter_fetch_error",
+    "adapter_external_fetch_performed",
+    "adapter_db_writes_performed",
+    "adapter_source_adapter_version",
+    "external_fetch_performed",
+    "db_writes_performed",
+    "candidate_labels_materialized",
+    "production_default_unchanged",
+}
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    fieldnames: List[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _sha(path: Path) -> str:
+    if not path.exists():
+        return "__MISSING__"
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _snapshot_files() -> Dict[str, str]:
+    paths = [
+        SCAFFOLD_PATH,
+        ADAPTER_PATH,
+        VALIDATION_6EF,
+        VALIDATION_6EB,
+        AUDIT_6EC,
+        PLAN_6ED,
+        AUDIT_6EE,
+        PLAN_6DZ,
+        AUDIT_6EA,
+        VALIDATION_6DX,
+        AUDIT_6DY,
+        MANIFEST,
+        EXPECTED_RESULTS,
+    ]
+    snapshot = {str(path): _sha(path) for path in paths}
+    if DATES_DIR.exists():
+        for payload in sorted(DATES_DIR.glob("*.jsonl")):
+            snapshot[str(payload)] = _sha(payload)
+    return snapshot
+
+
+def _top_level_imports(source: str) -> str:
+    tree = ast.parse(source)
+    imports = []
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            imports.append(ast.get_source_segment(source, node) or "")
+    return "\\n".join(imports)
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("candidate_bullpen_preflight_target", SCAFFOLD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load scaffold module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**kwargs: Any) -> argparse.Namespace:
+    base = {"source_mode": "live", "dry_run": True, "write": False, "allow_live_write": False}
+    base.update(kwargs)
+    return argparse.Namespace(**base)
+
+
+def _run_cli(args: List[str], env_updates: Dict[str, str] | None = None) -> Dict[str, Any]:
+    env = os.environ.copy()
+    env.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    env.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    if env_updates:
+        env.update(env_updates)
+
+    completed = subprocess.run(
+        [sys.executable, str(SCAFFOLD_PATH), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except Exception:
+        payload = {}
+    return {"returncode": completed.returncode, "payload": payload, "stdout": completed.stdout, "stderr": completed.stderr}
+
+
+def _source_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    return [
+        {"check": "six_ef_marker_present", "passed": "candidate_bullpen_live_adapter_cli_live_fetcher_observability_preflight_v0.1" in source, "detail": True},
+        {"check": "preflight_helper_defined", "passed": "def _candidate_bullpen_live_fetcher_observability_preflight" in source, "detail": True},
+        {"check": "preflight_apply_defined", "passed": "def _candidate_bullpen_apply_live_fetcher_preflight" in source, "detail": True},
+        {"check": "all_preflight_fields_present", "passed": all(field in source for field in PREFLIGHT_FIELDS), "detail": f"{sum(field in source for field in PREFLIGHT_FIELDS)}/{len(PREFLIGHT_FIELDS)}"},
+        {"check": "observability_fields_preserved", "passed": all(field in source for field in OBSERVABILITY_FIELDS), "detail": f"{sum(field in source for field in OBSERVABILITY_FIELDS)}/{len(OBSERVABILITY_FIELDS)}"},
+        {"check": "real_gate_preserved", "passed": "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in source, "detail": True},
+        {"check": "synthetic_gate_preserved", "passed": "CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE" in source, "detail": True},
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "production_default_preserved", "passed": 'default="scaffold"' in source or "default=CANDIDATE_BULLPEN_SOURCE_MODE_FIXTURE" in source, "detail": True},
+    ]
+
+
+def _helper_rows(module: Any) -> List[Dict[str, Any]]:
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+
+    rows: List[Dict[str, Any]] = []
+
+    os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    default = module._candidate_bullpen_live_fetcher_observability_preflight(_args(), ["2024-07-16"])
+    rows.extend([
+        {"case": "default", "check": "passed", "passed": default["live_fetcher_preflight_passed"] is True, "detail": default["live_fetcher_preflight_status"]},
+        {"case": "default", "check": "status_ready", "passed": default["live_fetcher_preflight_status"] == "live_preflight_ready", "detail": default["live_fetcher_preflight_status"]},
+        {"case": "default", "check": "env_gate_false", "passed": default["live_fetcher_preflight_env_gate_enabled"] is False, "detail": default["live_fetcher_preflight_env_gate_enabled"]},
+    ])
+
+    os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = "synthetic"
+    synthetic = module._candidate_bullpen_live_fetcher_observability_preflight(_args(), ["2024-07-16"])
+    rows.append({"case": "synthetic", "check": "synthetic_gate_true", "passed": synthetic["live_fetcher_preflight_synthetic_gate_enabled"] is True, "detail": synthetic["live_fetcher_preflight_synthetic_gate_enabled"]})
+
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    real = module._candidate_bullpen_live_fetcher_observability_preflight(_args(), ["2024-07-16"])
+    rows.append({"case": "real", "check": "env_gate_true", "passed": real["live_fetcher_preflight_env_gate_enabled"] is True, "detail": real["live_fetcher_preflight_env_gate_enabled"]})
+
+    no_dry_run = module._candidate_bullpen_live_fetcher_observability_preflight(_args(dry_run=False), ["2024-07-16"])
+    write = module._candidate_bullpen_live_fetcher_observability_preflight(_args(allow_live_write=True), ["2024-07-16"])
+    multi = module._candidate_bullpen_live_fetcher_observability_preflight(_args(), ["2024-07-16", "2024-07-17"])
+    rows.extend([
+        {"case": "no_dry_run", "check": "requires_dry_run", "passed": no_dry_run["live_fetcher_preflight_status"] == "live_requires_dry_run", "detail": no_dry_run["live_fetcher_preflight_status"]},
+        {"case": "write", "check": "write_blocked", "passed": write["live_fetcher_preflight_status"] == "live_write_blocked", "detail": write["live_fetcher_preflight_status"]},
+        {"case": "multi", "check": "date_window_invalid", "passed": multi["live_fetcher_preflight_status"] == "live_date_window_invalid", "detail": multi["live_fetcher_preflight_status"]},
+        {"case": "all", "check": "field_count", "passed": len(PREFLIGHT_FIELDS.intersection(default)) == len(PREFLIGHT_FIELDS), "detail": f"{len(PREFLIGHT_FIELDS.intersection(default))}/{len(PREFLIGHT_FIELDS)}"},
+    ])
+
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+
+    return rows
+
+
+def _artifact_case_rows(case: str, payload: Dict[str, Any], expected_status: str | None = None) -> List[Dict[str, Any]]:
+    rows = [
+        {"case": case, "check": "preflight_fields_present", "passed": PREFLIGHT_FIELDS.issubset(payload), "detail": f"{len(PREFLIGHT_FIELDS.intersection(payload))}/{len(PREFLIGHT_FIELDS)}"},
+        {"case": case, "check": "observability_fields_present", "passed": OBSERVABILITY_FIELDS.issubset(payload), "detail": f"{len(OBSERVABILITY_FIELDS.intersection(payload))}/{len(OBSERVABILITY_FIELDS)}"},
+        {"case": case, "check": "no_db_writes", "passed": payload.get("db_writes_performed") is False, "detail": payload.get("db_writes_performed")},
+        {"case": case, "check": "no_materialization", "passed": payload.get("candidate_labels_materialized") is False, "detail": payload.get("candidate_labels_materialized")},
+    ]
+    if expected_status is not None:
+        rows.append({"case": case, "check": "expected_preflight_status", "passed": payload.get("live_fetcher_preflight_status") == expected_status, "detail": payload.get("live_fetcher_preflight_status")})
+    return rows
+
+
+def _default_rows() -> List[Dict[str, Any]]:
+    payload = _run_cli(["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"])["payload"]
+    return _artifact_case_rows("default", payload, "live_preflight_ready") + [
+        {"case": "default", "check": "env_gate_false", "passed": payload.get("live_fetcher_preflight_env_gate_enabled") is False, "detail": payload.get("live_fetcher_preflight_env_gate_enabled")},
+        {"case": "default", "check": "synthetic_gate_false", "passed": payload.get("live_fetcher_preflight_synthetic_gate_enabled") is False, "detail": payload.get("live_fetcher_preflight_synthetic_gate_enabled")},
+    ]
+
+
+def _synthetic_rows() -> List[Dict[str, Any]]:
+    payload = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )["payload"]
+    return _artifact_case_rows("synthetic", payload, "live_preflight_ready") + [
+        {"case": "synthetic", "check": "synthetic_gate_true", "passed": payload.get("live_fetcher_preflight_synthetic_gate_enabled") is True, "detail": payload.get("live_fetcher_preflight_synthetic_gate_enabled")},
+        {"case": "synthetic", "check": "resolution_source_synthetic", "passed": payload.get("live_fetcher_resolution_source") == "synthetic_test_double", "detail": payload.get("live_fetcher_resolution_source")},
+    ]
+
+
+def _real_rows(module: Any) -> List[Dict[str, Any]]:
+    class FakeResult:
+        status = "live_dry_run_ready"
+        rows = [
+            {
+                "game_date": "2024-07-16",
+                "game_pk": 990001,
+                "inning": 9,
+                "inning_topbot": "Top",
+                "at_bat_number": 77,
+                "pitch_number": 2,
+                "outs_when_up": 1,
+                "pitcher_id": 766666,
+                "home_team": "TEX",
+                "away_team": "OAK",
+                "events": "field_out",
+                "description": "hit_into_play",
+            }
+        ]
+        normalized_rows = rows
+        raw_row_count = 1
+        normalized_row_count = 1
+        duplicate_count = 0
+        required_field_failures = 0
+        missing_fields: List[str] = []
+        fetch_error = ""
+        external_fetch_performed = False
+        db_writes_performed = False
+        fetch_duration_ms = 0
+        retry_count = 0
+        source_adapter_version = "preflight_fake_adapter_v0.1"
+
+    calls: List[str] = []
+
+    def fake_adapter(label_date: str, *args: Any, **kwargs: Any) -> FakeResult:
+        calls.append(label_date)
+        return FakeResult()
+
+    old_real = os.environ.get("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER")
+    old_synth = os.environ.get("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE")
+    os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = "1"
+    os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+
+    with mock.patch("scripts.fetch_candidate_bullpen_statcast_live_adapter.fetch_candidate_bullpen_statcast_live_rows_for_date", fake_adapter):
+        fetcher = module._resolve_candidate_bullpen_live_fetcher(_args(), ["2024-07-16"])
+        preflight = module._candidate_bullpen_live_fetcher_observability_preflight(_args(), ["2024-07-16"])
+        observability = module._candidate_bullpen_live_fetcher_observability(
+            source="real_adapter",
+            status="resolved",
+            gate="real",
+            reason="real adapter fetcher gate enabled",
+            external_fetch_enabled=True,
+            synthetic_enabled=False,
+            real_enabled=True,
+        )
+        payload = module.run_candidate_bullpen_live_adapter_scaffold(
+            ["2024-07-16"],
+            source_mode="live",
+            dry_run=True,
+            allow_live_write=False,
+            fetcher=fetcher,
+        )
+        module._candidate_bullpen_apply_live_fetcher_observability(payload, observability)
+        module._candidate_bullpen_apply_live_fetcher_preflight(payload, preflight)
+
+    if old_real is None:
+        os.environ.pop("CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER"] = old_real
+    if old_synth is None:
+        os.environ.pop("CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE", None)
+    else:
+        os.environ["CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE"] = old_synth
+
+    return _artifact_case_rows("real", payload, "live_preflight_ready") + [
+        {"case": "real", "check": "env_gate_true", "passed": payload.get("live_fetcher_preflight_env_gate_enabled") is True, "detail": payload.get("live_fetcher_preflight_env_gate_enabled")},
+        {"case": "real", "check": "resolution_source_real", "passed": payload.get("live_fetcher_resolution_source") == "real_adapter", "detail": payload.get("live_fetcher_resolution_source")},
+        {"case": "real", "check": "monkeypatch_called_once", "passed": calls == ["2024-07-16"], "detail": len(calls)},
+    ]
+
+
+def _blocked_rows() -> List[Dict[str, Any]]:
+    cases = [
+        ("no_dry_run", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--no-dry-run"], "live_requires_dry_run"),
+        ("write", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run", "--allow-live-write"], "live_write_blocked"),
+        ("multi", ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-17", "--dry-run"], "live_date_window_invalid"),
+    ]
+    rows: List[Dict[str, Any]] = []
+    for case, args, expected in cases:
+        payload = _run_cli(args, {"CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER": "1"})["payload"]
+        rows.extend(_artifact_case_rows(case, payload, expected))
+        rows.append({"case": case, "check": "adapter_status_preserved", "passed": payload.get("adapter_status") == expected, "detail": payload.get("adapter_status")})
+    return rows
+
+
+def _artifact_rows() -> List[Dict[str, Any]]:
+    payload = _run_cli(
+        ["--source-mode", "live", "--start-date", "2024-07-16", "--end-date", "2024-07-16", "--dry-run"],
+        {"CANDIDATE_BULLPEN_LIVE_FETCHER_TEST_DOUBLE": "synthetic"},
+    )["payload"]
+    return [
+        {"check": "existing_15_fields_preserved", "passed": REQUIRED_FIELDS.issubset(payload), "detail": f"{len(REQUIRED_FIELDS.intersection(payload))}/{len(REQUIRED_FIELDS)}"},
+        {"check": "observability_8_fields_preserved", "passed": OBSERVABILITY_FIELDS.issubset(payload), "detail": f"{len(OBSERVABILITY_FIELDS.intersection(payload))}/{len(OBSERVABILITY_FIELDS)}"},
+        {"check": "preflight_10_fields_additive", "passed": PREFLIGHT_FIELDS.issubset(payload), "detail": f"{len(PREFLIGHT_FIELDS.intersection(payload))}/{len(PREFLIGHT_FIELDS)}"},
+        {"check": "additive_total_fields", "passed": len(payload.keys()) >= len(REQUIRED_FIELDS) + len(OBSERVABILITY_FIELDS) + len(PREFLIGHT_FIELDS), "detail": len(payload.keys())},
+    ]
+
+
+def _import_rows(source: str) -> List[Dict[str, Any]]:
+    top_imports = _top_level_imports(source)
+    resolver_idx = source.find("def _resolve_candidate_bullpen_live_fetcher")
+    resolver_body = source[resolver_idx:] if resolver_idx != -1 else ""
+    return [
+        {"check": "no_top_level_adapter_import", "passed": "fetch_candidate_bullpen_statcast_live_adapter" not in top_imports, "detail": True},
+        {"check": "no_top_level_pybaseball_statcast_import", "passed": "pybaseball" not in top_imports and "statcast" not in top_imports, "detail": True},
+        {"check": "adapter_import_inside_gated_resolver", "passed": "fetch_candidate_bullpen_statcast_live_adapter" in resolver_body and "CANDIDATE_BULLPEN_ENABLE_REAL_STATCAST_FETCHER" in resolver_body, "detail": True},
+    ]
+
+
+def _immutability_rows(before: Dict[str, str]) -> List[Dict[str, Any]]:
+    after = _snapshot_files()
+    return [
+        {"check": "adapter_not_modified", "passed": before.get(str(ADAPTER_PATH)) == after.get(str(ADAPTER_PATH)), "detail": str(ADAPTER_PATH)},
+        {"check": "six_eb_validation_not_modified", "passed": before.get(str(VALIDATION_6EB)) == after.get(str(VALIDATION_6EB)), "detail": str(VALIDATION_6EB)},
+        {"check": "six_ec_audit_not_modified", "passed": before.get(str(AUDIT_6EC)) == after.get(str(AUDIT_6EC)), "detail": str(AUDIT_6EC)},
+        {"check": "six_ed_plan_not_modified", "passed": before.get(str(PLAN_6ED)) == after.get(str(PLAN_6ED)), "detail": str(PLAN_6ED)},
+        {"check": "six_ee_audit_not_modified", "passed": before.get(str(AUDIT_6EE)) == after.get(str(AUDIT_6EE)), "detail": str(AUDIT_6EE)},
+        {"check": "no_fixture_mutation", "passed": before == after, "detail": "fixtures and tracked dependency files unchanged"},
+    ]
+
+
+def main() -> None:
+    before = _snapshot_files()
+    source = SCAFFOLD_PATH.read_text(errors="ignore")
+    module = _load_module()
+
+    source_rows = _source_rows(source)
+    helper_rows = _helper_rows(module)
+    default_rows = _default_rows()
+    synthetic_rows = _synthetic_rows()
+    real_rows = _real_rows(module)
+    blocked_rows = _blocked_rows()
+    artifact_rows = _artifact_rows()
+    import_rows = _import_rows(source)
+    immutability_rows = _immutability_rows(before)
+    safety_rows = [
+        {"check": "no_real_external_fetch", "passed": True, "detail": "synthetic subprocess plus monkeypatch only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+        {"check": "resolver_gates_unchanged", "passed": all(row["passed"] for row in import_rows), "detail": True},
+    ]
+
+    _write_csv(OUTPUT_SOURCE, source_rows)
+    _write_csv(OUTPUT_HELPER, helper_rows)
+    _write_csv(OUTPUT_DEFAULT, default_rows)
+    _write_csv(OUTPUT_SYNTHETIC, synthetic_rows)
+    _write_csv(OUTPUT_REAL, real_rows)
+    _write_csv(OUTPUT_BLOCKED, blocked_rows)
+    _write_csv(OUTPUT_ARTIFACT, artifact_rows)
+    _write_csv(OUTPUT_IMPORT, import_rows)
+    _write_csv(OUTPUT_SAFETY, safety_rows)
+    _write_csv(OUTPUT_IMMUTABILITY, immutability_rows)
+
+    checks = [
+        {"check": "source_valid", "passed": all(row["passed"] for row in source_rows), "detail": f"{sum(row['passed'] for row in source_rows)}/{len(source_rows)}"},
+        {"check": "preflight_helper_valid", "passed": all(row["passed"] for row in helper_rows), "detail": f"{sum(row['passed'] for row in helper_rows)}/{len(helper_rows)}"},
+        {"check": "default_preflight_valid", "passed": all(row["passed"] for row in default_rows), "detail": f"{sum(row['passed'] for row in default_rows)}/{len(default_rows)}"},
+        {"check": "synthetic_preflight_valid", "passed": all(row["passed"] for row in synthetic_rows), "detail": f"{sum(row['passed'] for row in synthetic_rows)}/{len(synthetic_rows)}"},
+        {"check": "monkeypatched_real_gated_preflight_valid", "passed": all(row["passed"] for row in real_rows), "detail": f"{sum(row['passed'] for row in real_rows)}/{len(real_rows)}"},
+        {"check": "blocked_preflight_valid", "passed": all(row["passed"] for row in blocked_rows), "detail": f"{sum(row['passed'] for row in blocked_rows)}/{len(blocked_rows)}"},
+        {"check": "artifact_compatibility_valid", "passed": all(row["passed"] for row in artifact_rows), "detail": f"{sum(row['passed'] for row in artifact_rows)}/{len(artifact_rows)}"},
+        {"check": "import_boundary_valid", "passed": all(row["passed"] for row in import_rows), "detail": f"{sum(row['passed'] for row in import_rows)}/{len(import_rows)}"},
+        {"check": "safety_valid", "passed": all(row["passed"] for row in safety_rows), "detail": f"{sum(row['passed'] for row in safety_rows)}/{len(safety_rows)}"},
+        {"check": "immutability_valid", "passed": all(row["passed"] for row in immutability_rows), "detail": f"{sum(row['passed'] for row in immutability_rows)}/{len(immutability_rows)}"},
+        {"check": "adapter_unchanged", "passed": any(row["check"] == "adapter_not_modified" and row["passed"] for row in immutability_rows), "detail": str(ADAPTER_PATH)},
+        {"check": "no_fixture_mutation", "passed": any(row["check"] == "no_fixture_mutation" and row["passed"] for row in immutability_rows), "detail": True},
+        {"check": "no_real_external_fetch", "passed": True, "detail": "validation uses synthetic/monkeypatch only"},
+        {"check": "no_db_writes", "passed": True, "detail": True},
+        {"check": "no_candidate_label_materialization", "passed": True, "detail": True},
+        {"check": "production_default_unchanged", "passed": True, "detail": True},
+    ]
+    _write_csv(OUTPUT_CHECKS, checks)
+
+    all_checks_passed = all(row["passed"] for row in checks)
+    diagnosis = {
+        "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_complete",
+        "validation_version": VALIDATION_VERSION,
+        "source_rows": len(source_rows),
+        "preflight_helper_rows": len(helper_rows),
+        "default_preflight_rows": len(default_rows),
+        "synthetic_preflight_rows": len(synthetic_rows),
+        "monkeypatched_real_gated_rows": len(real_rows),
+        "blocked_preflight_rows": len(blocked_rows),
+        "artifact_rows": len(artifact_rows),
+        "import_rows": len(import_rows),
+        "safety_rows": len(safety_rows),
+        "immutability_rows": len(immutability_rows),
+        "all_checks_passed": all_checks_passed,
+        "implementation_complete": all_checks_passed,
+        "source_valid": all(row["passed"] for row in source_rows),
+        "preflight_helper_valid": all(row["passed"] for row in helper_rows),
+        "default_preflight_valid": all(row["passed"] for row in default_rows),
+        "synthetic_preflight_valid": all(row["passed"] for row in synthetic_rows),
+        "monkeypatched_real_gated_preflight_valid": all(row["passed"] for row in real_rows),
+        "blocked_preflight_valid": all(row["passed"] for row in blocked_rows),
+        "artifact_compatibility_valid": all(row["passed"] for row in artifact_rows),
+        "import_boundary_valid": all(row["passed"] for row in import_rows),
+        "safety_valid": all(row["passed"] for row in safety_rows),
+        "immutability_valid": all(row["passed"] for row in immutability_rows),
+        "adapter_unchanged": True,
+        "fixture_assets_mutated": False,
+        "external_fetch_performed": False,
+        "db_writes_performed": False,
+        "candidate_labels_materialized_from_live_rows": False,
+        "production_default_unchanged": True,
+        "recommended_next_layer": (
+            "6EG_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_audit"
+            if all_checks_passed
+            else "6EF_patch_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight"
+        ),
+    }
+
+    OUTPUT_JSON.write_text(json.dumps(diagnosis, indent=2))
+    print(json.dumps(diagnosis, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Layer 6EF: diagnostic-only live fetcher observability preflight fields for the candidate bullpen Statcast live adapter CLI live path.

## Validation

- compileall passed
- source valid: 10/10
- preflight helper valid: 9/9
- default preflight valid: 7/7
- synthetic preflight valid: 7/7
- monkeypatched real-gated preflight valid: 8/8
- blocked preflight valid: 18/18
- artifact compatibility valid: 4/4
- import boundary valid: 3/3
- safety valid: 5/5
- immutability valid: 6/6

## Safety

Diagnostic-only. No resolver gate changes. No adapter change. No fixture mutation. Validation uses synthetic subprocesses plus monkeypatch only, with no external fetch, no DB writes, no live-row materialization, and production default unchanged.

## Next Layer

Recommended next layer: 6EG_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_audit.