### PR TITLE
Restore My Dashboard interaction flow with titled board saves, folders, and restore-state actions

### DIFF
--- a/frontend/src/pages/MyDashboardWorkspacePage.jsx
+++ b/frontend/src/pages/MyDashboardWorkspacePage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
-const CACHE_PREFIX = 'my-dashboard:v2:'
+const CACHE_PREFIX = 'my-dashboard:v3:'
 
 const COMPONENTS = [
   { key: 'hitters', title: 'My Top Hitters Today', description: 'Stored 365 hitter board with pitch-type matchup, EV, LA, and arsenal context.' },
@@ -22,7 +22,6 @@ function formatNumber(value) { const num = Number(value); if (!Number.isFinite(n
 function cacheKey(kind, payload) { return `${CACHE_PREFIX}${kind}:${JSON.stringify(payload)}` }
 function readSessionCache(key) { if (typeof window === 'undefined' || !window.sessionStorage) return null; try { const raw = window.sessionStorage.getItem(key); return raw ? JSON.parse(raw) : null } catch { return null } }
 function writeSessionCache(key, value) { if (typeof window === 'undefined' || !window.sessionStorage) return; try { window.sessionStorage.setItem(key, JSON.stringify(value)) } catch {} }
-
 function cleanFilters(filters) {
   const source = filters || {}
   const cleaned = {}
@@ -47,7 +46,14 @@ function cleanFilters(filters) {
   if (Object.keys(weights).length) cleaned.weights = weights
   return cleaned
 }
-
+function mergeFilterState(savedFilters) {
+  return {
+    ...emptyFilters(),
+    ...(savedFilters || {}),
+    metrics: clone(savedFilters?.metrics || {}),
+    weights: clone(savedFilters?.weights || {}),
+  }
+}
 function available(result, componentKey) {
   const defaults = {
     hitters: { pitch_types: [], suggested_metric_filters: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'HardHit', 'Usage'], suggested_weight_metrics: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'Usage'] },
@@ -58,6 +64,18 @@ function available(result, componentKey) {
   }
   return { ...(defaults[componentKey] || {}), ...(result?.available_filters || {}) }
 }
+function emptySaveDraft(folderId = '') {
+  return { folder_id: folderId, title: '', subtitle: '', notes: '' }
+}
+function defaultSaveDrafts(folderId = '') {
+  return Object.fromEntries(COMPONENTS.map(component => [component.key, emptySaveDraft(folderId)]))
+}
+function sourceComponentKey(item) {
+  return item?.payload_json?.saved_from_component || item?.payload_json?.component_key || item?.payload_json?.board_state?.component || null
+}
+function sourceItems(item) {
+  return item?.payload_json?.board_state?.items || []
+}
 
 export default function MyDashboardWorkspacePage() {
   const today = todayIso()
@@ -66,11 +84,14 @@ export default function MyDashboardWorkspacePage() {
   const [workspace, setWorkspace] = useState(null)
   const [results, setResults] = useState({})
   const [filters, setFilters] = useState(defaultFiltersByComponent)
+  const [saveDrafts, setSaveDrafts] = useState(defaultSaveDrafts)
+  const [newFolder, setNewFolder] = useState({ folder_name: '', folder_date: today })
   const [loading, setLoading] = useState({})
   const [runErrors, setRunErrors] = useState({})
   const [saveMessage, setSaveMessage] = useState(null)
   const [authError, setAuthError] = useState(null)
   const [savingProfile, setSavingProfile] = useState(false)
+  const [creatingFolder, setCreatingFolder] = useState(false)
   const [form, setForm] = useState({ email: '', username: '', password: '', feature_interests: ['Matchups', 'Model Projections'], wants_newsletter: false, plan_type: 'free' })
 
   useEffect(() => {
@@ -89,6 +110,20 @@ export default function MyDashboardWorkspacePage() {
     }
     bootstrap()
   }, [])
+
+  useEffect(() => {
+    const folderId = workspace?.today_folder_id ? String(workspace.today_folder_id) : ''
+    setSaveDrafts(prev => {
+      const next = clone(prev)
+      for (const component of COMPONENTS) {
+        if (!next[component.key]) next[component.key] = emptySaveDraft(folderId)
+        if (!next[component.key].folder_id) next[component.key].folder_id = folderId
+        if (!next[component.key].title) next[component.key].title = `${component.title} | ${today}`
+        if (!next[component.key].subtitle) next[component.key].subtitle = component.description
+      }
+      return next
+    })
+  }, [workspace?.today_folder_id, today])
 
   async function loadWorkspace() {
     const res = await fetch(`${API}/my-dashboard/workspace`, { credentials: 'include' })
@@ -138,6 +173,10 @@ export default function MyDashboardWorkspacePage() {
 
   function setWeight(componentKey, metric, value) {
     setFilters(prev => ({ ...prev, [componentKey]: { ...prev[componentKey], weights: { ...(prev[componentKey].weights || {}), [metric]: value } } }))
+  }
+
+  function setSaveDraft(componentKey, key, value) {
+    setSaveDrafts(prev => ({ ...prev, [componentKey]: { ...prev[componentKey], [key]: value } }))
   }
 
   function resetFilters(componentKey) {
@@ -219,12 +258,100 @@ export default function MyDashboardWorkspacePage() {
     }
   }
 
-  const todayFolder = useMemo(() => (workspace?.folders || []).find(folder => folder.id === workspace?.today_folder_id), [workspace])
+  async function saveBoardState(component) {
+    const componentKey = component.key
+    const boardResult = results[componentKey]
+    const draft = saveDrafts[componentKey] || emptySaveDraft(String(workspace?.today_folder_id || ''))
+    const folderId = Number(draft.folder_id || workspace?.today_folder_id)
+    if (!folderId) {
+      setSaveMessage('Choose a folder before saving this dashboard state.')
+      return
+    }
+    if (!boardResult?.items?.length) {
+      setSaveMessage('Run the board before saving a dashboard state.')
+      return
+    }
+    const title = (draft.title || `${component.title} | ${today}`).trim()
+    setSaveMessage(null)
+    try {
+      const payload = {
+        saved_from_component: componentKey,
+        saved_on_date: today,
+        board_state: boardResult,
+        saved_item_count: boardResult.items.length,
+      }
+      const res = await fetch(`${API}/my-dashboard/items`, {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({
+          folder_id: folderId,
+          source_tab: 'my-dashboard',
+          source_type: 'solver_board_state',
+          title,
+          subtitle: (draft.subtitle || component.description || '').trim() || null,
+          notes: (draft.notes || '').trim() || null,
+          payload_json: payload,
+          filter_json: cleanFilters(filters[componentKey] || {}),
+          sort_json: { by: 'score', direction: 'desc', component: componentKey },
+        }) })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      await loadWorkspace()
+      setSaveMessage(`Saved dashboard state: ${title}`)
+    } catch (err) {
+      setSaveMessage(err.message || 'Failed to save dashboard state')
+    }
+  }
+
+  async function createFolder() {
+    if (!newFolder.folder_name.trim()) {
+      setSaveMessage('Folder name is required.')
+      return
+    }
+    setCreatingFolder(true)
+    setSaveMessage(null)
+    try {
+      const res = await fetch(`${API}/my-dashboard/folders`, {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ folder_name: newFolder.folder_name.trim(), folder_date: newFolder.folder_date || null, is_default: false })
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(typeof json.detail === 'string' ? json.detail : JSON.stringify(json.detail || json))
+      const folderId = String(json.folder?.id || '')
+      setNewFolder({ folder_name: '', folder_date: today })
+      await loadWorkspace()
+      if (folderId) {
+        setSaveDrafts(prev => Object.fromEntries(Object.entries(prev).map(([key, value]) => [key, { ...value, folder_id: folderId }])))
+      }
+      setSaveMessage(`Created folder: ${json.folder?.folder_name || 'New folder'}`)
+    } catch (err) {
+      setSaveMessage(err.message || 'Failed to create folder')
+    } finally {
+      setCreatingFolder(false)
+    }
+  }
+
+  async function restoreSavedState(item) {
+    const componentKey = sourceComponentKey(item)
+    if (!componentKey) {
+      setSaveMessage('This saved item does not contain a restorable dashboard state.')
+      return
+    }
+    const savedFilters = mergeFilterState(item.filter_json || {})
+    setFilters(prev => ({ ...prev, [componentKey]: savedFilters }))
+    if (item.payload_json?.board_state) {
+      setResults(prev => ({ ...prev, [componentKey]: item.payload_json.board_state }))
+      setSaveMessage(`Loaded saved dashboard state: ${item.title}`)
+      return
+    }
+    await runBoard(componentKey)
+    setSaveMessage(`Restored filters for ${componentKey} from ${item.title}`)
+  }
+
+  const folders = workspace?.folders || []
+  const todayFolder = useMemo(() => folders.find(folder => folder.id === workspace?.today_folder_id), [folders, workspace?.today_folder_id])
 
   if (!authChecked) return <div style={stateStyle}>Loading dashboard workspace…</div>
 
   if (!profile) {
-    return <div style={pageStyle}><section style={heroStyle}><div><div style={eyebrowStyle}>My Dashboard</div><h1 style={titleStyle}>Create your analyst profile</h1><p style={subtitleStyle}>Restore stronger daily board filters, slider weights, and faster reruns from cached board results.</p></div></section><form onSubmit={handleProfileSubmit} style={panelStyle}><label style={labelStyle}>Email</label><input style={inputStyle} value={form.email} onChange={e => setForm(prev => ({ ...prev, email: e.target.value }))} /><label style={labelStyle}>Username</label><input style={inputStyle} value={form.username} onChange={e => setForm(prev => ({ ...prev, username: e.target.value }))} /><label style={labelStyle}>Password (optional)</label><input style={inputStyle} type="password" value={form.password} onChange={e => setForm(prev => ({ ...prev, password: e.target.value }))} /><div style={pillWrapStyle}>{FEATURE_CHOICES.map(choice => <button key={choice} type="button" onClick={() => toggleInterest(choice)} style={form.feature_interests.includes(choice) ? activePillStyle : pillStyle}>{choice}</button>)}</div>{authError && <div style={errorStyle}>{authError}</div>}<button type="submit" style={primaryButtonStyle} disabled={savingProfile}>{savingProfile ? 'Creating…' : 'Enter My Dashboard'}</button></form></div>
+    return <div style={pageStyle}><section style={heroStyle}><div><div style={eyebrowStyle}>My Dashboard</div><h1 style={titleStyle}>Create your analyst profile</h1><p style={subtitleStyle}>Restore stronger daily board filters, slider weights, folders, titled dashboard saves, and saved-state restoration.</p></div></section><form onSubmit={handleProfileSubmit} style={panelStyle}><label style={labelStyle}>Email</label><input style={inputStyle} value={form.email} onChange={e => setForm(prev => ({ ...prev, email: e.target.value }))} /><label style={labelStyle}>Username</label><input style={inputStyle} value={form.username} onChange={e => setForm(prev => ({ ...prev, username: e.target.value }))} /><label style={labelStyle}>Password (optional)</label><input style={inputStyle} type="password" value={form.password} onChange={e => setForm(prev => ({ ...prev, password: e.target.value }))} /><div style={pillWrapStyle}>{FEATURE_CHOICES.map(choice => <button key={choice} type="button" onClick={() => toggleInterest(choice)} style={form.feature_interests.includes(choice) ? activePillStyle : pillStyle}>{choice}</button>)}</div>{authError && <div style={errorStyle}>{authError}</div>}<button type="submit" style={primaryButtonStyle} disabled={savingProfile}>{savingProfile ? 'Creating…' : 'Enter My Dashboard'}</button></form></div>
   }
 
   return (
@@ -233,19 +360,32 @@ export default function MyDashboardWorkspacePage() {
         <div>
           <div style={eyebrowStyle}>My Dashboard</div>
           <h1 style={titleStyle}>Welcome back, {profile.username}</h1>
-          <p style={subtitleStyle}>Restore stronger filters, hitter pitch-type controls, EV/LA thresholds, pitches-seen filters, and weight sliders. Solver reruns are also cached in your browser session.</p>
+          <p style={subtitleStyle}>Restore stronger filters, hitter pitch-type controls, titled board saves, notes, folder selection, and restore-state interactions.</p>
         </div>
         <div style={summaryCardStyle}>
           <div style={metaStyle}>Email: {profile.email}</div>
           <div style={metaStyle}>Plan: {profile.preferences?.plan_type || 'free'}</div>
+          <div style={metaStyle}>Folders: {folders.length}</div>
           <div style={metaStyle}>Today saved: {todayFolder?.item_count || 0}</div>
+        </div>
+      </section>
+
+      <section style={panelStyle}>
+        <div style={rowStyle}><h2 style={sectionTitleStyle}>Folders and saved dashboards</h2><button onClick={loadWorkspace} style={secondaryButtonStyle}>Refresh workspace</button></div>
+        <div style={folderCreateGridStyle}>
+          <input style={inputStyle} placeholder="New folder title" value={newFolder.folder_name} onChange={e => setNewFolder(prev => ({ ...prev, folder_name: e.target.value }))} />
+          <input style={inputStyle} type="date" value={newFolder.folder_date} onChange={e => setNewFolder(prev => ({ ...prev, folder_date: e.target.value }))} />
+          <button onClick={createFolder} style={primaryButtonStyle} disabled={creatingFolder}>{creatingFolder ? 'Creating…' : 'Create folder'}</button>
+        </div>
+        {saveMessage && <div style={successStyle}>{saveMessage}</div>}
+        <div style={foldersGridStyle}>
+          {folders.map(folder => <div key={folder.id} style={folderCardStyle}><div style={rowStyle}><div><div style={boardTitleStyle}>{folder.folder_name}</div><div style={metaStyle}>{folder.folder_date || (folder.is_default ? 'Default dashboard' : 'No date')}</div></div><div style={countBadgeStyle}>{folder.item_count}</div></div><div style={savedItemsGridStyle}>{(folder.items || []).length === 0 ? <div style={emptyStyle}>No saved items in this folder.</div> : folder.items.map(item => <div key={item.id} style={savedItemCardStyle}><div style={savedTitleStyle}>{item.title}</div><div style={metaStyle}>{item.subtitle || item.source_type}</div>{item.notes ? <div style={resultBodyStyle}>{item.notes}</div> : null}<div style={metaStyle}>Source: {item.source_tab} • {item.source_type}</div><div style={pillWrapStyle}>{item.filter_json ? Object.keys(item.filter_json).slice(0, 4).map(key => <span key={`${item.id}-${key}`} style={metricPillStyle}>{key}</span>) : null}</div><div style={rowStyle}><button onClick={() => restoreSavedState(item)} style={secondaryButtonStyle}>Load saved state</button></div></div>)}</div></div>)}
         </div>
       </section>
 
       <section style={panelStyle}>
         <div style={rowStyle}><h2 style={sectionTitleStyle}>Daily boards</h2><div style={rowStyle}><button onClick={() => runAllBoards()} style={primaryButtonStyle}>Populate all</button><button onClick={loadWorkspace} style={secondaryButtonStyle}>Refresh workspace</button></div></div>
         {runErrors._all && <div style={errorStyle}>{runErrors._all}</div>}
-        {saveMessage && <div style={successStyle}>{saveMessage}</div>}
         <div style={boardGridStyle}>
           {COMPONENTS.map(component => {
             const result = results[component.key]
@@ -254,6 +394,7 @@ export default function MyDashboardWorkspacePage() {
             const metricFilters = (helper.suggested_metric_filters || []).slice(0, 6)
             const weightMetrics = (helper.suggested_weight_metrics || []).slice(0, 5)
             const filterState = filters[component.key] || emptyFilters()
+            const draft = saveDrafts[component.key] || emptySaveDraft(String(workspace?.today_folder_id || ''))
             return <div key={component.key} style={boardCardStyle}>
               <div style={rowStyle}><div><div style={boardTitleStyle}>{component.title}</div><div style={boardDescriptionStyle}>{component.description}</div></div><div style={countBadgeStyle}>{items.length}/10</div></div>
               <div style={metaStyle}>Before/after filters: {result?.result_count_before_filters ?? '—'} / {result?.result_count_after_filters ?? '—'}</div>
@@ -271,13 +412,23 @@ export default function MyDashboardWorkspacePage() {
               </div>
 
               <div style={metricGridStyle}>{metricFilters.map(metric => <div key={`${component.key}-${metric}`} style={metricCardStyle}><div style={metricTitleStyle}>{metric}</div><div style={metricInputRowStyle}><input style={smallInputStyle} placeholder="Min" value={filterState.metrics?.[metric]?.min || ''} onChange={e => setMetricFilter(component.key, metric, 'min', e.target.value)} /><input style={smallInputStyle} placeholder="Max" value={filterState.metrics?.[metric]?.max || ''} onChange={e => setMetricFilter(component.key, metric, 'max', e.target.value)} /></div></div>)}</div>
-
               <div style={sliderGridStyle}>{weightMetrics.map(metric => { const value = Number(filterState.weights?.[metric] ?? 1); return <div key={`${component.key}-weight-${metric}`} style={metricCardStyle}><div style={metricTitleStyle}>{metric}</div><input type="range" min="0" max="2" step="0.1" value={value} onChange={e => setWeight(component.key, metric, e.target.value)} style={{ width: '100%' }} /><div style={metaStyle}>Weight {value.toFixed(1)}</div></div> })}</div>
+
+              <div style={saveBoardPanelStyle}>
+                <div style={metricTitleStyle}>Save dashboard state</div>
+                <div style={filterGridStyle}>
+                  <select style={smallInputStyle} value={draft.folder_id || ''} onChange={e => setSaveDraft(component.key, 'folder_id', e.target.value)}><option value="">Choose folder</option>{folders.map(folder => <option key={folder.id} value={String(folder.id)}>{folder.folder_name}</option>)}</select>
+                  <input style={smallInputStyle} placeholder="Dashboard title" value={draft.title || ''} onChange={e => setSaveDraft(component.key, 'title', e.target.value)} />
+                  <input style={smallInputStyle} placeholder="Subtitle" value={draft.subtitle || ''} onChange={e => setSaveDraft(component.key, 'subtitle', e.target.value)} />
+                </div>
+                <textarea style={textAreaStyle} placeholder="Notes" value={draft.notes || ''} onChange={e => setSaveDraft(component.key, 'notes', e.target.value)} />
+                <div style={rowStyle}><button onClick={() => saveBoardState(component)} style={primaryButtonStyle}>Save board state</button></div>
+              </div>
 
               <div style={rowStyle}><button onClick={() => runBoard(component.key)} style={secondaryButtonStyle} disabled={loading[component.key]}>{loading[component.key] ? 'Running…' : 'Run board'}</button><button onClick={() => runBoard(component.key, { preferCache: true })} style={ghostButtonStyle}>Use cached</button><button onClick={() => resetFilters(component.key)} style={ghostButtonStyle}>Reset filters</button></div>
               {runErrors[component.key] && <div style={errorStyle}>{runErrors[component.key]}</div>}
 
-              <div style={resultsGridStyle}>{items.length === 0 ? <div style={emptyStyle}>No results yet. Run this board to populate fresh discovery for today.</div> : items.map((item, idx) => <div key={`${component.key}-${idx}-${item.entity_id || item.entity_name || idx}`} style={resultCardStyle}><div style={rowStyle}><div><div style={resultTitleStyle}>{item.entity_name || 'Ranked item'}</div><div style={metaStyle}>{item.team || 'Team unavailable'} {item.opponent ? `vs ${item.opponent}` : ''}</div></div><div style={scorePillStyle}>{formatNumber(item.score)}</div></div><div style={resultBodyStyle}>{item.primary_reason || 'Model solver ranked this item.'}</div><div style={metaStyle}>Confidence: {item.confidence || 'low'}</div>{item.pitch_name || item.pitch_type ? <div style={metaStyle}>Pitch context: {item.pitch_name || item.pitch_type}</div> : null}<div style={pillWrapStyle}>{Object.entries(item.metrics || {}).slice(0, 6).map(([key, value]) => <span key={`${item.entity_id}-${key}`} style={metricPillStyle}>{key}: {value ?? '—'}</span>)}</div>{item.weight_explanation?.length ? <div style={metaStyle}>Weights: {item.weight_explanation.join(' • ')}</div> : null}<div style={rowStyle}><button onClick={() => saveItemToToday(component, item)} style={miniPrimaryStyle}>Save to Today</button></div></div>)}</div>
+              <div style={resultsGridStyle}>{items.length === 0 ? <div style={emptyStyle}>No results yet. Run this board to populate fresh discovery for today.</div> : items.map((item, idx) => <div key={`${component.key}-${idx}-${item.entity_id || item.entity_name || idx}`} style={resultCardStyle}><div style={rowStyle}><div><div style={resultTitleStyle}>{item.entity_name || 'Ranked item'}</div><div style={metaStyle}>{item.team || 'Team unavailable'} {item.opponent ? `vs ${item.opponent}` : ''}</div></div><div style={scorePillStyle}>{formatNumber(item.score)}</div></div><div style={resultBodyStyle}>{item.primary_reason || 'Model solver ranked this item.'}</div><div style={metaStyle}>Confidence: {item.confidence || 'low'}</div>{item.pitch_name || item.pitch_type ? <div style={metaStyle}>Pitch context: {item.pitch_name || item.pitch_type}</div> : null}<div style={pillWrapStyle}>{Object.entries(item.metrics || {}).slice(0, 6).map(([key, value]) => <span key={`${item.entity_id}-${key}`} style={metricPillStyle}>{key}: {value ?? '—'}</span>)}</div>{item.weight_explanation?.length ? <div style={metaStyle}>Weights: {item.weight_explanation.join(' • ')}</div> : null}<div style={rowStyle}><button onClick={() => saveItemToToday(component, item)} style={miniPrimaryStyle}>Save item to Today</button></div></div>)}</div>
             </div>
           })}
         </div>
@@ -304,11 +455,18 @@ const filterGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit
 const metricGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10 }
 const sliderGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 }
 const resultsGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 12 }
+const foldersGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 14 }
+const savedItemsGridStyle = { display: 'grid', gap: 10 }
+const folderCardStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: 16, padding: 14, display: 'grid', gap: 12 }
+const savedItemCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 12, display: 'grid', gap: 8 }
+const folderCreateGridStyle = { display: 'grid', gridTemplateColumns: 'minmax(220px, 1fr) 180px auto', gap: 10 }
+const saveBoardPanelStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 12, display: 'grid', gap: 10 }
 const metricCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 10, display: 'grid', gap: 8 }
 const metricTitleStyle = { color: '#e6edf3', fontWeight: 600, fontSize: 12 }
 const metricInputRowStyle = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }
 const resultCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 14, padding: 12, display: 'grid', gap: 8 }
 const resultTitleStyle = { color: '#e6edf3', fontWeight: 700 }
+const savedTitleStyle = { color: '#e6edf3', fontWeight: 700, fontSize: 14 }
 const resultBodyStyle = { color: '#97a3b6', fontSize: 13, lineHeight: 1.5 }
 const scorePillStyle = { background: '#1d4ed8', color: '#fff', borderRadius: 999, padding: '6px 10px', fontSize: 12, fontWeight: 700, height: 'fit-content' }
 const pillWrapStyle = { display: 'flex', flexWrap: 'wrap', gap: 6 }
@@ -316,6 +474,7 @@ const metricPillStyle = { background: '#0b1220', border: '1px solid #223049', co
 const labelStyle = { color: '#c9d1d9', fontSize: 13, fontWeight: 600 }
 const inputStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 10, padding: '10px 12px' }
 const smallInputStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 8, padding: '8px 10px', fontSize: 12, width: '100%' }
+const textAreaStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 8, padding: '10px 12px', minHeight: 72, resize: 'vertical' }
 const primaryButtonStyle = { background: '#7c3aed', color: '#fff', border: 0, borderRadius: 10, padding: '12px 16px', fontWeight: 700, cursor: 'pointer' }
 const secondaryButtonStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 10, padding: '10px 14px', fontWeight: 600, cursor: 'pointer' }
 const ghostButtonStyle = { background: '#0f172a', color: '#97a3b6', border: '1px solid #30363d', borderRadius: 10, padding: '10px 12px', fontWeight: 600, cursor: 'pointer' }

