### PR TITLE
Fix Bet105 price extraction for fixture market rows

### DIFF
--- a/mlb_app/bet105_normalizer.py
+++ b/mlb_app/bet105_normalizer.py
@@ -45,11 +45,64 @@ def _binary_side(row: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _price(row: Dict[str, Any]) -> Optional[int]:
-    parsed = legacy._safe_int(_value(row, ("price_american", "american", "price", "line_price")))
+def _direct_value(row: Dict[str, Any], keys: tuple[str, ...]) -> Any:
+    info = row.get("info") if isinstance(row.get("info"), dict) else {}
+    for key in keys:
+        if row.get(key) not in (None, ""):
+            return row.get(key)
+        if info.get(key) not in (None, ""):
+            return info.get(key)
+    return None
+
+
+def _american_from_value(value: Any) -> Optional[int]:
+    parsed = legacy._safe_int(value)
+    if parsed is None or parsed == 0:
+        return None
+    return parsed
+
+
+def _decimal_from_value(value: Any) -> Optional[float]:
+    parsed = legacy._safe_float(value)
+    if parsed is None or parsed <= 1:
+        return None
+    return parsed
+
+
+def _price_from_object(value: Any) -> Optional[int]:
+    if isinstance(value, dict):
+        for key in ("price_american", "american", "american_odds", "americanOdds", "odds_american", "line_price", "value"):
+            parsed = _american_from_value(value.get(key))
+            if parsed is not None:
+                return parsed
+        for key in ("price_decimal", "decimal", "decimal_odds", "decimalOdds", "odds_decimal"):
+            decimal = _decimal_from_value(value.get(key))
+            if decimal is not None:
+                return legacy._american_from_decimal(decimal)
+        return None
+    parsed = _american_from_value(value)
     if parsed is not None:
         return parsed
-    return legacy._american_from_decimal(legacy._safe_float(_value(row, ("price_decimal", "decimal", "decimal_odds"))))
+    decimal = _decimal_from_value(value)
+    if decimal is not None:
+        return legacy._american_from_decimal(decimal)
+    return None
+
+
+def _price(row: Dict[str, Any]) -> Optional[int]:
+    for key in ("price_american", "american", "american_odds", "americanOdds", "odds_american", "line_price"):
+        parsed = _american_from_value(_direct_value(row, (key,)))
+        if parsed is not None:
+            return parsed
+    for key in ("price", "odds", "current_price", "currentPrice"):
+        parsed = _price_from_object(_direct_value(row, (key,)))
+        if parsed is not None:
+            return parsed
+    for key in ("price_decimal", "decimal", "decimal_odds", "decimalOdds", "odds_decimal"):
+        decimal = _decimal_from_value(_direct_value(row, (key,)))
+        if decimal is not None:
+            return legacy._american_from_decimal(decimal)
+    return None
 
 
 def _fixture_meta(row: Dict[str, Any], index: int = 0) -> Dict[str, Any]:

--- a/tests/test_bet105_market_coverage.py
+++ b/tests/test_bet105_market_coverage.py
@@ -81,3 +81,32 @@ def test_normalizer_labels_participantless_total_rows_from_kibl():
     assert total["market_key"] == "totals"
     assert total["selections"][0]["name"] == "Total Runs"
     assert total["selections"][0]["price"] == -110
+
+
+def test_normalizer_extracts_nested_kibl_price_object():
+    board = Bet105RawBoard(
+        filters={"date": "2026-06-14"},
+        fixture_rows=[FIXTURE],
+        market_rows=[
+            {
+                "fixture_id": "fx-1",
+                "market_id": 1,
+                "market_type_id": 1,
+                "fixture_participant_id": "fp-away",
+                "participant_id": "p-away",
+                "price": {"american": -128, "decimal": 1.78125},
+                "is_current": True,
+            }
+        ],
+        participant_rows=[],
+        notes=[],
+        ids={},
+    )
+
+    payload = normalize_board(board, live_only=False, raw=True)
+    selection = payload["events"][0]["markets"][0]["selections"][0]
+
+    assert selection["name"] == "Arizona Diamondbacks"
+    assert selection["price"] == -128
+    assert selection["odds"]["american"] == -128
+    assert selection["odds"]["implied_probability"] == 0.5614


### PR DESCRIPTION
## Summary

Fixes the Bet105 regression where markets render but odds show as `0` / `Imp 0%`.

The route is alive and returning markets. The issue is normalization: newer fixture-scoped market rows can expose odds as nested `price` / `odds` objects, while `_price()` only handled narrow scalar top-level fields.

## Changes

- Parse direct American price fields.
- Parse nested `price` objects.
- Parse nested `odds` objects.
- Fall back to decimal odds when needed.
- Treat American `0` as invalid, not a displayable price.
- Add a regression test for `price: { american: -128, decimal: 1.78125 }`.

## Expected result

The board should keep 15 events / 45 markets, but Moneyline, Run Line, and Total Runs should display real prices instead of `0`.