### PR TITLE
Expose Bet105 KIBL debug payload on fixture-only board

### DIFF
--- a/frontend/src/pages/Bet105SportsbookPage.jsx
+++ b/frontend/src/pages/Bet105SportsbookPage.jsx
@@ -53,20 +53,13 @@ const s = {
   td: { color: '#c9d1d9', padding: 11, borderBottom: '1px solid #21262d', fontSize: 12.5 },
   error: { color: '#ffb4b4', background: '#2b1218', border: '1px solid #6e2633', borderRadius: 16, padding: 14 },
   empty: { color: '#8b949e', textAlign: 'center', padding: 24, border: '1px solid #30363d', borderRadius: 16, background: '#0d1117' },
+  debugPre: { margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontSize: 11, lineHeight: 1.45, color: '#c9d1d9', background: '#010409', border: '1px solid #30363d', borderRadius: 12, padding: 12, maxHeight: 440, overflow: 'auto' },
 }
 
 function asArray(value) { return Array.isArray(value) ? value : [] }
 function hasPrice(selection) { return selection?.price !== null && selection?.price !== undefined && Number.isFinite(Number(selection.price)) }
-function teamName(team) {
-  if (!team) return null
-  if (typeof team === 'string') return team
-  return team.name || team.display_name || team.displayName || team.fullName || team.full_name || team.team?.name || team.participant?.name || null
-}
-function eventName(event) {
-  const away = teamName(event?.away_team) || 'Away'
-  const home = teamName(event?.home_team) || 'Home'
-  return `${away} @ ${home}`
-}
+function teamName(team) { if (!team) return null; if (typeof team === 'string') return team; return team.name || team.display_name || team.displayName || team.fullName || team.full_name || team.team?.name || team.participant?.name || null }
+function eventName(event) { const away = teamName(event?.away_team) || 'Away'; const home = teamName(event?.home_team) || 'Home'; return `${away} @ ${home}` }
 function formatTime(iso) { if (!iso) return 'Time pending'; try { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' }) + ' ET' } catch { return 'Time pending' } }
 function american(price) { const n = Number(price); if (!Number.isFinite(n)) return '—'; return n > 0 ? `+${n}` : `${n}` }
 function pct(v) { const n = Number(v); if (!Number.isFinite(n)) return '—'; return `${Math.round(n * 1000) / 10}%` }
@@ -81,11 +74,7 @@ function groupMarkets(event) { const groups = { Featured: [], 'Game Lines': [], 
 
 function OddsButton({ event, market, selection, selected, onToggle }) {
   const leg = { book: 'Bet105', event_id: event.event_id, game: eventName(event), market_key: marketKey(market), market_name: market.market_name || marketKey(market), label: selectionLabel(selection), selection: selection.name || selection.description, line: selection.line, price: selection.price, implied_probability: selection?.odds?.implied_probability }
-  return <button type="button" style={s.oddsButton(selected)} onClick={() => onToggle(leg)}>
-    <div style={s.oddsLabel}>{leg.label}</div>
-    <div style={s.oddsPrice}>{american(leg.price)}</div>
-    <div style={s.oddsMeta}><span>Bet105</span><span>Imp {pct(leg.implied_probability)}</span></div>
-  </button>
+  return <button type="button" style={s.oddsButton(selected)} onClick={() => onToggle(leg)}><div style={s.oddsLabel}>{leg.label}</div><div style={s.oddsPrice}>{american(leg.price)}</div><div style={s.oddsMeta}><span>Bet105</span><span>Imp {pct(leg.implied_probability)}</span></div></button>
 }
 
 function BetSlip({ legs, stake, setStake, onRemove, onClear }) {
@@ -97,39 +86,13 @@ function BetSlip({ legs, stake, setStake, onRemove, onClear }) {
   const warnings = new Set()
   const seen = new Set()
   legs.forEach(leg => { const key = `${leg.event_id}:${leg.market_key}`; if (seen.has(key)) warnings.add('Multiple selections from the same game market may be correlated.'); seen.add(key) })
-  return <aside style={{ ...s.panel, ...s.slip }}>
-    <div style={s.panelInner}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}><div><div style={s.panelTitle}>Bet Slip</div><div style={s.panelSub}>Informational parlay calculator. No wagers are placed.</div></div>{legs.length > 0 && <button type="button" style={s.remove} onClick={onClear}>Clear</button>}</div>
-      {legs.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>Tap any Bet105 price to build a slip.</div>}
-      {legs.map(leg => <div key={legKey(leg)} style={s.leg}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}><strong>{leg.label}</strong><button type="button" style={s.remove} onClick={() => onRemove(leg)}>×</button></div>
-        <div style={s.panelSub}>{leg.game}</div>
-        <div style={s.chipRow}><span style={s.chip}>{cleanMarketName(leg.market_name)}</span><span style={s.chip}>{american(leg.price)}</span></div>
-      </div>)}
-      {Array.from(warnings).map(w => <div key={w} style={{ ...s.panelSub, color: '#f2cc60', marginTop: 10 }}>{w}</div>)}
-      <label style={{ display: 'block', marginTop: 13 }}><div style={s.panelSub}>Simulated stake</div><input type="number" min="0" step="1" value={stake} onChange={e => setStake(e.target.value)} style={{ ...s.input, width: '100%', marginTop: 6 }} /></label>
-      <div style={s.calcGrid}>
-        <div style={s.calcBox}><div style={s.calcLabel}>Decimal</div><div style={s.calcValue}>{activeDecimal ? activeDecimal.toFixed(4) : '—'}</div></div>
-        <div style={s.calcBox}><div style={s.calcLabel}>American</div><div style={s.calcValue}>{activeDecimal ? american(decimalToAmerican(activeDecimal)) : '—'}</div></div>
-        <div style={s.calcBox}><div style={s.calcLabel}>Implied</div><div style={s.calcValue}>{activeDecimal ? pct(1 / activeDecimal) : '—'}</div></div>
-        <div style={s.calcBox}><div style={s.calcLabel}>Payout</div><div style={s.calcValue}>${payout.toFixed(2)}</div></div>
-      </div>
-      <div style={{ ...s.calcBox, marginTop: 8 }}><div style={s.calcLabel}>Potential profit</div><div style={{ ...s.calcValue, color: '#7ee787', fontSize: 22 }}>${profit.toFixed(2)}</div></div>
-    </div>
-  </aside>
+  return <aside style={{ ...s.panel, ...s.slip }}><div style={s.panelInner}><div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'center' }}><div><div style={s.panelTitle}>Bet Slip</div><div style={s.panelSub}>Informational parlay calculator. No wagers are placed.</div></div>{legs.length > 0 && <button type="button" style={s.remove} onClick={onClear}>Clear</button>}</div>{legs.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>Tap any Bet105 price to build a slip.</div>}{legs.map(leg => <div key={legKey(leg)} style={s.leg}><div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}><strong>{leg.label}</strong><button type="button" style={s.remove} onClick={() => onRemove(leg)}>×</button></div><div style={s.panelSub}>{leg.game}</div><div style={s.chipRow}><span style={s.chip}>{cleanMarketName(leg.market_name)}</span><span style={s.chip}>{american(leg.price)}</span></div></div>)}{Array.from(warnings).map(w => <div key={w} style={{ ...s.panelSub, color: '#f2cc60', marginTop: 10 }}>{w}</div>)}<label style={{ display: 'block', marginTop: 13 }}><div style={s.panelSub}>Simulated stake</div><input type="number" min="0" step="1" value={stake} onChange={e => setStake(e.target.value)} style={{ ...s.input, width: '100%', marginTop: 6 }} /></label><div style={s.calcGrid}><div style={s.calcBox}><div style={s.calcLabel}>Decimal</div><div style={s.calcValue}>{activeDecimal ? activeDecimal.toFixed(4) : '—'}</div></div><div style={s.calcBox}><div style={s.calcLabel}>American</div><div style={s.calcValue}>{activeDecimal ? american(decimalToAmerican(activeDecimal)) : '—'}</div></div><div style={s.calcBox}><div style={s.calcLabel}>Implied</div><div style={s.calcValue}>{activeDecimal ? pct(1 / activeDecimal) : '—'}</div></div><div style={s.calcBox}><div style={s.calcLabel}>Payout</div><div style={s.calcValue}>${payout.toFixed(2)}</div></div></div><div style={{ ...s.calcBox, marginTop: 8 }}><div style={s.calcLabel}>Potential profit</div><div style={{ ...s.calcValue, color: '#7ee787', fontSize: 22 }}>${profit.toFixed(2)}</div></div></div></aside>
 }
 
 function MarketBoard({ event, selectedKeys, onToggle }) {
   const groups = groupMarkets(event)
   const ordered = ['Featured', 'Game Lines', 'Batter Props', 'Pitcher Props', 'Team Props', 'Innings / Periods', 'Other Markets']
-  return <section style={s.panel}>
-    <div style={s.boardHero}><div style={s.matchup}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event?.start_time)}</span><span style={s.chip}>Bet105</span><span style={s.chip}>{asArray(event?.markets).length} markets</span></div></div>
-    <div style={s.marketWrap}>{ordered.map(category => {
-      const markets = groups[category] || []
-      if (!markets.length) return null
-      return <div key={category} style={s.accordion}><div style={s.accordionHead}><div style={s.marketTitle}>{category}</div><span style={s.chip}>{markets.length} markets</span></div>{markets.map((market, idx) => <div key={`${category}-${marketKey(market)}-${idx}`}><div style={{ ...s.panelSub, padding: '12px 12px 0', color: '#58a6ff', fontWeight: 950 }}>{cleanMarketName(market.market_name || marketKey(market))}</div><div style={s.oddsGrid}>{asArray(market.selections).filter(hasPrice).map((selection, sidx) => { const tempLeg = { event_id: event.event_id, market_key: marketKey(market), label: selectionLabel(selection), line: selection.line, price: selection.price }; return <OddsButton key={`${selectionLabel(selection)}-${selection.price}-${sidx}`} event={event} market={market} selection={selection} selected={selectedKeys.has(legKey(tempLeg))} onToggle={onToggle} /> })}</div></div>)}</div>
-    })}</div>
-  </section>
+  return <section style={s.panel}><div style={s.boardHero}><div style={s.matchup}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event?.start_time)}</span><span style={s.chip}>Bet105</span><span style={s.chip}>{asArray(event?.markets).length} markets</span></div></div><div style={s.marketWrap}>{ordered.map(category => { const markets = groups[category] || []; if (!markets.length) return null; return <div key={category} style={s.accordion}><div style={s.accordionHead}><div style={s.marketTitle}>{category}</div><span style={s.chip}>{markets.length} markets</span></div>{markets.map((market, idx) => <div key={`${category}-${marketKey(market)}-${idx}`}><div style={{ ...s.panelSub, padding: '12px 12px 0', color: '#58a6ff', fontWeight: 950 }}>{cleanMarketName(market.market_name || marketKey(market))}</div><div style={s.oddsGrid}>{asArray(market.selections).filter(hasPrice).map((selection, sidx) => { const tempLeg = { event_id: event.event_id, market_key: marketKey(market), label: selectionLabel(selection), line: selection.line, price: selection.price }; return <OddsButton key={`${selectionLabel(selection)}-${selection.price}-${sidx}`} event={event} market={market} selection={selection} selected={selectedKeys.has(legKey(tempLeg))} onToggle={onToggle} /> })}</div></div>)}</div> })}</div></section>
 }
 
 function ComparisonPanel({ comparison, loading, error }) {
@@ -138,18 +101,26 @@ function ComparisonPanel({ comparison, loading, error }) {
   return <section style={s.panel}><div style={s.panelInner}><div style={s.panelTitle}>Bet105 vs DraftKings</div><div style={s.panelSub}>Best-price comparison across normalized markets. Model edge columns can be joined here as the Daily Odds model payload expands.</div></div>{loading && <div style={s.empty}>Loading comparison board...</div>}{error && <div style={{ ...s.error, margin: 16 }}>{error}</div>}{!loading && !error && rows.length === 0 && <div style={{ ...s.empty, margin: 16 }}>No comparable rows returned.</div>}{rows.length > 0 && <div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>Game</th><th style={s.th}>Market</th><th style={s.th}>Selection</th><th style={s.th}>Line</th><th style={s.th}>Bet105</th><th style={s.th}>DraftKings</th><th style={s.th}>Best</th><th style={s.th}>Gap</th><th style={s.th}>Model Prob</th><th style={s.th}>Edge</th></tr></thead><tbody>{rows.slice(0, 250).map(({ event, market, selection }, idx) => { const bet105 = selection.books?.bet105; const dk = selection.books?.draftkings; return <tr key={`${event.match_key}-${market.market_key}-${selection.selection_key}-${idx}`}><td style={s.td}>{event.away_team} @ {event.home_team}</td><td style={s.td}>{cleanMarketName(market.market_name || market.market_key)}</td><td style={s.td}>{selection.label}</td><td style={s.td}>{selection.line ?? '—'}</td><td style={{ ...s.td, color: selection.best_book === 'bet105' ? '#7ee787' : '#c9d1d9', fontWeight: 950 }}>{bet105 ? american(bet105.price) : '—'}</td><td style={{ ...s.td, color: selection.best_book === 'draftkings' ? '#7ee787' : '#c9d1d9', fontWeight: 950 }}>{dk ? american(dk.price) : '—'}</td><td style={s.td}>{selection.best_book || '—'}</td><td style={s.td}>{selection.price_gap ?? '—'}</td><td style={s.td}>Pending</td><td style={s.td}>Pending</td></tr> })}</tbody></table></div>}</section>
 }
 
+function Bet105DebugPanel({ debugPayload, debugLoading, debugError, onRefresh }) {
+  const summary = debugPayload ? { status: debugPayload.status, event_count: debugPayload.event_count, market_count: debugPayload.market_count, raw_count: debugPayload.raw_count, request_params: debugPayload.request_params, normalization_notes: debugPayload.normalization_notes, raw_items_sample: debugPayload.raw_items_sample } : null
+  return <section style={{ ...s.panel, marginTop: 16 }}><div style={s.panelInner}><div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}><div><div style={s.panelTitle}>KIBL Bet105 Debug</div><div style={s.panelSub}>This is the backend truth source for why the page is still fixture-only.</div></div><button type="button" style={s.mutedButton} onClick={onRefresh} disabled={debugLoading}>{debugLoading ? 'Loading debug...' : 'Refresh Debug'}</button></div>{debugError && <div style={{ ...s.error, marginTop: 12 }}>{debugError}</div>}{!debugPayload && !debugError && <div style={{ ...s.empty, marginTop: 12 }}>{debugLoading ? 'Loading KIBL debug payload...' : 'Debug payload not loaded yet.'}</div>}{summary && <pre style={{ ...s.debugPre, marginTop: 12 }}>{JSON.stringify(summary, null, 2)}</pre>}</div></section>
+}
+
 export default function Bet105SportsbookPage() {
   const [date, setDate] = useState(getMlbToday())
   const [live, setLive] = useState(false)
   const [activeTab, setActiveTab] = useState('board')
   const [payload, setPayload] = useState(null)
+  const [debugPayload, setDebugPayload] = useState(null)
   const [comparison, setComparison] = useState(null)
   const [selectedEventId, setSelectedEventId] = useState('')
   const [legs, setLegs] = useState([])
   const [stake, setStake] = useState('25')
   const [loading, setLoading] = useState(false)
+  const [debugLoading, setDebugLoading] = useState(false)
   const [compareLoading, setCompareLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [debugError, setDebugError] = useState(null)
   const [compareError, setCompareError] = useState(null)
   const [lastRefreshed, setLastRefreshed] = useState(null)
 
@@ -158,6 +129,13 @@ export default function Bet105SportsbookPage() {
   const boardEvents = marketCount > 0 ? events.filter(event => asArray(event.markets).some(market => asArray(market.selections).some(hasPrice))) : []
   const selectedEvent = boardEvents.find(event => String(event.event_id) === String(selectedEventId)) || boardEvents[0]
   const selectedKeys = useMemo(() => new Set(legs.map(legKey)), [legs])
+  const fixtureOnly = !loading && events.length > 0 && marketCount === 0
+
+  function loadDebug(forceRefresh = true) {
+    setDebugLoading(true); setDebugError(null)
+    const url = `${API_BASE}/odds/bet105/debug?date=${date}&live=${live ? 'true' : 'false'}`
+    fetchJson(url, { ttlSeconds: 0, forceRefresh }).then(json => { setDebugPayload(json); setDebugLoading(false) }).catch(err => { setDebugError(String(err?.message || err)); setDebugLoading(false) })
+  }
 
   function load(forceRefresh = false) {
     setLoading(true); setError(null)
@@ -166,6 +144,7 @@ export default function Bet105SportsbookPage() {
       const nextEvents = asArray(json?.events)
       const nextMarketCount = Number(json?.market_count ?? nextEvents.reduce((sum, event) => sum + asArray(event.markets).length, 0))
       setPayload(json); setSelectedEventId(nextMarketCount > 0 ? nextEvents[0]?.event_id || '' : ''); setLastRefreshed(new Date()); setLoading(false)
+      if (nextEvents.length > 0 && nextMarketCount === 0) loadDebug(true)
     }).catch(err => { setError(String(err?.message || err)); setLoading(false) })
   }
 
@@ -178,7 +157,7 @@ export default function Bet105SportsbookPage() {
   function toggleLeg(leg) { const key = legKey(leg); setLegs(prev => prev.some(item => legKey(item) === key) ? prev.filter(item => legKey(item) !== key) : [...prev, leg]) }
   function removeLeg(leg) { const key = legKey(leg); setLegs(prev => prev.filter(item => legKey(item) !== key)) }
 
-  useEffect(() => { load(false) }, [date, live])
+  useEffect(() => { setDebugPayload(null); load(false) }, [date, live])
   useEffect(() => { setComparison(null) }, [date])
   useEffect(() => { if (activeTab === 'compare') loadComparison(false) }, [activeTab, date])
 
@@ -186,7 +165,7 @@ export default function Bet105SportsbookPage() {
     <style>{`@media (max-width: 1100px){.bet105-shell{grid-template-columns:1fr!important}.bet105-slip{position:static!important}.bet105-game-rail{order:1}.bet105-board{order:2}.bet105-slip{order:3}}`}</style>
     <section style={s.hero}><div style={s.header}><div><div style={s.eyebrow}>Bet105 Sportsbook</div><h1 style={s.title}>Premium MLB Odds Board</h1><div style={s.subtitle}>Browse normalized Bet105 markets, build an informational slip, and compare prices against DraftKings without leaving MLBGPT.</div></div><div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={live ? s.button : s.mutedButton} onClick={() => setLive(v => !v)}>{live ? 'Live On' : 'Prematch'}</button><button type="button" style={s.button} onClick={() => { load(true); if (activeTab === 'compare') loadComparison(true) }} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh'}</button></div></div><div style={s.tabs}><button type="button" style={s.tab(activeTab === 'board')} onClick={() => setActiveTab('board')}>Sportsbook Board</button><button type="button" style={s.tab(activeTab === 'compare')} onClick={() => setActiveTab('compare')}>Compare Books</button></div><div style={s.stats}><div style={s.stat}><div style={s.statLabel}>Bet105 Events</div><div style={s.statValue}>{events.length}</div></div><div style={s.stat}><div style={s.statLabel}>Markets</div><div style={s.statValue}>{marketCount}</div></div><div style={s.stat}><div style={s.statLabel}>Slip Legs</div><div style={s.statValue}>{legs.length}</div></div><div style={s.stat}><div style={s.statLabel}>Provider</div><div style={{ ...s.statValue, fontSize: 16 }}>{payload?.status || 'pending'}</div></div><div style={s.stat}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: 16 }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Not loaded'}</div></div></div></section>
     {error && <div style={s.error}>{error}</div>}
-    {activeTab === 'board' && <div className="bet105-shell" style={s.shell}><aside className="bet105-game-rail" style={s.panel}><div style={s.panelInner}><div style={s.panelTitle}>Games</div><div style={s.panelSub}>Select a game to expand all available Bet105 markets.</div>{loading && <div style={{ ...s.empty, marginTop: 12 }}>Loading board...</div>}{!loading && events.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Bet105 events returned for {date}.</div>}{!loading && events.length > 0 && marketCount === 0 && <div style={{ ...s.empty, marginTop: 12 }}>Bet105 returned fixtures but no markets for {date}.</div>}{boardEvents.map(event => <button type="button" key={event.event_id} style={s.gameButton(String(event.event_id) === String(selectedEvent?.event_id))} onClick={() => setSelectedEventId(event.event_id)}><div style={s.gameName}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event.start_time)}</span><span style={s.chip}>{asArray(event.markets).length} markets</span></div></button>)}</div></aside><main className="bet105-board">{marketCount > 0 && selectedEvent ? <MarketBoard event={selectedEvent} selectedKeys={selectedKeys} onToggle={toggleLeg} /> : <div style={s.empty}>{events.length > 0 ? 'No Bet105 market board is available for this slate yet.' : 'Choose a game to view markets.'}</div>}</main><div className="bet105-slip"><BetSlip legs={legs} stake={stake} setStake={setStake} onRemove={removeLeg} onClear={() => setLegs([])} /></div></div>}
+    {activeTab === 'board' && <><div className="bet105-shell" style={s.shell}><aside className="bet105-game-rail" style={s.panel}><div style={s.panelInner}><div style={s.panelTitle}>Games</div><div style={s.panelSub}>Select a game to expand all available Bet105 markets.</div>{loading && <div style={{ ...s.empty, marginTop: 12 }}>Loading board...</div>}{!loading && events.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Bet105 events returned for {date}.</div>}{fixtureOnly && <div style={{ ...s.empty, marginTop: 12 }}>Bet105 returned fixtures but no markets for {date}. Debug payload is shown below.</div>}{boardEvents.map(event => <button type="button" key={event.event_id} style={s.gameButton(String(event.event_id) === String(selectedEvent?.event_id))} onClick={() => setSelectedEventId(event.event_id)}><div style={s.gameName}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event.start_time)}</span><span style={s.chip}>{asArray(event.markets).length} markets</span></div></button>)}</div></aside><main className="bet105-board">{marketCount > 0 && selectedEvent ? <MarketBoard event={selectedEvent} selectedKeys={selectedKeys} onToggle={toggleLeg} /> : <div style={s.empty}>{events.length > 0 ? 'No Bet105 market board is available for this slate yet.' : 'Choose a game to view markets.'}</div>}</main><div className="bet105-slip"><BetSlip legs={legs} stake={stake} setStake={setStake} onRemove={removeLeg} onClear={() => setLegs([])} /></div></div>{fixtureOnly && <Bet105DebugPanel debugPayload={debugPayload} debugLoading={debugLoading} debugError={debugError} onRefresh={() => loadDebug(true)} />}</>}
     {activeTab === 'compare' && <ComparisonPanel comparison={comparison} loading={compareLoading} error={compareError} />}
   </div>
 }


