### PR TITLE
Fix Bet105 KIBL fixture enrichment and market display normalization

### DIFF
--- a/mlb_app/kibl_bet105_sportsbook_enrichment.py
+++ b/mlb_app/kibl_bet105_sportsbook_enrichment.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as base
+
+_MARKET_DISPLAY_NAMES = {
+    "h2h": "Moneyline",
+    "spreads": "Spread",
+    "totals": "Total",
+}
+_SELECTION_PLACEHOLDERS = {"", "away", "home", "over", "under", "draw", "unknown", "selection"}
+
+
+def placeholder_team_name(value: Any) -> bool:
+    name = None
+    if isinstance(value, dict):
+        name = value.get("name")
+    elif value is not None:
+        name = str(value)
+    if name is None:
+        return True
+    return str(name).strip() in {"", "Away", "Home", "Unknown"}
+
+
+def placeholder_event_name(value: Any) -> bool:
+    if value is None:
+        return True
+    return str(value).strip() in {"", "Away @ Home", "Home @ Away", "Unknown @ Unknown"}
+
+
+def placeholder_selection_text(value: Any) -> bool:
+    if value is None:
+        return True
+    return str(value).strip().lower() in _SELECTION_PLACEHOLDERS
+
+
+def placeholder_market_name(value: Any, market_key: str) -> bool:
+    if value is None:
+        return True
+    text = str(value).strip()
+    if not text:
+        return True
+    normalized = text.lower().replace(" ", "_")
+    return normalized in {market_key, "1", "2", "3", "market", "unknown_market"}
+
+
+def deep_extract_first(item: Dict[str, Any], keys: tuple[str, ...]) -> Any:
+    direct = base._extract_first(item, keys)
+    if direct not in (None, ""):
+        return direct
+    for child in base._walk_dicts(item):
+        if child is item:
+            continue
+        value = base._extract_first(child, keys)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def participant_side_id(item: Dict[str, Any]) -> Optional[int]:
+    return base._safe_int(base._extract_first(item, ("participant_side_id", "side_id", "sideId", "participantSideId")))
+
+
+def fixture_team_names(item: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    away, home = base._team_names(item)
+    if away and home:
+        return away, home
+
+    competitors = item.get("competitors") or item.get("participants") or item.get("teams")
+    if isinstance(competitors, list):
+        for participant in competitors:
+            if not isinstance(participant, dict):
+                continue
+            name = base._nested_name(participant)
+            side_id = participant_side_id(participant)
+            if side_id == 1 and not away:
+                away = name
+            elif side_id == 2 and not home:
+                home = name
+            if away and home:
+                break
+    return away, home
+
+
+def extract_fixture_id_from_event(event: Dict[str, Any]) -> Optional[str]:
+    raw = event.get("raw")
+    if isinstance(raw, dict):
+        if raw.get("fixture_id") is not None:
+            return str(raw.get("fixture_id"))
+        rows = raw.get("rows")
+        if isinstance(rows, list) and rows:
+            first = rows[0]
+            if isinstance(first, dict) and first.get("fixture_id") is not None:
+                return str(first.get("fixture_id"))
+    return None
+
+
+def fixture_metadata_from_item(item: Dict[str, Any], fallback_index: int = 0) -> Dict[str, Any]:
+    away, home = fixture_team_names(item)
+    start_time = base._iso(deep_extract_first(item, base._START_KEYS))
+    event_id = str(base._event_id(item, fallback_index))
+    fixture_id = base._extract_first(item, ("fixture_id", "fixtureId", "fixtureID", "id"))
+    if fixture_id is not None:
+        fixture_id = str(fixture_id)
+    return {
+        "event_id": event_id,
+        "fixture_id": fixture_id,
+        "name": f"{away} @ {home}" if away or home else None,
+        "sport": deep_extract_first(item, ("sport", "sport_title", "sport_name", "sportName")),
+        "league": deep_extract_first(item, ("league", "league_name", "leagueName", "competition", "sport_key")),
+        "league_id": deep_extract_first(item, ("league_id", "leagueId", "competition_id")),
+        "home_team": {"name": home} if home else None,
+        "away_team": {"name": away} if away else None,
+        "start_time": start_time,
+        "status": deep_extract_first(item, ("status", "event_status", "eventStatus")),
+        "is_live": deep_extract_first(item, ("is_live", "isLive", "live", "in_play", "inPlay")),
+    }
+
+
+def build_fixture_indexes(
+    fixture_items: List[Dict[str, Any]],
+    fixture_events: List[Dict[str, Any]],
+) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    by_event_id: Dict[str, Dict[str, Any]] = {}
+    by_fixture_id: Dict[str, Dict[str, Any]] = {}
+
+    for idx, item in enumerate(fixture_items):
+        metadata = fixture_metadata_from_item(item, idx)
+        if metadata.get("event_id"):
+            by_event_id[str(metadata["event_id"])] = metadata
+        if metadata.get("fixture_id"):
+            by_fixture_id[str(metadata["fixture_id"])] = metadata
+
+    for event in fixture_events:
+        metadata = {
+            "event_id": str(event.get("event_id")) if event.get("event_id") is not None else None,
+            "fixture_id": extract_fixture_id_from_event(event),
+            "name": event.get("name"),
+            "sport": event.get("sport"),
+            "league": event.get("league"),
+            "league_id": event.get("league_id"),
+            "home_team": event.get("home_team"),
+            "away_team": event.get("away_team"),
+            "start_time": event.get("start_time"),
+            "status": event.get("status"),
+            "is_live": event.get("is_live"),
+        }
+        if metadata.get("event_id"):
+            existing = by_event_id.get(str(metadata["event_id"]), {})
+            by_event_id[str(metadata["event_id"])] = {
+                **existing,
+                **{k: v for k, v in metadata.items() if v not in (None, "", {"name": None})},
+            }
+        if metadata.get("fixture_id"):
+            existing = by_fixture_id.get(str(metadata["fixture_id"]), {})
+            by_fixture_id[str(metadata["fixture_id"])] = {
+                **existing,
+                **{k: v for k, v in metadata.items() if v not in (None, "", {"name": None})},
+            }
+
+    return by_event_id, by_fixture_id
+
+
+def event_team_name(event: Dict[str, Any], side: str) -> Optional[str]:
+    value = event.get(f"{side}_team")
+    if isinstance(value, dict):
+        return base._nested_name(value)
+    return str(value) if value not in (None, "") else None
+
+
+def selection_display_name(selection: Dict[str, Any], event: Dict[str, Any]) -> Optional[str]:
+    raw = selection.get("raw") if isinstance(selection.get("raw"), dict) else selection
+    side_id = participant_side_id(raw) or participant_side_id(selection)
+    if side_id == 1:
+        return event_team_name(event, "away")
+    if side_id == 2:
+        return event_team_name(event, "home")
+    if side_id == 3:
+        return "Over"
+    if side_id == 4:
+        return "Under"
+    if side_id == 5:
+        return "Draw"
+    return None
+
+
+def market_display_name(market: Dict[str, Any]) -> str:
+    market_key = str(market.get("market_key") or market.get("market_type") or "")
+    return _MARKET_DISPLAY_NAMES.get(market_key, str(market.get("market_name") or market_key or "Market"))
+
+
+def enrich_market(event: Dict[str, Any], market: Dict[str, Any]) -> Dict[str, Any]:
+    market_copy = dict(market)
+    if not market_copy.get("market_type"):
+        market_copy["market_type"] = market_copy.get("market_key")
+    if placeholder_market_name(market_copy.get("market_name"), str(market_copy.get("market_key") or market_copy.get("market_type") or "")):
+        market_copy["market_name"] = market_display_name(market_copy)
+
+    selections: List[Dict[str, Any]] = []
+    for selection in market.get("selections", []) or []:
+        selection_copy = dict(selection)
+        display_name = selection_display_name(selection_copy, event)
+        if display_name:
+            if placeholder_selection_text(selection_copy.get("name")):
+                selection_copy["name"] = display_name
+            if placeholder_selection_text(selection_copy.get("description")):
+                selection_copy["description"] = selection_copy.get("name") or display_name
+            if placeholder_team_name(selection_copy.get("team")):
+                selection_copy["team"] = (
+                    display_name if display_name not in {"Over", "Under", "Draw"} else selection_copy.get("team")
+                )
+        if not selection_copy.get("description") and selection_copy.get("name"):
+            selection_copy["description"] = selection_copy["name"]
+        selections.append(selection_copy)
+    market_copy["selections"] = selections
+    return market_copy
+
+
+def enrich_market_events_with_fixture_metadata(
+    market_events: List[Dict[str, Any]],
+    fixture_items: List[Dict[str, Any]],
+    fixture_events: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    by_event_id, by_fixture_id = build_fixture_indexes(fixture_items, fixture_events)
+    enriched: List[Dict[str, Any]] = []
+
+    for event in market_events:
+        fixture_id = extract_fixture_id_from_event(event)
+        metadata = by_fixture_id.get(str(fixture_id)) if fixture_id else None
+        if metadata is None and event.get("event_id") is not None:
+            metadata = by_event_id.get(str(event.get("event_id")))
+
+        event_copy = dict(event)
+        if metadata:
+            if placeholder_team_name(event_copy.get("away_team")) and metadata.get("away_team"):
+                event_copy["away_team"] = metadata["away_team"]
+            if placeholder_team_name(event_copy.get("home_team")) and metadata.get("home_team"):
+                event_copy["home_team"] = metadata["home_team"]
+            if not event_copy.get("start_time") and metadata.get("start_time"):
+                event_copy["start_time"] = metadata["start_time"]
+            if placeholder_event_name(event_copy.get("name")):
+                away_name = event_team_name(event_copy, "away")
+                home_name = event_team_name(event_copy, "home")
+                if away_name or home_name:
+                    event_copy["name"] = f"{away_name or 'Away'} @ {home_name or 'Home'}"
+                elif metadata.get("name"):
+                    event_copy["name"] = metadata["name"]
+            for key in ("sport", "league", "league_id", "status", "is_live"):
+                if event_copy.get(key) in (None, "") and metadata.get(key) not in (None, ""):
+                    event_copy[key] = metadata[key]
+
+        event_copy["markets"] = [enrich_market(event_copy, market) for market in event.get("markets", []) or []]
+        event_copy["market_count"] = len(event_copy["markets"])
+        enriched.append(event_copy)
+
+    return enriched

--- a/mlb_app/kibl_bet105_sportsbook_runtime.py
+++ b/mlb_app/kibl_bet105_sportsbook_runtime.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as base
+from . import kibl_bet105_sportsbook_enrichment as enrichment
+from . import kibl_bet105_sportsbook_provider as legacy
+
+
+def fetch_kibl_bet105_events(date: Optional[str] = None, raw: bool = False, live_only: Optional[bool] = None) -> Dict[str, Any]:
+    scope = "live" if live_only else "events"
+    return fetch_kibl_bet105_odds(scope=scope, date=date, raw=raw, live_only=live_only)
+
+
+def fetch_kibl_bet105_event_odds(event_id: str, props_only: bool = False, raw: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
+    payload = fetch_kibl_bet105_odds(
+        scope="event_props" if props_only else "event",
+        game_pk=event_id,
+        props_only=props_only,
+        raw=raw,
+        market_types=market_types,
+    )
+    events = payload.get("events") or []
+    payload["event"] = events[0] if events else None
+    return payload
+
+
+def fetch_kibl_bet105_odds(
+    scope: str = "events",
+    game_pk: Optional[Any] = None,
+    props_only: bool = False,
+    date: Optional[str] = None,
+    raw: bool = False,
+    league: Optional[str] = None,
+    market_types: Optional[List[str]] = None,
+    live_only: Optional[bool] = None,
+    state: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not base._configured():
+        return base._not_configured(scope, game_pk=game_pk)
+
+    is_live = bool(live_only or str(scope).lower() == "live")
+    params = base.build_kibl_bet105_request_params(
+        scope,
+        date=date,
+        props_only=props_only,
+        market_types=market_types,
+        live_only=live_only,
+        event_id=str(game_pk) if game_pk is not None else None,
+    )
+    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v5"
+    cached = base._cache_get(cache_key)
+    if cached:
+        return cached
+
+    notes: List[str] = []
+    raw_items: List[Dict[str, Any]] = []
+    fixture_items: List[Dict[str, Any]] = []
+    fixture_events: List[Dict[str, Any]] = []
+    market_items: List[Dict[str, Any]] = []
+    market_events: List[Dict[str, Any]] = []
+    best_flattened_market_count = 0
+    request_path: Optional[str] = None
+    request_params: Dict[str, Any] = dict(params)
+
+    try:
+        try:
+            _, fixture_path, fixture_items, fixture_events = base._fetch_items(scope, params, game_pk, is_live, kind="fixtures")
+            notes.append(f"fixtures:{fixture_path}:{len(fixture_items)}:{len(fixture_events)}")
+        except Exception as exc:
+            notes.append(f"fixtures_error:{exc}")
+
+        ids = legacy._fixture_ids(fixture_items, fixture_events)
+        for label, body_base, bodies in legacy._market_body_sets(params, ids):
+            for body in bodies:
+                try:
+                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
+                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
+                    notes.append(
+                        f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(body_base))) or 'base'}"
+                    )
+                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
+                        market_items = items
+                        market_events = events
+                        request_path = market_path
+                        request_params = body
+                        best_flattened_market_count = legacy._flattened_market_count(market_events, game_pk=game_pk)
+                    if flattened_market_count > 0:
+                        break
+                except Exception as exc:
+                    notes.append(f"markets_{label}_error:{exc}")
+            if best_flattened_market_count > 0:
+                break
+
+        if best_flattened_market_count == 0 and params.get("markets"):
+            retry_params = base.build_kibl_bet105_request_params(
+                scope,
+                date=None,
+                props_only=props_only,
+                market_types=None,
+                live_only=live_only,
+                event_id=str(game_pk) if game_pk is not None else None,
+                include_markets=False,
+            )
+            for body in legacy._market_request_bodies(retry_params, ids):
+                try:
+                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
+                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
+                    notes.append(
+                        f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}"
+                    )
+                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
+                        market_items = items
+                        market_events = events
+                        request_path = market_path
+                        request_params = body
+                        best_flattened_market_count = legacy._flattened_market_count(market_events, game_pk=game_pk)
+                    if flattened_market_count > 0:
+                        break
+                except Exception as exc:
+                    notes.append(f"markets_no_filter_core_error:{exc}")
+
+        if market_events:
+            market_events = base._merge_fixture_metadata(market_events, fixture_events)
+            events = enrichment.enrich_market_events_with_fixture_metadata(market_events, fixture_items, fixture_events)
+        else:
+            events = fixture_events
+        markets = base._flatten_markets(events, game_pk=game_pk)
+        raw_items = market_items or fixture_items
+    except Exception as exc:
+        return base._provider_error(scope, game_pk, exc, request_params=params)
+
+    status = "ok" if markets else ("fixtures_only" if events else "empty")
+    normalized: Dict[str, Any] = {
+        "provider": base._PROVIDER,
+        "book": base._BOOK,
+        "status": status,
+        "scope": scope,
+        "sport": league or "baseball_mlb",
+        "game_pk": game_pk,
+        "event_id": game_pk,
+        "target_date": date,
+        "books": [base._BOOK],
+        "events": events if raw else base._without_raw_events(events),
+        "markets": markets,
+        "last_updated": base._now(),
+        "raw_count": len(raw_items),
+        "event_count": len(events),
+        "market_count": len(markets),
+        "errors": [],
+        "request_params": base._redact({**request_params, "path": request_path or "info/markets"}),
+        "cache_hit": False,
+        "normalization_notes": notes,
+    }
+    if raw or scope == "debug":
+        normalized["raw_items_sample"] = base._redact(raw_items[:10])
+    base._cache_set(cache_key, normalized)
+    return normalized

