### PR TITLE
Probe short Bet105 market pages

### DIFF
--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -87,6 +87,7 @@ class KiblBet105Repository:
     def _paged_summary_rows(self, path: str, body: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
         limit = int(os.getenv("KIBL_SUMMARY_LIMIT", "250"))
         max_pages = int(os.getenv("KIBL_SUMMARY_MAX_PAGES", "20"))
+        short_page_probe_offsets = int(os.getenv("KIBL_SHORT_PAGE_PROBE_OFFSETS", "20"))
         rows: List[Dict[str, Any]] = []
         for page in range(max_pages):
             offset = page * limit
@@ -95,6 +96,24 @@ class KiblBet105Repository:
             notes.append(f"{label}_page:{path}:offset={offset}:limit={limit}:rows={len(page_rows)}")
             rows.extend(page_rows)
             if len(page_rows) < limit:
+                # Normal row-offset pagination would be complete here. KIBL production
+                # currently returns exactly one Bet105 baseball row at offset 0. Probe
+                # small offsets 1..N to detect APIs that treat offset as an item/page
+                # cursor or ignore limit, without changing the known-good base filters.
+                if page == 0 and page_rows and short_page_probe_offsets > 0:
+                    empty_streak = 0
+                    for probe_offset in range(1, short_page_probe_offsets + 1):
+                        probe_body = {**body, "offset": probe_offset, "limit": limit}
+                        probe_rows = self._summary_rows(path, probe_body, notes, f"{label}:probe{probe_offset}")
+                        notes.append(f"{label}_probe:{path}:offset={probe_offset}:limit={limit}:rows={len(probe_rows)}")
+                        rows.extend(probe_rows)
+                        if probe_rows:
+                            empty_streak = 0
+                        else:
+                            empty_streak += 1
+                        if empty_streak >= 3:
+                            notes.append(f"{label}_probe_stopped:empty_streak={empty_streak}:last_offset={probe_offset}")
+                            break
                 break
         return rows
 


### PR DESCRIPTION
## Summary

Tests the likely cap/pagination issue without changing the working Bet105 request filters.

Current production proves `info/markets` returns one real Bet105 baseball row at offset 0. The repository treated that short page as complete because one row is less than limit 250.

This PR keeps the known-good request body and adds short-page probing:

- keep existing feed/date/league filters
- keep existing market candidate flow
- when offset 0 returns a non-empty short page, probe offsets 1..20
- stop after 3 empty probe offsets
- log probe notes per offset

If KIBL uses offset as an item/page cursor or ignores the limit field, this should find the other baseball rows using the same working request shape.