### PR TITLE
Rebuild Bet105 integration pipeline

### DIFF
--- a/mlb_app/bet105_normalizer.py
+++ b/mlb_app/bet105_normalizer.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as legacy
+from . import kibl_bet105_sportsbook_enrichment as enrichment
+from .kibl_bet105_types import Bet105RawBoard
+
+
+def _value(row: Dict[str, Any], keys: tuple[str, ...]) -> Any:
+    return enrichment.deep_extract_first(row, keys)
+
+
+def _text(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _id(value: Any) -> Optional[str]:
+    text = _text(value)
+    return text.strip() if text else None
+
+
+def _name(row: Dict[str, Any]) -> Optional[str]:
+    value = _value(row, ("name", "display_name", "displayName", "team_name", "teamName", "fullName", "title"))
+    if isinstance(value, dict):
+        value = _value(value, ("name", "display_name", "displayName", "team_name", "teamName", "fullName", "title"))
+    return _text(value)
+
+
+def _binary_side(row: Dict[str, Any]) -> Optional[str]:
+    info = row.get("info") if isinstance(row.get("info"), dict) else {}
+    value = info.get("side") or row.get("side")
+    text = str(value or "").strip().lower()
+    if text in {"yes", "y"}:
+        return "Yes"
+    if text in {"no", "n"}:
+        return "No"
+    return None
+
+
+def _price(row: Dict[str, Any]) -> Optional[int]:
+    parsed = legacy._safe_int(_value(row, ("price_american", "american", "price", "line_price")))
+    if parsed is not None:
+        return parsed
+    return legacy._american_from_decimal(legacy._safe_float(_value(row, ("price_decimal", "decimal", "decimal_odds"))))
+
+
+def _fixture_meta(row: Dict[str, Any], index: int = 0) -> Dict[str, Any]:
+    return enrichment.fixture_metadata_from_item(row, index)
+
+
+def _fixture_indexes(board: Bet105RawBoard) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Dict[str, Any]]]:
+    by_fixture: Dict[str, Dict[str, Any]] = {}
+    by_event: Dict[str, Dict[str, Any]] = {}
+    for idx, row in enumerate(board.fixture_rows):
+        meta = _fixture_meta(row, idx)
+        if meta.get("fixture_id"):
+            by_fixture[str(meta["fixture_id"])] = meta
+        if meta.get("event_id"):
+            by_event[str(meta["event_id"])] = meta
+    return by_fixture, by_event
+
+
+def _participant_index(board: Bet105RawBoard) -> Dict[str, Dict[str, Any]]:
+    index: Dict[str, Dict[str, Any]] = {}
+    for row in board.participant_rows:
+        for key in ("fixture_participant_id", "participant_id", "contestant_id", "line_id", "id"):
+            value = _id(_value(row, (key,)))
+            if value:
+                index[value] = row
+    return index
+
+
+def _selection(row: Dict[str, Any], participant_rows: Dict[str, Dict[str, Any]], event: Dict[str, Any], index: int) -> Dict[str, Any]:
+    label = _binary_side(row)
+    participant = None
+    info = row.get("info") if isinstance(row.get("info"), dict) else {}
+    for key in ("fixture_participant_id", "participant_id"):
+        participant = participant_rows.get(_id(row.get(key)) or "")
+        if participant:
+            break
+    if participant is None:
+        for key in ("contestant_id", "line_id"):
+            participant = participant_rows.get(_id(info.get(key)) or "")
+            if participant:
+                break
+    if not label and participant:
+        label = _name(participant)
+    if not label:
+        side_id = legacy._safe_int(row.get("participant_side_id") or row.get("side_id"))
+        if side_id == 1:
+            label = enrichment.event_team_name(event, "away")
+        elif side_id == 2:
+            label = enrichment.event_team_name(event, "home")
+        elif side_id == 3:
+            label = "Over"
+        elif side_id == 4:
+            label = "Under"
+    label = label or "Selection metadata missing"
+    price = _price(row)
+    return {
+        "selection_id": _id(row.get("fixture_participant_id") or row.get("participant_id") or row.get("market_id")) or f"selection_{index}",
+        "name": label,
+        "description": label,
+        "team": label,
+        "side": str(label).lower(),
+        "line": legacy._safe_float(row.get("point")),
+        "price": price,
+        "odds": {
+            "american": price,
+            "decimal": legacy._safe_float(row.get("price_decimal")) or legacy._decimal_from_american(price),
+            "fractional": row.get("price_fraction"),
+            "implied_probability": legacy._implied_from_american(price),
+        },
+        "is_open": bool(row.get("is_current", True)),
+        "raw": row,
+    }
+
+
+def _market_name(row: Dict[str, Any]) -> tuple[str, str]:
+    market_type_id = _id(row.get("market_type_id"))
+    if market_type_id == "1":
+        return "h2h", "Moneyline"
+    if market_type_id == "2":
+        return "spreads", "Run Line"
+    if market_type_id == "3":
+        return "totals", "Total Runs"
+    if market_type_id == "0":
+        return "binary_yes_no", "Binary Yes/No Market"
+    return f"market_{market_type_id or 'unknown'}", f"Unknown Market Type {market_type_id or 'unknown'}"
+
+
+def normalize_board(board: Bet105RawBoard, live_only: Optional[bool] = None, game_pk: Optional[Any] = None, raw: bool = False) -> Dict[str, Any]:
+    by_fixture, by_event = _fixture_indexes(board)
+    participants = _participant_index(board)
+    groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for row in board.market_rows:
+        fixture_id = _id(row.get("fixture_id")) or _id(row.get("event_id")) or "unknown_fixture"
+        groups[fixture_id].append(row)
+
+    events: List[Dict[str, Any]] = []
+    for idx, (fixture_id, rows) in enumerate(groups.items()):
+        meta = by_fixture.get(fixture_id) or by_event.get(fixture_id) or {}
+        away = meta.get("away_team")
+        home = meta.get("home_team")
+        away_name = away.get("name") if isinstance(away, dict) else None
+        home_name = home.get("name") if isinstance(home, dict) else None
+        event_name = f"{away_name} @ {home_name}" if away_name and home_name else fixture_id
+        event = {
+            "event_id": fixture_id,
+            "fixture_id": fixture_id,
+            "name": event_name,
+            "sport": meta.get("sport") or "Baseball",
+            "league": meta.get("league") or "MLB",
+            "league_id": meta.get("league_id") or "mlb",
+            "home_team": home,
+            "away_team": away,
+            "start_time": meta.get("start_time"),
+            "commence_time": meta.get("start_time"),
+            "status": meta.get("status") or ("live" if live_only else "scheduled"),
+            "is_live": bool(live_only),
+            "source_url": None,
+            "scraped_at": legacy._now(),
+            "markets": [],
+            "raw": {"rows": rows, "fixture_meta": meta},
+        }
+        market_groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            market_key, market_name = _market_name(row)
+            market_groups[market_key].append(row)
+        for market_key, market_rows in market_groups.items():
+            _, market_name = _market_name(market_rows[0])
+            selections = [_selection(row, participants, event, sel_idx) for sel_idx, row in enumerate(market_rows)]
+            event["markets"].append({
+                "market_key": market_key,
+                "market_type": market_key,
+                "market_name": market_name,
+                "selections": selections,
+                "selection_count": len(selections),
+                "raw": {"rows": market_rows},
+            })
+        event["market_count"] = len(event["markets"])
+        events.append(event)
+
+    events = sorted(events, key=lambda row: (row.get("start_time") or "", row.get("event_id") or ""))
+    markets = legacy._flatten_markets(events, game_pk=game_pk)
+    diagnostics = {
+        "placeholder_event_names": sum(1 for event in events if str(event.get("name") or "") in {"", "Away @ Home", "Home @ Away"}),
+        "placeholder_market_names": 0,
+        "placeholder_selection_names": sum(1 for event in events for market in event.get("markets") or [] for selection in market.get("selections") or [] if "metadata missing" in str(selection.get("name") or "").lower()),
+        "missing_start_times": sum(1 for event in events if not event.get("start_time")),
+    }
+    status = "ok" if markets and not any(diagnostics.values()) else "incomplete_normalization" if markets else "empty"
+    payload = {
+        "provider": "kibl_bet105",
+        "book": "bet105",
+        "status": status,
+        "scope": "live" if live_only else "events",
+        "events": events,
+        "markets": markets,
+        "books": ["Bet105"],
+        "last_updated": legacy._now(),
+        "raw_count": len(board.market_rows),
+        "event_count": len(events),
+        "market_count": len(markets),
+        "diagnostics": diagnostics,
+        "fixtures": {
+            "count": len(board.fixture_rows),
+            "fixture_ids": board.ids.get("fixture_id") or [],
+            "market_detail_ids": board.ids,
+            "fixture_row_count": len(board.fixture_rows),
+            "participant_row_count": len(board.participant_rows),
+        },
+        "request_params": board.filters,
+        "normalization_notes": board.notes,
+        "raw_items_sample": board.market_rows[:5],
+        "cache_hit": False,
+    }
+    if not raw:
+        payload["events"] = legacy._without_raw_events(payload["events"])
+    return payload

