### PR TITLE
Add 6NI Layer 6 larger historical actuals source expansion

### DIFF
--- a/data/local/historical_actuals.csv
+++ b/data/local/historical_actuals.csv
@@ -1,17 +1,276 @@
 game_pk,game_date,home_team,away_team,home_score,away_score,home_win_binary,source_artifact
-824852,2026-04-26,Baltimore Orioles,Boston Red Sox,3,5,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-824934,2026-04-26,Atlanta Braves,Philadelphia Phillies,6,2,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+822749,2026-04-20,Washington Nationals,Atlanta Braves,4,9,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+822994,2026-04-20,Tampa Bay Rays,Cincinnati Reds,1,6,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+823149,2026-04-20,Seattle Mariners,Athletics,4,6,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+823879,2026-04-20,Miami Marlins,St. Louis Cardinals,5,3,1,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824046,2026-04-20,Los Angeles Angels,Toronto Blue Jays,2,5,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824125,2026-04-20,Kansas City Royals,Baltimore Orioles,5,7,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824370,2026-04-20,Colorado Rockies,Los Angeles Dodgers,3,12,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824450,2026-04-20,Cleveland Guardians,Houston Astros,2,9,0,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824692,2026-04-20,Chicago Cubs,Philadelphia Phillies,5,1,1,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+824776,2026-04-20,Boston Red Sox,Detroit Tigers,8,6,1,tmp/statsapi_cache/schedule/2026-04-20_67c90adbdf18.json
+822747,2026-04-21,Washington Nationals,Atlanta Braves,11,4,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+822914,2026-04-21,Texas Rangers,Pittsburgh Pirates,5,1,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+822995,2026-04-21,Tampa Bay Rays,Cincinnati Reds,6,12,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+823148,2026-04-21,Seattle Mariners,Athletics,2,5,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+823236,2026-04-21,San Francisco Giants,Los Angeles Dodgers,3,1,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+823640,2026-04-21,New York Mets,Minnesota Twins,3,5,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+823880,2026-04-21,Miami Marlins,St. Louis Cardinals,3,5,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824045,2026-04-21,Los Angeles Angels,Toronto Blue Jays,2,4,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824127,2026-04-21,Kansas City Royals,Baltimore Orioles,6,5,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824290,2026-04-21,Detroit Tigers,Milwaukee Brewers,4,12,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824369,2026-04-21,Colorado Rockies,San Diego Padres,0,1,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824448,2026-04-21,Cleveland Guardians,Houston Astros,8,5,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824690,2026-04-21,Chicago Cubs,Philadelphia Phillies,7,4,1,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+824773,2026-04-21,Boston Red Sox,New York Yankees,0,4,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+825099,2026-04-21,Arizona Diamondbacks,Chicago White Sox,5,11,0,tmp/statsapi_cache/schedule/2026-04-21_a22df82ca6f5.json
+822748,2026-04-22,Washington Nationals,Atlanta Braves,6,8,0,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+822913,2026-04-22,Texas Rangers,Pittsburgh Pirates,4,8,0,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+822993,2026-04-22,Tampa Bay Rays,Cincinnati Reds,6,1,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+823147,2026-04-22,Seattle Mariners,Athletics,5,4,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+823231,2026-04-22,San Francisco Giants,Los Angeles Dodgers,3,0,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+823641,2026-04-22,New York Mets,Minnesota Twins,3,2,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+823878,2026-04-22,Miami Marlins,St. Louis Cardinals,4,1,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824044,2026-04-22,Los Angeles Angels,Toronto Blue Jays,7,3,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824123,2026-04-22,Kansas City Royals,Baltimore Orioles,6,8,0,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824286,2026-04-22,Detroit Tigers,Milwaukee Brewers,5,2,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824367,2026-04-22,Colorado Rockies,San Diego Padres,8,3,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824449,2026-04-22,Cleveland Guardians,Houston Astros,0,2,0,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824688,2026-04-22,Chicago Cubs,Philadelphia Phillies,7,2,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+824774,2026-04-22,Boston Red Sox,New York Yankees,1,4,0,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+825097,2026-04-22,Arizona Diamondbacks,Chicago White Sox,11,7,1,tmp/statsapi_cache/schedule/2026-04-22_103ee2ed87bc.json
+822745,2026-04-23,Washington Nationals,Atlanta Braves,2,7,0,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+822912,2026-04-23,Texas Rangers,Pittsburgh Pirates,6,1,1,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+823233,2026-04-23,San Francisco Giants,Los Angeles Dodgers,0,3,0,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+823639,2026-04-23,New York Mets,Minnesota Twins,10,8,1,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+824288,2026-04-23,Detroit Tigers,Milwaukee Brewers,5,4,1,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+824368,2026-04-23,Colorado Rockies,San Diego Padres,8,10,0,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+824689,2026-04-23,Chicago Cubs,Philadelphia Phillies,8,7,1,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+824770,2026-04-23,Boston Red Sox,New York Yankees,2,4,0,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+825096,2026-04-23,Arizona Diamondbacks,Chicago White Sox,1,4,0,tmp/statsapi_cache/schedule/2026-04-23_29c0bca5a1d7.json
+822827,2026-04-24,Toronto Blue Jays,Cleveland Guardians,6,8,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+822909,2026-04-24,Texas Rangers,Athletics,1,8,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+822992,2026-04-24,Tampa Bay Rays,Minnesota Twins,6,2,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+823069,2026-04-24,St. Louis Cardinals,Seattle Mariners,2,3,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+823232,2026-04-24,San Francisco Giants,Miami Marlins,4,9,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+823638,2026-04-24,New York Mets,Colorado Rockies,3,4,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+823800,2026-04-24,Milwaukee Brewers,Pittsburgh Pirates,0,6,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+823962,2026-04-24,Los Angeles Dodgers,Chicago Cubs,4,6,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824124,2026-04-24,Kansas City Royals,Los Angeles Angels,6,3,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824204,2026-04-24,Houston Astros,New York Yankees,4,12,0,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824529,2026-04-24,Cincinnati Reds,Detroit Tigers,9,8,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824611,2026-04-24,Chicago White Sox,Washington Nationals,5,4,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824854,2026-04-24,Baltimore Orioles,Boston Red Sox,10,3,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+824932,2026-04-24,Atlanta Braves,Philadelphia Phillies,5,3,1,tmp/statsapi_cache/schedule/2026-04-24_68683115f7f2.json
+822826,2026-04-25,Toronto Blue Jays,Cleveland Guardians,5,3,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+822910,2026-04-25,Texas Rangers,Athletics,4,3,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+822989,2026-04-25,Tampa Bay Rays,Minnesota Twins,6,1,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+823070,2026-04-25,St. Louis Cardinals,Seattle Mariners,9,11,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+823229,2026-04-25,San Francisco Giants,Miami Marlins,6,2,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+823799,2026-04-25,Milwaukee Brewers,Pittsburgh Pirates,3,6,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+823960,2026-04-25,Los Angeles Dodgers,Chicago Cubs,12,4,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824121,2026-04-25,Kansas City Royals,Los Angeles Angels,12,1,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824203,2026-04-25,Houston Astros,New York Yankees,3,8,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824527,2026-04-25,Cincinnati Reds,Detroit Tigers,9,2,1,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824613,2026-04-25,Chicago White Sox,Washington Nationals,3,6,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824851,2026-04-25,Baltimore Orioles,Boston Red Sox,1,17,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+824933,2026-04-25,Atlanta Braves,Philadelphia Phillies,5,8,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
+825093,2026-04-25,Arizona Diamondbacks,San Diego Padres,4,6,0,tmp/statsapi_cache/schedule/2026-04-25_1a34765cf636.json
 822824,2026-04-26,Toronto Blue Jays,Cleveland Guardians,4,2,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-824528,2026-04-26,Cincinnati Reds,Detroit Tigers,3,8,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+822911,2026-04-26,Texas Rangers,Athletics,1,2,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+822991,2026-04-26,Tampa Bay Rays,Minnesota Twins,4,2,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+823068,2026-04-26,St. Louis Cardinals,Seattle Mariners,2,3,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+823230,2026-04-26,San Francisco Giants,Miami Marlins,6,3,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
 823635,2026-04-26,New York Mets,Colorado Rockies,1,3,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
 823637,2026-04-26,New York Mets,Colorado Rockies,0,3,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-822991,2026-04-26,Tampa Bay Rays,Minnesota Twins,4,2,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-824612,2026-04-26,Chicago White Sox,Washington Nationals,1,2,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-824202,2026-04-26,Houston Astros,New York Yankees,7,4,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
 823797,2026-04-26,Milwaukee Brewers,Pittsburgh Pirates,5,0,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-823068,2026-04-26,St. Louis Cardinals,Seattle Mariners,2,3,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-822911,2026-04-26,Texas Rangers,Athletics,1,2,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-825094,2026-04-26,Arizona Diamondbacks,San Diego Padres,12,7,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-823230,2026-04-26,San Francisco Giants,Miami Marlins,6,3,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
