### PR TITLE
Integrate KIBL Bet105 fixtures and markets feed

### DIFF
--- a/docs/kibl-bet105.md
+++ b/docs/kibl-bet105.md
@@ -1,0 +1,131 @@
+# KIBL Bet105 feed 171 integration
+
+This integration pulls Bet105 fixtures and markets from KIBL into the backend database so the app can compare sportsbook lines against model outputs.
+
+## Runtime flow
+
+```text
+Scheduled job / worker
+    ↓
+Get Cognito token
+    ↓
+Pull KIBL fixtures baseline
+    ↓
+Store fixtures in DB
+    ↓
+Pull KIBL markets baseline
+    ↓
+Store odds/markets in DB
+    ↓
+Every X seconds/minutes:
+        call same endpoints with since_last_updated
+        upsert changed rows
+        update watermark
+```
+
+## Environment variables
+
+Do not commit real values.
+
+```env
+KIBL_COGNITO_REGION=us-west-2
+KIBL_COGNITO_CLIENT_ID=3udv7qsqgju8c4riqvk72bqcl
+KIBL_USERNAME=
+KIBL_PASSWORD=
+KIBL_BASE_URL=https://api.kibl.io/sports/get
+KIBL_FEED_SOURCE_ID=171
+KIBL_DEFAULT_LEAGUE_IDS=20,643
+KIBL_FROM_CACHE=false
+DATABASE_URL=sqlite:///mlb.db
+```
+
+## Important constants
+
+- Bet105 feed source: `feed_source_id=171`
+- Prematch betting type: `betting_type_id=1`
+- Live betting type: `betting_type_id=3`
+- Fixture path: `info/fixtures`
+- Market path: `info/markets`
+- KIBL watermark format: US Eastern `YYYY-MM-DD HH:MM:SS`
+
+## Authentication
+
+`mlb_app.kibl_integration.KiblAuthClient` calls Amazon Cognito `InitiateAuth` with `USER_PASSWORD_AUTH` using environment values. The password is only sent to Cognito. KIBL receives only:
+
+```http
+Authorization: Bearer <access token>
+```
+
+The client caches the access token in memory and refreshes/re-authenticates when KIBL returns `401`, then retries the KIBL request once.
+
+## Baseline sync
+
+Baseline calls do not include `since_last_updated`.
+
+```bash
+python scripts/sync_kibl_bet105.py --baseline --prematch
+python scripts/sync_kibl_bet105.py --baseline --live
+```
+
+Fixtures only:
+
+```bash
+python scripts/sync_kibl_bet105.py --baseline --prematch --fixtures-only
+```
+
+Markets only:
+
+```bash
+python scripts/sync_kibl_bet105.py --baseline --prematch --markets-only
+```
+
+## Diff sync
+
+Diff calls read the stored watermark for the endpoint/filter and include it as `since_last_updated`.
+
+```bash
+python scripts/sync_kibl_bet105.py --diff --prematch
+python scripts/sync_kibl_bet105.py --diff --live
+```
+
+If KIBL returns no rows, the sync no-ops safely and leaves the previous watermark unchanged.
+
+## Persistence
+
+The integration defines three SQLAlchemy models in `mlb_app.kibl_integration`:
+
+- `KiblFixture`
+- `KiblMarket`
+- `KiblSyncWatermark`
+
+The sync stores normalized fields where they are available and always preserves `raw_payload` JSON for forward compatibility with KIBL schema changes.
+
+## Scheduling
+
+The repo can wire the CLI into the existing deployment scheduler/worker. A safe default cadence is controlled outside this module, for example every 60 seconds for live and less frequently for prematch. Keep the cadence configurable in hosting/runtime configuration.
+
+## Troubleshooting
+
+### 401 from KIBL
+
+The client automatically re-authenticates with Cognito and retries once. If it still fails, verify `KIBL_USERNAME`, `KIBL_PASSWORD`, region, and client id.
+
+### Empty diff response
+
+Usually means no rows changed since the stored `since_last_updated` watermark. This is not an error.
+
+### Duplicate rows
+
+The module uses stable keys and idempotent upserts. If duplicates appear, inspect whether KIBL changed identifiers for fixture/market/selection rows and adjust the key extraction candidates.
+
+### Timestamp issues
+
+KIBL expects US Eastern timestamp strings in `YYYY-MM-DD HH:MM:SS`, not UTC ISO strings with `Z`.
+
+## Security boundaries
+
+- Do not log `KIBL_PASSWORD`.
+- Do not log full access tokens.
+- Do not commit credentials.
+- Do not expose sync endpoints publicly.
+- Tests must mock Cognito and KIBL; CI should not call live KIBL.

