### PR TITLE
Use KIBL ID-list fixture retries for Bet105 metadata

### DIFF
--- a/mlb_app/sportsbook_bet105_runtime_v10.py
+++ b/mlb_app/sportsbook_bet105_runtime_v10.py
@@ -7,75 +7,113 @@ from . import kibl_bet105_sportsbook_enrichment as enrichment
 from . import sportsbook_bet105_service as service
 
 _ID_KEYS = ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id")
+_DROP = {"path", "from_cache", "combined_market_candidates"}
+_DATE_KEYS = {"start_date", "end_date", "from", "to"}
 
 
 def _add(out: List[str], value: Any) -> None:
-    if value in (None, ""):
-        return
-    text = str(value)
-    if text not in out:
-        out.append(text)
+    if value not in (None, "") and str(value) not in out:
+        out.append(str(value))
 
 
-def _market_fixture_ids(payload: Dict[str, Any]) -> List[str]:
-    out: List[str] = []
-    for item in payload.get("raw_items_sample") or []:
-        if isinstance(item, dict):
-            _add(out, enrichment.deep_extract_first(item, _ID_KEYS))
+def _rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    rows.extend([x for x in payload.get("raw_items_sample") or [] if isinstance(x, dict)])
     for event in payload.get("events") or []:
         if not isinstance(event, dict):
             continue
-        _add(out, enrichment.extract_fixture_id_from_event(event) or event.get("event_id"))
+        raw = event.get("raw")
+        if isinstance(raw, dict):
+            rows.append(raw)
+            if isinstance(raw.get("rows"), list):
+                rows.extend([x for x in raw["rows"] if isinstance(x, dict)])
         for market in event.get("markets") or []:
-            for row in service._raw_market_rows(market):
-                _add(out, enrichment.deep_extract_first(row, _ID_KEYS))
+            rows.extend(service._raw_market_rows(market))
             for selection in market.get("selections") or []:
                 raw_sel = selection.get("raw") if isinstance(selection, dict) else None
                 if isinstance(raw_sel, dict):
-                    _add(out, enrichment.deep_extract_first(raw_sel, _ID_KEYS))
-    return out
+                    rows.append(raw_sel)
+    return rows
+
+
+def _fixture_ids(payload: Dict[str, Any]) -> List[str]:
+    ids: List[str] = []
+    for row in _rows(payload):
+        _add(ids, enrichment.deep_extract_first(row, _ID_KEYS))
+    return ids
+
+
+def _detail_ids(payload: Dict[str, Any]) -> Dict[str, List[str]]:
+    found = {"fixture_participant_id": [], "participant_id": [], "market_id": [], "contestant_id": [], "line_id": []}
+    for row in _rows(payload):
+        info = row.get("info") if isinstance(row.get("info"), dict) else {}
+        for key in found:
+            _add(found[key], row.get(key))
+            _add(found[key], info.get(key))
+    return found
+
+
+def _clean(params: Dict[str, Any], compact: bool = False) -> Dict[str, Any]:
+    banned = _DROP | (_DATE_KEYS if compact else set())
+    return {k: v for k, v in params.items() if k not in banned and v not in (None, "")}
 
 
 def _fixture_events(items: List[Dict[str, Any]], live: bool) -> List[Dict[str, Any]]:
-    events: List[Dict[str, Any]] = []
+    out: List[Dict[str, Any]] = []
     for idx, item in enumerate(items):
         meta = enrichment.fixture_metadata_from_item(item, idx)
         if not meta.get("event_id"):
             continue