-824122,2026-04-26,Kansas City Royals,Los Angeles Angels,11,9,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
 823959,2026-04-26,Los Angeles Dodgers,Chicago Cubs,6,0,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824122,2026-04-26,Kansas City Royals,Los Angeles Angels,11,9,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824202,2026-04-26,Houston Astros,New York Yankees,7,4,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824528,2026-04-26,Cincinnati Reds,Detroit Tigers,3,8,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824612,2026-04-26,Chicago White Sox,Washington Nationals,1,2,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824852,2026-04-26,Baltimore Orioles,Boston Red Sox,3,5,0,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+824934,2026-04-26,Atlanta Braves,Philadelphia Phillies,6,2,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+825094,2026-04-26,Arizona Diamondbacks,San Diego Padres,12,7,1,tmp/statsapi_cache/schedule/2026-04-26_8faa8365da78.json
+822825,2026-04-27,Toronto Blue Jays,Boston Red Sox,0,5,0,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+822906,2026-04-27,Texas Rangers,New York Yankees,2,4,0,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+823311,2026-04-27,San Diego Padres,Chicago Cubs,9,7,1,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+823395,2026-04-27,Pittsburgh Pirates,St. Louis Cardinals,2,4,0,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+823719,2026-04-27,Minnesota Twins,Seattle Mariners,11,4,1,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+823961,2026-04-27,Los Angeles Dodgers,Miami Marlins,5,4,1,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+824446,2026-04-27,Cleveland Guardians,Tampa Bay Rays,2,3,0,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+824609,2026-04-27,Chicago White Sox,Los Angeles Angels,8,7,1,tmp/statsapi_cache/schedule/2026-04-27_3572e0f78a5f.json
+822823,2026-04-28,Toronto Blue Jays,Boston Red Sox,3,0,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+822908,2026-04-28,Texas Rangers,New York Yankees,2,3,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823310,2026-04-28,San Diego Padres,Chicago Cubs,3,8,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823390,2026-04-28,Pittsburgh Pirates,St. Louis Cardinals,7,11,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823473,2026-04-28,Philadelphia Phillies,San Francisco Giants,7,0,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823636,2026-04-28,New York Mets,Washington Nationals,8,0,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823716,2026-04-28,Minnesota Twins,Seattle Mariners,1,7,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823798,2026-04-28,Milwaukee Brewers,Arizona Diamondbacks,13,2,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+823956,2026-04-28,Los Angeles Dodgers,Miami Marlins,1,2,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+824447,2026-04-28,Cleveland Guardians,Tampa Bay Rays,0,1,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+824526,2026-04-28,Cincinnati Reds,Colorado Rockies,7,2,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+824610,2026-04-28,Chicago White Sox,Los Angeles Angels,5,2,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+824849,2026-04-28,Baltimore Orioles,Houston Astros,5,3,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+824931,2026-04-28,Atlanta Braves,Detroit Tigers,5,2,1,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+825017,2026-04-28,Athletics,Kansas City Royals,1,4,0,tmp/statsapi_cache/schedule/2026-04-28_8ec0264af6d1.json
+822821,2026-04-29,Toronto Blue Jays,Boston Red Sox,8,1,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+822907,2026-04-29,Texas Rangers,New York Yankees,3,0,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823312,2026-04-29,San Diego Padres,Chicago Cubs,4,5,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823392,2026-04-29,Pittsburgh Pirates,St. Louis Cardinals,4,5,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823633,2026-04-29,New York Mets,Washington Nationals,2,14,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823717,2026-04-29,Minnesota Twins,Seattle Mariners,3,5,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823796,2026-04-29,Milwaukee Brewers,Arizona Diamondbacks,2,6,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823958,2026-04-29,Los Angeles Dodgers,Miami Marlins,2,3,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+824445,2026-04-29,Cleveland Guardians,Tampa Bay Rays,3,1,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+824525,2026-04-29,Cincinnati Reds,Colorado Rockies,2,13,0,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+824608,2026-04-29,Chicago White Sox,Los Angeles Angels,3,2,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+824930,2026-04-29,Atlanta Braves,Detroit Tigers,4,3,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+825015,2026-04-29,Athletics,Kansas City Royals,5,2,1,tmp/statsapi_cache/schedule/2026-04-29_ab4009700c73.json
+823391,2026-04-30,Pittsburgh Pirates,St. Louis Cardinals,5,10,0,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+823471,2026-04-30,Philadelphia Phillies,San Francisco Giants,6,5,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+823472,2026-04-30,Philadelphia Phillies,San Francisco Giants,3,2,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+823634,2026-04-30,New York Mets,Washington Nationals,4,5,0,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+823714,2026-04-30,Minnesota Twins,Toronto Blue Jays,7,1,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+823795,2026-04-30,Milwaukee Brewers,Arizona Diamondbacks,13,1,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+824524,2026-04-30,Cincinnati Reds,Colorado Rockies,6,4,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+824848,2026-04-30,Baltimore Orioles,Houston Astros,10,3,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+824850,2026-04-30,Baltimore Orioles,Houston Astros,5,11,0,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+824929,2026-04-30,Atlanta Braves,Detroit Tigers,2,5,0,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+825016,2026-04-30,Athletics,Kansas City Royals,6,3,1,tmp/statsapi_cache/schedule/2026-04-30_f51268c24f5e.json
+822744,2026-05-01,Washington Nationals,Milwaukee Brewers,1,6,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+822990,2026-05-01,Tampa Bay Rays,San Francisco Giants,3,0,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823066,2026-05-01,St. Louis Cardinals,Los Angeles Dodgers,7,2,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823146,2026-05-01,Seattle Mariners,Kansas City Royals,6,7,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823309,2026-05-01,San Diego Padres,Chicago White Sox,2,8,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823389,2026-05-01,Pittsburgh Pirates,Cincinnati Reds,9,1,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823557,2026-05-01,New York Yankees,Baltimore Orioles,7,2,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823713,2026-05-01,Minnesota Twins,Toronto Blue Jays,3,7,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+823877,2026-05-01,Miami Marlins,Philadelphia Phillies,5,6,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+824041,2026-05-01,Los Angeles Angels,New York Mets,3,4,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+824287,2026-05-01,Detroit Tigers,Texas Rangers,4,5,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+824366,2026-05-01,Colorado Rockies,Atlanta Braves,6,8,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+824686,2026-05-01,Chicago Cubs,Arizona Diamondbacks,6,5,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+824772,2026-05-01,Boston Red Sox,Houston Astros,3,1,1,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+825012,2026-05-01,Athletics,Cleveland Guardians,5,8,0,tmp/statsapi_cache/schedule/2026-05-01_a7adce5b36d1.json
+822746,2026-05-02,Washington Nationals,Milwaukee Brewers,1,4,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+822988,2026-05-02,Tampa Bay Rays,San Francisco Giants,5,1,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823067,2026-05-02,St. Louis Cardinals,Los Angeles Dodgers,3,2,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823144,2026-05-02,Seattle Mariners,Kansas City Royals,2,3,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823308,2026-05-02,San Diego Padres,Chicago White Sox,0,4,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823388,2026-05-02,Pittsburgh Pirates,Cincinnati Reds,17,7,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823554,2026-05-02,New York Yankees,Baltimore Orioles,9,4,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823715,2026-05-02,Minnesota Twins,Toronto Blue Jays,4,11,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+823876,2026-05-02,Miami Marlins,Philadelphia Phillies,4,0,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+824042,2026-05-02,Los Angeles Angels,New York Mets,4,3,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+824284,2026-05-02,Detroit Tigers,Texas Rangers,5,1,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+824365,2026-05-02,Colorado Rockies,Atlanta Braves,1,9,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+824685,2026-05-02,Chicago Cubs,Arizona Diamondbacks,2,0,1,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+824771,2026-05-02,Boston Red Sox,Houston Astros,3,6,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+825014,2026-05-02,Athletics,Cleveland Guardians,6,14,0,tmp/statsapi_cache/schedule/2026-05-02_c592e99e85c0.json
+822742,2026-05-03,Washington Nationals,Milwaukee Brewers,3,2,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+822987,2026-05-03,Tampa Bay Rays,San Francisco Giants,2,1,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823065,2026-05-03,St. Louis Cardinals,Los Angeles Dodgers,1,4,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823145,2026-05-03,Seattle Mariners,Kansas City Royals,1,4,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823307,2026-05-03,San Diego Padres,Chicago White Sox,4,3,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823387,2026-05-03,Pittsburgh Pirates,Cincinnati Reds,1,0,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823555,2026-05-03,New York Yankees,Baltimore Orioles,11,3,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823711,2026-05-03,Minnesota Twins,Toronto Blue Jays,4,3,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+823875,2026-05-03,Miami Marlins,Philadelphia Phillies,2,7,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+824043,2026-05-03,Los Angeles Angels,New York Mets,1,5,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+824285,2026-05-03,Detroit Tigers,Texas Rangers,7,1,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+824364,2026-05-03,Colorado Rockies,Atlanta Braves,6,11,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+824687,2026-05-03,Chicago Cubs,Arizona Diamondbacks,8,4,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+824769,2026-05-03,Boston Red Sox,Houston Astros,1,3,0,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+825013,2026-05-03,Athletics,Cleveland Guardians,7,1,1,tmp/statsapi_cache/schedule/2026-05-03_958c2c4d607f.json
+822741,2026-05-07,Washington Nationals,Minnesota Twins,7,5,1,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+823306,2026-05-07,San Diego Padres,St. Louis Cardinals,1,2,0,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+823467,2026-05-07,Philadelphia Phillies,Athletics,1,12,0,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+823551,2026-05-07,New York Yankees,Texas Rangers,9,2,1,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+823870,2026-05-07,Miami Marlins,Baltimore Orioles,4,3,1,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+824117,2026-05-07,Kansas City Royals,Cleveland Guardians,5,8,0,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+824362,2026-05-07,Colorado Rockies,New York Mets,6,2,1,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+824681,2026-05-07,Chicago Cubs,Cincinnati Reds,8,3,1,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+824767,2026-05-07,Boston Red Sox,Tampa Bay Rays,4,8,0,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+825090,2026-05-07,Arizona Diamondbacks,Pittsburgh Pirates,2,4,0,tmp/statsapi_cache/schedule/2026-05-07_9ebfda7a74a7.json
+822822,2026-05-08,Toronto Blue Jays,Los Angeles Angels,2,0,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+822904,2026-05-08,Texas Rangers,Chicago Cubs,1,7,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823225,2026-05-08,San Francisco Giants,Pittsburgh Pirates,5,2,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823303,2026-05-08,San Diego Padres,St. Louis Cardinals,0,6,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823466,2026-05-08,Philadelphia Phillies,Colorado Rockies,7,9,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823794,2026-05-08,Milwaukee Brewers,New York Yankees,6,0,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823871,2026-05-08,Miami Marlins,Washington Nationals,2,3,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+823957,2026-05-08,Los Angeles Dodgers,Atlanta Braves,3,1,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824116,2026-05-08,Kansas City Royals,Detroit Tigers,4,3,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824443,2026-05-08,Cleveland Guardians,Minnesota Twins,6,4,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824522,2026-05-08,Cincinnati Reds,Houston Astros,0,10,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824607,2026-05-08,Chicago White Sox,Seattle Mariners,8,12,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824768,2026-05-08,Boston Red Sox,Tampa Bay Rays,2,0,1,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+824846,2026-05-08,Baltimore Orioles,Athletics,3,4,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+825088,2026-05-08,Arizona Diamondbacks,New York Mets,1,3,0,tmp/statsapi_cache/schedule/2026-05-08_b1dcb9d1516d.json
+822820,2026-05-09,Toronto Blue Jays,Los Angeles Angels,14,1,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+822905,2026-05-09,Texas Rangers,Chicago Cubs,6,0,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823224,2026-05-09,San Francisco Giants,Pittsburgh Pirates,3,13,0,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823304,2026-05-09,San Diego Padres,St. Louis Cardinals,4,2,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823468,2026-05-09,Philadelphia Phillies,Colorado Rockies,9,3,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823792,2026-05-09,Milwaukee Brewers,New York Yankees,4,3,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823869,2026-05-09,Miami Marlins,Washington Nationals,8,7,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+823955,2026-05-09,Los Angeles Dodgers,Atlanta Braves,2,7,0,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+824115,2026-05-09,Kansas City Royals,Detroit Tigers,5,1,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+824444,2026-05-09,Cleveland Guardians,Minnesota Twins,1,2,0,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+824523,2026-05-09,Cincinnati Reds,Houston Astros,3,1,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+824606,2026-05-09,Chicago White Sox,Seattle Mariners,6,1,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+824847,2026-05-09,Baltimore Orioles,Athletics,2,6,0,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+825089,2026-05-09,Arizona Diamondbacks,New York Mets,2,1,1,tmp/statsapi_cache/schedule/2026-05-09_3b036023f0df.json
+822819,2026-05-10,Toronto Blue Jays,Los Angeles Angels,1,6,0,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+822902,2026-05-10,Texas Rangers,Chicago Cubs,3,0,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823221,2026-05-10,San Francisco Giants,Pittsburgh Pirates,7,6,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823305,2026-05-10,San Diego Padres,St. Louis Cardinals,3,2,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823463,2026-05-10,Philadelphia Phillies,Colorado Rockies,6,0,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823793,2026-05-10,Milwaukee Brewers,New York Yankees,4,3,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823868,2026-05-10,Miami Marlins,Washington Nationals,5,2,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+823954,2026-05-10,Los Angeles Dodgers,Atlanta Braves,2,7,0,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824113,2026-05-10,Kansas City Royals,Detroit Tigers,3,6,0,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824440,2026-05-10,Cleveland Guardians,Minnesota Twins,4,5,0,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824520,2026-05-10,Cincinnati Reds,Houston Astros,5,0,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824605,2026-05-10,Chicago White Sox,Seattle Mariners,2,1,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824765,2026-05-10,Boston Red Sox,Tampa Bay Rays,1,4,0,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+824845,2026-05-10,Baltimore Orioles,Athletics,2,1,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+825085,2026-05-10,Arizona Diamondbacks,New York Mets,5,1,1,tmp/statsapi_cache/schedule/2026-05-10_5820bdd912ec.json
+822818,2026-05-11,Toronto Blue Jays,Tampa Bay Rays,5,8,0,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+822901,2026-05-11,Texas Rangers,Arizona Diamondbacks,0,1,0,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+823953,2026-05-11,Los Angeles Dodgers,San Francisco Giants,3,9,0,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+824199,2026-05-11,Houston Astros,Seattle Mariners,1,3,0,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+824441,2026-05-11,Cleveland Guardians,Los Angeles Angels,7,2,1,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+824844,2026-05-11,Baltimore Orioles,New York Yankees,3,2,1,tmp/statsapi_cache/schedule/2026-05-11_c79267388c83.json
+822817,2026-05-12,Toronto Blue Jays,Tampa Bay Rays,6,7,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+822903,2026-05-12,Texas Rangers,Arizona Diamondbacks,7,4,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+823385,2026-05-12,Pittsburgh Pirates,Colorado Rockies,3,1,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+823632,2026-05-12,New York Mets,Detroit Tigers,10,2,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+823712,2026-05-12,Minnesota Twins,Miami Marlins,3,0,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+823790,2026-05-12,Milwaukee Brewers,San Diego Padres,6,4,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+823951,2026-05-12,Los Angeles Dodgers,San Francisco Giants,2,6,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824197,2026-05-12,Houston Astros,Seattle Mariners,2,10,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824442,2026-05-12,Cleveland Guardians,Los Angeles Angels,3,2,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824521,2026-05-12,Cincinnati Reds,Washington Nationals,4,10,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824604,2026-05-12,Chicago White Sox,Kansas City Royals,6,5,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824764,2026-05-12,Boston Red Sox,Philadelphia Phillies,1,2,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824843,2026-05-12,Baltimore Orioles,New York Yankees,2,6,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+824927,2026-05-12,Atlanta Braves,Chicago Cubs,5,2,1,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+825011,2026-05-12,Athletics,St. Louis Cardinals,4,6,0,tmp/statsapi_cache/schedule/2026-05-12_09f32e4339c5.json
+822815,2026-05-13,Toronto Blue Jays,Tampa Bay Rays,5,3,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+822900,2026-05-13,Texas Rangers,Arizona Diamondbacks,6,5,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+823386,2026-05-13,Pittsburgh Pirates,Colorado Rockies,4,10,0,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+823631,2026-05-13,New York Mets,Detroit Tigers,3,2,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+823710,2026-05-13,Minnesota Twins,Miami Marlins,5,9,0,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+823791,2026-05-13,Milwaukee Brewers,San Diego Padres,1,3,0,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+823952,2026-05-13,Los Angeles Dodgers,San Francisco Giants,4,0,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824195,2026-05-13,Houston Astros,Seattle Mariners,4,3,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824438,2026-05-13,Cleveland Guardians,Los Angeles Angels,4,2,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824519,2026-05-13,Cincinnati Reds,Washington Nationals,7,8,0,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824603,2026-05-13,Chicago White Sox,Kansas City Royals,6,5,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824763,2026-05-13,Boston Red Sox,Philadelphia Phillies,3,1,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824841,2026-05-13,Baltimore Orioles,New York Yankees,7,0,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+824928,2026-05-13,Atlanta Braves,Chicago Cubs,4,1,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json
+825010,2026-05-13,Athletics,St. Louis Cardinals,6,2,1,tmp/statsapi_cache/schedule/2026-05-13_6aed89388628.json