--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as legacy
+from .kibl_bet105_types import Bet105RawBoard
+from .kibl_client import KiblClient, find_rows
+
+
+class KiblBet105Repository:
+    market_summary_path = "info/markets"
+    fixture_paths = ("info/fixtures", "fixtures", "events", "info/events", "info/games", "info/matches")
+    metadata_paths = ("info/fixture_participants", "info/participants", "info/contestants", "info/competitors", "info/teams")
+
+    def __init__(self, client: Optional[KiblClient] = None) -> None:
+        self.client = client or KiblClient()
+
+    def build_filters(self, date: Optional[str] = None, live_only: Optional[bool] = None, event_id: Optional[str] = None) -> Dict[str, Any]:
+        filters = legacy.build_kibl_bet105_request_params(
+            "live" if live_only else "events",
+            date=date,
+            live_only=live_only,
+            event_id=event_id,
+            include_markets=False,
+        )
+        filters.pop("from_cache", None)
+        return filters
+
+    def fetch_market_summary(self, filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        limit = int(os.getenv("KIBL_SUMMARY_LIMIT", "1000"))
+        max_pages = int(os.getenv("KIBL_SUMMARY_MAX_PAGES", "5"))
+        for page in range(max_pages):
+            offset = page * limit
+            payload = self.client.post_summary(self.market_summary_path, filters, offset=offset, limit=limit)
+            page_rows = find_rows(payload)
+            notes.append(f"market_summary:{self.market_summary_path}:offset={offset}:limit={limit}:rows={len(page_rows)}")
+            rows.extend(page_rows)
+            if len(page_rows) < limit:
+                break
+        return rows
+
+    @staticmethod
+    def _add(ids: Dict[str, List[str]], key: str, value: Any) -> None:
+        if value in (None, ""):
+            return
+        text = str(value)
+        if text not in ids.setdefault(key, []):
+            ids[key].append(text)
+
+    def extract_ids(self, market_rows: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+        ids: Dict[str, List[str]] = {key: [] for key in ("fixture_id", "market_id", "participant_id", "fixture_participant_id", "contestant_id", "line_id")}
+        for row in market_rows:
+            info = row.get("info") if isinstance(row.get("info"), dict) else {}
+            for key in ("fixture_id", "market_id", "participant_id", "fixture_participant_id"):
+                self._add(ids, key, row.get(key))
+            self._add(ids, "contestant_id", info.get("contestant_id"))
+            self._add(ids, "line_id", info.get("line_id"))
+        return ids
+
+    def _clean(self, filters: Dict[str, Any], compact: bool = False) -> Dict[str, Any]:
+        drop = {"from_cache", "path", "combined_market_candidates"}
+        if compact:
+            drop.update({"start_date", "end_date", "from", "to"})
+        return {key: value for key, value in filters.items() if key not in drop and value not in (None, "")}
+
+    def _detail_bodies(self, filters: Dict[str, Any], ids: Dict[str, List[str]], source_keys: List[str]) -> List[tuple[str, Dict[str, Any]]]:
+        bodies: List[tuple[str, Dict[str, Any]]] = []
+        for root in (self._clean(filters), self._clean(filters, compact=True)):
+            for source_key in source_keys:
+                values = ids.get(source_key) or []
+                if not values:
+                    continue
+                for body_key in (source_key, f"{source_key}s", "ids"):
+                    bodies.append((f"{source_key}->{body_key}", {**root, body_key: values[:500]}))
+        seen: set[str] = set()
+        out: List[tuple[str, Dict[str, Any]]] = []
+        for label, body in bodies:
+            fingerprint = repr(sorted((key, str(value)) for key, value in body.items()))
+            if fingerprint not in seen:
+                seen.add(fingerprint)
+                out.append((label, body))
+        return out
+
+    def fetch_details(self, paths: tuple[str, ...], filters: Dict[str, Any], ids: Dict[str, List[str]], keys: List[str], notes: List[str], label: str) -> List[Dict[str, Any]]:
+        rows: List[Dict[str, Any]] = []
+        for path in paths:
+            for body_label, body in self._detail_bodies(filters, ids, keys):
+                try:
+                    payload = self.client.post(path, body)
+                    found = find_rows(payload)
+                    notes.append(f"{label}_detail:{path}:{body_label}:rows={len(found)}")
+                    if found:
+                        rows.extend(found)
+                        return rows
+                except Exception as exc:
+                    notes.append(f"{label}_detail_error:{path}:{body_label}:{str(exc)[:120]}")
+        return rows
+
+    def fetch_board(self, date: Optional[str] = None, live_only: Optional[bool] = None, event_id: Optional[str] = None) -> Bet105RawBoard:
+        filters = self.build_filters(date=date, live_only=live_only, event_id=event_id)
+        board = Bet105RawBoard(filters=filters)
+        board.market_rows = self.fetch_market_summary(filters, board.notes)
+        board.ids = self.extract_ids(board.market_rows)
+        board.fixture_rows = self.fetch_details(self.fixture_paths, filters, board.ids, ["fixture_id"], board.notes, "fixture")
+        board.participant_rows = self.fetch_details(
+            self.metadata_paths,
+            filters,
+            board.ids,
+            ["fixture_participant_id", "participant_id", "contestant_id", "line_id"],
+            board.notes,
+            "metadata",
+        )
+        return board

--- a/mlb_app/kibl_bet105_types.py
+++ b/mlb_app/kibl_bet105_types.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Bet105RawBoard:
+    filters: Dict[str, Any]
+    market_rows: List[Dict[str, Any]] = field(default_factory=list)
+    fixture_rows: List[Dict[str, Any]] = field(default_factory=list)
+    participant_rows: List[Dict[str, Any]] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    ids: Dict[str, List[str]] = field(default_factory=dict)

--- a/mlb_app/kibl_client.py
+++ b/mlb_app/kibl_client.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import kibl_bet105_provider as legacy
+
+
+class KiblClient:
+    """Small KIBL HTTP client: auth lives in the legacy provider, request shape lives here."""
+
+    def __init__(self, base_url: Optional[str] = None, timeout_seconds: Optional[int] = None) -> None:
+        self.base_url = (base_url or os.getenv("KIBL_BASE_URL", legacy._DEFAULT_BASE_URL)).rstrip("/")
+        self.timeout_seconds = int(timeout_seconds or os.getenv("KIBL_TIMEOUT_SECONDS", str(legacy._DEFAULT_TIMEOUT_SECONDS)))
+
+    def configured(self) -> bool:
+        return legacy._configured()
+
+    def post(self, path: str, body: Dict[str, Any]) -> Any:
+        url = f"{self.base_url}/{path.strip('/')}/"
+        return legacy._post_kibl_json(url, body, self.timeout_seconds)
+
+    def post_summary(self, path: str, filters: Dict[str, Any], offset: int = 0, limit: int = 1000) -> Any:
+        body = {**filters, "offset": int(offset), "limit": int(limit)}
+        return self.post(path, body)
+
+    def post_detail(self, path: str, ids: List[Any], filters: Optional[Dict[str, Any]] = None, id_key: str = "ids") -> Any:
+        body = {**(filters or {}), id_key: [str(value) for value in ids if value not in (None, "")]}
+        return self.post(path, body)
+
+    def first_non_empty(self, requests: List[Tuple[str, Dict[str, Any]]]) -> Tuple[Any, str, int]:
+        first_payload: Any = None
+        first_path = ""
+        for path, body in requests:
+            payload = self.post(path, body)
+            count = len(legacy._find_list_payload(payload))
+            if first_payload is None:
+                first_payload = payload
+                first_path = path
+            if count:
+                return payload, path, count
+        return first_payload if first_payload is not None else {}, first_path, 0
+
+
+def find_rows(payload: Any) -> List[Dict[str, Any]]:
+    return legacy._find_list_payload(payload)

--- a/mlb_app/sportsbook_bet105_runtime_v10.py
+++ b/mlb_app/sportsbook_bet105_runtime_v10.py
@@ -6,6 +6,7 @@ from . import kibl_bet105_provider as base
 from . import kibl_bet105_sportsbook_enrichment as enrichment
 from . import sportsbook_bet105_fixture_discovery as discovery
 from . import sportsbook_bet105_service as service
+from . import sportsbook_bet105_service_v11 as v11
 
 _ID_KEYS = ("fixture_id", "fixtureId", "fixtureID", "event_id", "eventId", "id")
 _DROP = {"path", "from_cache", "combined_market_candidates"}
@@ -156,24 +157,8 @@ def _refresh(payload: Dict[str, Any], game_pk: Optional[Any], raw: bool) -> Dict
 
 
 def fetch_board(date: Optional[str] = None, raw: bool = False, live_only: Optional[bool] = None, game_pk: Optional[Any] = None, props_only: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
-    payload = service.fetch_board(date=date, raw=True, live_only=live_only, game_pk=game_pk, props_only=props_only, market_types=market_types)
-    payload.setdefault("fixtures", {})["market_fixture_ids"] = _fixture_ids(payload)[:20]
-    fixtures = payload.get("fixtures") if isinstance(payload.get("fixtures"), dict) else {}
-    if not fixtures.get("count"):
-        params = payload.get("request_params") if isinstance(payload.get("request_params"), dict) else {}
-        scope = str(payload.get("scope") or ("live" if live_only else "events"))
-        items = _retry_fixture_items(payload, params, scope)
-        if items:
-            live = bool(live_only or scope == "live")
-            fixture_events = _fixture_events(items, live)
-            payload["events"] = enrichment.enrich_market_events_with_fixture_metadata(payload.get("events") or [], items, fixture_events)
-            payload["fixtures"].update({"count": len(items), "fixture_ids": [str(enrichment.deep_extract_first(item, _ID_KEYS)) for item in items[:20]]})
-            payload["normalization_notes"].append(f"fixtures_id_list_retry_selected:{len(items)}:{len(fixture_events)}")
-    return _refresh(payload, game_pk, raw)
+    return v11.fetch_board(date=date, raw=raw, live_only=live_only, game_pk=game_pk, props_only=props_only, market_types=market_types)
 
 
 def fetch_event_board(event_id: str, props_only: bool = False, raw: bool = False, market_types: Optional[List[str]] = None) -> Dict[str, Any]:
-    payload = fetch_board(game_pk=event_id, props_only=props_only, raw=raw, market_types=market_types)
-    events = payload.get("events") or []
-    payload["event"] = events[0] if events else None
-    return payload
+    return v11.fetch_event_board(event_id=event_id, props_only=props_only, raw=raw, market_types=market_types)

--- a/mlb_app/sportsbook_bet105_service_v11.py
+++ b/mlb_app/sportsbook_bet105_service_v11.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from . import kibl_bet105_provider as legacy
+from .bet105_normalizer import normalize_board
+from .kibl_bet105_repository import KiblBet105Repository
+
+
+def fetch_board(
+    date: Optional[str] = None,
+    raw: bool = False,
+    live_only: Optional[bool] = None,
+    game_pk: Optional[Any] = None,
+    props_only: bool = False,
+    market_types: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    scope = "live" if live_only else "events"
+    if not legacy._configured():
+        return legacy._not_configured(scope, game_pk=game_pk)
+    cache_key = f"bet105-v11:{scope}:{date or 'any'}:{game_pk or 'all'}:{raw}:{live_only}"
+    cached = legacy._cache_get(cache_key)
+    if cached:
+        return cached
+    try:
+        board = KiblBet105Repository().fetch_board(date=date, live_only=live_only, event_id=str(game_pk) if game_pk else None)
+        payload = normalize_board(board, live_only=live_only, game_pk=game_pk, raw=raw)
+        legacy._cache_set(cache_key, payload)
+        return payload
+    except Exception as exc:
+        return legacy._provider_error(scope, game_pk=game_pk, exc=exc, request_params={"date": date, "live_only": live_only})
+
+
+def fetch_event_board(
+    event_id: str,
+    props_only: bool = False,
+    raw: bool = False,
+    market_types: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    payload = fetch_board(game_pk=event_id, props_only=props_only, raw=raw, market_types=market_types)
+    events = payload.get("events") or []
+    payload["event"] = events[0] if events else None
+    return payload


### PR DESCRIPTION
## Summary

Rebuilds Bet105 around the clean integration architecture:

- `kibl_client.py`: POST client, summary calls, detail calls.
- `kibl_bet105_repository.py`: fetch market summary, extract IDs, fetch fixture/metadata detail rows.
- `bet105_normalizer.py`: join raw rows into events, markets, selections without fake teams or start times.
- `sportsbook_bet105_service_v11.py`: thin orchestration only.
- `sportsbook_bet105_runtime_v10.py`: delegates existing route imports to v11.

## Verification

After deploy, check:

```bash
curl -s "https://mlbgpt.com/odds/bet105/debug?date=2026-06-14&live=false" | jq '{status,event_count,market_count,raw_count,diagnostics,fixtures,normalization_notes,raw_items_sample}'
```

Expected debug evidence:

- `normalization_notes` includes `market_summary:info/markets...`
- `fixtures.market_detail_ids.fixture_id` includes `638170`
- fixture/participant row counts show whether the documented detail calls return metadata
- no fake teams or fake start times