### PR TITLE
Make pitcher landing page baseball-logical

### DIFF
--- a/frontend/src/pages/PitcherPage.jsx
+++ b/frontend/src/pages/PitcherPage.jsx
@@ -16,7 +16,7 @@ const s = {
   input: { flex: 1, background: C.card, border: `1px solid ${C.border}`, color: C.text, borderRadius: 8, padding: '11px 14px', fontSize: 14, outline: 'none' },
   hero: { background: `linear-gradient(135deg, ${C.card}, #111827)`, border: `1px solid ${C.border}`, borderRadius: 14, padding: '22px 24px', marginBottom: 22 },
   playerName: { fontSize: 28, fontWeight: 800, color: C.text, marginBottom: 8 },
-  sub: { color: C.muted, fontSize: 13, lineHeight: 1.5, maxWidth: 860 },
+  sub: { color: C.muted, fontSize: 13, lineHeight: 1.5, maxWidth: 900 },
   chipRow: { display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 14 },
   chip: { background: C.elevated, border: `1px solid ${C.border}`, borderRadius: 999, padding: '4px 10px', color: C.text, fontSize: 12 },
   rollingLink: { display: 'inline-block', background: C.elevated, border: `1px solid ${C.border}`, color: C.blue, textDecoration: 'none', borderRadius: 8, padding: '8px 15px', fontSize: 13, fontWeight: 600, marginBottom: 24 },
@@ -51,12 +51,12 @@ const hasValue = (v) => v !== null && v !== undefined && v !== '' && v !== '—'
 const safeRows = (rows) => Array.isArray(rows) ? rows : []
 
 const LB_CONFIG = [
-  { key: 'avg_velocity', title: 'Velocity Leaders', fmt: v => `${v.toFixed(1)} mph`, color: C.orange, group: 'Stuff' },
-  { key: 'k_pct', title: 'Strikeout Rate', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.green, group: 'Stuff' },
-  { key: 'xwoba_lowest', title: 'xwOBA Suppression', fmt: v => v.toFixed(3), color: C.red, group: 'Run Prevention', inverse: true },
-  { key: 'hard_hit_pct_lowest', title: 'Weak Contact', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.orange, group: 'Run Prevention', inverse: true },
-  { key: 'extension', title: 'Extension', fmt: v => `${v.toFixed(2)} ft`, color: C.teal, group: 'Release' },
-  { key: 'arsenal_whiff', title: 'Best Whiff Pitch', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.blue, group: 'Arsenal' },
+  { key: 'pitcher_quality', title: 'Overall Pitcher Quality', fmt: v => v.toFixed(3), color: C.green, subtitle: 'K-BB, xwOBA, hard contact, velo' },
+  { key: 'command_index', title: 'Command Edge', fmt: v => `${(v * 100).toFixed(1)} pts`, color: C.teal, subtitle: 'K% minus BB%, minimum sample' },
+  { key: 'damage_suppression', title: 'Damage Suppression', fmt: v => v.toFixed(3), color: C.red, subtitle: 'xwOBA + hard-hit prevention' },
+  { key: 'power_stuff', title: 'Power Stuff', fmt: v => v.toFixed(3), color: C.orange, subtitle: 'velocity, spin, extension blend' },
+  { key: 'release_weapon', title: 'Release Weapon', fmt: v => v.toFixed(3), color: C.purple, subtitle: 'extension + velocity plane' },
+  { key: 'arsenal_weapon', title: 'Best Individual Pitch', fmt: v => v.toFixed(3), color: C.blue, subtitle: 'pitch-level whiff and xwOBA' },
 ]
 
 function StatCard({ label, value, sub }) {
@@ -64,10 +64,9 @@ function StatCard({ label, value, sub }) {
   return <div style={s.statCard}><div style={s.statLabel}>{label}</div><div style={s.statVal}>{value}</div>{sub && <div style={s.statSub}>{sub}</div>}</div>
 }
 
-function MiniBar({ value, maxVal, minVal, color, inverse }) {
+function MiniBar({ value, maxVal, minVal, color }) {
   const range = maxVal - minVal || 1
-  const raw = inverse ? ((maxVal - value) / range) * 100 : ((value - minVal) / range) * 100
-  const width = Math.max(4, Math.min(100, raw))
+  const width = Math.max(4, Math.min(100, ((value - minVal) / range) * 100))
   return <div style={{ background: C.elevated, borderRadius: 4, height: 6, width: 54 }}><div style={{ width: `${width}%`, height: '100%', background: color, borderRadius: 4, opacity: 0.9 }} /></div>
 }
 
@@ -78,7 +77,7 @@ function cleanLeaderboardRows(board) {
     .slice(0, 10)
 }
 
-function LeaderboardCard({ title, board, fmtVal, color, inverse = false }) {
+function LeaderboardCard({ cfg, board }) {
   const rows = cleanLeaderboardRows(board)
   if (!rows.length) return null
   const vals = rows.map(r => r.value)
@@ -86,20 +85,20 @@ function LeaderboardCard({ title, board, fmtVal, color, inverse = false }) {
   const minVal = Math.min(...vals)
   return (
     <div style={{ background: C.card, border: `1px solid ${C.border}`, borderRadius: 12, overflow: 'hidden' }}>
-      <div style={{ padding: '12px 16px', borderBottom: `1px solid ${C.elevated}`, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ fontSize: 13, fontWeight: 700, color: C.text }}>{title}</span>
-        <span style={{ fontSize: 11, color, fontWeight: 800 }}>TOP {rows.length}</span>
+      <div style={{ padding: '12px 16px', borderBottom: `1px solid ${C.elevated}` }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}><span style={{ fontSize: 13, fontWeight: 750, color: C.text }}>{cfg.title}</span><span style={{ fontSize: 11, color: cfg.color, fontWeight: 850 }}>INDEX</span></div>
+        <div style={{ fontSize: 11, color: C.muted, marginTop: 4 }}>{cfg.subtitle}</div>
       </div>
       {rows.map(row => (
-        <div key={`${title}-${row.player_id}-${row.rank}-${row.pitch_type || ''}`} style={{ display: 'grid', gridTemplateColumns: '22px 1fr auto', gap: 8, padding: '9px 14px', borderBottom: `1px solid ${C.bg}`, alignItems: 'center' }}>
+        <div key={`${cfg.key}-${row.player_id}-${row.rank}-${row.pitch_type || ''}`} style={{ display: 'grid', gridTemplateColumns: '22px 1fr auto', gap: 8, padding: '9px 14px', borderBottom: `1px solid ${C.bg}`, alignItems: 'center' }}>
           <span style={{ fontSize: 11, color: C.muted, fontWeight: 800, textAlign: 'right' }}>{row.rank}</span>
           <div style={{ overflow: 'hidden' }}>
             <Link to={`/pitcher/${row.player_id}`} style={{ color: C.blue, textDecoration: 'none', fontSize: 13, fontWeight: 650, display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.player_name || `MLB ID ${row.player_id}`}</Link>
-            <div style={{ fontSize: 11, color: C.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.team ? `${row.team} · ` : ''}{row.sample || row.window || ''}</div>
+            <div style={{ fontSize: 11, color: C.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{row.team ? `${row.team} · ` : ''}{row.detail || row.sample || ''}</div>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <MiniBar value={row.value} maxVal={maxVal} minVal={minVal} color={color} inverse={inverse} />
-            <span style={{ fontSize: 12, fontWeight: 800, color: C.text, minWidth: 60, textAlign: 'right' }}>{fmtVal(row.value)}</span>
+            <MiniBar value={row.value} maxVal={maxVal} minVal={minVal} color={cfg.color} />
+            <span style={{ fontSize: 12, fontWeight: 800, color: C.text, minWidth: 58, textAlign: 'right' }}>{cfg.fmt(row.value)}</span>
           </div>
         </div>
       ))}
@@ -115,16 +114,17 @@ function PitcherLeaderboardDashboard({ data, loading }) {
   return (
     <div>
       <div style={s.hero}>
-        <div style={s.playerName}>Pitcher Intelligence</div>
-        <div style={s.sub}>A cleaner view of the arms that matter: power, strikeout ability, contact suppression, extension, and bat-missing pitches. Built from your aggregate tables so the landing page stays fast.</div>
+        <div style={s.playerName}>Pitching Intelligence Board</div>
+        <div style={s.sub}>Not raw rate traps. These boards use minimum samples and baseball-composite indexes to surface arms with real stuff, command, damage suppression, release traits, and pitch-level weapons.</div>
         <div style={s.chipRow}>
           <span style={s.chip}>{data.season} season</span>
+          <span style={s.chip}>Min {data.sample_rules?.profile_min_pitches || 250} pitches</span>
+          <span style={s.chip}>Min {data.sample_rules?.arsenal_min_pitch_count || 75} pitch-type sample</span>
           <span style={s.chip}>{data.identity_source === 'mlb_stats_api_people' ? 'MLB names loaded' : 'Name fallback active'}</span>
-          <span style={s.chip}>No per-pitcher page fanout</span>
         </div>
       </div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(330px, 1fr))', gap: 14 }}>
-        {cards.map(cfg => <LeaderboardCard key={cfg.key} title={cfg.title} board={boards[cfg.key]} fmtVal={cfg.fmt} color={cfg.color} inverse={cfg.inverse} />)}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(370px, 1fr))', gap: 14 }}>
+        {cards.map(cfg => <LeaderboardCard key={cfg.key} cfg={cfg} board={boards[cfg.key]} />)}
       </div>
     </div>
   )
@@ -170,53 +170,23 @@ function IntelligenceSummary({ intelligence }) {
 
 function ReleaseProfileCard({ release }) {
   if (!release) return null
-  return (
-    <div style={s.section}>
-      <div style={s.sectionTitle}>Release / Deception Profile</div>
-      <div style={s.grid}>
-        <StatCard label="Release Side" value={release.avg_release_pos_x != null ? `${fmt(release.avg_release_pos_x, 2)} ft` : null} />
-        <StatCard label="Release Height" value={release.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null} />
-        <StatCard label="Extension" value={release.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null} />
-        <StatCard label="Source" value={release.source || null} sub={release.window || release.end_date} />
-      </div>
-    </div>
-  )
+  return <div style={s.section}><div style={s.sectionTitle}>Release / Deception Profile</div><div style={s.grid}><StatCard label="Release Side" value={release.avg_release_pos_x != null ? `${fmt(release.avg_release_pos_x, 2)} ft` : null} /><StatCard label="Release Height" value={release.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null} /><StatCard label="Extension" value={release.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null} /><StatCard label="Source" value={release.source || null} sub={release.window || release.end_date} /></div></div>
 }
 
 function chartDataFromArsenal(arsenal) {
-  return safeRows(arsenal).filter(p => p.pitch_type).map(p => ({
-    pitch: p.pitch_type,
-    usage: p.usage_pct != null ? p.usage_pct * 100 : null,
-    whiff: p.whiff_pct != null ? p.whiff_pct * 100 : null,
-    csw: p.csw_pct != null ? p.csw_pct * 100 : null,
-    hardHit: p.hard_hit_pct != null ? p.hard_hit_pct * 100 : null,
-    xwoba: p.xwoba,
-    velo: p.avg_velocity,
-    spin: p.avg_spin_rate,
-  }))
+  return safeRows(arsenal).filter(p => p.pitch_type).map(p => ({ pitch: p.pitch_type, usage: p.usage_pct != null ? p.usage_pct * 100 : null, whiff: p.whiff_pct != null ? p.whiff_pct * 100 : null, csw: p.csw_pct != null ? p.csw_pct * 100 : null, hardHit: p.hard_hit_pct != null ? p.hard_hit_pct * 100 : null, xwoba: p.xwoba, velo: p.avg_velocity, spin: p.avg_spin_rate }))
 }
 
 function ArsenalCharts({ arsenal }) {
   const rows = chartDataFromArsenal(arsenal)
   if (!rows.length) return null
-  return (
-    <div style={s.section}>
-      <div style={s.sectionTitle}>Arsenal Graphs</div>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))', gap: 14 }}>
-        <div style={s.chartBox}><div style={s.sectionTitle}>Pitch Mix</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Bar dataKey="usage" name="Usage %" fill={C.blue} /></BarChart></ResponsiveContainer></div>
-        <div style={s.chartBox}><div style={s.sectionTitle}>Whiff / CSW</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Bar dataKey="whiff" name="Whiff %" fill={C.green} /><Bar dataKey="csw" name="CSW %" fill={C.teal} /></BarChart></ResponsiveContainer></div>
-        <div style={s.chartBox}><div style={s.sectionTitle}>Damage Allowed</div><ResponsiveContainer width="100%" height={220}><LineChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Line type="monotone" dataKey="xwoba" name="xwOBA" stroke={C.red} connectNulls /><Line type="monotone" dataKey="hardHit" name="HH %" stroke={C.orange} connectNulls /></LineChart></ResponsiveContainer></div>
-      </div>
-    </div>
-  )
+  return <div style={s.section}><div style={s.sectionTitle}>Arsenal Graphs</div><div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))', gap: 14 }}><div style={s.chartBox}><div style={s.sectionTitle}>Pitch Mix</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Bar dataKey="usage" name="Usage %" fill={C.blue} /></BarChart></ResponsiveContainer></div><div style={s.chartBox}><div style={s.sectionTitle}>Whiff / CSW</div><ResponsiveContainer width="100%" height={220}><BarChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Bar dataKey="whiff" name="Whiff %" fill={C.green} /><Bar dataKey="csw" name="CSW %" fill={C.teal} /></BarChart></ResponsiveContainer></div><div style={s.chartBox}><div style={s.sectionTitle}>Damage Allowed</div><ResponsiveContainer width="100%" height={220}><LineChart data={rows}><CartesianGrid strokeDasharray="3 3" stroke={C.border} /><XAxis dataKey="pitch" stroke={C.muted} /><YAxis stroke={C.muted} /><Tooltip contentStyle={tooltipStyle} /><Legend /><Line type="monotone" dataKey="xwoba" name="xwOBA" stroke={C.red} connectNulls /><Line type="monotone" dataKey="hardHit" name="HH %" stroke={C.orange} connectNulls /></LineChart></ResponsiveContainer></div></div></div>
 }
 
 function ArsenalTable({ arsenal }) {
   const rows = safeRows(arsenal)
   if (!rows.length) return null
-  const columns = [
-    ['pitch_type', 'Pitch', v => v], ['usage_pct', 'Usage%', v => pct(v)], ['avg_velocity', 'Velo', v => fmt(v)], ['avg_spin_rate', 'Spin', v => fmt(v, 0)], ['whiff_pct', 'Whiff%', v => pct(v)], ['csw_pct', 'CSW%', v => pct(v)], ['in_zone_pct', 'Zone%', v => pct(v)], ['heart_zone_pct', 'Heart%', v => pct(v)], ['hard_hit_pct', 'HH%', v => pct(v)], ['xwoba', 'xwOBA', v => fmt(v, 3)], ['quality_score', 'Quality', v => score(v)], ['damage_score', 'Damage', v => score(v)],
-  ].filter(([key]) => rows.some(row => row[key] != null))
+  const columns = [['pitch_type', 'Pitch', v => v], ['usage_pct', 'Usage%', v => pct(v)], ['avg_velocity', 'Velo', v => fmt(v)], ['avg_spin_rate', 'Spin', v => fmt(v, 0)], ['whiff_pct', 'Whiff%', v => pct(v)], ['csw_pct', 'CSW%', v => pct(v)], ['in_zone_pct', 'Zone%', v => pct(v)], ['heart_zone_pct', 'Heart%', v => pct(v)], ['hard_hit_pct', 'HH%', v => pct(v)], ['xwoba', 'xwOBA', v => fmt(v, 3)], ['quality_score', 'Quality', v => score(v)], ['damage_score', 'Damage', v => score(v)]].filter(([key]) => rows.some(row => row[key] != null))
   return <div style={s.section}><div style={s.sectionTitle}>Arsenal 2.0</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{columns.map(([key, label], idx) => <th key={key} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{label}</th>)}</tr></thead><tbody>{rows.map((row, i) => <tr key={`${row.pitch_type}-${i}`}>{columns.map(([key,, render], idx) => <td key={key} style={idx === 0 ? s.td : { ...s.td, ...s.tdR }}>{render(row[key])}</td>)}</tr>)}</tbody></table></div></div>
 }
 
@@ -246,27 +216,17 @@ export default function PitcherPage() {
   function load(pid) {
     if (!pid) return
     setLoading(true); setError(null); setResults([]); setIntelligence(null)
-    Promise.all([
-      fetch(`${API}/pitcher/${pid}`).then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText))),
-      fetch(`${API}/pitcher/${pid}/intelligence`).then(r => r.ok ? r.json() : null).catch(() => null),
-    ]).then(([profile, intel]) => { setData(profile); setIntelligence(intel); setLoading(false) }).catch(e => { setError(String(e)); setLoading(false); setData(null); setIntelligence(null) })
+    Promise.all([fetch(`${API}/pitcher/${pid}`).then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText))), fetch(`${API}/pitcher/${pid}/intelligence`).then(r => r.ok ? r.json() : null).catch(() => null)]).then(([profile, intel]) => { setData(profile); setIntelligence(intel); setLoading(false) }).catch(e => { setError(String(e)); setLoading(false); setData(null); setIntelligence(null) })
   }
 
   useEffect(() => { if (id) load(id) }, [id])
-  useEffect(() => {
-    if (id) return
-    setLbLoading(true)
-    fetch(`${API}/pitchers/leaderboards?limit=10`).then(r => r.ok ? r.json() : null).then(d => { setLeaderboards(d); setLbLoading(false) }).catch(() => setLbLoading(false))
-  }, [id])
+  useEffect(() => { if (id) return; setLbLoading(true); fetch(`${API}/pitchers/leaderboards?limit=10`).then(r => r.ok ? r.json() : null).then(d => { setLeaderboards(d); setLbLoading(false) }).catch(() => setLbLoading(false)) }, [id])
 
   function onQueryChange(e) {
     const val = e.target.value
     setQuery(val); setHoverIdx(-1); clearTimeout(debounceRef.current)
     if (val.length < 2) { setResults([]); return }
-    debounceRef.current = setTimeout(() => {
-      setSearching(true)
-      fetch(`${API}/players/search?name=${encodeURIComponent(val)}`).then(r => r.ok ? r.json() : []).then(d => { setResults((d || []).filter(p => p.position_type === 'Pitcher')); setSearching(false) }).catch(() => setSearching(false))
-    }, 300)
+    debounceRef.current = setTimeout(() => { setSearching(true); fetch(`${API}/players/search?name=${encodeURIComponent(val)}`).then(r => r.ok ? r.json() : []).then(d => { setResults((d || []).filter(p => p.position_type === 'Pitcher')); setSearching(false) }).catch(() => setSearching(false)) }, 300)
   }
 
   function selectPlayer(p) { setQuery(p.name); setResults([]); navigate(`/pitcher/${p.id}`) }
@@ -276,40 +236,7 @@ export default function PitcherPage() {
   const multiSeason = data?.multi_season || []
   const gameLog = data?.game_log || []
   const release = intelligence?.release_profile
-  const currentCards = [
-    ['Avg Velocity', agg.avg_velocity != null ? `${fmt(agg.avg_velocity)} mph` : null],
-    ['Spin Rate', agg.avg_spin_rate != null ? `${fmt(agg.avg_spin_rate, 0)} rpm` : null],
-    ['K%', agg.k_pct != null ? pct(agg.k_pct) : null],
-    ['BB%', agg.bb_pct != null ? pct(agg.bb_pct) : null],
-    ['Hard Hit%', agg.hard_hit_pct != null ? pct(agg.hard_hit_pct) : null],
-    ['xwOBA', agg.xwoba != null ? fmt(agg.xwoba, 3) : null],
-    ['Extension', release?.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null],
-    ['Release Height', release?.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null],
-  ]
+  const currentCards = [['Avg Velocity', agg.avg_velocity != null ? `${fmt(agg.avg_velocity)} mph` : null], ['Spin Rate', agg.avg_spin_rate != null ? `${fmt(agg.avg_spin_rate, 0)} rpm` : null], ['K%', agg.k_pct != null ? pct(agg.k_pct) : null], ['BB%', agg.bb_pct != null ? pct(agg.bb_pct) : null], ['Hard Hit%', agg.hard_hit_pct != null ? pct(agg.hard_hit_pct) : null], ['xwOBA', agg.xwoba != null ? fmt(agg.xwoba, 3) : null], ['Extension', release?.avg_release_extension != null ? `${fmt(release.avg_release_extension, 2)} ft` : null], ['Release Height', release?.avg_release_pos_z != null ? `${fmt(release.avg_release_pos_z, 2)} ft` : null]]
 
-  return (
-    <div>
-      <h1 style={{ fontSize: 24, fontWeight: 800, marginBottom: 20 }}>Pitcher Profile</h1>
-      <div style={{ position: 'relative', marginBottom: 26 }}><div style={s.searchRow}><input style={s.input} placeholder="Search pitcher by name" value={query} onChange={onQueryChange} autoComplete="off" />{searching && <span style={{ color: C.muted, fontSize: 13, alignSelf: 'center' }}>Searching…</span>}</div>{results.length > 0 && <div style={searchDropStyle}>{results.slice(0, 10).map((p, i) => <div key={p.id} style={searchItemStyle(i === hoverIdx)} onMouseEnter={() => setHoverIdx(i)} onMouseLeave={() => setHoverIdx(-1)} onClick={() => selectPlayer(p)}><span style={{ color: C.text }}>{p.name}</span><span style={{ color: C.muted, fontSize: 12 }}>{p.team || ''}</span></div>)}</div>}</div>
-      {!id && <PitcherLeaderboardDashboard data={leaderboards} loading={lbLoading} />}
-      {loading && <div style={s.loader}>Loading…</div>}
-      {error && <div style={s.error}>{error}</div>}
-      {id && !loading && !error && !data && <div style={s.hint}>Search for a pitcher by name to view their stats.</div>}
-      {data?.no_data && <div style={s.error}>No Statcast data on file for {data.player_name || `pitcher ${id}`}.</div>}
-
-      {data && !data.no_data && <>
-        <div style={s.hero}><div style={s.playerName}>{data.player_name || data.player_info?.name || `Pitcher #${id}`}</div><div style={s.sub}>Pitcher profile built from aggregate performance, arsenal quality, release traits, and plate-location outcomes.</div><div style={s.chipRow}><span style={s.chip}>MLB ID {id}</span>{data.data_source && <span style={s.chip}>{data.data_source}</span>}{intelligence?.sample_size?.deduped_pitch_rows != null && <span style={s.chip}>{intelligence.sample_size.deduped_pitch_rows} tracked pitches</span>}</div></div>
-        {id && <Link to={`/pitcher/${id}/rolling`} style={s.rollingLink}>View Rolling Stats →</Link>}
-        <QABox intelligence={intelligence} />
-        {currentCards.some(([, value]) => hasValue(value)) && <div style={s.section}><div style={s.sectionTitle}>Current Metrics</div><div style={s.grid}>{currentCards.map(([label, value]) => <StatCard key={label} label={label} value={value} />)}</div></div>}
-        <IntelligenceSummary intelligence={intelligence} />
-        <ReleaseProfileCard release={release} />
-        <ArsenalCharts arsenal={arsenal} />
-        <ArsenalTable arsenal={arsenal} />
-        <LocationGrid profile={intelligence?.location_profile} />
-        {multiSeason.some(r => r.avg_velocity != null || r.k_pct != null) && <div style={s.section}><div style={s.sectionTitle}>Season-by-Season</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Season', 'Velo', 'Spin', 'K%', 'BB%', 'Hard Hit%', 'xwOBA', 'xBA'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{multiSeason.map((row, i) => <tr key={i}><td style={{ ...s.td, fontWeight: 700, color: C.blue }}>{row.label}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_velocity)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_spin_rate, 0)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.k_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.bb_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.hard_hit_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xwoba, 3)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xba, 3)}</td></tr>)}</tbody></table></div></div>}
-        {gameLog.length > 0 && <div style={s.section}><div style={s.sectionTitle}>Recent Outings</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Date', 'Pitches', 'PA', 'K', 'BB', 'HR', 'HH%', 'Velo'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{gameLog.map((g, i) => <tr key={i}><td style={{ ...s.td, color: C.muted, fontSize: 12 }}>{g.game_date}</td><td style={{ ...s.td, ...s.tdR }}>{g.pitch_count ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.plate_appearances ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.green }}>{g.strikeouts ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.orange }}>{g.walks ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: g.home_runs > 0 ? C.red : C.text }}>{g.home_runs ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.hard_hit_pct != null ? pct(g.hard_hit_pct) : '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.avg_velocity != null ? fmt(g.avg_velocity) : '—'}</td></tr>)}</tbody></table></div></div>}
-      </>}
-    </div>
-  )
+  return <div><h1 style={{ fontSize: 24, fontWeight: 800, marginBottom: 20 }}>Pitcher Profile</h1><div style={{ position: 'relative', marginBottom: 26 }}><div style={s.searchRow}><input style={s.input} placeholder="Search pitcher by name" value={query} onChange={onQueryChange} autoComplete="off" />{searching && <span style={{ color: C.muted, fontSize: 13, alignSelf: 'center' }}>Searching…</span>}</div>{results.length > 0 && <div style={searchDropStyle}>{results.slice(0, 10).map((p, i) => <div key={p.id} style={searchItemStyle(i === hoverIdx)} onMouseEnter={() => setHoverIdx(i)} onMouseLeave={() => setHoverIdx(-1)} onClick={() => selectPlayer(p)}><span style={{ color: C.text }}>{p.name}</span><span style={{ color: C.muted, fontSize: 12 }}>{p.team || ''}</span></div>)}</div>}</div>{!id && <PitcherLeaderboardDashboard data={leaderboards} loading={lbLoading} />}{loading && <div style={s.loader}>Loading…</div>}{error && <div style={s.error}>{error}</div>}{id && !loading && !error && !data && <div style={s.hint}>Search for a pitcher by name to view their stats.</div>}{data?.no_data && <div style={s.error}>No Statcast data on file for {data.player_name || `pitcher ${id}`}.</div>}{data && !data.no_data && <><div style={s.hero}><div style={s.playerName}>{data.player_name || data.player_info?.name || `Pitcher #${id}`}</div><div style={s.sub}>Pitcher profile built from aggregate performance, arsenal quality, release traits, and plate-location outcomes.</div><div style={s.chipRow}><span style={s.chip}>MLB ID {id}</span>{data.data_source && <span style={s.chip}>{data.data_source}</span>}{intelligence?.sample_size?.deduped_pitch_rows != null && <span style={s.chip}>{intelligence.sample_size.deduped_pitch_rows} tracked pitches</span>}</div></div>{id && <Link to={`/pitcher/${id}/rolling`} style={s.rollingLink}>View Rolling Stats →</Link>}<QABox intelligence={intelligence} />{currentCards.some(([, value]) => hasValue(value)) && <div style={s.section}><div style={s.sectionTitle}>Current Metrics</div><div style={s.grid}>{currentCards.map(([label, value]) => <StatCard key={label} label={label} value={value} />)}</div></div>}<IntelligenceSummary intelligence={intelligence} /><ReleaseProfileCard release={release} /><ArsenalCharts arsenal={arsenal} /><ArsenalTable arsenal={arsenal} /><LocationGrid profile={intelligence?.location_profile} />{multiSeason.some(r => r.avg_velocity != null || r.k_pct != null) && <div style={s.section}><div style={s.sectionTitle}>Season-by-Season</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Season', 'Velo', 'Spin', 'K%', 'BB%', 'Hard Hit%', 'xwOBA', 'xBA'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{multiSeason.map((row, i) => <tr key={i}><td style={{ ...s.td, fontWeight: 700, color: C.blue }}>{row.label}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_velocity)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.avg_spin_rate, 0)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.k_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.bb_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{pct(row.hard_hit_pct)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xwoba, 3)}</td><td style={{ ...s.td, ...s.tdR }}>{fmt(row.xba, 3)}</td></tr>)}</tbody></table></div></div>}{gameLog.length > 0 && <div style={s.section}><div style={s.sectionTitle}>Recent Outings</div><div style={s.tableWrap}><table style={s.table}><thead><tr>{['Date', 'Pitches', 'PA', 'K', 'BB', 'HR', 'HH%', 'Velo'].map((h, idx) => <th key={h} style={idx === 0 ? s.th : { ...s.th, ...s.thR }}>{h}</th>)}</tr></thead><tbody>{gameLog.map((g, i) => <tr key={i}><td style={{ ...s.td, color: C.muted, fontSize: 12 }}>{g.game_date}</td><td style={{ ...s.td, ...s.tdR }}>{g.pitch_count ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.plate_appearances ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.green }}>{g.strikeouts ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: C.orange }}>{g.walks ?? '—'}</td><td style={{ ...s.td, ...s.tdR, color: g.home_runs > 0 ? C.red : C.text }}>{g.home_runs ?? '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.hard_hit_pct != null ? pct(g.hard_hit_pct) : '—'}</td><td style={{ ...s.td, ...s.tdR }}>{g.avg_velocity != null ? fmt(g.avg_velocity) : '—'}</td></tr>)}</tbody></table></div></div>}</>}</div>
 }

