### PR TITLE
Fix Bet105 market retry root cause

### DIFF
--- a/mlb_app/kibl_bet105_provider.py
+++ b/mlb_app/kibl_bet105_provider.py
@@ -188,7 +188,20 @@ def _extract_first(item: Dict[str, Any], keys: Iterable[str]) -> Any:
 
 def _nested_name(value: Any) -> Optional[str]:
     if isinstance(value, dict):
-        value = _extract_first(value, ("name", "display_name", "displayName", "team_name", "teamName", "fullName", "title"))
+        direct = _extract_first(value, ("name", "display_name", "displayName", "team_name", "teamName", "fullName", "title"))
+        if direct not in (None, ""):
+            return str(direct)
+        for nested_key in ("team", "participant", "competitor", "competitorTeam", "runner", "selection"):
+            nested = _nested_name(value.get(nested_key))
+            if nested:
+                return nested
+        return None
+    if isinstance(value, list):
+        for child in value:
+            nested = _nested_name(child)
+            if nested:
+                return nested
+        return None
     if value in (None, ""):
         return None
     return str(value)
@@ -377,6 +390,24 @@ def _get_access_token() -> str:
     return str(access_token)
 
 
+def _post_kibl_json(url: str, params: Dict[str, Any], timeout: int) -> Any:
+    def _headers(token: str) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    token = _get_access_token()
+    response = requests.post(url, json=params, headers=_headers(token), timeout=timeout)
+    if response.status_code == 401:
+        _TOKEN_CACHE.clear()
+        token = _get_access_token()
+        response = requests.post(url, json=params, headers=_headers(token), timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
 def _market_filter(market_types: Optional[List[str]], props_only: bool = False) -> List[str]:
     if props_only:
         env_value = os.getenv("KIBL_PROP_MARKETS", "")
@@ -443,18 +474,14 @@ def _payload_item_count(payload: Any) -> int:
 
 
 def _fetch_kibl_payload(scope: str, params: Dict[str, Any], event_id: Optional[str] = None, kind: str = "markets") -> Tuple[Any, str]:
-    token = _get_access_token()
     base_url = os.getenv("KIBL_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
     timeout = int(os.getenv("KIBL_TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT_SECONDS)))
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json", "Content-Type": "application/json"}
     errors: List[str] = []
     first_success: Optional[Tuple[Any, str]] = None
     for path in _candidate_paths(scope, event_id=event_id, kind=kind):
         url = f"{base_url}/{path}/"
         try:
-            response = requests.post(url, json=params, headers=headers, timeout=timeout)
-            response.raise_for_status()
-            payload = response.json()
+            payload = _post_kibl_json(url, params, timeout)
             if first_success is None:
                 first_success = (payload, path)
             if _payload_item_count(payload) > 0:
@@ -787,7 +814,7 @@ def fetch_kibl_bet105_odds(
     league: Optional[str] = None,
     market_types: Optional[List[str]] = None,
     live_only: Optional[bool] = None,
-    state: Optional[str] = None,
+    state: Optional[str] = None
 ) -> Dict[str, Any]:
     if not _configured():
         return _not_configured(scope, game_pk=game_pk)

--- a/mlb_app/kibl_bet105_sportsbook_provider.py
+++ b/mlb_app/kibl_bet105_sportsbook_provider.py
@@ -62,6 +62,35 @@ def _market_body_sets(params: Dict[str, Any], fixture_ids: List[str]) -> List[tu
     ]
 
 
+def _flattened_market_count(events: List[Dict[str, Any]], game_pk: Optional[Any] = None) -> int:
+    return len(base._flatten_markets(events, game_pk=game_pk))
+
+
+def _event_market_count(events: List[Dict[str, Any]]) -> int:
+    total = 0
+    for event in events:
+        try:
+            total += int(event.get("market_count") or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _prefer_market_candidate(candidate_events: List[Dict[str, Any]], current_events: List[Dict[str, Any]], game_pk: Optional[Any] = None) -> bool:
+    """Prefer candidates with real flattenable markets over fixture-like events."""
+    candidate_flat = _flattened_market_count(candidate_events, game_pk=game_pk)
+    current_flat = _flattened_market_count(current_events, game_pk=game_pk)
+    if candidate_flat != current_flat:
+        return candidate_flat > current_flat
+
+    candidate_markets = _event_market_count(candidate_events)
+    current_markets = _event_market_count(current_events)
+    if candidate_markets != current_markets:
+        return candidate_markets > current_markets
+
+    return len(candidate_events) > len(current_events)
+
+
 def fetch_kibl_bet105_events(date: Optional[str] = None, raw: bool = False, live_only: Optional[bool] = None) -> Dict[str, Any]:
     scope = "live" if live_only else "events"
     return fetch_kibl_bet105_odds(scope=scope, date=date, raw=raw, live_only=live_only)
@@ -103,7 +132,7 @@ def fetch_kibl_bet105_odds(
         live_only=live_only,
         event_id=str(game_pk) if game_pk is not None else None,
     )
-    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v2"
+    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v3"
     cached = base._cache_get(cache_key)
     if cached:
         return cached
@@ -114,6 +143,7 @@ def fetch_kibl_bet105_odds(
     fixture_events: List[Dict[str, Any]] = []
     market_items: List[Dict[str, Any]] = []
     market_events: List[Dict[str, Any]] = []
+    best_flattened_market_count = 0
     request_path: Optional[str] = None
     request_params: Dict[str, Any] = dict(params)
 
@@ -129,20 +159,24 @@ def fetch_kibl_bet105_odds(
             for body in bodies:
                 try:
                     _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
-                    notes.append(f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{','.join(sorted(set(body) - set(body_base))) or 'base'}")
-                    if len(events) > len(market_events) or sum(event.get("market_count", 0) for event in events) > sum(event.get("market_count", 0) for event in market_events):
+                    flattened_market_count = _flattened_market_count(events, game_pk=game_pk)
+                    notes.append(
+                        f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(body_base))) or 'base'}"
+                    )
+                    if _prefer_market_candidate(events, market_events, game_pk=game_pk):
                         market_items = items
                         market_events = events
                         request_path = market_path
                         request_params = body
-                    if base._flatten_markets(events, game_pk=game_pk):
+                        best_flattened_market_count = _flattened_market_count(market_events, game_pk=game_pk)
+                    if flattened_market_count > 0:
                         break
                 except Exception as exc:
                     notes.append(f"markets_{label}_error:{exc}")
-            if base._flatten_markets(market_events, game_pk=game_pk):
+            if best_flattened_market_count > 0:
                 break
 
-        if not market_events and params.get("markets"):
+        if best_flattened_market_count == 0 and params.get("markets"):
             retry_params = base.build_kibl_bet105_request_params(
                 scope,
                 date=None,
@@ -155,12 +189,17 @@ def fetch_kibl_bet105_odds(
             for body in _market_request_bodies(retry_params, ids):
                 try:
                     _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
-                    notes.append(f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}")
-                    if events:
+                    flattened_market_count = _flattened_market_count(events, game_pk=game_pk)
+                    notes.append(
+                        f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}"
+                    )
+                    if _prefer_market_candidate(events, market_events, game_pk=game_pk):
                         market_items = items
                         market_events = events
                         request_path = market_path
                         request_params = body
+                        best_flattened_market_count = _flattened_market_count(market_events, game_pk=game_pk)
+                    if flattened_market_count > 0:
                         break
                 except Exception as exc:
                     notes.append(f"markets_no_filter_core_error:{exc}")

--- a/tests/test_bet105_sportsbook_provider.py
+++ b/tests/test_bet105_sportsbook_provider.py
@@ -1,0 +1,129 @@
+from mlb_app import kibl_bet105_provider as base
+from mlb_app import kibl_bet105_sportsbook_provider as sportsbook
+
+
+def _fixture_row():
+    return {
+        "fixture_id": "fx-1",
+        "away_team": {"name": "New York Yankees"},
+        "home_team": {"name": "Boston Red Sox"},
+        "start_time": "2026-06-12 19:10:00",
+    }
+
+
+def _market_row(selection="New York Yankees", side="away", price=-118):
+    return {
+        "fixture_id": "fx-1",
+        "away_team": {"name": "New York Yankees"},
+        "home_team": {"name": "Boston Red Sox"},
+        "start_time": "2026-06-12 19:10:00",
+        "market": "moneyline",
+        "selection": selection,
+        "side": side,
+        "price": price,
+    }
+
+
+def _normalize(rows):
+    return base._normalize_payload_items(rows, is_live=False)
+
+
+def _common_monkeypatch(monkeypatch):
+    monkeypatch.setattr(base, "_configured", lambda: True)
+    monkeypatch.setattr(base, "_cache_get", lambda key: None)
+    monkeypatch.setattr(base, "_cache_set", lambda key, value: None)
+    monkeypatch.setattr(
+        base,
+        "build_kibl_bet105_request_params",
+        lambda *args, **kwargs: {
+            **{
+                "feed_source_id": 171,
+                "betting_type_id": 1,
+                "league_id": "20,643",
+                "from_cache": False,
+                "start_date": "2026-06-12 00:00:00",
+                "end_date": "2026-06-13 00:00:00",
+                "from": "2026-06-12 00:00:00",
+                "to": "2026-06-13 00:00:00",
+            },
+            **({"markets": "h2h,spreads,totals"} if kwargs.get("include_markets", True) else {}),
+        },
+    )
+
+
+def test_retries_without_market_filter_when_filtered_market_response_contains_fixture_only_rows(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        if kind == "fixtures":
+            rows = [_fixture_row()]
+            return {}, "info/fixtures", rows, _normalize(rows)
+
+        if params.get("markets"):
+            rows = [_fixture_row()]  # nonempty events, but zero flattenable markets
+            return {}, "info/markets", rows, _normalize(rows)
+
+        if params.get("fixture_id") == "fx-1":
+            rows = [_market_row()]
+            return {}, "info/markets", rows, _normalize(rows)
+
+        rows = [_fixture_row()]  # generic unfiltered body must not stop the loop
+        return {}, "info/markets", rows, _normalize(rows)
+
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = sportsbook.fetch_kibl_bet105_events(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["status"] == "ok"
+    assert payload["event_count"] == 1
+    assert payload["market_count"] == 1
+    assert any(note.startswith("markets_no_filter_core:") for note in payload["normalization_notes"])
+
+
+def test_continues_id_scoped_unfiltered_retries_until_markets_are_found(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        if kind == "fixtures":
+            rows = [_fixture_row()]
+            return {}, "info/fixtures", rows, _normalize(rows)
+
+        if params.get("markets"):
+            return {}, "info/markets", [], []
+
+        if "fixture_id" not in params:
+            rows = [_fixture_row()]  # generic unfiltered response still has zero markets
+            return {}, "info/markets", rows, _normalize(rows)
+
+        rows = [_market_row(selection="Boston Red Sox", side="home", price=108)]
+        return {}, "info/markets", rows, _normalize(rows)
+
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = sportsbook.fetch_kibl_bet105_events(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["status"] == "ok"
+    assert payload["market_count"] == 1
+    assert payload["events"][0]["home_team"]["name"] == "Boston Red Sox"
+    assert payload["events"][0]["away_team"]["name"] == "New York Yankees"
+
+
+def test_returns_fixtures_only_when_no_market_request_shape_returns_odds(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        rows = [_fixture_row()]
+        return {}, "info/fixtures" if kind == "fixtures" else "info/markets", rows, _normalize(rows)
+
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = sportsbook.fetch_kibl_bet105_events(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["status"] == "fixtures_only"
+    assert payload["event_count"] == 1
+    assert payload["market_count"] == 0
+
+
+def test_recursive_nested_name_extracts_team_objects():
+    assert base._nested_name({"team": {"name": "Boston Red Sox"}}) == "Boston Red Sox"
+    assert base._nested_name({"participant": {"displayName": "New York Yankees"}}) == "New York Yankees"


### PR DESCRIPTION
## Summary

Applies the root-cause fix from the Bet105 RCA.

Production was stuck at:

```text
Bet105 Events: 1
Markets: 0
Provider: fixtures_only
```

Root cause: the sportsbook provider treated nonempty normalized `events` as a successful market-response candidate even when those events were fixture-like and contained zero flattenable markets. That allowed a fixture-shaped `info/markets` response to block later request shapes that could return actual odds rows.

## Changes

### `mlb_app/kibl_bet105_sportsbook_provider.py`

- Adds `_flattened_market_count()`.
- Adds `_prefer_market_candidate()`.
- Tracks `best_flattened_market_count`.
- Stops market retries only when `flattened_market_count > 0`.
- Runs the no-filter retry whenever the filtered pass produced zero flattenable markets, even if it produced fixture-like events.
- Updates `normalization_notes` to include flattened market count:

```text
markets_core:info/markets:<raw_count>:<event_count>:<flattened_market_count>:<body_delta>
markets_no_filter_core:info/markets:<raw_count>:<event_count>:<flattened_market_count>:<body_delta>
```

- Bumps provider cache key to `fixture-first-v3` so deployed app does not reuse old `fixtures_only` cache entries.

### `mlb_app/kibl_bet105_provider.py`

- Makes `_nested_name()` recurse into common nested objects like `team`, `participant`, `competitor`, `runner`, and `selection`.
- Adds `_post_kibl_json()`.
- Retries once on KIBL HTTP 401 after clearing the Cognito token cache.

### `tests/test_bet105_sportsbook_provider.py`

Adds regression coverage for the exact failure mode:

- filtered market responses contain fixture-like events with zero flattenable markets
- generic unfiltered market response contains fixture-like events with zero flattenable markets
- later fixture-id response returns priced flat rows
- no market response shape returns odds, preserving `fixtures_only`
- recursive nested team-name extraction

## Validation after deploy

Restart the backend process or wait beyond the provider cache TTL, then run:

```bash
curl -sS "$API_BASE/odds/bet105/debug?date=2026-06-12&live=false" | jq '{
  status,
  event_count,
  market_count,
  request_params,
  normalization_notes,
  raw_items_sample
}'
```

Healthy result if KIBL has Bet105 odds:

```text
status: ok
market_count > 0
normalization_notes includes markets_core or markets_no_filter_core with flattened_market_count > 0
```

If it still returns `fixtures_only`, the next step is not more retry orchestration. Inspect `raw_items_sample`; if KIBL is returning priced rows under unexpected keys, expand `_PRICE_KEYS`, `_MARKET_KEYS`, `_SELECTION_KEYS`, or `_LINE_KEYS` based on the actual debug sample.

No fake data. No DraftKings fallback.