### PR TITLE
Bet105 fixture-first service

### DIFF
--- a/mlb_app/kibl_bet105_sportsbook_runtime.py
+++ b/mlb_app/kibl_bet105_sportsbook_runtime.py
@@ -2,157 +2,26 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from . import kibl_bet105_provider as base
-from . import kibl_bet105_sportsbook_enrichment as enrichment
-from . import kibl_bet105_sportsbook_provider as legacy
+from .sportsbook_bet105_service import fetch_board, fetch_event_board
 
 
-def fetch_kibl_bet105_events(date: Optional[str] = None, raw: bool = False, live_only: Optional[bool] = None) -> Dict[str, Any]:
-    scope = "live" if live_only else "events"
-    return fetch_kibl_bet105_odds(scope=scope, date=date, raw=raw, live_only=live_only)
+def fetch_kibl_bet105_events(
+    date: Optional[str] = None,
+    raw: bool = False,
+    live_only: Optional[bool] = None,
+) -> Dict[str, Any]:
+    return fetch_board(date=date, raw=raw, live_only=live_only)
 
 
-def fetch_kibl_bet105_event_odds(event_id: str, props_only: bool = False, raw: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
-    payload = fetch_kibl_bet105_odds(
-        scope="event_props" if props_only else "event",
-        game_pk=event_id,
+def fetch_kibl_bet105_event_odds(
+    event_id: str,
+    props_only: bool = False,
+    raw: bool = False,
+    market_types: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    return fetch_event_board(
+        event_id=event_id,
         props_only=props_only,
         raw=raw,
         market_types=market_types,
     )
-    events = payload.get("events") or []
-    payload["event"] = events[0] if events else None
-    return payload
-
-
-def fetch_kibl_bet105_odds(
-    scope: str = "events",
-    game_pk: Optional[Any] = None,
-    props_only: bool = False,
-    date: Optional[str] = None,
-    raw: bool = False,
-    league: Optional[str] = None,
-    market_types: Optional[List[str]] = None,
-    live_only: Optional[bool] = None,
-    state: Optional[str] = None,
-) -> Dict[str, Any]:
-    if not base._configured():
-        return base._not_configured(scope, game_pk=game_pk)
-
-    is_live = bool(live_only or str(scope).lower() == "live")
-    params = base.build_kibl_bet105_request_params(
-        scope,
-        date=date,
-        props_only=props_only,
-        market_types=market_types,
-        live_only=live_only,
-        event_id=str(game_pk) if game_pk is not None else None,
-    )
-    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v5"
-    cached = base._cache_get(cache_key)
-    if cached:
-        return cached
-
-    notes: List[str] = []
-    raw_items: List[Dict[str, Any]] = []
-    fixture_items: List[Dict[str, Any]] = []
-    fixture_events: List[Dict[str, Any]] = []
-    market_items: List[Dict[str, Any]] = []
-    market_events: List[Dict[str, Any]] = []
-    best_flattened_market_count = 0
-    request_path: Optional[str] = None
-    request_params: Dict[str, Any] = dict(params)
-
-    try:
-        try:
-            _, fixture_path, fixture_items, fixture_events = base._fetch_items(scope, params, game_pk, is_live, kind="fixtures")
-            notes.append(f"fixtures:{fixture_path}:{len(fixture_items)}:{len(fixture_events)}")
-        except Exception as exc:
-            notes.append(f"fixtures_error:{exc}")
-
-        ids = legacy._fixture_ids(fixture_items, fixture_events)
-        for label, body_base, bodies in legacy._market_body_sets(params, ids):
-            for body in bodies:
-                try:
-                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
-                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
-                    notes.append(
-                        f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(body_base))) or 'base'}"
-                    )
-                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
-                        market_items = items
-                        market_events = events
-                        request_path = market_path
-                        request_params = body
-                        best_flattened_market_count = legacy._flattened_market_count(market_events, game_pk=game_pk)
-                    if flattened_market_count > 0:
-                        break
-                except Exception as exc:
-                    notes.append(f"markets_{label}_error:{exc}")
-            if best_flattened_market_count > 0:
-                break
-
-        if best_flattened_market_count == 0 and params.get("markets"):
-            retry_params = base.build_kibl_bet105_request_params(
-                scope,
-                date=None,
-                props_only=props_only,
-                market_types=None,
-                live_only=live_only,
-                event_id=str(game_pk) if game_pk is not None else None,
-                include_markets=False,
-            )
-            for body in legacy._market_request_bodies(retry_params, ids):
-                try:
-                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
-                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
-                    notes.append(
-                        f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}"
-                    )
-                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
-                        market_items = items
-                        market_events = events
-                        request_path = market_path
-                        request_params = body
-                        best_flattened_market_count = legacy._flattened_market_count(market_events, game_pk=game_pk)
-                    if flattened_market_count > 0:
-                        break
-                except Exception as exc:
-                    notes.append(f"markets_no_filter_core_error:{exc}")
-
-        if market_events:
-            market_events = base._merge_fixture_metadata(market_events, fixture_events)
-            events = enrichment.enrich_market_events_with_fixture_metadata(market_events, fixture_items, fixture_events)
-        else:
-            events = fixture_events
-        markets = base._flatten_markets(events, game_pk=game_pk)
-        raw_items = market_items or fixture_items
-    except Exception as exc:
-        return base._provider_error(scope, game_pk, exc, request_params=params)
-
-    status = "ok" if markets else ("fixtures_only" if events else "empty")
-    normalized: Dict[str, Any] = {
-        "provider": base._PROVIDER,
-        "book": base._BOOK,
-        "status": status,
-        "scope": scope,
-        "sport": league or "baseball_mlb",
-        "game_pk": game_pk,
-        "event_id": game_pk,
-        "target_date": date,
-        "books": [base._BOOK],
-        "events": events if raw else base._without_raw_events(events),
-        "markets": markets,
-        "last_updated": base._now(),
-        "raw_count": len(raw_items),
-        "event_count": len(events),
-        "market_count": len(markets),
-        "errors": [],
-        "request_params": base._redact({**request_params, "path": request_path or "info/markets"}),
-        "cache_hit": False,
-        "normalization_notes": notes,
-    }
-    if raw or scope == "debug":
-        normalized["raw_items_sample"] = base._redact(raw_items[:10])
-    base._cache_set(cache_key, normalized)
-    return normalized

