### PR TITLE
Render Bet105 board from selected MLB fixtures first

### DIFF
--- a/mlb_app/bet105_normalizer.py
+++ b/mlb_app/bet105_normalizer.py
@@ -157,6 +157,8 @@ def normalize_board(board: Bet105RawBoard, live_only: Optional[bool] = None, gam
     by_fixture, by_event = _fixture_indexes(board)
     participants = _participant_index(board)
     groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for fixture_id in _fixture_summary_ids(board):
+        groups[fixture_id] = []
     for row in board.market_rows:
         fixture_id = _id(row.get("fixture_id")) or _id(row.get("event_id")) or "unknown_fixture"
         groups[fixture_id].append(row)
@@ -168,14 +170,14 @@ def normalize_board(board: Bet105RawBoard, live_only: Optional[bool] = None, gam
         home = meta.get("home_team")
         away_name = away.get("name") if isinstance(away, dict) else None
         home_name = home.get("name") if isinstance(home, dict) else None
-        event_name = f"{away_name} @ {home_name}" if away_name and home_name else fixture_id
+        event_name = meta.get("name") or (f"{away_name} @ {home_name}" if away_name and home_name else fixture_id)
         event = {
             "event_id": fixture_id,
             "fixture_id": fixture_id,
             "name": event_name,
             "sport": meta.get("sport") or "Baseball",
             "league": meta.get("league") or "MLB",
-            "league_id": meta.get("league_id") or "mlb",
+            "league_id": meta.get("league_id") or "7",
             "home_team": home,
             "away_team": away,
             "start_time": meta.get("start_time"),

--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
 
 from . import kibl_bet105_provider as legacy
 from .kibl_bet105_types import Bet105RawBoard
@@ -13,6 +15,8 @@ class KiblBet105Repository:
     market_summary_path = "info/markets"
     mlb_sport_id = "2"
     mlb_league_id = "7"
+    game_fixture_type_id = "1"
+    eastern_tz = ZoneInfo("America/New_York")
     fixture_excluded_filter_keys = {
         "feed_source_id",
         "betting_type_id",
@@ -117,12 +121,11 @@ class KiblBet105Repository:
         return rows
 
     def _date_body(self, filters: Dict[str, Any]) -> Dict[str, Any]:
-        body = {
+        return {
             key: value
             for key, value in filters.items()
             if key not in self.fixture_excluded_filter_keys and value not in (None, "")
         }
-        return body
 
     def _fixture_request_bodies(self, filters: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any]]]:
         body = {
@@ -131,6 +134,53 @@ class KiblBet105Repository:
             "league_id": self.mlb_league_id,
         }
         return [("mlb_sport2_league7", body)]
+
+    def _selected_eastern_date(self, filters: Dict[str, Any]) -> Optional[str]:
+        for key in ("start_date", "from", "date"):
+            value = self._safe_text(filters.get(key))
+            if value:
+                return value[:10]
+        return None
+
+    def _parse_utc_start(self, value: Any) -> Optional[datetime]:
+        text = self._safe_text(value)
+        if not text:
+            return None
+        normalized = text.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            try:
+                parsed = datetime.strptime(text[:19], "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _is_selected_mlb_game_fixture(self, row: Dict[str, Any], selected_date: Optional[str]) -> bool:
+        if self._safe_text(row.get("sport_id")) != self.mlb_sport_id:
+            return False
+        if self._safe_text(row.get("league_id")) != self.mlb_league_id:
+            return False
+        # KIBL routing shows fixture_type_id=1 for real games; 3=props, 4=futures/outrights, 6=other alternates.
+        if self._safe_text(row.get("fixture_type_id")) != self.game_fixture_type_id:
+            return False
+        if selected_date:
+            start = self._parse_utc_start(row.get("start_time") or row.get("start_date") or row.get("date"))
+            if not start:
+                return False
+            if start.astimezone(self.eastern_tz).date().isoformat() != selected_date:
+                return False
+        return True
+
+    def _filter_fixture_rows_to_selected_games(self, rows: List[Dict[str, Any]], filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
+        selected_date = self._selected_eastern_date(filters)
+        kept = [row for row in rows if self._is_selected_mlb_game_fixture(row, selected_date)]
+        notes.append(
+            f"fixture_game_filter:selected_date={selected_date}:raw={len(rows)}:kept={len(kept)}:sport_id=2:league_id=7:fixture_type_id=1"
+        )
+        return kept
 
     def _dedupe_fixture_rows(self, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         seen: set[str] = set()
@@ -157,8 +207,9 @@ class KiblBet105Repository:
                 f"fixture_candidate:{label}:keys={','.join(sorted(body.keys()))}:rows={len(rows)}:book_filters_removed={not any(key in body for key in ('feed_source_id', 'betting_type_id'))}"
             )
             all_rows.extend(rows)
-        deduped = self._dedupe_fixture_rows(all_rows)
-        notes.append(f"fixture_summary:{self.fixture_summary_path}:raw={len(all_rows)}:deduped={len(deduped)}:scope=sport_id=2,league_id=7")
+        game_rows = self._filter_fixture_rows_to_selected_games(all_rows, filters, notes)
+        deduped = self._dedupe_fixture_rows(game_rows)
+        notes.append(f"fixture_summary:{self.fixture_summary_path}:raw={len(all_rows)}:games={len(game_rows)}:deduped={len(deduped)}:scope=sport_id=2,league_id=7")
         return deduped
 
     def fixture_ids_from_fixtures(self, fixture_rows: List[Dict[str, Any]]) -> List[str]:
@@ -186,7 +237,7 @@ class KiblBet105Repository:
         kept = [row for row in rows if str(row.get("fixture_id") or row.get("event_id") or row.get("id") or "") in allowed]
         dropped = len(rows) - len(kept)
         if dropped:
-            notes.append(f"{label}:dropped_non_mlb_market_rows={dropped}:allowed_fixture_ids={len(allowed)}")
+            notes.append(f"{label}:dropped_non_selected_mlb_market_rows={dropped}:allowed_fixture_ids={len(allowed)}")
         return kept
 
     def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:

--- a/tests/test_bet105_normalizer_fixture_first.py
+++ b/tests/test_bet105_normalizer_fixture_first.py
@@ -1,0 +1,48 @@
+from mlb_app.bet105_normalizer import normalize_board
+from mlb_app.kibl_bet105_types import Bet105RawBoard
+
+
+def test_normalizer_renders_fixture_events_when_markets_are_empty():
+    board = Bet105RawBoard(
+        filters={"date": "2026-06-14"},
+        fixture_rows=[
+            {
+                "fixture_id": "fx-mlb-1",
+                "sport_id": 2,
+                "league_id": 7,
+                "fixture_type_id": 1,
+                "name": "New York Yankees vs Toronto Blue Jays",
+                "start_time": "2026-06-14T17:37:00.000Z",
+                "participants": [
+                    {"name": "New York Yankees"},
+                    {"name": "Toronto Blue Jays"},
+                ],
+            },
+            {
+                "fixture_id": "fx-mlb-2",
+                "sport_id": 2,
+                "league_id": 7,
+                "fixture_type_id": 1,
+                "name": "Los Angeles Dodgers vs Chicago White Sox",
+                "start_time": "2026-06-14T18:10:00.000Z",
+                "participants": [
+                    {"name": "Los Angeles Dodgers"},
+                    {"name": "Chicago White Sox"},
+                ],
+            },
+        ],
+        market_rows=[],
+        participant_rows=[],
+        notes=[],
+        ids={},
+    )
+
+    payload = normalize_board(board, live_only=False, raw=True)
+
+    assert payload["status"] == "fixtures_only"
+    assert payload["event_count"] == 2
+    assert payload["market_count"] == 0
+    assert [event["fixture_id"] for event in payload["events"]] == ["fx-mlb-1", "fx-mlb-2"]
+    assert payload["events"][0]["name"] == "New York Yankees @ Toronto Blue Jays"
+    assert payload["events"][1]["name"] == "Los Angeles Dodgers @ Chicago White Sox"
+    assert payload["diagnostics"]["missing_start_times"] == 0

--- a/tests/test_bet105_repository_fixture_discovery.py
+++ b/tests/test_bet105_repository_fixture_discovery.py
@@ -18,6 +18,7 @@ class FakeClient:
                         "fixture_id": "fx-mlb-1",
                         "sport_id": 2,
                         "league_id": 7,
+                        "fixture_type_id": 1,
                         "name": "New York Yankees vs Toronto Blue Jays",
                         "start_time": "2026-06-14T17:37:00.000Z",
                     },
@@ -25,8 +26,41 @@ class FakeClient:
                         "fixture_id": "fx-mlb-2",
                         "sport_id": 2,
                         "league_id": 7,
+                        "fixture_type_id": 1,
                         "name": "Los Angeles Dodgers vs Chicago White Sox",
                         "start_time": "2026-06-14T18:10:00.000Z",
+                    },
+                    {
+                        "fixture_id": "fx-prev-day",
+                        "sport_id": 2,
+                        "league_id": 7,
+                        "fixture_type_id": 1,
+                        "name": "Chicago Cubs vs San Francisco Giants",
+                        "start_time": "2026-06-14T02:05:00.000Z",
+                    },
+                    {
+                        "fixture_id": "fx-prop",
+                        "sport_id": 2,
+                        "league_id": 7,
+                        "fixture_type_id": 3,
+                        "name": "Grayson Rodriguez Props",
+                        "start_time": "2026-06-14T20:07:00.000Z",
+                    },
+                    {
+                        "fixture_id": "fx-future",
+                        "sport_id": 2,
+                        "league_id": 7,
+                        "fixture_type_id": 4,
+                        "name": "2026 World Series Champion",
+                        "start_time": "2026-09-08T22:00:00.000Z",
+                    },
+                    {
+                        "fixture_id": "fx-kbo",
+                        "sport_id": 2,
+                        "league_id": 14,
+                        "fixture_type_id": 1,
+                        "name": "Doosan Bears vs Kia Tigers",
+                        "start_time": "2026-06-14T08:00:00.000Z",
                     },
                 ]
             }
@@ -67,7 +101,8 @@ def test_fixture_discovery_uses_mlb_sport_2_league_7_without_book_filters():
     assert "feed_source_id" not in fixture_calls[0]
     assert "betting_type_id" not in fixture_calls[0]
     assert any("fixture_candidate:mlb_sport2_league7" in note for note in notes)
-    assert any("fixture_summary:info/fixtures:raw=2:deduped=2:scope=sport_id=2,league_id=7" in note for note in notes)
+    assert any("fixture_game_filter:selected_date=2026-06-14:raw=6:kept=2" in note for note in notes)
+    assert any("fixture_summary:info/fixtures:raw=6:games=2:deduped=2:scope=sport_id=2,league_id=7" in note for note in notes)
 
 
 def test_fetch_board_keeps_fixture_seeded_market_calls_disabled_by_default(monkeypatch):


### PR DESCRIPTION
## Summary

This is the official integration cleanup after discovering the correct KIBL baseball scope.

Verified KIBL baseball scope:

```text
sport_id=2
league_id=7
```

This PR fixes the remaining Bet105 board issues shown in production:

- wrong date rows, including September futures/outrights
- one-row Bet105 market result being treated as the event source
- selected date showing only one game
- stale/non-selected market rows appearing as MLB games

## What changed

### Repository

- Uses `info/fixtures` as the source of MLB fixture/event data.
- Fixture requests use `sport_id=2`, `league_id=7`, and date filters only.
- Fixture requests still omit `feed_source_id` and `betting_type_id`.
- Filters returned fixture rows to selected Eastern slate date.
- Keeps only real game fixtures: `fixture_type_id=1`.
- Drops props/futures/outrights/other alternates such as fixture type `3`, `4`, and `6`.
- Keeps Bet105 market calls scoped to `feed_source_id=171`, the selected betting type, `sport_id=2`, and `league_id=7`.
- Attaches market rows only when their `fixture_id` matches the selected MLB fixture IDs.

### Normalizer

- Builds events from `fixture_rows` first.
- Renders the selected MLB schedule even if no Bet105 market rows are available yet.
- Attaches Bet105 markets only to matching fixture events.
- Returns truthful `fixtures_only` / `incomplete_market_discovery` status instead of rendering an unrelated futures row.

### Tests

- Repository tests assert:
  - `sport_id=2`, `league_id=7`
  - no book filters on fixture calls
  - selected date filtering
  - only fixture type `1` survives
  - props/futures/other-date/other-league rows are dropped
  - fixture-seeded market calls remain opt-in
- Normalizer test asserts fixture-first rendering with empty market rows.

## Expected production behavior after merge/deploy

For:

```bash
curl -i "https://mlbgpt.com/odds/bet105/events?date=2026-06-14&live=false"
```

Expected:

- no tennis rows
- no September futures rows
- no props rows such as `Grayson Rodriguez Props`
- selected June 14 MLB games appear as events
- `fixtures.fixture_row_count` equals the selected MLB game count
- `event_count` reflects selected MLB fixtures, not one broad Bet105 market row
- `market_count` may still be `0` until the exact Bet105 market-board call is found
- status should be `fixtures_only` or `incomplete_market_discovery`, not fake `ok`

## What this does not claim

This does not claim the full Bet105 odds board is solved if KIBL still does not return game market rows for feed `171`. It fixes the MLB fixture/event foundation and prevents wrong-sport/wrong-date data from rendering as the board.