### PR TITLE
Hotfix: restore My Dashboard page render

### DIFF
--- a/frontend/src/pages/MyDashboardWorkspacePage.jsx
+++ b/frontend/src/pages/MyDashboardWorkspacePage.jsx
@@ -1,19 +1,47 @@
+
 import React, { useEffect, useMemo, useState } from 'react'
+import { DEFAULT_BUILDER_FIELDS, collectBuilderFieldGroups, getValueByPath } from './myDashboardWorkspaceFieldLibrary'
 
 const API = import.meta.env.VITE_API_BASE_URL || ''
 const CACHE_PREFIX = 'my-dashboard:v5:'
 const DASHBOARD_SESSION_STORAGE_KEY = 'mlbgpt_dashboard_session_token'
+const SHELF_PREF_KEY = 'my-dashboard:v6:saved-shelf-open'
+const SURFACE_PREF_KEY = 'my-dashboard:v6:surface'
+const ACTIVE_COMPONENT_PREF_KEY = 'my-dashboard:v6:active-component'
 
 const COMPONENTS = [
-  { key: 'hitters', title: 'My Top Hitters Today', description: 'Stored 365 hitter board with pitch-type matchup, EV, LA, and arsenal context.' },
-  { key: 'pitchers', title: 'My Top Pitchers Today', description: 'Pitcher lean board using K profile, contact suppression, and opponent context.' },
-  { key: 'teams', title: 'My Top Teams Today', description: 'Team board from model side edge, projected runs, and offense profile.' },
-  { key: 'totals', title: 'My Top Totals Today', description: 'Game total board from projected runs, run environment, and simulation context.' },
-  { key: 'overall_players', title: 'My Top Overall Players Today', description: 'Combined player board blending hitter and pitcher solver outputs.' },
+  { key: 'hitters', title: 'My Top Hitters Today', shortTitle: 'Hitters', description: 'Stored 365 hitter board with pitch-type matchup, EV, LA, and arsenal context.' },
+  { key: 'pitchers', title: 'My Top Pitchers Today', shortTitle: 'Pitchers', description: 'Pitcher lean board using K profile, contact suppression, and opponent context.' },
+  { key: 'teams', title: 'My Top Teams Today', shortTitle: 'Teams', description: 'Team board from model side edge, projected runs, and offense profile.' },
+  { key: 'totals', title: 'My Top Totals Today', shortTitle: 'Totals', description: 'Game total board from projected runs, run environment, and simulation context.' },
+  { key: 'overall_players', title: 'My Top Overall Players Today', shortTitle: 'Overall', description: 'Combined player board blending hitter and pitcher solver outputs.' },
 ]
 
 const FEATURE_CHOICES = ['Matchups', 'Daily Odds', 'Model Projections', 'News', 'Props', 'Pitchers', 'Batters']
 const BASIC_FILTERS = { search_text: '', team: '', opponent: '', min_score: '', max_score: '', min_confidence: '', category: '', player_type: '', pitch_type: '', source: '' }
+const SURFACES = [
+  { key: 'boards', label: 'Daily Boards', description: 'Run, filter, and save the live boards.' },
+  { key: 'builder', label: 'Create Dashboard', description: 'Select fields and shape your own report view.' },
+]
+
+const C = {
+  bg: '#0b1020',
+  canvas: '#111827',
+  canvasAlt: '#0f172a',
+  panel: '#111c34',
+  panelMuted: '#15213d',
+  panelElevated: '#192747',
+  border: 'rgba(148, 163, 184, 0.18)',
+  text: '#e5eefc',
+  muted: '#9aa9c7',
+  subtle: '#7f8fb0',
+  blue: '#5ea2ff',
+  blueSoft: 'rgba(94, 162, 255, 0.16)',
+  green: '#43c59e',
+  amber: '#f1b75c',
+  red: '#f87171',
+  purple: '#9f7aea',
+}
 
 function todayIso() { return new Date().toISOString().slice(0, 10) }
 function clone(value) { return JSON.parse(JSON.stringify(value)) }
