### PR TITLE
Fix Bet105 mobile game list scrolling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
+import './styles/bet105-mobile.css'
 import HomePage from './pages/HomePage'
 import LandingV2Page from './pages/LandingV2Page'
 import MatchupDetailPage from './pages/MatchupDetailPage'

--- a/frontend/src/styles/bet105-mobile.css
+++ b/frontend/src/styles/bet105-mobile.css
@@ -1,0 +1,59 @@
+@media (max-width: 1100px) {
+  .bet105-shell {
+    display: flex !important;
+    flex-direction: column !important;
+    grid-template-columns: none !important;
+    align-items: stretch !important;
+    overflow: visible !important;
+    min-height: 0 !important;
+    height: auto !important;
+  }
+
+  .bet105-game-rail,
+  .bet105-board,
+  .bet105-slip {
+    order: initial !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+    position: static !important;
+    top: auto !important;
+    overflow: visible !important;
+    max-height: none !important;
+    height: auto !important;
+  }
+
+  .bet105-game-rail {
+    order: 1 !important;
+  }
+
+  .bet105-board {
+    order: 2 !important;
+  }
+
+  .bet105-slip {
+    order: 3 !important;
+    padding-bottom: 28px !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .bet105-shell {
+    gap: 14px !important;
+    padding-bottom: 44px !important;
+  }
+
+  .bet105-game-rail {
+    margin-bottom: 4px !important;
+  }
+
+  .bet105-game-rail::after {
+    content: "Showing full Bet105 slate — scroll page for all games";
+    display: block;
+    margin: 10px 4px 0;
+    color: #8b949e;
+    font-size: 11px;
+    font-weight: 800;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the mobile Bet105 issue where the counter reports 15 events but only part of the game list is reachable.

## Changes

- Adds a Bet105-specific mobile CSS override.
- Forces the Bet105 desktop grid into normal stacked mobile flow under 1100px.
- Removes sticky/sidebar constraints from the game rail, board, and slip on mobile.
- Ensures the game rail has full width, no max height, no trapped overflow, and normal page scrolling.
- Adds a small mobile affordance after the game rail indicating the full slate is available by page scroll.

## Expected result

On mobile, all 15 Bet105 games should be reachable in the normal page scroll instead of only the first visible subset.