### PR TITLE
Rework /landing-v2 into Bet of the Day sales page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/lib/landing/selectBetOfTheDay.mjs
+++ b/frontend/src/lib/landing/selectBetOfTheDay.mjs
@@ -1,0 +1,239 @@
+export function americanOddsToImpliedProbability(odds) {
+  const n = Number(odds)
+  if (!Number.isFinite(n) || n === 0) return null
+  return n < 0 ? Math.abs(n) / (Math.abs(n) + 100) : 100 / (n + 100)
+}
+
+export function americanOddsToDecimal(odds) {
+  const n = Number(odds)
+  if (!Number.isFinite(n) || n === 0) return null
+  return n > 0 ? 1 + n / 100 : 1 + 100 / Math.abs(n)
+}
+
+export function probabilityToFairAmericanOdds(probability) {
+  const p = normalizeProbability(probability)
+  if (p == null || p <= 0 || p >= 1) return null
+  return p >= 0.5 ? -1 * ((p / (1 - p)) * 100) : ((1 - p) / p) * 100
+}
+
+export function calculateEdge(modelProbability, impliedProbability) {
+  const model = normalizeProbability(modelProbability)
+  const implied = normalizeProbability(impliedProbability)
+  if (model == null || implied == null) return null
+  return model - implied
+}
+
+export function calculateEvPer100(modelProbability, americanOdds) {
+  const model = normalizeProbability(modelProbability)
+  const decimal = americanOddsToDecimal(americanOdds)
+  if (model == null || decimal == null) return null
+  const evPerDollar = model * (decimal - 1) - (1 - model)
+  return evPerDollar * 100
+}
+
+export function selectBetOfTheDay({ matchups = [], events = [], modelPayload = null, boardPayload = null } = {}) {
+  const matchupByKey = new Map()
+  asArray(matchups).forEach(matchup => {
+    const key = keyFromMatchup(matchup)
+    if (key !== '@') matchupByKey.set(key, matchup)
+  })
+
+  const modelByKey = new Map()
+  modelGamesFromPayload(modelPayload).forEach(game => {
+    const key = matchupKey(
+      firstValue(game, ['away_team', 'away_team_name', 'away', 'teams.away.name']),
+      firstValue(game, ['home_team', 'home_team_name', 'home', 'teams.home.name']),
+    )
+    if (key !== '@') modelByKey.set(key, game)
+  })
+
+  const boardItems = boardItemsFromPayload(boardPayload)
+  const candidates = []
+
+  asArray(events).forEach(event => {
+    const key = keyFromEvent(event)
+    const matchup = matchupByKey.get(key)
+    const modelGame = modelByKey.get(key)
+    const away = teamName(event?.away_team) || matchup?.away_team_name || matchup?.away_team || modelGame?.away_team || 'Away'
+    const home = teamName(event?.home_team) || matchup?.home_team_name || matchup?.home_team || modelGame?.home_team || 'Home'
+    const modelSources = [matchup, modelGame, ...(boardItems.filter(item => sameTeamText(item, away) || sameTeamText(item, home)))]
+
+    gameMarkets(event).forEach(market => {
+      asArray(market.selections).forEach(selection => {
+        const americanOdds = number(selection.price ?? selection.american_odds ?? selection.odds?.american)
+        if (americanOdds == null) return
+        const pick = selection.description || selection.name || selectionLabel(selection)
+        const side = inferSide(selection, away, home)
+        const modelProbability = probabilityForSelection({ side, market, selection, matchup, modelGame, sources: modelSources })
+        if (modelProbability == null) return
+        const impliedProbability = americanOddsToImpliedProbability(americanOdds)
+        const fairOdds = probabilityToFairAmericanOdds(modelProbability)
+        const edgePct = calculateEdge(modelProbability, impliedProbability)
+        const evPer100 = calculateEvPer100(modelProbability, americanOdds)
+        if (edgePct == null || evPer100 == null || edgePct <= 0 || evPer100 <= 0) return
+
+        candidates.push({
+          id: `${event.event_id || matchup?.game_pk || key}-${marketKey(market)}-${pick}-${americanOdds}`,
+          gameId: matchup?.game_pk || event.event_id,
+          matchup: `${away} @ ${home}`,
+          market: cleanMarketName(market.market_name || marketKey(market)),
+          pick,
+          americanOdds,
+          modelProbability,
+          impliedProbability,
+          fairOdds,
+          edgePct,
+          evPer100,
+          reason: reasonForCandidate({ market, side, away, home, matchup, modelGame }),
+          riskNote: 'If confirmed lineups, starters, or market prices change materially, the edge should be recalculated.',
+          href: matchup?.game_pk ? `/matchup/${matchup.game_pk}` : '/',
+          source: {
+            modelProbabilityField: sourceFieldForSelection(side, market),
+            oddsField: 'selection.price',
+          },
+        })
+      })
+    })
+  })
+
+  candidates.sort((a, b) => b.evPer100 - a.evPer100 || b.edgePct - a.edgePct)
+  return candidates[0] || null
+}
+
+function normalizeProbability(value) {
+  const n = number(value)
+  if (n == null) return null
+  if (n > 1 && n <= 100) return n / 100
+  if (n <= 0 || n >= 1) return null
+  return n
+}
+
+function number(value) {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function cleanMarketName(value) {
+  return String(value || 'Market').replaceAll('_', ' ').replace(/\b\w/g, c => c.toUpperCase())
+}
+
+function normalizeTeamName(name) {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9]/g, '').replace(/^the/, '')
+}
+
+function matchupKey(away, home) {
+  return `${normalizeTeamName(away)}@${normalizeTeamName(home)}`
+}
+
+function teamName(value) {
+  if (!value) return ''
+  return typeof value === 'string' ? value : value.name || value.fullName || value.teamName || ''
+}
+
+function keyFromMatchup(matchup) {
+  return matchupKey(matchup?.away_team_name || matchup?.away_team || matchup?.away_name, matchup?.home_team_name || matchup?.home_team || matchup?.home_name)
+}
+
+function keyFromEvent(event) {
+  return matchupKey(teamName(event?.away_team) || event?.away_team, teamName(event?.home_team) || event?.home_team)
+}
+
+function marketKey(market) {
+  return String(market?.market_key || market?.market_type || market?.market_name || '').toLowerCase()
+}
+
+function gameMarkets(event) {
+  return asArray(event?.markets).filter(market => {
+    const key = marketKey(market)
+    const name = String(market?.market_name || '').toLowerCase()
+    return ['h2h', 'spreads', 'totals'].includes(key) || name.includes('moneyline') || name.includes('run line') || name.includes('total') || name.includes('first 5') || name.includes('f5')
+  })
+}
+
+function selectionLabel(selection) {
+  return `${selection?.description || selection?.name || 'Selection'}${selection?.line != null ? ` ${selection.line}` : ''}`
+}
+
+function inferSide(selection, away, home) {
+  const text = `${selection?.description || ''} ${selection?.name || ''}`.toLowerCase()
+  if (text.includes(normalizeTeamName(away)) || normalizeTeamName(text).includes(normalizeTeamName(away))) return 'away'
+  if (text.includes(normalizeTeamName(home)) || normalizeTeamName(text).includes(normalizeTeamName(home))) return 'home'
+  if (text.includes('over')) return 'over'
+  if (text.includes('under')) return 'under'
+  return null
+}
+
+function probabilityForSelection({ side, market, selection, matchup, modelGame, sources }) {
+  const key = marketKey(market)
+  if (side === 'away') return firstProbability(sources, ['away_win_prob', 'away_win_probability', 'away_model_probability', 'away_projected_probability'])
+  if (side === 'home') return firstProbability(sources, ['home_win_prob', 'home_win_probability', 'home_model_probability', 'home_projected_probability'])
+  const selectionProb = firstProbability([selection, market, matchup, modelGame], ['model_probability', 'projected_probability', 'projectedProbability', 'fair_probability', 'modelProbability'])
+  if (selectionProb != null) return selectionProb
+  if (key === 'totals') return null
+  return firstProbability(sources, ['model_probability', 'projected_probability', 'win_probability', 'projectedWinProb', 'modelWinProb'])
+}
+
+function firstProbability(sources, keys) {
+  for (const source of sources.filter(Boolean)) {
+    for (const key of keys) {
+      const value = firstValue(source, [key])
+      const p = normalizeProbability(value)
+      if (p != null) return p
+    }
+  }
+  return null
+}
+
+function firstValue(source, paths) {
+  for (const path of paths) {
+    const value = getPath(source, path)
+    if (value !== null && value !== undefined && value !== '') return value
+  }
+  return null
+}
+
+function getPath(obj, path) {
+  if (!obj || !path) return null
+  const parts = String(path).split('.')
+  let cur = obj
+  for (const part of parts) {
+    if (!cur || typeof cur !== 'object') return null
+    cur = cur[part]
+  }
+  return cur
+}
+
+function modelGamesFromPayload(payload) {
+  if (Array.isArray(payload?.games)) return payload.games
+  if (Array.isArray(payload?.models)) return payload.models
+  return []
+}
+
+function boardItemsFromPayload(payload) {
+  const results = payload?.results || {}
+  return Object.values(results).flatMap(result => asArray(result?.items))
+}
+
+function sameTeamText(item, team) {
+  const t = normalizeTeamName(team)
+  const haystack = normalizeTeamName(`${item?.team || ''} ${item?.opponent || ''} ${item?.entity_name || ''} ${item?.pick || ''}`)
+  return Boolean(t && haystack.includes(t))
+}
+
+function sourceFieldForSelection(side, market) {
+  if (side === 'away') return 'away_win_prob / away_win_probability'
+  if (side === 'home') return 'home_win_prob / home_win_probability'
+  return `${marketKey(market)} model probability field`
+}
+
+function reasonForCandidate({ market, side, away, home }) {
+  const marketName = cleanMarketName(market.market_name || marketKey(market))
+  if (side === 'away') return `MLBGPT model probability on ${away} is higher than the sportsbook implied probability for this ${marketName} price.`
+  if (side === 'home') return `MLBGPT model probability on ${home} is higher than the sportsbook implied probability for this ${marketName} price.`
+  return `MLBGPT found a positive value gap between model probability and sportsbook implied probability for this ${marketName}.`
+}

