### PR TITLE
Expose Bet105 diagnostics and strengthen real-shape enrichment

### DIFF
--- a/frontend/src/pages/Bet105SportsbookPage.jsx
+++ b/frontend/src/pages/Bet105SportsbookPage.jsx
@@ -29,6 +29,7 @@ const s = {
   gameName: { fontWeight: 950, fontSize: 13.5, lineHeight: 1.3 },
   chipRow: { display: 'flex', gap: 7, flexWrap: 'wrap', marginTop: 8 },
   chip: { color: '#8b949e', border: '1px solid #30363d', borderRadius: 999, padding: '4px 8px', fontSize: 10.5, fontWeight: 850, background: 'rgba(1,4,9,.44)' },
+  warningChip: { color: '#f2cc60', border: '1px solid rgba(242,204,96,.45)', borderRadius: 999, padding: '4px 8px', fontSize: 10.5, fontWeight: 850, background: 'rgba(154,103,0,.18)' },
   boardHero: { borderBottom: '1px solid #30363d', padding: 18, background: 'linear-gradient(135deg,rgba(88,166,255,.13),rgba(126,231,135,.07))' },
   matchup: { fontSize: 24, fontWeight: 950, color: '#f0f6fc' },
   marketWrap: { padding: 16, display: 'grid', gap: 12 },
@@ -52,20 +53,27 @@ const s = {
   th: { textAlign: 'left', color: '#8b949e', fontSize: 11, textTransform: 'uppercase', letterSpacing: .7, padding: 11, background: '#111820', borderBottom: '1px solid #30363d' },
   td: { color: '#c9d1d9', padding: 11, borderBottom: '1px solid #21262d', fontSize: 12.5 },
   error: { color: '#ffb4b4', background: '#2b1218', border: '1px solid #6e2633', borderRadius: 16, padding: 14 },
+  warn: { color: '#f2cc60', background: 'rgba(154,103,0,.15)', border: '1px solid rgba(242,204,96,.35)', borderRadius: 16, padding: 14 },
   empty: { color: '#8b949e', textAlign: 'center', padding: 24, border: '1px solid #30363d', borderRadius: 16, background: '#0d1117' },
+  pre: { overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: '#010409', border: '1px solid #30363d', borderRadius: 12, color: '#c9d1d9', padding: 12, fontSize: 11, lineHeight: 1.45, marginTop: 10 },
 }
 
 function asArray(value) { return Array.isArray(value) ? value : [] }
 function hasPrice(selection) { return selection?.price !== null && selection?.price !== undefined && Number.isFinite(Number(selection.price)) }
+function missingText(value) { return !value || ['Away', 'Home', 'Unknown', 'Selection', 'market', 'Away @ Home'].includes(String(value).trim()) }
 function teamName(team) {
   if (!team) return null
-  if (typeof team === 'string') return team
-  return team.name || team.display_name || team.displayName || team.fullName || team.full_name || team.team?.name || team.participant?.name || null
+  if (typeof team === 'string') return missingText(team) ? null : team
+  const value = team.name || team.display_name || team.displayName || team.fullName || team.full_name || team.team?.name || team.participant?.name || null
+  return missingText(value) ? null : value
 }
 function eventName(event) {
-  const away = teamName(event?.away_team) || 'Away'
-  const home = teamName(event?.home_team) || 'Home'
-  return `${away} @ ${home}`
+  const explicit = event?.name
+  if (explicit && !['Away @ Home', 'Home @ Away', 'Unknown @ Unknown'].includes(String(explicit).trim())) return explicit
+  const away = teamName(event?.away_team)
+  const home = teamName(event?.home_team)
+  if (away && home) return `${away} @ ${home}`
+  return 'Team metadata missing'
 }
 function formatTime(iso) {
   if (!iso) return 'Time pending'
@@ -77,13 +85,18 @@ function formatTime(iso) {
 }
 function american(price) { const n = Number(price); if (!Number.isFinite(n)) return '—'; return n > 0 ? `+${n}` : `${n}` }
 function pct(v) { const n = Number(v); if (!Number.isFinite(n)) return '—'; return `${Math.round(n * 1000) / 10}%` }
-function cleanMarketName(name) { return String(name || 'Market').replaceAll('_', ' ') }
+function cleanMarketName(name) {
+  const value = String(name || '').trim()
+  if (!value || ['market', 'unknown_market'].includes(value.toLowerCase())) return 'Market metadata missing'
+  return value.replaceAll('_', ' ')
+}
 function marketKey(m) { return String(m?.market_key || m?.market_type || m?.market_name || 'other') }
 function marketDisplayKey(market) {
   return [market?.market_id || '', marketKey(market), market?.line ?? 'none', asArray(market?.selections).map(selection => `${selection?.selection_id || selection?.name || selection?.team}:${selection?.price}`).join('|')].join('::')
 }
 function selectionLabel(selection, market) {
-  const baseLabel = selection?.description || selection?.name || selection?.team || 'Selection'
+  const rawLabel = selection?.description || selection?.name || selection?.team
+  const baseLabel = missingText(rawLabel) ? 'Selection metadata missing' : rawLabel
   const key = marketKey(market)
   const line = selection?.line
   if (['h2h', 'moneyline'].includes(key) || line == null || Number(line) === 0) return `${baseLabel}`
@@ -115,6 +128,33 @@ function groupMarkets(event) {
   const featuredKeys = new Set(groups.Featured.map(marketDisplayKey))
   groups['Game Lines'] = groups['Game Lines'].filter(market => !featuredKeys.has(marketDisplayKey(market)))
   return groups
+}
+function hasPlaceholders(payload) {
+  const events = asArray(payload?.events)
+  if (['incomplete_normalization', 'fixtures_only', 'provider_error', 'provider_not_configured', 'empty'].includes(payload?.status)) return true
+  return events.some(event => eventName(event) === 'Team metadata missing' || asArray(event.markets).some(market => cleanMarketName(market.market_name || marketKey(market)) === 'Market metadata missing' || asArray(market.selections).some(selection => selectionLabel(selection, market).includes('metadata missing'))))
+}
+function summarizeDebug(debugPayload) {
+  if (!debugPayload) return null
+  return {
+    status: debugPayload.status,
+    event_count: debugPayload.event_count,
+    market_count: debugPayload.market_count,
+    raw_count: debugPayload.raw_count,
+    diagnostics: debugPayload.diagnostics,
+    fixtures: debugPayload.fixtures,
+    markets_meta: debugPayload.markets_meta,
+    request_params: debugPayload.request_params,
+    normalization_notes: asArray(debugPayload.normalization_notes).slice(0, 18),
+    raw_items_sample: asArray(debugPayload.raw_items_sample).slice(0, 2),
+  }
+}
+
+function DiagnosticsPanel({ payload, debugPayload, loading, error, onRefreshDebug }) {
+  const show = hasPlaceholders(payload) || debugPayload || error
+  if (!show) return null
+  const summary = summarizeDebug(debugPayload)
+  return <section style={s.warn}><div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}><div><div style={{ fontWeight: 950, color: '#f2cc60' }}>Bet105 diagnostics</div><div style={{ marginTop: 4, color: '#d29922', fontSize: 12 }}>The page is no longer hiding incomplete normalization behind generic labels. Use this panel to see the live backend/debug shape.</div></div><button type="button" style={s.mutedButton} onClick={onRefreshDebug} disabled={loading}>{loading ? 'Loading debug...' : 'Refresh debug'}</button></div>{error && <div style={{ ...s.error, marginTop: 10 }}>{error}</div>}{summary && <pre style={s.pre}>{JSON.stringify(summary, null, 2)}</pre>}{!summary && !error && <div style={{ ...s.panelSub, marginTop: 10 }}>Debug payload has not loaded yet.</div>}</section>
 }
 
 function OddsButton({ event, market, selection, selected, onToggle }) {
@@ -153,7 +193,8 @@ function BetSlip({ legs, stake, setStake, onRemove, onClear }) {
 function MarketBoard({ event, selectedKeys, onToggle }) {
   const groups = groupMarkets(event)
   const ordered = ['Featured', 'Game Lines', 'Batter Props', 'Pitcher Props', 'Team Props', 'Innings / Periods', 'Other Markets']
-  return <section style={s.panel}><div style={s.boardHero}><div style={s.matchup}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event?.start_time)}</span><span style={s.chip}>Bet105</span><span style={s.chip}>{asArray(event?.markets).length} markets</span></div></div><div style={s.marketWrap}>{ordered.map(category => { const markets = groups[category] || []; if (!markets.length) return null; return <div key={category} style={s.accordion}><div style={s.accordionHead}><div style={s.marketTitle}>{category}</div><span style={s.chip}>{markets.length} markets</span></div>{markets.map((market, idx) => <div key={`${category}-${marketDisplayKey(market)}-${idx}`}><div style={{ ...s.panelSub, padding: '12px 12px 0', color: '#58a6ff', fontWeight: 950 }}>{cleanMarketName(market.market_name || marketKey(market))}</div><div style={s.oddsGrid}>{asArray(market.selections).filter(hasPrice).map((selection, sidx) => { const tempLeg = { event_id: event.event_id, market_key: marketKey(market), label: selectionLabel(selection, market), line: ['h2h', 'moneyline'].includes(marketKey(market)) ? null : selection.line, price: selection.price }; return <OddsButton key={`${selectionLabel(selection, market)}-${selection.price}-${sidx}`} event={event} market={market} selection={selection} selected={selectedKeys.has(legKey(tempLeg))} onToggle={onToggle} /> })}</div></div>)}</div> })}</div></section>
+  const missingGame = eventName(event) === 'Team metadata missing'
+  return <section style={s.panel}><div style={s.boardHero}><div style={s.matchup}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event?.start_time)}</span><span style={s.chip}>Bet105</span><span style={s.chip}>{asArray(event?.markets).length} markets</span>{missingGame && <span style={s.warningChip}>missing team metadata</span>}</div></div><div style={s.marketWrap}>{ordered.map(category => { const markets = groups[category] || []; if (!markets.length) return null; return <div key={category} style={s.accordion}><div style={s.accordionHead}><div style={s.marketTitle}>{category}</div><span style={s.chip}>{markets.length} markets</span></div>{markets.map((market, idx) => <div key={`${category}-${marketDisplayKey(market)}-${idx}`}><div style={{ ...s.panelSub, padding: '12px 12px 0', color: '#58a6ff', fontWeight: 950 }}>{cleanMarketName(market.market_name || marketKey(market))}</div><div style={s.oddsGrid}>{asArray(market.selections).filter(hasPrice).map((selection, sidx) => { const tempLeg = { event_id: event.event_id, market_key: marketKey(market), label: selectionLabel(selection, market), line: ['h2h', 'moneyline'].includes(marketKey(market)) ? null : selection.line, price: selection.price }; return <OddsButton key={`${selectionLabel(selection, market)}-${selection.price}-${sidx}`} event={event} market={market} selection={selection} selected={selectedKeys.has(legKey(tempLeg))} onToggle={onToggle} /> })}</div></div>)}</div> })}</div></section>
 }
 
 function ComparisonPanel({ comparison, loading, error }) {
@@ -167,13 +208,16 @@ export default function Bet105SportsbookPage() {
   const [live, setLive] = useState(false)
   const [activeTab, setActiveTab] = useState('board')
   const [payload, setPayload] = useState(null)
+  const [debugPayload, setDebugPayload] = useState(null)
   const [comparison, setComparison] = useState(null)
   const [selectedEventId, setSelectedEventId] = useState('')
   const [legs, setLegs] = useState([])
   const [stake, setStake] = useState('25')
   const [loading, setLoading] = useState(false)
+  const [debugLoading, setDebugLoading] = useState(false)
   const [compareLoading, setCompareLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [debugError, setDebugError] = useState(null)
   const [compareError, setCompareError] = useState(null)
   const [lastRefreshed, setLastRefreshed] = useState(null)
 
@@ -182,6 +226,19 @@ export default function Bet105SportsbookPage() {
   const boardEvents = marketCount > 0 ? events.filter(event => asArray(event.markets).some(market => asArray(market.selections).some(hasPrice))) : []
   const selectedEvent = boardEvents.find(event => String(event.event_id) === String(selectedEventId)) || boardEvents[0]
   const selectedKeys = useMemo(() => new Set(legs.map(legKey)), [legs])
+
+  function loadDebug(forceRefresh = false) {
+    setDebugLoading(true)
+    setDebugError(null)
+    const url = `${API_BASE}/odds/bet105/debug?date=${date}&live=${live ? 'true' : 'false'}`
+    fetchJson(url, { ttlSeconds: TTL, forceRefresh }).then(json => {
+      setDebugPayload(json)
+      setDebugLoading(false)
+    }).catch(err => {
+      setDebugError(String(err?.message || err))
+      setDebugLoading(false)
+    })
+  }
 
   function load(forceRefresh = false) {
     setLoading(true)
@@ -194,6 +251,7 @@ export default function Bet105SportsbookPage() {
       setSelectedEventId(nextMarketCount > 0 ? nextEvents[0]?.event_id || '' : '')
       setLastRefreshed(new Date())
       setLoading(false)
+      if (hasPlaceholders(json)) loadDebug(forceRefresh)
     }).catch(err => {
       setError(String(err?.message || err))
       setLoading(false)
@@ -216,15 +274,16 @@ export default function Bet105SportsbookPage() {
   function toggleLeg(leg) { const key = legKey(leg); setLegs(prev => prev.some(item => legKey(item) === key) ? prev.filter(item => legKey(item) !== key) : [...prev, leg]) }
   function removeLeg(leg) { const key = legKey(leg); setLegs(prev => prev.filter(item => legKey(item) !== key)) }
 
-  useEffect(() => { load(false) }, [date, live])
+  useEffect(() => { setDebugPayload(null); load(false) }, [date, live])
   useEffect(() => { setComparison(null) }, [date])
   useEffect(() => { if (activeTab === 'compare') loadComparison(false) }, [activeTab, date])
 
   return <div style={s.page}>
     <style>{`@media (max-width: 1100px){.bet105-shell{grid-template-columns:1fr!important}.bet105-slip{position:static!important}.bet105-game-rail{order:1}.bet105-board{order:2}.bet105-slip{order:3}}`}</style>
-    <section style={s.hero}><div style={s.header}><div><div style={s.eyebrow}>Bet105 Sportsbook</div><h1 style={s.title}>Premium MLB Odds Board</h1><div style={s.subtitle}>Browse normalized Bet105 markets, build an informational slip, and compare prices against DraftKings without leaving MLBGPT.</div></div><div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={live ? s.button : s.mutedButton} onClick={() => setLive(v => !v)}>{live ? 'Live On' : 'Prematch'}</button><button type="button" style={s.button} onClick={() => { load(true); if (activeTab === 'compare') loadComparison(true) }} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh'}</button></div></div><div style={s.tabs}><button type="button" style={s.tab(activeTab === 'board')} onClick={() => setActiveTab('board')}>Sportsbook Board</button><button type="button" style={s.tab(activeTab === 'compare')} onClick={() => setActiveTab('compare')}>Compare Books</button></div><div style={s.stats}><div style={s.stat}><div style={s.statLabel}>Bet105 Events</div><div style={s.statValue}>{events.length}</div></div><div style={s.stat}><div style={s.statLabel}>Markets</div><div style={s.statValue}>{marketCount}</div></div><div style={s.stat}><div style={s.statLabel}>Slip Legs</div><div style={s.statValue}>{legs.length}</div></div><div style={s.stat}><div style={s.statLabel}>Provider</div><div style={{ ...s.statValue, fontSize: 16 }}>{payload?.status || 'pending'}</div></div><div style={s.stat}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: 16 }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Not loaded'}</div></div></div></section>
+    <section style={s.hero}><div style={s.header}><div><div style={s.eyebrow}>Bet105 Sportsbook</div><h1 style={s.title}>Premium MLB Odds Board</h1><div style={s.subtitle}>Browse normalized Bet105 markets, build an informational slip, and compare prices against DraftKings without leaving MLBGPT. If KIBL normalization is incomplete, live diagnostics are shown below instead of fake placeholder labels.</div></div><div style={s.controls}><input type="date" value={date} onChange={e => setDate(e.target.value)} style={s.input} /><button type="button" style={live ? s.button : s.mutedButton} onClick={() => setLive(v => !v)}>{live ? 'Live On' : 'Prematch'}</button><button type="button" style={s.button} onClick={() => { load(true); loadDebug(true); if (activeTab === 'compare') loadComparison(true) }} disabled={loading}>{loading ? 'Refreshing...' : 'Refresh'}</button></div></div><div style={s.tabs}><button type="button" style={s.tab(activeTab === 'board')} onClick={() => setActiveTab('board')}>Sportsbook Board</button><button type="button" style={s.tab(activeTab === 'compare')} onClick={() => setActiveTab('compare')}>Compare Books</button></div><div style={s.stats}><div style={s.stat}><div style={s.statLabel}>Bet105 Events</div><div style={s.statValue}>{events.length}</div></div><div style={s.stat}><div style={s.statLabel}>Markets</div><div style={s.statValue}>{marketCount}</div></div><div style={s.stat}><div style={s.statLabel}>Slip Legs</div><div style={s.statValue}>{legs.length}</div></div><div style={s.stat}><div style={s.statLabel}>Provider</div><div style={{ ...s.statValue, fontSize: 16 }}>{payload?.status || 'pending'}</div></div><div style={s.stat}><div style={s.statLabel}>Last Refreshed</div><div style={{ ...s.statValue, fontSize: 16 }}>{lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Not loaded'}</div></div></div></section>
     {error && <div style={s.error}>{error}</div>}
-    {activeTab === 'board' && <div className="bet105-shell" style={s.shell}><aside className="bet105-game-rail" style={s.panel}><div style={s.panelInner}><div style={s.panelTitle}>Games</div><div style={s.panelSub}>Select a game to expand all available Bet105 markets.</div>{loading && <div style={{ ...s.empty, marginTop: 12 }}>Loading board...</div>}{!loading && events.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Bet105 events returned for {date}.</div>}{!loading && events.length > 0 && marketCount === 0 && <div style={{ ...s.empty, marginTop: 12 }}>Bet105 returned fixtures but no markets for {date}.</div>}{boardEvents.map(event => <button type="button" key={event.event_id} style={s.gameButton(String(event.event_id) === String(selectedEvent?.event_id))} onClick={() => setSelectedEventId(event.event_id)}><div style={s.gameName}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event.start_time)}</span><span style={s.chip}>{asArray(event.markets).length} markets</span></div></button>)}</div></aside><main className="bet105-board">{marketCount > 0 && selectedEvent ? <MarketBoard event={selectedEvent} selectedKeys={selectedKeys} onToggle={toggleLeg} /> : <div style={s.empty}>{events.length > 0 ? 'No Bet105 market board is available for this slate yet.' : 'Choose a game to view markets.'}</div>}</main><div className="bet105-slip"><BetSlip legs={legs} stake={stake} setStake={setStake} onRemove={removeLeg} onClear={() => setLegs([])} /></div></div>}
+    <DiagnosticsPanel payload={payload} debugPayload={debugPayload} loading={debugLoading} error={debugError} onRefreshDebug={() => loadDebug(true)} />
+    {activeTab === 'board' && <div className="bet105-shell" style={s.shell}><aside className="bet105-game-rail" style={s.panel}><div style={s.panelInner}><div style={s.panelTitle}>Games</div><div style={s.panelSub}>Select a game to expand all available Bet105 markets.</div>{loading && <div style={{ ...s.empty, marginTop: 12 }}>Loading board...</div>}{!loading && events.length === 0 && <div style={{ ...s.empty, marginTop: 12 }}>No Bet105 events returned for {date}.</div>}{!loading && events.length > 0 && marketCount === 0 && <div style={{ ...s.empty, marginTop: 12 }}>Bet105 returned fixtures but no markets for {date}.</div>}{boardEvents.map(event => <button type="button" key={event.event_id} style={s.gameButton(String(event.event_id) === String(selectedEvent?.event_id))} onClick={() => setSelectedEventId(event.event_id)}><div style={s.gameName}>{eventName(event)}</div><div style={s.chipRow}><span style={s.chip}>{formatTime(event.start_time)}</span><span style={s.chip}>{asArray(event.markets).length} markets</span>{eventName(event) === 'Team metadata missing' && <span style={s.warningChip}>debug needed</span>}</div></button>)}</div></aside><main className="bet105-board">{marketCount > 0 && selectedEvent ? <MarketBoard event={selectedEvent} selectedKeys={selectedKeys} onToggle={toggleLeg} /> : <div style={s.empty}>{events.length > 0 ? 'No Bet105 market board is available for this slate yet.' : 'Choose a game to view markets.'}</div>}</main><div className="bet105-slip"><BetSlip legs={legs} stake={stake} setStake={setStake} onRemove={removeLeg} onClear={() => setLegs([])} /></div></div>}
     {activeTab === 'compare' && <ComparisonPanel comparison={comparison} loading={compareLoading} error={compareError} />}
   </div>
 }

--- a/mlb_app/kibl_bet105_sportsbook_enrichment.py
+++ b/mlb_app/kibl_bet105_sportsbook_enrichment.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 from . import kibl_bet105_provider as base
 
 # Display names for known market keys. These map canonical Bet105/KIBL market identifiers
-# to human‑friendly labels.
+# to human-friendly labels.
 _MARKET_DISPLAY_NAMES = {
     "h2h": "Moneyline",
     "spreads": "Spread",
@@ -23,6 +23,26 @@ _KIBL_MARKET_TYPE_MAP = {
 }
 
 _SELECTION_PLACEHOLDERS = {"", "away", "home", "over", "under", "draw", "unknown", "selection"}
+_FIXTURE_ID_KEYS = ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "eventID", "id")
+_SIDE_KEYS = ("participant_side_id", "side_id", "sideId", "participantSideId", "home_away", "homeAway", "side", "type", "qualifier")
+_PARTICIPANT_NAME_KEYS = (
+    "participant_name",
+    "participantName",
+    "team_name",
+    "teamName",
+    "team",
+    "participant",
+    "competitor",
+    "competitor_name",
+    "competitorName",
+    "runner",
+    "runner_name",
+    "name",
+    "display_name",
+    "displayName",
+    "fullName",
+    "full_name",
+)
 
 
 def placeholder_team_name(value: Any) -> bool:
@@ -33,19 +53,19 @@ def placeholder_team_name(value: Any) -> bool:
         name = str(value)
     if name is None:
         return True
-    return str(name).strip() in {"", "Away", "Home", "Unknown"}
+    return str(name).strip() in {"", "Away", "Home", "Unknown", "Team metadata missing"}
 
 
 def placeholder_event_name(value: Any) -> bool:
     if value is None:
         return True
-    return str(value).strip() in {"", "Away @ Home", "Home @ Away", "Unknown @ Unknown"}
+    return str(value).strip() in {"", "Away @ Home", "Home @ Away", "Unknown @ Unknown", "Team metadata missing"}
 
 
 def placeholder_selection_text(value: Any) -> bool:
     if value is None:
         return True
-    return str(value).strip().lower() in _SELECTION_PLACEHOLDERS
+    return str(value).strip().lower() in _SELECTION_PLACEHOLDERS or str(value).strip() == "Selection metadata missing"
 
 
 def placeholder_market_name(value: Any, market_key: str) -> bool:
@@ -55,7 +75,7 @@ def placeholder_market_name(value: Any, market_key: str) -> bool:
     if not text:
         return True
     normalized = text.lower().replace(" ", "_")
-    return normalized in {market_key, "1", "2", "3", "market", "unknown_market"}
+    return normalized in {market_key, "1", "2", "3", "market", "unknown_market", "market_metadata_missing"}
 
 
 def deep_extract_first(item: Dict[str, Any], keys: tuple[str, ...]) -> Any:
@@ -72,53 +92,107 @@ def deep_extract_first(item: Dict[str, Any], keys: tuple[str, ...]) -> Any:
 
 
 def participant_side_id(item: Dict[str, Any]) -> Optional[int]:
-    return base._safe_int(base._extract_first(item, ("participant_side_id", "side_id", "sideId", "participantSideId")))
+    value = deep_extract_first(item, _SIDE_KEYS)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if "away" in normalized:
+            return 1
+        if "home" in normalized:
+            return 2
+        if "over" in normalized:
+            return 3
+        if "under" in normalized:
+            return 4
+    return base._safe_int(value)
+
+
+def _participant_name(item: Dict[str, Any]) -> Optional[str]:
+    value = deep_extract_first(item, _PARTICIPANT_NAME_KEYS)
+    if isinstance(value, dict) or isinstance(value, list):
+        return base._nested_name(value)
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    if text.lower() in {"away", "home", "over", "under", "draw", "selection", "market"}:
+        return None
+    return text
+
+
+def _side_from_role(participant: Dict[str, Any]) -> Optional[int]:
+    side_id = participant_side_id(participant)
+    if side_id in {1, 2, 3, 4, 5}:
+        return side_id
+    role = str(deep_extract_first(participant, _SIDE_KEYS) or "").lower()
+    if "away" in role:
+        return 1
+    if "home" in role:
+        return 2
+    if "over" in role:
+        return 3
+    if "under" in role:
+        return 4
+    return None
 
 
 def fixture_team_names(item: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
     away, home = base._team_names(item)
     if away and home:
         return away, home
+
     competitors = item.get("competitors") or item.get("participants") or item.get("teams")
+    if not isinstance(competitors, list):
+        competitors = [child for child in base._walk_dicts(item) if isinstance(child.get("participants"), list) for child in child.get("participants")]
+
     if isinstance(competitors, list):
         for participant in competitors:
             if not isinstance(participant, dict):
                 continue
-            name = base._nested_name(participant)
-            side_id = participant_side_id(participant)
+            name = _participant_name(participant) or base._nested_name(participant)
+            side_id = _side_from_role(participant)
             if side_id == 1 and not away:
                 away = name
             elif side_id == 2 and not home:
                 home = name
             if away and home:
                 break
+        real_participants = [p for p in competitors if isinstance(p, dict)]
+        if len(real_participants) >= 2:
+            away = away or _participant_name(real_participants[0]) or base._nested_name(real_participants[0])
+            home = home or _participant_name(real_participants[1]) or base._nested_name(real_participants[1])
+
     return away, home
 
 
 def extract_fixture_id_from_event(event: Dict[str, Any]) -> Optional[str]:
+    direct = base._extract_first(event, _FIXTURE_ID_KEYS)
+    if direct not in (None, ""):
+        return str(direct)
     raw = event.get("raw")
     if isinstance(raw, dict):
-        if raw.get("fixture_id") is not None:
-            return str(raw.get("fixture_id"))
+        value = deep_extract_first(raw, _FIXTURE_ID_KEYS)
+        if value not in (None, ""):
+            return str(value)
         rows = raw.get("rows")
-        if isinstance(rows, list) and rows:
-            first = rows[0]
-            if isinstance(first, dict) and first.get("fixture_id") is not None:
-                return str(first.get("fixture_id"))
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, dict):
+                    value = deep_extract_first(row, _FIXTURE_ID_KEYS)
+                    if value not in (None, ""):
+                        return str(value)
     return None
 
 
 def fixture_metadata_from_item(item: Dict[str, Any], fallback_index: int = 0) -> Dict[str, Any]:
     away, home = fixture_team_names(item)
     start_time = base._iso(deep_extract_first(item, base._START_KEYS))
-    event_id = str(base._event_id(item, fallback_index))
-    fixture_id = base._extract_first(item, ("fixture_id", "fixtureId", "fixtureID", "id"))
+    fixture_id = deep_extract_first(item, _FIXTURE_ID_KEYS)
+    event_id = str(fixture_id) if fixture_id not in (None, "") else str(base._event_id(item, fallback_index))
     if fixture_id is not None:
         fixture_id = str(fixture_id)
     return {
         "event_id": event_id,
         "fixture_id": fixture_id,
-        "name": f"{away} @ {home}" if away or home else None,
+        "name": f"{away} @ {home}" if away and home else None,
         "sport": deep_extract_first(item, ("sport", "sport_title", "sport_name", "sportName")),
         "league": deep_extract_first(item, ("league", "league_name", "leagueName", "competition", "sport_key")),
         "league_id": deep_extract_first(item, ("league_id", "leagueId", "competition_id")),
@@ -130,6 +204,66 @@ def fixture_metadata_from_item(item: Dict[str, Any], fallback_index: int = 0) ->
     }
 
 
+def _metadata_from_market_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    away = event_team_name(event, "away")
+    home = event_team_name(event, "home")
+    rows: List[Dict[str, Any]] = []
+    raw = event.get("raw")
+    if isinstance(raw, dict):
+        if isinstance(raw.get("rows"), list):
+            rows.extend([row for row in raw["rows"] if isinstance(row, dict)])
+        else:
+            rows.append(raw)
+    for market in event.get("markets") or []:
+        market_raw = market.get("raw") if isinstance(market, dict) else None
+        if isinstance(market_raw, dict):
+            if isinstance(market_raw.get("rows"), list):
+                rows.extend([row for row in market_raw["rows"] if isinstance(row, dict)])
+            else:
+                rows.append(market_raw)
+        for selection in market.get("selections", []) if isinstance(market, dict) else []:
+            selection_raw = selection.get("raw") if isinstance(selection, dict) else None
+            if isinstance(selection_raw, dict):
+                rows.append(selection_raw)
+
+    for row in rows:
+        name = _participant_name(row)
+        side_id = _side_from_role(row)
+        if side_id == 1 and name and not away:
+            away = name
+        elif side_id == 2 and name and not home:
+            home = name
+        if away and home:
+            break
+
+    fixture_id = extract_fixture_id_from_event(event)
+    start_time = event.get("start_time")
+    if not start_time:
+        for row in rows:
+            start_time = base._iso(deep_extract_first(row, base._START_KEYS))
+            if start_time:
+                break
+    return {
+        "event_id": str(event.get("event_id")) if event.get("event_id") not in (None, "") else fixture_id,
+        "fixture_id": fixture_id,
+        "name": f"{away} @ {home}" if away and home else event.get("name"),
+        "home_team": {"name": home} if home else event.get("home_team"),
+        "away_team": {"name": away} if away else event.get("away_team"),
+        "start_time": start_time,
+    }
+
+
+def _merge_metadata(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(existing)
+    for key, value in incoming.items():
+        if value in (None, "", {"name": None}, {"name": ""}):
+            continue
+        current = merged.get(key)
+        if current in (None, "", {"name": None}, {"name": ""}) or key in {"away_team", "home_team", "name", "start_time"}:
+            merged[key] = value
+    return merged
+
+
 def build_fixture_indexes(
     fixture_items: List[Dict[str, Any]],
     fixture_events: List[Dict[str, Any]],
@@ -139,9 +273,9 @@ def build_fixture_indexes(
     for idx, item in enumerate(fixture_items):
         metadata = fixture_metadata_from_item(item, idx)
         if metadata.get("event_id"):
-            by_event_id[str(metadata["event_id"])] = metadata
+            by_event_id[str(metadata["event_id"])] = _merge_metadata(by_event_id.get(str(metadata["event_id"]), {}), metadata)
         if metadata.get("fixture_id"):
-            by_fixture_id[str(metadata["fixture_id"])] = metadata
+            by_fixture_id[str(metadata["fixture_id"])] = _merge_metadata(by_fixture_id.get(str(metadata["fixture_id"]), {}), metadata)
     for event in fixture_events:
         metadata = {
             "event_id": str(event.get("event_id")) if event.get("event_id") is not None else None,
@@ -157,17 +291,9 @@ def build_fixture_indexes(
             "is_live": event.get("is_live"),
         }
         if metadata.get("event_id"):
-            existing = by_event_id.get(str(metadata["event_id"]), {})
-            by_event_id[str(metadata["event_id"])] = {
-                **existing,
-                **{k: v for k, v in metadata.items() if v not in (None, "", {"name": None})},
-            }
+            by_event_id[str(metadata["event_id"])] = _merge_metadata(by_event_id.get(str(metadata["event_id"]), {}), metadata)
         if metadata.get("fixture_id"):
-            existing = by_fixture_id.get(str(metadata["fixture_id"]), {})
-            by_fixture_id[str(metadata["fixture_id"])] = {
-                **existing,
-                **{k: v for k, v in metadata.items() if v not in (None, "", {"name": None})},
-            }
+            by_fixture_id[str(metadata["fixture_id"])] = _merge_metadata(by_fixture_id.get(str(metadata["fixture_id"]), {}), metadata)
     return by_event_id, by_fixture_id
 
 
@@ -180,6 +306,9 @@ def event_team_name(event: Dict[str, Any], side: str) -> Optional[str]:
 
 def selection_display_name(selection: Dict[str, Any], event: Dict[str, Any]) -> Optional[str]:
     raw = selection.get("raw") if isinstance(selection.get("raw"), dict) else selection
+    explicit = _participant_name(raw) or _participant_name(selection)
+    if explicit:
+        return explicit
     side_id = participant_side_id(raw) or participant_side_id(selection)
     if side_id == 1:
         return event_team_name(event, "away")
@@ -201,18 +330,16 @@ def market_display_name(market: Dict[str, Any]) -> str:
     explicitly to aid diagnostics rather than silently falling back to a generic label.
     """
     market_key = market.get("market_key") or market.get("market_type") or ""
-    # Attempt to derive a numeric market_type_id from the market or its raw payload.
     market_type_id = None
     raw = market.get("raw") if isinstance(market.get("raw"), dict) else None
     if market.get("market_type_id") is not None:
         market_type_id = market.get("market_type_id")
-    elif raw and raw.get("market_type_id") is not None:
-        market_type_id = raw.get("market_type_id")
+    elif raw and deep_extract_first(raw, ("market_type_id", "marketTypeId", "marketTypeID")) is not None:
+        market_type_id = deep_extract_first(raw, ("market_type_id", "marketTypeId", "marketTypeID"))
     try:
         mt_int = int(market_type_id) if market_type_id is not None else None
     except (TypeError, ValueError):
         mt_int = None
-    # If this id maps to a canonical key, override the market_key for display purposes.
     if mt_int is not None:
         canonical_key = _KIBL_MARKET_TYPE_MAP.get(mt_int)
         if canonical_key:
@@ -220,20 +347,17 @@ def market_display_name(market: Dict[str, Any]) -> str:
         else:
             return f"Unknown Market Type {mt_int}"
     key_str = str(market_key)
-    return _MARKET_DISPLAY_NAMES.get(key_str, str(market.get("market_name") or key_str or "Market"))
+    return _MARKET_DISPLAY_NAMES.get(key_str, str(market.get("market_name") or key_str or "Market metadata missing"))
 
 
 def enrich_market(event: Dict[str, Any], market: Dict[str, Any]) -> Dict[str, Any]:
     market_copy = dict(market)
-    # Attempt to map KIBL's numeric market_type_id to a canonical market key. This
-    # ensures that markets such as moneyline, spread, and totals are consistently
-    # labeled regardless of KIBL's raw identifiers. Unknown identifiers are preserved.
     market_type_id = None
     raw = market_copy.get("raw") if isinstance(market_copy.get("raw"), dict) else None
     if market_copy.get("market_type_id") is not None:
         market_type_id = market_copy.get("market_type_id")
-    elif raw and raw.get("market_type_id") is not None:
-        market_type_id = raw.get("market_type_id")
+    elif raw and deep_extract_first(raw, ("market_type_id", "marketTypeId", "marketTypeID")) is not None:
+        market_type_id = deep_extract_first(raw, ("market_type_id", "marketTypeId", "marketTypeID"))
     try:
         mt_int = int(market_type_id) if market_type_id is not None else None
     except (TypeError, ValueError):
@@ -241,21 +365,13 @@ def enrich_market(event: Dict[str, Any], market: Dict[str, Any]) -> Dict[str, An
     if mt_int is not None:
         canonical_key = _KIBL_MARKET_TYPE_MAP.get(mt_int)
         if canonical_key:
-            # Set both market_key and market_type to the canonical name when absent.
-            if not market_copy.get("market_key"):
-                market_copy["market_key"] = canonical_key
-            if not market_copy.get("market_type"):
-                market_copy["market_type"] = canonical_key
+            market_copy["market_key"] = canonical_key
+            market_copy["market_type"] = canonical_key
         else:
-            # Preserve unknown ids as string identifiers for debugging.
-            if not market_copy.get("market_key"):
-                market_copy["market_key"] = str(market_type_id)
-            if not market_copy.get("market_type"):
-                market_copy["market_type"] = str(market_type_id)
-    # Ensure market_type is present when only market_key is available.
+            market_copy.setdefault("market_key", str(market_type_id))
+            market_copy.setdefault("market_type", str(market_type_id))
     if not market_copy.get("market_type"):
         market_copy["market_type"] = market_copy.get("market_key")
-    # Compute a user‑friendly market_name using the resolved market_key or fallback.
     if placeholder_market_name(
         market_copy.get("market_name"), str(market_copy.get("market_key") or market_copy.get("market_type") or "")
     ):
@@ -292,6 +408,8 @@ def enrich_market_events_with_fixture_metadata(
         metadata = by_fixture_id.get(str(fixture_id)) if fixture_id else None
         if metadata is None and event.get("event_id") is not None:
             metadata = by_event_id.get(str(event.get("event_id")))
+        market_metadata = _metadata_from_market_event(event)
+        metadata = _merge_metadata(metadata or {}, market_metadata)
         event_copy = dict(event)
         if metadata:
             if placeholder_team_name(event_copy.get("away_team")) and metadata.get("away_team"):
@@ -303,9 +421,9 @@ def enrich_market_events_with_fixture_metadata(
             if placeholder_event_name(event_copy.get("name")):
                 away_name = event_team_name(event_copy, "away")
                 home_name = event_team_name(event_copy, "home")
-                if away_name or home_name:
-                    event_copy["name"] = f"{away_name or 'Away'} @ {home_name or 'Home'}"
-                elif metadata.get("name"):
+                if away_name and home_name:
+                    event_copy["name"] = f"{away_name} @ {home_name}"
+                elif metadata.get("name") and not placeholder_event_name(metadata.get("name")):
                     event_copy["name"] = metadata["name"]
             for key in ("sport", "league", "league_id", "status", "is_live"):
                 if event_copy.get(key) in (None, "") and metadata.get(key) not in (None, ""):

--- a/tests/test_bet105_real_shape_enrichment.py
+++ b/tests/test_bet105_real_shape_enrichment.py
@@ -1,0 +1,94 @@
+from mlb_app import kibl_bet105_sportsbook_enrichment as enrichment
+
+
+def test_fixture_metadata_extracts_deep_nested_participants_and_fixture_id():
+    item = {
+        "fixture": {
+            "id": 777001,
+            "scheduled_time": "2026-06-14 19:10:00",
+            "competition": {"name": "MLB"},
+            "participants": [
+                {"side": "away", "team": {"displayName": "Toronto Blue Jays"}},
+                {"side": "home", "team": {"displayName": "Philadelphia Phillies"}},
+            ],
+        }
+    }
+
+    meta = enrichment.fixture_metadata_from_item(item)
+
+    assert meta["fixture_id"] == "777001"
+    assert meta["event_id"] == "777001"
+    assert meta["away_team"] == {"name": "Toronto Blue Jays"}
+    assert meta["home_team"] == {"name": "Philadelphia Phillies"}
+    assert meta["name"] == "Toronto Blue Jays @ Philadelphia Phillies"
+    assert meta["start_time"] == "2026-06-14T23:10:00Z"
+
+
+def test_market_event_enrichment_can_recover_team_names_from_market_rows():
+    market_events = [
+        {
+            "event_id": "777002",
+            "name": "Away @ Home",
+            "away_team": {"name": None},
+            "home_team": {"name": None},
+            "markets": [
+                {
+                    "market_id": "m1",
+                    "market_type_id": 1,
+                    "market_name": "1",
+                    "selections": [
+                        {
+                            "name": "Away",
+                            "description": "Away",
+                            "team": "Away",
+                            "price": -120,
+                            "raw": {
+                                "fixture_id": 777002,
+                                "participant_side_id": 1,
+                                "participant": {"name": "Milwaukee Brewers"},
+                                "price_american": -120,
+                                "market_type_id": 1,
+                            },
+                        },
+                        {
+                            "name": "Home",
+                            "description": "Home",
+                            "team": "Home",
+                            "price": 110,
+                            "raw": {
+                                "fixture_id": 777002,
+                                "participant_side_id": 2,
+                                "participant": {"name": "Cincinnati Reds"},
+                                "price_american": 110,
+                                "market_type_id": 1,
+                            },
+                        },
+                    ],
+                    "raw": {
+                        "rows": [
+                            {"fixture_id": 777002, "participant_side_id": 1, "participant": {"name": "Milwaukee Brewers"}, "market_type_id": 1},
+                            {"fixture_id": 777002, "participant_side_id": 2, "participant": {"name": "Cincinnati Reds"}, "market_type_id": 1},
+                        ]
+                    },
+                }
+            ],
+            "raw": {
+                "rows": [
+                    {"fixture_id": 777002, "participant_side_id": 1, "participant": {"name": "Milwaukee Brewers"}},
+                    {"fixture_id": 777002, "participant_side_id": 2, "participant": {"name": "Cincinnati Reds"}},
+                ]
+            },
+        }
+    ]
+
+    enriched = enrichment.enrich_market_events_with_fixture_metadata(market_events, [], [])
+
+    event = enriched[0]
+    assert event["name"] == "Milwaukee Brewers @ Cincinnati Reds"
+    assert event["away_team"] == {"name": "Milwaukee Brewers"}
+    assert event["home_team"] == {"name": "Cincinnati Reds"}
+    market = event["markets"][0]
+    assert market["market_key"] == "h2h"
+    assert market["market_name"] == "Moneyline"
+    assert [selection["name"] for selection in market["selections"]] == ["Milwaukee Brewers", "Cincinnati Reds"]
+    assert [selection["description"] for selection in market["selections"]] == ["Milwaukee Brewers", "Cincinnati Reds"]


### PR DESCRIPTION
## Summary

This PR follows up #755 and addresses the visible failure mode directly:

- Backend now handles deeper/nested KIBL fixture/team/selection shapes.
- Frontend no longer hides missing metadata behind `Away @ Home`, generic `market`, or generic `Selection` labels.
- The Bet105 page now fetches `/odds/bet105/debug` when normalization looks incomplete and renders diagnostics/raw samples on the page.

## Backend changes

### `mlb_app/kibl_bet105_sportsbook_enrichment.py`

- Deeply extracts fixture IDs from nested fixture/event objects and market rows.
- Extracts away/home teams from nested participants using side IDs, `home_away`, `side`, `type`, or qualifier-like fields.
- Recovers team names directly from market rows/selections when fixture metadata does not match the market event.
- Avoids rebuilding event names unless both real away/home teams exist.
- Improves selection labels from nested participant/team/competitor fields.
- Keeps unknown market type IDs visible instead of mapping to fake-friendly labels.

## Frontend changes

### `frontend/src/pages/Bet105SportsbookPage.jsx`

- Adds debug-state loading from:

```text
/odds/bet105/debug?date=YYYY-MM-DD&live=false
```

- Automatically loads debug payload when provider status or placeholder detection looks suspicious.
- Displays:
  - status
  - event_count
  - market_count
  - raw_count
  - diagnostics
  - fixtures
  - markets_meta
  - request_params
  - normalization_notes
  - first raw item samples
- Replaces `Away @ Home` fallback with explicit `Team metadata missing` so bad normalization is visible.
- Replaces generic market/selection fallback labels with explicit metadata-missing states.

## Tests

### `tests/test_bet105_real_shape_enrichment.py`

Adds regression coverage for:

- nested fixture participant/team extraction
- nested fixture ID extraction
- market-row-only team recovery
- real moneyline selection names from raw participant rows
- no placeholder event/selection labels when raw fields exist

## Important limitation

I still cannot directly access production deployment logs, KIBL credentials, or live endpoint responses from the connector environment. This PR makes the production page expose the data needed to finish the remaining normalization work from the actual live response.

## Required verification after deploy

Open:

```text
https://mlbgpt.com/sportsbook/bet105
```

Then inspect the new diagnostics panel if the board is incomplete. Also run:

```bash
curl -s "https://mlbgpt.com/odds/bet105/debug?date=YYYY-MM-DD&live=false" | jq '{status,event_count,market_count,raw_count,diagnostics,fixtures,markets_meta,request_params,normalization_notes,raw_items_sample}'
```

Acceptance:

- No `Away @ Home` rendered on the frontend.
- If teams/selections are missing, the diagnostics panel shows the raw/debug cause.
- Nested participant/team rows normalize into real team/selection labels.
- If production still fails, the raw samples shown in the panel are the next source of truth for the exact KIBL shape.
