### PR TITLE
Fix Bet105 board when KIBL returns partial market candidates

### DIFF
--- a/mlb_app/sportsbook_bet105_service.py
+++ b/mlb_app/sportsbook_bet105_service.py
@@ -92,13 +92,40 @@ def _market_group_line(market: Dict[str, Any]) -> Any:
     return line if line is not None else "none"
 
 
+def _selection_fingerprint(selection: Dict[str, Any]) -> tuple[Any, ...]:
+    raw = _raw_dict(selection)
+    return (
+        base._extract_first(selection, ("selection_id", "selectionId", "id", "outcome_id", "outcomeId", "fixture_participant_id"))
+        or base._extract_first(raw, ("selection_id", "selectionId", "id", "outcome_id", "outcomeId", "fixture_participant_id")),
+        base._extract_first(selection, ("participant_id", "participantId"))
+        or base._extract_first(raw, ("participant_id", "participantId")),
+        _selection_side_id(selection),
+        base._extract_first(raw, ("market_id", "marketId")),
+        base._extract_first(selection, ("price", "price_american")) or base._price_from_selection(raw),
+        selection.get("line") if selection.get("line") is not None else base._extract_first(raw, base._LINE_KEYS),
+    )
+
+
 def _merge_market_group(group: List[Dict[str, Any]]) -> Dict[str, Any]:
     merged = dict(group[0])
     selections: List[Dict[str, Any]] = []
+    seen_selections: set[tuple[Any, ...]] = set()
     raw_rows: List[Dict[str, Any]] = []
+    seen_rows: set[str] = set()
     for market in group:
-        selections.extend([dict(selection) for selection in market.get("selections", []) or []])
-        raw_rows.extend(_raw_market_rows(market))
+        for selection in market.get("selections", []) or []:
+            selection_copy = dict(selection)
+            fingerprint = _selection_fingerprint(selection_copy)
+            if fingerprint in seen_selections:
+                continue
+            seen_selections.add(fingerprint)
+            selections.append(selection_copy)
+        for row in _raw_market_rows(market):
+            row_key = repr(sorted(row.items()))
+            if row_key in seen_rows:
+                continue
+            seen_rows.add(row_key)
+            raw_rows.append(row)
     merged["selections"] = selections
     if raw_rows:
         merged["raw"] = {"rows": raw_rows}
@@ -108,6 +135,63 @@ def _merge_market_group(group: List[Dict[str, Any]]) -> Dict[str, Any]:
 def _selection_side_id(selection: Dict[str, Any]) -> Optional[int]:
     raw = _raw_dict(selection)
     return base._safe_int(base._extract_first(raw, ("participant_side_id", "side_id", "sideId", "participantSideId")) or base._extract_first(selection, ("participant_side_id", "side_id", "sideId", "participantSideId")))