--- a/frontend/src/lib/landing/selectBetOfTheDay.test.mjs
+++ b/frontend/src/lib/landing/selectBetOfTheDay.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  americanOddsToDecimal,
+  americanOddsToImpliedProbability,
+  calculateEdge,
+  calculateEvPer100,
+  probabilityToFairAmericanOdds,
+} from './selectBetOfTheDay.mjs'
+
+const near = (actual, expected, epsilon = 0.000001) => assert.ok(Math.abs(actual - expected) < epsilon, `${actual} not within ${epsilon} of ${expected}`)
+
+test('+100 implied probability = 50%', () => {
+  near(americanOddsToImpliedProbability(100), 0.5)
+})
+
+test('+150 implied probability = 40%', () => {
+  near(americanOddsToImpliedProbability(150), 0.4)
+})
+
+test('-150 implied probability = 60%', () => {
+  near(americanOddsToImpliedProbability(-150), 0.6)
+})
+
+test('model 55%, market 50% edge = 5%', () => {
+  near(calculateEdge(0.55, 0.5), 0.05)
+})
+
+test('fair American odds from model probability', () => {
+  near(probabilityToFairAmericanOdds(0.55), -122.2222222222, 0.0001)
+  near(probabilityToFairAmericanOdds(0.4), 150)
+})
+
+test('decimal odds for positive and negative American odds', () => {
+  near(americanOddsToDecimal(150), 2.5)
+  near(americanOddsToDecimal(-150), 1.6666666667, 0.0001)
+})
+
+test('EV calculation works for positive odds', () => {
+  near(calculateEvPer100(0.55, 150), 37.5)
+})
+
+test('EV calculation works for negative odds', () => {
+  near(calculateEvPer100(0.65, -150), 8.3333333333, 0.0001)
+})

--- a/frontend/src/pages/LandingV2Page.jsx
+++ b/frontend/src/pages/LandingV2Page.jsx
@@ -1,384 +1,189 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { API_BASE, getMlbLiveDate } from '../lib/api'
+import { API_BASE, fetchJson, getMlbLiveDate, readCachedJson } from '../lib/api'
+import { selectBetOfTheDay } from '../lib/landing/selectBetOfTheDay.mjs'
 
-const SESSION_KEY = 'mlbgpt_dashboard_session_token'
+const TTL = { matchups: 120, events: 90, models: 120, board: 300 }
+const C = { bg: '#070b14', border: '#21304a', text: '#eef5ff', muted: '#91a1bb', green: '#42f58d', blue: '#56b7ff', yellow: '#ffd166', red: '#ff6b7a' }
 