--- a/mlb_app/pitcher_leaderboards.py
+++ b/mlb_app/pitcher_leaderboards.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import requests
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from mlb_app.database import PitchArsenal, PitcherAggregate
+from mlb_app.database import PitchArsenal, PitcherAggregate, StatcastEvent
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+MIN_PROFILE_PITCHES = 250
+MIN_DAMAGE_BBE = 35
+MIN_ARSENAL_PITCHES = 75
 
 
 def _fetch_pitcher_names(player_ids: Set[int]) -> Dict[int, Dict[str, Optional[str]]]:
-    """Best-effort player identity hydration for leaderboard display.
-
-    The aggregate tables are metric stores, not identity tables. Use MLB Stats
-    people hydrate to avoid ugly `Pitcher #ID` rows on the landing dashboard.
-    If this external lookup fails, callers still receive stable fallback rows.
-    """
     ids = sorted(pid for pid in player_ids if pid)
     if not ids:
         return {}
@@ -38,7 +36,7 @@ def _fetch_pitcher_names(player_ids: Set[int]) -> Dict[int, Dict[str, Optional[s
                     continue
                 team = person.get("currentTeam") or {}
                 out[int(pid)] = {
-                    "player_name": person.get("fullName") or f"Pitcher #{pid}",
+                    "player_name": person.get("fullName") or f"MLB ID {pid}",
                     "team": team.get("abbreviation") or team.get("name"),
                 }
         except Exception:
@@ -47,61 +45,166 @@ def _fetch_pitcher_names(player_ids: Set[int]) -> Dict[int, Dict[str, Optional[s
 
 
 def _display_name(pid: int, identities: Dict[int, Dict[str, Optional[str]]]) -> str:
-    return (identities.get(pid) or {}).get("player_name") or f"Pitcher #{pid}"
+    return (identities.get(pid) or {}).get("player_name") or f"MLB ID {pid}"
 
 
 def _team(pid: int, identities: Dict[int, Dict[str, Optional[str]]]) -> Optional[str]:
     return (identities.get(pid) or {}).get("team")
 
 
-def _serialize_aggregate_row(row: PitcherAggregate, value: float, rank: int, identities: Dict[int, Dict[str, Optional[str]]]) -> Dict[str, Any]:
+def _event_samples(session: Session, season: int) -> Dict[int, Dict[str, int]]:
+    rows = (
+        session.query(
+            StatcastEvent.pitcher_id,
+            func.count(StatcastEvent.id),
+            func.count(StatcastEvent.launch_speed),
+        )
+        .filter(StatcastEvent.game_date >= dt.date(int(season), 1, 1))
+        .group_by(StatcastEvent.pitcher_id)
+        .all()
+    )
+    return {int(pid): {"pitches": int(pitches or 0), "batted_balls": int(bbe or 0)} for pid, pitches, bbe in rows if pid}
+
+
+def _latest_aggregates(session: Session, season: int) -> List[PitcherAggregate]:
+    rows = (
+        session.query(PitcherAggregate)
+        .filter(PitcherAggregate.end_date >= dt.date(int(season), 1, 1))
+        .order_by(PitcherAggregate.end_date.desc())
+        .all()
+    )
+    latest_by_pitcher: Dict[int, PitcherAggregate] = {}
+    for row in rows:
+        latest_by_pitcher.setdefault(row.pitcher_id, row)
+    return list(latest_by_pitcher.values())
+
+
+def _sample_label(pid: int, samples: Dict[int, Dict[str, int]], fallback: Optional[str] = None) -> str:
+    sample = samples.get(pid) or {}
+    pitches = sample.get("pitches") or 0
+    bbe = sample.get("batted_balls") or 0
+    if pitches:
+        return f"{pitches} pitches · {bbe} BBE"
+    return fallback or "sample pending"
+
+
+def _row(pid: int, value: float, rank: int, identities: Dict[int, Dict[str, Optional[str]]], samples: Dict[int, Dict[str, int]], *, sample: Optional[str] = None, detail: Optional[str] = None, extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     return {
         "rank": rank,
-        "player_id": row.pitcher_id,
-        "player_name": _display_name(row.pitcher_id, identities),
-        "team": _team(row.pitcher_id, identities),
-        "value": value,
-        "sample": row.window,
-        "window": row.window,
-        "end_date": row.end_date.isoformat() if row.end_date else None,
+        "player_id": pid,
+        "player_name": _display_name(pid, identities),
+        "team": _team(pid, identities),
+        "value": round(float(value), 4),
+        "sample": sample or _sample_label(pid, samples),
+        "detail": detail,
+        **(extra or {}),
     }
 
 
-def _aggregate_board(rows: List[PitcherAggregate], attr: str, *, limit: int, reverse: bool, identities: Dict[int, Dict[str, Optional[str]]]) -> List[Dict[str, Any]]:
-    usable = []
-    for row in rows:
-        value = getattr(row, attr, None)
-        if value is None:
-            continue
-        usable.append((row, float(value)))
-    usable.sort(key=lambda item: item[1], reverse=reverse)
-    return [_serialize_aggregate_row(row, value, idx + 1, identities) for idx, (row, value) in enumerate(usable[:limit])]
+def _rank_profile(rows: List[Tuple[PitcherAggregate, float, str]], identities: Dict[int, Dict[str, Optional[str]]], samples: Dict[int, Dict[str, int]], limit: int) -> List[Dict[str, Any]]:
+    rows.sort(key=lambda item: item[1], reverse=True)
+    return [_row(row.pitcher_id, value, idx + 1, identities, samples, detail=detail) for idx, (row, value, detail) in enumerate(rows[:limit])]
 
 
-def _pitch_board(rows: List[PitchArsenal], attr: str, *, limit: int, reverse: bool, identities: Dict[int, Dict[str, Optional[str]]]) -> List[Dict[str, Any]]:
+def _quality_profiles(latest: List[PitcherAggregate], samples: Dict[int, Dict[str, int]], identities: Dict[int, Dict[str, Optional[str]]], limit: int) -> List[Dict[str, Any]]:
+    scored = []
+    for row in latest:
+        sample = samples.get(row.pitcher_id, {})
+        if (sample.get("pitches") or 0) < MIN_PROFILE_PITCHES:
+            continue
+        if None in (row.k_pct, row.bb_pct, row.xwoba, row.hard_hit_pct):
+            continue
+        k_minus_bb = float(row.k_pct) - float(row.bb_pct)
+        value = (k_minus_bb * 1.6) + ((0.330 - float(row.xwoba)) * 2.2) + ((0.380 - float(row.hard_hit_pct)) * 0.9)
+        if row.avg_velocity is not None:
+            value += (float(row.avg_velocity) - 92.0) / 100.0
+        detail = f"K-BB {k_minus_bb * 100:.1f}% · xwOBA {row.xwoba:.3f} · HH {row.hard_hit_pct * 100:.1f}%"
+        scored.append((row, value, detail))
+    return _rank_profile(scored, identities, samples, limit)
+
+
+def _command_profiles(latest: List[PitcherAggregate], samples: Dict[int, Dict[str, int]], identities: Dict[int, Dict[str, Optional[str]]], limit: int) -> List[Dict[str, Any]]:
+    scored = []
+    for row in latest:
+        sample = samples.get(row.pitcher_id, {})
+        if (sample.get("pitches") or 0) < MIN_PROFILE_PITCHES:
+            continue
+        if row.k_pct is None or row.bb_pct is None:
+            continue
+        value = float(row.k_pct) - float(row.bb_pct)
+        detail = f"K {row.k_pct * 100:.1f}% · BB {row.bb_pct * 100:.1f}%"
+        scored.append((row, value, detail))
+    return _rank_profile(scored, identities, samples, limit)
+
+
+def _damage_profiles(latest: List[PitcherAggregate], samples: Dict[int, Dict[str, int]], identities: Dict[int, Dict[str, Optional[str]]], limit: int) -> List[Dict[str, Any]]:
+    scored = []
+    for row in latest:
+        sample = samples.get(row.pitcher_id, {})
+        if (sample.get("pitches") or 0) < MIN_PROFILE_PITCHES or (sample.get("batted_balls") or 0) < MIN_DAMAGE_BBE:
+            continue
+        if row.xwoba is None or row.hard_hit_pct is None:
+            continue
+        value = (0.330 - float(row.xwoba)) + ((0.380 - float(row.hard_hit_pct)) * 0.45)
+        detail = f"xwOBA {row.xwoba:.3f} · HH {row.hard_hit_pct * 100:.1f}%"
+        scored.append((row, value, detail))
+    return _rank_profile(scored, identities, samples, limit)
+
+
+def _release_profiles(latest: List[PitcherAggregate], samples: Dict[int, Dict[str, int]], identities: Dict[int, Dict[str, Optional[str]]], limit: int) -> List[Dict[str, Any]]:
+    scored = []
+    for row in latest:
+        sample = samples.get(row.pitcher_id, {})
+        if (sample.get("pitches") or 0) < MIN_PROFILE_PITCHES:
+            continue
+        if row.avg_release_extension is None or row.avg_velocity is None:
+            continue
+        value = float(row.avg_release_extension) + ((float(row.avg_velocity) - 92.0) / 10.0)
+        detail = f"Ext {row.avg_release_extension:.2f} ft · Velo {row.avg_velocity:.1f}"
+        scored.append((row, value, detail))
+    return _rank_profile(scored, identities, samples, limit)
+
+
+def _power_profiles(latest: List[PitcherAggregate], samples: Dict[int, Dict[str, int]], identities: Dict[int, Dict[str, Optional[str]]], limit: int) -> List[Dict[str, Any]]:
+    scored = []
+    for row in latest:
+        sample = samples.get(row.pitcher_id, {})
+        if (sample.get("pitches") or 0) < MIN_PROFILE_PITCHES:
+            continue
+        if row.avg_velocity is None:
+            continue
+        spin_bonus = ((float(row.avg_spin_rate or 0) - 2300.0) / 10000.0) if row.avg_spin_rate else 0.0
+        extension_bonus = ((float(row.avg_release_extension or 0) - 6.0) / 10.0) if row.avg_release_extension else 0.0
+        value = (float(row.avg_velocity) - 90.0) / 10.0 + spin_bonus + extension_bonus
+        detail = f"Velo {row.avg_velocity:.1f}" + (f" · Spin {row.avg_spin_rate:.0f}" if row.avg_spin_rate else "")
+        scored.append((row, value, detail))
+    return _rank_profile(scored, identities, samples, limit)
+
+
+def _arsenal_profiles(rows: List[PitchArsenal], identities: Dict[int, Dict[str, Optional[str]]], samples: Dict[int, Dict[str, int]], limit: int) -> List[Dict[str, Any]]:
     usable = []
     for row in rows:
-        value = getattr(row, attr, None)
-        if value is None:
+        if (row.pitch_count or 0) < MIN_ARSENAL_PITCHES:
             continue
-        usable.append((row, float(value)))
-    usable.sort(key=lambda item: item[1], reverse=reverse)
+        if row.whiff_pct is None or row.xwoba is None:
+            continue
+        value = (float(row.whiff_pct) * 1.2) + ((0.330 - float(row.xwoba)) * 1.8)
+        label = row.pitch_name or row.pitch_type or "Pitch"
+        detail = f"{label} · Whiff {row.whiff_pct * 100:.1f}% · xwOBA {row.xwoba:.3f}"
+        usable.append((row, value, detail))
+    usable.sort(key=lambda item: item[1], reverse=True)
     board = []
-    for idx, (row, value) in enumerate(usable[:limit]):
-        pitch_label = row.pitch_name or row.pitch_type or "Pitch"
-        board.append({
-            "rank": idx + 1,
-            "player_id": row.pitcher_id,
-            "player_name": _display_name(row.pitcher_id, identities),
-            "team": _team(row.pitcher_id, identities),
-            "value": value,
-            "sample": f"{pitch_label} · {row.pitch_count or 0} pitches",
-            "window": str(row.season),
-            "pitch_type": row.pitch_type,
-            "pitch_name": row.pitch_name,
-            "pitch_count": row.pitch_count,
-            "end_date": None,
-        })
+    for idx, (row, value, detail) in enumerate(usable[:limit]):
+        board.append(_row(
+            row.pitcher_id,
+            value,
+            idx + 1,
+            identities,
+            samples,
+            sample=f"{row.pitch_count or 0} {row.pitch_name or row.pitch_type or 'pitch'}",
+            detail=detail,
+            extra={"pitch_type": row.pitch_type, "pitch_name": row.pitch_name, "pitch_count": row.pitch_count},
+        ))
     return board
 
 
@@ -109,34 +212,19 @@ def build_pitcher_leaderboards(session: Session, season: Optional[int] = None, l
     if season is None:
         season = dt.date.today().year
 
-    aggregate_rows = (
-        session.query(PitcherAggregate)
-        .filter(PitcherAggregate.end_date >= dt.date(int(season), 1, 1))
-        .order_by(PitcherAggregate.end_date.desc())
-        .all()
-    )
-
-    latest_by_pitcher: Dict[int, PitcherAggregate] = {}
-    for row in aggregate_rows:
-        latest_by_pitcher.setdefault(row.pitcher_id, row)
-    latest = list(latest_by_pitcher.values())
-
+    samples = _event_samples(session, int(season))
+    latest = _latest_aggregates(session, int(season))
     arsenal_rows = session.query(PitchArsenal).filter(PitchArsenal.season == int(season)).all()
     identity_ids = {row.pitcher_id for row in latest} | {row.pitcher_id for row in arsenal_rows}
     identities = _fetch_pitcher_names(identity_ids)
 
     leaderboards = {
-        "avg_velocity": _aggregate_board(latest, "avg_velocity", limit=limit, reverse=True, identities=identities),
-        "avg_spin_rate": _aggregate_board(latest, "avg_spin_rate", limit=limit, reverse=True, identities=identities),
-        "k_pct": _aggregate_board(latest, "k_pct", limit=limit, reverse=True, identities=identities),
-        "bb_pct_lowest": _aggregate_board(latest, "bb_pct", limit=limit, reverse=False, identities=identities),
-        "hard_hit_pct_lowest": _aggregate_board(latest, "hard_hit_pct", limit=limit, reverse=False, identities=identities),
-        "xwoba_lowest": _aggregate_board(latest, "xwoba", limit=limit, reverse=False, identities=identities),
-        "xba_lowest": _aggregate_board(latest, "xba", limit=limit, reverse=False, identities=identities),
-        "extension": _aggregate_board(latest, "avg_release_extension", limit=limit, reverse=True, identities=identities),
-        "release_height": _aggregate_board(latest, "avg_release_pos_z", limit=limit, reverse=True, identities=identities),
-        "arsenal_whiff": _pitch_board(arsenal_rows, "whiff_pct", limit=limit, reverse=True, identities=identities),
-        "arsenal_xwoba_lowest": _pitch_board(arsenal_rows, "xwoba", limit=limit, reverse=False, identities=identities),
+        "pitcher_quality": _quality_profiles(latest, samples, identities, limit),
+        "command_index": _command_profiles(latest, samples, identities, limit),
+        "damage_suppression": _damage_profiles(latest, samples, identities, limit),
+        "power_stuff": _power_profiles(latest, samples, identities, limit),
+        "release_weapon": _release_profiles(latest, samples, identities, limit),
+        "arsenal_weapon": _arsenal_profiles(arsenal_rows, identities, samples, limit),
     }
 
     unavailable = [key for key, rows in leaderboards.items() if not rows]
@@ -145,9 +233,14 @@ def build_pitcher_leaderboards(session: Session, season: Optional[int] = None, l
         "limit": int(limit),
         "leaderboards": leaderboards,
         "identity_source": "mlb_stats_api_people" if identities else "fallback_player_id",
+        "sample_rules": {
+            "profile_min_pitches": MIN_PROFILE_PITCHES,
+            "arsenal_min_pitch_count": MIN_ARSENAL_PITCHES,
+            "damage_min_batted_balls": MIN_DAMAGE_BBE,
+        },
         "notes": [
-            "Pitcher leaderboard rows use PitcherAggregate and PitchArsenal, with MLB Stats API identity hydration for display names.",
-            "Release leaderboards use PitcherAggregate release fields. Plate-location visuals use plate_x/plate_z in the pitcher intelligence endpoint.",
+            "Landing boards use baseball-composite indexes with minimum samples instead of raw lowest/highest rate traps.",
+            "Release leaderboards use PitcherAggregate release fields; location visuals use plate_x/plate_z in the pitcher intelligence endpoint.",
         ],
         "unavailable_metrics": unavailable,
     }


### PR DESCRIPTION
## Summary

Follow-up pass on the pitcher landing page after the screenshots showed the dashboard still lacked real baseball logic. The prior version had technically populated leaderboards, but raw rate boards produced bad baseball artifacts: tiny-sample K% outliers, 0.0% BB% boards, generic contact boards, and too much stat-list noise.

This PR changes the landing page from raw stat leaderboards into baseball-composite intelligence boards with minimum sample rules.

## Backend changes

File changed:

- `mlb_app/pitcher_leaderboards.py`

### Replaces raw leaderboards with composite boards

New board keys:

- `pitcher_quality`
- `command_index`
- `damage_suppression`
- `power_stuff`
- `release_weapon`
- `arsenal_weapon`

### Adds sample discipline

Uses `statcast_events` counts to filter out junk samples:

- profile boards require at least 250 pitches
- damage board requires at least 35 batted balls
- arsenal board requires at least 75 pitches of that pitch type

### Baseball logic by board

- **Overall Pitcher Quality:** blends K-BB%, xwOBA suppression, hard-hit suppression, and velocity.
- **Command Edge:** K% minus BB%, not raw K% or raw lowest BB%.
- **Damage Suppression:** xwOBA and hard-hit prevention with batted-ball sample filter.
- **Power Stuff:** velocity, spin, and extension blend.
- **Release Weapon:** extension plus velocity.
- **Best Individual Pitch:** pitch-level whiff% plus xwOBA suppression, with pitch-count minimum.

This removes the 0.0% BB leaderboard and 100% K tiny-sample nonsense.

## Frontend changes

File changed:

- `frontend/src/pages/PitcherPage.jsx`

### Landing page retitled and reframed

- Hero now says `Pitching Intelligence Board`.
- Copy explicitly says these are not raw rate traps.
- Chips show sample rules.
- Cards are labeled as baseball indexes, not generic stat rankings.
- Leaderboard rows show detail strings like `K-BB 18.2% · xwOBA .284 · HH 33.1%` instead of just `90d`.

## Safety

- Does not touch canonical probability logic.
- Does not touch homepage or Batter Page.
- Does not change `/pitcher/{id}/intelligence`.
- Does not add per-pitcher fanout calls to the landing page.
- Keeps MLB name hydration from prior PR.

## Manual QA checklist

- `/pitcher` should no longer show raw BB% lowest or raw K% traps.
- `/pitcher` should show composite baseball intelligence boards.
- Rows should include baseball explanation detail, not just window labels.
- `/pitcher/{id}` still loads individual profile, charts, release profile, location grid, and game log.
- Search still works.

## Next recommended PR

Improve the individual pitcher page visual hierarchy next: fewer charts above the fold, better PitchProfiler-style pitch cards, and a true location heatmap instead of the current 3x3 grid.