### PR TITLE
Probe alternate KIBL fixture metadata paths for Bet105

### DIFF
--- a/mlb_app/sportsbook_bet105_fixture_discovery.py
+++ b/mlb_app/sportsbook_bet105_fixture_discovery.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Tuple
+
+from . import kibl_bet105_provider as base
+from . import kibl_bet105_sportsbook_enrichment as enrichment
+from . import sportsbook_bet105_service as service
+
+ID_KEYS = ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id")
+DETAIL_KEYS = ("fixture_participant_id", "participant_id", "market_id", "contestant_id", "line_id")
+DROP_KEYS = {"path", "from_cache", "combined_market_candidates"}
+DATE_KEYS = {"start_date", "end_date", "from", "to"}
+PATHS = (
+    "info/fixtures",
+    "fixtures",
+    "events",
+    "info/events",
+    "info/games",
+    "info/matches",
+    "info/participants",
+    "info/fixture_participants",
+    "info/fixture-participants",
+    "info/contestants",
+    "info/competitors",
+    "info/teams",
+)
+
+
+def _add(out: List[str], value: Any) -> None:
+    if value not in (None, "") and str(value) not in out:
+        out.append(str(value))
+
+
+def _rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    rows.extend([row for row in payload.get("raw_items_sample") or [] if isinstance(row, dict)])
+    for event in payload.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        raw = event.get("raw")
+        if isinstance(raw, dict):
+            rows.append(raw)
+            if isinstance(raw.get("rows"), list):
+                rows.extend([row for row in raw["rows"] if isinstance(row, dict)])
+        for market in event.get("markets") or []:
+            rows.extend(service._raw_market_rows(market))
+            for selection in market.get("selections") or []:
+                raw_selection = selection.get("raw") if isinstance(selection, dict) else None
+                if isinstance(raw_selection, dict):
+                    rows.append(raw_selection)
+    return rows
+
+
+def fixture_ids(payload: Dict[str, Any]) -> List[str]:
+    ids: List[str] = []
+    for row in _rows(payload):
+        _add(ids, enrichment.deep_extract_first(row, ID_KEYS))
+    return ids
+
+
+def detail_ids(payload: Dict[str, Any]) -> Dict[str, List[str]]:
+    found = {key: [] for key in DETAIL_KEYS}
+    for row in _rows(payload):
+        info = row.get("info") if isinstance(row.get("info"), dict) else {}
+        for key in DETAIL_KEYS:
+            _add(found[key], row.get(key))
+            _add(found[key], info.get(key))
+    return found
+
+
+def _clean(params: Dict[str, Any], compact: bool = False) -> Dict[str, Any]:
+    banned = DROP_KEYS | (DATE_KEYS if compact else set())
+    return {key: value for key, value in params.items() if key not in banned and value not in (None, "")}
+
+
+def _bodies(payload: Dict[str, Any], params: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
+    fixture_values = fixture_ids(payload)[:50]
+    details = detail_ids(payload)
+    bodies: List[Tuple[str, Dict[str, Any]]] = []
+    for root in (_clean(params), _clean(params, compact=True)):
+        for paging in ({}, {"offset": 0, "limit": 1000}, {"offset": 0, "limit": 5000}):
+            base_body = {**root, **paging}
+            if fixture_values:
+                for key in ("ids", "fixture_ids", "event_ids"):
+                    bodies.append((key, {**base_body, key: fixture_values}))
+                for value in fixture_values[:20]:
+                    bodies.append(("ids_single", {**base_body, "ids": [value]}))
+                    bodies.append(("fixture_ids_single", {**base_body, "fixture_ids": [value]}))
+            for key, values in details.items():
+                if values:
+                    bodies.append((f"{key}_list", {**base_body, key: values[:50]}))
+    seen: set[str] = set()
+    deduped: List[Tuple[str, Dict[str, Any]]] = []
+    for label, body in bodies:
+        fingerprint = repr(sorted((key, str(value)) for key, value in body.items()))
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append((label, body))
+    return deduped
+
+
+def _post_path(path: str, body: Dict[str, Any]) -> Any:
+    base_url = os.getenv("KIBL_BASE_URL", base._DEFAULT_BASE_URL).rstrip("/")
+    timeout = int(os.getenv("KIBL_TIMEOUT_SECONDS", str(base._DEFAULT_TIMEOUT_SECONDS)))
+    return base._post_kibl_json(f"{base_url}/{path.strip('/')}/", body, timeout)
+
+
+def discover_fixture_items(payload: Dict[str, Any], params: Dict[str, Any]) -> List[Dict[str, Any]]:
+    fixtures = payload.setdefault("fixtures", {})
+    notes = payload.setdefault("normalization_notes", [])
+    probes: List[Dict[str, Any]] = []
+    items: List[Dict[str, Any]] = []
+    for path in PATHS:
+        for label, body in _bodies(payload, params)[:80]:
+            try:
+                raw = _post_path(path, body)
+                count = len(base._find_list_payload(raw))
+                found = service._fixture_items_from_payload(raw)
+                probes.append({"path": path, "label": label, "count": count, "fixture_count": len(found)})
+                notes.append(f"fixtures_path_probe:{path}:{label}:{count}:{len(found)}")
+                if found:
+                    items.extend(found)
+                    fixtures["fixture_discovery_path"] = path
+                    fixtures["fixture_discovery_label"] = label
+                    return service._dedupe_items(items)
+            except Exception as exc:
+                probes.append({"path": path, "label": label, "error": str(exc)[:180]})
+                notes.append(f"fixtures_path_probe_error:{path}:{label}:{str(exc)[:120]}")
+    fixtures["path_probe_sample"] = probes[:40]
+    fixtures["market_detail_ids"] = detail_ids(payload)
+    fixtures["market_fixture_ids"] = fixture_ids(payload)[:20]
+    return service._dedupe_items(items)

--- a/mlb_app/sportsbook_bet105_runtime_v10.py
+++ b/mlb_app/sportsbook_bet105_runtime_v10.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from . import kibl_bet105_provider as base
 from . import kibl_bet105_sportsbook_enrichment as enrichment
+from . import sportsbook_bet105_fixture_discovery as discovery
 from . import sportsbook_bet105_service as service
 
 _ID_KEYS = ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id")
@@ -114,6 +115,9 @@ def _retry_fixture_items(payload: Dict[str, Any], params: Dict[str, Any], scope:
             notes.append(f"fixtures_id_list_retry_error:{label}:{exc}")
     payload.setdefault("fixtures", {})["fixture_retry_labels"] = labels[:40]
     payload["fixtures"]["market_detail_ids"] = _detail_ids(payload)
+    if not items:
+        notes.append("fixtures_id_list_retry_empty:starting_path_discovery")
+        items = discovery.discover_fixture_items(payload, params)
     return service._dedupe_items(items)
 
 


### PR DESCRIPTION
## Summary

Production after #758 proves the Bet105 wrapper now discovers the market fixture ID and detail IDs, but every request through the fixture kind returns zero rows:

```text
fixtures_id_list_retry:ids:info/fixtures:0
fixtures_id_list_retry:fixture_ids:info/fixtures:0
fixtures_id_list_retry:event_ids:info/fixtures:0
fixtures_id_list_retry:fixture_participant_id_list:info/fixtures:0
...
```

So the remaining problem is no longer frontend, not the Yes/No label, and not scalar vs ID-list bodies. The provider is still using the wrong KIBL metadata source/path for this market row.

## Changes

### Added `mlb_app/sportsbook_bet105_fixture_discovery.py`

A targeted metadata discovery helper that runs only after the routed v10 wrapper fails to get fixture rows from the normal fixture retries.

It probes alternate KIBL metadata paths directly with the same ID-list/detail bodies:

- `info/fixtures`
- `fixtures`
- `events`
- `info/events`
- `info/games`
- `info/matches`
- `info/participants`
- `info/fixture_participants`
- `info/fixture-participants`
- `info/contestants`
- `info/competitors`
- `info/teams`

It tries both normal and compact bodies, including paged variants with `offset`/`limit`, because the KIBL documentation/context says summary endpoints use offset/limit and details require ID lists.

### Updated `mlb_app/sportsbook_bet105_runtime_v10.py`

After existing `info/fixtures` retries return empty, it now calls `discovery.discover_fixture_items(...)`.

## Debug added

If no fixture metadata is found, debug will now include:

- `normalization_notes` entries like `fixtures_path_probe:<path>:<label>:<row_count>:<fixture_count>`
- `fixtures.path_probe_sample`
- `fixtures.market_fixture_ids`
- `fixtures.market_detail_ids`

If a path returns fixture-like rows, the wrapper enriches events with team/start metadata and records:

- `fixtures.fixture_discovery_path`
- `fixtures.fixture_discovery_label`
- `fixtures_id_list_retry_selected:...`

## Required verification

After merge/deploy, run:

```bash
curl -s "https://mlbgpt.com/odds/bet105/debug?date=2026-06-14&live=false" | jq '{status,event_count,market_count,diagnostics,fixtures,normalization_notes,raw_items_sample}'
```

Expected outcome:

1. Best case: one of the probed paths returns fixture/team/start metadata and the board populates real teams/start time.
2. If not, the debug output shows exactly which KIBL metadata paths returned rows or zero rows, so the next fix can target the actual table/path instead of guessing.

No fake teams or fake start times are introduced.