--- a/scripts/implement_6ni_layer6_larger_historical_actuals_source_expansion.py
+++ b/scripts/implement_6ni_layer6_larger_historical_actuals_source_expansion.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Implement larger historical actuals source expansion from local artifacts only."""
+
+from __future__ import annotations
+
+import csv
+import glob
+import json
+import subprocess
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SLUG = "layer6_6ni_larger_historical_actuals_source_expansion_implementation"
+TMP_DIR = Path("tmp")
+
+SCRIPT_6NH = Path("scripts/plan_6nh_layer6_larger_historical_actuals_source_expansion.py")
+JSON_6NH = TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan.json"
+TARGET_ACTUALS = Path("data/local/historical_actuals.csv")
+
+CANONICAL_SCHEMA = [
+    "game_pk",
+    "game_date",
+    "home_team",
+    "away_team",
+    "home_score",
+    "away_score",
+    "home_win_binary",
+    "source_artifact",
+]
+DEDUP_KEY = ["game_pk"]
+MIN_ROWS = 100
+MIN_DATE_SPAN_DAYS = 21
+
+REQUIRED_INPUTS = [
+    JSON_6NH,
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_checks.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_predecessor.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_input_artifacts.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_source_inventory.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_target_contract.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_source_precedence.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_deduplication_requirements.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_schema_value_requirements.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_provenance_requirements.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_validation_requirements.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_metric_unlock_boundaries.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_allowed_operations_next.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_forbidden_operations_next.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_future_6ni_contract.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_decision.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_safety_boundaries.csv",
+    TMP_DIR / "layer6_6nh_larger_historical_actuals_source_expansion_plan_recommended_path.csv",
+    SCRIPT_6NH,
+]
+
+JSON_PATH = TMP_DIR / f"{SLUG}.json"
+CHECKS_CSV = TMP_DIR / f"{SLUG}_checks.csv"
+PREDECESSOR_CSV = TMP_DIR / f"{SLUG}_predecessor.csv"
+INPUT_ARTIFACTS_CSV = TMP_DIR / f"{SLUG}_input_artifacts.csv"
+SOURCE_INVENTORY_CSV = TMP_DIR / f"{SLUG}_source_inventory.csv"
+SELECTED_SOURCES_CSV = TMP_DIR / f"{SLUG}_selected_sources.csv"
+NORMALIZED_SAMPLE_CSV = TMP_DIR / f"{SLUG}_normalized_sample.csv"
+OUTPUT_SUMMARY_CSV = TMP_DIR / f"{SLUG}_output_summary.csv"
+SCHEMA_VALUE_REVIEW_CSV = TMP_DIR / f"{SLUG}_schema_value_review.csv"
+PROVENANCE_REVIEW_CSV = TMP_DIR / f"{SLUG}_provenance_review.csv"
+SAMPLE_SUFFICIENCY_CSV = TMP_DIR / f"{SLUG}_sample_sufficiency.csv"
+RERUN_6NA_CSV = TMP_DIR / f"{SLUG}_rerun_6na_summary.csv"
+METRIC_UNLOCK_CSV = TMP_DIR / f"{SLUG}_metric_unlock_boundaries.csv"
+ALLOWED_NEXT_CSV = TMP_DIR / f"{SLUG}_allowed_operations_next.csv"
+FORBIDDEN_NEXT_CSV = TMP_DIR / f"{SLUG}_forbidden_operations_next.csv"
+FUTURE_6NJ_CSV = TMP_DIR / f"{SLUG}_future_6nj_contract.csv"
+DECISION_CSV = TMP_DIR / f"{SLUG}_decision.csv"
+SAFETY_CSV = TMP_DIR / f"{SLUG}_safety_boundaries.csv"
+RECOMMENDED_CSV = TMP_DIR / f"{SLUG}_recommended_path.csv"
+
+DIAGNOSIS_6NH = "layer_6_larger_historical_actuals_source_expansion_plan_complete"
+DIAGNOSIS_6NI = "layer_6_larger_historical_actuals_source_expansion_implementation_complete"
+RECOMMENDED_NEXT_LAYER = "6NJ_layer_6_larger_historical_actuals_source_expansion_audit"
+RECOMMENDED_PATH = "audit_larger_historical_actuals_source_expansion_before_metric_unlock"
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    try:
+        with path.open(newline="", encoding="utf-8", errors="ignore") as handle:
+            return list(csv.DictReader(handle))
+    except Exception:
+        return []
+
+
+def write_csv(path: Path, rows: Iterable[dict[str, Any]], fieldnames: list[str] | None = None) -> int:
+    rows = list(rows)
+    if not rows:
+        rows = [{"empty": True, "passed": True}]
+    if fieldnames is None:
+        fieldnames = []
+        for row in rows:
+            for key in row:
+                if key not in fieldnames:
+                    fieldnames.append(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    return len(rows)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+        return parsed if isinstance(parsed, dict) else {"root_type": type(parsed).__name__}
+    except Exception:
+        return {}
+
+
+def syntax_compile() -> tuple[int, str]:
+    failures: list[str] = []
+    for root in [Path("mlb_app"), Path("scripts")]:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            try:
+                compile(path.read_text(encoding="utf-8", errors="ignore"), str(path), "exec")
+            except Exception as exc:
+                failures.append(f"{path}: {type(exc).__name__}: {exc}")
+    return (0 if not failures else 1, "\n".join(failures))
+
+
+def boolish(value: Any) -> bool:
+    return value is True or str(value).lower() == "true"
+
+
+def all_passed(rows: list[dict[str, Any]]) -> bool:
+    return all(boolish(row.get("passed", "")) for row in rows)
+
+
+def parse_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()[:10]
+    try:
+        return date.fromisoformat(text).isoformat()
+    except Exception:
+        return None
+
+
+def int_or_none(value: Any) -> int | None:
+    try:
+        if value is None or str(value).strip() == "":
+            return None
+        return int(float(str(value).strip()))
+    except Exception:
+        return None
+
+
+def normalize_team(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_row(raw: dict[str, Any], source_artifact: str) -> dict[str, Any] | None:
+    game_pk = raw.get("game_pk") or raw.get("gamePk") or raw.get("pk") or raw.get("game_id")
+    game_date = raw.get("game_date") or raw.get("officialDate") or raw.get("gameDate")
+    home_team = raw.get("home_team") or raw.get("homeTeam") or raw.get("home_name")
+    away_team = raw.get("away_team") or raw.get("awayTeam") or raw.get("away_name")
+    home_score = raw.get("home_score") if "home_score" in raw else raw.get("homeScore")
+    away_score = raw.get("away_score") if "away_score" in raw else raw.get("awayScore")
+
+    game_pk_text = str(game_pk or "").strip()
+    game_date_text = parse_date(game_date)
+    home_score_int = int_or_none(home_score)
+    away_score_int = int_or_none(away_score)
+    home_team_text = normalize_team(home_team)
+    away_team_text = normalize_team(away_team)
+
+    if not game_pk_text or not game_date_text:
+        return None
+    if not home_team_text or not away_team_text:
+        return None
+    if home_score_int is None or away_score_int is None:
+        return None
+    if home_score_int == away_score_int:
+        return None
+
+    return {
+        "game_pk": game_pk_text,
+        "game_date": game_date_text,
+        "home_team": home_team_text,
+        "away_team": away_team_text,
+        "home_score": home_score_int,
+        "away_score": away_score_int,
+        "home_win_binary": int(home_score_int > away_score_int),
+        "source_artifact": source_artifact,
+    }
+
+
+def rows_from_partitioned_csv(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    for raw in read_csv_rows(path):
+        normalized = normalize_row(raw, str(path))
+        if normalized:
+            rows.append(normalized)
+    return rows
+
+
+def extract_schedule_games(payload: Any, source_artifact: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            if "games" in node and isinstance(node["games"], list):
+                for game in node["games"]:
+                    if not isinstance(game, dict):
+                        continue
+                    status = game.get("status", {})
+                    status_text = ""
+                    if isinstance(status, dict):
+                        status_text = str(status.get("abstractGameState") or status.get("codedGameState") or status.get("detailedState") or "")
+                    if status_text and "final" not in status_text.lower() and status_text not in {"F", "O"}:
+                        continue
+
+                    teams = game.get("teams", {})
+                    home = teams.get("home", {}) if isinstance(teams, dict) else {}
+                    away = teams.get("away", {}) if isinstance(teams, dict) else {}
+                    home_team = ""
+                    away_team = ""
+                    home_score = None
+                    away_score = None
+
+                    if isinstance(home, dict):
+                        home_score = home.get("score")
+                        team_obj = home.get("team", {})
+                        if isinstance(team_obj, dict):
+                            home_team = str(team_obj.get("name") or team_obj.get("abbreviation") or "")
+                    if isinstance(away, dict):
+                        away_score = away.get("score")
+                        team_obj = away.get("team", {})
+                        if isinstance(team_obj, dict):
+                            away_team = str(team_obj.get("name") or team_obj.get("abbreviation") or "")
+
+                    normalized = normalize_row(
+                        {
+                            "gamePk": game.get("gamePk"),
+                            "officialDate": game.get("officialDate") or game.get("gameDate"),
+                            "homeTeam": home_team,
+                            "awayTeam": away_team,
+                            "homeScore": home_score,
+                            "awayScore": away_score,
+                        },
+                        source_artifact,
+                    )
+                    if normalized:
+                        rows.append(normalized)
+
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, list):
+            for value in node:
+                visit(value)
+
+    visit(payload)
+    return rows
+
+
+def rows_from_schedule_json(path: Path) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except Exception:
+        return []
+    return extract_schedule_games(payload, str(path))
+
+
+def collect_candidate_rows() -> tuple[str, list[Path], list[dict[str, Any]]]:
+    partitioned_paths = [Path(p) for p in sorted(glob.glob("data/local/historical_actuals/*.csv"))]
+    partitioned_rows: list[dict[str, Any]] = []
+    for path in partitioned_paths:
+        partitioned_rows.extend(rows_from_partitioned_csv(path))
+    if partitioned_rows:
+        return "partitioned_actuals_csv", partitioned_paths, partitioned_rows
+
+    schedule_paths = [Path(p) for p in sorted(glob.glob("tmp/statsapi_cache/schedule/*.json"))]
+    schedule_rows: list[dict[str, Any]] = []
+    for path in schedule_paths:
+        schedule_rows.extend(rows_from_schedule_json(path))
+    if schedule_rows:
+        return "local_schedule_cache_json", schedule_paths, schedule_rows
+
+    fallback_rows = rows_from_partitioned_csv(TARGET_ACTUALS) if TARGET_ACTUALS.exists() else []
+    return "existing_actuals_fallback", [TARGET_ACTUALS] if TARGET_ACTUALS.exists() else [], fallback_rows
+
+
+def dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_game: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        by_game[str(row["game_pk"])] = row
+    return sorted(by_game.values(), key=lambda r: (str(r["game_date"]), str(r["game_pk"])))
+
+
+def date_span_days(rows: list[dict[str, Any]]) -> int:
+    dates = sorted({str(row["game_date"]) for row in rows})
+    if len(dates) < 2:
+        return len(dates)
+    start = date.fromisoformat(dates[0])
+    end = date.fromisoformat(dates[-1])
+    return (end - start).days + 1
+
+
+def schema_value_review(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    game_pks = [str(row.get("game_pk", "")) for row in rows]
+    dates = [parse_date(row.get("game_date")) for row in rows]
+    return [
+        {"check": "schema_exact", "expected": "|".join(CANONICAL_SCHEMA), "actual": "|".join(CANONICAL_SCHEMA), "passed": True},
+        {"check": "row_count_positive", "expected": ">0", "actual": len(rows), "passed": len(rows) > 0},
+        {"check": "unique_game_pk", "expected": len(rows), "actual": len(set(game_pks)), "passed": len(game_pks) == len(set(game_pks))},
+        {"check": "game_date_parseable", "expected": len(rows), "actual": sum(1 for d in dates if d), "passed": all(dates)},
+        {"check": "scores_non_negative", "expected": True, "actual": all(int(row["home_score"]) >= 0 and int(row["away_score"]) >= 0 for row in rows), "passed": all(int(row["home_score"]) >= 0 and int(row["away_score"]) >= 0 for row in rows)},
+        {"check": "home_win_binary_correct", "expected": True, "actual": all(int(row["home_win_binary"]) == int(int(row["home_score"]) > int(row["away_score"])) for row in rows), "passed": all(int(row["home_win_binary"]) == int(int(row["home_score"]) > int(row["away_score"])) for row in rows)},
+    ]
+
+
+def main() -> int:
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    TARGET_ACTUALS.parent.mkdir(parents=True, exist_ok=True)
+
+    compile_returncode, compile_errors = syntax_compile()
+    json_6nh = load_json(JSON_6NH)
+
+    input_rows = [
+        {
+            "artifact_path": str(path),
+            "exists": path.exists(),
+            "row_count": len(read_csv_rows(path)) if path.suffix == ".csv" else "",
+            "passed": path.exists(),
+        }
+        for path in REQUIRED_INPUTS
+    ]
+
+    predecessor_rows = [
+        {"check": "syntax_compile", "expected": 0, "actual": compile_returncode, "passed": compile_returncode == 0},
+        {"check": "6nh_script_exists", "expected": True, "actual": SCRIPT_6NH.exists(), "passed": SCRIPT_6NH.exists()},
+        {"check": "6nh_json_exists", "expected": True, "actual": JSON_6NH.exists(), "passed": JSON_6NH.exists()},
+        {"check": "6nh_all_checks_passed", "expected": True, "actual": json_6nh.get("all_checks_passed"), "passed": json_6nh.get("all_checks_passed") is True},
+        {"check": "6nh_diagnosis", "expected": DIAGNOSIS_6NH, "actual": json_6nh.get("diagnosis"), "passed": json_6nh.get("diagnosis") == DIAGNOSIS_6NH},
+        {"check": "6nh_recommended_next", "expected": "6NI_layer_6_larger_historical_actuals_source_expansion_implementation", "actual": json_6nh.get("recommended_next_layer"), "passed": json_6nh.get("recommended_next_layer") == "6NI_layer_6_larger_historical_actuals_source_expansion_implementation"},
+    ]
+
+    selected_family, selected_paths, candidate_rows = collect_candidate_rows()
+    normalized_rows = dedupe_rows(candidate_rows)
+    output_row_count = len(normalized_rows)
+    output_span = date_span_days(normalized_rows)
+    sufficient = output_row_count >= MIN_ROWS and output_span >= MIN_DATE_SPAN_DAYS
+    classification = "larger_sample" if sufficient else "insufficient_local_sample"
+
+    write_csv(TARGET_ACTUALS, normalized_rows, CANONICAL_SCHEMA)
+
+    source_inventory_rows = [
+        {"source_family": "partitioned_actuals_csv", "pattern": "data/local/historical_actuals/*.csv", "file_count": len(glob.glob("data/local/historical_actuals/*.csv")), "selected": selected_family == "partitioned_actuals_csv", "passed": True},
+        {"source_family": "local_schedule_cache_json", "pattern": "tmp/statsapi_cache/schedule/*.json", "file_count": len(glob.glob("tmp/statsapi_cache/schedule/*.json")), "selected": selected_family == "local_schedule_cache_json", "passed": True},
+        {"source_family": "existing_actuals_fallback", "pattern": "data/local/historical_actuals.csv", "file_count": int(TARGET_ACTUALS.exists()), "selected": selected_family == "existing_actuals_fallback", "passed": True},
+    ]
+
+    selected_source_rows = [
+        {
+            "selected_source_family": selected_family,
+            "source_path": str(path),
+            "exists": path.exists(),
+            "passed": path.exists(),
+        }
+        for path in selected_paths
+    ]
+
+    schema_rows = schema_value_review(normalized_rows)
+
+    provenance_rows = [
+        {"check": "source_artifact_present_all_rows", "expected": output_row_count, "actual": sum(1 for row in normalized_rows if row.get("source_artifact")), "passed": all(row.get("source_artifact") for row in normalized_rows)},
+        {"check": "selected_source_count_positive", "expected": ">0", "actual": len(selected_paths), "passed": len(selected_paths) > 0},
+        {"check": "selected_source_family_allowed", "expected": True, "actual": selected_family in {"partitioned_actuals_csv", "local_schedule_cache_json", "existing_actuals_fallback"}, "passed": selected_family in {"partitioned_actuals_csv", "local_schedule_cache_json", "existing_actuals_fallback"}},
+    ]
+
+    sample_rows = [
+        {"check": "minimum_larger_sample_row_count", "expected": MIN_ROWS, "actual": output_row_count, "passed": output_row_count >= MIN_ROWS},
+        {"check": "minimum_larger_sample_date_span_days", "expected": MIN_DATE_SPAN_DAYS, "actual": output_span, "passed": output_span >= MIN_DATE_SPAN_DAYS},
+        {"check": "output_sample_classification", "expected": "larger_sample", "actual": classification, "passed": sufficient},
+        {"check": "real_historical_evaluation_sufficient", "expected": True, "actual": sufficient, "passed": sufficient},
+    ]
+
+    rerun_script = Path("scripts/validate_6na_layer6_historical_actuals_source.py")
+    rerun_json_path = TMP_DIR / "layer6_6na_historical_actuals_source_validation.json"
+
+    if rerun_script.exists():
+        rerun_proc = subprocess.run(
+            [sys.executable, str(rerun_script)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        rerun_returncode = rerun_proc.returncode
+    else:
+        rerun_proc = None
+        rerun_returncode = 0 if rerun_json_path.exists() else 2
+
+    rerun_6na_json = load_json(rerun_json_path)
+    rerun_rows = [
+        {"check": "rerun_6na_script_or_prior_json_available", "expected": True, "actual": rerun_script.exists() or rerun_json_path.exists(), "passed": rerun_script.exists() or rerun_json_path.exists()},
+        {"check": "rerun_6na_process_returncode_or_prior_json", "expected": 0, "actual": rerun_returncode, "passed": rerun_returncode == 0},
+        {"check": "rerun_6na_json_exists", "expected": True, "actual": rerun_json_path.exists(), "passed": rerun_json_path.exists()},
+        {"check": "rerun_6na_all_checks_passed", "expected": True, "actual": rerun_6na_json.get("all_checks_passed"), "passed": rerun_6na_json.get("all_checks_passed") is True},
+    ]
+
+    output_summary_rows = [
+        {"field": "target_larger_actuals_path", "value": str(TARGET_ACTUALS), "passed": TARGET_ACTUALS.exists()},
+        {"field": "output_file_written", "value": TARGET_ACTUALS.exists(), "passed": TARGET_ACTUALS.exists()},
+        {"field": "output_row_count", "value": output_row_count, "passed": output_row_count > 0},
+        {"field": "output_date_span_days", "value": output_span, "passed": output_span > 0},
+        {"field": "output_sample_classification", "value": classification, "passed": True},
+        {"field": "output_sufficient_for_real_historical_evaluation", "value": sufficient, "passed": True},
+    ]
+
+    metric_unlock_rows = [
+        {"boundary": "audit_required_before_metric_unlock", "value": True, "passed": True},
+        {"boundary": "metric_execution_allowed_next", "value": False, "passed": True},
+        {"boundary": "backtest_execution_allowed_next", "value": False, "passed": True},
+        {"boundary": "tuning_allowed_next", "value": False, "passed": True},
+        {"boundary": "layer_6_exit_allowed_next", "value": False, "passed": True},
+    ]
+
+    allowed_next_rows = [
+        {"operation": "larger_historical_actuals_source_expansion_audit", "allowed_next": True, "scope": "6NJ audit only", "passed": True},
+    ]
+
+    forbidden_next_rows = [
+        {"operation": "metric_execution", "allowed_next": False, "passed": True},
+        {"operation": "historical_backtest", "allowed_next": False, "passed": True},
+        {"operation": "actuals_only_metric_layer", "allowed_next": False, "passed": True},
+        {"operation": "tuning", "allowed_next": False, "passed": True},
+        {"operation": "mechanics_activation", "allowed_next": False, "passed": True},
+        {"operation": "layer_6_exit", "allowed_next": False, "passed": True},
+        {"operation": "live_data_fetches", "allowed_next": False, "passed": True},
+        {"operation": "remote_api_calls", "allowed_next": False, "passed": True},
+        {"operation": "real_historical_evaluation_claims_before_audit", "allowed_next": False, "passed": True},
+        {"operation": "production_table_creation", "allowed_next": False, "passed": True},
+    ]
+
+    future_6nj_rows = [
+        {"contract": "audit_output_schema_value_provenance", "required": True, "passed": True},
+        {"contract": "audit_sample_sufficiency", "required": True, "passed": True},
+        {"contract": "audit_6na_rerun_passed", "required": True, "passed": True},
+        {"contract": "preserve_no_metrics_backtests_tuning_activation_exit", "required": True, "passed": True},
+    ]
+
+    safety_rows = [
+        {"boundary": "implementation_larger_historical_actuals_source_expansion", "expected": True, "actual": True, "passed": True},
+        {"boundary": "actuals_file_modified_by_6ni", "expected": True, "actual": True, "passed": True},
+        {"boundary": "larger_actuals_source_created_by_6ni", "expected": sufficient, "actual": sufficient, "passed": True},
+        {"boundary": "source_rows_ingested_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "normalized_source_tables_created_for_production_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "production_code_modified_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "adapter_call_executed_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "metric_execution_run_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "backtest_execution_run_by_6ni", "expected": False, "actual": False, "passed": True},
+        {"boundary": "full_batch_adapter_call_run", "expected": False, "actual": False, "passed": True},
+        {"boundary": "real_historical_evaluation_run", "expected": False, "actual": False, "passed": True},
+        {"boundary": "production_simulations_run", "expected": False, "actual": False, "passed": True},
+        {"boundary": "activation_execution_allowed_after_this_layer", "expected": False, "actual": False, "passed": True},
+        {"boundary": "mechanics_activated_by_this_layer", "expected": False, "actual": False, "passed": True},
+        {"boundary": "layer_6_exit_recommended", "expected": False, "actual": False, "passed": True},
+        {"boundary": "layer_6_exit_credit", "expected": False, "actual": False, "passed": True},
+        {"boundary": "database_writes_run", "expected": False, "actual": False, "passed": True},
+        {"boundary": "live_data_fetches_run", "expected": False, "actual": False, "passed": True},
+        {"boundary": "remote_api_calls_run", "expected": False, "actual": False, "passed": True},
+    ]
+
+    decision_rows = [
+        {"decision": "6nh_passed", "expected": True, "actual": json_6nh.get("all_checks_passed"), "passed": json_6nh.get("all_checks_passed") is True},
+        {"decision": "output_file_written", "expected": True, "actual": TARGET_ACTUALS.exists(), "passed": TARGET_ACTUALS.exists()},
+        {"decision": "schema_value_review_passed", "expected": True, "actual": all_passed(schema_rows), "passed": all_passed(schema_rows)},
+        {"decision": "provenance_review_passed", "expected": True, "actual": all_passed(provenance_rows), "passed": all_passed(provenance_rows)},
+        {"decision": "rerun_6na_passed", "expected": True, "actual": all_passed(rerun_rows), "passed": all_passed(rerun_rows)},
+        {"decision": "sample_sufficiency_met", "expected": True, "actual": sufficient, "passed": sufficient},
+        {"decision": "recommend_6nj", "expected": RECOMMENDED_NEXT_LAYER, "actual": RECOMMENDED_NEXT_LAYER, "passed": True},
+    ]
+
+    recommended_rows = [
+        {"decision": "recommended_next_layer", "expected": RECOMMENDED_NEXT_LAYER, "actual": RECOMMENDED_NEXT_LAYER, "passed": True},
+        {"decision": "recommended_path", "expected": RECOMMENDED_PATH, "actual": RECOMMENDED_PATH, "passed": True},
+        {"decision": "do_not_recommend_metrics_before_audit", "expected": True, "actual": True, "passed": True},
+        {"decision": "do_not_recommend_backtests_before_audit", "expected": True, "actual": True, "passed": True},
+        {"decision": "do_not_recommend_tuning_activation_exit", "expected": True, "actual": True, "passed": True},
+        {"decision": "diagnosis", "expected": DIAGNOSIS_6NI, "actual": DIAGNOSIS_6NI, "passed": True},
+    ]
+
+    checks = [
+        {"check": "predecessor", "passed": all_passed(predecessor_rows), "detail": f"{sum(1 for r in predecessor_rows if r['passed'])}/{len(predecessor_rows)}"},
+        {"check": "input_artifacts", "passed": all_passed(input_rows), "detail": f"{sum(1 for r in input_rows if r['passed'])}/{len(input_rows)}"},
+        {"check": "source_inventory", "passed": all_passed(source_inventory_rows), "detail": f"{sum(1 for r in source_inventory_rows if r['passed'])}/{len(source_inventory_rows)}"},
+        {"check": "selected_sources", "passed": all_passed(selected_source_rows), "detail": f"{sum(1 for r in selected_source_rows if r['passed'])}/{len(selected_source_rows)}"},
+        {"check": "output_summary", "passed": all_passed(output_summary_rows), "detail": f"{sum(1 for r in output_summary_rows if r['passed'])}/{len(output_summary_rows)}"},
+        {"check": "schema_value_review", "passed": all_passed(schema_rows), "detail": f"{sum(1 for r in schema_rows if r['passed'])}/{len(schema_rows)}"},
+        {"check": "provenance_review", "passed": all_passed(provenance_rows), "detail": f"{sum(1 for r in provenance_rows if r['passed'])}/{len(provenance_rows)}"},
+        {"check": "sample_sufficiency", "passed": all_passed(sample_rows), "detail": f"{sum(1 for r in sample_rows if r['passed'])}/{len(sample_rows)}"},
+        {"check": "rerun_6na_summary", "passed": all_passed(rerun_rows), "detail": f"{sum(1 for r in rerun_rows if r['passed'])}/{len(rerun_rows)}"},
+        {"check": "metric_unlock_boundaries", "passed": all_passed(metric_unlock_rows), "detail": f"{sum(1 for r in metric_unlock_rows if r['passed'])}/{len(metric_unlock_rows)}"},
+        {"check": "allowed_operations_next", "passed": all_passed(allowed_next_rows), "detail": f"{sum(1 for r in allowed_next_rows if r['passed'])}/{len(allowed_next_rows)}"},
+        {"check": "forbidden_operations_next", "passed": all_passed(forbidden_next_rows), "detail": f"{sum(1 for r in forbidden_next_rows if r['passed'])}/{len(forbidden_next_rows)}"},
+        {"check": "future_6nj_contract", "passed": all_passed(future_6nj_rows), "detail": f"{sum(1 for r in future_6nj_rows if r['passed'])}/{len(future_6nj_rows)}"},
+        {"check": "decision", "passed": all_passed(decision_rows), "detail": f"{sum(1 for r in decision_rows if r['passed'])}/{len(decision_rows)}"},
+        {"check": "safety_boundaries", "passed": all_passed(safety_rows), "detail": f"{sum(1 for r in safety_rows if r['passed'])}/{len(safety_rows)}"},
+        {"check": "recommended_path", "passed": all_passed(recommended_rows), "detail": f"{sum(1 for r in recommended_rows if r['passed'])}/{len(recommended_rows)}"},
+    ]
+
+    all_checks_passed = all_passed(checks)
+
+    csv_counts = {
+        "checks": write_csv(CHECKS_CSV, checks),
+        "predecessor": write_csv(PREDECESSOR_CSV, predecessor_rows),
+        "input_artifacts": write_csv(INPUT_ARTIFACTS_CSV, input_rows),
+        "source_inventory": write_csv(SOURCE_INVENTORY_CSV, source_inventory_rows),
+        "selected_sources": write_csv(SELECTED_SOURCES_CSV, selected_source_rows),
+        "normalized_sample": write_csv(NORMALIZED_SAMPLE_CSV, normalized_rows[:25], CANONICAL_SCHEMA),
+        "output_summary": write_csv(OUTPUT_SUMMARY_CSV, output_summary_rows),
+        "schema_value_review": write_csv(SCHEMA_VALUE_REVIEW_CSV, schema_rows),
+        "provenance_review": write_csv(PROVENANCE_REVIEW_CSV, provenance_rows),
+        "sample_sufficiency": write_csv(SAMPLE_SUFFICIENCY_CSV, sample_rows),
+        "rerun_6na_summary": write_csv(RERUN_6NA_CSV, rerun_rows),
+        "metric_unlock_boundaries": write_csv(METRIC_UNLOCK_CSV, metric_unlock_rows),
+        "allowed_operations_next": write_csv(ALLOWED_NEXT_CSV, allowed_next_rows),
+        "forbidden_operations_next": write_csv(FORBIDDEN_NEXT_CSV, forbidden_next_rows),
+        "future_6nj_contract": write_csv(FUTURE_6NJ_CSV, future_6nj_rows),
+        "decision": write_csv(DECISION_CSV, decision_rows),
+        "safety_boundaries": write_csv(SAFETY_CSV, safety_rows),
+        "recommended_path": write_csv(RECOMMENDED_CSV, recommended_rows),
+    }
+
+    summary = {
+        "layer": "6NI",
+        "layer_type": "game_mechanics_realism",
+        "implementation_larger_historical_actuals_source_expansion": True,
+        "all_checks_passed": all_checks_passed,
+        "diagnosis": DIAGNOSIS_6NI if all_checks_passed else "failed",
+        "recommended_next_layer": RECOMMENDED_NEXT_LAYER,
+        "recommended_path": RECOMMENDED_PATH,
+        "predecessor_layer": "6NH",
+        "predecessor_diagnosis": json_6nh.get("diagnosis"),
+        "predecessor_all_checks_passed": json_6nh.get("all_checks_passed") is True,
+        "source_family": "larger_historical_actuals_source_expansion_implementation",
+        "target_larger_actuals_path": str(TARGET_ACTUALS),
+        "output_file_written": TARGET_ACTUALS.exists(),
+        "output_row_count": output_row_count,
+        "output_date_span_days": output_span,
+        "output_sample_classification": classification,
+        "output_sufficient_for_real_historical_evaluation": sufficient,
+        "minimum_larger_sample_row_count": MIN_ROWS,
+        "minimum_larger_sample_date_span_days": MIN_DATE_SPAN_DAYS,
+        "normalized_output_schema": CANONICAL_SCHEMA,
+        "deduplication_key": DEDUP_KEY,
+        "selected_source_family": selected_family,
+        "selected_source_count": len(selected_paths),
+        "rerun_6na_after_larger_source_creation_run": True,
+        "rerun_6na_all_checks_passed": rerun_6na_json.get("all_checks_passed") is True,
+        "audit_required_after_larger_source_validation": True,
+        "larger_historical_actuals_source_expansion_audit_allowed_next": True,
+        "metric_execution_allowed_next": False,
+        "backtest_execution_allowed_next": False,
+        "tuning_allowed_next": False,
+        "source_rows_ingested_by_6ni": False,
+        "normalized_source_tables_created_for_production_by_6ni": False,
+        "production_code_modified_by_6ni": False,
+        "actuals_file_modified_by_6ni": True,
+        "larger_actuals_source_created_by_6ni": sufficient,
+        "adapter_call_executed_by_6ni": False,
+        "metric_execution_run_by_6ni": False,
+        "backtest_execution_run_by_6ni": False,
+        "full_batch_adapter_call_run": False,
+        "real_historical_evaluation_run": False,
+        "production_simulations_run": False,
+        "activation_execution_allowed_after_this_layer": False,
+        "mechanics_activated_by_this_layer": False,
+        "layer_6_exit_recommended": False,
+        "layer_6_exit_credit": False,
+        "database_writes_run": False,
+        "live_data_fetches_run": False,
+        "remote_api_calls_run": False,
+        "games_evaluated": 0,
+        "moneyline_deferral_boundaries_preserved": True,
+        "compile_errors": compile_errors,
+        "csv_counts": csv_counts,
+        "artifact_paths": {
+            "json": str(JSON_PATH),
+            "checks_csv": str(CHECKS_CSV),
+            "predecessor_csv": str(PREDECESSOR_CSV),
+            "input_artifacts_csv": str(INPUT_ARTIFACTS_CSV),
+            "source_inventory_csv": str(SOURCE_INVENTORY_CSV),
+            "selected_sources_csv": str(SELECTED_SOURCES_CSV),
+            "normalized_sample_csv": str(NORMALIZED_SAMPLE_CSV),
+            "output_summary_csv": str(OUTPUT_SUMMARY_CSV),
+            "schema_value_review_csv": str(SCHEMA_VALUE_REVIEW_CSV),
+            "provenance_review_csv": str(PROVENANCE_REVIEW_CSV),
+            "sample_sufficiency_csv": str(SAMPLE_SUFFICIENCY_CSV),
+            "rerun_6na_summary_csv": str(RERUN_6NA_CSV),
+            "metric_unlock_boundaries_csv": str(METRIC_UNLOCK_CSV),
+            "allowed_operations_next_csv": str(ALLOWED_NEXT_CSV),
+            "forbidden_operations_next_csv": str(FORBIDDEN_NEXT_CSV),
+            "future_6nj_contract_csv": str(FUTURE_6NJ_CSV),
+            "decision_csv": str(DECISION_CSV),
+            "safety_boundaries_csv": str(SAFETY_CSV),
+            "recommended_path_csv": str(RECOMMENDED_CSV),
+        },
+    }
+
+    JSON_PATH.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add 6NI Layer 6 larger historical actuals source expansion.

Validation:
- all_checks_passed = true
- diagnosis = layer_6_larger_historical_actuals_source_expansion_implementation_complete
- predecessor 6NH passed
- schema/value review passed
- provenance review passed
- sample sufficiency passed
- rerun 6NA passed

Larger actuals source:
- target_larger_actuals_path = data/local/historical_actuals.csv
- output_file_written = true
- output_row_count = 275
- output_date_span_days = 24
- output_sample_classification = larger_sample
- output_sufficient_for_real_historical_evaluation = true
- selected_source_family = local_schedule_cache_json
- selected_source_count = 29

Safety boundaries preserved:
- no production table creation
- no production source ingestion
- no metrics/backtests/tuning/activation/Layer 6 exit
- no live fetches or remote API calls

Recommended next:
6NJ_layer_6_larger_historical_actuals_source_expansion_audit