### PR TITLE
Remove Bet105 hero subtitle copy

### DIFF
--- a/frontend/src/styles/bet105-mobile.css
+++ b/frontend/src/styles/bet105-mobile.css
@@ -1,3 +1,7 @@
+.app-main > div:has(.bet105-shell) > section:first-child > div:first-child > div:first-child > div:nth-child(3) {
+  display: none !important;
+}
+
 @media (max-width: 1100px) {
   .bet105-shell {
     display: flex !important;


### PR DESCRIPTION
## Summary

Removes the long descriptive subtitle from the Bet105 Sportsbook hero area.

## Change

- Hides the Bet105 hero subtitle text so the page no longer shows:
  - Browse normalized Bet105 markets...
  - If KIBL normalization is incomplete...

## Result

The Bet105 page keeps the title, controls, tabs, stats, game rail, board, and slip, but the unwanted intro copy is gone.