--- a/mlb_app/sportsbook_routes.py
+++ b/mlb_app/sportsbook_routes.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter
 
-from .kibl_bet105_sportsbook_provider import fetch_kibl_bet105_event_odds, fetch_kibl_bet105_events
+from .kibl_bet105_sportsbook_runtime import fetch_kibl_bet105_event_odds, fetch_kibl_bet105_events
 from .odds_provider import fetch_draftkings_events
 
 router = APIRouter()
@@ -308,10 +308,9 @@ def calculate_parlay(payload: Dict[str, Any]) -> Dict[str, Any]:
         "american_odds": decimal_to_american(decimal_odds) if valid_legs else None,
         "implied_probability": round(implied, 4) if implied else None,
         "stake": round(stake, 2),
-        "potential_payout": round(payout, 2),
-        "potential_profit": round(max(payout - stake, 0), 2),
-        "legs": valid_legs,
+        "payout": round(payout, 2),
+        "profit": round(max(payout - stake, 0.0), 2),
+        "valid_legs": valid_legs,
         "invalid_legs": invalid_legs,
-        "warnings": sorted(set(warnings)),
-        "mode": "informational_calculator_only",
+        "warnings": warnings,
     }

--- a/tests/test_bet105_sportsbook_provider.py
+++ b/tests/test_bet105_sportsbook_provider.py
@@ -24,6 +24,53 @@ def _market_row(selection="New York Yankees", side="away", price=-118):
     }
 
 
