### PR TITLE
Align Bet105 repository with source contract

### DIFF
--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from . import kibl_bet105_provider as legacy
 from .kibl_bet105_types import Bet105RawBoard
@@ -9,9 +9,8 @@ from .kibl_client import KiblClient, find_rows
 
 
 class KiblBet105Repository:
+    fixture_summary_path = "info/fixtures"
     market_summary_path = "info/markets"
-    fixture_paths = ("info/fixtures", "fixtures", "events", "info/events", "info/games", "info/matches")
-    metadata_paths = ("info/fixture_participants", "info/participants", "info/contestants", "info/competitors", "info/teams")
 
     def __init__(self, client: Optional[KiblClient] = None) -> None:
         self.client = client or KiblClient()
@@ -41,6 +40,14 @@ class KiblBet105Repository:
             return None
         return str(value).strip()
 
+    @staticmethod
+    def _add(ids: Dict[str, List[str]], key: str, value: Any) -> None:
+        if value in (None, ""):
+            return
+        text = str(value)
+        if text not in ids.setdefault(key, []):
+            ids[key].append(text)
+
     def _row_matches_requested_feed(self, row: Dict[str, Any], filters: Dict[str, Any]) -> bool:
         expected_feed = self._safe_text(filters.get("feed_source_id"))
         expected_betting = self._safe_text(filters.get("betting_type_id"))
@@ -60,46 +67,78 @@ class KiblBet105Repository:
         for key in ("league_id", "leagueId", "competition_id", "competitionId", "sport_id", "sportId"):
             row_values.update(self._csv_values(row.get(key)))
         if not row_values:
-            # Current KIBL market rows may not carry league_id directly. Keep the row,
-            # but diagnostics will show that the filter was request-only.
             return True
         return bool(row_values.intersection(requested))
 