-const COMPONENTS = [
-  { key: 'hitters', title: 'My Top Hitters Today', shortTitle: 'Hitters', description: 'Stored 365 hitter board with pitch-type matchup, EV, LA, and arsenal context.' },
-  { key: 'pitchers', title: 'My Top Pitchers Today', shortTitle: 'Pitchers', description: 'Pitcher lean board using K profile, contact suppression, and opponent context.' },
-  { key: 'teams', title: 'My Top Teams Today', shortTitle: 'Teams', description: 'Team board from model side edge, projected runs, and offense profile.' },
-  { key: 'totals', title: 'My Top Totals Today', shortTitle: 'Totals', description: 'Game total board from projected runs, run environment, and simulation context.' },
-  { key: 'overall_players', title: 'My Top Overall Players Today', shortTitle: 'Overall', description: 'Combined player board blending hitter and pitcher solver outputs.' },
-]
+const pct = v => Number.isFinite(Number(v)) ? `${(Number(v) * 100).toFixed(1)}%` : 'Unavailable'
+const odds = v => Number.isFinite(Number(v)) ? (Math.round(Number(v)) > 0 ? `+${Math.round(Number(v))}` : `${Math.round(Number(v))}`) : 'Unavailable'
+const money = v => Number.isFinite(Number(v)) ? `${Number(v) >= 0 ? '+' : '-'}$${Math.abs(Number(v)).toFixed(1)}` : 'Unavailable'
+const dateLabel = d => { try { return new Date(`${d}T12:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) } catch { return d } }
+const impliedFormula = o => Number(o) > 0 ? `100 / (${Number(o)} + 100)` : `${Math.abs(Number(o))} / (${Math.abs(Number(o))} + 100)`
 
-const C = {
-  bg: '#070b14',
-  panel: '#0d1424',
-  panel2: '#101a2e',
-  border: '#21304a',
-  text: '#eef5ff',
-  muted: '#91a1bb',
-  green: '#42f58d',
-  blue: '#56b7ff',
-}
-
-function token() {
-  if (typeof window === 'undefined' || !window.localStorage) return ''
-  return window.localStorage.getItem(SESSION_KEY) || ''
-}
-
-function saveToken(value) {
-  if (typeof window !== 'undefined' && value) window.localStorage.setItem(SESSION_KEY, value)
-}
-
-function fmt(value) {
-  const num = Number(value)
-  if (!Number.isFinite(num)) return value == null || value === '' ? '—' : String(value)
-  return Math.abs(num) >= 10 ? num.toFixed(1) : num.toFixed(3)
-}
-
-function title(item) {
-  return item?.entity_name || item?.player || item?.game || item?.teams || 'Dashboard result'
-}
-
-function subtitle(item, component) {
-  return item?.primary_reason || item?.market || item?.pick || item?.entity_type || component?.description || ''
-}
-
-function metrics(item) {
-  return Object.entries(item?.metrics || {}).filter(([, value]) => value !== null && value !== undefined && value !== '')
-}
-
-function dateLabel(date) {
-  try {
-    return new Date(`${date}T12:00:00`).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  } catch {
-    return date
-  }
-}
-
-function Pill({ children, tone = '' }) {
-  if (children === null || children === undefined || children === '') return null
-  return <span className={`status-badge ${tone}`}>{children}</span>
-}
-
-function Metric({ label, value }) {
-  if (value === null || value === undefined || value === '') return null
-  return (
-    <div style={s.metric}>
-      <span style={s.metricLabel}>{label}</span>
-      <strong style={s.metricValue}>{value}</strong>
-    </div>
-  )
-}
-
-function useDashboardPreview(date) {
-  const [profile, setProfile] = useState(null)
-  const [checked, setChecked] = useState(false)
-  const [results, setResults] = useState({})
+function useLandingBet(date) {
+  const matchupsUrl = `${API_BASE}/matchups?date=${date}`
+  const eventsUrl = `${API_BASE}/odds/draftkings/events?date=${date}`
+  const modelsUrl = `${API_BASE}/daily-odds/models?date=${date}`
+  const boardKey = `${API_BASE}/my-dashboard/solver/batch::landing-bet-of-day::${date}`
+  const [matchups, setMatchups] = useState(() => readCachedJson(matchupsUrl, TTL.matchups) || [])
+  const [eventsPayload, setEventsPayload] = useState(() => readCachedJson(eventsUrl, TTL.events))
+  const [modelPayload, setModelPayload] = useState(() => readCachedJson(modelsUrl, TTL.models))
+  const [boardPayload, setBoardPayload] = useState(() => readCachedJson(boardKey, TTL.board))
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
     let cancelled = false
-
     async function load() {
+      setLoading(true)
       setError('')
       try {
-        const session = token()
-        const profileResponse = await fetch(`${API_BASE}/my-dashboard/profile`, {
-          credentials: 'include',
-          headers: session ? { 'X-Dashboard-Session': session } : {},
-        })
-        const profileJson = await profileResponse.json().catch(() => ({}))
+        const [m, e, models] = await Promise.all([
+          fetchJson(matchupsUrl, { ttlSeconds: TTL.matchups }),
+          fetchJson(eventsUrl, { ttlSeconds: TTL.events }),
+          fetchJson(modelsUrl, { ttlSeconds: TTL.models }).catch(() => null),
+        ])
         if (cancelled) return
-
-        if (profileJson?.session_token) saveToken(profileJson.session_token)
-        if (!profileJson?.authenticated) {
-          setProfile(null)
-          setChecked(true)
-          return
-        }
-
-        setProfile(profileJson.user || null)
-        setChecked(true)
-        setLoading(true)
-
-        const keys = COMPONENTS.map(component => component.key)
-        const boardResponse = await fetch(`${API_BASE}/my-dashboard/solver/batch`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token() ? { 'X-Dashboard-Session': token() } : {}),
-          },
-          body: JSON.stringify({
-            date,
-            components: keys,
-            filters_by_component: Object.fromEntries(keys.map(key => [key, {}])),
-            active_lineups: false,
-          }),
-        })
-        const boardJson = await boardResponse.json().catch(() => ({}))
-        if (cancelled) return
-        if (!boardResponse.ok) throw new Error(typeof boardJson?.detail === 'string' ? boardJson.detail : 'Dashboard solver unavailable')
-        setResults(boardJson.results || {})
+        setMatchups(Array.isArray(m) ? m : [])
+        setEventsPayload(e)
+        setModelPayload(models)
       } catch (err) {
-        if (!cancelled) setError(err.message || 'Dashboard preview unavailable')
+        if (!cancelled) setError(String(err?.message || err))
       } finally {
-        if (!cancelled) {
-          setChecked(true)
-          setLoading(false)
-        }
+        if (!cancelled) setLoading(false)
       }
-    }
 
+      try {
+        const res = await fetch(`${API_BASE}/my-dashboard/solver/batch`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ date, components: ['teams', 'totals'], filters_by_component: { teams: {}, totals: {} }, active_lineups: false }),
+        })
+        const json = await res.json().catch(() => null)
+        if (!cancelled && res.ok) {
+          sessionStorage.setItem(`mlb-json-cache:v1:${boardKey}`, JSON.stringify({ createdAt: Date.now(), value: json }))
+          setBoardPayload(json)
+        }
+      } catch {}
+    }
     load()
     return () => { cancelled = true }
-  }, [date])
+  }, [date, matchupsUrl, eventsUrl, modelsUrl, boardKey])
 
-  return { profile, checked, results, loading, error }
+  const events = Array.isArray(eventsPayload?.events) ? eventsPayload.events : []
+  const bet = useMemo(() => selectBetOfTheDay({ matchups, events, modelPayload, boardPayload }), [matchups, events, modelPayload, boardPayload])
+  const modelRows = Array.isArray(modelPayload?.games) ? modelPayload.games.length : Array.isArray(modelPayload?.models) ? modelPayload.models.length : 0
+  return { bet, loading, error, counts: { matchups: matchups.length, events: events.length, modelRows } }
 }
 
-function buildSections(results) {
-  return COMPONENTS.map(component => ({
-    ...component,
-    items: Array.isArray(results?.[component.key]?.items) ? results[component.key].items.slice(0, 3) : [],
-  })).filter(section => section.items.length > 0)
+function ValueMetric({ label, value, accent }) {
+  return <div style={s.metric}><span style={s.metricLabel}>{label}</span><strong style={{ ...s.metricValue, color: accent ? C.green : C.text }}>{value}</strong></div>
 }
 
-function DashboardCard({ item, component, active, onClick }) {
-  const confidence = String(item?.confidence || '').toLowerCase()
-  const tone = confidence.includes('high') ? 'success' : confidence.includes('medium') ? 'warning' : confidence.includes('low') ? 'danger' : ''
-  return (
-    <button type="button" onClick={onClick} style={active ? s.previewCardActive : s.previewCard}>
-      <div style={s.cardTop}>
-        <div>
-          <div style={s.cardTitle}>{title(item)}</div>
-          <div style={s.cardMeta}>{subtitle(item, component)}</div>
-        </div>
-        <div style={s.scoreBox}>
-          <span style={s.scoreLabel}>Score</span>
-          <strong style={s.score}>{fmt(item?.score)}</strong>
-        </div>
-      </div>
-      <div style={s.pills}>
-        <Pill>{item?.entity_type}</Pill>
-        <Pill tone="success">{item?.team}</Pill>
-        {item?.opponent ? <Pill tone="warning">vs {item.opponent}</Pill> : null}
-        <Pill tone={tone}>{item?.confidence}</Pill>
-      </div>
-    </button>
-  )
+function BetCard({ bet, loading, onUnlock }) {
+  if (!bet) return <article style={s.betCard}>
+    <div style={s.kicker}>Bet of the Day</div>
+    <h2 style={s.betTitle}>{loading ? 'Finding today’s best value...' : 'Today’s full card is available inside Pro.'}</h2>
+    <p style={s.sub}>{loading ? 'Scanning model probabilities and market prices.' : 'No public Bet of the Day is available yet because no eligible play has both model probability and odds. No fake play is shown.'}</p>
+    <div style={s.blurRows}><span style={s.blurLine} /><span style={s.blurLine} /><span style={s.blurLineShort} /></div>
+    <button type="button" onClick={onUnlock} style={{ ...s.primary, marginTop: 18 }}>Unlock Today’s Card</button>
+  </article>
+
+  return <article style={s.betCard}>
+    <div style={s.cardTop}><span style={s.kicker}>Bet of the Day</span><span style={s.livePill}>Value math</span></div>
+    <h2 style={s.betTitle}>{bet.matchup}</h2>
+    <div style={s.pickLine}>{bet.pick}</div>
+    <div style={s.marketLine}>{bet.market}</div>
+    <div style={s.valueGrid}>
+      <ValueMetric label="Sportsbook Price" value={odds(bet.americanOdds)} />
+      <ValueMetric label="MLBGPT Fair Price" value={odds(bet.fairOdds)} />
+      <ValueMetric label="Model Probability" value={pct(bet.modelProbability)} />
+      <ValueMetric label="Market Implied" value={pct(bet.impliedProbability)} />
+      <ValueMetric label="Edge" value={`+${pct(bet.edgePct)}`} accent />
+      <ValueMetric label="EV per $100" value={money(bet.evPer100)} accent />
+    </div>
+    <div style={s.reason}><strong>Why it grades well:</strong><p>{bet.reason}</p></div>
+    <div style={s.risk}><strong>Risk note:</strong><p>{bet.riskNote}</p></div>
+    <div style={s.buttons}><button type="button" onClick={onUnlock} style={s.primary}>Unlock Full Card</button>{bet.href && <Link to={bet.href} style={s.secondary}>View Matchup</Link>}</div>
+  </article>
 }
 
-function SelectedBreakdown({ selected, onUnlock }) {
-  if (!selected) {
-    return (
-      <section style={s.section}>
-        <div style={s.panelLarge}>
-          <p style={s.kicker}>Selected Play Breakdown</p>
-          <h2 style={s.h2}>Why this grades well</h2>
-          <p style={s.sub}>Select a preview card to inspect its real dashboard fields.</p>
-        </div>
-      </section>
-    )
-  }
+function FormulaPanel({ bet }) {
+  return <section style={s.section}>
+    <h2 style={s.h2}>How MLBGPT finds value</h2>
+    <p style={s.sub}>The landing page calculates odds math only. It does not create baseball projections.</p>
+    {bet ? <div style={s.grid4}>
+      <Formula title="1. Convert odds" body={`For ${odds(bet.americanOdds)}: ${impliedFormula(bet.americanOdds)} = ${pct(bet.impliedProbability)}`} />
+      <Formula title="2. Compare probability" body={`Model probability: ${pct(bet.modelProbability)}. Market probability: ${pct(bet.impliedProbability)}.`} />
+      <Formula title="3. Calculate edge" body={`${pct(bet.modelProbability)} - ${pct(bet.impliedProbability)} = +${pct(bet.edgePct)}`} />
+      <Formula title="4. Estimate EV" body={`EV per $100 = ${money(bet.evPer100)} using the sportsbook price and model probability.`} />
+    </div> : <div style={s.panel}>Formula panel appears only when a real candidate has both model probability and odds.</div>}
+  </section>
+}
 
-  const { component, item } = selected
-  const itemMetrics = metrics(item)
-  const reasoning = Array.isArray(item?.reasoning) ? item.reasoning.filter(Boolean) : []
+function Formula({ title, body }) {
+  return <div style={s.panel}><div style={s.panelTitle}>{title}</div><div>{body}</div></div>
+}
 
-  return (
-    <section style={s.section}>
-      <div style={s.panelLarge}>
-        <div style={s.sectionHead}>
-          <div>
-            <p style={s.kicker}>{component.title}</p>
-            <h2 style={s.h2}>Why this grades well</h2>
-            <p style={s.sub}>{title(item)} — {subtitle(item, component)}</p>
-          </div>
-          <button type="button" onClick={onUnlock} style={s.primary}>Unlock Today’s Card</button>
-        </div>
-        <div style={s.metricGrid}>
-          <Metric label="Score" value={fmt(item?.score)} />
-          <Metric label="Confidence" value={item?.confidence || '—'} />
-          <Metric label="Team" value={item?.team} />
-          <Metric label="Opponent" value={item?.opponent ? `vs ${item.opponent}` : null} />
-        </div>
-        {reasoning.length ? (
-          <div style={s.reasonBox}>
-            <h3 style={s.h3}>Reason / explanation</h3>
-            <ul style={s.reasons}>{reasoning.slice(0, 5).map((reason, index) => <li key={`${title(item)}-${index}`}>{reason}</li>)}</ul>
-          </div>
-        ) : null}
-        {itemMetrics.length ? (
-          <div style={s.reasonBox}>
-            <h3 style={s.h3}>Supporting metrics</h3>
-            <div style={s.metricGrid}>{itemMetrics.slice(0, 12).map(([key, value]) => <Metric key={key} label={key} value={fmt(value)} />)}</div>
-          </div>
-        ) : null}
-      </div>
-    </section>
-  )
+function LockedPreview({ onUnlock }) {
+  const cards = [['Sides & Totals', 'Moneylines, run lines, totals, F5 angles'], ['Hitter Props', 'Hits, total bases, home runs, runs, RBI'], ['Pitcher Props', 'Strikeouts, outs, walks, earned runs']]
+  return <section style={s.section}>
+    <h2 style={s.h2}>The full card stays inside Pro.</h2>
+    <p style={s.sub}>See every qualified side, total, F5 angle, hitter prop, and pitcher prop with model context, odds value, and risk notes.</p>
+    <div style={s.lockGrid}>{cards.map(([title, body]) => <div key={title} style={s.lockCard}><div style={s.lockText}>LOCKED</div><h3 style={s.h3}>{title}</h3><p style={s.sub}>{body}</p><div style={s.blurRows}><span style={s.blurLine} /><span style={s.blurLine} /><span style={s.blurLineShort} /></div><button type="button" onClick={onUnlock} style={s.lockButton}>Unlock Pro</button></div>)}</div>
+  </section>
+}
+
+function ProductProof() {
+  const cards = [['Model Projection', 'MLBGPT starts with a projected probability from the model.'], ['Market Odds', 'The app compares that projection against live or stored sportsbook prices.'], ['Implied Probability', 'Odds are converted into market-implied probability.'], ['Expected Value', 'The difference between the model probability and market price creates the edge.']]
+  return <section style={s.section}><h2 style={s.h2}>What MLBGPT evaluates</h2><div style={s.grid4}>{cards.map(([title, body]) => <div key={title} style={s.panel}><div style={s.panelTitle}>{title}</div><p style={s.sub}>{body}</p></div>)}</div></section>
 }
 
 export default function LandingV2Page() {
   const navigate = useNavigate()
   const date = getMlbLiveDate()
-  const { profile, checked, results, loading, error } = useDashboardPreview(date)
-  const sections = useMemo(() => buildSections(results), [results])
-  const [selected, setSelected] = useState(null)
-
-  useEffect(() => {
-    if (!selected && sections[0]?.items?.[0]) setSelected({ component: sections[0], item: sections[0].items[0] })
-  }, [sections, selected])
-
-  function unlock() {
-    navigate('/my-dashboard')
-  }
-
-  const topSection = sections[0]
-
-  return (
-    <div style={s.page}>
-      <section style={s.hero}>
-        <div>
-          <div style={s.eyebrow}>● Live MLB Prediction Engine</div>
-          <h1 style={s.h1}>Today’s MLB card, ranked by edge.</h1>
-          <p style={s.heroText}>MLBGPT scans every matchup using pitcher trends, bullpen form, team offense, weather, odds, and AI model projections to surface the strongest betting angles before first pitch.</p>
-          <div style={s.buttons}>
-            <button type="button" onClick={unlock} style={s.primary}>Unlock Today’s Card</button>
-            <Link to="/" style={s.secondary}>View Matchups</Link>
-          </div>
-        </div>
-        <div style={s.terminal}>
-          <div style={s.terminalHead}>
-            <strong>{topSection?.title || 'Today’s Best Scores'}</strong>
-            <span style={s.green}>{profile ? 'Dashboard Data' : 'Preview Locked'}</span>
-            <span style={s.muted}>{dateLabel(date)}</span>
-          </div>
-          <div style={s.boardRows}>
-            {topSection?.items?.length ? topSection.items.map((item, index) => (
-              <div key={`${topSection.key}-${item?.entity_id || index}`} style={s.heroRow}>
-                <span style={s.rowTitle}>{title(item)}</span>
-                <span>{item?.entity_type || topSection.shortTitle}</span>
-                <strong style={s.green}>{fmt(item?.score)}</strong>
-                <strong style={s.blue}>{item?.confidence || '—'}</strong>
-              </div>
-            )) : (
-              <div style={s.emptyPreview}>Sign in to preview today’s ranked dashboard cards. This page does not show fake plays.</div>
-            )}
-          </div>
-          {selected ? <div style={s.heroMetrics}><Metric label="Selected" value={title(selected.item)} /><Metric label="Score" value={fmt(selected.item?.score)} /><Metric label="Confidence" value={selected.item?.confidence || '—'} /></div> : null}
-        </div>
-      </section>
-
-      {loading ? <div className="state-panel" style={s.notice}>Loading real dashboard preview…</div> : null}
-      {error ? <div className="state-panel error" style={s.notice}>Dashboard preview unavailable: {error}</div> : null}
-
-      <section style={s.section}>
-        <div style={s.sectionHead}>
-          <div>
-            <h2 style={s.h2}>Today’s Best Scores</h2>
-            <p style={s.sub}>A public preview layer composed from the same My Dashboard board outputs.</p>
-          </div>
-          <button type="button" onClick={unlock} style={s.secondary}>Unlock Full Card</button>
-        </div>
-        {sections.length ? (
-          <div style={s.previewGrid}>{sections.map(section => (
-            <div key={section.key} style={s.panel}>
-              <h3 style={s.h3}>{section.title}</h3>
-              <p style={s.cardMeta}>{section.description}</p>
-              <div style={s.stack}>{section.items.map((item, index) => <DashboardCard key={`${section.key}-${item?.entity_id || index}`} item={item} component={section} active={selected?.item === item} onClick={() => checked && !profile ? unlock() : setSelected({ component: section, item })} />)}</div>
-            </div>
-          ))}</div>
-        ) : (
-          <div className="state-panel" style={{ textAlign: 'left' }}><strong>No fabricated picks are displayed.</strong><p style={{ margin: '8px 0 0' }}>Sign in to run the existing dashboard board engine.</p></div>
-        )}
-      </section>
-
-      <SelectedBreakdown selected={selected} onUnlock={unlock} />
-
-      <section style={s.section}>
-        <h2 style={s.h2}>Built like a sportsbook dashboard. Explained like an analyst.</h2>
-        <p style={s.sub}>The preview preserves the existing My Dashboard categories, solver endpoint, score field, confidence field, metrics, and reasoning.</p>
-        <div style={s.proofGrid}>
-          <div style={s.panel}><h3 style={s.h3}>Dashboard boards</h3>{COMPONENTS.map(component => <div key={component.key} style={component.key === (topSection?.key || 'hitters') ? s.navActive : s.navItem}>{component.shortTitle}</div>)}</div>
-          <div style={s.panel}><h3 style={s.h3}>Real output fields</h3><p style={s.sub}>entity_name, primary_reason, score, confidence, entity_type, team, opponent, metrics, reasoning.</p></div>
-          <div style={s.panel}><h3 style={s.h3}>No new model logic</h3><p style={s.sub}>This route consumes `/my-dashboard/solver/batch` and does not calculate new scores client-side.</p></div>
-        </div>
-      </section>
-
-      <section style={s.section}>
-        <div style={s.assistant}>
-          <div><h2 style={s.h2}>Ask MLBGPT before you bet.</h2><p style={s.sub}>The existing AI Data Assistant is available for slate, matchup, model-edge, and data-quality questions.</p></div>
-          <div style={s.prompt}><strong>Prompt:</strong> What is the strongest model edge?<div style={s.answer}>Open the AI Data Assistant to ask this against live app-owned data.</div><Link to="/ai-data-assistant" style={{ ...s.secondary, display: 'inline-flex', marginTop: 14 }}>Open AI Data Assistant</Link></div>
-        </div>
-      </section>
-
-      <section style={s.final}>
-        <h2 style={s.finalTitle}>Stop building your MLB card from scratch.</h2>
-        <p style={s.finalText}>Let MLBGPT rank the board, explain the edge, and show the risk before first pitch.</p>
-        <button type="button" onClick={unlock} style={s.primary}>Unlock Today’s Card</button>
-      </section>
-    </div>
-  )
+  const { bet, loading, error, counts } = useLandingBet(date)
+  const unlock = () => navigate('/my-dashboard')
+  return <div style={s.page}>
+    <section style={s.hero}><div><div style={s.eyebrow}>Live MLB Prediction Engine</div><h1 style={s.h1}>Today’s MLB card, ranked by edge.</h1><p style={s.heroText}>MLBGPT compares model projections, sportsbook odds, implied probability, and market value to find the best MLB betting angles before first pitch.</p><div style={s.buttons}><button type="button" onClick={unlock} style={s.primary}>Unlock Today’s Card</button><Link to="/" style={s.secondary}>View Matchups</Link></div></div><BetCard bet={bet} loading={loading} onUnlock={unlock} /></section>
+    <div style={s.status}><span>{dateLabel(date)}</span><span>{loading ? 'Scanning prices...' : 'Scan complete'}</span><span>{counts.matchups} matchups | {counts.events} events | {counts.modelRows} model rows</span>{error && <span style={{ color: C.red }}>{error.slice(0, 90)}</span>}</div>
+    <FormulaPanel bet={bet} />
+    <LockedPreview onUnlock={unlock} />
+    <ProductProof />
+    <section style={s.final}><h2 style={s.finalTitle}>Want the full card?</h2><p style={s.finalText}>Unlock every qualified play with odds value, model context, and risk notes.</p><button type="button" onClick={unlock} style={s.primary}>Unlock Today’s Card</button></section>
+  </div>
 }
 
 const s = {
   page: { margin: '-34px calc(50% - 50vw) -56px', padding: '76px 28px 0', minHeight: '100vh', color: C.text, background: `radial-gradient(circle at top left, rgba(66,245,141,.12), transparent 32%), radial-gradient(circle at 75% 10%, rgba(86,183,255,.12), transparent 28%), ${C.bg}` },
-  hero: { maxWidth: 1220, margin: '0 auto', paddingBottom: 48, display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 40, alignItems: 'center' },
+  hero: { maxWidth: 1220, margin: '0 auto', paddingBottom: 28, display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(340px,1fr))', gap: 40, alignItems: 'center' },
   eyebrow: { display: 'inline-flex', padding: '8px 12px', border: `1px solid ${C.border}`, borderRadius: 999, background: 'rgba(13,20,36,.72)', color: C.green, fontSize: 13, fontWeight: 800, marginBottom: 22 },
   h1: { fontSize: 'clamp(48px,7vw,78px)', lineHeight: .94, letterSpacing: '-0.075em', margin: '0 0 24px' },
   h2: { fontSize: 'clamp(32px,5vw,42px)', lineHeight: 1, letterSpacing: '-0.05em', margin: '0 0 14px' },
   h3: { margin: '0 0 10px', fontSize: 21, letterSpacing: '-0.03em' },
   heroText: { color: '#b6c4d9', fontSize: 19, lineHeight: 1.55, maxWidth: 600, margin: '0 0 30px' },
-  buttons: { display: 'flex', gap: 14, flexWrap: 'wrap', alignItems: 'center' },
-  primary: { background: `linear-gradient(135deg, ${C.green}, ${C.blue})`, color: '#04100b', padding: '15px 22px', borderRadius: 14, fontWeight: 900, border: 0, textDecoration: 'none' },
+  buttons: { display: 'flex', gap: 14, flexWrap: 'wrap', alignItems: 'center', marginTop: 18 },
+  primary: { background: `linear-gradient(135deg, ${C.green}, ${C.blue})`, color: '#04100b', padding: '15px 22px', borderRadius: 14, fontWeight: 900, border: 0, textDecoration: 'none', cursor: 'pointer' },
   secondary: { border: `1px solid ${C.border}`, color: C.text, padding: '14px 20px', borderRadius: 14, fontWeight: 800, background: 'rgba(13,20,36,.56)', textDecoration: 'none' },
-  terminal: { border: `1px solid ${C.border}`, borderRadius: 26, background: 'linear-gradient(180deg,rgba(16,26,46,.96),rgba(7,11,20,.98))', boxShadow: '0 30px 100px rgba(0,0,0,.38)', overflow: 'hidden' },
-  terminalHead: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap', padding: '18px 20px', borderBottom: `1px solid ${C.border}` },
-  boardRows: { padding: 18 },
-  heroRow: { display: 'grid', gridTemplateColumns: '1fr .6fr .35fr .55fr', gap: 12, alignItems: 'center', padding: '14px', marginBottom: 10, border: '1px solid rgba(255,255,255,.06)', borderRadius: 16, background: 'rgba(255,255,255,.035)' },
-  rowTitle: { fontWeight: 850 },
-  heroMetrics: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(140px,1fr))', gap: 10, padding: '0 18px 18px' },
-  emptyPreview: { padding: 18, border: '1px solid rgba(255,255,255,.06)', borderRadius: 16, color: C.muted, background: 'rgba(255,255,255,.035)' },
-  section: { maxWidth: 1180, margin: '0 auto', padding: '48px 0' },
-  sectionHead: { display: 'flex', justifyContent: 'space-between', gap: 18, alignItems: 'start', flexWrap: 'wrap', marginBottom: 22 },
-  sub: { color: C.muted, fontSize: 17, lineHeight: 1.55, margin: 0 },
-  previewGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 18 },
-  panel: { border: `1px solid ${C.border}`, borderRadius: 22, padding: 20, background: 'rgba(13,20,36,.72)' },
-  panelLarge: { border: `1px solid ${C.border}`, borderRadius: 28, padding: 24, background: '#0a1020', boxShadow: '0 24px 80px rgba(0,0,0,.28)' },
-  stack: { display: 'grid', gap: 12, marginTop: 14 },
-  previewCard: { width: '100%', border: '1px solid rgba(255,255,255,.08)', borderRadius: 18, padding: 14, background: 'rgba(255,255,255,.035)', color: C.text, textAlign: 'left' },
-  previewCardActive: { width: '100%', border: '1px solid rgba(66,245,141,.42)', borderRadius: 18, padding: 14, background: 'rgba(66,245,141,.10)', color: C.text, textAlign: 'left' },
-  cardTop: { display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 12 },
-  cardTitle: { fontSize: 16, fontWeight: 850, color: C.text },
-  cardMeta: { color: C.muted, fontSize: 12, lineHeight: 1.5 },
-  scoreBox: { textAlign: 'right' },
-  scoreLabel: { display: 'block', color: C.muted, fontSize: 10, textTransform: 'uppercase', letterSpacing: '.08em' },
-  score: { display: 'block', color: C.green, fontSize: 22 },
-  pills: { display: 'flex', gap: 8, flexWrap: 'wrap' },
-  metricGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(140px,1fr))', gap: 10, marginTop: 18 },
+  betCard: { border: `1px solid ${C.border}`, borderRadius: 28, background: 'linear-gradient(180deg,rgba(16,26,46,.96),rgba(7,11,20,.98))', boxShadow: '0 30px 100px rgba(0,0,0,.38)', padding: 24 },
+  cardTop: { display: 'flex', justifyContent: 'space-between', gap: 14, alignItems: 'center', marginBottom: 12 },
+  kicker: { color: C.green, fontSize: 12, fontWeight: 850, letterSpacing: '.12em', textTransform: 'uppercase' },
+  livePill: { color: C.green, border: '1px solid rgba(66,245,141,.35)', borderRadius: 999, padding: '6px 10px', fontSize: 12, fontWeight: 850, background: 'rgba(66,245,141,.08)' },
+  betTitle: { margin: 0, fontSize: 32, letterSpacing: '-0.04em', lineHeight: 1.05 },
+  pickLine: { color: C.green, fontSize: 27, fontWeight: 950, marginTop: 12 },
+  marketLine: { color: C.muted, fontSize: 14, fontWeight: 800, textTransform: 'uppercase', letterSpacing: '.08em', marginTop: 4 },
+  valueGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(145px,1fr))', gap: 10, marginTop: 20 },
   metric: { background: 'rgba(86,183,255,.06)', border: '1px solid rgba(86,183,255,.14)', borderRadius: 16, padding: 14 },
-  metricLabel: { display: 'block', color: C.muted, fontSize: 11, textTransform: 'uppercase', letterSpacing: '.07em', marginBottom: 7 },
-  metricValue: { display: 'block', color: C.text, fontSize: 19, overflowWrap: 'anywhere' },
-  reasonBox: { marginTop: 20 },
-  reasons: { color: '#b6c4d9', lineHeight: 1.7, paddingLeft: 20 },
-  proofGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(250px,1fr))', gap: 18, marginTop: 22 },
-  navItem: { padding: 12, borderRadius: 12, color: C.muted, marginBottom: 8 },
-  navActive: { padding: 12, borderRadius: 12, background: 'rgba(66,245,141,.12)', color: C.green, fontWeight: 800, marginBottom: 8 },
-  assistant: { border: `1px solid ${C.border}`, borderRadius: 28, padding: 28, background: 'linear-gradient(135deg,rgba(66,245,141,.08),rgba(86,183,255,.08))', display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 20, alignItems: 'center' },
-  prompt: { background: 'rgba(7,11,20,.72)', border: '1px solid rgba(255,255,255,.09)', borderRadius: 18, padding: 18, color: '#dbe9ff', lineHeight: 1.5 },
-  answer: { marginTop: 12, borderLeft: `3px solid ${C.green}`, paddingLeft: 14, color: C.muted },
+  metricLabel: { display: 'block', color: C.muted, fontSize: 10, textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 7, fontWeight: 850 },
+  metricValue: { display: 'block', color: C.text, fontSize: 19, fontWeight: 950, overflowWrap: 'anywhere' },
+  reason: { marginTop: 18, borderLeft: `3px solid ${C.green}`, paddingLeft: 14, color: '#b6c4d9', lineHeight: 1.55 },
+  risk: { marginTop: 14, borderLeft: `3px solid ${C.yellow}`, paddingLeft: 14, color: '#b6c4d9', lineHeight: 1.55 },
+  sub: { color: C.muted, fontSize: 17, lineHeight: 1.55, margin: 0 },
+  status: { maxWidth: 1220, margin: '0 auto', display: 'flex', flexWrap: 'wrap', gap: 10, color: C.muted, fontSize: 12, border: `1px solid ${C.border}`, background: 'rgba(13,20,36,.52)', borderRadius: 999, padding: '10px 14px' },
+  section: { maxWidth: 1180, margin: '0 auto', padding: '48px 0' },
+  grid4: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(230px,1fr))', gap: 14, marginTop: 18 },
+  panel: { border: `1px solid ${C.border}`, borderRadius: 20, padding: 18, background: 'rgba(13,20,36,.72)', color: C.text, lineHeight: 1.55 },
+  panelTitle: { color: C.green, fontSize: 13, fontWeight: 900, textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: 10 },
+  lockGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 18, marginTop: 22 },
+  lockCard: { border: `1px solid ${C.border}`, borderRadius: 22, padding: 20, background: 'rgba(13,20,36,.72)' },
+  lockText: { color: C.yellow, fontSize: 12, fontWeight: 900, letterSpacing: '.12em', marginBottom: 10 },
+  blurRows: { display: 'grid', gap: 9, marginTop: 18, filter: 'blur(2px)' },
+  blurLine: { display: 'block', height: 16, borderRadius: 999, background: 'rgba(255,255,255,.16)' },
+  blurLineShort: { display: 'block', width: '72%', height: 16, borderRadius: 999, background: 'rgba(255,255,255,.16)' },
+  lockButton: { marginTop: 16, width: '100%', border: `1px solid ${C.border}`, color: C.text, padding: '12px 16px', borderRadius: 12, fontWeight: 900, background: 'rgba(255,255,255,.05)', cursor: 'pointer' },
   final: { textAlign: 'center', padding: '76px 28px 90px' },
   finalTitle: { fontSize: 'clamp(38px,6vw,66px)', lineHeight: .95, letterSpacing: '-0.065em', margin: '0 auto 20px', maxWidth: 760 },
   finalText: { color: C.muted, fontSize: 18, marginBottom: 28 },
-  notice: { maxWidth: 1180, margin: '0 auto 24px' },
-  green: { color: C.green, fontWeight: 850 },
-  blue: { color: C.blue, fontWeight: 850 },
-  muted: { color: C.muted },
-  kicker: { margin: '0 0 8px', color: C.green, fontSize: 12, fontWeight: 850, letterSpacing: '.12em', textTransform: 'uppercase' },
 }


### PR DESCRIPTION
## Summary

Reworks `/landing-v2` so it is a sales-focused landing page instead of a free dashboard preview.

Closes #685.

## What changed

- Replaces the multi-section dashboard preview with one `Bet of the Day` card.
- Adds a landing-specific adapter at `frontend/src/lib/landing/selectBetOfTheDay.mjs`.
- Adds odds/value utility functions:
  - `americanOddsToImpliedProbability`
  - `americanOddsToDecimal`
  - `probabilityToFairAmericanOdds`
  - `calculateEdge`
  - `calculateEvPer100`
- Adds Node test coverage for the odds math.
- Adds a `frontend` test script.
- Adds a locked Pro preview with visual-only cards for:
  - Sides & Totals
  - Hitter Props
  - Pitcher Props
- Adds product proof cards for model projection, market odds, implied probability, and expected value.

## Bet of the Day data source

The selector consumes existing frontend-loaded production data:

- `/matchups?date=YYYY-MM-DD`
- `/odds/draftkings/events?date=YYYY-MM-DD`
- `/daily-odds/models?date=YYYY-MM-DD`
- `/my-dashboard/solver/batch` limited to `teams` and `totals` for context only

## Model probability field

The adapter uses existing probability fields only, preferring side-specific fields when available:

- `away_win_prob`
- `away_win_probability`
- `away_model_probability`
- `away_projected_probability`
- `home_win_prob`
- `home_win_probability`
- `home_model_probability`
- `home_projected_probability`

It also checks generic probability fields for non-side candidates, but no play is shown unless a valid model probability exists.

## Odds field

The adapter uses existing DraftKings selection price fields:

- `selection.price`
- fallback: `selection.american_odds`
- fallback: `selection.odds.american`

## Odds math

- Implied probability:
  - Negative odds: `abs(odds) / (abs(odds) + 100)`
  - Positive odds: `100 / (odds + 100)`
- Fair odds:
  - Probability >= 0.5: `-1 * ((p / (1 - p)) * 100)`
  - Probability < 0.5: `((1 - p) / p) * 100`
- Edge: `modelProbability - impliedProbability`
- EV per $100: `(modelProbability * (decimalOdds - 1) - (1 - modelProbability)) * 100`

## Fallback behavior

If no eligible play has both model probability and sportsbook odds, `/landing-v2` shows a locked Pro fallback card and does not fabricate a play.

## Guardrails

- No full ranked dashboard on the landing page.
- No hitter/pitcher/team section giveaway.
- No fake play.
- No fake odds.
- No new baseball projection logic.
- Locked cards do not reveal actual picks.

## Validation

Not run locally through the connector. Branch is currently behind latest `main` and should be updated before merge.