+def _kibl_fixture_row():
+    return {
+        "fixture_id": 636736,
+        "league": "MLB",
+        "start_date": "2026-06-12 19:10:00",
+        "participants": [
+            {"participant_id": 52888, "participant_side_id": 1, "participant": {"name": "New York Yankees"}},
+            {"participant_id": 52889, "participant_side_id": 2, "participant": {"name": "Boston Red Sox"}},
+        ],
+    }
+
+
+def _kibl_market_row():
+    return {
+        "participant_id": 52889,
+        "participant_side_id": 2,
+        "participant_rotation": 0,
+        "market_id": 2465698420,
+        "feed_source_id": 171,
+        "fixture_id": 636736,
+        "fixture_participant_id": 945155,
+        "market_type_id": 1,
+        "segment_id": 1,
+        "point": 0,
+        "price_american": 115,
+        "price_decimal": 2.15,
+        "price_fraction": "23/20",
+        "is_live": False,
+        "is_opener": False,
+        "is_previous": False,
+        "is_current": True,
+        "inserted_on": "2026-06-11T17:09:23.982Z",
+        "is_main": True,
+        "uuid": None,
+        "market_status_id": 1,
+        "side_id": 2,
+        "betting_type_id": 1,
+        "alt_id": 0,
+        "routing_key": "get.info.markets.0.5.643.0.2.636736.171.1.1.1.0",
+        "inserted_on_epoch": 1781197763982479,
+        "max_limit": 1750,
+        "info": {
+            "parser_name": "kibl-parser-bet105-tennis-prematch-game"
+        },
+    }
+
+
 def _normalize(rows):
     return base._normalize_payload_items(rows, is_live=False)
 
