### PR TITLE
Split Bet105 baseball league filters

### DIFF
--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -48,6 +48,19 @@ class KiblBet105Repository:
         if text not in ids.setdefault(key, []):
             ids[key].append(text)
 
+    def _league_variants(self, league_id: Any) -> List[Optional[str]]:
+        values = sorted(self._csv_values(league_id))
+        variants: List[Optional[str]] = []
+        if league_id not in (None, ""):
+            variants.append(str(league_id))
+        variants.extend(values)
+        variants.append(None)
+        out: List[Optional[str]] = []
+        for value in variants:
+            if value not in out:
+                out.append(value)
+        return out
+
     def _row_matches_requested_feed(self, row: Dict[str, Any], filters: Dict[str, Any]) -> bool:
         expected_feed = self._safe_text(filters.get("feed_source_id"))
         expected_betting = self._safe_text(filters.get("betting_type_id"))
@@ -98,9 +111,33 @@ class KiblBet105Repository:
                 break
         return rows
 
+    def fixture_request_bodies(self, filters: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
+        # Fixtures are schedule/match entities, not Bet105 book-price rows. Do not require
+        # feed_source_id=171 or betting_type_id to resolve baseball game metadata.
+        dated = {key: value for key, value in filters.items() if key not in {"feed_source_id", "betting_type_id", "from_cache", "path"} and value not in (None, "")}
+        core = {key: value for key, value in dated.items() if key not in {"start_date", "end_date", "from", "to"}}
+        bodies: List[Tuple[str, Dict[str, Any]]] = []
+        for root_label, root in (("dated", dated), ("core", core)):
+            for league in self._league_variants(root.get("league_id")):
+                body = dict(root)
+                if league is None:
+                    body.pop("league_id", None)
+                    label = f"{root_label}:no_league"
+                else:
+                    body["league_id"] = league
+                    label = f"{root_label}:league_{league}"
+                bodies.append((label, body))
+        return self._dedupe_bodies(bodies)
+
     def fetch_fixture_summary(self, filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
-        rows = self._paged_summary_rows(self.fixture_summary_path, filters, notes, "fixture")
-        notes.append(f"fixture_summary:{self.fixture_summary_path}:rows={len(rows)}")
+        all_rows: List[Dict[str, Any]] = []
+        bodies = self.fixture_request_bodies(filters)
+        for label, body in bodies:
+            rows = self._paged_summary_rows(self.fixture_summary_path, body, notes, f"fixture_{label}")
+            notes.append(f"fixture_candidate:{label}:rows={len(rows)}")
+            all_rows.extend(rows)
+        rows = self._dedupe_fixture_rows(all_rows)
+        notes.append(f"fixture_summary:{self.fixture_summary_path}:raw={len(all_rows)}:deduped={len(rows)}:candidates={len(bodies)}")
         return rows
 
     def fixture_ids_from_fixtures(self, fixture_rows: List[Dict[str, Any]]) -> List[str]:
@@ -121,22 +158,7 @@ class KiblBet105Repository:
                         values.append(value)
         return values
 
-    def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:
-        clean = {key: value for key, value in filters.items() if key not in {"from_cache", "path", "combined_market_candidates"} and value not in (None, "")}
-        core = {key: value for key, value in clean.items() if key not in {"start_date", "end_date", "from", "to"}}
-        roots = (("dated", clean), ("core", core))
-        bodies: List[Tuple[str, Dict[str, Any]]] = []
-        for root_label, root in roots:
-            bodies.append((f"{root_label}:base", root))
-            if fixture_ids:
-                bodies.append((f"{root_label}:fixture_ids", {**root, "fixture_ids": fixture_ids[:100]}))
-                bodies.append((f"{root_label}:event_ids", {**root, "event_ids": fixture_ids[:100]}))
-                bodies.append((f"{root_label}:ids", {**root, "ids": fixture_ids[:100]}))
-                bodies.append((f"{root_label}:fixture_ids_csv", {**root, "fixture_ids": ",".join(fixture_ids[:100])}))
-                for value in fixture_ids[:20]:
-                    bodies.append((f"{root_label}:fixture_id", {**root, "fixture_id": value}))
-                    bodies.append((f"{root_label}:event_id", {**root, "event_id": value}))
-                    bodies.append((f"{root_label}:id", {**root, "id": value}))
+    def _dedupe_bodies(self, bodies: List[Tuple[str, Dict[str, Any]]]) -> List[Tuple[str, Dict[str, Any]]]:
         seen: set[str] = set()
         out: List[Tuple[str, Dict[str, Any]]] = []
         for label, body in bodies:
@@ -146,21 +168,55 @@ class KiblBet105Repository:
                 out.append((label, body))
         return out
 
+    def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:
+        clean = {key: value for key, value in filters.items() if key not in {"from_cache", "path", "combined_market_candidates"} and value not in (None, "")}
+        core = {key: value for key, value in clean.items() if key not in {"start_date", "end_date", "from", "to"}}
+        roots = (("dated", clean), ("core", core))
+        bodies: List[Tuple[str, Dict[str, Any]]] = []
+        for root_label, root in roots:
+            for league in self._league_variants(root.get("league_id")):
+                base_root = dict(root)
+                if league is None:
+                    base_root.pop("league_id", None)
+                    league_label = "no_league"
+                else:
+                    base_root["league_id"] = league
+                    league_label = f"league_{league}"
+                bodies.append((f"{root_label}:{league_label}:base", base_root))
+                if fixture_ids:
+                    bodies.append((f"{root_label}:{league_label}:fixture_ids", {**base_root, "fixture_ids": fixture_ids[:100]}))
+                    bodies.append((f"{root_label}:{league_label}:event_ids", {**base_root, "event_ids": fixture_ids[:100]}))
+                    bodies.append((f"{root_label}:{league_label}:ids", {**base_root, "ids": fixture_ids[:100]}))
+                    bodies.append((f"{root_label}:{league_label}:fixture_ids_csv", {**base_root, "fixture_ids": ",".join(fixture_ids[:100])}))
+                    for value in fixture_ids[:20]:
+                        bodies.append((f"{root_label}:{league_label}:fixture_id", {**base_root, "fixture_id": value}))
+                        bodies.append((f"{root_label}:{league_label}:event_id", {**base_root, "event_id": value}))
+                        bodies.append((f"{root_label}:{league_label}:id", {**base_root, "id": value}))
+        return self._dedupe_bodies(bodies)
+
+    def _fixture_fingerprint(self, row: Dict[str, Any]) -> str:
+        for key in ("fixture_id", "event_id", "id"):
+            value = row.get(key)
+            if value not in (None, ""):
+                return str(value)
+        return repr(sorted((key, str(value)) for key, value in row.items()))
+
+    def _dedupe_fixture_rows(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        seen: set[str] = set()
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            fp = self._fixture_fingerprint(row)
+            if fp not in seen:
+                seen.add(fp)
+                out.append(row)
+        return out
+
     def _market_fingerprint(self, row: Dict[str, Any]) -> str:
         info = row.get("info") if isinstance(row.get("info"), dict) else {}
         parts = [
-            row.get("fixture_id"),
-            row.get("market_id"),
-            row.get("participant_id"),
-            row.get("fixture_participant_id"),
-            row.get("market_type_id"),
-            row.get("segment_id"),
-            row.get("point"),
-            row.get("side_id"),
-            info.get("line_id"),
-            info.get("contestant_id"),
-            row.get("price_american"),
-            row.get("price_decimal"),
+            row.get("fixture_id"), row.get("market_id"), row.get("participant_id"), row.get("fixture_participant_id"),
+            row.get("market_type_id"), row.get("segment_id"), row.get("point"), row.get("side_id"),
+            info.get("line_id"), info.get("contestant_id"), row.get("price_american"), row.get("price_decimal"),
         ]
         return "|".join(str(part) for part in parts)
 


### PR DESCRIPTION
Closed before merge. This changed outer fixture/league strategy and included broad no-league variants. We are not moving away from the working Bet105 info/markets path. Next work should expand from the known-good market row IDs instead.