### PR TITLE
Speed up Bet105 board fast mode

### DIFF
--- a/mlb_app/kibl_bet105_fast_repository.py
+++ b/mlb_app/kibl_bet105_fast_repository.py
@@ -45,9 +45,16 @@ class KiblBet105Repository(FullMarketRepository):
             configured = 8
         return max(1, min(configured, 12))
 
-    def _summary_rows(self, path: str, body: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
+    def _increment_call_count(self) -> None:
         self.performance_meta["kibl_call_count"] = int(self.performance_meta.get("kibl_call_count") or 0) + 1
+
+    def _summary_rows(self, path: str, body: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
+        self._increment_call_count()
         return super()._summary_rows(path, body, notes, label)
+
+    def _market_rows_for_body(self, body: Dict[str, Any], notes: List[str], label: str, fixture_ids: List[str]) -> List[Dict[str, Any]]:
+        self._increment_call_count()
+        return super()._market_rows_for_body(body, notes, label, fixture_ids)
 
     def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:
         clean = self._clean_market_body(filters)
@@ -114,7 +121,7 @@ class KiblBet105Repository(FullMarketRepository):
                 idx, label = future_map[future]
                 try:
                     rows = future.result()
-                except Exception as exc:  # noqa: BLE001 - record per-request failures without killing the full slate.
+                except Exception as exc:
                     notes.append(f"fixture_market_summary_error:label={stage}:{label}:error={exc}")
                     rows = []
                 results[idx] = rows

--- a/mlb_app/kibl_bet105_fast_repository.py
+++ b/mlb_app/kibl_bet105_fast_repository.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional, Tuple
+
+from .kibl_bet105_full_market_repository import KiblBet105Repository as FullMarketRepository
+
+
+class KiblBet105Repository(FullMarketRepository):
+    """Production-fast Bet105 repository.
+
+    The full fixture-scoped discovery contract remains available for debug, but
+    normal board requests only use the verified fixture_id + market_type_id 1/2/3
+    calls. Market calls are fetched with bounded concurrency and expose compact
+    timing/call-count metadata for verification.
+    """
+
+    def __init__(self, *args: Any, discovery_probes: Optional[bool] = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        if discovery_probes is None:
+            discovery_probes = str(os.getenv("KIBL_BET105_ENABLE_DISCOVERY_PROBES", "false")).lower() in {"1", "true", "yes", "on"}
+        self.discovery_probes = bool(discovery_probes)
+        self.performance_meta: Dict[str, Any] = {
+            "mode": "discovery" if self.discovery_probes else "fast",
+            "cache_hit": False,
+            "kibl_call_count": 0,
+            "fixture_count": 0,
+            "market_request_count": 0,
+            "total_ms": 0,
+            "fixtures_ms": 0,
+            "markets_ms": 0,
+        }
+
+    @staticmethod
+    def _elapsed_ms(start: float) -> int:
+        return int(round((time.perf_counter() - start) * 1000))
+
+    @staticmethod
+    def _worker_count() -> int:
+        try:
+            configured = int(os.getenv("KIBL_BET105_MARKET_WORKERS", "8"))
+        except ValueError:
+            configured = 8
+        return max(1, min(configured, 12))
+
+    def _summary_rows(self, path: str, body: Dict[str, Any], notes: List[str], label: str) -> List[Dict[str, Any]]:
+        self.performance_meta["kibl_call_count"] = int(self.performance_meta.get("kibl_call_count") or 0) + 1
+        return super()._summary_rows(path, body, notes, label)
+
+    def market_request_bodies(self, filters: Dict[str, Any], fixture_ids: List[str]) -> List[Tuple[str, Dict[str, Any]]]:
+        clean = self._clean_market_body(filters)
+        if not fixture_ids:
+            return [("dated:base", clean)] if self.discovery_probes else []
+
+        fixture_id_limit = int(os.getenv("KIBL_MARKET_FIXTURE_ID_LIMIT", str(len(fixture_ids))))
+        limited_fixture_ids = fixture_ids[: max(0, fixture_id_limit)]
+        bodies: List[Tuple[str, Dict[str, Any]]] = []
+        for fixture_id in limited_fixture_ids:
+            root = {**clean, "fixture_id": fixture_id}
+            if self.discovery_probes:
+                bodies.append((f"dated:fixture_id:{fixture_id}", root))
+            for market_type_id in self.game_line_market_type_ids:
+                bodies.append((f"dated:fixture_id:{fixture_id}:market_type_id:{market_type_id}", {**root, "market_type_id": int(market_type_id)}))
+            if self.discovery_probes:
+                bodies.append((f"dated:fixture_id:{fixture_id}:market_type_ids:list", {**root, "market_type_ids": [1, 2, 3]}))
+                bodies.append((f"dated:fixture_id:{fixture_id}:market_type_ids:csv", {**root, "market_type_ids": "1,2,3"}))
+
+        seen: set[str] = set()
+        out: List[Tuple[str, Dict[str, Any]]] = []
+        for label, body in bodies:
+            fp = repr(sorted((key, str(value)) for key, value in body.items()))
+            if fp not in seen:
+                seen.add(fp)
+                out.append((label, body))
+        return out
+
+    def fetch_fixture_summary(self, filters: Dict[str, Any], notes: List[str]) -> List[Dict[str, Any]]:
+        start = time.perf_counter()
+        try:
+            return super().fetch_fixture_summary(filters, notes)
+        finally:
+            self.performance_meta["fixtures_ms"] = self._elapsed_ms(start)
+
+    def fetch_market_candidates(self, filters: Dict[str, Any], fixture_ids: List[str], notes: List[str], stage: str) -> List[Dict[str, Any]]:
+        start = time.perf_counter()
+        all_rows: List[Dict[str, Any]] = []
+        candidates = self.market_request_bodies(filters, fixture_ids)
+        workers = min(self._worker_count(), max(1, len(candidates) or 1))
+        self.performance_meta["fixture_count"] = len(fixture_ids)
+        self.performance_meta["market_request_count"] = len(candidates)
+        self.performance_meta["market_workers"] = workers
+        notes.append(
+            f"fixture_scoped_market_requests:enabled:mode={self.performance_meta['mode']}:fixture_ids_available={len(fixture_ids)}:requests={len(candidates)}:workers={workers}:market_type_probes=1,2,3"
+        )
+
+        if not candidates:
+            self.markets_meta["fixture_count"] = len(fixture_ids)
+            self.markets_meta["request_count"] = 0
+            self.markets_meta["raw_union_rows"] = 0
+            self.markets_meta["deduped_rows"] = 0
+            self.markets_meta["market_type_ids"] = {}
+            self.performance_meta["markets_ms"] = self._elapsed_ms(start)
+            return []
+
+        results: List[List[Dict[str, Any]]] = [[] for _ in candidates]
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            future_map = {
+                pool.submit(self._market_rows_for_body, body, notes, f"{stage}:{label}", fixture_ids): (idx, label)
+                for idx, (label, body) in enumerate(candidates)
+            }
+            for future in as_completed(future_map):
+                idx, label = future_map[future]
+                try:
+                    rows = future.result()
+                except Exception as exc:  # noqa: BLE001 - record per-request failures without killing the full slate.
+                    notes.append(f"fixture_market_summary_error:label={stage}:{label}:error={exc}")
+                    rows = []
+                results[idx] = rows
+                notes.append(f"market_candidate:{stage}:{label}:rows={len(rows)}")
+
+        for rows in results:
+            all_rows.extend(rows)
+        deduped = self._dedupe_market_rows(all_rows)
+        self.markets_meta["fixture_count"] = len(fixture_ids)
+        self.markets_meta["request_count"] = len(candidates)
+        self.markets_meta["raw_union_rows"] = len(all_rows)
+        self.markets_meta["deduped_rows"] = len(deduped)
+        self.markets_meta["market_type_ids"] = self._distribution(deduped, "market_type_id", "marketTypeId")
+        self.markets_meta["mode"] = self.performance_meta["mode"]
+        self.markets_meta["market_workers"] = workers
+        self.performance_meta["markets_ms"] = self._elapsed_ms(start)
+        notes.append(f"market_union:{stage}:mode={self.performance_meta['mode']}:raw={len(all_rows)}:deduped={len(deduped)}:candidates={len(candidates)}")
+        return deduped
+
+    def fetch_board(self, date: Optional[str] = None, live_only: Optional[bool] = None, event_id: Optional[str] = None):
+        start = time.perf_counter()
+        board = super().fetch_board(date=date, live_only=live_only, event_id=event_id)
+        self.performance_meta["total_ms"] = self._elapsed_ms(start)
+        self.performance_meta["fixture_count"] = len(board.fixture_rows)
+        self.performance_meta["market_row_count"] = len(board.market_rows)
+        self.performance_meta["mode"] = "discovery" if self.discovery_probes else "fast"
+        setattr(board, "performance_meta", dict(self.performance_meta))
+        setattr(board, "markets_meta", self.markets_meta)
+        board.notes.append(
+            f"performance:mode={self.performance_meta['mode']}:total_ms={self.performance_meta['total_ms']}:fixtures_ms={self.performance_meta['fixtures_ms']}:markets_ms={self.performance_meta['markets_ms']}:kibl_calls={self.performance_meta['kibl_call_count']}:market_requests={self.performance_meta['market_request_count']}"
+        )
+        return board

--- a/mlb_app/kibl_bet105_repository.py
+++ b/mlb_app/kibl_bet105_repository.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .kibl_bet105_full_market_repository import KiblBet105Repository
+from .kibl_bet105_fast_repository import KiblBet105Repository
 
 __all__ = ["KiblBet105Repository"]

--- a/mlb_app/sportsbook_bet105_service_v11.py
+++ b/mlb_app/sportsbook_bet105_service_v11.py
@@ -1,10 +1,48 @@
 from __future__ import annotations
 
+import os
+import time
 from typing import Any, Dict, List, Optional
 
 from . import kibl_bet105_provider as legacy
 from .bet105_normalizer import normalize_board
 from .kibl_bet105_repository import KiblBet105Repository
+
+
+def _elapsed_ms(start: float) -> int:
+    return int(round((time.perf_counter() - start) * 1000))
+
+
+def _cache_ttl(live_only: Optional[bool], raw: bool) -> int:
+    if raw:
+        return int(os.getenv("KIBL_BET105_DEBUG_CACHE_TTL_SECONDS", "30"))
+    if live_only:
+        return int(os.getenv("KIBL_BET105_LIVE_CACHE_TTL_SECONDS", "15"))
+    return int(os.getenv("KIBL_BET105_FAST_CACHE_TTL_SECONDS", "90"))
+
+
+def _compact_normal_payload(payload: Dict[str, Any], raw: bool) -> Dict[str, Any]:
+    if raw:
+        return payload
+    payload.pop("raw_items_sample", None)
+    markets_meta = dict(payload.get("markets_meta") or {})
+    markets_meta.pop("fixture_request_summaries", None)
+    if markets_meta:
+        payload["markets_meta"] = markets_meta
+    else:
+        payload.pop("markets_meta", None)
+    notes = payload.get("normalization_notes") or []
+    payload["normalization_notes"] = [note for note in notes if str(note).startswith(("fixture_scoped_market_requests", "market_selected", "performance:"))][:8]
+    return payload
+
+
+def _cache_hit_payload(cached: Dict[str, Any]) -> Dict[str, Any]:
+    payload = dict(cached)
+    perf = dict(payload.get("performance_meta") or {})
+    perf["cache_hit"] = True
+    payload["performance_meta"] = perf
+    payload["cache_hit"] = True
+    return payload
 
 
 def fetch_board(
@@ -18,14 +56,35 @@ def fetch_board(
     scope = "live" if live_only else "events"
     if not legacy._configured():
         return legacy._not_configured(scope, game_pk=game_pk)
-    cache_key = f"bet105-v11:{scope}:{date or 'any'}:{game_pk or 'all'}:{raw}:{live_only}"
+    mode = "debug" if raw else "fast"
+    cache_key = f"bet105-board-{mode}:{scope}:{date or 'any'}:{game_pk or 'all'}"
     cached = legacy._cache_get(cache_key)
     if cached:
-        return cached
+        return _cache_hit_payload(cached)
+    total_start = time.perf_counter()
     try:
-        board = KiblBet105Repository().fetch_board(date=date, live_only=live_only, event_id=str(game_pk) if game_pk else None)
+        repo = KiblBet105Repository(discovery_probes=raw)
+        board = repo.fetch_board(date=date, live_only=live_only, event_id=str(game_pk) if game_pk else None)
+        normalize_start = time.perf_counter()
         payload = normalize_board(board, live_only=live_only, game_pk=game_pk, raw=raw)
-        legacy._cache_set(cache_key, payload)
+        normalize_ms = _elapsed_ms(normalize_start)
+        perf = dict(getattr(board, "performance_meta", {}) or {})
+        perf.update(
+            {
+                "normalize_ms": normalize_ms,
+                "total_service_ms": _elapsed_ms(total_start),
+                "cache_hit": False,
+                "mode": perf.get("mode") or ("discovery" if raw else "fast"),
+                "events": payload.get("event_count"),
+                "markets": payload.get("market_count"),
+                "selections": sum(len(market.get("selections") or []) for event in payload.get("events") or [] for market in event.get("markets") or []),
+                "raw_diagnostics_included": bool(raw),
+            }
+        )
+        payload["performance_meta"] = perf
+        payload = _compact_normal_payload(payload, raw=raw)
+        if payload.get("status") not in {"provider_error", "provider_not_configured"}:
+            legacy._cache_set(cache_key, payload, ttl=_cache_ttl(live_only, raw))
         return payload
     except Exception as exc:
         return legacy._provider_error(scope, game_pk=game_pk, exc=exc, request_params={"date": date, "live_only": live_only})

--- a/tests/test_bet105_market_coverage.py
+++ b/tests/test_bet105_market_coverage.py
@@ -1,4 +1,5 @@
 from mlb_app.bet105_normalizer import normalize_board
+from mlb_app.kibl_bet105_fast_repository import KiblBet105Repository
 from mlb_app.kibl_bet105_types import Bet105RawBoard
 
 
@@ -16,10 +17,57 @@ FIXTURE = {
 }
 
 
+def request_filters():
+    return {
+        "feed_source_id": 171,
+        "betting_type_id": 1,
+        "sport_id": "2",
+        "league_id": "7",
+        "start_date": "2026-06-14 00:00:00",
+        "end_date": "2026-06-15 00:00:00",
+    }
+
+
 def row(**kwargs):
     base = {"fixture_id": "fx-1", "is_current": True, "price_decimal": 1.91}
     base.update(kwargs)
     return base
+
+
+def test_fast_mode_builds_only_three_market_type_requests_per_fixture():
+    repo = KiblBet105Repository(client=None, discovery_probes=False)
+
+    bodies = repo.market_request_bodies(request_filters(), ["fixture-a", "fixture-b"])
+    labels = [label for label, _body in bodies]
+
+    assert len(bodies) == 6
+    assert all("market_type_id:" in label for label in labels)
+    assert not any("market_type_ids:list" in label for label in labels)
+    assert not any("market_type_ids:csv" in label for label in labels)
+    assert [body["market_type_id"] for _label, body in bodies[:3]] == [1, 2, 3]
+
+
+def test_discovery_mode_keeps_extra_probe_variants():
+    repo = KiblBet105Repository(client=None, discovery_probes=True)
+
+    bodies = repo.market_request_bodies(request_filters(), ["fixture-a"])
+    labels = [label for label, _body in bodies]
+
+    assert len(bodies) == 6
+    assert "dated:fixture_id:fixture-a" in labels
+    assert "dated:fixture_id:fixture-a:market_type_id:1" in labels
+    assert "dated:fixture_id:fixture-a:market_type_id:2" in labels
+    assert "dated:fixture_id:fixture-a:market_type_id:3" in labels
+    assert "dated:fixture_id:fixture-a:market_type_ids:list" in labels
+    assert "dated:fixture_id:fixture-a:market_type_ids:csv" in labels
+
+
+def test_worker_count_is_bounded(monkeypatch):
+    monkeypatch.setenv("KIBL_BET105_MARKET_WORKERS", "999")
+    assert KiblBet105Repository._worker_count() == 12
+
+    monkeypatch.setenv("KIBL_BET105_MARKET_WORKERS", "0")
+    assert KiblBet105Repository._worker_count() == 1
 
 
 def test_normalizer_preserves_three_game_line_families():


### PR DESCRIPTION
## Summary

Speeds up the Bet105 board while keeping the working fixture scoped data path.

## Changes

- Normal mode uses only fixture id plus market type 1, 2, and 3.
- Extra discovery probes move to debug/raw mode.
- Market requests use bounded parallel workers.
- Adds compact performance metadata.
- Splits fast and debug cache keys.
- Trims heavy debug fields from normal event responses.

## Expected effect

A 15 game slate now builds 45 normal market request bodies instead of the heavier discovery set, and requests are gathered concurrently.