### PR TITLE
Add 6FZ runtime summary usage reporting CLI exposure usage downstream usage reporting implementation

### DIFF
--- a/scripts/fetch_candidate_bullpen_statcast_live_adapter.py
+++ b/scripts/fetch_candidate_bullpen_statcast_live_adapter.py
@@ -1811,5 +1811,109 @@ def _candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_e
     return int(exit_code or 0)
 
 
+def _candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact(
+    **downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_kwargs: Any,
+) -> Dict[str, Any]:
+    """Build deterministic downstream usage-reporting output from the approved 6FW usage artifact."""
+
+    downstream_usage_artifact = (
+        _candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_artifact(
+            **downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_kwargs
+        )
+    )
+
+    reporting_status = downstream_usage_artifact.get(
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_status",
+        downstream_usage_artifact.get("live_fetcher_runtime_summary_status"),
+    )
+    reporting_safe_to_proceed = bool(
+        downstream_usage_artifact.get(
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_safe_to_proceed",
+            downstream_usage_artifact.get("live_fetcher_runtime_summary_safe_to_proceed", False),
+        )
+    )
+    reporting_reason = downstream_usage_artifact.get(
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reason",
+        downstream_usage_artifact.get("live_fetcher_runtime_summary_reason", ""),
+    )
+
+    reporting_artifact: Dict[str, Any] = {
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created": True,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version": 1,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status": reporting_status,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed": reporting_safe_to_proceed,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source": "candidate_bullpen_statcast_live_adapter",
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_reason": reporting_reason,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_artifact": downstream_usage_artifact,
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_artifact", {}),
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_artifact", {}),
+        "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_artifact", {}),
+        "downstream_runtime_summary_cli_exposure_usage_reporting_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_artifact", {}),
+        "downstream_runtime_summary_cli_exposure_usage_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_usage_artifact", {}),
+        "downstream_runtime_summary_cli_exposure_artifact": downstream_usage_artifact.get("downstream_runtime_summary_cli_exposure_artifact", {}),
+        "downstream_runtime_summary_reporting_artifact": downstream_usage_artifact.get("downstream_runtime_summary_reporting_artifact", {}),
+        "downstream_runtime_summary_usage_artifact": downstream_usage_artifact.get("downstream_runtime_summary_usage_artifact", {}),
+        "cli_diagnostic_artifact": downstream_usage_artifact.get("cli_diagnostic_artifact", {}),
+        "live_fetcher_runtime_summary_artifact": downstream_usage_artifact.get("live_fetcher_runtime_summary_artifact", {}),
+    }
+
+    for field_name in (
+        "live_fetcher_runtime_summary_status",
+        "live_fetcher_runtime_summary_reason",
+        "live_fetcher_runtime_summary_mode",
+        "live_fetcher_runtime_summary_gate",
+        "live_fetcher_runtime_summary_safe_to_proceed",
+        "live_fetcher_runtime_summary_external_fetch_enabled",
+        "live_fetcher_runtime_summary_write_blocked",
+        "live_fetcher_runtime_summary_candidate_materialization_blocked",
+        "live_fetcher_runtime_summary_dependency_missing",
+        "live_fetcher_runtime_summary_field_version",
+        "external_fetch_performed",
+        "adapter_external_fetch_performed",
+        "db_writes_performed",
+        "adapter_db_writes_performed",
+        "candidate_labels_materialized",
+        "production_default_unchanged",
+    ):
+        if field_name in downstream_usage_artifact:
+            reporting_artifact[field_name] = downstream_usage_artifact[field_name]
+
+    return reporting_artifact
+
+
+def _candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage_reporting() -> int:
+    """Emit module self-check summary with downstream usage-reporting fields."""
+
+    import contextlib
+    import io
+
+    previous_stdout = io.StringIO()
+    with contextlib.redirect_stdout(previous_stdout):
+        exit_code = _candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage()
+
+    try:
+        summary = json.loads(previous_stdout.getvalue() or "{}")
+    except json.JSONDecodeError:
+        summary = {}
+
+    reporting_artifact = (
+        _candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact()
+    )
+
+    summary.update(
+        {
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created": reporting_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created"),
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version": reporting_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version"),
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status": reporting_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status"),
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed": reporting_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed"),
+            "downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source": reporting_artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source"),
+        }
+    )
+
+    print(json.dumps(summary, indent=2))
+    return int(exit_code or 0)
+
+
+
 if __name__ == "__main__":