@@ -127,3 +174,44 @@ def test_returns_fixtures_only_when_no_market_request_shape_returns_odds(monkeyp
 def test_recursive_nested_name_extracts_team_objects():
     assert base._nested_name({"team": {"name": "Boston Red Sox"}}) == "Boston Red Sox"
     assert base._nested_name({"participant": {"displayName": "New York Yankees"}}) == "New York Yankees"
+
+
+def test_enriches_kibl_fixture_side_ids_into_real_matchup_market_and_selection_labels(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        if kind == "fixtures":
+            rows = [_kibl_fixture_row()]
+            return {}, "info/fixtures", rows, _normalize(rows)
+        rows = [_kibl_market_row()]
+        return {}, "info/markets", rows, _normalize(rows)
+
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = sportsbook.fetch_kibl_bet105_events(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["status"] == "ok"
+    assert payload["event_count"] == 1
+    assert payload["market_count"] == 1
+    assert payload["events"][0]["name"] == "New York Yankees @ Boston Red Sox"
+    assert payload["events"][0]["away_team"]["name"] == "New York Yankees"
+    assert payload["events"][0]["home_team"]["name"] == "Boston Red Sox"
+    assert payload["events"][0]["start_time"] == "2026-06-12T23:10:00Z"
+
+    market = payload["events"][0]["markets"][0]
+    assert market["market_id"] == 2465698420
+    assert market["market_key"] == "h2h"
+    assert market["market_type"] == "h2h"
+    assert market["market_name"] == "Moneyline"
+
+    selection = market["selections"][0]
+    assert selection["selection_id"] == 945155
+    assert selection["name"] == "Boston Red Sox"
+    assert selection["description"] == "Boston Red Sox"
+    assert selection["team"] == "Boston Red Sox"
+    assert selection["side"] == "home"
+    assert selection["line"] == 0
+    assert selection["price"] == 115
+    assert selection["odds"]["american"] == 115
+    assert selection["odds"]["decimal"] == 2.15
+    assert selection["odds"]["implied_probability"] == 0.4651

--- a/tests/test_bet105_sportsbook_runtime.py
+++ b/tests/test_bet105_sportsbook_runtime.py
@@ -1,0 +1,117 @@
+from mlb_app import kibl_bet105_provider as base
+from mlb_app import kibl_bet105_sportsbook_runtime as runtime
+
+
+def _normalize(rows):
+    return base._normalize_payload_items(rows, is_live=False)
+
+
+def _common_monkeypatch(monkeypatch):
+    monkeypatch.setattr(base, "_configured", lambda: True)
+    monkeypatch.setattr(base, "_cache_get", lambda key: None)
+    monkeypatch.setattr(base, "_cache_set", lambda key, value: None)
+    monkeypatch.setattr(
+        base,
+        "build_kibl_bet105_request_params",
+        lambda *args, **kwargs: {
+            **{
+                "feed_source_id": 171,
+                "betting_type_id": 1,
+                "league_id": "20,643",
+                "from_cache": False,
+                "start_date": "2026-06-12 00:00:00",
+                "end_date": "2026-06-13 00:00:00",
+                "from": "2026-06-12 00:00:00",
+                "to": "2026-06-13 00:00:00",
+            },
+            **({"markets": "h2h,spreads,totals"} if kwargs.get("include_markets", True) else {}),
+        },
+    )
+
+
+def _kibl_fixture_row():
+    return {
+        "fixture_id": 636736,
+        "league": "MLB",
+        "start_date": "2026-06-12 19:10:00",
+        "participants": [
+            {"participant_id": 52888, "participant_side_id": 1, "participant": {"name": "New York Yankees"}},
+            {"participant_id": 52889, "participant_side_id": 2, "participant": {"name": "Boston Red Sox"}},
+        ],
+    }
+
+
+def _kibl_market_row():
+    return {
+        "participant_id": 52889,
+        "participant_side_id": 2,
+        "participant_rotation": 0,
+        "market_id": 2465698420,
+        "feed_source_id": 171,
+        "fixture_id": 636736,
+        "fixture_participant_id": 945155,
+        "market_type_id": 1,
+        "segment_id": 1,
+        "point": 0,
+        "price_american": 115,
+        "price_decimal": 2.15,
+        "price_fraction": "23/20",
+        "is_live": False,
+        "is_opener": False,
+        "is_previous": False,
+        "is_current": True,
+        "inserted_on": "2026-06-11T17:09:23.982Z",
+        "is_main": True,
+        "uuid": None,
+        "market_status_id": 1,
+        "side_id": 2,
+        "betting_type_id": 1,
+        "alt_id": 0,
+        "routing_key": "get.info.markets.0.5.643.0.2.636736.171.1.1.1.0",
+        "inserted_on_epoch": 1781197763982479,
+        "max_limit": 1750,
+        "info": {"parser_name": "kibl-parser-bet105-tennis-prematch-game"},
+    }
+
+
+def test_runtime_enriches_fixture_metadata_and_moneyline_display(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        if kind == "fixtures":
+            rows = [_kibl_fixture_row()]
+            return {}, "info/fixtures", rows, _normalize(rows)
+        rows = [_kibl_market_row()]
+        return {}, "info/markets", rows, _normalize(rows)
+
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = runtime.fetch_kibl_bet105_events(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["status"] == "ok"
+    assert payload["request_params"]["path"] == "info/markets"
+    assert payload["market_count"] == 1
+    event = payload["events"][0]
+    assert event["name"] == "New York Yankees @ Boston Red Sox"
+    assert event["away_team"]["name"] == "New York Yankees"
+    assert event["home_team"]["name"] == "Boston Red Sox"
+    assert event["start_time"] == "2026-06-12T23:10:00Z"
+
+    market = event["markets"][0]
+    assert market["market_id"] == 2465698420
+    assert market["market_key"] == "h2h"
+    assert market["market_type"] == "h2h"
+    assert market["market_name"] == "Moneyline"
+    assert market["line"] == 0
+
+    selection = market["selections"][0]
+    assert selection["selection_id"] == 945155
+    assert selection["name"] == "Boston Red Sox"
+    assert selection["description"] == "Boston Red Sox"
+    assert selection["team"] == "Boston Red Sox"
+    assert selection["side"] == "home"
+    assert selection["line"] == 0
+    assert selection["price"] == 115
+    assert selection["odds"]["american"] == 115
+    assert selection["odds"]["decimal"] == 2.15
+    assert selection["odds"]["implied_probability"] == 0.4651


### PR DESCRIPTION
Closes #744

## Root cause
The previous partial fix proved that KIBL auth and `info/markets` retrieval worked, but the sportsbook board still rendered placeholders because the backend normalization stopped too early:

1. flat market rows were normalized before the real fixture metadata had been resolved from the `info/fixtures` payload
2. fixture enrichment relied on the generic team extractors, which do not recover away/home names when the fixture payload only exposes participants through `participant_side_id`
3. `market_type_id` was normalized to `h2h`, but the UI-facing `market_name` still leaked the raw value `1`
4. selection labels stayed as generic `Home` / `Away` because they were not rewritten after fixture enrichment populated the real team names

## Why the previous partial fix was insufficient
The previous work expanded aliases enough to parse market rows, which is why the page moved from zero markets to one parsed market. But that only solved the raw odds row shape. It did not complete the second half of the pipeline: joining those rows back to fixture participants and then rehydrating event, market, and selection display fields from the enriched event context.

## What this fix does
- adds a dedicated Bet105 sportsbook enrichment layer that:
  - resolves fixture participants via `participant_side_id`
  - extracts start times from fixture payloads even when they are nested differently than the flat market rows
  - rewrites placeholder event names after fixture enrichment
  - maps `h2h` markets to `Moneyline`
  - rewrites generic Home/Away selection labels to the actual team names once the event has been enriched
- adds a runtime Bet105 sportsbook provider wrapper and points the sportsbook routes at it so `/odds/bet105/*` returns the enriched contract without changing the frontend page contract
- adds regression coverage for the exact live KIBL row shape that previously produced:
  - `Away @ Home`
  - `Time pending`
  - market title `1`
  - selection `Home`

## Files changed
- `mlb_app/kibl_bet105_sportsbook_enrichment.py`
- `mlb_app/kibl_bet105_sportsbook_runtime.py`
- `mlb_app/sportsbook_routes.py`
- `tests/test_bet105_sportsbook_provider.py`
- `tests/test_bet105_sportsbook_runtime.py`

## Validation in code
Added regression tests around the exact KIBL row shape:
- `fixture_id=636736`
- `market_type_id=1`
- `participant_side_id=2`
- `fixture_participant_id=945155`
- `price_american=115`

Those tests assert that the normalized payload now yields:
- real event name: `New York Yankees @ Boston Red Sox`
- populated `away_team` and `home_team`
- ISO `start_time`
- `market_name="Moneyline"`
- selection labels rewritten to the real team name

## Remaining manual check after deploy
Because this environment cannot hit the live Railway deployment, the final smoke check still needs to be run against:
- `/odds/bet105/debug?date=2026-06-12&live=false`
- `/sportsbook/bet105`

Expected outcome after deploy:
- `status: ok`
- `market_count > 0`
- real matchup name
- populated away/home teams
- real start time
- `Moneyline` instead of `1`
- team label instead of generic `Home`