### PR TITLE
Route Bet105 sportsbook endpoints through canonical KIBL provider

### DIFF
--- a/mlb_app/sportsbook_routes.py
+++ b/mlb_app/sportsbook_routes.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter
 
-from .bet105_sportsbook_wrapper import fetch_bet105_sportsbook_event, fetch_bet105_sportsbook_events
+from .kibl_bet105_provider import fetch_kibl_bet105_event_odds, fetch_kibl_bet105_events
 from .odds_provider import fetch_draftkings_events
 
 router = APIRouter()
@@ -121,6 +121,32 @@ def _events(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     return payload.get("events") if isinstance(payload.get("events"), list) else []
 
 
+def _payload_market_count(payload: Dict[str, Any]) -> int:
+    value = payload.get("market_count")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return sum(len(event.get("markets") or []) for event in _events(payload))
+
+
+def _normalize_bet105_route_status(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    The sportsbook page needs a hard distinction between real odds boards and
+    fixture-only responses. The canonical provider already returns normalized
+    fixtures/markets; enforce the route contract here so the frontend never has
+    to infer provider state from missing odds.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    events = _events(payload)
+    market_count = _payload_market_count(payload)
+    if events and market_count == 0 and payload.get("status") not in {"provider_not_configured", "provider_error"}:
+        payload = dict(payload)
+        payload["status"] = "fixtures_only"
+        payload["market_count"] = 0
+    return payload
+
+
 def _index_events(payload: Dict[str, Any], book: str) -> Dict[str, Dict[str, Any]]:
     indexed: Dict[str, Dict[str, Any]] = {}
     for event in _events(payload):
@@ -216,22 +242,26 @@ def _comparison_payload(date: Optional[str], books: List[str], payloads: Dict[st
 
 @router.get("/odds/bet105/events")
 def bet105_events(date: Optional[str] = None, live: bool = False, raw: bool = False) -> Dict[str, Any]:
-    return fetch_bet105_sportsbook_events(date=date, raw=raw, live_only=live)
+    payload = fetch_kibl_bet105_events(date=date, raw=raw, live_only=live)
+    return _normalize_bet105_route_status(payload)
 
 
 @router.get("/odds/bet105/event/{event_id}/markets")
 def bet105_event_markets(event_id: str, raw: bool = False) -> Dict[str, Any]:
-    return fetch_bet105_sportsbook_event(event_id=event_id, raw=raw, props_only=False)
+    payload = fetch_kibl_bet105_event_odds(event_id=event_id, raw=raw, props_only=False)
+    return _normalize_bet105_route_status(payload)
 
 
 @router.get("/odds/bet105/event/{event_id}/props")
 def bet105_event_props(event_id: str, raw: bool = False) -> Dict[str, Any]:
-    return fetch_bet105_sportsbook_event(event_id=event_id, raw=raw, props_only=True)
+    payload = fetch_kibl_bet105_event_odds(event_id=event_id, raw=raw, props_only=True)
+    return _normalize_bet105_route_status(payload)
 
 
 @router.get("/odds/bet105/debug")
 def bet105_debug(date: Optional[str] = None, live: bool = False) -> Dict[str, Any]:
-    return fetch_bet105_sportsbook_events(date=date, raw=True, live_only=live)
+    payload = fetch_kibl_bet105_events(date=date, raw=True, live_only=live)
+    return _normalize_bet105_route_status(payload)
 
 
 @router.get("/odds/compare/events")
@@ -239,7 +269,7 @@ def compare_odds_events(date: Optional[str] = None, books: str = "bet105,draftki
     requested = [book.strip().lower() for book in books.split(",") if book.strip()]
     payloads: Dict[str, Dict[str, Any]] = {}
     if "bet105" in requested:
-        payloads["bet105"] = fetch_bet105_sportsbook_events(date=date, raw=False)
+        payloads["bet105"] = _normalize_bet105_route_status(fetch_kibl_bet105_events(date=date, raw=False))
     if "draftkings" in requested:
         with _force_default_draftkings_provider():
             payloads["draftkings"] = fetch_draftkings_events(date=date, raw=False)


### PR DESCRIPTION
## Summary

This fixes the actual backend path behind `/sportsbook/bet105` after the live page still returned `provider/status: empty` with `events: 0` and `markets: 0`.

The route was still importing `bet105_sportsbook_wrapper.py`, so the frontend page was not using the canonical KIBL Bet105 provider implementation that already handles the documented `info/markets` and `info/fixtures` POST flow.

Changes:
- Route `/odds/bet105/events`, `/odds/bet105/debug`, `/odds/bet105/event/{event_id}/markets`, and `/odds/bet105/event/{event_id}/props` through `kibl_bet105_provider.py`.
- Keep DraftKings comparison isolated to the real DraftKings provider.
- Add route-level Bet105 status normalization:
  - `fixtures_only` when normalized events exist but `market_count` is zero.
  - preserve `provider_not_configured` and `provider_error`.
- Apply the same Bet105 status normalization to compare payloads.

## Why

The visible production state showed:

```text
Bet105 Events: 0
Markets: 0
Provider: empty
No Bet105 events returned for 2026-06-12.
```

That means the prior frontend-only PR was not enough. The request path had to be corrected so the Bet105 sportsbook routes consume the canonical KIBL provider instead of the older wrapper.

## Testing

- Verified branch diff against `main`: one backend route file changed.
- Live KIBL validation still needs to be run after deploy with Railway credentials using:

```bash
curl "$API_BASE/odds/bet105/debug?date=2026-06-12&live=false"
```

Expected:
- If fixtures exist but no odds rows: `status: fixtures_only`, `event_count > 0`, `market_count: 0`.
- If market rows exist: `status: ok`, `market_count > 0`, grouped events/markets/selections render on `/sportsbook/bet105`.

No mock data. No DraftKings fallback.