-        events.append({
-            "event_id": meta.get("event_id"),
-            "fixture_id": meta.get("fixture_id"),
-            "name": meta.get("name"),
-            "sport": meta.get("sport") or "Baseball",
-            "league": meta.get("league") or "MLB",
-            "league_id": meta.get("league_id") or "mlb",
-            "home_team": meta.get("home_team"),
-            "away_team": meta.get("away_team"),
-            "start_time": meta.get("start_time"),
-            "commence_time": meta.get("start_time"),
-            "status": meta.get("status") or ("live" if live else "scheduled"),
-            "is_live": live if meta.get("is_live") is None else bool(meta.get("is_live")),
-            "source_url": None,
-            "scraped_at": base._now(),
-            "markets": [],
-            "market_count": 0,
-            "raw": item,
+        out.append({
+            "event_id": meta.get("event_id"), "fixture_id": meta.get("fixture_id"), "name": meta.get("name"),
+            "sport": meta.get("sport") or "Baseball", "league": meta.get("league") or "MLB", "league_id": meta.get("league_id") or "mlb",
+            "home_team": meta.get("home_team"), "away_team": meta.get("away_team"),
+            "start_time": meta.get("start_time"), "commence_time": meta.get("start_time"),
+            "status": meta.get("status") or ("live" if live else "scheduled"), "is_live": live if meta.get("is_live") is None else bool(meta.get("is_live")),
+            "source_url": None, "scraped_at": base._now(), "markets": [], "market_count": 0, "raw": item,
         })
-    return events
+    return out
+
+
+def _retry_bodies(payload: Dict[str, Any], params: Dict[str, Any]) -> List[tuple[str, Dict[str, Any]]]:
+    bodies: List[tuple[str, Dict[str, Any]]] = []
+    ids = _fixture_ids(payload)[:50]
+    for root in (_clean(params), _clean(params, compact=True)):
+        for key in ("ids", "fixture_ids", "event_ids"):
+            if ids:
+                bodies.append((key, {**root, key: ids}))
+        for value in ids[:20]:
+            bodies.append(("ids_single_list", {**root, "ids": [value]}))
+            bodies.append(("fixture_ids_single_list", {**root, "fixture_ids": [value]}))
+    details = _detail_ids(payload)
+    for key, values in details.items():
+        for root in (_clean(params), _clean(params, compact=True)):
+            if values:
+                bodies.append((f"{key}_list", {**root, key: values[:50]}))
+    seen: set[str] = set()
+    out: List[tuple[str, Dict[str, Any]]] = []
+    for label, body in bodies:
+        fp = repr(sorted((k, str(v)) for k, v in body.items()))
+        if fp not in seen:
+            seen.add(fp); out.append((label, body))
+    return out
 
 
 def _retry_fixture_items(payload: Dict[str, Any], params: Dict[str, Any], scope: str) -> List[Dict[str, Any]]:
     notes = payload.setdefault("normalization_notes", [])
     items: List[Dict[str, Any]] = []
-    for fixture_id in _market_fixture_ids(payload)[:20]:
-        for key in ("fixture_id", "event_id", "id"):
-            try:
-                raw, path = base._fetch_kibl_payload(scope, {**params, key: fixture_id}, event_id=fixture_id, kind="fixtures")
-                found = service._fixture_items_from_payload(raw)
-                notes.append(f"fixtures_market_id_retry:{key}:{path}:{len(found)}")
-                items.extend(found)
-            except Exception as exc:
-                notes.append(f"fixtures_market_id_retry_error:{key}:{exc}")
+    labels: List[str] = []
+    for label, body in _retry_bodies(payload, params)[:60]:
+        labels.append(label)
+        try:
+            raw, path = base._fetch_kibl_payload(scope, body, kind="fixtures")
+            found = service._fixture_items_from_payload(raw)
+            notes.append(f"fixtures_id_list_retry:{label}:{path}:{len(found)}")
+            items.extend(found)
+        except Exception as exc:
+            notes.append(f"fixtures_id_list_retry_error:{label}:{exc}")
+    payload.setdefault("fixtures", {})["fixture_retry_labels"] = labels[:40]
+    payload["fixtures"]["market_detail_ids"] = _detail_ids(payload)
     return service._dedupe_items(items)
 
 
@@ -84,11 +122,7 @@ def _side_label(selection: Dict[str, Any]) -> Optional[str]:
     info = raw.get("info") if isinstance(raw, dict) else None
     side = info.get("side") if isinstance(info, dict) else raw.get("side") if isinstance(raw, dict) else None
     text = str(side or "").strip().lower()
-    if text in {"yes", "y"}:
-        return "Yes"
-    if text in {"no", "n"}:
-        return "No"
-    return None
+    return "Yes" if text in {"yes", "y"} else "No" if text in {"no", "n"} else None
 
 
 def _label_binary(events: List[Dict[str, Any]]) -> None:
@@ -96,13 +130,12 @@ def _label_binary(events: List[Dict[str, Any]]) -> None:
         for market in event.get("markets") or []:
             for selection in market.get("selections") or []:
                 label = _side_label(selection)
-                if not label:
-                    continue
-                if enrichment.placeholder_selection_text(selection.get("name")):
+                if label and enrichment.placeholder_selection_text(selection.get("name")):
                     selection["name"] = label
-                if enrichment.placeholder_selection_text(selection.get("description")):
+                if label and enrichment.placeholder_selection_text(selection.get("description")):
                     selection["description"] = label
-                selection["side"] = label.lower()
+                if label:
+                    selection["side"] = label.lower()
 
 
 def _refresh(payload: Dict[str, Any], game_pk: Optional[Any], raw: bool) -> Dict[str, Any]:
@@ -110,9 +143,7 @@ def _refresh(payload: Dict[str, Any], game_pk: Optional[Any], raw: bool) -> Dict
     payload["events"] = service._finalize_events(payload.get("events") or [])
     payload["markets"] = base._flatten_markets(payload["events"], game_pk=game_pk)
     diagnostics = service._incomplete_count(payload["events"])
-    payload["diagnostics"] = diagnostics
-    payload["event_count"] = len(payload["events"])
-    payload["market_count"] = len(payload["markets"])
+    payload.update({"diagnostics": diagnostics, "event_count": len(payload["events"]), "market_count": len(payload["markets"])})
     if payload["markets"] and not any(diagnostics.values()):
         payload["status"] = "ok"
     if not raw:
@@ -122,7 +153,7 @@ def _refresh(payload: Dict[str, Any], game_pk: Optional[Any], raw: bool) -> Dict
 
 def fetch_board(date: Optional[str] = None, raw: bool = False, live_only: Optional[bool] = None, game_pk: Optional[Any] = None, props_only: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
     payload = service.fetch_board(date=date, raw=True, live_only=live_only, game_pk=game_pk, props_only=props_only, market_types=market_types)
-    payload.setdefault("fixtures", {})["market_fixture_ids"] = _market_fixture_ids(payload)[:20]
+    payload.setdefault("fixtures", {})["market_fixture_ids"] = _fixture_ids(payload)[:20]
     fixtures = payload.get("fixtures") if isinstance(payload.get("fixtures"), dict) else {}
     if not fixtures.get("count"):
         params = payload.get("request_params") if isinstance(payload.get("request_params"), dict) else {}
@@ -132,9 +163,8 @@ def fetch_board(date: Optional[str] = None, raw: bool = False, live_only: Option
             live = bool(live_only or scope == "live")
             fixture_events = _fixture_events(items, live)
             payload["events"] = enrichment.enrich_market_events_with_fixture_metadata(payload.get("events") or [], items, fixture_events)
-            payload["fixtures"]["count"] = len(items)
-            payload["fixtures"]["fixture_ids"] = [str(enrichment.deep_extract_first(item, _ID_KEYS)) for item in items[:20]]
-            payload["normalization_notes"].append(f"fixtures_market_id_retry_selected:{len(items)}:{len(fixture_events)}")
+            payload["fixtures"].update({"count": len(items), "fixture_ids": [str(enrichment.deep_extract_first(item, _ID_KEYS)) for item in items[:20]]})
+            payload["normalization_notes"].append(f"fixtures_id_list_retry_selected:{len(items)}:{len(fixture_events)}")
     return _refresh(payload, game_pk, raw)
 
 


### PR DESCRIPTION
## Summary

Follow-up to #757. The production debug output proved scalar fixture retries were wrong:

```text
fixtures_market_id_retry:fixture_id:info/fixtures:0
fixtures_market_id_retry:event_id:info/fixtures:0
fixtures_market_id_retry:id:info/fixtures:0
```

The KIBL docs/context says summary endpoints use offset/limit and detail requires an ID list. This PR updates the small routed wrapper to use ID-list/detail-style fixture retries instead of scalar key guessing.

## Changed file

- `mlb_app/sportsbook_bet105_runtime_v10.py`

## What changed

When `fixtures.count` is zero but market rows contain fixture/detail IDs, the wrapper now builds documented-style detail bodies:

- `ids: [638170]`
- `fixture_ids: [638170]`
- `event_ids: [638170]`
- single-item list variants
- compact versions with date-window keys removed
- detail list bodies for raw row IDs:
  - `fixture_participant_id`
  - `participant_id`
  - `market_id`
  - `contestant_id`
  - `line_id`

It also adds more debug evidence:

- `fixtures.fixture_retry_labels`
- `fixtures.market_detail_ids`
- `fixtures.market_fixture_ids`
- `normalization_notes` entries prefixed with `fixtures_id_list_retry:`

## Why this is correct

The live KIBL market payload had:

```json
{
  "fixture_id": 638170,
  "fixture_participant_id": 947741,
  "participant_id": 2628,
  "market_id": 2483711255,
  "info": {
    "side": "yes",
    "line_id": "3481684",
    "contestant_id": "3481684"
  }
}
```

The old scalar fixture retries proved the ID was discovered, but the request shape was wrong. This change follows the documented detail-ID-list pattern.

## Required production verification

After merge/deploy:

```bash
curl -s "https://mlbgpt.com/odds/bet105/debug?date=2026-06-14&live=false" | jq '{status,event_count,market_count,diagnostics,fixtures,normalization_notes,raw_items_sample}'
```

Expected proof:

- `fixtures.market_fixture_ids` includes `"638170"`
- `fixtures.fixture_retry_labels` includes `ids`, `fixture_ids`, or `event_ids`
- `fixtures.market_detail_ids` includes the raw row detail IDs
- `normalization_notes` includes `fixtures_id_list_retry:...`
- If KIBL returns fixture detail for an ID-list body, teams/start_time populate
- If KIBL still returns zero fixture rows, the output proves the documented ID-list bodies tried and confirms fixture metadata is not available from `info/fixtures` for that market row

No fake teams or fake start times are introduced.