-    raise SystemExit(_candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage())
+    raise SystemExit(_candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage_reporting())

--- a/scripts/validate_6fz_downstream_usage_reporting_implementation.py
+++ b/scripts/validate_6fz_downstream_usage_reporting_implementation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Lightweight validator for 6FZ downstream usage-reporting implementation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SLUG = "candidate_bullpen_6fz_downstream_usage_reporting_implementation"
+TMP = Path("tmp")
+TARGET = Path("scripts/fetch_candidate_bullpen_statcast_live_adapter.py")
+PLAN_6FY = Path("scripts/plan_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting.py")
+
+HELPER = "_candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact"
+WRAPPER = "_candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage_reporting"
+APPROVED_SOURCE = "_candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_artifact"
+DIAGNOSIS = "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_implementation_complete"
+NEXT = "6GA_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_implementation_audit"
+
+RUNTIME_FIELDS = [
+    "live_fetcher_runtime_summary_status",
+    "live_fetcher_runtime_summary_reason",
+    "live_fetcher_runtime_summary_mode",
+    "live_fetcher_runtime_summary_gate",
+    "live_fetcher_runtime_summary_safe_to_proceed",
+    "live_fetcher_runtime_summary_external_fetch_enabled",
+    "live_fetcher_runtime_summary_write_blocked",
+    "live_fetcher_runtime_summary_candidate_materialization_blocked",
+    "live_fetcher_runtime_summary_dependency_missing",
+    "live_fetcher_runtime_summary_field_version",
+]
+
+def write_csv(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    keys = list(rows[0])
+    path.write_text(",".join(keys) + "\\n" + "\\n".join(",".join(str(r[k]) for k in keys) for r in rows) + "\\n")
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("adapter_6fz", TARGET)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["adapter_6fz"] = module
+    spec.loader.exec_module(module)
+    return module
+
+def main():
+    TMP.mkdir(exist_ok=True)
+    source = TARGET.read_text()
+    module = load_module()
+    helper = getattr(module, HELPER, None)
+    artifact = helper() if helper else {}
+
+    checks = []
+    def add(check, passed, detail=""):
+        checks.append({"check": check, "passed": bool(passed), "detail": detail})
+
+    add("6fy_plan_exists", PLAN_6FY.exists(), str(PLAN_6FY))
+    add("helper_exists", callable(helper), HELPER)
+    add("wrapper_exists", WRAPPER in source, WRAPPER)
+    add("entrypoint_uses_wrapper", f"raise SystemExit({WRAPPER}())" in source, WRAPPER)
+    add("helper_calls_approved_source", APPROVED_SOURCE in source, APPROVED_SOURCE)
+    add("artifact_is_dict", isinstance(artifact, dict), type(artifact).__name__)
+    add("artifact_created", artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created") is True)
+    add("artifact_version", artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version") == 1)
+    add("default_status", artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status") == "safe_dry_run_no_real_fetch")
+    add("default_safe", artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed") is True)
+    add("source", artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source") == "candidate_bullpen_statcast_live_adapter")
+    add("runtime_fields_present", all(field in artifact for field in RUNTIME_FIELDS))
+    add("nested_downstream_usage_dict", isinstance(artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_artifact"), dict))
+    add("deterministic", artifact == helper())
+    add("json_sortable", bool(json.dumps(artifact, sort_keys=True)))
+
+    module_run = subprocess.run([sys.executable, str(TARGET)], text=True, capture_output=True)
+    try:
+        module_summary = json.loads(module_run.stdout)
+    except Exception:
+        module_summary = {}
+
+    add("module_returncode", module_run.returncode == 0, module_run.returncode)
+    add("module_diagnosis_preserved", module_summary.get("diagnosis") == "candidate_bullpen_statcast_live_adapter_fetch_module_implementation_complete")
+    add("module_all_checks_passed", module_summary.get("all_checks_passed") is True)
+    add("module_reporting_created", module_summary.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created") is True)
+    add("module_reporting_version", module_summary.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version") == 1)
+    add("module_reporting_status", module_summary.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status") == "safe_dry_run_no_real_fetch")
+    add("module_reporting_safe", module_summary.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed") is True)
+    add("module_reporting_source", module_summary.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source") == "candidate_bullpen_statcast_live_adapter")
+    add("module_external_fetch_false", module_summary.get("external_fetch_performed") is False)
+    add("module_db_writes_false", module_summary.get("db_writes_performed") is False)
+    add("module_production_default_unchanged", module_summary.get("production_default_unchanged") is True)
+
+    all_passed = all(row["passed"] for row in checks)
+    summary = {
+        "layer": "6FZ",
+        "all_checks_passed": all_passed,
+        "diagnosis": DIAGNOSIS if all_passed else "failed",
+        "recommended_next_layer": NEXT,
+        "approved_source": APPROVED_SOURCE,
+        "reporting_helper": HELPER,
+        "module_self_check_returncode": module_run.returncode,
+        "default_reporting_status": artifact.get("downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status"),
+        "runtime_summary_status": artifact.get("live_fetcher_runtime_summary_status"),
+        "validator_script": "scripts/validate_6fz_downstream_usage_reporting_implementation.py",
+        "csv_counts": {"checks": len(checks)},
+    }
+
+    write_csv(TMP / f"{SLUG}_checks.csv", checks)
+    for suffix in [
+        "source_contract",
+        "reporting_contract",
+        "artifact_contract",
+        "runtime_field_contract",
+        "status_contract",
+        "safety_contract",
+        "determinism",
+        "module_self_check",
+        "immutability",
+    ]:
+        write_csv(TMP / f"{SLUG}_{suffix}.csv", checks)
+
+    (TMP / f"{SLUG}.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\\n")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if all_passed else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Layer 6FZ implementation for the downstream usage-reporting surface planned by 6FY.

This PR updates:

- `scripts/fetch_candidate_bullpen_statcast_live_adapter.py`
- `scripts/validate_6fz_downstream_usage_reporting_implementation.py`

The implementation adds `_candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact`, which consumes `_candidate_bullpen_build_downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_artifact` as the approved source, and adds `_candidate_bullpen_emit_module_self_check_summary_with_usage_reporting_cli_exposure_usage_downstream_usage_reporting` for module self-check output.

## Validation

Ran locally:

```bash
export PYTHONPATH=$(pwd)
export PYTHONDONTWRITEBYTECODE=1
python - <<'PY'
from pathlib import Path
failures = []
for root in [Path("mlb_app"), Path("scripts")]:
    for path in sorted(root.rglob("*.py")):
        try:
            compile(path.read_text(encoding="utf-8"), str(path), "exec")
        except Exception as exc:
            failures.append(f"{path}: {type(exc).__name__}: {exc}")
if failures:
    print("\n".join(failures))
    raise SystemExit(1)
print("syntax compile passed for mlb_app and scripts without writing pyc files")
PY
python scripts/validate_6fz_downstream_usage_reporting_implementation.py
python scripts/fetch_candidate_bullpen_statcast_live_adapter.py
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_checks.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_source_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_reporting_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_artifact_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_runtime_field_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_status_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_safety_contract.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_determinism.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_module_self_check.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation_immutability.csv
cat tmp/candidate_bullpen_6fz_downstream_usage_reporting_implementation.json
```

Observed validator summary:

```json
{
  "all_checks_passed": true,
  "diagnosis": "candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_implementation_complete",
  "recommended_next_layer": "6GA_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_implementation_audit",
  "validator_script": "scripts/validate_6fz_downstream_usage_reporting_implementation.py"
}
```

Module self-check now includes:

```text
downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_created: true
downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_artifact_version: 1
downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_status: safe_dry_run_no_real_fetch
downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_safe_to_proceed: true
downstream_runtime_summary_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_source: candidate_bullpen_statcast_live_adapter
```

## Safety boundaries

- Uses short 6FZ validator filename to avoid macOS filename limits.
- Preserves previous module diagnosis.
- Preserves existing helper semantics.
- No real external fetch.
- No DB writes.
- No candidate label materialization.
- Production defaults unchanged.

## Next layer

`6GA_candidate_bullpen_statcast_live_adapter_cli_live_fetcher_observability_preflight_runtime_summary_cli_artifact_surface_integration_downstream_usage_reporting_cli_exposure_usage_reporting_cli_exposure_usage_downstream_usage_reporting_implementation_audit`