-    def _filter_market_rows(self, rows: List[Dict[str, Any]], filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
-        kept: List[Dict[str, Any]] = []
-        for row in rows:
-            if not self._row_matches_requested_feed(row, filters):
-                continue
-            if not self._row_matches_requested_league(row, filters):
-                continue
-            kept.append(row)
+    def _filter_rows(self, rows: List[Dict[str, Any]], filters: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
+        kept = [row for row in rows if self._row_matches_requested_feed(row, filters) and self._row_matches_requested_league(row, filters)]
         notes.append(
-            f"market_filter:raw={len(rows)}:kept={len(kept)}:feed={filters.get('feed_source_id')}:betting={filters.get('betting_type_id')}:league={filters.get('league_id')}"
+            f"{label}_filter:raw={len(rows)}:kept={len(kept)}:feed={filters.get('feed_source_id')}:betting={filters.get('betting_type_id')}:league={filters.get('league_id')}"
         )
         return kept
 
-    def fetch_market_summary(self, filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
-        rows: List[Dict[str, Any]] = []
+    def _summary_rows(self, path: str, body: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
+        payload = self.client.post(path, body)
+        rows = find_rows(payload)
+        filtered = self._filter_rows(rows, body, notes, label)
+        notes.append(f"{label}_request:{path}:keys={','.join(sorted(body.keys()))}:raw={len(rows)}:kept={len(filtered)}")
+        return filtered
+
+    def fetch_fixture_summary(self, filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
         limit = int(os.getenv("KIBL_SUMMARY_LIMIT", "250"))
-        max_pages = int(os.getenv("KIBL_SUMMARY_MAX_PAGES", "1"))
-        for page in range(max_pages):
-            offset = page * limit
-            payload = self.client.post_summary(self.market_summary_path, filters, offset=offset, limit=limit)
-            page_rows = find_rows(payload)
-            filtered = self._filter_market_rows(page_rows, filters, notes)
-            notes.append(f"market_summary:{self.market_summary_path}:offset={offset}:limit={limit}:raw={len(page_rows)}:kept={len(filtered)}")
-            rows.extend(filtered)
-            if len(page_rows) < limit:
-                break
+        body = {**filters, "offset": 0, "limit": limit}
+        rows = self._summary_rows(self.fixture_summary_path, body, notes, "fixture")
+        notes.append(f"fixture_summary:{self.fixture_summary_path}:offset=0:limit={limit}:rows={len(rows)}")
         return rows
 
-    @staticmethod
-    def _add(ids: Dict[str, List[str]], key: str, value: Any) -> None:
-        if value in (None, ""):
-            return
-        text = str(value)
-        if text not in ids.setdefault(key, []):
-            ids[key].append(text)
+    def fixture_ids_from_fixtures(self, fixture_rows: List[Dict[str, Any]]) -> List[str]:
+        values: List[str] = []
+        for row in fixture_rows:
+            for key in ("fixture_id", "event_id", "id"):
+                for value in self._csv_values(row.get(key)):
+                    if value and value not in values:
+                        values.append(value)
+        return values
+
+    def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:
+        clean = {key: value for key, value in filters.items() if key not in {"from_cache", "path", "combined_market_candidates"} and value not in (None, "")}
+        core = {key: value for key, value in clean.items() if key not in {"start_date", "end_date", "from", "to"}}
+        limit = int(os.getenv("KIBL_SUMMARY_LIMIT", "250"))
+        roots = (("dated", clean), ("core", core))
+        bodies: List[Tuple[str, Dict[str, Any]]] = []
+        for root_label, root in roots:
+            base = {**root, "offset": 0, "limit": limit}
+            bodies.append((f"{root_label}:base", base))
+            if fixture_ids:
+                bodies.append((f"{root_label}:fixture_ids", {**base, "fixture_ids": fixture_ids[:100]}))
+                bodies.append((f"{root_label}:event_ids", {**base, "event_ids": fixture_ids[:100]}))
+                bodies.append((f"{root_label}:ids", {**base, "ids": fixture_ids[:100]}))
+                bodies.append((f"{root_label}:fixture_ids_csv", {**base, "fixture_ids": ",".join(fixture_ids[:100])}))
+                for value in fixture_ids[:20]:
+                    bodies.append((f"{root_label}:fixture_id", {**base, "fixture_id": value}))
+                    bodies.append((f"{root_label}:event_id", {**base, "event_id": value}))
+                    bodies.append((f"{root_label}:id", {**base, "id": value}))
+        seen: set[str] = set()
+        out: List[Tuple[str, Dict[str, Any]]] = []
+        for label, body in bodies:
+            fp = repr(sorted((key, str(value)) for key, value in body.items()))
+            if fp not in seen:
+                seen.add(fp)
+                out.append((label, body))
+        return out
+
+    def fetch_market_summary(self, filters: Dict[str, Any], fixture_ids: List[str], notes: List[str]) -> List[Dict[str, Any]]:
+        best_label = "none"
+        best_rows: List[Dict[str, Any]] = []
+        candidates = self.market_request_bodies(filters, fixture_ids)
+        for label, body in candidates:
+            rows = self._summary_rows(self.market_summary_path, body, notes, f"market_{label}")
+            notes.append(f"market_candidate:{label}:rows={len(rows)}")
+            if len(rows) > len(best_rows):
+                best_label = label
+                best_rows = rows
+        notes.append(f"market_selected:{best_label}:rows={len(best_rows)}:candidates={len(candidates)}")
+        return best_rows
 
     def extract_ids(self, market_rows: List[Dict[str, Any]]) -> Dict[str, List[str]]:
         ids: Dict[str, List[str]] = {key: [] for key in ("fixture_id", "market_id", "participant_id", "fixture_participant_id", "contestant_id", "line_id")}
@@ -111,69 +150,18 @@ class KiblBet105Repository:
             self._add(ids, "line_id", info.get("line_id"))
         return ids
 
-    def _clean(self, filters: Dict[str, Any], compact: bool = False) -> Dict[str, Any]:
-        drop = {"from_cache", "path", "combined_market_candidates"}
-        if compact:
-            drop.update({"start_date", "end_date", "from", "to"})
-        return {key: value for key, value in filters.items() if key not in drop and value not in (None, "")}
-
-    def _detail_bodies(self, filters: Dict[str, Any], ids: Dict[str, List[str]], source_keys: List[str]) -> List[tuple[str, Dict[str, Any]]]:
-        bodies: List[tuple[str, Dict[str, Any]]] = []
-        for root in (self._clean(filters), self._clean(filters, compact=True)):
-            for source_key in source_keys:
-                values = ids.get(source_key) or []
-                if not values:
-                    continue
-                for body_key in (source_key, f"{source_key}s", "ids"):
-                    bodies.append((f"{source_key}->{body_key}", {**root, body_key: values[:100]}))
-        seen: set[str] = set()
-        out: List[tuple[str, Dict[str, Any]]] = []
-        for label, body in bodies:
-            fingerprint = repr(sorted((key, str(value)) for key, value in body.items()))
-            if fingerprint not in seen:
-                seen.add(fingerprint)
-                out.append((label, body))
-        return out
-
-    def fetch_details(self, paths: tuple[str, ...], filters: Dict[str, Any], ids: Dict[str, List[str]], keys: List[str], notes: List[str], label: str) -> List[Dict[str, Any]]:
-        if not any(ids.get(key) for key in keys):
-            notes.append(f"{label}_detail_skipped:no_ids")
-            return []
-        rows: List[Dict[str, Any]] = []
-        max_attempts = int(os.getenv("KIBL_DETAIL_MAX_ATTEMPTS", "12"))
-        attempts = 0
-        for path in paths:
-            for body_label, body in self._detail_bodies(filters, ids, keys):
-                attempts += 1
-                if attempts > max_attempts:
-                    notes.append(f"{label}_detail_stopped:max_attempts={max_attempts}")
-                    return rows
-                try:
-                    payload = self.client.post(path, body)
-                    found = find_rows(payload)
-                    notes.append(f"{label}_detail:{path}:{body_label}:rows={len(found)}")
-                    if found:
-                        rows.extend(found)
-                        return rows
-                except Exception as exc:
-                    notes.append(f"{label}_detail_error:{path}:{body_label}:{str(exc)[:120]}")
-        return rows
-
     def fetch_board(self, date: Optional[str] = None, live_only: Optional[bool] = None, event_id: Optional[str] = None) -> Bet105RawBoard:
         filters = self.build_filters(date=date, live_only=live_only, event_id=event_id)
         board = Bet105RawBoard(filters=filters)
-        board.market_rows = self.fetch_market_summary(filters, board.notes)
+        board.fixture_rows = self.fetch_fixture_summary(filters, board.notes)
+        fixture_ids = self.fixture_ids_from_fixtures(board.fixture_rows)
+        board.notes.append(f"fixture_ids_from_summary:{len(fixture_ids)}")
+        board.market_rows = self.fetch_market_summary(filters, fixture_ids, board.notes)
         board.ids = self.extract_ids(board.market_rows)
         board.notes.append(
             f"market_ids:fixtures={len(board.ids.get('fixture_id') or [])}:participants={len(board.ids.get('participant_id') or [])}:fixture_participants={len(board.ids.get('fixture_participant_id') or [])}:markets={len(board.ids.get('market_id') or [])}"
         )
-        board.fixture_rows = self.fetch_details(self.fixture_paths, filters, board.ids, ["fixture_id"], board.notes, "fixture")
-        board.participant_rows = self.fetch_details(
-            self.metadata_paths,
-            filters,
-            board.ids,
-            ["fixture_participant_id", "participant_id", "contestant_id", "line_id"],
-            board.notes,
-            "metadata",
-        )
+        if not board.fixture_rows and board.ids.get("fixture_id"):
+            board.notes.append("fixture_summary_empty:market_rows_have_fixture_ids")
+        board.participant_rows = []
         return board


### PR DESCRIPTION
## Summary

Implements the Bet105/KIBL source-contract flow from #763 instead of endpoint probing.

What changed:

- uses only documented core paths as the primary flow: `info/fixtures` and `info/markets`
- fetches fixture summary first
- extracts fixture IDs from fixture rows
- fetches market candidates from `info/markets` using dated/core/base and fixture-specific bodies
- selects the candidate with the most real kept market rows
- stops using participant/team metadata endpoint probing as the primary architecture
- leaves missing fixture metadata as diagnostics instead of faking teams or start times

## Verify

After deploy, `/odds/bet105/debug` should show notes like:

- `fixture_request:info/fixtures:...`
- `fixture_summary:info/fixtures:...`
- `market_candidate:...`
- `market_selected:...`
- `market_ids:...`

This PR is intentionally only the repository-layer orchestration fix.