+
+
+def _event_merge_key(event: Dict[str, Any], fallback_index: int) -> str:
+    fixture_id = enrichment.extract_fixture_id_from_event(event)
+    if fixture_id:
+        return f"fixture:{fixture_id}"
+    event_id = event.get("event_id")
+    if event_id not in (None, ""):
+        return f"event:{event_id}"
+    return f"fallback:{fallback_index}"
+
+
+def _merge_market_event_candidates(candidate_sets: List[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """Union market candidates returned by different KIBL request bodies.
+
+    KIBL can return a partial board for a specific request body, especially when
+    fixture-specific filters are used. The board endpoint should keep scanning
+    every viable request and combine compatible event buckets instead of keeping
+    only the single largest response.
+    """
+
+    merged_by_key: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+    for candidate_set in candidate_sets:
+        for event in candidate_set:
+            key = _event_merge_key(event, len(order))
+            if key not in merged_by_key:
+                event_copy = dict(event)
+                event_copy["markets"] = [dict(market) for market in event.get("markets", []) or []]
+                merged_by_key[key] = event_copy
+                order.append(key)
+                continue
+
+            target = merged_by_key[key]
+            for meta_key in ("name", "sport", "league", "league_id", "home_team", "away_team", "start_time", "commence_time", "status", "is_live", "source_url"):
+                current = target.get(meta_key)
+                incoming = event.get(meta_key)
+                if current in (None, "", {"name": None}, {"name": ""}) and incoming not in (None, "", {"name": None}, {"name": ""}):
+                    target[meta_key] = incoming
+            target.setdefault("markets", [])
+            target["markets"].extend([dict(market) for market in event.get("markets", []) or []])
+            target["market_count"] = len(target["markets"])
+            if target.get("raw") is None and event.get("raw") is not None:
+                target["raw"] = event.get("raw")
+    return [merged_by_key[key] for key in order]
+
+
+def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    deduped: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        key = repr(sorted(item.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
 
 
 def _finalize_selection(selection: Dict[str, Any]) -> Dict[str, Any]:
@@ -241,7 +325,7 @@ def fetch_board(
         live_only=live_only,
         event_id=str(game_pk) if game_pk is not None else None,
     )
-    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v8"
+    cache_key = f"kibl-sportsbook:{scope}:{game_pk or 'all'}:{props_only}:{date or 'any'}:{params}:{raw}:{live_only}:fixture-first-v9"
     cached = base._cache_get(cache_key)
     if cached:
         return cached
@@ -251,6 +335,8 @@ def fetch_board(
     fixture_events: List[Dict[str, Any]] = []
     market_items: List[Dict[str, Any]] = []
     market_events: List[Dict[str, Any]] = []
+    candidate_event_sets: List[List[Dict[str, Any]]] = []
+    candidate_market_items: List[Dict[str, Any]] = []
     request_path: Optional[str] = None
     request_params: Dict[str, Any] = dict(params)
 
@@ -293,6 +379,10 @@ def fetch_board(
                     _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
                     flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
                     notes.append(f"markets_{label}:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(body_base))) or 'base'}")
+                    if events:
+                        candidate_event_sets.append(events)
+                    if items:
+                        candidate_market_items.extend(items)
                     if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
                         market_items = items
                         market_events = events
@@ -320,6 +410,10 @@ def fetch_board(
                     _, market_path, items, events = base._fetch_items(scope, body, game_pk, is_live, kind="markets")
                     flattened_market_count = legacy._flattened_market_count(events, game_pk=game_pk)
                     notes.append(f"markets_no_filter_core:{market_path}:{len(items)}:{len(events)}:{flattened_market_count}:{','.join(sorted(set(body) - set(retry_params))) or 'base'}")
+                    if events:
+                        candidate_event_sets.append(events)
+                    if items:
+                        candidate_market_items.extend(items)
                     if legacy._prefer_market_candidate(events, market_events, game_pk=game_pk):
                         market_items = items
                         market_events = events
@@ -329,6 +423,18 @@ def fetch_board(
                     # Do not break here either; the unfiltered response may also be partial.
                 except Exception as exc:
                     notes.append(f"markets_no_filter_core_error:{exc}")
+
+        union_market_events = _merge_market_event_candidates(candidate_event_sets)
+        union_flattened_market_count = legacy._flattened_market_count(union_market_events, game_pk=game_pk)
+        if union_market_events and union_flattened_market_count > best_flattened_market_count:
+            notes.append(f"markets_union_selected:{len(candidate_event_sets)}:{len(union_market_events)}:{union_flattened_market_count}")
+            market_events = union_market_events
+            market_items = _dedupe_items(candidate_market_items)
+            best_flattened_market_count = union_flattened_market_count
+            request_path = request_path or "info/markets"
+            request_params = {**params, "combined_market_candidates": True}
+        elif candidate_event_sets:
+            notes.append(f"markets_union_not_selected:{len(candidate_event_sets)}:{len(union_market_events)}:{union_flattened_market_count}")
 
         events = enrichment.enrich_market_events_with_fixture_metadata(market_events, fixture_items, fixture_events) if market_events else fixture_events
         events = _finalize_events(events)
@@ -354,7 +460,7 @@ def fetch_board(
         "events": events if raw else base._without_raw_events(events),
         "markets": markets,
         "last_updated": base._now(),
-        "raw_count": len(market_items or fixture_items),
+        "raw_count": len(raw_debug_items),
         "event_count": len(events),
         "market_count": len(markets),
         "errors": [],
@@ -373,6 +479,7 @@ def fetch_board(
             "row_count": len(market_items),
             "market_type_ids": [base._extract_first(item, ("market_type_id", "marketTypeId")) for item in market_items[:20]],
             "best_flattened_market_count": best_flattened_market_count,
+            "candidate_event_set_count": len(candidate_event_sets),
         }
     base._cache_set(cache_key, normalized)
     return normalized

--- a/scripts/debug_bet105_kibl_shape.py
+++ b/scripts/debug_bet105_kibl_shape.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Capture redacted Bet105/KIBL payload shape summaries.
+
+This script is intentionally diagnostic-only. It authenticates with the same
+KIBL provider code used by production, calls fixtures and markets directly, and
+prints/saves shape metadata without writing tokens or passwords.
+
+Usage:
+    python scripts/debug_bet105_kibl_shape.py --date 2026-06-14 --live false
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from mlb_app import kibl_bet105_provider as base
+
+
+def _walk_dicts(value: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
+
+
+def _shape(value: Any, limit: int = 8) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _shape(child, limit=limit) for key, child in list(value.items())[:limit]}
+    if isinstance(value, list):
+        return [_shape(value[0], limit=limit)] if value else []
+    return type(value).__name__
+
+
+def _first_rows(payload: Any, limit: int = 3) -> List[Dict[str, Any]]:
+    rows = base._find_list_payload(payload)
+    return [row for row in rows[:limit] if isinstance(row, dict)]
+
+
+def _summarize_payload(kind: str, path: str, request_body: Dict[str, Any], payload: Any) -> Dict[str, Any]:
+    rows = _first_rows(payload, limit=5)
+    all_dicts = list(_walk_dicts(payload))
+    return {
+        "kind": kind,
+        "path": path,
+        "request_body": base._redact(request_body),
+        "top_level_type": type(payload).__name__,
+        "top_level_keys": list(payload.keys()) if isinstance(payload, dict) else None,
+        "list_item_count": len(base._find_list_payload(payload)),
+        "sample_shape": _shape(payload),
+        "sample_rows": base._redact(rows),
+        "all_keys_sample": sorted({key for item in all_dicts[:100] for key in item.keys()})[:200],
+        "fixture_id_fields_seen": sorted(
+            {
+                key
+                for item in all_dicts[:100]
+                for key in item.keys()
+                if "fixture" in str(key).lower() or str(key).lower() in {"event_id", "eventid", "id"}
+            }
+        ),
+        "market_type_ids_seen": sorted(
+            {
+                str(base._extract_first(item, ("market_type_id", "marketTypeId", "marketTypeID")))
+                for item in all_dicts
+                if base._extract_first(item, ("market_type_id", "marketTypeId", "marketTypeID")) is not None
+            }
+        )[:50],
+        "side_ids_seen": sorted(
+            {
+                str(base._extract_first(item, ("participant_side_id", "side_id", "sideId", "participantSideId")))
+                for item in all_dicts
+                if base._extract_first(item, ("participant_side_id", "side_id", "sideId", "participantSideId")) is not None
+            }
+        )[:50],
+        "price_fields_seen": sorted(
+            {
+                key
+                for item in all_dicts[:100]
+                for key in item.keys()
+                if "price" in str(key).lower() or "odds" in str(key).lower() or str(key).lower() in {"american", "decimal"}
+            }
+        ),
+    }
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", required=True, help="Slate date in YYYY-MM-DD.")
+    parser.add_argument("--live", default="false", choices=("true", "false"))
+    parser.add_argument("--out-dir", default="docs/debug")
+    args = parser.parse_args()
+
+    live_only = args.live == "true"
+    scope = "live" if live_only else "events"
+    params = base.build_kibl_bet105_request_params(scope, date=args.date, live_only=live_only)
+
+    output_dir = Path(args.out_dir)
+    summaries: List[Dict[str, Any]] = []
+
+    for kind in ("fixtures", "markets"):
+        payload, path = base._fetch_kibl_payload(scope, params, kind=kind)
+        summary = _summarize_payload(kind, path, params, payload)
+        summaries.append(summary)
+        _write_json(output_dir / f"bet105_{args.date}_{kind}_shape.json", summary)
+
+    combined = {"date": args.date, "live": live_only, "summaries": summaries}
+    _write_json(output_dir / f"bet105_{args.date}_shape_summary.json", combined)
+    print(json.dumps(combined, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bet105_candidate_union_service.py
+++ b/tests/test_bet105_candidate_union_service.py
@@ -1,0 +1,123 @@
+from mlb_app import kibl_bet105_provider as base
+from mlb_app import sportsbook_bet105_service as service
+
+
+def _common_monkeypatch(monkeypatch):
+    monkeypatch.setattr(base, "_configured", lambda: True)
+    monkeypatch.setattr(base, "_cache_get", lambda key: None)
+    monkeypatch.setattr(base, "_cache_set", lambda key, value: None)
+    monkeypatch.setattr(
+        base,
+        "build_kibl_bet105_request_params",
+        lambda *args, **kwargs: {
+            **{
+                "feed_source_id": 171,
+                "betting_type_id": 1,
+                "league_id": "20,643",
+                "from_cache": False,
+                "start_date": "2026-06-12 00:00:00",
+                "end_date": "2026-06-13 00:00:00",
+                "from": "2026-06-12 00:00:00",
+                "to": "2026-06-13 00:00:00",
+            },
+            **({"markets": "h2h,spreads,totals"} if kwargs.get("include_markets", True) else {}),
+        },
+    )
+
+
+def _fixtures_payload():
+    return {
+        "data": [
+            {
+                "fixture_id": 636736,
+                "league": "MLB",
+                "start_date": "2026-06-12 19:10:00",
+                "participants": [
+                    {"participant_id": 52888, "participant_side_id": 1, "participant": {"name": "New York Yankees"}},
+                    {"participant_id": 52889, "participant_side_id": 2, "participant": {"name": "Boston Red Sox"}},
+                ],
+            },
+            {
+                "fixture_id": 636737,
+                "league": "MLB",
+                "start_date": "2026-06-12 20:10:00",
+                "participants": [
+                    {"participant_id": 52900, "participant_side_id": 1, "participant": {"name": "Chicago Cubs"}},
+                    {"participant_id": 52901, "participant_side_id": 2, "participant": {"name": "St. Louis Cardinals"}},
+                ],
+            },
+        ]
+    }
+
+
+def _market_row(fixture_id, participant_id, side_id, market_id, market_type_id, point, price):
+    return {
+        "fixture_id": fixture_id,
+        "participant_id": participant_id,
+        "participant_side_id": side_id,
+        "market_id": market_id,
+        "market_type_id": market_type_id,
+        "segment_id": 1,
+        "point": point,
+        "price_american": price,
+        "price_decimal": 1.91,
+        "is_current": True,
+        "side_id": side_id,
+        "betting_type_id": 1,
+        "feed_source_id": 171,
+    }
+
+
+def _rows_for_fixture(fixture_id):
+    if str(fixture_id) == "636736":
+        return [
+            _market_row(636736, 52888, 1, 1001, 1, 0, -125),
+            _market_row(636736, 52889, 2, 1002, 1, 0, 115),
+        ]
+    if str(fixture_id) == "636737":
+        return [
+            _market_row(636737, 52900, 1, 2001, 1, 0, 105),
+            _market_row(636737, 52901, 2, 2002, 1, 0, -115),
+        ]
+    return []
+
+
+def test_service_unions_partial_fixture_market_candidates(monkeypatch):
+    _common_monkeypatch(monkeypatch)
+
+    def fake_fetch_kibl_payload(scope, params, event_id=None, kind="markets"):
+        if kind == "fixtures":
+            return _fixtures_payload(), "info/fixtures"
+        return {"data": []}, "info/markets"
+
+    def fake_fetch_items(scope, params, game_pk, is_live, kind):
+        # Simulate production KIBL behavior where broad market requests are empty,
+        # but fixture-specific request bodies each return one real event.
+        fixture_value = params.get("fixture_id") or params.get("event_id") or params.get("id")
+        rows = _rows_for_fixture(fixture_value) if fixture_value else []
+        return {}, "info/markets", rows, base._normalize_payload_items(rows, is_live=is_live)
+
+    monkeypatch.setattr(base, "_fetch_kibl_payload", fake_fetch_kibl_payload)
+    monkeypatch.setattr(base, "_fetch_items", fake_fetch_items)
+
+    payload = service.fetch_board(date="2026-06-12", raw=True, live_only=False)
+
+    assert payload["event_count"] == 2
+    assert payload["market_count"] == 2
+    assert payload["markets_meta"]["candidate_event_set_count"] >= 2
+    assert payload["markets_meta"]["best_flattened_market_count"] == 2
+    assert any(note.startswith("markets_union_selected") for note in payload["normalization_notes"])
+
+    games = {event["name"] for event in payload["events"]}
+    assert "New York Yankees @ Boston Red Sox" in games
+    assert "Chicago Cubs @ St. Louis Cardinals" in games
+
+    selections = [
+        selection["name"]
+        for event in payload["events"]
+        for market in event["markets"]
+        for selection in market["selections"]
+    ]
+    assert {"New York Yankees", "Boston Red Sox", "Chicago Cubs", "St. Louis Cardinals"}.issubset(set(selections))
+    assert "Away @ Home" not in games
+    assert "Selection" not in selections


### PR DESCRIPTION
## Summary

This PR addresses the production symptom from #754 where `/sportsbook/bet105` can remain stuck at one event / one market even after PR #749.

The route audit shows `/odds/bet105/events` does use `kibl_bet105_sportsbook_runtime.fetch_kibl_bet105_events`, which is a thin wrapper around `sportsbook_bet105_service.fetch_board`; it is not bypassing the latest service code.

## Root cause found in code

The service scanned many KIBL market request bodies but kept only the single best response. That still fails when KIBL returns a partial board per request body, such as one event for each `fixture_id` request. In that case, every candidate can have one event / one market, and the service discards all but one instead of unioning them.

This matches the reported production symptom:

- event_count: 1
- market_count: 1
- generic/incomplete normalization still visible

## Changes

- `mlb_app/sportsbook_bet105_service.py`
  - Adds candidate unioning across all viable market request responses.
  - Keeps the previous best-single-candidate selection logic as a fallback.
  - Selects the union only when it improves flattened market count.
  - Dedupes raw rows and selections when market candidates overlap.
  - Bumps cache key to `fixture-first-v9` to avoid stale v8 responses.
  - Fixes `raw_count` to count combined debug raw items instead of only one source list.
  - Adds debug metadata: `markets_meta.candidate_event_set_count`.

- `tests/test_bet105_candidate_union_service.py`
  - Reproduces the partial production failure mode: broad KIBL market request returns empty, fixture-specific requests each return one real event.
  - Verifies the service returns multiple fixtures, real team labels, real selections, and no `Away @ Home` / `Selection` placeholders.

- `scripts/debug_bet105_kibl_shape.py`
  - Adds a safe redacted shape capture script for the real KIBL fixtures and markets payloads.
  - Writes summaries under `docs/debug/` and redacts secrets/tokens/passwords.

## Required production verification after merge/deploy

Run from a shell after deployment:

```bash
curl -s "https://mlbgpt.com/odds/bet105/events?date=YYYY-MM-DD&live=false" | jq '{status,event_count,market_count,raw_count,normalization_notes}'
curl -s "https://mlbgpt.com/odds/bet105/debug?date=YYYY-MM-DD" | jq '{status,event_count,market_count,diagnostics,fixtures,markets_meta,normalization_notes,request_params}'
```

Expected improvement when KIBL is returning fixture-specific partial candidates:

- `normalization_notes` includes `markets_union_selected:...`
- `event_count > 1` when the slate has multiple Bet105 MLB fixtures
- `market_count > 1` when markets exist
- no `Away @ Home`, generic `market`, or generic `Selection` when fixture and market rows expose the needed fields

## What is still required

I could not verify the live production endpoint or KIBL credentials from the connector. The debug script must be run in the environment that has `KIBL_USERNAME`, `KIBL_PASSWORD`, and deployment/log access.

Closes #754