--- a/mlb_app/kibl_integration.py
+++ b/mlb_app/kibl_integration.py
@@ -1,0 +1,489 @@
+"""KIBL Bet105 sportsbook feed integration.
+
+This module handles the safe backend-only flow for Bet105 feed ingestion:
+Cognito token -> KIBL baseline fixture/market pulls -> idempotent persistence ->
+watermark-driven diff polling.
+
+No live API calls run on import. Credentials are read only from environment at
+runtime and are never logged by helper functions in this module.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import requests
+from sqlalchemy import Column, DateTime, Float, Index, Integer, JSON, String, Text
+from sqlalchemy.orm import Session
+
+from .database import Base
+
+KIBL_COGNITO_REGION_DEFAULT = "us-west-2"
+KIBL_COGNITO_CLIENT_ID_DEFAULT = "3udv7qsqgju8c4riqvk72bqcl"
+KIBL_BASE_URL_DEFAULT = "https://api.kibl.io/sports/get"
+KIBL_FEED_SOURCE_ID_DEFAULT = 171
+KIBL_PREMATCH_BETTING_TYPE_ID = 1
+KIBL_LIVE_BETTING_TYPE_ID = 3
+KIBL_DEFAULT_LEAGUE_IDS = "20,643"
+KIBL_FIXTURES_PATH = "info/fixtures"
+KIBL_MARKETS_PATH = "info/markets"
+KIBL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+_SECRET_KEYS = {"password", "token", "access_token", "authorization", "secret"}
+
+
+class KiblIntegrationError(RuntimeError):
+    """Raised when KIBL auth, fetch, or persistence fails."""
+
+
+@dataclass(frozen=True)
+class KiblConfig:
+    cognito_region: str
+    cognito_client_id: str
+    username: str
+    password: str
+    base_url: str
+    feed_source_id: int
+    default_league_ids: str
+    from_cache: bool
+
+    @classmethod
+    def from_env(cls) -> "KiblConfig":
+        username = os.getenv("KIBL_USERNAME", "")
+        password = os.getenv("KIBL_PASSWORD", "")
+        if not username or not password:
+            raise KiblIntegrationError("KIBL_USERNAME and KIBL_PASSWORD must be set")
+        return cls(
+            cognito_region=os.getenv("KIBL_COGNITO_REGION", KIBL_COGNITO_REGION_DEFAULT),
+            cognito_client_id=os.getenv("KIBL_COGNITO_CLIENT_ID", KIBL_COGNITO_CLIENT_ID_DEFAULT),
+            username=username,
+            password=password,
+            base_url=os.getenv("KIBL_BASE_URL", KIBL_BASE_URL_DEFAULT).rstrip("/"),
+            feed_source_id=int(os.getenv("KIBL_FEED_SOURCE_ID", str(KIBL_FEED_SOURCE_ID_DEFAULT))),
+            default_league_ids=os.getenv("KIBL_DEFAULT_LEAGUE_IDS", KIBL_DEFAULT_LEAGUE_IDS),
+            from_cache=_env_bool("KIBL_FROM_CACHE", default=False),
+        )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def redact_secrets(value: Any) -> Any:
+    """Return a copy with secret-like fields redacted for safe logging."""
+    if isinstance(value, Mapping):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key).lower()
+            if any(secret in key_text for secret in _SECRET_KEYS):
+                redacted[str(key)] = "***REDACTED***"
+            else:
+                redacted[str(key)] = redact_secrets(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_secrets(item) for item in value]
+    return value
+
+
+def eastern_now_string() -> str:
+    """Return the current timestamp in KIBL's expected US Eastern text format."""
+    try:
+        from zoneinfo import ZoneInfo
+
+        now = _dt.datetime.now(ZoneInfo("America/New_York"))
+    except Exception:
+        now = _dt.datetime.utcnow() - _dt.timedelta(hours=5)
+    return now.strftime(KIBL_TIME_FORMAT)
+
+
+def newest_kibl_timestamp(rows: Iterable[Mapping[str, Any]]) -> Optional[str]:
+    """Return the newest last_updated/inserted_on watermark string from rows."""
+    newest: Optional[_dt.datetime] = None
+    newest_raw: Optional[str] = None
+    for row in rows:
+        for field in ("last_updated", "inserted_on"):
+            raw = row.get(field)
+            if not raw:
+                continue
+            parsed = _parse_kibl_time(str(raw))
+            if parsed is None:
+                continue
+            if newest is None or parsed > newest:
+                newest = parsed
+                newest_raw = parsed.strftime(KIBL_TIME_FORMAT)
+    return newest_raw
+
+
+def _parse_kibl_time(raw: str) -> Optional[_dt.datetime]:
+    for fmt in (KIBL_TIME_FORMAT, "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+        try:
+            return _dt.datetime.strptime(raw[:26], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _stable_json_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _first_present(row: Mapping[str, Any], names: Sequence[str]) -> Optional[Any]:
+    for name in names:
+        value = row.get(name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _as_int(value: Any) -> Optional[int]:
+    try:
+        return int(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> Optional[float]:
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_rows(payload: Any) -> List[Dict[str, Any]]:
+    """Extract result rows defensively across likely KIBL response wrappers."""
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if not isinstance(payload, Mapping):
+        return []
+    for key in ("data", "rows", "results", "items", "fixtures", "markets"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, dict)]
+        if isinstance(value, Mapping):
+            nested = extract_rows(value)
+            if nested:
+                return nested
+    return [dict(payload)] if payload else []
+
+
+class KiblFixture(Base):
+    __tablename__ = "kibl_fixtures"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    fixture_key = Column(String(128), nullable=False, unique=True, index=True)
+    external_fixture_id = Column(String(128), nullable=True, index=True)
+    feed_source_id = Column(Integer, nullable=False, index=True)
+    betting_type_id = Column(Integer, nullable=False, index=True)
+    league_id = Column(String(255), nullable=True, index=True)
+    sport_name = Column(String(120), nullable=True)
+    league_name = Column(String(255), nullable=True)
+    home_team = Column(String(255), nullable=True)
+    away_team = Column(String(255), nullable=True)
+    start_time = Column(String(64), nullable=True)
+    last_updated = Column(String(64), nullable=True, index=True)
+    inserted_on = Column(String(64), nullable=True)
+    raw_payload = Column(JSON, nullable=False)
+    created_at = Column(DateTime, default=_dt.datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=_dt.datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("ix_kibl_fixtures_feed_type_league", "feed_source_id", "betting_type_id", "league_id"),
+    )
+
+
+class KiblMarket(Base):
+    __tablename__ = "kibl_markets"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    market_key = Column(String(128), nullable=False, unique=True, index=True)
+    external_market_id = Column(String(128), nullable=True, index=True)
+    external_fixture_id = Column(String(128), nullable=True, index=True)
+    feed_source_id = Column(Integer, nullable=False, index=True)
+    betting_type_id = Column(Integer, nullable=False, index=True)
+    league_id = Column(String(255), nullable=True, index=True)
+    market_name = Column(String(255), nullable=True)
+    selection_name = Column(String(255), nullable=True)
+    price = Column(Float, nullable=True)
+    line = Column(Float, nullable=True)
+    status = Column(String(80), nullable=True)
+    last_updated = Column(String(64), nullable=True, index=True)
+    inserted_on = Column(String(64), nullable=True)
+    raw_payload = Column(JSON, nullable=False)
+    created_at = Column(DateTime, default=_dt.datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=_dt.datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("ix_kibl_markets_fixture_market", "external_fixture_id", "external_market_id"),
+        Index("ix_kibl_markets_feed_type_league", "feed_source_id", "betting_type_id", "league_id"),
+    )
+
+
+class KiblSyncWatermark(Base):
+    __tablename__ = "kibl_sync_watermarks"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    sync_key = Column(String(128), nullable=False, unique=True, index=True)
+    endpoint_path = Column(String(120), nullable=False, index=True)
+    feed_source_id = Column(Integer, nullable=False, index=True)
+    betting_type_id = Column(Integer, nullable=False, index=True)
+    league_id = Column(String(255), nullable=True, index=True)
+    filter_hash = Column(String(64), nullable=False)
+    last_watermark = Column(String(64), nullable=True)
+    updated_at = Column(DateTime, default=_dt.datetime.utcnow, nullable=False)
+
+
+class KiblAuthClient:
+    def __init__(self, config: KiblConfig, http_session: Optional[requests.Session] = None) -> None:
+        self.config = config
+        self.http = http_session or requests.Session()
+        self._access_token: Optional[str] = None
+        self._expires_at: Optional[_dt.datetime] = None
+
+    def get_access_token(self, force_refresh: bool = False) -> str:
+        if not force_refresh and self._access_token and not self._token_expired():
+            return self._access_token
+        endpoint = f"https://cognito-idp.{self.config.cognito_region}.amazonaws.com/"
+        body = {
+            "AuthFlow": "USER_PASSWORD_AUTH",
+            "ClientId": self.config.cognito_client_id,
+            "AuthParameters": {
+                "USERNAME": self.config.username,
+                "PASSWORD": self.config.password,
+            },
+        }
+        headers = {
+            "Content-Type": "application/x-amz-json-1.1",
+            "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+        }
+        resp = self.http.post(endpoint, headers=headers, json=body, timeout=30)
+        if resp.status_code >= 400:
+            raise KiblIntegrationError(f"Cognito auth failed: {resp.status_code} {resp.text[:240]}")
+        payload = resp.json()
+        auth = payload.get("AuthenticationResult") or {}
+        token = auth.get("AccessToken")
+        if not token:
+            raise KiblIntegrationError("Cognito auth response did not include AuthenticationResult.AccessToken")
+        expires_in = _as_int(auth.get("ExpiresIn")) or 3600
+        self._access_token = token
+        self._expires_at = _dt.datetime.utcnow() + _dt.timedelta(seconds=max(expires_in - 60, 60))
+        return token
+
+    def _token_expired(self) -> bool:
+        return bool(self._expires_at and _dt.datetime.utcnow() >= self._expires_at)
+
+
+class KiblApiClient:
+    def __init__(self, config: KiblConfig, auth_client: KiblAuthClient, http_session: Optional[requests.Session] = None) -> None:
+        self.config = config
+        self.auth_client = auth_client
+        self.http = http_session or requests.Session()
+
+    def post(self, path: str, ticket: Mapping[str, Any]) -> Any:
+        clean_path = path.strip("/")
+        url = f"{self.config.base_url}/{clean_path}/"
+        body = {key: value for key, value in ticket.items() if key not in {"request_uuid", "requested"}}
+        token = self.auth_client.get_access_token()
+        resp = self.http.post(
+            url,
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            json=body,
+            timeout=30,
+        )
+        if resp.status_code == 401:
+            token = self.auth_client.get_access_token(force_refresh=True)
+            resp = self.http.post(
+                url,
+                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                json=body,
+                timeout=30,
+            )
+        if resp.status_code >= 400:
+            raise KiblIntegrationError(f"KIBL {clean_path} failed: {resp.status_code} {resp.text[:240]}")
+        return resp.json()
+
+    def build_ticket(
+        self,
+        betting_type_id: int,
+        league_id: Optional[str] = None,
+        since_last_updated: Optional[str] = None,
+        extra_filters: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        ticket: Dict[str, Any] = {
+            "feed_source_id": self.config.feed_source_id,
+            "betting_type_id": betting_type_id,
+            "league_id": league_id or self.config.default_league_ids,
+            "from_cache": self.config.from_cache,
+        }
+        if since_last_updated:
+            ticket["since_last_updated"] = since_last_updated
+        if extra_filters:
+            ticket.update(extra_filters)
+        ticket.pop("request_uuid", None)
+        ticket.pop("requested", None)
+        return ticket
+
+    def fixtures(self, betting_type_id: int, league_id: Optional[str] = None, since_last_updated: Optional[str] = None) -> List[Dict[str, Any]]:
+        return extract_rows(self.post(KIBL_FIXTURES_PATH, self.build_ticket(betting_type_id, league_id, since_last_updated)))
+
+    def markets(self, betting_type_id: int, league_id: Optional[str] = None, since_last_updated: Optional[str] = None) -> List[Dict[str, Any]]:
+        return extract_rows(self.post(KIBL_MARKETS_PATH, self.build_ticket(betting_type_id, league_id, since_last_updated)))
+
+
+def filter_hash(path: str, feed_source_id: int, betting_type_id: int, league_id: Optional[str]) -> str:
+    return _stable_json_hash({
+        "path": path.strip("/"),
+        "feed_source_id": feed_source_id,
+        "betting_type_id": betting_type_id,
+        "league_id": league_id or "",
+    })
+
+
+def sync_key(path: str, feed_source_id: int, betting_type_id: int, league_id: Optional[str]) -> str:
+    return f"{path.strip('/')}:{feed_source_id}:{betting_type_id}:{filter_hash(path, feed_source_id, betting_type_id, league_id)[:16]}"
+
+
+def get_watermark(session: Session, path: str, feed_source_id: int, betting_type_id: int, league_id: Optional[str]) -> Optional[str]:
+    key = sync_key(path, feed_source_id, betting_type_id, league_id)
+    row = session.query(KiblSyncWatermark).filter_by(sync_key=key).one_or_none()
+    return row.last_watermark if row else None
+
+
+def set_watermark(session: Session, path: str, feed_source_id: int, betting_type_id: int, league_id: Optional[str], watermark: str) -> None:
+    key = sync_key(path, feed_source_id, betting_type_id, league_id)
+    row = session.query(KiblSyncWatermark).filter_by(sync_key=key).one_or_none()
+    now = _dt.datetime.utcnow()
+    if row is None:
+        row = KiblSyncWatermark(
+            sync_key=key,
+            endpoint_path=path.strip("/"),
+            feed_source_id=feed_source_id,
+            betting_type_id=betting_type_id,
+            league_id=league_id,
+            filter_hash=filter_hash(path, feed_source_id, betting_type_id, league_id),
+            last_watermark=watermark,
+            updated_at=now,
+        )
+        session.add(row)
+    else:
+        row.last_watermark = watermark
+        row.updated_at = now
+
+
+def upsert_fixtures(session: Session, rows: Sequence[Mapping[str, Any]], feed_source_id: int, betting_type_id: int, league_id: Optional[str]) -> Tuple[int, int]:
+    inserted = updated = 0
+    now = _dt.datetime.utcnow()
+    for source in rows:
+        row = dict(source)
+        external_id = _first_present(row, ["fixture_id", "event_id", "game_id", "id", "fixtureId", "eventId"])
+        key = str(external_id) if external_id is not None else _stable_json_hash(row)
+        fixture_key = f"{feed_source_id}:{betting_type_id}:{key}"
+        target = session.query(KiblFixture).filter_by(fixture_key=fixture_key).one_or_none()
+        values = {
+            "external_fixture_id": str(external_id) if external_id is not None else None,
+            "feed_source_id": feed_source_id,
+            "betting_type_id": betting_type_id,
+            "league_id": str(_first_present(row, ["league_id", "leagueId"]) or league_id or ""),
+            "sport_name": _first_present(row, ["sport_name", "sport", "sportName"]),
+            "league_name": _first_present(row, ["league_name", "league", "leagueName"]),
+            "home_team": _first_present(row, ["home_team", "homeTeam", "home_name"]),
+            "away_team": _first_present(row, ["away_team", "awayTeam", "away_name"]),
+            "start_time": _first_present(row, ["start_time", "startTime", "event_time", "game_time"]),
+            "last_updated": _first_present(row, ["last_updated", "lastUpdated"]),
+            "inserted_on": _first_present(row, ["inserted_on", "insertedOn"]),
+            "raw_payload": row,
+            "updated_at": now,
+        }
+        if target is None:
+            session.add(KiblFixture(fixture_key=fixture_key, created_at=now, **values))
+            inserted += 1
+        else:
+            for attr, value in values.items():
+                setattr(target, attr, value)
+            updated += 1
+    return inserted, updated
+
+
+def upsert_markets(session: Session, rows: Sequence[Mapping[str, Any]], feed_source_id: int, betting_type_id: int, league_id: Optional[str]) -> Tuple[int, int]:
+    inserted = updated = 0
+    now = _dt.datetime.utcnow()
+    for source in rows:
+        row = dict(source)
+        market_id = _first_present(row, ["market_id", "marketId", "id"])
+        fixture_id = _first_present(row, ["fixture_id", "event_id", "game_id", "fixtureId", "eventId"])
+        selection_id = _first_present(row, ["selection_id", "outcome_id", "selectionId", "outcomeId"])
+        key_source = {"market_id": market_id, "fixture_id": fixture_id, "selection_id": selection_id, "row": row if market_id is None else None}
+        market_key = f"{feed_source_id}:{betting_type_id}:{_stable_json_hash(key_source)}"
+        target = session.query(KiblMarket).filter_by(market_key=market_key).one_or_none()
+        values = {
+            "external_market_id": str(market_id) if market_id is not None else None,
+            "external_fixture_id": str(fixture_id) if fixture_id is not None else None,
+            "feed_source_id": feed_source_id,
+            "betting_type_id": betting_type_id,
+            "league_id": str(_first_present(row, ["league_id", "leagueId"]) or league_id or ""),
+            "market_name": _first_present(row, ["market_name", "marketName", "name"]),
+            "selection_name": _first_present(row, ["selection_name", "outcome_name", "selectionName", "outcomeName"]),
+            "price": _as_float(_first_present(row, ["price", "odds", "american_odds", "americanOdds"])),
+            "line": _as_float(_first_present(row, ["line", "handicap", "total", "points"])),
+            "status": _first_present(row, ["status", "market_status", "marketStatus"]),
+            "last_updated": _first_present(row, ["last_updated", "lastUpdated"]),
+            "inserted_on": _first_present(row, ["inserted_on", "insertedOn"]),
+            "raw_payload": row,
+            "updated_at": now,
+        }
+        if target is None:
+            session.add(KiblMarket(market_key=market_key, created_at=now, **values))
+            inserted += 1
+        else:
+            for attr, value in values.items():
+                setattr(target, attr, value)
+            updated += 1
+    return inserted, updated
+
+
+def sync_kibl_endpoint(
+    session: Session,
+    client: KiblApiClient,
+    path: str,
+    betting_type_id: int,
+    league_id: Optional[str] = None,
+    baseline: bool = False,
+) -> Dict[str, Any]:
+    active_league_id = league_id or client.config.default_league_ids
+    watermark = None if baseline else get_watermark(session, path, client.config.feed_source_id, betting_type_id, active_league_id)
+    rows = client.fixtures(betting_type_id, active_league_id, watermark) if path == KIBL_FIXTURES_PATH else client.markets(betting_type_id, active_league_id, watermark)
+    if path == KIBL_FIXTURES_PATH:
+        inserted, updated = upsert_fixtures(session, rows, client.config.feed_source_id, betting_type_id, active_league_id)
+    elif path == KIBL_MARKETS_PATH:
+        inserted, updated = upsert_markets(session, rows, client.config.feed_source_id, betting_type_id, active_league_id)
+    else:
+        raise KiblIntegrationError(f"Unsupported KIBL path: {path}")
+    new_watermark = newest_kibl_timestamp(rows)
+    if new_watermark:
+        set_watermark(session, path, client.config.feed_source_id, betting_type_id, active_league_id, new_watermark)
+    session.commit()
+    return {
+        "path": path,
+        "betting_type_id": betting_type_id,
+        "league_id": active_league_id,
+        "baseline": baseline,
+        "previous_watermark": watermark,
+        "new_watermark": new_watermark,
+        "rows_received": len(rows),
+        "rows_inserted": inserted,
+        "rows_updated": updated,
+    }
+
+
+def build_default_client(config: Optional[KiblConfig] = None) -> KiblApiClient:
+    active_config = config or KiblConfig.from_env()
+    auth = KiblAuthClient(active_config)
+    return KiblApiClient(active_config, auth)

--- a/scripts/sync_kibl_bet105.py
+++ b/scripts/sync_kibl_bet105.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Run KIBL Bet105 baseline or diff syncs.
+
+Examples:
+    python scripts/sync_kibl_bet105.py --baseline --prematch
+    python scripts/sync_kibl_bet105.py --diff --live
+    python scripts/sync_kibl_bet105.py --baseline --prematch --markets-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.kibl_integration import (
+    KIBL_FIXTURES_PATH,
+    KIBL_LIVE_BETTING_TYPE_ID,
+    KIBL_MARKETS_PATH,
+    KIBL_PREMATCH_BETTING_TYPE_ID,
+    build_default_client,
+    redact_secrets,
+    sync_kibl_endpoint,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync KIBL Bet105 fixtures and markets")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--baseline", action="store_true", help="Run baseline pulls without since_last_updated")
+    mode.add_argument("--diff", action="store_true", help="Run diff pulls with stored since_last_updated watermarks")
+
+    segment = parser.add_mutually_exclusive_group(required=True)
+    segment.add_argument("--prematch", action="store_true", help="Use prematch betting_type_id")
+    segment.add_argument("--live", action="store_true", help="Use live betting_type_id")
+    segment.add_argument("--all", action="store_true", help="Run both prematch and live")
+
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument("--fixtures-only", action="store_true", help="Only sync fixtures")
+    scope.add_argument("--markets-only", action="store_true", help="Only sync markets")
+    parser.add_argument("--league-id", default=None, help="Override KIBL league_id filter, e.g. 20,643")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    engine = get_engine(os.getenv("DATABASE_URL", "sqlite:///mlb.db"))
+    create_tables(engine)
+    SessionLocal = get_session(engine)
+    client = build_default_client()
+
+    betting_types: List[int]
+    if args.all:
+        betting_types = [KIBL_PREMATCH_BETTING_TYPE_ID, KIBL_LIVE_BETTING_TYPE_ID]
+    elif args.live:
+        betting_types = [KIBL_LIVE_BETTING_TYPE_ID]
+    else:
+        betting_types = [KIBL_PREMATCH_BETTING_TYPE_ID]
+
+    paths: List[str]
+    if args.fixtures_only:
+        paths = [KIBL_FIXTURES_PATH]
+    elif args.markets_only:
+        paths = [KIBL_MARKETS_PATH]
+    else:
+        paths = [KIBL_FIXTURES_PATH, KIBL_MARKETS_PATH]
+
+    summaries: List[Dict[str, Any]] = []
+    with SessionLocal() as session:
+        for betting_type_id in betting_types:
+            for path in paths:
+                summaries.append(
+                    sync_kibl_endpoint(
+                        session=session,
+                        client=client,
+                        path=path,
+                        betting_type_id=betting_type_id,
+                        league_id=args.league_id,
+                        baseline=args.baseline,
+                    )
+                )
+    print(json.dumps(redact_secrets({"kibl_sync": summaries}), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_kibl_integration.py
+++ b/tests/test_kibl_integration.py
@@ -1,12 +1,9 @@
-import os
-
 import pytest
 
 from mlb_app.database import create_tables, get_engine, get_session
 from mlb_app.kibl_integration import (
     KIBL_FIXTURES_PATH,
     KIBL_LIVE_BETTING_TYPE_ID,
-    KIBL_MARKETS_PATH,
     KIBL_PREMATCH_BETTING_TYPE_ID,
     KiblApiClient,
     KiblAuthClient,
@@ -44,6 +41,23 @@ class FakeSession:
         if not self.responses:
             raise AssertionError("No fake response queued")
         return self.responses.pop(0)
+
+
+class StubClient:
+    def __init__(self, config, fixture_rows=None, market_rows=None):
+        self.config = config
+        self.fixture_rows = fixture_rows if fixture_rows is not None else []
+        self.market_rows = market_rows if market_rows is not None else []
+        self.fixture_calls = []
+        self.market_calls = []
+
+    def fixtures(self, betting_type_id, league_id, watermark):
+        self.fixture_calls.append((betting_type_id, league_id, watermark))
+        return self.fixture_rows
+
+    def markets(self, betting_type_id, league_id, watermark):
+        self.market_calls.append((betting_type_id, league_id, watermark))
+        return self.market_rows
 
 
 @pytest.fixture()
@@ -148,16 +162,11 @@ def test_401_refreshes_token_and_retries_once(config):
 
 
 def test_empty_diff_response_does_not_crash_or_advance_watermark(config, db_session):
-    class StubClient:
-        config = config
-
-        def fixtures(self, betting_type_id, league_id, watermark):
-            assert watermark is None
-            return []
+    client = StubClient(config, fixture_rows=[])
 
     result = sync_kibl_endpoint(
         db_session,
-        StubClient(),
+        client,
         KIBL_FIXTURES_PATH,
         KIBL_PREMATCH_BETTING_TYPE_ID,
         league_id="20,643",
@@ -166,6 +175,7 @@ def test_empty_diff_response_does_not_crash_or_advance_watermark(config, db_sess
 
     assert result["rows_received"] == 0
     assert result["new_watermark"] is None
+    assert client.fixture_calls[0] == (KIBL_PREMATCH_BETTING_TYPE_ID, "20,643", None)
     assert db_session.query(KiblSyncWatermark).count() == 0
 
 
@@ -174,16 +184,11 @@ def test_watermark_updates_to_newest_timestamp(config, db_session):
         {"id": "a", "last_updated": "2026-06-02 14:30:00"},
         {"id": "b", "inserted_on": "2026-06-02 14:35:00"},
     ]
-
-    class StubClient:
-        config = config
-
-        def fixtures(self, betting_type_id, league_id, watermark):
-            return rows
+    client = StubClient(config, fixture_rows=rows)
 
     result = sync_kibl_endpoint(
         db_session,
-        StubClient(),
+        client,
         KIBL_FIXTURES_PATH,
         KIBL_PREMATCH_BETTING_TYPE_ID,
         league_id="20,643",

--- a/tests/test_kibl_integration.py
+++ b/tests/test_kibl_integration.py
@@ -1,0 +1,243 @@
+import os
+
+import pytest
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.kibl_integration import (
+    KIBL_FIXTURES_PATH,
+    KIBL_LIVE_BETTING_TYPE_ID,
+    KIBL_MARKETS_PATH,
+    KIBL_PREMATCH_BETTING_TYPE_ID,
+    KiblApiClient,
+    KiblAuthClient,
+    KiblConfig,
+    KiblFixture,
+    KiblMarket,
+    KiblSyncWatermark,
+    extract_rows,
+    get_watermark,
+    newest_kibl_timestamp,
+    redact_secrets,
+    sync_kibl_endpoint,
+    upsert_fixtures,
+    upsert_markets,
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError("No fake response queued")
+        return self.responses.pop(0)
+
+
+@pytest.fixture()
+def config():
+    return KiblConfig(
+        cognito_region="us-west-2",
+        cognito_client_id="client-id",
+        username="user@example.com",
+        password="super-secret",
+        base_url="https://api.kibl.io/sports/get",
+        feed_source_id=171,
+        default_league_ids="20,643",
+        from_cache=False,
+    )
+
+
+@pytest.fixture()
+def db_session():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    SessionLocal = get_session(engine)
+    with SessionLocal() as session:
+        yield session
+
+
+def test_cognito_auth_request_uses_expected_password_flow(config):
+    http = FakeSession([
+        FakeResponse(payload={"AuthenticationResult": {"AccessToken": "token-1", "ExpiresIn": 3600}})
+    ])
+    auth = KiblAuthClient(config, http_session=http)
+
+    assert auth.get_access_token() == "token-1"
+
+    call = http.calls[0]
+    assert call["url"] == "https://cognito-idp.us-west-2.amazonaws.com/"
+    assert call["headers"]["X-Amz-Target"] == "AWSCognitoIdentityProviderService.InitiateAuth"
+    assert call["json"]["AuthFlow"] == "USER_PASSWORD_AUTH"
+    assert call["json"]["ClientId"] == "client-id"
+    assert call["json"]["AuthParameters"] == {
+        "USERNAME": "user@example.com",
+        "PASSWORD": "super-secret",
+    }
+
+
+def test_kibl_request_uses_bearer_token_and_strips_server_fields(config):
+    auth_http = FakeSession([
+        FakeResponse(payload={"AuthenticationResult": {"AccessToken": "token-1", "ExpiresIn": 3600}})
+    ])
+    kibl_http = FakeSession([FakeResponse(payload={"data": []})])
+    client = KiblApiClient(config, KiblAuthClient(config, auth_http), http_session=kibl_http)
+
+    client.post(KIBL_FIXTURES_PATH, {"feed_source_id": 171, "request_uuid": "no", "requested": "no"})
+
+    call = kibl_http.calls[0]
+    assert call["url"] == "https://api.kibl.io/sports/get/info/fixtures/"
+    assert call["headers"]["Authorization"] == "Bearer token-1"
+    assert call["headers"]["Content-Type"] == "application/json"
+    assert "request_uuid" not in call["json"]
+    assert "requested" not in call["json"]
+
+
+def test_baseline_ticket_omits_since_last_updated(config):
+    auth = KiblAuthClient(config, http_session=FakeSession([]))
+    client = KiblApiClient(config, auth, http_session=FakeSession([]))
+
+    ticket = client.build_ticket(KIBL_PREMATCH_BETTING_TYPE_ID)
+
+    assert ticket["feed_source_id"] == 171
+    assert ticket["betting_type_id"] == KIBL_PREMATCH_BETTING_TYPE_ID
+    assert ticket["league_id"] == "20,643"
+    assert ticket["from_cache"] is False
+    assert "since_last_updated" not in ticket
+
+
+def test_diff_ticket_includes_since_last_updated(config):
+    auth = KiblAuthClient(config, http_session=FakeSession([]))
+    client = KiblApiClient(config, auth, http_session=FakeSession([]))
+
+    ticket = client.build_ticket(KIBL_LIVE_BETTING_TYPE_ID, since_last_updated="2026-06-02 14:30:00")
+
+    assert ticket["betting_type_id"] == KIBL_LIVE_BETTING_TYPE_ID
+    assert ticket["since_last_updated"] == "2026-06-02 14:30:00"
+
+
+def test_401_refreshes_token_and_retries_once(config):
+    auth_http = FakeSession([
+        FakeResponse(payload={"AuthenticationResult": {"AccessToken": "old-token", "ExpiresIn": 3600}}),
+        FakeResponse(payload={"AuthenticationResult": {"AccessToken": "new-token", "ExpiresIn": 3600}}),
+    ])
+    kibl_http = FakeSession([
+        FakeResponse(status_code=401, payload={}, text="unauthorized"),
+        FakeResponse(payload={"data": [{"id": 1}]}),
+    ])
+    client = KiblApiClient(config, KiblAuthClient(config, auth_http), http_session=kibl_http)
+
+    rows = client.fixtures(KIBL_PREMATCH_BETTING_TYPE_ID)
+
+    assert rows == [{"id": 1}]
+    assert len(kibl_http.calls) == 2
+    assert kibl_http.calls[0]["headers"]["Authorization"] == "Bearer old-token"
+    assert kibl_http.calls[1]["headers"]["Authorization"] == "Bearer new-token"
+
+
+def test_empty_diff_response_does_not_crash_or_advance_watermark(config, db_session):
+    class StubClient:
+        config = config
+
+        def fixtures(self, betting_type_id, league_id, watermark):
+            assert watermark is None
+            return []
+
+    result = sync_kibl_endpoint(
+        db_session,
+        StubClient(),
+        KIBL_FIXTURES_PATH,
+        KIBL_PREMATCH_BETTING_TYPE_ID,
+        league_id="20,643",
+        baseline=False,
+    )
+
+    assert result["rows_received"] == 0
+    assert result["new_watermark"] is None
+    assert db_session.query(KiblSyncWatermark).count() == 0
+
+
+def test_watermark_updates_to_newest_timestamp(config, db_session):
+    rows = [
+        {"id": "a", "last_updated": "2026-06-02 14:30:00"},
+        {"id": "b", "inserted_on": "2026-06-02 14:35:00"},
+    ]
+
+    class StubClient:
+        config = config
+
+        def fixtures(self, betting_type_id, league_id, watermark):
+            return rows
+
+    result = sync_kibl_endpoint(
+        db_session,
+        StubClient(),
+        KIBL_FIXTURES_PATH,
+        KIBL_PREMATCH_BETTING_TYPE_ID,
+        league_id="20,643",
+        baseline=True,
+    )
+
+    assert result["new_watermark"] == "2026-06-02 14:35:00"
+    assert get_watermark(db_session, KIBL_FIXTURES_PATH, 171, KIBL_PREMATCH_BETTING_TYPE_ID, "20,643") == "2026-06-02 14:35:00"
+
+
+def test_fixture_upsert_is_idempotent(db_session):
+    rows = [{"fixture_id": "fx-1", "home_team": "Cubs", "last_updated": "2026-06-02 14:30:00"}]
+
+    assert upsert_fixtures(db_session, rows, 171, KIBL_PREMATCH_BETTING_TYPE_ID, "20,643") == (1, 0)
+    assert upsert_fixtures(db_session, rows, 171, KIBL_PREMATCH_BETTING_TYPE_ID, "20,643") == (0, 1)
+    db_session.commit()
+
+    assert db_session.query(KiblFixture).count() == 1
+
+
+def test_market_upsert_is_idempotent(db_session):
+    rows = [{"market_id": "m-1", "fixture_id": "fx-1", "selection_id": "s-1", "price": -115}]
+
+    assert upsert_markets(db_session, rows, 171, KIBL_PREMATCH_BETTING_TYPE_ID, "20,643") == (1, 0)
+    assert upsert_markets(db_session, rows, 171, KIBL_PREMATCH_BETTING_TYPE_ID, "20,643") == (0, 1)
+    db_session.commit()
+
+    assert db_session.query(KiblMarket).count() == 1
+
+
+def test_secret_redaction():
+    payload = {
+        "Authorization": "Bearer abc",
+        "password": "hidden",
+        "nested": {"access_token": "token"},
+        "safe": "visible",
+    }
+
+    assert redact_secrets(payload) == {
+        "Authorization": "***REDACTED***",
+        "password": "***REDACTED***",
+        "nested": {"access_token": "***REDACTED***"},
+        "safe": "visible",
+    }
+
+
+def test_extract_rows_supports_wrapped_and_plain_payloads():
+    assert extract_rows({"data": [{"id": 1}]}) == [{"id": 1}]
+    assert extract_rows({"results": [{"id": 2}]}) == [{"id": 2}]
+    assert extract_rows([{"id": 3}]) == [{"id": 3}]
+
+
+def test_newest_kibl_timestamp_prefers_latest_last_updated_or_inserted_on():
+    assert newest_kibl_timestamp([
+        {"last_updated": "2026-06-02 14:30:00"},
+        {"inserted_on": "2026-06-02 15:30:00"},
+    ]) == "2026-06-02 15:30:00"


### PR DESCRIPTION
## Summary

Adds a backend KIBL Bet105 ingestion scaffold for fixtures and markets.

Closes #689.

## Changes

- Adds `mlb_app/kibl_integration.py` with:
  - environment-driven KIBL config
  - Cognito `USER_PASSWORD_AUTH` token retrieval
  - KIBL bearer-token POST client
  - 401 re-auth/retry once
  - defensive response row extraction
  - fixture, market, and watermark SQLAlchemy models
  - idempotent fixture/market upsert helpers
  - baseline/diff sync orchestration with watermarks
- Adds `scripts/sync_kibl_bet105.py` CLI for baseline and diff syncs.
- Adds `docs/kibl-bet105.md` with env vars, runtime flow, CLI usage, security notes, and troubleshooting.
- Adds mocked tests for auth, request shape, baseline/diff tickets, 401 retry, idempotent persistence, watermarks, empty diffs, row extraction, and secret redaction.

## Security

- No real credentials committed.
- Password is read from env and sent only to Cognito.
- KIBL receives only `Authorization: Bearer <token>`.
- Secret-like fields are redacted by helper before logging/printing.
- Tests use mocked HTTP only; no live Cognito/KIBL calls.

## Validation

Not run locally in this environment. Recommended validation:

```bash
python -m pytest tests/test_kibl_integration.py
python scripts/sync_kibl_bet105.py --baseline --prematch --fixtures-only
```

The second command requires real KIBL env vars and should be run only in a secure backend environment.