--- a/mlb_app/sportsbook_bet105_service.py
+++ b/mlb_app/sportsbook_bet105_service.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as base
+from . import kibl_bet105_sportsbook_enrichment as enrichment
+from . import kibl_bet105_sportsbook_provider as legacy
+
+
+def _walk_dicts(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
+
+
+def _is_fixture_candidate(item: Dict[str, Any]) -> bool:
+    if base._extract_first(item, ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId")) is None:
+        return False
+    competitors = item.get("participants") or item.get("competitors") or item.get("teams")
+    if isinstance(competitors, list) and any(isinstance(child, dict) for child in competitors):
+        return True
+    if base._extract_first(item, base._HOME_KEYS) is not None or base._extract_first(item, base._AWAY_KEYS) is not None:
+        return True
+    return False
+
+
+def _fixture_items_from_payload(payload: Any) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in _walk_dicts(payload):
+        if not _is_fixture_candidate(item):
+            continue
+        fixture_id = base._extract_first(item, ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id"))
+        fingerprint = str(fixture_id) if fixture_id is not None else str(id(item))
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        items.append(item)
+    return items
+
+
+def _incomplete_count(events: List[Dict[str, Any]]) -> Dict[str, int]:
+    placeholder_event_names = 0
+    placeholder_market_names = 0
+    placeholder_selection_names = 0
+    missing_start_times = 0
+    for event in events:
+        if enrichment.placeholder_event_name(event.get("name")):
+            placeholder_event_names += 1
+        if not event.get("start_time"):
+            missing_start_times += 1
+        for market in event.get("markets") or []:
+            market_key = str(market.get("market_key") or market.get("market_type") or "")
+            if enrichment.placeholder_market_name(market.get("market_name"), market_key):
+                placeholder_market_names += 1
+            for selection in market.get("selections") or []:
+                if enrichment.placeholder_selection_text(selection.get("name")) or enrichment.placeholder_selection_text(selection.get("description")):
+                    placeholder_selection_names += 1
+    return {
+        "placeholder_event_names": placeholder_event_names,
+        "placeholder_market_names": placeholder_market_names,
+        "placeholder_selection_names": placeholder_selection_names,
+        "missing_start_times": missing_start_times,
+    }
+
+
+def fetch_board(
+    date: Optional[str] = None,
+    raw: bool = False,
+    live_only: Optional[bool] = None,
+    game_pk: Optional[Any] = None,
+    props_only: bool = False,
+    market_types: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    scope = "event_props" if props_only and game_pk is not None else ("event" if game_pk is not None else ("live" if live_only else "events"))
+    if not base._configured():
+        return base._not_configured(scope, game_pk=game_pk)
+
+    is_live = bool(live_only or str(scope).lower() == "live")
+    params = base.build_kibl_bet105_request_params(
+        scope,
+        date=date,
+        props_only=props_only,
+        market_types=market_types,
+        live_only=live_only,
+        event_id=str(game_pk) if game_pk is not None else None,
+    )
+    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v6"
+    cached = base._cache_get(cache_key)
+    if cached:
+        return cached
+
+    notes: List[str] = []
+    fixture_items: List[Dict[str, Any]] = []
+    fixture_events: List[Dict[str, Any]] = []
+    market_items: List[Dict[str, Any]] = []
+    market_events: List[Dict[str, Any]] = []
+    request_path: Optional[str] = None
+    request_params: Dict[str, Any] = dict(params)
+
+    try:
+        try:
+            fixture_payload, fixture_path = base._fetch_kibl_payload(scope, params, event_id=str(game_pk) if game_pk is not None else None, kind="fixtures")
+            fixture_items = _fixture_items_from_payload(fixture_payload)
+            fixture_events = [
+                {
+                    "event_id": meta.get("event_id"),
+                    "name": meta.get("name"),
+                    "sport": meta.get("sport") or "Baseball",
+                    "league": meta.get("league") or "MLB",
+                    "league_id": meta.get("league_id") or "mlb",
+                    "home_team": meta.get("home_team"),
+                    "away_team": meta.get("away_team"),
+                    "start_time": meta.get("start_time"),
+                    "status": meta.get("status") or ("live" if is_live else "scheduled"),
+                    "is_live": bool(is_live if meta.get("is_live") is None else meta.get("is_live")),
+                    "source_url": None,
+                    "scraped_at": base._now(),
+                    "markets": [],
+                    "market_count": 0,
+                    "raw": item,
+                }
+                for item, meta in ((item, enrichment.fixture_metadata_from_item(item, idx)) for idx, item in enumerate(fixture_items))
+                if meta.get("event_id")
+            ]
+            notes.append(f"fixtures_direct:{fixture_path}:{len(fixture_items)}:{len(fixture_events)}")
+        except Exception as exc:
+            notes.append(f"fixtures_direct_error:{exc}")
+
+        ids = legacy._fixture_ids(fixture_items, fixture_events)
+        best_flattened_market_count = 0
+        for label, body_base, bodies in legacy._market_body_sets(params, ids):
+            for body in bodies:
+                try:
+                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
+                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
+                    notes.append(f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(body_base))) or 'base'}")
+                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
+                        market_items = items
+                        market_events = events
+                        request_path = market_path
+                        request_params = body
+                        best_flattened_market_count = flattened_market_count
+                    if flattened_market_count > 0:
+                        break
+                except Exception as exc:
+                    notes.append(f"markets_{label}_error:{exc}")
+            if best_flattened_market_count > 0:
+                break
+
+        if best_flattened_market_count == 0 and params.get("markets"):
+            retry_params = base.build_kibl_bet105_request_params(
+                scope,
+                date=None,
+                props_only=props_only,
+                market_types=None,
+                live_only=live_only,
+                event_id=str(game_pk) if game_pk is not None else None,
+                include_markets=False,
+            )
+            for body in legacy._market_request_bodies(retry_params, ids):
+                try:
+                    _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
+                    flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
+                    notes.append(f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}")
+                    if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
+                        market_items = items
+                        market_events = events
+                        request_path = market_path
+                        request_params = body
+                        best_flattened_market_count = flattened_market_count
+                    if flattened_market_count > 0:
+                        break
+                except Exception as exc:
+                    notes.append(f"markets_no_filter_core_error:{exc}")
+
+        events = enrichment.enrich_market_events_with_fixture_metadata(market_events, fixture_items, fixture_events) if market_events else fixture_events
+        markets = base._flatten_markets(events, game_pk=game_pk)
+        diagnostics = _incomplete_count(events)
+        status = "ok" if markets else ("fixtures_only" if events else "empty")
+        if status == "ok" and any(diagnostics.values()):
+            status = "incomplete_normalization"
+    except Exception as exc:
+        return base._provider_error(scope, game_pk, exc, request_params=params)
+
+    normalized: Dict[str, Any] = {
+        "provider": base._PROVIDER,
+        "book": base._BOOK,
+        "status": status,
+        "scope": scope,
+        "sport": "baseball_mlb",
+        "game_pk": game_pk,
+        "event_id": game_pk,
+        "target_date": date,
+        "books": [base._BOOK],
+        "events": events if raw else base._without_raw_events(events),
+        "markets": markets,
+        "last_updated": base._now(),
+        "raw_count": len(market_items or fixture_items),
+        "event_count": len(events),
+        "market_count": len(markets),
+        "errors": [],
+        "request_params": base._redact({**request_params, "path": request_path or "info/markets"}),
+        "cache_hit": False,
+        "normalization_notes": notes,
+    }
+    if raw or scope == "debug":
+        normalized["raw_items_sample"] = base._redact((market_items or fixture_items)[:10])
+        normalized["diagnostics"] = diagnostics
+        normalized["fixtures"] = {
+            "count": len(fixture_items),
+            "fixture_ids": [str(base._extract_first(item, ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id"))) for item in fixture_items[:20]],
+        }
+        normalized["markets_meta"] = {
+            "row_count": len(market_items),
+            "market_type_ids": [base._extract_first(item, ("market_type_id", "marketTypeId")) for item in market_items[:20]],
+        }
+    base._cache_set(cache_key, normalized)
+    return normalized
+
+
+def fetch_event_board(event_id: str, props_only: bool = False, raw: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
+    payload = fetch_board(game_pk=event_id, props_only=props_only, raw=raw, market_types=market_types)
+    events = payload.get("events") or []
+    payload["event"] = events[0] if events else None
+    return payload

--- a/tests/test_bet105_fixture_first_service.py
+++ b/tests/test_bet105_fixture_first_service.py
@@ -1,0 +1,137 @@
+from mlb_app import kibl_bet105_provider as base
+from mlb_app import sportsbook_bet105_service as service
+
+
+def _common_monkeypatch(monkeypatch):
+    monkeypatch.setattr(base, "_configured", lambda: True)
+    monkeypatch.setattr(base, "_cache_get", lambda key: None)
+    monkeypatch.setattr(base, "_cache_set", lambda key, value: None)
+    monkeypatch.setattr(
+        base,
+        "build_kibl_bet105_request_params",
+        lambda *args, **kwargs: {
+            **{
+                "feed_source_id": 171,
+                "betting_type_id": 1,
+                "league_id": "20,643",
+                "from_cache": False,
+                "start_date": "2026-06-12 00:00:00",
+                "end_date": "2026-06-13 00:00:00",
+                "from": "2026-06-12 00:00:00",
+                "to": "2026-06-13 00:00:00",
+            },
+            **({"markets": "h2h,spreads,totals"} if kwargs.get("include_markets", True) else {}),
+        },
+    )
+
+
+def _kibl_fixture_payload():
+    return {
+        "data": [
+            {
+                "fixture_id": 636736,
+                "league": "MLB",
+                "start_date": "2026-06-12 19:10:00",
+                "participants": [
+                    {"participant_id": 52888, "participant_side_id": 1, "participant": {"name": "New York Yankees"}},
+                    {"participant_id": 52889, "participant_side_id": 2, "participant": {"name": "Boston Red Sox"}},
+                ],
+            }
+        ]
+    }
+
+
+def _kibl_market_rows():
+    return [
+        {
+            "participant_id": 52889,
+            "participant_side_id": 2,
+            "participant_rotation": 0,
+            "market_id": 2465698420,
+            "feed_source_id": 171,
+            "fixture_id": 636736,
+            "fixture_participant_id": 945155,
+            "market_type_id": 1,
+            "segment_id": 1,
+            "point": 0,
+            "price_american": 115,
+            "price_decimal": 2.15,
+            "price_fraction": "23/20",
+            "is_live": False,
+            "is_opener": False,
+            "is_previous": False,
+            "is_current": True,
+            "inserted_on": "2026-06-11T17:09:23.982Z",
+            "is_main": True,
+            "uuid": None,
+            "market_status_id": 1,
+            "side_id": 2,
+            "betting_type_id": 1,
+            "alt_id": 0,
+            "routing_key": "get.info.markets.0.5.643.0.2.636736.171.1.1.1.0",
+            "inserted_on_epoch": 1781197763982479,
+            "max_limit": 1750,
+            "info": {"parser_name": "kibl-parser-bet105-tennis-prematch-game"},
+        }
+    ]
+
+
+def test_fixture_first_service_enriches_real_matchup_labels(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_kibl_payload(scope, params, event_id=None, kind="markets"):
+        if kind == "fixtures":
+            return _kibl_fixture_payload(), "info/fixtures"
+        return {"data": _kibl_market_rows()}, "info/markets"
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        rows = _kibl_market_rows()
+        return {}, "info/markets", rows, base._normalize_payload_items(rows, is_live=is_live)
+
+    monkeypatch.setattr(base, "_fetch_kibl_payload", fake_fetch_kibl_payload)
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = service.fetch_board(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["event_count"] == 1
+    assert payload["market_count"] == 1
+    assert payload["events"][0]["name"] == "New York Yankees @ Boston Red Sox"
+    assert payload["events"][0]["away_team"]["name"] == "New York Yankees"
+    assert payload["events"][0]["home_team"]["name"] == "Boston Red Sox"
+    assert payload["events"][0]["start_time"] == "2026-06-12T23:10:00Z"
+
+    market = payload["events"][0]["markets"][0]
+    assert market["market_name"] == "Moneyline"
+    assert market["market_key"] == "h2h"
+
+    selection = market["selections"][0]
+    assert selection["name"] == "Boston Red Sox"
+    assert selection["description"] == "Boston Red Sox"
+    assert selection["team"] == "Boston Red Sox"
+    assert selection["price"] == 115
+
+
+def test_fixture_first_service_exposes_debug_diagnostics(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_kibl_payload(scope, params, event_id=None, kind="markets"):
+        if kind == "fixtures":
+            return _kibl_fixture_payload(), "info/fixtures"
+        return {"data": _kibl_market_rows()}, "info/markets"
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        rows = _kibl_market_rows()
+        return {}, "info/markets", rows, base._normalize_payload_items(rows, is_live=is_live)
+
+    monkeypatch.setattr(base, "_fetch_kibl_payload", fake_fetch_kibl_payload)
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = service.fetch_board(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["fixtures"]["count"] == 1
+    assert payload["fixtures"]["fixture_ids"] == ["636736"]
+    assert payload["markets_meta"]["row_count"] == 1
+    assert payload["markets_meta"]["market_type_ids"] == [1]
+    assert payload["diagnostics"]["placeholder_event_names"] == 0
+    assert payload["diagnostics"]["placeholder_market_names"] == 0
+    assert payload["diagnostics"]["placeholder_selection_names"] == 0


### PR DESCRIPTION
Moves Bet105 to a fixture-first board service, retires the legacy runtime path into a delegate, and adds regression tests for the live failing KIBL row shape.