@@ -24,8 +52,11 @@ function formatNumber(value) { const num = Number(value); if (!Number.isFinite(n
 function cacheKey(kind, payload) { return `${CACHE_PREFIX}${kind}:${JSON.stringify(payload)}` }
 function readSessionCache(key) { if (typeof window === 'undefined' || !window.sessionStorage) return null; try { const raw = window.sessionStorage.getItem(key); return raw ? JSON.parse(raw) : null } catch { return null } }
 function writeSessionCache(key, value) { if (typeof window === 'undefined' || !window.sessionStorage) return; try { window.sessionStorage.setItem(key, JSON.stringify(value)) } catch {} }
+function readSessionPref(key, fallback) { if (typeof window === 'undefined' || !window.sessionStorage) return fallback; try { const raw = window.sessionStorage.getItem(key); return raw == null ? fallback : JSON.parse(raw) } catch { return fallback } }
+function writeSessionPref(key, value) { if (typeof window === 'undefined' || !window.sessionStorage) return; try { window.sessionStorage.setItem(key, JSON.stringify(value)) } catch {} }
 function getDashboardSessionToken() { if (typeof window === 'undefined' || !window.localStorage) return ''; return window.localStorage.getItem(DASHBOARD_SESSION_STORAGE_KEY) || '' }
 function setDashboardSessionToken(token) { if (typeof window === 'undefined' || !window.localStorage) return; if (token) window.localStorage.setItem(DASHBOARD_SESSION_STORAGE_KEY, token); else window.localStorage.removeItem(DASHBOARD_SESSION_STORAGE_KEY) }
+
 function cleanFilters(filters) {
   const source = filters || {}
   const cleaned = {}
@@ -50,6 +81,7 @@ function cleanFilters(filters) {
   if (Object.keys(weights).length) cleaned.weights = weights
   return cleaned
 }
+
 function mergeFilterState(savedFilters) {
   return {
     ...emptyFilters(),
@@ -58,19 +90,593 @@ function mergeFilterState(savedFilters) {
     weights: clone(savedFilters?.weights || {}),
   }
 }
+
 function available(result, componentKey) {
   const defaults = {
-    hitters: { pitch_types: [], suggested_metric_filters: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'HardHit', 'Usage'], suggested_weight_metrics: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'Usage'] },
-    pitchers: { suggested_metric_filters: ['K%', 'xwOBA Allowed', 'HardHit Allowed', 'Opp K%', 'Score'], suggested_weight_metrics: ['K%', 'xwOBA Allowed', 'HardHit Allowed', 'Score'] },
-    teams: { suggested_metric_filters: ['Edge Score', 'Win Edge', 'Run Diff', 'ISO', 'OBP'], suggested_weight_metrics: ['Edge Score', 'Win Edge', 'Run Diff', 'ISO'] },
-    totals: { suggested_metric_filters: ['Projected Total', 'Raw Total', 'Run Index', 'Score'], suggested_weight_metrics: ['Projected Total', 'Run Index', 'Score'] },
-    overall_players: { suggested_metric_filters: ['Score'], suggested_weight_metrics: ['Score'] },
+    hitters: {
+      pitch_types: [],
+      suggested_metric_filters: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'HardHit', 'Usage'],
+      suggested_weight_metrics: ['EV', 'LA', 'Pitches Seen', 'xwOBA', 'Usage'],
+    },
+    pitchers: {
+      suggested_metric_filters: ['K%', 'xwOBA Allowed', 'HardHit Allowed', 'Opp K%', 'Score'],
+      suggested_weight_metrics: ['K%', 'xwOBA Allowed', 'HardHit Allowed', 'Score'],
+    },
+    teams: {
+      suggested_metric_filters: ['Edge Score', 'Win Edge', 'Run Diff', 'ISO', 'OBP'],
+      suggested_weight_metrics: ['Edge Score', 'Win Edge', 'Run Diff', 'ISO'],
+    },
+    totals: {
+      suggested_metric_filters: ['Projected Total', 'Raw Total', 'Run Index', 'Score'],
+      suggested_weightMetrics: ['Projected Total', 'Run Index', 'Score'],
+      suggested_weight_metrics: ['Projected Total', 'Run Index', 'Score'],
+    },
+    overall_players: {
+      suggested_metric_filters: ['Score'],
+      suggested_weight_metrics: ['Score'],
+    },
   }
   return { ...(defaults[componentKey] || {}), ...(result?.available_filters || {}) }
 }
+
 function emptySaveDraft(folderId = '') { return { folder_id: folderId, title: '', subtitle: '', notes: '' } }
 function defaultSaveDrafts(folderId = '') { return Object.fromEntries(COMPONENTS.map(component => [component.key, emptySaveDraft(folderId)])) }
 function sourceComponentKey(item) { return item?.payload_json?.saved_from_component || item?.payload_json?.component_key || item?.payload_json?.board_state?.component || null }
+function ensureArray(value) { return Array.isArray(value) ? value : [] }
+function metricEntries(item) { return Object.entries(item?.metrics || {}) }
+function trimText(value) { return typeof value === 'string' ? value.trim() : value }
+
+function compareValues(a, b, direction = 'desc') {
+  const left = a == null ? '' : a
+  const right = b == null ? '' : b
+  if (typeof left === 'number' && typeof right === 'number') return direction === 'asc' ? left - right : right - left
+  return direction === 'asc' ? String(left).localeCompare(String(right)) : String(right).localeCompare(String(left))
+}
+
+function StatusPill({ children, tone = 'default' }) {
+  const toneMap = {
+    default: { background: C.blueSoft, color: C.blue },
+    success: { background: 'rgba(67, 197, 158, 0.14)', color: C.green },
+    warning: { background: 'rgba(241, 183, 92, 0.14)', color: C.amber },
+    danger: { background: 'rgba(248, 113, 113, 0.14)', color: C.red },
+  }
+  const style = toneMap[tone] || toneMap.default
+  return <span style={{ ...styles.pill, background: style.background, color: style.color }}>{children}</span>
+}
+
+function SectionCard({ title, subtitle, action, children, dense = false }) {
+  return (
+    <section style={{ ...styles.sectionCard, padding: dense ? 16 : 18 }}>
+      <div style={styles.sectionHeader}>
+        <div>
+          <div style={styles.sectionTitle}>{title}</div>
+          {subtitle ? <div style={styles.sectionSubtitle}>{subtitle}</div> : null}
+        </div>
+        {action}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function WorkspaceNav({ activeSurface, setActiveSurface, activeComponent, setActiveComponent, results }) {
+  return (
+    <aside style={styles.navRail}>
+      <div style={styles.brandBlock}>
+        <div style={styles.brandEyebrow}>Workspace</div>
+        <div style={styles.brandTitle}>My Dashboard</div>
+        <div style={styles.brandSubtitle}>Cleaner board control, better saved-state UX, and a report-builder canvas.</div>
+      </div>
+      <div style={styles.navGroup}>
+        {SURFACES.map(surface => (
+          <button key={surface.key} type="button" onClick={() => setActiveSurface(surface.key)} style={activeSurface === surface.key ? styles.navButtonActive : styles.navButton}>
+            <div style={styles.navButtonTitle}>{surface.label}</div>
+            <div style={styles.navButtonSubtitle}>{surface.description}</div>
+          </button>
+        ))}
+      </div>
+      <div style={styles.navGroupLabel}>Board sources</div>
+      <div style={styles.navGroup}>
+        {COMPONENTS.map(component => {
+          const count = ensureArray(results?.[component.key]?.items).length
+          return (
+            <button key={component.key} type="button" onClick={() => { setActiveSurface('boards'); setActiveComponent(component.key) }} style={activeComponent === component.key ? styles.subNavButtonActive : styles.subNavButton}>
+              <span>{component.shortTitle}</span>
+              <span style={styles.subNavCount}>{count}</span>
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}
+
+function CommandBar({ profile, folders, todayCount, setActiveSurface, loadWorkspace, runAllBoards, saveMessage }) {
+  return (
+    <section style={styles.commandBar}>
+      <div>
+        <div style={styles.eyebrow}>My Dashboard</div>
+        <h1 style={styles.pageTitle}>Welcome back, {profile.username}</h1>
+        <p style={styles.pageSubtitle}>Enterprise workspace shell, retractable saved boards, cleaner board management, and a customizable builder without touching the solver logic.</p>
+      </div>
+      <div style={styles.commandRight}>
+        <div style={styles.accountMetaCard}>
+          <div style={styles.metaLine}>Email: {profile.email}</div>
+          <div style={styles.metaLine}>Plan: {profile.preferences?.plan_type || 'free'}</div>
+          <div style={styles.metaLine}>Folders: {folders.length}</div>
+          <div style={styles.metaLine}>Today saved: {todayCount}</div>
+        </div>
+        <div style={styles.commandButtons}>
+          <button type="button" onClick={loadWorkspace} style={styles.secondaryButton}>Refresh workspace</button>
+          <button type="button" onClick={() => runAllBoards()} style={styles.primaryButton}>Populate all</button>
+          <button type="button" onClick={() => runAllBoards({ activeLineups: true })} style={styles.secondaryButton}>Confirmed lineups only</button>
+          <button type="button" onClick={() => setActiveSurface('builder')} style={styles.ghostButton}>Create dashboard</button>
+        </div>
+        {saveMessage ? <div style={styles.successBanner}>{saveMessage}</div> : null}
+      </div>
+    </section>
+  )
+}
+
+function SavedBoardsShelf({
+  open,
+  onToggle,
+  folders,
+  todayCount,
+  newFolder,
+  setNewFolder,
+  createFolder,
+  creatingFolder,
+  selectedFolderId,
+  setSelectedFolderId,
+  selectedSavedItemId,
+  setSelectedSavedItemId,
+  restoreSavedState,
+}) {
+  const selectedFolder = folders.find(folder => String(folder.id) === String(selectedFolderId)) || folders[0] || null
+  const selectedItem = ensureArray(selectedFolder?.items).find(item => String(item.id) === String(selectedSavedItemId)) || ensureArray(selectedFolder?.items)[0] || null
+
+  useEffect(() => {
+    if (!selectedFolder && folders[0]) setSelectedFolderId(String(folders[0].id))
+  }, [folders, selectedFolder, setSelectedFolderId])
+
+  useEffect(() => {
+    if (!selectedItem && selectedFolder?.items?.[0]) setSelectedSavedItemId(String(selectedFolder.items[0].id))
+  }, [selectedFolder, selectedItem, setSelectedSavedItemId])
+
+  return (
+    <SectionCard
+      title="Saved Boards"
+      subtitle="A retractable folder-first browser for saved board states and saved items."
+      action={<button type="button" onClick={onToggle} style={styles.secondaryButton}>{open ? 'Collapse shelf' : 'Expand shelf'}</button>}
+    >
+      <div style={styles.shelfSummaryRow}>
+        <StatusPill>{folders.length} folders</StatusPill>
+        <StatusPill tone="success">{todayCount} saved today</StatusPill>
+        <StatusPill tone="warning">{folders.reduce((sum, folder) => sum + (folder.item_count || 0), 0)} total items</StatusPill>
+      </div>
+      {!open ? null : (
+        <div style={styles.shelfContentGrid}>
+          <div style={styles.folderColumn}>
+            <div style={styles.inlineRow}>
+              <input style={styles.input} placeholder="New folder title" value={newFolder.folder_name} onChange={e => setNewFolder(prev => ({ ...prev, folder_name: e.target.value }))} />
+              <input style={styles.input} type="date" value={newFolder.folder_date} onChange={e => setNewFolder(prev => ({ ...prev, folder_date: e.target.value }))} />
+              <button type="button" onClick={createFolder} style={styles.primaryButton} disabled={creatingFolder}>{creatingFolder ? 'Creating…' : 'Create folder'}</button>
+            </div>
+            <div style={styles.folderList}>
+              {folders.length === 0 ? <div style={styles.emptyState}>No folders yet.</div> : folders.map(folder => {
+                const active = String(folder.id) === String(selectedFolderId)
+                return (
+                  <button key={folder.id} type="button" onClick={() => { setSelectedFolderId(String(folder.id)); setSelectedSavedItemId('') }} style={active ? styles.folderButtonActive : styles.folderButton}>
+                    <div>
+                      <div style={styles.folderTitle}>📁 {folder.folder_name}</div>
+                      <div style={styles.folderMeta}>{folder.folder_date || (folder.is_default ? 'Default dashboard' : 'No date')}</div>
+                    </div>
+                    <div style={styles.countBadge}>{folder.item_count || 0}</div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+          <div style={styles.folderDetailColumn}>
+            {!selectedFolder ? (
+              <div style={styles.emptyState}>Select a folder to browse saved dashboards.</div>
+            ) : (
+              <>
+                <div style={styles.folderHeader}>
+                  <div>
+                    <div style={styles.sectionTitle}>{selectedFolder.folder_name}</div>
+                    <div style={styles.sectionSubtitle}>{selectedFolder.folder_date || 'No folder date'} • {selectedFolder.item_count || 0} saved items</div>
+                  </div>
+                </div>
+                <div style={styles.folderInspectorGrid}>
+                  <div style={styles.savedList}>
+                    {ensureArray(selectedFolder.items).length === 0 ? <div style={styles.emptyState}>No saved items in this folder.</div> : ensureArray(selectedFolder.items).map(item => {
+                      const active = String(item.id) === String(selectedItem?.id)
+                      return (
+                        <button key={item.id} type="button" onClick={() => setSelectedSavedItemId(String(item.id))} style={active ? styles.savedItemButtonActive : styles.savedItemButton}>
+                          <div style={styles.savedItemTitle}>{item.title}</div>
+                          <div style={styles.savedItemMeta}>{item.subtitle || item.source_type}</div>
+                          <div style={styles.savedItemMeta}>Source: {item.source_tab} • {item.source_type}</div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                  <div style={styles.savedInspector}>
+                    {!selectedItem ? <div style={styles.emptyState}>Choose a saved item to inspect its details.</div> : (
+                      <>
+                        <div style={styles.savedInspectorTitle}>{selectedItem.title}</div>
+                        <div style={styles.savedInspectorSubtitle}>{selectedItem.subtitle || selectedItem.source_type}</div>
+                        {selectedItem.notes ? <div style={styles.notesBox}>{selectedItem.notes}</div> : null}
+                        <div style={styles.metaWrap}>
+                          <StatusPill>{selectedItem.source_type}</StatusPill>
+                          <StatusPill tone="success">{sourceComponentKey(selectedItem) || 'saved'}</StatusPill>
+                        </div>
+                        <div style={styles.metaWrap}>
+                          {selectedItem.filter_json ? Object.keys(selectedItem.filter_json).slice(0, 6).map(key => <span key={`${selectedItem.id}-${key}`} style={styles.metricPill}>{key}</span>) : null}
+                        </div>
+                        <button type="button" onClick={() => restoreSavedState(selectedItem)} style={styles.primaryButton}>Load saved state</button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </SectionCard>
+  )
+}
+
+function BoardControls({
+  component,
+  result,
+  filterState,
+  helper,
+  draft,
+  folders,
+  activeLineups,
+  setBasicFilter,
+  setMetricFilter,
+  setWeight,
+  setSaveDraft,
+  resetFilters,
+  toggleActiveLineups,
+  saveBoardState,
+  runBoard,
+  loading,
+  runError,
+}) {
+  const metricFilters = ensureArray(helper.suggested_metric_filters).slice(0, 8)
+  const weightMetrics = ensureArray(helper.suggested_weight_metrics).slice(0, 6)
+
+  return (
+    <div style={styles.boardControlColumn}>
+      <SectionCard title="Board controls" subtitle={component.description}>
+        <div style={styles.metaWrap}>
+          <StatusPill>{ensureArray(result?.items).length} results</StatusPill>
+          <StatusPill tone="success">Before {result?.result_count_before_filters ?? '—'}</StatusPill>
+          <StatusPill tone="warning">After {result?.result_count_after_filters ?? '—'}</StatusPill>
+        </div>
+        {result?.filter_warnings?.length ? <div style={styles.warningBanner}>{result.filter_warnings.join(' • ')}</div> : null}
+        <label style={styles.checkboxRow}>
+          <input type="checkbox" checked={!!activeLineups} onChange={() => toggleActiveLineups(component.key)} />
+          Confirmed lineup players only on rerun
+        </label>
+        <div style={styles.buttonRow}>
+          <button type="button" onClick={() => runBoard(component.key)} style={styles.primaryButton} disabled={loading}>{loading ? 'Running…' : 'Run board'}</button>
+          <button type="button" onClick={() => runBoard(component.key, { preferCache: true })} style={styles.secondaryButton}>Use cached</button>
+          <button type="button" onClick={() => resetFilters(component.key)} style={styles.ghostButton}>Reset filters</button>
+        </div>
+        {runError ? <div style={styles.errorBanner}>{runError}</div> : null}
+      </SectionCard>
+
+      <SectionCard title="Default filters" subtitle="Keep the existing filter model, but present it more cleanly.">
+        <div style={styles.filterGrid}>
+          <input style={styles.smallInput} placeholder="Search" value={filterState.search_text || ''} onChange={e => setBasicFilter(component.key, 'search_text', e.target.value)} />
+          <input style={styles.smallInput} placeholder="Team" value={filterState.team || ''} onChange={e => setBasicFilter(component.key, 'team', e.target.value)} />
+          <input style={styles.smallInput} placeholder="Opponent" value={filterState.opponent || ''} onChange={e => setBasicFilter(component.key, 'opponent', e.target.value)} />
+          <input style={styles.smallInput} placeholder="Min score" value={filterState.min_score || ''} onChange={e => setBasicFilter(component.key, 'min_score', e.target.value)} />
+          <input style={styles.smallInput} placeholder="Max score" value={filterState.max_score || ''} onChange={e => setBasicFilter(component.key, 'max_score', e.target.value)} />
+          <select style={styles.smallInput} value={filterState.min_confidence || ''} onChange={e => setBasicFilter(component.key, 'min_confidence', e.target.value)}>
+            <option value="">Any confidence</option>
+            <option value="low">Low+</option>
+            <option value="medium">Medium+</option>
+            <option value="high">High only</option>
+          </select>
+          {component.key === 'hitters' ? (
+            <select style={styles.smallInput} value={filterState.pitch_type || ''} onChange={e => setBasicFilter(component.key, 'pitch_type', e.target.value)}>
+              <option value="">Any pitch type</option>
+              {ensureArray(helper.pitch_types).map(value => <option key={value} value={value}>{value}</option>)}
+            </select>
+          ) : null}
+          {ensureArray(helper.categories).length ? (
+            <select style={styles.smallInput} value={filterState.category || ''} onChange={e => setBasicFilter(component.key, 'category', e.target.value)}>
+              <option value="">Any category</option>
+              {ensureArray(helper.categories).map(value => <option key={value} value={value}>{value}</option>)}
+            </select>
+          ) : null}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Metric thresholds" subtitle="Min/max thresholds still map to the same payload shape.">
+        <div style={styles.metricGrid}>
+          {metricFilters.map(metric => (
+            <div key={`${component.key}-${metric}`} style={styles.metricCard}>
+              <div style={styles.metricTitle}>{metric}</div>
+              <div style={styles.metricInputRow}>
+                <input style={styles.smallInput} placeholder="Min" value={filterState.metrics?.[metric]?.min || ''} onChange={e => setMetricFilter(component.key, metric, 'min', e.target.value)} />
+                <input style={styles.smallInput} placeholder="Max" value={filterState.metrics?.[metric]?.max || ''} onChange={e => setMetricFilter(component.key, metric, 'max', e.target.value)} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Weighting" subtitle="Existing weight sliders, cleaner presentation.">
+        <div style={styles.sliderGrid}>
+          {weightMetrics.map(metric => {
+            const value = Number(filterState.weights?.[metric] ?? 1)
+            return (
+              <div key={`${component.key}-weight-${metric}`} style={styles.metricCard}>
+                <div style={styles.metricTitle}>{metric}</div>
+                <input type="range" min="0" max="2" step="0.1" value={value} onChange={e => setWeight(component.key, metric, e.target.value)} style={{ width: '100%' }} />
+                <div style={styles.sectionSubtitle}>Weight {value.toFixed(1)}</div>
+              </div>
+            )
+          })}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Save current board" subtitle="Folder-first save flow with title, subtitle, and notes.">
+        <div style={styles.filterGrid}>
+          <select style={styles.smallInput} value={draft.folder_id || ''} onChange={e => setSaveDraft(component.key, 'folder_id', e.target.value)}>
+            <option value="">Choose folder</option>
+            {folders.map(folder => <option key={folder.id} value={String(folder.id)}>{folder.folder_name}</option>)}
+          </select>
+          <input style={styles.smallInput} placeholder="Dashboard title" value={draft.title || ''} onChange={e => setSaveDraft(component.key, 'title', e.target.value)} />
+          <input style={styles.smallInput} placeholder="Subtitle" value={draft.subtitle || ''} onChange={e => setSaveDraft(component.key, 'subtitle', e.target.value)} />
+        </div>
+        <textarea style={styles.textArea} placeholder="Notes" value={draft.notes || ''} onChange={e => setSaveDraft(component.key, 'notes', e.target.value)} />
+        <button type="button" onClick={() => saveBoardState(component)} style={styles.primaryButton}>Save board state</button>
+      </SectionCard>
+    </div>
+  )
+}
+
+function ResultList({ component, result, saveItemToToday }) {
+  const items = ensureArray(result?.items)
+
+  return (
+    <div style={styles.boardResultsColumn}>
+      <SectionCard title={component.title} subtitle="Cleaner result cards with the same saved-item workflow.">
+        {items.length === 0 ? <div style={styles.emptyState}>No results yet. Run this board to populate fresh discovery for today.</div> : (
+          <div style={styles.resultsGrid}>
+            {items.map((item, index) => (
+              <article key={`${component.key}-${index}-${item.entity_id || item.entity_name || index}`} style={styles.resultCard}>
+                <div style={styles.resultTopRow}>
+                  <div>
+                    <div style={styles.resultTitle}>{item.entity_name || 'Unnamed result'}</div>
+                    <div style={styles.resultSubTitle}>{item.primary_reason || component.description}</div>
+                  </div>
+                  <div style={styles.resultScoreStack}>
+                    <div style={styles.scoreLabel}>Score</div>
+                    <div style={styles.scoreValue}>{formatNumber(item.score)}</div>
+                    <div style={styles.scoreConfidence}>{item.confidence || '—'}</div>
+                  </div>
+                </div>
+                <div style={styles.metaWrap}>
+                  {item.entity_type ? <StatusPill>{item.entity_type}</StatusPill> : null}
+                  {item.team ? <StatusPill tone="success">{item.team}</StatusPill> : null}
+                  {item.opponent ? <StatusPill tone="warning">vs {item.opponent}</StatusPill> : null}
+                </div>
+                <div style={styles.metricWrap}>
+                  {metricEntries(item).slice(0, 8).map(([key, value]) => (
+                    <div key={`${item.entity_id || item.entity_name}-${key}`} style={styles.metricChip}>
+                      <span style={styles.metricChipLabel}>{key}</span>
+                      <span style={styles.metricChipValue}>{formatNumber(value)}</span>
+                    </div>
+                  ))}
+                </div>
+                {ensureArray(item.reasoning).length ? (
+                  <ul style={styles.reasonList}>
+                    {ensureArray(item.reasoning).slice(0, 4).map((reason, idx) => <li key={`${item.entity_id || item.entity_name}-reason-${idx}`}>{reason}</li>)}
+                  </ul>
+                ) : null}
+                <div style={styles.buttonRow}>
+                  <button type="button" onClick={() => saveItemToToday(component, item)} style={styles.secondaryButton}>Save item to Today</button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </SectionCard>
+    </div>
+  )
+}
+
+function BuilderWorkspace({
+  builderState,
+  setBuilderState,
+  builderDraft,
+  setBuilderDraft,
+  fieldGroups,
+  builderItems,
+  builderFilters,
+  folders,
+  saveBuilderView,
+  runBoard,
+  loading,
+}) {
+  const selectedFieldSet = new Set(builderState.selectedFields || [])
+  const filteredGroups = fieldGroups
+    .map(group => ({
+      ...group,
+      fields: group.fields.filter(field => {
+        const query = trimText(builderState.search || '').toLowerCase()
+        if (!query) return true
+        return field.label.toLowerCase().includes(query) || field.accessor.toLowerCase().includes(query)
+      }),
+    }))
+    .filter(group => group.fields.length > 0)
+
+  const previewRows = useMemo(() => {
+    const rows = ensureArray(builderItems).map(item => {
+      const row = {}
+      ;(builderState.selectedFields || []).forEach(accessor => {
+        row[accessor] = getValueByPath(item, accessor)
+      })
+      return { __raw: item, ...row }
+    })
+
+    if (builderState.sortBy) {
+      rows.sort((left, right) => compareValues(left[builderState.sortBy], right[builderState.sortBy], builderState.sortDir))
+    }
+
+    return rows.slice(0, 12)
+  }, [builderItems, builderState.selectedFields, builderState.sortBy, builderState.sortDir])
+
+  function addField(accessor) {
+    if (selectedFieldSet.has(accessor)) return
+    setBuilderState(prev => ({ ...prev, selectedFields: [...prev.selectedFields, accessor] }))
+  }
+
+  function removeField(accessor) {
+    setBuilderState(prev => ({ ...prev, selectedFields: prev.selectedFields.filter(field => field !== accessor) }))
+  }
+
+  function moveField(accessor, direction) {
+    setBuilderState(prev => {
+      const current = [...prev.selectedFields]
+      const index = current.indexOf(accessor)
+      if (index < 0) return prev
+      const nextIndex = direction === 'up' ? index - 1 : index + 1
+      if (nextIndex < 0 || nextIndex >= current.length) return prev
+      const swap = current[nextIndex]
+      current[nextIndex] = accessor
+      current[index] = swap
+      return { ...prev, selectedFields: current }
+    })
+  }
+
+  return (
+    <div style={styles.builderGrid}>
+      <div style={styles.builderColumn}>
+        <SectionCard title="Builder source" subtitle="Choose the live board result set you want to shape into a custom dashboard.">
+          <div style={styles.filterGrid}>
+            <select style={styles.smallInput} value={builderState.component} onChange={e => setBuilderState(prev => ({ ...prev, component: e.target.value }))}>
+              {COMPONENTS.map(component => <option key={component.key} value={component.key}>{component.title}</option>)}
+            </select>
+            <input style={styles.smallInput} placeholder="Search fields" value={builderState.search || ''} onChange={e => setBuilderState(prev => ({ ...prev, search: e.target.value }))} />
+            <button type="button" onClick={() => runBoard(builderState.component)} style={styles.secondaryButton} disabled={loading}>{loading ? 'Refreshing…' : 'Refresh source board'}</button>
+          </div>
+          <div style={styles.metaWrap}>
+            <StatusPill>{ensureArray(builderItems).length} source rows</StatusPill>
+            <StatusPill tone="success">{(builderState.selectedFields || []).length} selected fields</StatusPill>
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Field library" subtitle="Built from the live board payloads, saved states, metrics, and identity fields already available in the app.">
+          <div style={styles.builderFieldGroups}>
+            {filteredGroups.map(group => (
+              <div key={group.groupKey} style={styles.fieldGroup}>
+                <div style={styles.fieldGroupTitle}>{group.title}</div>
+                <div style={styles.fieldList}>
+                  {group.fields.map(field => (
+                    <div key={field.accessor} style={styles.fieldRow}>
+                      <div>
+                        <div style={styles.fieldLabel}>{field.label}</div>
+                        <div style={styles.fieldAccessor}>{field.accessor}</div>
+                      </div>
+                      <button type="button" onClick={() => addField(field.accessor)} style={selectedFieldSet.has(field.accessor) ? styles.fieldAddButtonDisabled : styles.fieldAddButton} disabled={selectedFieldSet.has(field.accessor)}>
+                        {selectedFieldSet.has(field.accessor) ? 'Added' : 'Add'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div style={styles.builderColumn}>
+        <SectionCard title="Selected fields" subtitle="Reorder the canvas fields and shape the preview without changing solver logic.">
+          {(builderState.selectedFields || []).length === 0 ? <div style={styles.emptyState}>No fields selected yet.</div> : (
+            <div style={styles.selectedFieldList}>
+              {builderState.selectedFields.map((accessor, index) => (
+                <div key={accessor} style={styles.selectedFieldRow}>
+                  <div>
+                    <div style={styles.fieldLabel}>{accessor}</div>
+                    <div style={styles.fieldAccessor}>Column {index + 1}</div>
+                  </div>
+                  <div style={styles.selectedFieldActions}>
+                    <button type="button" onClick={() => moveField(accessor, 'up')} style={styles.iconButton}>↑</button>
+                    <button type="button" onClick={() => moveField(accessor, 'down')} style={styles.iconButton}>↓</button>
+                    <button type="button" onClick={() => removeField(accessor)} style={styles.iconButtonDanger}>✕</button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div style={styles.filterGrid}>
+            <select style={styles.smallInput} value={builderState.sortBy || ''} onChange={e => setBuilderState(prev => ({ ...prev, sortBy: e.target.value }))}>
+              <option value="">No sort</option>
+              {(builderState.selectedFields || []).map(accessor => <option key={`sort-${accessor}`} value={accessor}>{accessor}</option>)}
+            </select>
+            <select style={styles.smallInput} value={builderState.sortDir || 'desc'} onChange={e => setBuilderState(prev => ({ ...prev, sortDir: e.target.value }))}>
+              <option value="desc">Descending</option>
+              <option value="asc">Ascending</option>
+            </select>
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Builder save options" subtitle="Save the current board state plus the builder layout so it can be restored later.">
+          <div style={styles.filterGrid}>
+            <select style={styles.smallInput} value={builderDraft.folder_id || ''} onChange={e => setBuilderDraft(prev => ({ ...prev, folder_id: e.target.value }))}>
+              <option value="">Choose folder</option>
+              {folders.map(folder => <option key={folder.id} value={String(folder.id)}>{folder.folder_name}</option>)}
+            </select>
+            <input style={styles.smallInput} placeholder="Builder title" value={builderDraft.title || ''} onChange={e => setBuilderDraft(prev => ({ ...prev, title: e.target.value }))} />
+            <input style={styles.smallInput} placeholder="Subtitle" value={builderDraft.subtitle || ''} onChange={e => setBuilderDraft(prev => ({ ...prev, subtitle: e.target.value }))} />
+          </div>
+          <textarea style={styles.textArea} placeholder="Notes" value={builderDraft.notes || ''} onChange={e => setBuilderDraft(prev => ({ ...prev, notes: e.target.value }))} />
+          <button type="button" onClick={saveBuilderView} style={styles.primaryButton}>Save builder view</button>
+        </SectionCard>
+
+        <SectionCard title="Current source filters" subtitle="Builder works on top of the same filter state already powering the source board.">
+          <div style={styles.metaWrap}>
+            {Object.entries(cleanFilters(builderFilters || {})).length === 0 ? <div style={styles.emptyState}>No active source filters.</div> : Object.entries(cleanFilters(builderFilters || {})).map(([key, value]) => <span key={`filter-${key}`} style={styles.metricPill}>{key}: {typeof value === 'object' ? 'configured' : String(value)}</span>)}
+          </div>
+        </SectionCard>
+      </div>
+
+      <div style={styles.builderPreviewColumn}>
+        <SectionCard title="Canvas preview" subtitle="A live table preview of the selected fields from the current source board.">
+          {previewRows.length === 0 ? <div style={styles.emptyState}>Run the selected source board and add fields to preview a custom dashboard.</div> : (
+            <div style={styles.tableWrap}>
+              <table style={styles.table}>
+                <thead>
+                  <tr>
+                    {(builderState.selectedFields || []).map(accessor => <th key={`head-${accessor}`} style={styles.th}>{accessor}</th>)}
+                  </tr>
+                </thead>
+                <tbody>
+                  {previewRows.map((row, index) => (
+                    <tr key={`preview-${index}`}>
+                      {(builderState.selectedFields || []).map(accessor => <td key={`cell-${index}-${accessor}`} style={styles.td}>{String(row[accessor] ?? '—')}</td>)}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionCard>
+      </div>
+    </div>
+  )
+}
 
 export default function MyDashboardWorkspacePage() {
   const today = todayIso()
@@ -88,7 +694,24 @@ export default function MyDashboardWorkspacePage() {
   const [authError, setAuthError] = useState(null)
   const [savingProfile, setSavingProfile] = useState(false)
   const [creatingFolder, setCreatingFolder] = useState(false)
+  const [activeSurface, setActiveSurface] = useState(() => readSessionPref(SURFACE_PREF_KEY, 'boards'))
+  const [savedShelfOpen, setSavedShelfOpen] = useState(() => readSessionPref(SHELF_PREF_KEY, true))
+  const [activeComponent, setActiveComponent] = useState(() => readSessionPref(ACTIVE_COMPONENT_PREF_KEY, COMPONENTS[0].key))
+  const [selectedFolderId, setSelectedFolderId] = useState('')
+  const [selectedSavedItemId, setSelectedSavedItemId] = useState('')
+  const [builderState, setBuilderState] = useState({
+    component: COMPONENTS[0].key,
+    search: '',
+    selectedFields: DEFAULT_BUILDER_FIELDS,
+    sortBy: 'score',
+    sortDir: 'desc',
+  })
+  const [builderDraft, setBuilderDraft] = useState(emptySaveDraft())
   const [form, setForm] = useState({ email: '', username: '', password: '', feature_interests: ['Matchups', 'Model Projections'], wants_newsletter: false, plan_type: 'free' })
+
+  useEffect(() => { writeSessionPref(SURFACE_PREF_KEY, activeSurface) }, [activeSurface])
+  useEffect(() => { writeSessionPref(SHELF_PREF_KEY, savedShelfOpen) }, [savedShelfOpen])
+  useEffect(() => { writeSessionPref(ACTIVE_COMPONENT_PREF_KEY, activeComponent) }, [activeComponent])
 
   useEffect(() => {
     async function bootstrap() {
@@ -122,7 +745,15 @@ export default function MyDashboardWorkspacePage() {
       }
       return next
     })
-  }, [workspace?.today_folder_id, today])
+    setBuilderDraft(prev => ({
+      ...emptySaveDraft(folderId),
+      ...prev,
+      folder_id: prev.folder_id || folderId,
+      title: prev.title || `Custom Dashboard | ${today}`,
+      subtitle: prev.subtitle || 'Builder view saved from My Dashboard',
+    }))
+    if (!selectedFolderId && folderId) setSelectedFolderId(folderId)
+  }, [workspace?.today_folder_id, today, selectedFolderId])
 
   async function handleUnauthorized(message = 'Dashboard sign-in required') {
     setDashboardSessionToken('')
@@ -260,6 +891,43 @@ export default function MyDashboardWorkspacePage() {
     }
   }
 
+  async function saveBuilderView() {
+    const componentKey = builderState.component
+    const boardResult = results[componentKey]
+    const folderId = Number(builderDraft.folder_id || workspace?.today_folder_id)
+    if (!folderId) { setSaveMessage('Choose a folder before saving this builder view.'); return }
+    if (!boardResult?.items?.length) { setSaveMessage('Run the source board before saving this builder view.'); return }
+    const title = (builderDraft.title || `Custom Dashboard | ${today}`).trim()
+    try {
+      await apiJson(`${API}/my-dashboard/items`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          folder_id: folderId,
+          source_tab: 'my-dashboard',
+          source_type: 'solver_board_state',
+          title,
+          subtitle: trimText(builderDraft.subtitle) || 'Saved custom dashboard builder view',
+          notes: trimText(builderDraft.notes) || null,
+          payload_json: {
+            saved_from_component: componentKey,
+            saved_on_date: today,
+            board_state: boardResult,
+            builder_state: builderState,
+            saved_item_count: boardResult.items.length,
+            active_lineups_only: !!activeLineupsByComponent[componentKey],
+          },
+          filter_json: cleanFilters(filters[componentKey] || {}),
+          sort_json: { by: builderState.sortBy || 'score', direction: builderState.sortDir || 'desc', component: componentKey, active_lineups: !!activeLineupsByComponent[componentKey] },
+        }),
+      })
+      await loadWorkspace()
+      setSaveMessage(`Saved builder view: ${title}`)
+    } catch (err) {
+      setSaveMessage(err.message || 'Failed to save builder view')
+    }
+  }
+
   async function createFolder() {
     if (!newFolder.folder_name.trim()) { setSaveMessage('Folder name is required.'); return }
     setCreatingFolder(true)
@@ -269,7 +937,11 @@ export default function MyDashboardWorkspacePage() {
       const folderId = String(json.folder?.id || '')
       setNewFolder({ folder_name: '', folder_date: today })
       await loadWorkspace()
-      if (folderId) setSaveDrafts(prev => Object.fromEntries(Object.entries(prev).map(([key, value]) => [key, { ...value, folder_id: folderId }])))
+      if (folderId) {
+        setSelectedFolderId(folderId)
+        setSaveDrafts(prev => Object.fromEntries(Object.entries(prev).map(([key, value]) => [key, { ...value, folder_id: folderId }])))
+        setBuilderDraft(prev => ({ ...prev, folder_id: folderId }))
+      }
       setSaveMessage(`Created folder: ${json.folder?.folder_name || 'New folder'}`)
     } catch (err) {
       setSaveMessage(err.message || 'Failed to create folder')
@@ -281,10 +953,20 @@ export default function MyDashboardWorkspacePage() {
   async function restoreSavedState(item) {
     const componentKey = sourceComponentKey(item)
     if (!componentKey) { setSaveMessage('This saved item does not contain a restorable dashboard state.'); return }
+    setActiveComponent(componentKey)
     setFilters(prev => ({ ...prev, [componentKey]: mergeFilterState(item.filter_json || {}) }))
     setActiveLineupsByComponent(prev => ({ ...prev, [componentKey]: !!(item.sort_json?.active_lineups || item.payload_json?.active_lineups_only) }))
     if (item.payload_json?.board_state) {
       setResults(prev => ({ ...prev, [componentKey]: item.payload_json.board_state }))
+    }
+    if (item.payload_json?.builder_state) {
+      setBuilderState(item.payload_json.builder_state)
+      setActiveSurface('builder')
+      setSaveMessage(`Loaded saved builder view: ${item.title}`)
+      return
+    }
+    setActiveSurface('boards')
+    if (item.payload_json?.board_state) {
       setSaveMessage(`Loaded saved dashboard state: ${item.title}`)
       return
     }
@@ -294,102 +976,582 @@ export default function MyDashboardWorkspacePage() {
 
   const folders = workspace?.folders || []
   const todayFolder = useMemo(() => folders.find(folder => folder.id === workspace?.today_folder_id), [folders, workspace?.today_folder_id])
+  const activeComponentMeta = COMPONENTS.find(component => component.key === activeComponent) || COMPONENTS[0]
+  const activeResult = results[activeComponent] || null
+  const activeFilters = filters[activeComponent] || emptyFilters()
+  const activeDraft = saveDrafts[activeComponent] || emptySaveDraft(String(workspace?.today_folder_id || ''))
+  const activeHelper = available(activeResult, activeComponent)
+  const fieldGroups = useMemo(() => collectBuilderFieldGroups({ results, workspace }), [results, workspace])
+  const builderItems = ensureArray(results?.[builderState.component]?.items)
+  const builderFilters = filters?.[builderState.component] || emptyFilters()
 
-  if (!authChecked) return <div style={stateStyle}>Loading dashboard workspace…</div>
+  if (!authChecked) return <div style={styles.stateView}>Loading dashboard workspace…</div>
 
   if (!profile) {
-    return <div style={pageStyle}><section style={heroStyle}><div><div style={eyebrowStyle}>My Dashboard</div><h1 style={titleStyle}>Create your analyst profile</h1><p style={subtitleStyle}>Restore stronger daily board filters, slider weights, folders, titled dashboard saves, and saved-state restoration.</p></div></section><form onSubmit={handleProfileSubmit} style={panelStyle}><label style={labelStyle}>Email</label><input style={inputStyle} value={form.email} onChange={e => setForm(prev => ({ ...prev, email: e.target.value }))} /><label style={labelStyle}>Username</label><input style={inputStyle} value={form.username} onChange={e => setForm(prev => ({ ...prev, username: e.target.value }))} /><label style={labelStyle}>Password</label><input style={inputStyle} type="password" value={form.password} onChange={e => setForm(prev => ({ ...prev, password: e.target.value }))} /><div style={pillWrapStyle}>{FEATURE_CHOICES.map(choice => <button key={choice} type="button" onClick={() => toggleInterest(choice)} style={form.feature_interests.includes(choice) ? activePillStyle : pillStyle}>{choice}</button>)}</div>{authError && <div style={errorStyle}>{authError}</div>}<button type="submit" style={primaryButtonStyle} disabled={savingProfile}>{savingProfile ? 'Creating…' : 'Enter My Dashboard'}</button></form></div>
+    return (
+      <div style={styles.authPage}>
+        <section style={styles.authHero}>
+          <div style={styles.eyebrow}>My Dashboard</div>
+          <h1 style={styles.pageTitle}>Create your analyst profile</h1>
+          <p style={styles.pageSubtitle}>Store folders, save board states, restore views, and build reusable dashboard layouts on top of the existing fast board engine.</p>
+        </section>
+        <form onSubmit={handleProfileSubmit} style={styles.authPanel}>
+          <label style={styles.label}>Email</label>
+          <input style={styles.input} value={form.email} onChange={e => setForm(prev => ({ ...prev, email: e.target.value }))} />
+          <label style={styles.label}>Username</label>
+          <input style={styles.input} value={form.username} onChange={e => setForm(prev => ({ ...prev, username: e.target.value }))} />
+          <label style={styles.label}>Password</label>
+          <input style={styles.input} type="password" value={form.password} onChange={e => setForm(prev => ({ ...prev, password: e.target.value }))} />
+          <div style={styles.metaWrap}>{FEATURE_CHOICES.map(choice => <button key={choice} type="button" onClick={() => toggleInterest(choice)} style={form.feature_interests.includes(choice) ? styles.activeChoice : styles.choicePill}>{choice}</button>)}</div>
+          {authError ? <div style={styles.errorBanner}>{authError}</div> : null}
+          <button type="submit" style={styles.primaryButton} disabled={savingProfile}>{savingProfile ? 'Creating…' : 'Enter My Dashboard'}</button>
+        </form>
+      </div>
+    )
   }
 
   return (
-    <div style={pageStyle}>
-      <section style={heroStyle}>
-        <div>
-          <div style={eyebrowStyle}>My Dashboard</div><h1 style={titleStyle}>Welcome back, {profile.username}</h1><p style={subtitleStyle}>Restore stronger filters, hitter pitch-type controls, titled board saves, notes, folder selection, confirmed-lineup reruns, and restore-state interactions.</p>
-        </div>
-        <div style={summaryCardStyle}><div style={metaStyle}>Email: {profile.email}</div><div style={metaStyle}>Plan: {profile.preferences?.plan_type || 'free'}</div><div style={metaStyle}>Folders: {folders.length}</div><div style={metaStyle}>Today saved: {todayFolder?.item_count || 0}</div></div>
-      </section>
+    <div style={styles.page}>
+      <CommandBar
+        profile={profile}
+        folders={folders}
+        todayCount={todayFolder?.item_count || 0}
+        setActiveSurface={setActiveSurface}
+        loadWorkspace={loadWorkspace}
+        runAllBoards={runAllBoards}
+        saveMessage={saveMessage}
+      />
+      <div style={styles.workspaceShell}>
+        <WorkspaceNav
+          activeSurface={activeSurface}
+          setActiveSurface={setActiveSurface}
+          activeComponent={activeComponent}
+          setActiveComponent={setActiveComponent}
+          results={results}
+        />
+        <main style={styles.mainColumn}>
+          <SavedBoardsShelf
+            open={savedShelfOpen}
+            onToggle={() => setSavedShelfOpen(prev => !prev)}
+            folders={folders}
+            todayCount={todayFolder?.item_count || 0}
+            newFolder={newFolder}
+            setNewFolder={setNewFolder}
+            createFolder={createFolder}
+            creatingFolder={creatingFolder}
+            selectedFolderId={selectedFolderId}
+            setSelectedFolderId={setSelectedFolderId}
+            selectedSavedItemId={selectedSavedItemId}
+            setSelectedSavedItemId={setSelectedSavedItemId}
+            restoreSavedState={restoreSavedState}
+          />
 
-      <section style={panelStyle}>
-        <div style={rowStyle}><h2 style={sectionTitleStyle}>Folders and saved dashboards</h2><button onClick={loadWorkspace} style={secondaryButtonStyle}>Refresh workspace</button></div>
-        <div style={folderCreateGridStyle}><input style={inputStyle} placeholder="New folder title" value={newFolder.folder_name} onChange={e => setNewFolder(prev => ({ ...prev, folder_name: e.target.value }))} /><input style={inputStyle} type="date" value={newFolder.folder_date} onChange={e => setNewFolder(prev => ({ ...prev, folder_date: e.target.value }))} /><button onClick={createFolder} style={primaryButtonStyle} disabled={creatingFolder}>{creatingFolder ? 'Creating…' : 'Create folder'}</button></div>
-        {saveMessage && <div style={successStyle}>{saveMessage}</div>}
-        <div style={foldersGridStyle}>{folders.map(folder => <div key={folder.id} style={folderCardStyle}><div style={rowStyle}><div><div style={boardTitleStyle}>{folder.folder_name}</div><div style={metaStyle}>{folder.folder_date || (folder.is_default ? 'Default dashboard' : 'No date')}</div></div><div style={countBadgeStyle}>{folder.item_count}</div></div><div style={savedItemsGridStyle}>{(folder.items || []).length === 0 ? <div style={emptyStyle}>No saved items in this folder.</div> : folder.items.map(item => <div key={item.id} style={savedItemCardStyle}><div style={savedTitleStyle}>{item.title}</div><div style={metaStyle}>{item.subtitle || item.source_type}</div>{item.notes ? <div style={resultBodyStyle}>{item.notes}</div> : null}<div style={metaStyle}>Source: {item.source_tab} • {item.source_type}</div><div style={pillWrapStyle}>{item.filter_json ? Object.keys(item.filter_json).slice(0, 4).map(key => <span key={`${item.id}-${key}`} style={metricPillStyle}>{key}</span>) : null}</div><div style={rowStyle}><button onClick={() => restoreSavedState(item)} style={secondaryButtonStyle}>Load saved state</button></div></div>)}</div></div>)}</div>
-      </section>
-
-      <section style={panelStyle}>
-        <div style={rowStyle}><h2 style={sectionTitleStyle}>Daily boards</h2><div style={rowStyle}><button onClick={() => runAllBoards()} style={primaryButtonStyle}>Populate all</button><button onClick={() => runAllBoards({ activeLineups: true })} style={secondaryButtonStyle}>Populate confirmed lineups only</button><button onClick={loadWorkspace} style={secondaryButtonStyle}>Refresh workspace</button></div></div>
-        {runErrors._all && <div style={errorStyle}>{runErrors._all}</div>}
-        <div style={boardGridStyle}>{COMPONENTS.map(component => {
-          const result = results[component.key]
-          const items = result?.items || []
-          const helper = available(result, component.key)
-          const metricFilters = (helper.suggested_metric_filters || []).slice(0, 6)
-          const weightMetrics = (helper.suggested_weight_metrics || []).slice(0, 5)
-          const filterState = filters[component.key] || emptyFilters()
-          const draft = saveDrafts[component.key] || emptySaveDraft(String(workspace?.today_folder_id || ''))
-          return <div key={component.key} style={boardCardStyle}><div style={rowStyle}><div><div style={boardTitleStyle}>{component.title}</div><div style={boardDescriptionStyle}>{component.description}</div></div><div style={countBadgeStyle}>{items.length}/10</div></div><div style={metaStyle}>Before/after filters: {result?.result_count_before_filters ?? '—'} / {result?.result_count_after_filters ?? '—'}</div>{result?.filter_warnings?.length ? <div style={warningStyle}>{result.filter_warnings.join(' • ')}</div> : null}
-          <label style={checkRowStyle}><input type="checkbox" checked={!!activeLineupsByComponent[component.key]} onChange={() => toggleActiveLineups(component.key)} /> Confirmed lineup players only on rerun</label>
-          <div style={filterGridStyle}><input style={smallInputStyle} placeholder="Search" value={filterState.search_text || ''} onChange={e => setBasicFilter(component.key, 'search_text', e.target.value)} /><input style={smallInputStyle} placeholder="Team" value={filterState.team || ''} onChange={e => setBasicFilter(component.key, 'team', e.target.value)} /><input style={smallInputStyle} placeholder="Opponent" value={filterState.opponent || ''} onChange={e => setBasicFilter(component.key, 'opponent', e.target.value)} /><input style={smallInputStyle} placeholder="Min score" value={filterState.min_score || ''} onChange={e => setBasicFilter(component.key, 'min_score', e.target.value)} /><input style={smallInputStyle} placeholder="Max score" value={filterState.max_score || ''} onChange={e => setBasicFilter(component.key, 'max_score', e.target.value)} /><select style={smallInputStyle} value={filterState.min_confidence || ''} onChange={e => setBasicFilter(component.key, 'min_confidence', e.target.value)}><option value="">Any confidence</option><option value="low">Low+</option><option value="medium">Medium+</option><option value="high">High only</option></select>{component.key === 'hitters' ? <select style={smallInputStyle} value={filterState.pitch_type || ''} onChange={e => setBasicFilter(component.key, 'pitch_type', e.target.value)}><option value="">Any pitch type</option>{(helper.pitch_types || []).map(value => <option key={value} value={value}>{value}</option>)}</select> : null}{(helper.categories || []).length ? <select style={smallInputStyle} value={filterState.category || ''} onChange={e => setBasicFilter(component.key, 'category', e.target.value)}><option value="">Any category</option>{(helper.categories || []).map(value => <option key={value} value={value}>{value}</option>)}</select> : null}</div>
-          <div style={metricGridStyle}>{metricFilters.map(metric => <div key={`${component.key}-${metric}`} style={metricCardStyle}><div style={metricTitleStyle}>{metric}</div><div style={metricInputRowStyle}><input style={smallInputStyle} placeholder="Min" value={filterState.metrics?.[metric]?.min || ''} onChange={e => setMetricFilter(component.key, metric, 'min', e.target.value)} /><input style={smallInputStyle} placeholder="Max" value={filterState.metrics?.[metric]?.max || ''} onChange={e => setMetricFilter(component.key, metric, 'max', e.target.value)} /></div></div>)}</div>
-          <div style={sliderGridStyle}>{weightMetrics.map(metric => { const value = Number(filterState.weights?.[metric] ?? 1); return <div key={`${component.key}-weight-${metric}`} style={metricCardStyle}><div style={metricTitleStyle}>{metric}</div><input type="range" min="0" max="2" step="0.1" value={value} onChange={e => setWeight(component.key, metric, e.target.value)} style={{ width: '100%' }} /><div style={metaStyle}>Weight {value.toFixed(1)}</div></div> })}</div>
-          <div style={saveBoardPanelStyle}><div style={metricTitleStyle}>Save dashboard state</div><div style={filterGridStyle}><select style={smallInputStyle} value={draft.folder_id || ''} onChange={e => setSaveDraft(component.key, 'folder_id', e.target.value)}><option value="">Choose folder</option>{folders.map(folder => <option key={folder.id} value={String(folder.id)}>{folder.folder_name}</option>)}</select><input style={smallInputStyle} placeholder="Dashboard title" value={draft.title || ''} onChange={e => setSaveDraft(component.key, 'title', e.target.value)} /><input style={smallInputStyle} placeholder="Subtitle" value={draft.subtitle || ''} onChange={e => setSaveDraft(component.key, 'subtitle', e.target.value)} /></div><textarea style={textAreaStyle} placeholder="Notes" value={draft.notes || ''} onChange={e => setSaveDraft(component.key, 'notes', e.target.value)} /><div style={rowStyle}><button onClick={() => saveBoardState(component)} style={primaryButtonStyle}>Save board state</button></div></div>
-          <div style={rowStyle}><button onClick={() => runBoard(component.key)} style={secondaryButtonStyle} disabled={loading[component.key]}>{loading[component.key] ? 'Running…' : 'Run board'}</button><button onClick={() => runBoard(component.key, { preferCache: true })} style={ghostButtonStyle}>Use cached</button><button onClick={() => resetFilters(component.key)} style={ghostButtonStyle}>Reset filters</button></div>{runErrors[component.key] && <div style={errorStyle}>{runErrors[component.key]}</div>}
-          <div style={resultsGridStyle}>{items.length === 0 ? <div style={emptyStyle}>No results yet. Run this board to populate fresh discovery for today.</div> : items.map((item, idx) => <div key={`${component.key}-${idx}-${item.entity_id || item.entity_name || idx}`} style={resultCardStyle}><div style={rowStyle}><div><div style={resultTitleStyle}>{item.entity_name || 'Ranked item'}</div><div style={metaStyle}>{item.team || 'Team unavailable'} {item.opponent ? `vs ${item.opponent}` : ''}</div></div><div style={scorePillStyle}>{formatNumber(item.score)}</div></div><div style={resultBodyStyle}>{item.primary_reason || 'Model solver ranked this item.'}</div><div style={metaStyle}>Confidence: {item.confidence || 'low'}</div>{item.pitch_name || item.pitch_type ? <div style={metaStyle}>Pitch context: {item.pitch_name || item.pitch_type}</div> : null}<div style={pillWrapStyle}>{Object.entries(item.metrics || {}).slice(0, 6).map(([key, value]) => <span key={`${item.entity_id}-${key}`} style={metricPillStyle}>{key}: {value ?? '—'}</span>)}</div>{item.weight_explanation?.length ? <div style={metaStyle}>Weights: {item.weight_explanation.join(' • ')}</div> : null}<div style={rowStyle}><button onClick={() => saveItemToToday(component, item)} style={miniPrimaryStyle}>Save item to Today</button></div></div>)}</div></div>
-        })}</div>
-      </section>
+          {activeSurface === 'boards' ? (
+            <div style={styles.boardWorkspaceGrid}>
+              <BoardControls
+                component={activeComponentMeta}
+                result={activeResult}
+                filterState={activeFilters}
+                helper={activeHelper}
+                draft={activeDraft}
+                folders={folders}
+                activeLineups={activeLineupsByComponent[activeComponent]}
+                setBasicFilter={setBasicFilter}
+                setMetricFilter={setMetricFilter}
+                setWeight={setWeight}
+                setSaveDraft={setSaveDraft}
+                resetFilters={resetFilters}
+                toggleActiveLineups={toggleActiveLineups}
+                saveBoardState={saveBoardState}
+                runBoard={runBoard}
+                loading={loading[activeComponent]}
+                runError={runErrors[activeComponent] || runErrors._all}
+              />
+              <ResultList component={activeComponentMeta} result={activeResult} saveItemToToday={saveItemToToday} />
+            </div>
+          ) : (
+            <BuilderWorkspace
+              builderState={builderState}
+              setBuilderState={setBuilderState}
+              builderDraft={builderDraft}
+              setBuilderDraft={setBuilderDraft}
+              fieldGroups={fieldGroups}
+              builderItems={builderItems}
+              builderFilters={builderFilters}
+              folders={folders}
+              saveBuilderView={saveBuilderView}
+              runBoard={runBoard}
+              loading={loading[builderState.component]}
+            />
+          )}
+        </main>
+      </div>
     </div>
   )
 }
 
-const pageStyle = { display: 'grid', gap: 18 }
-const heroStyle = { display: 'flex', justifyContent: 'space-between', gap: 18, flexWrap: 'wrap', background: 'linear-gradient(135deg, #141925, #0d1117)', border: '1px solid #2a3243', borderRadius: 18, padding: 24 }
-const eyebrowStyle = { color: '#8ab4ff', fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 8 }
-const titleStyle = { margin: 0, fontSize: 34, color: '#e6edf3' }
-const subtitleStyle = { margin: '10px 0 0', color: '#97a3b6', maxWidth: 760, lineHeight: 1.6 }
-const panelStyle = { background: '#161b22', border: '1px solid #30363d', borderRadius: 18, padding: 20, display: 'grid', gap: 14 }
-const summaryCardStyle = { minWidth: 260, background: '#161b22', border: '1px solid #30363d', borderRadius: 16, padding: 18, display: 'grid', gap: 8 }
-const sectionTitleStyle = { margin: 0, color: '#e6edf3', fontSize: 24 }
-const rowStyle = { display: 'flex', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap', alignItems: 'center' }
-const checkRowStyle = { display: 'flex', gap: 8, alignItems: 'center', color: '#c9d1d9', fontSize: 13 }
-const boardGridStyle = { display: 'grid', gap: 18 }
-const boardCardStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: 16, padding: 16, display: 'grid', gap: 12 }
-const boardTitleStyle = { color: '#e6edf3', fontWeight: 700, fontSize: 18 }
-const boardDescriptionStyle = { color: '#97a3b6', fontSize: 13, lineHeight: 1.5, marginTop: 4 }
-const countBadgeStyle = { background: '#1d2432', border: '1px solid #334155', color: '#c9d1d9', borderRadius: 999, padding: '6px 10px', fontSize: 12, fontWeight: 700 }
-const filterGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 10 }
-const metricGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 10 }
-const sliderGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 10 }
-const resultsGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 12 }
-const foldersGridStyle = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: 14 }
-const savedItemsGridStyle = { display: 'grid', gap: 10 }
-const folderCardStyle = { background: '#0d1117', border: '1px solid #30363d', borderRadius: 16, padding: 14, display: 'grid', gap: 12 }
-const savedItemCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 12, display: 'grid', gap: 8 }
-const folderCreateGridStyle = { display: 'grid', gridTemplateColumns: 'minmax(220px, 1fr) 180px auto', gap: 10 }
-const saveBoardPanelStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 12, display: 'grid', gap: 10 }
-const metricCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 12, padding: 10, display: 'grid', gap: 8 }
-const metricTitleStyle = { color: '#e6edf3', fontWeight: 600, fontSize: 12 }
-const metricInputRowStyle = { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }
-const resultCardStyle = { background: '#111827', border: '1px solid #30363d', borderRadius: 14, padding: 12, display: 'grid', gap: 8 }
-const resultTitleStyle = { color: '#e6edf3', fontWeight: 700 }
-const savedTitleStyle = { color: '#e6edf3', fontWeight: 700, fontSize: 14 }
-const resultBodyStyle = { color: '#97a3b6', fontSize: 13, lineHeight: 1.5 }
-const scorePillStyle = { background: '#1d4ed8', color: '#fff', borderRadius: 999, padding: '6px 10px', fontSize: 12, fontWeight: 700, height: 'fit-content' }
-const pillWrapStyle = { display: 'flex', flexWrap: 'wrap', gap: 6 }
-const metricPillStyle = { background: '#0b1220', border: '1px solid #223049', color: '#c9d1d9', borderRadius: 999, padding: '4px 8px', fontSize: 11 }
-const labelStyle = { color: '#c9d1d9', fontSize: 13, fontWeight: 600 }
-const inputStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 10, padding: '10px 12px' }
-const smallInputStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 8, padding: '8px 10px', fontSize: 12, width: '100%' }
-const textAreaStyle = { background: '#111827', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 8, padding: '10px 12px', minHeight: 72, resize: 'vertical' }
-const primaryButtonStyle = { background: '#7c3aed', color: '#fff', border: 0, borderRadius: 10, padding: '12px 16px', fontWeight: 700, cursor: 'pointer' }
-const secondaryButtonStyle = { background: '#0d1117', color: '#e6edf3', border: '1px solid #30363d', borderRadius: 10, padding: '10px 14px', fontWeight: 600, cursor: 'pointer' }
-const ghostButtonStyle = { background: '#0f172a', color: '#97a3b6', border: '1px solid #30363d', borderRadius: 10, padding: '10px 12px', fontWeight: 600, cursor: 'pointer' }
-const miniPrimaryStyle = { background: '#2563eb', color: '#fff', border: 0, borderRadius: 8, padding: '8px 10px', fontSize: 12, fontWeight: 600, cursor: 'pointer' }
-const pillStyle = { background: '#0d1117', color: '#c9d1d9', border: '1px solid #30363d', borderRadius: 999, padding: '8px 12px', cursor: 'pointer' }
-const activePillStyle = { ...pillStyle, background: '#1c365d', borderColor: '#3b82f6' }
-const errorStyle = { background: '#2a1215', border: '1px solid #5f1d24', color: '#ff9aa2', borderRadius: 10, padding: '10px 12px' }
-const warningStyle = { background: '#2a2112', border: '1px solid #6b4f1d', color: '#f6d28b', borderRadius: 10, padding: '10px 12px' }
-const successStyle = { background: '#112818', border: '1px solid #1f6f3d', color: '#9be9a8', borderRadius: 10, padding: '10px 12px' }
-const stateStyle = { padding: 30, color: '#97a3b6' }
-const metaStyle = { color: '#97a3b6', fontSize: 12 }
-const emptyStyle = { background: '#0b1220', border: '1px dashed #30363d', color: '#97a3b6', borderRadius: 12, padding: 14, textAlign: 'center' }
+const styles = {
+  page: {
+    minHeight: '100vh',
+    background: `linear-gradient(180deg, ${C.bg} 0%, #09111f 100%)`,
+    color: C.text,
+    padding: '24px 24px 36px',
+  },
+  authPage: {
+    minHeight: '100vh',
+    background: `linear-gradient(180deg, ${C.bg} 0%, #09111f 100%)`,
+    color: C.text,
+    padding: 32,
+    display: 'grid',
+    gap: 24,
+    alignContent: 'center',
+    justifyItems: 'center',
+  },
+  authHero: {
+    maxWidth: 720,
+    textAlign: 'center',
+  },
+  authPanel: {
+    width: '100%',
+    maxWidth: 520,
+    background: 'rgba(17, 28, 52, 0.88)',
+    border: `1px solid ${C.border}`,
+    borderRadius: 24,
+    padding: 24,
+    display: 'grid',
+    gap: 12,
+    boxShadow: '0 18px 48px rgba(2, 6, 23, 0.32)',
+  },
+  stateView: {
+    minHeight: '100vh',
+    display: 'grid',
+    placeItems: 'center',
+    background: C.bg,
+    color: C.text,
+    fontSize: 18,
+  },
+  commandBar: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1.2fr) minmax(340px, 0.8fr)',
+    gap: 20,
+    marginBottom: 20,
+    padding: 24,
+    background: 'rgba(17, 28, 52, 0.92)',
+    border: `1px solid ${C.border}`,
+    borderRadius: 28,
+    boxShadow: '0 18px 46px rgba(2, 6, 23, 0.28)',
+  },
+  commandRight: { display: 'grid', gap: 12, alignContent: 'start' },
+  accountMetaCard: {
+    display: 'grid',
+    gap: 6,
+    padding: 14,
+    background: 'rgba(25, 39, 71, 0.72)',
+    border: `1px solid ${C.border}`,
+    borderRadius: 18,
+  },
+  metaLine: { color: C.muted, fontSize: 13 },
+  commandButtons: { display: 'flex', gap: 10, flexWrap: 'wrap' },
+  workspaceShell: {
+    display: 'grid',
+    gridTemplateColumns: '280px minmax(0, 1fr)',
+    gap: 18,
+    alignItems: 'start',
+  },
+  navRail: {
+    position: 'sticky',
+    top: 20,
+    display: 'grid',
+    gap: 14,
+    padding: 18,
+    background: 'rgba(15, 23, 42, 0.9)',
+    border: `1px solid ${C.border}`,
+    borderRadius: 24,
+  },
+  brandBlock: { display: 'grid', gap: 6 },
+  brandEyebrow: { color: C.blue, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.14em', fontWeight: 700 },
+  brandTitle: { color: C.text, fontSize: 24, fontWeight: 800 },
+  brandSubtitle: { color: C.muted, fontSize: 13, lineHeight: 1.6 },
+  navGroupLabel: { color: C.subtle, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.12em', fontWeight: 700, marginTop: 4 },
+  navGroup: { display: 'grid', gap: 10 },
+  navButton: {
+    textAlign: 'left',
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.74)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  navButtonActive: {
+    textAlign: 'left',
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid rgba(94, 162, 255, 0.36)`,
+    background: 'linear-gradient(180deg, rgba(94, 162, 255, 0.18), rgba(25, 39, 71, 0.92))',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  navButtonTitle: { fontSize: 14, fontWeight: 700 },
+  navButtonSubtitle: { fontSize: 12, color: C.muted, marginTop: 4, lineHeight: 1.5 },
+  subNavButton: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '11px 12px',
+    borderRadius: 14,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.56)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  subNavButtonActive: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '11px 12px',
+    borderRadius: 14,
+    border: `1px solid rgba(67, 197, 158, 0.36)`,
+    background: 'rgba(67, 197, 158, 0.14)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  subNavCount: { color: C.muted, fontSize: 12, fontWeight: 700 },
+  mainColumn: { display: 'grid', gap: 18 },
+  sectionCard: {
+    background: 'rgba(17, 28, 52, 0.88)',
+    border: `1px solid ${C.border}`,
+    borderRadius: 24,
+    boxShadow: '0 16px 44px rgba(2, 6, 23, 0.22)',
+  },
+  sectionHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 16,
+    alignItems: 'start',
+    marginBottom: 14,
+  },
+  sectionTitle: { color: C.text, fontSize: 18, fontWeight: 750 },
+  sectionSubtitle: { color: C.muted, fontSize: 13, lineHeight: 1.6, marginTop: 4 },
+  shelfSummaryRow: { display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 8 },
+  shelfContentGrid: { display: 'grid', gridTemplateColumns: '320px minmax(0, 1fr)', gap: 18 },
+  folderColumn: { display: 'grid', gap: 14 },
+  folderDetailColumn: { display: 'grid', gap: 14 },
+  inlineRow: { display: 'grid', gridTemplateColumns: '1fr auto auto', gap: 10, alignItems: 'center' },
+  folderList: { display: 'grid', gap: 10, maxHeight: 460, overflowY: 'auto', paddingRight: 4 },
+  folderButton: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.56)',
+    color: C.text,
+    cursor: 'pointer',
+    textAlign: 'left',
+  },
+  folderButtonActive: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid rgba(94, 162, 255, 0.36)`,
+    background: 'rgba(94, 162, 255, 0.12)',
+    color: C.text,
+    cursor: 'pointer',
+    textAlign: 'left',
+  },
+  folderTitle: { fontSize: 14, fontWeight: 700 },
+  folderMeta: { fontSize: 12, color: C.muted, marginTop: 4 },
+  countBadge: {
+    minWidth: 34,
+    height: 34,
+    borderRadius: 999,
+    display: 'grid',
+    placeItems: 'center',
+    background: 'rgba(25, 39, 71, 0.92)',
+    border: `1px solid ${C.border}`,
+    color: C.text,
+    fontWeight: 700,
+    fontSize: 12,
+  },
+  folderHeader: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
+  folderInspectorGrid: { display: 'grid', gridTemplateColumns: 'minmax(260px, 0.9fr) minmax(0, 1.1fr)', gap: 16 },
+  savedList: { display: 'grid', gap: 10, maxHeight: 460, overflowY: 'auto', paddingRight: 4 },
+  savedItemButton: {
+    textAlign: 'left',
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.56)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  savedItemButtonActive: {
+    textAlign: 'left',
+    padding: 14,
+    borderRadius: 18,
+    border: `1px solid rgba(67, 197, 158, 0.36)`,
+    background: 'rgba(67, 197, 158, 0.12)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  savedItemTitle: { fontSize: 14, fontWeight: 700 },
+  savedItemMeta: { fontSize: 12, color: C.muted, marginTop: 4 },
+  savedInspector: {
+    borderRadius: 20,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.56)',
+    padding: 18,
+    display: 'grid',
+    gap: 12,
+    alignContent: 'start',
+  },
+  savedInspectorTitle: { fontSize: 18, fontWeight: 750, color: C.text },
+  savedInspectorSubtitle: { fontSize: 13, color: C.muted },
+  notesBox: {
+    padding: 12,
+    borderRadius: 16,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.64)',
+    color: C.text,
+    lineHeight: 1.6,
+    whiteSpace: 'pre-wrap',
+  },
+  pill: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '6px 10px',
+    borderRadius: 999,
+    fontWeight: 700,
+    fontSize: 12,
+  },
+  boardWorkspaceGrid: { display: 'grid', gridTemplateColumns: '420px minmax(0, 1fr)', gap: 18, alignItems: 'start' },
+  boardControlColumn: { display: 'grid', gap: 16, position: 'sticky', top: 20 },
+  boardResultsColumn: { display: 'grid', gap: 16 },
+  filterGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 },
+  metricGrid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 10 },
+  sliderGrid: { display: 'grid', gap: 10 },
+  metricCard: {
+    borderRadius: 18,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.6)',
+    padding: 12,
+    display: 'grid',
+    gap: 8,
+  },
+  metricTitle: { fontSize: 12, color: C.subtle, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 700 },
+  metricInputRow: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 },
+  resultsGrid: { display: 'grid', gap: 14 },
+  resultCard: {
+    borderRadius: 20,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.66)',
+    padding: 18,
+    display: 'grid',
+    gap: 14,
+  },
+  resultTopRow: { display: 'flex', justifyContent: 'space-between', gap: 14, alignItems: 'start' },
+  resultTitle: { fontSize: 18, fontWeight: 750, color: C.text },
+  resultSubTitle: { fontSize: 13, color: C.muted, marginTop: 4, lineHeight: 1.5 },
+  resultScoreStack: { textAlign: 'right', minWidth: 96 },
+  scoreLabel: { color: C.subtle, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 700 },
+  scoreValue: { color: C.text, fontSize: 24, fontWeight: 800 },
+  scoreConfidence: { color: C.blue, fontSize: 12, fontWeight: 700 },
+  metricWrap: { display: 'flex', gap: 8, flexWrap: 'wrap' },
+  metricChip: {
+    display: 'grid',
+    gap: 2,
+    minWidth: 92,
+    padding: '8px 10px',
+    borderRadius: 14,
+    background: 'rgba(17, 28, 52, 0.84)',
+    border: `1px solid ${C.border}`,
+  },
+  metricChipLabel: { color: C.subtle, fontSize: 11, fontWeight: 700 },
+  metricChipValue: { color: C.text, fontSize: 13, fontWeight: 700 },
+  reasonList: { margin: 0, paddingLeft: 18, color: C.muted, lineHeight: 1.6 },
+  builderGrid: { display: 'grid', gridTemplateColumns: 'minmax(300px, 0.95fr) minmax(300px, 0.9fr) minmax(0, 1.15fr)', gap: 18, alignItems: 'start' },
+  builderColumn: { display: 'grid', gap: 16 },
+  builderPreviewColumn: { display: 'grid', gap: 16 },
+  builderFieldGroups: { display: 'grid', gap: 12, maxHeight: 760, overflowY: 'auto', paddingRight: 4 },
+  fieldGroup: { borderRadius: 18, border: `1px solid ${C.border}`, background: 'rgba(15, 23, 42, 0.56)', padding: 14 },
+  fieldGroupTitle: { fontSize: 13, fontWeight: 800, color: C.text, marginBottom: 10, textTransform: 'uppercase', letterSpacing: '0.08em' },
+  fieldList: { display: 'grid', gap: 8 },
+  fieldRow: { display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', padding: 10, borderRadius: 14, background: 'rgba(17, 28, 52, 0.7)' },
+  fieldLabel: { fontSize: 13, fontWeight: 700, color: C.text },
+  fieldAccessor: { fontSize: 11, color: C.muted, marginTop: 2, wordBreak: 'break-all' },
+  fieldAddButton: {
+    border: `1px solid rgba(94, 162, 255, 0.36)`,
+    background: 'rgba(94, 162, 255, 0.14)',
+    color: C.blue,
+    borderRadius: 12,
+    padding: '8px 10px',
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  fieldAddButtonDisabled: {
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.44)',
+    color: C.subtle,
+    borderRadius: 12,
+    padding: '8px 10px',
+    fontWeight: 700,
+  },
+  selectedFieldList: { display: 'grid', gap: 10 },
+  selectedFieldRow: { display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center', padding: 12, borderRadius: 16, border: `1px solid ${C.border}`, background: 'rgba(15, 23, 42, 0.56)' },
+  selectedFieldActions: { display: 'flex', gap: 8 },
+  iconButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 10,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.7)',
+    color: C.text,
+    cursor: 'pointer',
+  },
+  iconButtonDanger: {
+    width: 34,
+    height: 34,
+    borderRadius: 10,
+    border: `1px solid rgba(248, 113, 113, 0.3)`,
+    background: 'rgba(248, 113, 113, 0.1)',
+    color: C.red,
+    cursor: 'pointer',
+  },
+  tableWrap: { overflow: 'auto', borderRadius: 18, border: `1px solid ${C.border}` },
+  table: { width: '100%', borderCollapse: 'collapse', background: 'rgba(15, 23, 42, 0.62)' },
+  th: { padding: '12px 14px', textAlign: 'left', fontSize: 12, color: C.subtle, borderBottom: `1px solid ${C.border}` },
+  td: { padding: '12px 14px', fontSize: 13, color: C.text, borderBottom: `1px solid ${C.border}`, verticalAlign: 'top' },
+  input: {
+    width: '100%',
+    borderRadius: 14,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.72)',
+    color: C.text,
+    padding: '11px 12px',
+    outline: 'none',
+  },
+  smallInput: {
+    width: '100%',
+    borderRadius: 12,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.72)',
+    color: C.text,
+    padding: '10px 11px',
+    outline: 'none',
+  },
+  textArea: {
+    minHeight: 92,
+    width: '100%',
+    borderRadius: 16,
+    border: `1px solid ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.72)',
+    color: C.text,
+    padding: 12,
+    resize: 'vertical',
+    outline: 'none',
+  },
+  label: { color: C.muted, fontSize: 13, fontWeight: 700 },
+  primaryButton: {
+    border: `1px solid rgba(94, 162, 255, 0.36)`,
+    background: 'linear-gradient(180deg, rgba(94, 162, 255, 0.24), rgba(94, 162, 255, 0.12))',
+    color: C.text,
+    borderRadius: 14,
+    padding: '11px 14px',
+    fontWeight: 800,
+    cursor: 'pointer',
+  },
+  secondaryButton: {
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.74)',
+    color: C.text,
+    borderRadius: 14,
+    padding: '11px 14px',
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  ghostButton: {
+    border: `1px solid rgba(148, 163, 184, 0.14)`,
+    background: 'transparent',
+    color: C.muted,
+    borderRadius: 14,
+    padding: '11px 14px',
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  buttonRow: { display: 'flex', gap: 10, flexWrap: 'wrap' },
+  metaWrap: { display: 'flex', gap: 8, flexWrap: 'wrap' },
+  choicePill: {
+    border: `1px solid ${C.border}`,
+    background: 'rgba(17, 28, 52, 0.7)',
+    color: C.text,
+    borderRadius: 999,
+    padding: '9px 12px',
+    cursor: 'pointer',
+  },
+  activeChoice: {
+    border: `1px solid rgba(94, 162, 255, 0.36)`,
+    background: 'rgba(94, 162, 255, 0.14)',
+    color: C.blue,
+    borderRadius: 999,
+    padding: '9px 12px',
+    cursor: 'pointer',
+  },
+  warningBanner: {
+    padding: '11px 12px',
+    borderRadius: 14,
+    border: `1px solid rgba(241, 183, 92, 0.24)`,
+    background: 'rgba(241, 183, 92, 0.12)',
+    color: C.amber,
+    fontSize: 13,
+    lineHeight: 1.5,
+  },
+  errorBanner: {
+    padding: '11px 12px',
+    borderRadius: 14,
+    border: `1px solid rgba(248, 113, 113, 0.24)`,
+    background: 'rgba(248, 113, 113, 0.12)',
+    color: '#fecaca',
+    fontSize: 13,
+    lineHeight: 1.5,
+  },
+  successBanner: {
+    padding: '11px 12px',
+    borderRadius: 14,
+    border: `1px solid rgba(67, 197, 158, 0.24)`,
+    background: 'rgba(67, 197, 158, 0.12)',
+    color: '#bbf7d0',
+    fontSize: 13,
+    lineHeight: 1.5,
+  },
+  emptyState: {
+    borderRadius: 16,
+    border: `1px dashed ${C.border}`,
+    background: 'rgba(15, 23, 42, 0.34)',
+    padding: 18,
+    color: C.muted,
+    lineHeight: 1.6,
+  },
+  checkboxRow: { display: 'flex', gap: 10, alignItems: 'center', color: C.muted, fontSize: 13 },
+  eyebrow: { color: C.blue, fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.14em', fontWeight: 800, marginBottom: 8 },
+  pageTitle: { margin: 0, fontSize: 34, lineHeight: 1.1, color: C.text },
+  pageSubtitle: { margin: '10px 0 0', color: C.muted, maxWidth: 740, lineHeight: 1.7, fontSize: 14 },
+  metricPill: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '7px 10px',
+    borderRadius: 999,
+    background: 'rgba(25, 39, 71, 0.88)',
+    border: `1px solid ${C.border}`,
+    color: C.text,
+    fontSize: 12,
+    fontWeight: 700,
+  },
+}


### PR DESCRIPTION
Emergency hotfix for a bad merge on `main`.

Problem fixed:
- `frontend/src/pages/MyDashboardWorkspacePage.jsx` had regressed to a placeholder `return <div />`

Scope:
- restores the full My Dashboard page render
- preserves saved boards shelf, folder browser, board controls, save/restore flows, builder surface, and builder preview
- no solver logic changes
- no API changes
- no cache/session/save semantics changes
- no unrelated changes