--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -73,7 +73,7 @@ DEFAULT_COMPONENTS = [
         "source_type": "seeded_component",
     },
 ]
-DEFAULT_FILTER_FIELDS = ["search_text", "team", "opponent", "min_score", "min_confidence"]
+DEFAULT_FILTER_FIELDS = ["search_text", "team", "opponent", "min_score", "max_score", "min_confidence", "pitch_type", "category", "source"]
 
 
 class DashboardProfileRequest(BaseModel):
@@ -227,9 +227,9 @@ def _build_seed_payload(component: Dict[str, Any]) -> Dict[str, Any]:
                 "Team",
                 "Model Tracker",
             ],
-            "available_fields": ["title", "subtitle", "metrics", "reasoning", "game_pk", "entity_id", "entity_type"],
+            "available_fields": ["title", "subtitle", "metrics", "reasoning", "game_pk", "entity_id", "entity_type", "notes"],
             "conditions": ["equals", "contains", "min", "max", "in"],
-            "max_filters": 5,
+            "max_filters": 10,
             "default_filter_fields": DEFAULT_FILTER_FIELDS,
             "logic_mode": "AND",
         },
@@ -307,7 +307,7 @@ def _seed_default_dashboard(session, user_id: int, folder_id: int) -> None:
                 payload_json=_build_seed_payload(component),
                 filter_json={
                     "default_filter_fields": DEFAULT_FILTER_FIELDS,
-                    "max_filters": 5,
+                    "max_filters": 10,
                 },
                 sort_json={"mode": "manual_seed_order", "position": index},
                 pin_order=index,


