### PR TITLE
Speed only: persist frontend cache and reuse homepage and Daily Odds payloads

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -2,6 +2,7 @@ const PROD_API_BASE = 'https://mlb-prediction-app-production-732c.up.railway.app
 
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || PROD_API_BASE
 const JSON_CACHE = new Map()
+const STORAGE_PREFIX = 'mlb-json-cache:v1:'
 
 function nowMs() {
   return Date.now()
@@ -16,30 +17,92 @@ function cloneJson(value) {
   }
 }
 
-export function readCachedJson(url, ttlSeconds = 60) {
-  const key = String(url || '')
-  const record = JSON_CACHE.get(key)
-  if (!record) return null
-  if (ttlSeconds > 0 && nowMs() - record.createdAt > ttlSeconds * 1000) {
-    JSON_CACHE.delete(key)
+function storageKey(key) {
+  return `${STORAGE_PREFIX}${String(key || '')}`
+}
+
+function readStorageRecord(key) {
+  if (typeof window === 'undefined' || !window.sessionStorage) return null
+  try {
+    const raw = window.sessionStorage.getItem(storageKey(key))
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    if (typeof parsed.createdAt !== 'number') return null
+    return parsed
+  } catch {
     return null
   }
-  return cloneJson(record.value)
+}
+
+function writeStorageRecord(key, value) {
+  if (typeof window === 'undefined' || !window.sessionStorage) return
+  try {
+    window.sessionStorage.setItem(storageKey(key), JSON.stringify({
+      createdAt: nowMs(),
+      value: cloneJson(value),
+    }))
+  } catch {
+  }
+}
+
+function deleteStorageRecord(key) {
+  if (typeof window === 'undefined' || !window.sessionStorage) return
+  try {
+    window.sessionStorage.removeItem(storageKey(key))
+  } catch {
+  }
+}
+
+export function readCachedJson(url, ttlSeconds = 60) {
+  const key = String(url || '')
+  const memoryRecord = JSON_CACHE.get(key)
+  if (memoryRecord) {
+    if (ttlSeconds > 0 && nowMs() - memoryRecord.createdAt > ttlSeconds * 1000) {
+      JSON_CACHE.delete(key)
+      deleteStorageRecord(key)
+      return null
+    }
+    return cloneJson(memoryRecord.value)
+  }
+
+  const storageRecord = readStorageRecord(key)
+  if (!storageRecord) return null
+  if (ttlSeconds > 0 && nowMs() - storageRecord.createdAt > ttlSeconds * 1000) {
+    deleteStorageRecord(key)
+    return null
+  }
+
+  JSON_CACHE.set(key, {
+    createdAt: storageRecord.createdAt,
+    value: cloneJson(storageRecord.value),
+  })
+  return cloneJson(storageRecord.value)
 }
 
 export function writeCachedJson(url, value) {
   const key = String(url || '')
-  JSON_CACHE.set(key, {
+  const record = {
     createdAt: nowMs(),
     value: cloneJson(value),
-  })
+  }
+  JSON_CACHE.set(key, record)
+  writeStorageRecord(key, record.value)
   return cloneJson(value)
+}
+
+export function clearCachedJson(url) {
+  const key = String(url || '')
+  JSON_CACHE.delete(key)
+  deleteStorageRecord(key)
 }
 
 export async function fetchJson(url, { ttlSeconds = 60, forceRefresh = false, signal } = {}) {
   if (!forceRefresh) {
     const cached = readCachedJson(url, ttlSeconds)
     if (cached != null) return cached
+  } else {
+    clearCachedJson(url)
   }
 
   const response = await fetch(url, { signal })

--- a/frontend/src/pages/DailyOddsPage.jsx
+++ b/frontend/src/pages/DailyOddsPage.jsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { API_BASE } from '../lib/api'
+import { API_BASE, fetchJson, readCachedJson } from '../lib/api'
 
 const API = API_BASE
+const MATCHUPS_TTL_SECONDS = 120
+const ODDS_EVENTS_TTL_SECONDS = 90
+const DAILY_ODDS_MODELS_TTL_SECONDS = 120
+const DAILY_ODDS_UNIFIED_TTL_SECONDS = 180
+const EVENT_PROPS_TTL_SECONDS = 90
 
 const s = {
   page: { display: 'grid', gap: 18 },
@@ -167,29 +172,41 @@ function OddsBoard({ events, selectedEventId, setSelectedEventId, propsData, pro
 export default function DailyOddsPage() {
   const today = new Date().toISOString().slice(0, 10)
   const [date, setDate] = useState(today)
-  const [matchups, setMatchups] = useState([])
-  const [events, setEvents] = useState([])
-  const [modelPayload, setModelPayload] = useState(null)
+  const initialMatchupsUrl = `${API}/matchups?date=${today}`
+  const initialEventsUrl = `${API}/odds/draftkings/events?date=${today}`
+  const initialModelsUrl = `${API}/daily-odds/models?date=${today}`
+  const [matchups, setMatchups] = useState(() => {
+    const cached = readCachedJson(initialMatchupsUrl, MATCHUPS_TTL_SECONDS)
+    return Array.isArray(cached) ? cached : []
+  })
+  const [events, setEvents] = useState(() => {
+    const cached = readCachedJson(initialEventsUrl, ODDS_EVENTS_TTL_SECONDS)
+    return Array.isArray(cached?.events) ? cached.events : []
+  })
+  const [modelPayload, setModelPayload] = useState(() => readCachedJson(initialModelsUrl, DAILY_ODDS_MODELS_TTL_SECONDS))
   const [unifiedPayload, setUnifiedPayload] = useState(null)
   const [selectedEventId, setSelectedEventId] = useState('')
   const [propsData, setPropsData] = useState(null)
   const [propsLoading, setPropsLoading] = useState(false)
   const [propsError, setPropsError] = useState(null)
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(matchups.length === 0 && events.length === 0)
   const [unifiedLoading, setUnifiedLoading] = useState(false)
   const [error, setError] = useState(null)
   const [modelError, setModelError] = useState(null)
   const [lastRefreshed, setLastRefreshed] = useState(null)
 
-  function load() {
+  function load(forceRefresh = false) {
     setLoading(true)
     setError(null)
     setModelError(null)
     setUnifiedPayload(null)
+    const matchupsUrl = `${API}/matchups?date=${date}`
+    const eventsUrl = `${API}/odds/draftkings/events?date=${date}`
+    const modelsUrl = `${API}/daily-odds/models?date=${date}`
     Promise.all([
-      fetch(`${API}/matchups?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/matchups failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
-      fetch(`${API}/odds/draftkings/events?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/odds/draftkings/events failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }),
-      fetch(`${API}/daily-odds/models?date=${date}`).then(async r => { if (!r.ok) throw new Error(`/daily-odds/models failed: ${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }).catch(err => ({ __modelError: String(err?.message || err) })),
+      fetchJson(matchupsUrl, { ttlSeconds: MATCHUPS_TTL_SECONDS, forceRefresh }),
+      fetchJson(eventsUrl, { ttlSeconds: ODDS_EVENTS_TTL_SECONDS, forceRefresh }),
+      fetchJson(modelsUrl, { ttlSeconds: DAILY_ODDS_MODELS_TTL_SECONDS, forceRefresh }).catch(err => ({ __modelError: String(err?.message || err) })),
     ]).then(([matchupData, oddsData, modelsData]) => {
       const nextEvents = Array.isArray(oddsData?.events) ? oddsData.events : []
       setMatchups(Array.isArray(matchupData) ? matchupData : [])
@@ -201,22 +218,22 @@ export default function DailyOddsPage() {
     }).catch(err => { setError(String(err?.message || err)); setLoading(false) })
   }
 
-  function loadUnified() {
+  function loadUnified(forceRefresh = false) {
     setUnifiedLoading(true)
-    fetch(`${API}/daily-odds/models?date=${date}&include_unified=true`)
-      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+    const unifiedUrl = `${API}/daily-odds/models?date=${date}&include_unified=true`
+    fetchJson(unifiedUrl, { ttlSeconds: DAILY_ODDS_UNIFIED_TTL_SECONDS, forceRefresh })
       .then(json => { setUnifiedPayload(json); setUnifiedLoading(false) })
       .catch(err => { setModelError(String(err?.message || err)); setUnifiedLoading(false) })
   }
 
-  useEffect(() => { load() }, [date])
+  useEffect(() => { load(false) }, [date])
 
   useEffect(() => {
     if (!selectedEventId) { setPropsData(null); return }
     setPropsLoading(true)
     setPropsError(null)
-    fetch(`${API}/odds/draftkings/event/${selectedEventId}/props`)
-      .then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() })
+    const propsUrl = `${API}/odds/draftkings/event/${selectedEventId}/props`
+    fetchJson(propsUrl, { ttlSeconds: EVENT_PROPS_TTL_SECONDS })
       .then(json => { setPropsData(json); setPropsLoading(false) })
       .catch(err => { setPropsData(null); setPropsError(String(err?.message || err)); setPropsLoading(false) })
   }, [selectedEventId])
@@ -231,7 +248,7 @@ export default function DailyOddsPage() {
     <section style={s.hero}>
       <div style={s.header}>
         <div><div style={s.eyebrow}>DraftKings board</div><h1 style={s.title}>Daily Odds</h1><div style={s.subtitle}>Odds are organized by game, category, market, and player. The page loads fast first; heavier model recap data is pulled only when requested.</div></div>
-        <div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={s.button} onClick={load} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh Odds'}</button></div>
+        <div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={s.button} onClick={() => load(true)} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh Odds'}</button></div>
       </div>
       <div style={s.stats}>
         <div style={s.statCard}><div style={s.statLabel}>MLB Games</div><div style={s.statValue}>{matchups.length}</div></div>
@@ -250,7 +267,7 @@ export default function DailyOddsPage() {
 
     {!loading && !error && events.length > 0 && <OddsBoard events={events} selectedEventId={selectedEventId} setSelectedEventId={setSelectedEventId} propsData={propsData} propsLoading={propsLoading} propsError={propsError} />}
 
-    <DailyRecapPanel unifiedPayload={unifiedPayload} loading={unifiedLoading} onLoad={loadUnified} />
+    <DailyRecapPanel unifiedPayload={unifiedPayload} loading={unifiedLoading} onLoad={() => loadUnified(false)} />
 
     <section style={s.section}>
       <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Game Market Snapshot</div><div style={s.modelSubtitle}>Compact game-line view. Props are handled in the organized board above, not scattered cards.</div></div><span style={s.chip}>{rows.length} games</span></div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { API_BASE, getMlbLiveDate } from '../lib/api'
+import { API_BASE, fetchJson, getMlbLiveDate, readCachedJson } from '../lib/api'
 
 const API = API_BASE
+const MATCHUPS_TTL_SECONDS = 120
+const ODDS_EVENTS_TTL_SECONDS = 90
+const PROPS_TTL_SECONDS = 90
 
 function useIsMobile(breakpoint = 768) {
   const getMatches = () => (typeof window !== 'undefined' ? window.innerWidth <= breakpoint : false)
@@ -142,9 +145,10 @@ function OddsMarket({ label, market }) {
 }
 
 function PropPreview({ eventId, isMobile }) {
+  const cacheUrl = `${API}/odds/draftkings/event/${eventId}/props`
   const [open, setOpen] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [propsData, setPropsData] = useState(null)
+  const [propsData, setPropsData] = useState(() => readCachedJson(cacheUrl, PROPS_TTL_SECONDS))
   const [error, setError] = useState(null)
 
   function toggle(e) {
@@ -157,8 +161,7 @@ function PropPreview({ eventId, isMobile }) {
     if (propsData || loading) return
     setLoading(true)
     setError(null)
-    fetch(`${API}/odds/draftkings/event/${eventId}/props`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+    fetchJson(cacheUrl, { ttlSeconds: PROPS_TTL_SECONDS })
       .then(data => { setPropsData(data); setLoading(false) })
       .catch(err => { setError(String(err)); setLoading(false) })
   }
@@ -250,30 +253,71 @@ export default function HomePage() {
   const isMobile = useIsMobile()
   const today = getMlbLiveDate()
   const [date, setDate] = useState(today)
-  const [matchups, setMatchups] = useState([])
-  const [oddsEvents, setOddsEvents] = useState([])
-  const [loading, setLoading] = useState(false)
-  const [oddsLoading, setOddsLoading] = useState(false)
+  const initialMatchupsUrl = `${API}/matchups?date=${today}`
+  const initialOddsUrl = `${API}/odds/draftkings/events?date=${today}`
+  const [matchups, setMatchups] = useState(() => {
+    const cached = readCachedJson(initialMatchupsUrl, MATCHUPS_TTL_SECONDS)
+    return Array.isArray(cached) ? cached : []
+  })
+  const [oddsEvents, setOddsEvents] = useState(() => {
+    const cached = readCachedJson(initialOddsUrl, ODDS_EVENTS_TTL_SECONDS)
+    return Array.isArray(cached?.events) ? cached.events : []
+  })
+  const [loading, setLoading] = useState(matchups.length === 0)
+  const [oddsLoading, setOddsLoading] = useState(oddsEvents.length === 0)
   const [error, setError] = useState(null)
   const [oddsError, setOddsError] = useState(null)
   const navigate = useNavigate()
 
   useEffect(() => {
-    setLoading(true)
+    let cancelled = false
+    const url = `${API}/matchups?date=${date}`
+    const cached = readCachedJson(url, MATCHUPS_TTL_SECONDS)
+    if (Array.isArray(cached)) {
+      setMatchups(cached)
+      setLoading(false)
+    } else {
+      setLoading(true)
+    }
     setError(null)
-    fetch(`${API}/matchups?date=${date}`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => { setMatchups(Array.isArray(data) ? data : []); setLoading(false) })
-      .catch(e => { setError(String(e)); setLoading(false) })
+    fetchJson(url, { ttlSeconds: MATCHUPS_TTL_SECONDS })
+      .then(data => {
+        if (cancelled) return
+        setMatchups(Array.isArray(data) ? data : [])
+        setLoading(false)
+      })
+      .catch(e => {
+        if (cancelled) return
+        setError(String(e))
+        setLoading(false)
+      })
+    return () => { cancelled = true }
   }, [date])
 
   useEffect(() => {
-    setOddsLoading(true)
+    let cancelled = false
+    const url = `${API}/odds/draftkings/events?date=${date}`
+    const cached = readCachedJson(url, ODDS_EVENTS_TTL_SECONDS)
+    if (Array.isArray(cached?.events)) {
+      setOddsEvents(cached.events)
+      setOddsLoading(false)
+    } else {
+      setOddsLoading(true)
+    }
     setOddsError(null)
-    fetch(`${API}/odds/draftkings/events?date=${date}`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
-      .then(data => { setOddsEvents(Array.isArray(data?.events) ? data.events : []); setOddsLoading(false) })
-      .catch(e => { setOddsError(String(e)); setOddsEvents([]); setOddsLoading(false) })
+    fetchJson(url, { ttlSeconds: ODDS_EVENTS_TTL_SECONDS })
+      .then(data => {
+        if (cancelled) return
+        setOddsEvents(Array.isArray(data?.events) ? data.events : [])
+        setOddsLoading(false)
+      })
+      .catch(e => {
+        if (cancelled) return
+        setOddsError(String(e))
+        setOddsEvents([])
+        setOddsLoading(false)
+      })
+    return () => { cancelled = true }
   }, [date])
 
   const oddsByMatchup = useMemo(() => {


### PR DESCRIPTION
## What this does

This PR is performance-only and does not touch `mlb_app/app.py`.

### Changes
- Persists the existing frontend JSON cache into `sessionStorage` so cached responses survive browser refreshes during the same session
- Reuses cached homepage `/matchups` and `/odds/draftkings/events` payloads for the same date before refetching
- Reuses cached homepage DraftKings props payloads for the same event
- Reuses cached Daily Odds page payloads for:
  - `/matchups`
  - `/odds/draftkings/events`
  - `/daily-odds/models`
  - `/daily-odds/models?include_unified=true`
  - `/odds/draftkings/event/{event_id}/props`
- Keeps an explicit hard refresh path on the Daily Odds refresh button by bypassing the cache when requested

## Why

The app felt slow because the frontend was re-requesting the same date-scoped payloads repeatedly, even though a frontend cache helper already existed. That helper was mostly in-memory only and major pages were barely using it.

This PR makes the biggest no-`app.py` speed win first:
- faster homepage repeat loads
- faster homepage browser refreshes
- faster Daily Odds repeat loads
- faster Daily Odds recap reloads
- less repeated waiting for the same date/event payloads

## What this does not do
- no backend route changes
- no `app.py` changes
- no model logic changes
- no cache invalidation redesign
- no My Dashboard or Model Projections frontend caching yet

## Next best speed follow-up
- wire the same frontend cache reuse into `ModelProjectionsPage.jsx`
- add cache reuse for My Dashboard batch results keyed by date + filters
- audit remaining expensive pages for repeated same-date fetches
