### PR TITLE
Upgrade pitcher page with intelligence dashboard and charts

### DIFF
--- a/frontend/src/pages/PitcherPage.jsx
+++ b/frontend/src/pages/PitcherPage.jsx
@@ -1,67 +1,259 @@
 import React, { useState, useEffect } from 'react'
-import { fmtPct } from '../utils/formatters'
 import { useParams, useNavigate, Link } from 'react-router-dom'
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+  LineChart, Line, ReferenceLine,
+} from 'recharts'
+import { fmtPct } from '../utils/formatters'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
 
+const C = {
+  green: '#3fb950', blue: '#58a6ff', orange: '#d29922', red: '#f85149',
+  purple: '#bc8cff', teal: '#39d0d8', text: '#e6edf3', muted: '#8b949e',
+  bg: '#0d1117', card: '#161b22', border: '#30363d', elevated: '#21262d',
+}
+
 const s = {
-  searchRow: { display: 'flex', gap: '12px', marginBottom: '28px' },
-  input: {
-    flex: 1, background: '#161b22', border: '1px solid #30363d', color: '#e6edf3',
-    borderRadius: '6px', padding: '10px 14px', fontSize: '14px', outline: 'none',
-  },
-  btn: {
-    background: '#238636', color: '#fff', border: 'none', borderRadius: '6px',
-    padding: '10px 20px', fontSize: '14px', fontWeight: '600', cursor: 'pointer',
-  },
-  rollingLink: {
-    display: 'inline-block', background: '#21262d', border: '1px solid #30363d',
-    color: '#58a6ff', textDecoration: 'none', borderRadius: '6px',
-    padding: '7px 16px', fontSize: '13px', fontWeight: '500', marginBottom: '24px',
-  },
-  section: { marginBottom: '28px' },
-  sectionTitle: { fontSize: '16px', fontWeight: '600', color: '#e6edf3', marginBottom: '14px', borderBottom: '1px solid #21262d', paddingBottom: '8px' },
-  statsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: '12px' },
-  statCard: { background: '#161b22', border: '1px solid #30363d', borderRadius: '8px', padding: '14px 16px' },
-  statLabel: { fontSize: '12px', color: '#8b949e', marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.5px' },
-  statVal: { fontSize: '22px', fontWeight: '700', color: '#e6edf3' },
-  tableWrap: { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', overflow: 'auto' },
+  searchRow: { display: 'flex', gap: '12px', marginBottom: '20px' },
+  input: { flex: 1, background: C.card, border: `1px solid ${C.border}`, color: C.text, borderRadius: '6px', padding: '10px 14px', fontSize: '14px', outline: 'none' },
+  header: { background: C.card, border: `1px solid ${C.border}`, borderRadius: '10px', padding: '20px 24px', marginBottom: '20px' },
+  playerName: { fontSize: '26px', fontWeight: '700', color: C.text, marginBottom: '6px' },
+  playerMeta: { display: 'flex', gap: '10px', flexWrap: 'wrap', fontSize: '12px', color: C.muted },
+  chip: { background: C.elevated, border: `1px solid ${C.border}`, borderRadius: '999px', padding: '3px 9px', color: C.text },
+  rollingLink: { display: 'inline-block', background: C.elevated, border: `1px solid ${C.border}`, color: C.blue, textDecoration: 'none', borderRadius: '6px', padding: '7px 16px', fontSize: '13px', fontWeight: '500', marginBottom: '24px' },
+  section: { marginBottom: '32px' },
+  sectionTitle: { fontSize: '16px', fontWeight: '600', color: C.text, marginBottom: '14px', borderBottom: `1px solid ${C.elevated}`, paddingBottom: '8px' },
+  statsGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(145px, 1fr))', gap: '12px' },
+  statCard: { background: C.card, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '14px 16px' },
+  statLabel: { fontSize: '11px', color: C.muted, marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.5px' },
+  statVal: { fontSize: '22px', fontWeight: '700', color: C.text },
+  statSub: { fontSize: '11px', color: C.muted, marginTop: '5px' },
+  tableWrap: { background: C.card, border: `1px solid ${C.border}`, borderRadius: '10px', overflow: 'auto' },
   table: { width: '100%', borderCollapse: 'collapse', fontSize: '13px' },
-  th: { padding: '10px 14px', textAlign: 'left', color: '#8b949e', fontWeight: '500', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', borderBottom: '1px solid #21262d', whiteSpace: 'nowrap' },
-  thRight: { textAlign: 'right' },
-  td: { padding: '10px 14px', borderBottom: '1px solid #0d1117', color: '#e6edf3', whiteSpace: 'nowrap' },
-  tdRight: { textAlign: 'right' },
-  tdMuted: { color: '#8b949e' },
-  sourceBadge: { display: 'inline-block', fontSize: '11px', padding: '2px 7px', borderRadius: '3px', background: '#21262d', color: '#8b949e', marginLeft: '10px', verticalAlign: 'middle', fontWeight: '400' },
-  loader: { color: '#8b949e', padding: '48px', textAlign: 'center' },
-  error: { color: '#f85149', padding: '24px', background: '#1f1116', borderRadius: '8px' },
-  hint: { color: '#8b949e', textAlign: 'center', padding: '48px' },
+  th: { padding: '10px 14px', textAlign: 'left', color: C.muted, fontWeight: '500', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.4px', borderBottom: `1px solid ${C.elevated}`, whiteSpace: 'nowrap' },
+  thR: { textAlign: 'right' },
+  td: { padding: '10px 14px', borderBottom: `1px solid ${C.bg}`, color: C.text, whiteSpace: 'nowrap' },
+  tdR: { textAlign: 'right' },
+  muted: { color: C.muted },
+  sourceBadge: { display: 'inline-block', fontSize: '11px', padding: '2px 7px', borderRadius: '3px', background: C.elevated, color: C.muted, marginLeft: '10px', verticalAlign: 'middle', fontWeight: '400' },
+  loader: { color: C.muted, padding: '48px', textAlign: 'center' },
+  error: { color: C.red, padding: '24px', background: '#1f1116', borderRadius: '8px' },
+  hint: { color: C.muted, textAlign: 'center', padding: '48px' },
+  chartBox: { background: C.card, border: `1px solid ${C.border}`, borderRadius: '10px', padding: '18px', minHeight: '290px' },
+  qaBox: { background: C.card, border: `1px solid ${C.border}`, borderRadius: '8px', padding: '12px 14px', marginBottom: '20px', fontSize: '12px', color: C.muted, lineHeight: 1.5 },
 }
 
-const searchDropStyle = {
-  position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 100,
-  background: '#161b22', border: '1px solid #30363d', borderRadius: '6px',
-  marginTop: '4px', maxHeight: '280px', overflowY: 'auto',
-}
-const searchItemStyle = (hover) => ({
-  padding: '9px 14px', cursor: 'pointer', borderBottom: '1px solid #21262d',
-  background: hover ? '#21262d' : 'transparent',
-  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-})
+const tooltipStyle = { background: '#1c2128', border: `1px solid ${C.border}`, borderRadius: '6px', fontSize: '12px', color: C.text }
+const searchDropStyle = { position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 100, background: C.card, border: `1px solid ${C.border}`, borderRadius: '6px', marginTop: '4px', maxHeight: '280px', overflowY: 'auto' }
+const searchItemStyle = (hover) => ({ padding: '9px 14px', cursor: 'pointer', borderBottom: `1px solid ${C.elevated}`, background: hover ? C.elevated : 'transparent', display: 'flex', justifyContent: 'space-between', alignItems: 'center' })
 
-function fmt(val, decimals = 1) {
-  if (val == null) return '—'
-  return typeof val === 'number' ? val.toFixed(decimals) : val
-}
-function pct(val) {
-  return fmtPct(val, 1)
+const fmt = (v, d = 1) => v != null ? (typeof v === 'number' ? v.toFixed(d) : v) : '—'
+const pct = (v, d = 1) => v != null ? `${(v * 100).toFixed(d)}%` : '—'
+const score = (v) => v != null ? Number(v).toFixed(3) : '—'
+const hasValue = (v) => v !== null && v !== undefined && v !== '' && v !== '—'
+const safeRows = (rows) => Array.isArray(rows) ? rows : []
+
+const LB_CONFIG = [
+  { key: 'avg_velocity', title: 'Avg Velocity', fmt: v => `${v.toFixed(1)} mph`, color: C.orange, group: 'Power / Stuff' },
+  { key: 'avg_spin_rate', title: 'Spin Rate', fmt: v => `${Math.round(v)} rpm`, color: C.purple, group: 'Power / Stuff' },
+  { key: 'extension', title: 'Extension', fmt: v => `${v.toFixed(2)} ft`, color: C.teal, group: 'Power / Stuff' },
+  { key: 'release_height', title: 'Release Height', fmt: v => `${v.toFixed(2)} ft`, color: C.blue, group: 'Power / Stuff' },
+  { key: 'k_pct', title: 'K%', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.green, group: 'Command / Discipline' },
+  { key: 'bb_pct_lowest', title: 'BB% Lowest', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.teal, group: 'Command / Discipline', inverse: true },
+  { key: 'hard_hit_pct_lowest', title: 'Hard Hit% Allowed', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.orange, group: 'Contact Allowed', inverse: true },
+  { key: 'xwoba_lowest', title: 'xwOBA Allowed', fmt: v => v.toFixed(3), color: C.red, group: 'Contact Allowed', inverse: true },
+  { key: 'xba_lowest', title: 'xBA Allowed', fmt: v => v.toFixed(3), color: C.purple, group: 'Contact Allowed', inverse: true },
+  { key: 'arsenal_whiff', title: 'Pitch Whiff%', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.green, group: 'Arsenal Intelligence' },
+  { key: 'arsenal_xwoba_lowest', title: 'Pitch xwOBA Allowed', fmt: v => v.toFixed(3), color: C.blue, group: 'Arsenal Intelligence', inverse: true },
+]
+
+function StatCard({ label, value, sub }) {
+  if (!hasValue(value)) return null
+  return <div style={s.statCard}><div style={s.statLabel}>{label}</div><div style={s.statVal}>{value}</div>{sub && <div style={s.statSub}>{sub}</div>}</div>
 }
 
-function StatCard({ label, value }) {
+function MiniBar({ value, maxVal, minVal, color, inverse }) {
+  const range = maxVal - minVal || 1
+  const raw = inverse ? ((maxVal - value) / range) * 100 : ((value - minVal) / range) * 100
+  const width = Math.max(4, Math.min(100, raw))
+  return <div style={{ background: C.elevated, borderRadius: 3, height: 6, width: 52, display: 'inline-block' }}><div style={{ width: `${width}%`, height: '100%', background: color, borderRadius: 3, opacity: 0.85 }} /></div>
+}
+
+function cleanLeaderboardRows(board) {
+  return safeRows(board).map((row, idx) => ({ ...row, rank: row.rank || idx + 1, value: Number(row.value) })).filter(row => row.player_id && Number.isFinite(row.value)).slice(0, 10)
+}
+
+function LeaderboardCard({ title, board, fmtVal, color, inverse = false }) {
+  const rows = cleanLeaderboardRows(board)
+  if (!rows.length) return null
+  const vals = rows.map(r => r.value)
+  const maxVal = Math.max(...vals)
+  const minVal = Math.min(...vals)
   return (
-    <div style={s.statCard}>
-      <div style={s.statLabel}>{label}</div>
-      <div style={s.statVal}>{value}</div>
+    <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 10, overflow: 'hidden' }}>
+      <div style={{ padding: '12px 16px', borderBottom: `1px solid ${C.elevated}`, display: 'flex', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: C.text }}>{title}</span><span style={{ fontSize: 11, color, fontWeight: 700 }}>TOP {rows.length}</span>
+      </div>
+      {rows.map(row => (
+        <div key={`${title}-${row.player_id}-${row.rank}-${row.pitch_type || ''}`} style={{ display: 'grid', gridTemplateColumns: '22px 1fr auto', gap: 8, padding: '8px 14px', borderBottom: `1px solid ${C.bg}`, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: C.muted, fontWeight: 700, textAlign: 'right' }}>{row.rank}</span>
+          <div style={{ overflow: 'hidden' }}>
+            <Link to={`/pitcher/${row.player_id}`} style={{ color: C.blue, textDecoration: 'none', fontSize: 13, fontWeight: 500, display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.player_name || `Pitcher #${row.player_id}`}</Link>
+            <div style={{ fontSize: 11, color: C.muted }}>{row.sample || row.window || ''}</div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <MiniBar value={row.value} maxVal={maxVal} minVal={minVal} color={color} inverse={inverse} />
+            <span style={{ fontSize: 12, fontWeight: 700, color: C.text, minWidth: 58, textAlign: 'right' }}>{fmtVal(row.value)}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PitcherLeaderboardDashboard({ data, loading }) {
+  if (loading) return <div style={s.loader}>Loading pitcher leaderboards…</div>
+  if (!data) return null
+  const boards = data.leaderboards || {}
+  const groups = ['Power / Stuff', 'Command / Discipline', 'Contact Allowed', 'Arsenal Intelligence']
+  return (
+    <div>
+      <div style={s.header}>
+        <div style={s.playerName}>Pitcher Intelligence Hub</div>
+        <div style={s.playerMeta}>
+          <span style={s.chip}>Top-10 leaderboard dashboard</span>
+          <span style={s.chip}>{data.season} season</span>
+          <span style={s.chip}>PitchProfiler-inspired arsenal, command, and release views</span>
+        </div>
+      </div>
+      {(data.notes || []).length > 0 && <div style={s.qaBox}>{data.notes.slice(0, 2).map((note, i) => <div key={i}>• {note}</div>)}</div>}
+      {groups.map(group => {
+        const cards = LB_CONFIG.filter(cfg => cfg.group === group && cleanLeaderboardRows(boards[cfg.key]).length > 0)
+        if (!cards.length) return null
+        return (
+          <div key={group} style={s.section}>
+            <div style={s.sectionTitle}>{group}</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 14 }}>
+              {cards.map(cfg => <LeaderboardCard key={cfg.key} title={cfg.title} board={boards[cfg.key]} fmtVal={cfg.fmt} color={cfg.color} inverse={cfg.inverse} />)}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function QABox({ intelligence }) {
+  if (!intelligence) return null
+  const missing = intelligence.missing_inputs || []
+  const flags = intelligence.quality_flags || []
+  return (
+    <div style={s.qaBox}>
+      <div><strong style={{ color: C.text }}>Data QA:</strong> {intelligence.source || 'unknown'} · location source {intelligence.metadata?.location_source || 'plate_x/plate_z'} · release source {intelligence.metadata?.release_source || intelligence.release_profile?.source || 'unknown'}</div>
+      {flags.length > 0 && <div>Flags: {flags.join(', ')}</div>}
+      {missing.length > 0 && <div>Missing inputs: {missing.slice(0, 8).join(', ')}{missing.length > 8 ? '…' : ''}</div>}
+      {intelligence.metadata?.barrel_definition && <div>Barrel note: {intelligence.metadata.barrel_definition}</div>}
+    </div>
+  )
+}
+
+function IntelligenceSummary({ intelligence }) {
+  const summary = intelligence?.summary
+  if (!summary) return null
+  const best = summary.best_pitch
+  const risk = summary.riskiest_pitch
+  return (
+    <div style={s.section}>
+      <div style={s.sectionTitle}>Pitcher Intelligence Summary</div>
+      <div style={s.statsGrid}>
+        <StatCard label="Sample" value={fmt(summary.pitches, 0)} sub="Statcast pitches" />
+        <StatCard label="Best Pitch" value={best?.pitch_type || '—'} sub={best?.quality_score != null ? `Quality ${score(best.quality_score)}` : null} />
+        <StatCard label="Riskiest Pitch" value={risk?.pitch_type || '—'} sub={risk?.damage_score != null ? `Damage ${score(risk.damage_score)}` : null} />
+        <StatCard label="Whiff%" value={pct(summary.whiff_pct)} />
+        <StatCard label="CSW%" value={pct(summary.csw_pct)} />
+        <StatCard label="Hard Hit% Allowed" value={pct(summary.hard_hit_pct)} />
+        <StatCard label="Barrel% Allowed" value={pct(summary.barrel_pct)} />
+        <StatCard label="xwOBA Allowed" value={fmt(summary.xwoba, 3)} />
+      </div>
+    </div>
+  )
+}
+
+function ReleaseProfileCard({ release }) {
+  if (!release) return null
+  return (
+    <div style={s.section}>
+      <div style={s.sectionTitle}>Release / Deception Profile</div>
+      <div style={s.statsGrid}>
+        <StatCard label="Release Side" value={release.avg_release_pos_x != null ? `${fmt(release.avg_release_pos_x, 2)} ft` : null} />
+        <StatCard label="Release Height" value={release.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null} />
+        <StatCard label="Extension" value={release.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null} />
+        <StatCard label="Source" value={release.source || '—'} sub={release.window || release.end_date} />
+      </div>
+      <div style={{ ...s.qaBox, marginTop: 12 }}>{release.note || 'Release fields describe pitcher release geometry, not plate location.'}</div>
+    </div>
+  )
+}
+
+function chartDataFromArsenal(arsenal) {
+  return safeRows(arsenal).filter(p => p.pitch_type).map(p => ({
+    pitch: p.pitch_type,
+    usage: p.usage_pct != null ? p.usage_pct * 100 : null,
+    whiff: p.whiff_pct != null ? p.whiff_pct * 100 : null,
+    csw: p.csw_pct != null ? p.csw_pct * 100 : null,
+    hardHit: p.hard_hit_pct != null ? p.hard_hit_pct * 100 : null,
+    barrel: p.barrel_pct != null ? p.barrel_pct * 100 : null,
+    xwoba: p.xwoba,
+    velo: p.avg_velocity,
+    spin: p.avg_spin_rate,
+  }))
+}
+
+function ArsenalCharts({ arsenal }) {
+  const rows = chartDataFromArsenal(arsenal)
+  if (!rows.length) return null
+  return (
+    <div style={s.section}>
+      <div style={s.sectionTitle}>Arsenal Graphs</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(330px, 1fr))', gap: 14 }}>
+        <div style={s.chartBox}><div style={s.sectionTitle}>Pitch Mix</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Bar dataKey="usage" name="Usage %" fill={C.blue} /></BarChart></ResponsiveContainer></div>
+        <div style={s.chartBox}><div style={s.sectionTitle}>Whiff / CSW</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Bar dataKey="whiff" name="Whiff %" fill={C.green} /><Bar dataKey="csw" name="CSW %" fill={C.teal} /></BarChart></ResponsiveContainer></div>
+        <div style={s.chartBox}><div style={s.sectionTitle}>Contact Damage</div><ResponsiveContainer width="100%" height={220}><LineChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis yAxisId="left" stroke={C.muted} /><YAxis yAxisId="right" orientation="right" stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><ReferenceLine yAxisId="right" y={0.320} stroke={C.muted} strokeDasharray="3 3" /><Line yAxisId="right" type="monotone" dataKey="xwoba" name="xwOBA" stroke={C.red} connectNulls /><Line yAxisId="left" type="monotone" dataKey="hardHit" name="HH %" stroke={C.orange} connectNulls /><Line yAxisId="left" type="monotone" dataKey="barrel" name="Barrel %" stroke={C.purple} connectNulls /></LineChart></ResponsiveContainer></div>
+        <div style={s.chartBox}><div style={s.sectionTitle}>Velocity / Spin</div><ResponsiveContainer width="100%" height={220}><LineChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis yAxisId="left" stroke={C.muted} /><YAxis yAxisId="right" orientation="right" stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Line yAxisId="left" type="monotone" dataKey="velo" name="Velo" stroke={C.blue} connectNulls /><Line yAxisId="right" type="monotone" dataKey="spin" name="Spin" stroke={C.purple} connectNulls /></LineChart></ResponsiveContainer></div>
+      </div>
+    </div>
+  )
+}
+
+function ArsenalTable({ arsenal }) {
+  const rows = safeRows(arsenal)
+  if (!rows.length) return null
+  const columns = [
+    ['pitch_type', 'Pitch', v => v], ['usage_pct', 'Usage%', v => pct(v)], ['avg_velocity', 'Velo', v => fmt(v)], ['avg_spin_rate', 'Spin', v => fmt(v, 0)], ['whiff_pct', 'Whiff%', v => pct(v)], ['csw_pct', 'CSW%', v => pct(v)], ['in_zone_pct', 'Zone%', v => pct(v)], ['heart_zone_pct', 'Heart%', v => pct(v)], ['hard_hit_pct', 'HH%', v => pct(v)], ['barrel_pct', 'Barrel%', v => pct(v)], ['xwoba', 'xwOBA', v => fmt(v, 3)], ['xba', 'xBA', v => fmt(v, 3)], ['quality_score', 'Quality', v => score(v)], ['damage_score', 'Damage', v => score(v)],
+  ].filter(([key]) => rows.some(row => row[key] != null))
+  return (
+    <div style={s.section}>
+      <div style={s.sectionTitle}>Arsenal 2.0</div>
+      <div style={s.tableWrap}><table style={s.table}><thead><tr>{columns.map(([key, label], idx) => <th key={key} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{label}</th>)}</tr></thead><tbody>{rows.map((row, i) => <tr key={`${row.pitch_type}-${i}`}>{columns.map(([key,, render], idx) => <td key={key} style={idx === 0 ? s.td : { ...s.td, ...s.tdR }}>{render(row[key])}</td>)}</tr>)}</tbody></table></div>
+    </div>
+  )
+}
+
+function LocationGrid({ profile }) {
+  const buckets = safeRows(profile?.buckets)
+  if (!buckets.length) return null
+  const byBucket = Object.fromEntries(buckets.map(row => [row.bucket, row]))
+  const rows = [['inside_high', 'middle_high', 'outside_high'], ['inside_middle', 'middle_middle', 'outside_middle'], ['inside_low', 'middle_low', 'outside_low']]
+  return (
+    <div style={s.section}>
+      <div style={s.sectionTitle}>Location / Command Grid <span style={s.sourceBadge}>plate_x / plate_z</span></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(110px, 1fr))', gap: 8, maxWidth: 680 }}>
+        {rows.flat().map(name => {
+          const b = byBucket[name]
+          return <div key={name} style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 8, padding: 12, minHeight: 94 }}><div style={{ color: C.blue, fontWeight: 700, fontSize: 12, marginBottom: 6 }}>{name.replace('_', ' / ')}</div>{b ? <><div style={{ color: C.text, fontWeight: 700 }}>{b.pitches} pitches</div><div style={{ color: C.muted, fontSize: 12 }}>xwOBA {fmt(b.xwoba, 3)}</div><div style={{ color: C.muted, fontSize: 12 }}>HH {pct(b.hard_hit_pct)} · Brl {pct(b.barrel_pct)}</div><div style={{ color: C.muted, fontSize: 12 }}>Damage {score(b.damage_score)}</div></> : <div style={{ color: C.muted, fontSize: 12 }}>No sample</div>}</div>
+        })}
+      </div>
     </div>
   )
 }
@@ -74,240 +266,91 @@ export default function PitcherPage() {
   const [searching, setSearching] = useState(false)
   const [hoverIdx, setHoverIdx] = useState(-1)
   const [data, setData] = useState(null)
+  const [intelligence, setIntelligence] = useState(null)
+  const [leaderboards, setLeaderboards] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [lbLoading, setLbLoading] = useState(false)
   const [error, setError] = useState(null)
   const debounceRef = React.useRef(null)
 
   function load(pid) {
     if (!pid) return
-    setLoading(true); setError(null); setResults([])
-    fetch(`${API}/pitcher/${pid}`)
-      .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
-      .then(d => { setData(d); setLoading(false) })
-      .catch(e => { setError(String(e)); setLoading(false); setData(null) })
+    setLoading(true); setError(null); setResults([]); setIntelligence(null)
+    Promise.all([
+      fetch(`${API}/pitcher/${pid}`).then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText))),
+      fetch(`${API}/pitcher/${pid}/intelligence`).then(r => r.ok ? r.json() : null).catch(() => null),
+    ]).then(([profile, intel]) => { setData(profile); setIntelligence(intel); setLoading(false) }).catch(e => { setError(String(e)); setLoading(false); setData(null); setIntelligence(null) })
   }
 
   useEffect(() => { if (id) load(id) }, [id])
+  useEffect(() => {
+    if (id) return
+    setLbLoading(true)
+    fetch(`${API}/pitchers/leaderboards?limit=10`).then(r => r.ok ? r.json() : null).then(d => { setLeaderboards(d); setLbLoading(false) }).catch(() => setLbLoading(false))
+  }, [id])
 
   function onQueryChange(e) {
     const val = e.target.value
-    setQuery(val)
-    setHoverIdx(-1)
-    clearTimeout(debounceRef.current)
+    setQuery(val); setHoverIdx(-1); clearTimeout(debounceRef.current)
     if (val.length < 2) { setResults([]); return }
     debounceRef.current = setTimeout(() => {
       setSearching(true)
-      fetch(`${API}/players/search?name=${encodeURIComponent(val)}`)
-        .then(r => r.ok ? r.json() : [])
-        .then(d => {
-          setResults((d || []).filter(p => p.position_type === 'Pitcher'))
-          setSearching(false)
-        })
-        .catch(() => setSearching(false))
+      fetch(`${API}/players/search?name=${encodeURIComponent(val)}`).then(r => r.ok ? r.json() : []).then(d => { setResults((d || []).filter(p => p.position_type === 'Pitcher')); setSearching(false) }).catch(() => setSearching(false))
     }, 300)
   }
 
-  function selectPlayer(p) {
-    setQuery(p.name)
-    setResults([])
-    navigate(`/pitcher/${p.id}`)
-  }
+  function selectPlayer(p) { setQuery(p.name); setResults([]); navigate(`/pitcher/${p.id}`) }
 
-  const agg = data?.aggregate
-  const arsenal = data?.arsenal || []
+  const agg = data?.aggregate || {}
+  const oldArsenal = data?.arsenal || []
+  const arsenal = intelligence?.arsenal?.length ? intelligence.arsenal : oldArsenal
   const multiSeason = data?.multi_season || []
   const gameLog = data?.game_log || []
+  const release = intelligence?.release_profile
+
+  const currentCards = [
+    ['Avg Velocity', agg.avg_velocity != null ? `${fmt(agg.avg_velocity)} mph` : null],
+    ['Spin Rate', agg.avg_spin_rate != null ? `${fmt(agg.avg_spin_rate, 0)} rpm` : null],
+    ['K%', agg.k_pct != null ? pct(agg.k_pct) : null],
+    ['BB%', agg.bb_pct != null ? pct(agg.bb_pct) : null],
+    ['Hard Hit% Allowed', agg.hard_hit_pct != null ? pct(agg.hard_hit_pct) : null],
+    ['xwOBA Allowed', agg.xwoba != null ? fmt(agg.xwoba, 3) : null],
+    ['xBA Allowed', agg.xba != null ? fmt(agg.xba, 3) : null],
+    ['Extension', release?.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null],
+    ['Release Height', release?.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null],
+    ['Release Side', release?.avg_release_pos_x != null ? `${fmt(release.avg_release_pos_x, 2)} ft` : null],
+  ]
 
   return (
     <div>
-      <h1 style={{ fontSize: '24px', fontWeight: '700', marginBottom: '20px' }}>Pitcher Profile</h1>
-
-      <div style={{ position: 'relative', marginBottom: '28px' }}>
-        <div style={s.searchRow}>
-          <input
-            style={s.input}
-            placeholder="Search pitcher by name (e.g. Gerrit Cole)"
-            value={query}
-            onChange={onQueryChange}
-            autoComplete="off"
-          />
-          {searching && <span style={{ color: '#8b949e', fontSize: '13px', alignSelf: 'center' }}>Searching…</span>}
-        </div>
-        {results.length > 0 && (
-          <div style={searchDropStyle}>
-            {results.slice(0, 10).map((p, i) => (
-              <div
-                key={p.id}
-                style={searchItemStyle(i === hoverIdx)}
-                onMouseEnter={() => setHoverIdx(i)}
-                onMouseLeave={() => setHoverIdx(-1)}
-                onClick={() => selectPlayer(p)}
-              >
-                <span style={{ color: '#e6edf3' }}>{p.name}</span>
-                <span style={{ color: '#8b949e', fontSize: '12px' }}>{p.team || ''}</span>
-              </div>
-            ))}
-          </div>
-        )}
+      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 20 }}>Pitcher Profile</h1>
+      <div style={{ position: 'relative', marginBottom: 28 }}>
+        <div style={s.searchRow}><input style={s.input} placeholder="Search pitcher by name (e.g. Gerrit Cole)" value={query} onChange={onQueryChange} autoComplete="off" />{searching && <span style={{ color: C.muted, fontSize: 13, alignSelf: 'center' }}>Searching…</span>}</div>
+        {results.length > 0 && <div style={searchDropStyle}>{results.slice(0, 10).map((p, i) => <div key={p.id} style={searchItemStyle(i === hoverIdx)} onMouseEnter={() => setHoverIdx(i)} onMouseLeave={() => setHoverIdx(-1)} onClick={() => selectPlayer(p)}><span style={{ color: C.text }}>{p.name}</span><span style={{ color: C.muted, fontSize: 12 }}>{p.team || ''}</span></div>)}</div>}
       </div>
 
+      {!id && <PitcherLeaderboardDashboard data={leaderboards} loading={lbLoading} />}
       {loading && <div style={s.loader}>Loading…</div>}
       {error && <div style={s.error}>{error}</div>}
-      {!loading && !error && !data && <div style={s.hint}>Search for a pitcher by name to view their stats.</div>}
+      {id && !loading && !error && !data && <div style={s.hint}>Search for a pitcher by name to view their stats.</div>}
+      {data?.no_data && <div style={s.error}>No Statcast data on file for {data.player_name || `pitcher ${id}`}. This player may be inactive or data has not been ingested yet.</div>}
 
-      {data?.no_data && (
-        <div style={s.error}>
-          No Statcast data on file for {data.player_name || `pitcher ${id}`}. This player may be inactive or data hasn't been ingested yet.
-        </div>
-      )}
+      {data && !data.no_data && <>
+        <div style={s.header}><div style={s.playerName}>{data.player_name || data.player_info?.name || `Pitcher #${id}`}</div><div style={s.playerMeta}><span style={s.chip}>Player ID {id}</span>{data.data_source && <span style={s.chip}>{data.data_source}</span>}{data.arsenal_season && <span style={s.chip}>{data.arsenal_season} arsenal</span>}{intelligence?.sample_size?.deduped_pitch_rows != null && <span style={s.chip}>{intelligence.sample_size.deduped_pitch_rows} tracked pitches</span>}</div></div>
+        {id && <Link to={`/pitcher/${id}/rolling`} style={s.rollingLink}>View Rolling Stats (L15–L150 Games) →</Link>}
+        <QABox intelligence={intelligence} />
 
-      {data && !data.no_data && (
-        <>
-          {id && (
-            <Link to={`/pitcher/${id}/rolling`} style={s.rollingLink}>
-              View Rolling Stats (L15–L150 Games) →
-            </Link>
-          )}
+        {currentCards.some(([, value]) => hasValue(value)) && <div style={s.section}><div style={s.sectionTitle}>Current Metrics</div><div style={s.statsGrid}>{currentCards.map(([label, value]) => <StatCard key={label} label={label} value={value} />)}</div></div>}
+        <IntelligenceSummary intelligence={intelligence} />
+        <ReleaseProfileCard release={release} />
+        <ArsenalCharts arsenal={arsenal} />
+        <ArsenalTable arsenal={arsenal} />
+        <LocationGrid profile={intelligence?.location_profile} />
 
-          {agg && (
-            <div style={s.section}>
-              <div style={s.sectionTitle}>
-                Current Metrics
-                {data.data_source && <span style={s.sourceBadge}>{data.data_source}</span>}
-              </div>
-              <div style={s.statsGrid}>
-                <StatCard label="Avg Velocity" value={`${fmt(agg.avg_velocity)} mph`} />
-                <StatCard label="Spin Rate" value={`${fmt(agg.avg_spin_rate, 0)} rpm`} />
-                <StatCard label="K%" value={pct(agg.k_pct)} />
-                <StatCard label="BB%" value={pct(agg.bb_pct)} />
-                <StatCard label="Hard Hit%" value={pct(agg.hard_hit_pct)} />
-                <StatCard label="xwOBA" value={fmt(agg.xwoba, 3)} />
-                <StatCard label="xBA" value={fmt(agg.xba, 3)} />
-                <StatCard label="Horiz Break" value={`${fmt(agg.avg_horiz_break, 2)}"`} />
-                <StatCard label="Vert Break" value={`${fmt(agg.avg_vert_break, 2)}"`} />
-              </div>
-            </div>
-          )}
+        {multiSeason.some(r => r.avg_velocity != null || r.k_pct != null) && <div style={s.section}><div style={s.sectionTitle}>Season-by-Season</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Season', 'Velo', 'Spin', 'K%', 'BB%', 'Hard Hit%', 'xwOBA', 'xBA'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{multiSeason.map((row, i) => <tr key={i}><td style={{ ...s.td, fontWeight: 700, color: C.blue }}>{row.label}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_velocity)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_spin_rate, 0)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.k_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.bb_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.hard_hit_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xwoba, 3)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xba, 3)}</td></tr>)}</tbody></table></div></div>}
 
-          {multiSeason.some(r => r.avg_velocity != null || r.k_pct != null) && (
-            <div style={s.section}>
-              <div style={s.sectionTitle}>Season-by-Season</div>
-              <div style={s.tableWrap}>
-                <table style={s.table}>
-                  <thead>
-                    <tr>
-                      <th style={s.th}>Season</th>
-                      <th style={{ ...s.th, ...s.thRight }}>Velo</th>
-                      <th style={{ ...s.th, ...s.thRight }}>Spin</th>
-                      <th style={{ ...s.th, ...s.thRight }}>K%</th>
-                      <th style={{ ...s.th, ...s.thRight }}>BB%</th>
-                      <th style={{ ...s.th, ...s.thRight }}>Hard Hit%</th>
-                      <th style={{ ...s.th, ...s.thRight }}>xwOBA</th>
-                      <th style={{ ...s.th, ...s.thRight }}>xBA</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {multiSeason.map((row, i) => (
-                      <tr key={i}>
-                        <td style={{ ...s.td, fontWeight: '700', color: '#58a6ff' }}>{row.label}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_velocity)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.avg_spin_rate, 0)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.k_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.bb_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(row.hard_hit_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.xwoba, 3)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(row.xba, 3)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-
-          {gameLog.length > 0 && (
-            <div style={s.section}>
-              <div style={s.sectionTitle}>Recent Outings</div>
-              <div style={s.tableWrap}>
-                <table style={s.table}>
-                  <thead>
-                    <tr>
-                      <th style={s.th}>Date</th>
-                      <th style={{ ...s.th, ...s.thRight }}>Pitches</th>
-                      <th style={{ ...s.th, ...s.thRight }}>PA</th>
-                      <th style={{ ...s.th, ...s.thRight }}>K</th>
-                      <th style={{ ...s.th, ...s.thRight }}>BB</th>
-                      <th style={{ ...s.th, ...s.thRight }}>HR</th>
-                      <th style={{ ...s.th, ...s.thRight }}>HH%</th>
-                      <th style={{ ...s.th, ...s.thRight }}>Velo</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {gameLog.map((g, i) => (
-                      <tr key={i}>
-                        <td style={{ ...s.td, ...s.tdMuted, fontSize: '12px' }}>{g.game_date}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{g.pitch_count ?? '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{g.plate_appearances ?? '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight, color: '#3fb950' }}>{g.strikeouts ?? '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight, color: '#d29922' }}>{g.walks ?? '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight, color: g.home_runs > 0 ? '#f85149' : '#e6edf3' }}>{g.home_runs ?? '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{g.hard_hit_pct != null ? pct(g.hard_hit_pct) : '—'}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{g.avg_velocity != null ? `${g.avg_velocity.toFixed(1)}` : '—'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-
-          {arsenal.length > 0 && (
-            <div style={s.section}>
-              <div style={s.sectionTitle}>
-                Pitch Arsenal
-                {data.arsenal_season != null && (() => {
-                  const currentYear = new Date().getFullYear()
-                  const isPrior = data.arsenal_season < currentYear
-                  return (
-                    <span style={{
-                      ...s.sourceBadge,
-                      ...(isPrior ? { background: '#3a2a0f', color: '#d29922' } : {}),
-                    }}>
-                      {isPrior ? `${data.arsenal_season} Season — Prior Year` : `${data.arsenal_season} Season`}
-                    </span>
-                  )
-                })()}
-              </div>
-              <div style={s.tableWrap}>
-                <table style={s.table}>
-                  <thead>
-                    <tr>
-                      {['Pitch', 'Usage%', 'Whiff%', 'K%', 'RV/100', 'xwOBA', 'Hard Hit%'].map(h => (
-                        <th key={h} style={h === 'Pitch' ? s.th : { ...s.th, ...s.thRight }}>{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {arsenal.map((p, i) => (
-                      <tr key={i}>
-                        <td style={s.td}>{p.pitch_name || p.pitch_type}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.usage_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.whiff_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.strikeout_pct)}</td>
-                        <td style={{ ...s.td, ...s.tdRight, color: (p.rv_per_100 || 0) < 0 ? '#3fb950' : '#f85149' }}>
-                          {fmt(p.rv_per_100, 1)}
-                        </td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{fmt(p.xwoba, 3)}</td>
-                        <td style={{ ...s.td, ...s.tdRight }}>{pct(p.hard_hit_pct)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          )}
-        </>
-      )}
+        {gameLog.length > 0 && <div style={s.section}><div style={s.sectionTitle}>Recent Outings</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Date', 'Pitches', 'PA', 'K', 'BB', 'HR', 'HH%', 'Velo'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{gameLog.map((g, i) => <tr key={i}><td style={{ ...s.td, color: C.muted, fontSize: 12 }}>{g.game_date}</td><td style={{ ...s.td, ...s.tdR }}>{g.pitch_count ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.plate_appearances ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.green }}>{g.strikeouts ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.orange }}>{g.walks ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: g.home_runs > 0 ? C.red : C.text }}>{g.home_runs ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.hard_hit_pct != null ? pct(g.hard_hit_pct) : '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.avg_velocity != null ? fmt(g.avg_velocity) : '—'}</td></tr>)}</tbody></table></div></div>}
+      </>}
     </div>
   )
 }

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -23,6 +23,7 @@ from .db_utils import (
     get_player_splits_multi_season,
 )
 from .pitcher_intelligence import build_pitcher_intelligence_profile
+from .pitcher_leaderboards import build_pitcher_leaderboards
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 router = APIRouter()
@@ -32,6 +33,7 @@ router = APIRouter()
 # season's terminal-event rows. Caching prevents redundant work across requests.
 _LEADERBOARD_TTL_SECONDS = 3600  # 1 hour
 _leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
+_pitcher_leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
 
 
 def _get_session():
@@ -194,6 +196,26 @@ def batters_leaderboards(
         result = get_batter_leaderboards(session, season=season, min_pa=min_pa, min_bbe=min_bbe, limit=limit)
 
     _leaderboard_cache[cache_key] = (time.monotonic(), result)
+    return result
+
+
+@router.get("/pitchers/leaderboards")
+def pitchers_leaderboards(
+    season: Optional[int] = None,
+    limit: int = Query(10, ge=1, le=50),
+) -> Dict[str, Any]:
+    cache_key = f"pitchers:{season}:{limit}"
+    cached = _pitcher_leaderboard_cache.get(cache_key)
+    if cached is not None:
+        cached_at, data = cached
+        if time.monotonic() - cached_at < _LEADERBOARD_TTL_SECONDS:
+            return data
+
+    Session = _get_session()
+    with Session() as session:
+        result = build_pitcher_leaderboards(session, season=season, limit=limit)
+
+    _pitcher_leaderboard_cache[cache_key] = (time.monotonic(), result)
     return result
 
 

--- a/mlb_app/pitcher_leaderboards.py
+++ b/mlb_app/pitcher_leaderboards.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import PitchArsenal, PitcherAggregate
+
+
+def _serialize_aggregate_row(row: PitcherAggregate, value: float, rank: int) -> Dict[str, Any]:
+    return {
+        "rank": rank,
+        "player_id": row.pitcher_id,
+        "player_name": f"Pitcher #{row.pitcher_id}",
+        "team": None,
+        "value": value,
+        "sample": row.window,
+        "window": row.window,
+        "end_date": row.end_date.isoformat() if row.end_date else None,
+    }
+
+
+def _aggregate_board(rows: List[PitcherAggregate], attr: str, *, limit: int, reverse: bool) -> List[Dict[str, Any]]:
+    usable = []
+    for row in rows:
+        value = getattr(row, attr, None)
+        if value is None:
+            continue
+        usable.append((row, float(value)))
+    usable.sort(key=lambda item: item[1], reverse=reverse)
+    return [_serialize_aggregate_row(row, value, idx + 1) for idx, (row, value) in enumerate(usable[:limit])]
+
+
+def _pitch_board(rows: List[PitchArsenal], attr: str, *, limit: int, reverse: bool) -> List[Dict[str, Any]]:
+    usable = []
+    for row in rows:
+        value = getattr(row, attr, None)
+        if value is None:
+            continue
+        usable.append((row, float(value)))
+    usable.sort(key=lambda item: item[1], reverse=reverse)
+    board = []
+    for idx, (row, value) in enumerate(usable[:limit]):
+        pitch_label = row.pitch_name or row.pitch_type or "Pitch"
+        board.append({
+            "rank": idx + 1,
+            "player_id": row.pitcher_id,
+            "player_name": f"Pitcher #{row.pitcher_id}",
+            "team": None,
+            "value": value,
+            "sample": f"{pitch_label} · {row.pitch_count or 0} pitches",
+            "window": str(row.season),
+            "pitch_type": row.pitch_type,
+            "pitch_name": row.pitch_name,
+            "pitch_count": row.pitch_count,
+            "end_date": None,
+        })
+    return board
+
+
+def build_pitcher_leaderboards(session: Session, season: Optional[int] = None, limit: int = 10) -> Dict[str, Any]:
+    if season is None:
+        season = dt.date.today().year
+
+    aggregate_rows = (
+        session.query(PitcherAggregate)
+        .filter(PitcherAggregate.end_date >= dt.date(int(season), 1, 1))
+        .order_by(PitcherAggregate.end_date.desc())
+        .all()
+    )
+
+    latest_by_pitcher: Dict[int, PitcherAggregate] = {}
+    for row in aggregate_rows:
+        latest_by_pitcher.setdefault(row.pitcher_id, row)
+    latest = list(latest_by_pitcher.values())
+
+    arsenal_rows = session.query(PitchArsenal).filter(PitchArsenal.season == int(season)).all()
+
+    leaderboards = {
+        "avg_velocity": _aggregate_board(latest, "avg_velocity", limit=limit, reverse=True),
+        "avg_spin_rate": _aggregate_board(latest, "avg_spin_rate", limit=limit, reverse=True),
+        "k_pct": _aggregate_board(latest, "k_pct", limit=limit, reverse=True),
+        "bb_pct_lowest": _aggregate_board(latest, "bb_pct", limit=limit, reverse=False),
+        "hard_hit_pct_lowest": _aggregate_board(latest, "hard_hit_pct", limit=limit, reverse=False),
+        "xwoba_lowest": _aggregate_board(latest, "xwoba", limit=limit, reverse=False),
+        "xba_lowest": _aggregate_board(latest, "xba", limit=limit, reverse=False),
+        "extension": _aggregate_board(latest, "avg_release_extension", limit=limit, reverse=True),
+        "release_height": _aggregate_board(latest, "avg_release_pos_z", limit=limit, reverse=True),
+        "arsenal_whiff": _pitch_board(arsenal_rows, "whiff_pct", limit=limit, reverse=True),
+        "arsenal_xwoba_lowest": _pitch_board(arsenal_rows, "xwoba", limit=limit, reverse=False),
+    }
+
+    unavailable = [key for key, rows in leaderboards.items() if not rows]
+    return {
+        "season": int(season),
+        "limit": int(limit),
+        "leaderboards": leaderboards,
+        "notes": [
+            "Leaderboard rows use PitcherAggregate and PitchArsenal only; this avoids expensive per-pitcher intelligence calls on the landing page.",
+            "Release leaderboards use PitcherAggregate release fields. Plate-location visuals use plate_x/plate_z in the pitcher intelligence endpoint.",
+        ],
+        "unavailable_metrics": unavailable,
+    }


### PR DESCRIPTION
## Summary

Builds the next Issue #580 slice after merged PR #582: Pitcher Page UI parity with the Batter Page, plus a lightweight aggregate-driven pitcher leaderboard endpoint.

### Added

- New backend service:
  - `mlb_app/pitcher_leaderboards.py`
- New additive endpoint:
  - `GET /pitchers/leaderboards?season=YYYY&limit=10`
- Upgraded `frontend/src/pages/PitcherPage.jsx` to include:
  - Pitcher landing page leaderboard dashboard
  - BatterPage-style dark card system
  - search preserved
  - `GET /pitcher/{id}` profile fetch preserved
  - `GET /pitcher/{id}/intelligence` fetch added
  - Pitcher Intelligence Summary
  - Release / Deception Profile card
  - Arsenal 2.0 table
  - Recharts Pitch Mix chart
  - Recharts Whiff / CSW chart
  - Recharts Contact Damage chart
  - Recharts Velocity / Spin chart
  - plate_x / plate_z Location / Command grid
  - compact data QA box

### PitchProfiler-inspired product direction

Used `mlbpitchprofiler.com` as product inspiration for pitcher/pitch leaderboards, pitch graphs, arsenal intelligence, release/command views, and matchup-grade visual thinking. This does not copy their proprietary branding, models, or protected visual assets.

### Backend leaderboard logic

The pitcher leaderboard endpoint is intentionally aggregate-driven so the landing page does not make expensive per-pitcher intelligence calls.

Sources:

- `PitcherAggregate`
- `PitchArsenal`

Boards include:

- Avg Velocity
- Spin Rate
- K%
- Lowest BB%
- Lowest Hard Hit% allowed
- Lowest xwOBA allowed
- Lowest xBA allowed
- Extension
- Release Height
- Arsenal Whiff%
- Arsenal xwOBA allowed

### Intelligence fields used

From `/pitcher/{id}/intelligence`:

- `summary`
- `arsenal`
- `location_profile.buckets`
- `release_profile`
- `missing_inputs`
- `quality_flags`
- `metadata`

Release profile uses `PitcherAggregate` release fields from PR #582:

- `avg_release_pos_x`
- `avg_release_pos_z`
- `avg_release_extension`

Location grid uses plate-location fields only:

- `plate_x`
- `plate_z`

### Safety

- Does not touch canonical probability logic.
- Does not change `home_win_prob` / `away_win_prob`.
- Does not touch homepage data loading.
- Does not break Batter Page routes.
- Does not confuse release profile with plate location.
- Hides unavailable metric cards/columns instead of rendering polished N/A-heavy cards.

## Manual QA checklist

- `/pitcher` should load leaderboard dashboard.
- Pitcher search should still work.
- `/pitcher/{id}` should load profile and intelligence sections.
- Page should not crash if intelligence payload is unavailable.
- Charts should only render when arsenal rows exist.
- Location grid should only render when bucket data exists.
- Release card uses `pitcher_aggregates` release values when available.

## Known limitations

- Leaderboard rows currently display `Pitcher #ID` because there is no obvious local player-name table in the repo. A future PR should add a player identity cache or join source.
- Location grid is a clean 3x3 bucket view, not a full heatmap yet.
- PitchProfiler-inspired interaction is implemented as product direction, not a proprietary copy.

## Next recommended PR

Upgrade Matchup Detail Batter vs Arsenal with the same spatial/location intelligence style:

- batter damage zones
- pitcher attack zones
- pitch type + location mismatch notes
- compact prop/betting edge explanation

Closes part of #580.