### PR DESCRIPTION
## What this does

This PR restores the missing interactive My Dashboard workflow instead of only supporting one-off item saves.

### Restored interaction flow
- create folders directly from the My Dashboard page
- choose a folder when saving a board state
- save a full board state with:
  - custom title
  - subtitle
  - notes
  - filter state
  - sort state
  - saved board payload
- browse saved items inside each folder
- reload a saved dashboard state back into the workspace
- keep one-off "Save item to Today" behavior for individual board rows

### Backend alignment
- updates seeded dashboard metadata so the default dashboard no longer advertises the stale 5-filter cap
- aligns seeded save-ready metadata with the restored 10-filter workflow
- expands seeded available fields to include notes

### Why

The backend persistence model already supported richer dashboard interaction:
- folder names
- item titles
- subtitles
- notes
- payload JSON
- filter JSON
- sort JSON

But the frontend only exposed a much weaker save flow. This PR wires the intended interaction model back into My Dashboard.

## User-visible gains
- titled dashboards again
- better daily folder workflow
- whole-board save, not just one row at a time
- restore saved dashboard state into the active board
- notes on saved dashboards
- no more stale seeded metadata telling users only 5 filters are supported

## Scope
- My Dashboard interaction flow only
- no solver rewrites
- no schema migration
- no unrelated page changes
