### PR TITLE
Use MLB GPT logo for favicon and app icon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MLB Prediction Engine</title>
+    <meta name="theme-color" content="#151d22" />
+    <meta name="application-name" content="MLB GPT" />
+    <meta property="og:site_name" content="MLB GPT" />
+    <meta property="og:title" content="MLB GPT" />
+    <meta property="og:description" content="Machine learning baseball predictions, odds, and sportsbook analytics." />
+    <meta property="og:image" content="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="shortcut icon" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <title>MLB GPT</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
       body {

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">MLB GPT</title>
+  <desc id="desc">MLB GPT cream baseball diamond mark on a dark navy background.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="75%">
+      <stop offset="0%" stop-color="#263238"/>
+      <stop offset="58%" stop-color="#20282e"/>
+      <stop offset="100%" stop-color="#151d22"/>
+    </radialGradient>
+    <linearGradient id="gold" x1="130" y1="110" x2="390" y2="410" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#f1d3a5"/>
+      <stop offset="52%" stop-color="#dec198"/>
+      <stop offset="100%" stop-color="#cfae7f"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="104" fill="url(#bg)"/>
+  <g transform="translate(256 252) rotate(45) translate(-132 -132)">
+    <rect x="12" y="12" width="240" height="240" rx="16" fill="url(#gold)"/>
+    <path d="M63 9 C103 70 104 187 63 255" fill="none" stroke="#20282e" stroke-width="20" stroke-linecap="round"/>
+    <path d="M201 9 C161 70 160 187 201 255" fill="none" stroke="#20282e" stroke-width="20" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "MLB GPT",
+  "short_name": "MLB GPT",
+  "description": "Machine learning baseball predictions, odds, and sportsbook analytics.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#151d22",
+  "theme_color": "#151d22",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "form_factor": "wide"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Uses the new MLB GPT logo mark as the browser/app icon so the site no longer falls back to a generic or silly default icon.

## Changes

- Adds `frontend/public/favicon.svg` with the MLB GPT dark/navy + cream baseball-diamond mark.
- Adds `frontend/public/site.webmanifest` for browser/PWA icon metadata.
- Updates `frontend/index.html` with favicon, shortcut icon, Apple touch icon, manifest, theme color, and Open Graph metadata.
- Updates the document title from `MLB Prediction Engine` to `MLB GPT`.

## Notes

GitHub connector writes here are text-only, so this PR uses an SVG favicon recreated from the uploaded logo mark rather than committing the large PNG directly. The visual language matches the uploaded asset: dark navy background, cream mark, and baseball seam/motion curves.