### PR DESCRIPTION
## Summary

The page is still landing at:

```text
Bet105 Events: 1
Markets: 0
Provider: fixtures_only
```

At this point, another blind backend retry change is not responsible engineering. PR #740 is already merged, so the next missing information is the live KIBL debug payload.

This PR makes the sportsbook page automatically fetch `/odds/bet105/debug?date=YYYY-MM-DD&live=false` whenever the page lands in fixture-only mode and renders the key debug fields directly on the page.

## Changes

- Adds a `KIBL Bet105 Debug` panel below the sportsbook board when `events.length > 0 && marketCount === 0`.
- Auto-loads the debug endpoint when fixture-only state is detected.
- Shows:
  - `status`
  - `event_count`
  - `market_count`
  - `raw_count`
  - `request_params`
  - `normalization_notes`
  - `raw_items_sample`
- Adds a `Refresh Debug` button with `ttlSeconds: 0`.

## Why

If this still shows `fixtures_only` after PR #740, then one of two things is true:

1. KIBL is returning no Bet105 market rows for the fixture, or
2. KIBL is returning rows under field names not covered by `_PRICE_KEYS`, `_MARKET_KEYS`, `_SELECTION_KEYS`, or `_LINE_KEYS`.

The only way to make the next backend change accurately is to see `normalization_notes` and `raw_items_sample` from production.

No fake data. No DraftKings fallback.