### PR TITLE
Tighten Model Tracker projection view and collapse game breakdown

### DIFF
--- a/frontend/src/lib/modelTrackerPnl.mjs
+++ b/frontend/src/lib/modelTrackerPnl.mjs
@@ -39,13 +39,28 @@ export function normalizeStatus(value) {
   return String(value || '').trim().toLowerCase().replace(/\s+/g, '_')
 }
 
+function probabilityCandidate(value) {
+  const n = toNumber(value)
+  return n !== null && n >= 0 && n <= 1 ? n : null
+}
+
 export function numericScore(row) {
-  const candidates = [row?.confidence, row?.score, row?.model_probability].map(toNumber).filter(v => v !== null)
+  const candidates = [row?.confidence, row?.score, row?.model_probability].map(probabilityCandidate).filter(v => v !== null)
   return candidates.length ? Math.max(...candidates) : null
 }
 
+export function projectionValue(row) {
+  const score = toNumber(row?.score)
+  if (score !== null && score > 1) return score
+  return toNumber(row?.projection) ?? toNumber(row?.projected_total) ?? toNumber(row?.raw_payload?.projected_total) ?? toNumber(row?.raw_payload?.projection)
+}
+
+export function signalValue(row) {
+  return numericScore(row) ?? projectionValue(row) ?? toNumber(row?.expected_value) ?? toNumber(row?.edge)
+}
+
 export function confidenceBand(value) {
-  const n = toNumber(value)
+  const n = probabilityCandidate(value)
   if (n === null) return 'Unavailable'
   if (n >= 0.65) return '.65+'
   if (n >= 0.60) return '.60-.64'
@@ -88,12 +103,13 @@ export function recommendationBucket(row) {
   const score = numericScore(row)
   const edge = toNumber(row?.edge)
   const ev = toNumber(row?.expected_value)
+  const projection = projectionValue(row)
   const hasIdentity = Boolean(row?.pick_label || row?.player_name || row?.team_name)
-  const hasMetrics = [score, edge, ev, toNumber(row?.model_probability)].some(v => v !== null)
+  const hasMetrics = [score, edge, ev, projection].some(v => v !== null)
   if (!hasIdentity && !hasMetrics) return 'missing_data'
   if (isRejectedNoBet(row)) return 'rejected'
   if (status.includes('strong') || status.includes('recommended') || (score !== null && score >= 0.55) || (edge !== null && edge > 0) || (ev !== null && ev > 0)) return 'recommended'
-  if (row?.grade === 'watchlist_only' || row?.grade === 'ungraded' || (score !== null && score >= 0.50)) return 'lean'
+  if (projection !== null || row?.grade === 'watchlist_only' || row?.grade === 'ungraded' || (score !== null && score >= 0.50)) return 'lean'
   return 'missing_data'
 }
 
@@ -358,6 +374,7 @@ export function indexSeries(series = [], prefix = 'current') {
 
 export function playRank(row) {
   return {
+    projection: projectionValue(row) ?? -Infinity,
     score: numericScore(row) ?? -Infinity,
     edge: toNumber(row?.edge) ?? -Infinity,
     expected_value: toNumber(row?.expected_value) ?? -Infinity,
@@ -368,7 +385,40 @@ export function playRank(row) {
 export function comparePlayRank(a, b) {
   const ar = playRank(a)
   const br = playRank(b)
-  return (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.has_price - ar.has_price)
+  return (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.projection - ar.projection) || (br.has_price - ar.has_price)
+}
+
+export function compareModelOutputRank(a, b) {
+  const ar = playRank(a)
+  const br = playRank(b)
+  return (br.projection - ar.projection) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.has_price - ar.has_price)
+}
+
+export function modelOutputKey(row) {
+  return [
+    row?.game_pk || 'ungrouped',
+    row?.away_team || '',
+    row?.home_team || '',
+    row?.market_type || row?.pick_type || '',
+    row?.pick_label || row?.player_name || row?.team_name || row?.model_name || '',
+    toNumber(row?.line) ?? '',
+    projectionValue(row) ?? '',
+    numericScore(row) ?? '',
+    toNumber(row?.edge) ?? '',
+    toNumber(row?.expected_value) ?? '',
+  ].join('|').toLowerCase()
+}
+
+export function uniqueModelOutputs(rows = []) {
+  const seen = new Set()
+  const output = []
+  rows.forEach(row => {
+    const key = modelOutputKey(row)
+    if (seen.has(key)) return
+    seen.add(key)
+    output.push(row)
+  })
+  return output
 }
 
 export function gameFilterValue(value) {
@@ -392,11 +442,12 @@ export function groupRowsByGame(rows = [], games = []) {
       buckets: { recommended: [], lean: [], low_confidence: [] },
       sources: [],
       best_score: null,
+      best_projection: null,
       best_edge: null,
       price_count: 0,
     })
   })
-  rows.forEach(row => {
+  uniqueModelOutputs(rows).forEach(row => {
     const key = gameFilterValue(row.game_pk)
     const game = map.get(key) || {
       key,
@@ -410,16 +461,19 @@ export function groupRowsByGame(rows = [], games = []) {
       buckets: { recommended: [], lean: [], low_confidence: [] },
       sources: [],
       best_score: null,
+      best_projection: null,
       best_edge: null,
       price_count: 0,
     }
     const bucket = productionBucket(row)
     const score = numericScore(row)
+    const projection = projectionValue(row)
     const edge = toNumber(row.edge)
     game.rows.push(row)
     game.buckets[bucket].push(row)
     if (row.source && !game.sources.includes(row.source)) game.sources.push(row.source)
     if (score !== null) game.best_score = game.best_score === null ? score : Math.max(game.best_score, score)
+    if (projection !== null) game.best_projection = game.best_projection === null ? projection : Math.max(game.best_projection, projection)
     if (edge !== null) game.best_edge = game.best_edge === null ? edge : Math.max(game.best_edge, edge)
     if (rowHasPrice(row)) game.price_count += 1
     map.set(key, game)
@@ -430,14 +484,20 @@ export function groupRowsByGame(rows = [], games = []) {
       ...game,
       buckets: {
         recommended: game.buckets.recommended.sort(comparePlayRank),
-        lean: game.buckets.lean.sort(comparePlayRank),
+        lean: game.buckets.lean.sort(compareModelOutputRank),
         low_confidence: game.buckets.low_confidence.sort(comparePlayRank),
       },
-      rows: game.rows.sort(comparePlayRank),
+      rows: game.rows.sort(compareModelOutputRank),
     }))
     .sort((a, b) => String(a.game_time || '').localeCompare(String(b.game_time || '')) || a.label.localeCompare(b.label))
 }
 
 export function highestConfidenceRows(rows = []) {
-  return rows.filter(row => productionBucket(row) === 'recommended').sort(comparePlayRank)
+  return uniqueModelOutputs(rows).filter(row => productionBucket(row) === 'recommended').sort(comparePlayRank)
+}
+
+export function topModelProjectionRows(rows = []) {
+  return uniqueModelOutputs(rows)
+    .filter(row => projectionValue(row) !== null || numericScore(row) !== null || toNumber(row?.edge) !== null || toNumber(row?.expected_value) !== null)
+    .sort(compareModelOutputRank)
 }

--- a/frontend/src/lib/modelTrackerPnl.test.mjs
+++ b/frontend/src/lib/modelTrackerPnl.test.mjs
@@ -12,10 +12,14 @@ import {
   groupRowsByGame,
   highestConfidenceRows,
   maxDrawdown,
+  numericScore,
   periodDateKeys,
   productionBucketLabel,
+  projectionValue,
   recommendationBucket,
   summarizePnl,
+  topModelProjectionRows,
+  uniqueModelOutputs,
 } from './modelTrackerPnl.mjs'
 
 test('americanOddsToProfit handles positive odds wins', () => {
@@ -36,6 +40,13 @@ test('confidenceBand and edgeBand bucket values deterministically', () => {
   assert.equal(confidenceBand(0.66), '.65+')
   assert.equal(edgeBand(0.073), '+5% to +9.9%')
   assert.equal(edgeBand(-0.01), 'Negative')
+})
+
+test('projection values are not treated as probability confidence', () => {
+  const row = { pick_label: 'Projected total 10.8301', score: 10.8301 }
+  assert.equal(numericScore(row), null)
+  assert.equal(projectionValue(row), 10.8301)
+  assert.equal(recommendationBucket(row), 'lean')
 })
 
 test('summarizePnl excludes pending rows from realized P&L', () => {
@@ -87,11 +98,19 @@ test('comparePeriods returns current, previous, and deltas', () => {
   assert.equal(comparison.deltas.profit, 200)
 })
 
+test('uniqueModelOutputs collapses duplicate projection rows', () => {
+  const rows = uniqueModelOutputs([
+    { game_pk: 1, market_type: 'total', pick_label: 'Projected total 10.8301', score: 10.8301, grade: 'watchlist_only' },
+    { game_pk: 1, market_type: 'total', pick_label: 'Projected total 10.8301', score: 10.8301, grade: 'ungraded' },
+  ])
+  assert.equal(rows.length, 1)
+})
+
 test('groupRowsByGame creates production buckets per game', () => {
   const games = [{ game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', game_time: '2026-06-16T18:10:00Z' }]
   const grouped = groupRowsByGame([
     { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Cubs ML', confidence: 0.61, edge: 0.05, price: 120 },
-    { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Brewers F5 lean', confidence: 0.51, grade: 'watchlist_only' },
+    { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Projected total 10.4', score: 10.4, grade: 'watchlist_only' },
     { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'No play total', recommendation_status: 'no_bet', confidence: 0.70 },
   ], games)
   assert.equal(grouped.length, 1)
@@ -102,13 +121,22 @@ test('groupRowsByGame creates production buckets per game', () => {
   assert.equal(grouped[0].price_count, 1)
 })
 
-test('highestConfidenceRows sorts by confidence, edge, expected value, then price availability', () => {
+test('highestConfidenceRows sorts by probability confidence and excludes no-bet rows', () => {
   const rows = highestConfidenceRows([
     { pick_label: 'Lower score', confidence: 0.56, edge: 0.30, expected_value: 2, price: 100 },
     { pick_label: 'Top score', confidence: 0.62, edge: 0.01, expected_value: 1 },
     { pick_label: 'No play', recommendation_status: 'no_bet', confidence: 0.99 },
   ])
   assert.deepEqual(rows.map(row => row.pick_label), ['Top score', 'Lower score'])
+})
+
+test('topModelProjectionRows showcases projection values first', () => {
+  const rows = topModelProjectionRows([
+    { pick_label: 'Projected total 10.6', score: 10.6 },
+    { pick_label: 'Projected total 10.9', score: 10.9 },
+    { pick_label: 'Probability play', confidence: 0.65 },
+  ])
+  assert.deepEqual(rows.map(row => row.pick_label), ['Projected total 10.9', 'Projected total 10.6', 'Probability play'])
 })
 
 test('period windows generate correct DoD, WoW, and MoM ranges', () => {

--- a/frontend/src/pages/ModelTrackerPage.jsx
+++ b/frontend/src/pages/ModelTrackerPage.jsx
@@ -5,23 +5,22 @@ import {
   UNIT_SIZE_DOLLARS,
   buildPeriodComparison,
   comparePlayRank,
-  confidenceBand,
   dailySeries,
   effectivePrice,
-  edgeBand,
   gameFilterValue,
   gameLabel,
   groupProfit,
   groupRowsByGame,
-  highestConfidenceRows,
   maxDrawdown,
   numericScore,
   periodDateKeys,
   productionBucketLabel,
+  projectionValue,
   recommendationBucket,
   rowHasPrice,
   summarizePnl,
   toNumber,
+  topModelProjectionRows,
 } from '../lib/modelTrackerPnl.mjs'
 
 const API = API_BASE
@@ -61,7 +60,9 @@ const s = {
   warnChip: { border: '1px solid rgba(250,204,21,0.42)', borderRadius: 999, padding: '4px 8px', fontSize: 11, color: '#fef08a', fontWeight: 900, background: 'rgba(113,63,18,0.26)' },
   bucketGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 12, marginTop: 12 },
   bucket: { border: '1px solid rgba(148,163,184,0.14)', borderRadius: 14, padding: 12, background: 'rgba(15,23,42,0.44)', minWidth: 0 },
-  playRow: { display: 'grid', gap: 7, borderTop: '1px solid rgba(148,163,184,0.12)', paddingTop: 10, marginTop: 10 },
+  playRow: { display: 'grid', gap: 6, borderTop: '1px solid rgba(148,163,184,0.12)', paddingTop: 9, marginTop: 9 },
+  topGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: 10 },
+  topCard: { border: '1px solid rgba(148,163,184,0.16)', borderRadius: 14, padding: 12, background: 'rgba(8,12,20,0.42)', minWidth: 0 },
   rowTitle: { color: 'var(--text-primary)', fontSize: 13, fontWeight: 900, overflowWrap: 'anywhere' },
   tableWrap: { overflowX: 'auto', overflowY: 'hidden', WebkitOverflowScrolling: 'touch', border: '1px solid var(--border-subtle)', borderRadius: 14, scrollbarGutter: 'stable' },
   table: { width: 'max-content', minWidth: '100%', borderCollapse: 'collapse', fontSize: 12 },
@@ -74,14 +75,17 @@ function fmt(value, digits = 3) { if (value === null || value === undefined || v
 function fmtPct(value, digits = 1) { const n = toNumber(value); return n === null ? 'Unavailable' : `${(n * 100).toFixed(digits)}%` }
 function fmtMoney(value) { const n = toNumber(value); if (n === null) return 'Unavailable'; return `${n > 0 ? '+' : n < 0 ? '-' : ''}$${Math.abs(n).toFixed(0)}` }
 function fmtUnits(value) { const n = toNumber(value); return n === null ? 'Unavailable' : `${n > 0 ? '+' : ''}${n.toFixed(2)}u` }
-function fmtPrice(value) { const n = toNumber(value); return n === null ? 'Price unavailable' : n > 0 ? `+${n}` : String(n) }
+function fmtPrice(value) { const n = toNumber(value); return n === null ? null : n > 0 ? `+${n}` : String(n) }
 function textValue(value) { if (value === null || value === undefined || value === '') return ''; if (typeof value === 'string') return value; try { return JSON.stringify(value) } catch { return String(value) } }
 function parseMaybeJson(value) { if (!value) return null; if (typeof value === 'object') return value; try { return JSON.parse(value) } catch { return null } }
 function compactValue(value) { if (value === null || value === undefined || value === '') return 'Unavailable'; if (Array.isArray(value)) return value.filter(Boolean).slice(0, 3).map(textValue).join(', ') || 'Unavailable'; if (typeof value === 'object') return Object.keys(value).slice(0, 3).map(key => `${key}: ${compactValue(value[key])}`).join(' · ') || 'Unavailable'; return String(value) }
 function rowIdentity(row) { return row.pick_label || row.player_name || row.team_name || row.model_name || 'Tracked output' }
 function gradeLabel(row) { if (row.grade === 'pending') return 'Pending Result'; if (row.result_status === 'live') return 'Live Tracking'; if (row.result_status === 'final' && row.grade === 'ungraded') return 'Final Ungraded'; if (GRADED.includes(row.grade)) return 'Graded'; if (row.grade === 'watchlist_only') return 'Watchlist'; if (row.grade === 'ungraded') return 'Awaiting Result'; return row.grade || 'Untracked' }
-function topReason(row) { if (Array.isArray(row.reasoning) && row.reasoning.length) return compactValue(row.reasoning[0]); return textValue(row.primary_reason) || textValue(row.grade_reason) || 'No reason stored.' }
+function topReason(row) { if (Array.isArray(row.reasoning) && row.reasoning.length) return compactValue(row.reasoning[0]); return textValue(row.primary_reason) || textValue(row.grade_reason) || '' }
+function shortReason(row) { const reason = topReason(row); return reason.length > 130 ? `${reason.slice(0, 130)}...` : reason }
 function normalizePayloadRows(payload) { return (payload?.rows || []).map(row => { const next = { ...row, reasoning: parseMaybeJson(row.reasoning) || row.reasoning, features_used: parseMaybeJson(row.features_used) || row.features_used, missing_inputs: parseMaybeJson(row.missing_inputs) || row.missing_inputs, raw_payload: parseMaybeJson(row.raw_payload) || row.raw_payload, actual_result: parseMaybeJson(row.actual_result) || row.actual_result }; next.bucket = recommendationBucket(next); return next }) }
+function signalChip(row) { const probability = numericScore(row); if (probability !== null) return `Confidence ${fmtPct(probability)}`; const projection = projectionValue(row); if (projection !== null) return `Projection ${fmt(projection, 2)}`; return null }
+function outputTypeLabel(row) { return projectionValue(row) !== null && numericScore(row) === null ? 'Model Projection' : productionBucketLabel(row.bucket) }
 
 function ChartBox({ title, subtitle, children }) {
   return <div style={s.chartBox}><div style={s.sectionHeader}><div><div style={s.sectionTitle}>{title}</div>{subtitle && <div style={s.rowMeta}>{subtitle}</div>}</div></div><div style={{ height: 215 }}>{children}</div></div>
@@ -90,26 +94,39 @@ function EmptyState({ children }) { return <div className="state-panel">{childre
 function DataTable({ headers, rows, renderRow }) { return <div style={s.tableWrap}><table style={s.table}><thead><tr>{headers.map(h => <th key={h} style={s.th}>{h}</th>)}</tr></thead><tbody>{rows.map(renderRow)}</tbody></table></div> }
 
 function MetricChips({ row }) {
-  return <div style={s.chipRail}>
-    <span style={row.bucket === 'recommended' ? s.hotChip : row.bucket === 'lean' ? s.warnChip : s.chip}>{productionBucketLabel(row.bucket)}</span>
-    <span style={s.chip}>Confidence {fmtPct(numericScore(row))}</span>
-    <span style={s.chip}>Edge {fmtPct(row.edge)}</span>
-    <span style={s.chip}>EV {fmt(row.expected_value)}</span>
-    <span style={s.chip}>{fmtPrice(effectivePrice(row))}</span>
-  </div>
+  const chips = [outputTypeLabel(row), signalChip(row)]
+  const edge = toNumber(row.edge)
+  const ev = toNumber(row.expected_value)
+  const price = fmtPrice(effectivePrice(row))
+  if (edge !== null) chips.push(`Edge ${fmtPct(edge)}`)
+  if (ev !== null) chips.push(`EV ${fmt(ev, 3)}`)
+  if (price) chips.push(price)
+  return <div style={s.chipRail}>{chips.filter(Boolean).map((chip, index) => <span key={`${chip}-${index}`} style={index === 0 && row.bucket === 'recommended' ? s.hotChip : index === 0 && row.bucket === 'lean' ? s.warnChip : s.chip}>{chip}</span>)}</div>
 }
 
 function CompactPlayRow({ row }) {
+  const reason = shortReason(row)
   return <div style={s.playRow}>
-    <div><div style={s.rowTitle}>{rowIdentity(row)}</div><div style={s.rowMeta}>{row.market_type || row.pick_type || 'model'} · {gradeLabel(row)}</div></div>
+    <div><div style={s.rowTitle}>{rowIdentity(row)}</div><div style={s.rowMeta}>{row.market_type || row.pick_type || 'model'} · {gradeLabel(row)} · {gameLabel(row)}</div></div>
     <MetricChips row={row} />
-    <div style={s.rowMeta}>{topReason(row)}</div>
+    {reason && <div style={s.rowMeta}>{reason}</div>}
   </div>
+}
+
+function TopProjectionCard({ row }) {
+  const reason = shortReason(row)
+  return <article style={s.topCard}>
+    <div style={s.rowTitle}>{rowIdentity(row)}</div>
+    <div style={s.rowMeta}>{gameLabel(row)} · {row.market_type || row.pick_type || 'model'}</div>
+    <div style={{ marginTop: 8 }}><MetricChips row={row} /></div>
+    {reason && <div style={{ ...s.rowMeta, marginTop: 8 }}>{reason}</div>}
+  </article>
 }
 
 function GameAccordion({ game, defaultOpen = false }) {
   const [open, setOpen] = useState(defaultOpen)
   const priceCoverage = game.rows.length ? `${game.price_count}/${game.rows.length} priced` : 'No prices'
+  const bestSignal = game.best_projection !== null ? `Top Projection ${fmt(game.best_projection, 2)}` : `Top Confidence ${fmtPct(game.best_score)}`
   return <article>
     <button type="button" style={s.gameButton} onClick={() => setOpen(prev => !prev)} aria-expanded={open}>
       <div style={s.gameHeader}>
@@ -118,23 +135,24 @@ function GameAccordion({ game, defaultOpen = false }) {
       </div>
       <div style={{ ...s.chipRail, marginTop: 10 }}>
         <span style={s.hotChip}>{game.buckets.recommended.length} Recommendations</span>
-        <span style={s.warnChip}>{game.buckets.lean.length} Leans</span>
+        <span style={s.warnChip}>{game.buckets.lean.length} Model/Lean</span>
         <span style={s.chip}>{game.buckets.low_confidence.length} Low Confidence</span>
-        <span style={s.chip}>Best Confidence {fmtPct(game.best_score)}</span>
-        <span style={s.chip}>Best Edge {fmtPct(game.best_edge)}</span>
+        <span style={s.chip}>{bestSignal}</span>
+        {game.best_edge !== null && <span style={s.chip}>Best Edge {fmtPct(game.best_edge)}</span>}
         <span style={s.chip}>{priceCoverage}</span>
       </div>
     </button>
     {open && <div style={s.bucketGrid}>
       <BucketColumn title="Recommendations" rows={game.buckets.recommended} empty="No recommendations for this game." />
-      <BucketColumn title="Leans" rows={game.buckets.lean} empty="No leans for this game." />
+      <BucketColumn title="Model Projections / Leans" rows={game.buckets.lean} empty="No model projections or leans for this game." />
       <BucketColumn title="Low Confidence / No Play" rows={game.buckets.low_confidence} empty="No low-confidence outputs for this game." />
     </div>}
   </article>
 }
 
 function BucketColumn({ title, rows, empty }) {
-  return <section style={s.bucket}><div style={s.sectionHeader}><div><div style={s.rowTitle}>{title}</div><div style={s.rowMeta}>{rows.length} outputs</div></div></div>{rows.length ? rows.map(row => <CompactPlayRow key={row.id || row.tracker_key || rowIdentity(row)} row={row} />) : <div style={s.rowMeta}>{empty}</div>}</section>
+  const visibleRows = rows.slice(0, 6)
+  return <section style={s.bucket}><div style={s.sectionHeader}><div><div style={s.rowTitle}>{title}</div><div style={s.rowMeta}>{rows.length} outputs</div></div></div>{visibleRows.length ? visibleRows.map(row => <CompactPlayRow key={row.id || row.tracker_key || rowIdentity(row)} row={row} />) : <div style={s.rowMeta}>{empty}</div>}{rows.length > visibleRows.length && <div style={{ ...s.rowMeta, marginTop: 10 }}>+{rows.length - visibleRows.length} more in Details</div>}</section>
 }
 
 function Filters({ options, values, setters }) {
@@ -144,7 +162,7 @@ function Filters({ options, values, setters }) {
       <label><div style={s.label}>Source</div><select className="input-control" style={s.input} value={values.sourceFilter} onChange={e => setters.setSourceFilter(e.target.value)}>{options.sourceOptions.map(source => <option key={source} value={source}>{source}</option>)}</select></label>
       <label><div style={s.label}>Grade</div><select className="input-control" style={s.input} value={values.gradeFilter} onChange={e => setters.setGradeFilter(e.target.value)}>{options.gradeOptions.map(grade => <option key={grade} value={grade}>{grade}</option>)}</select></label>
       <label><div style={s.label}>Game</div><select className="input-control" style={s.input} value={values.gameFilter} onChange={e => setters.setGameFilter(e.target.value)}>{options.gameOptions.map(game => <option key={game.value} value={game.value}>{game.label}</option>)}</select></label>
-      <label><div style={s.label}>Bucket</div><select className="input-control" style={s.input} value={values.bucketFilter} onChange={e => setters.setBucketFilter(e.target.value)}><option value="all">all</option><option value="recommended">recommendations</option><option value="lean">leans</option><option value="low_confidence">low confidence / no play</option></select></label>
+      <label><div style={s.label}>Bucket</div><select className="input-control" style={s.input} value={values.bucketFilter} onChange={e => setters.setBucketFilter(e.target.value)}><option value="all">all</option><option value="recommended">recommendations</option><option value="lean">model projections / leans</option><option value="low_confidence">low confidence / no play</option></select></label>
       <label><div style={s.label}>Minimum Confidence</div><select className="input-control" style={s.input} value={values.confidenceFilter} onChange={e => setters.setConfidenceFilter(e.target.value)}><option value="all">all</option><option value="0.50">.50+</option><option value="0.55">.55+</option><option value="0.60">.60+</option></select></label>
       <label><div style={s.label}>Has Price</div><select className="input-control" style={s.input} value={values.priceFilter} onChange={e => setters.setPriceFilter(e.target.value)}><option value="all">all</option><option value="has_price">has price</option><option value="missing_price">missing price</option></select></label>
       <label><div style={s.label}>Has Edge</div><select className="input-control" style={s.input} value={values.edgeFilter} onChange={e => setters.setEdgeFilter(e.target.value)}><option value="all">all</option><option value="positive_edge">positive edge</option><option value="no_edge">no edge</option></select></label>
@@ -154,14 +172,18 @@ function Filters({ options, values, setters }) {
 }
 
 function PlaysTab({ groupedGames, topRows, gameFilter }) {
+  const [gamesOpen, setGamesOpen] = useState(gameFilter !== 'all')
+  useEffect(() => { if (gameFilter !== 'all') setGamesOpen(true) }, [gameFilter])
+  const visibleTopRows = topRows.slice(0, 12)
   return <div style={s.page}>
     <section style={s.section}>
-      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Games</div><div style={s.rowMeta}>Open a game to review recommendations, leans, and low-confidence outputs without losing slate context.</div></div></div>
-      {groupedGames.length ? <div style={s.accordionStack}>{groupedGames.map(game => <GameAccordion key={game.key} game={game} defaultOpen={gameFilter !== 'all'} />)}</div> : <EmptyState>No model plays found for this slate.</EmptyState>}
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Top Model Projections</div><div style={s.rowMeta}>Best available model outputs for the slate. Projection values are shown as projections, not confidence percentages.</div></div><span className="status-badge">{topRows.length} signals</span></div>
+      {visibleTopRows.length ? <div style={s.topGrid}>{visibleTopRows.map(row => <TopProjectionCard key={row.id || row.tracker_key || rowIdentity(row)} row={row} />)}</div> : <EmptyState>No model projections match the current filters.</EmptyState>}
+      {topRows.length > visibleTopRows.length && <div style={{ ...s.rowMeta, marginTop: 12 }}>Showing top {visibleTopRows.length}; use filters or Details for the full slate.</div>}
     </section>
     <section style={s.section}>
-      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Highest Confidence Plays of the Day</div><div style={s.rowMeta}>Sorted by confidence, edge, expected value, and price availability.</div></div></div>
-      {topRows.length ? <div style={s.accordionStack}>{topRows.map(row => <CompactPlayRow key={row.id || row.tracker_key || rowIdentity(row)} row={row} />)}</div> : <EmptyState>No recommendations meet the current filters.</EmptyState>}
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Game Breakdown</div><div style={s.rowMeta}>Collapsed by default so the slate stays scannable.</div></div><button className="button-secondary" type="button" onClick={() => setGamesOpen(prev => !prev)}>{gamesOpen ? 'Hide Games' : `Show Games (${groupedGames.length})`}</button></div>
+      {gamesOpen && (groupedGames.length ? <div style={s.accordionStack}>{groupedGames.map(game => <GameAccordion key={game.key} game={game} defaultOpen={gameFilter !== 'all'} />)}</div> : <EmptyState>No model plays found for this slate.</EmptyState>)}
     </section>
   </div>
 }
@@ -220,7 +242,7 @@ function BreakdownBar({ title, data }) {
 }
 
 function PeriodDetailTable({ rows }) {
-  return <DataTable headers={['Date', 'Game', 'Pick', 'Type', 'Confidence', 'Edge', 'Price', 'Grade', 'Profit', 'Units']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key || `${row.snapshot_date}-${rowIdentity(row)}`}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{rowIdentity(row)}</td><td style={s.td}>{productionBucketLabel(row.bucket)}</td><td style={s.td}>{fmtPct(numericScore(row))}</td><td style={s.td}>{fmtPct(row.edge)}</td><td style={s.td}>{fmtPrice(effectivePrice(row))}</td><td style={s.td}>{row.grade || 'pending'}</td><td style={s.td}>{fmtMoney(row.profit)}</td><td style={s.td}>{fmtUnits(row.units)}</td></tr>} />
+  return <DataTable headers={['Date', 'Game', 'Pick', 'Type', 'Confidence', 'Edge', 'Price', 'Grade', 'Profit', 'Units']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key || `${row.snapshot_date}-${rowIdentity(row)}`}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{rowIdentity(row)}</td><td style={s.td}>{outputTypeLabel(row)}</td><td style={s.td}>{numericScore(row) !== null ? fmtPct(numericScore(row)) : 'Unavailable'}</td><td style={s.td}>{fmtPct(row.edge)}</td><td style={s.td}>{fmtPrice(effectivePrice(row)) || 'Unavailable'}</td><td style={s.td}>{row.grade || 'pending'}</td><td style={s.td}>{fmtMoney(row.profit)}</td><td style={s.td}>{fmtUnits(row.units)}</td></tr>} />
 }
 
 function PnlTab({ rows }) {
@@ -236,11 +258,11 @@ function PnlTab({ rows }) {
 }
 
 function QualityTable({ rows }) {
-  return <DataTable headers={['Type', 'Pick / Player / Team', 'Source', 'Game', 'Price', 'Result State', 'Missing Inputs', 'Reason']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key}><td style={s.td}>{productionBucketLabel(row.bucket)}</td><td style={s.td}>{rowIdentity(row)}</td><td style={s.td}>{row.source || 'Unavailable'}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{rowHasPrice(row) ? 'Available' : 'Unavailable'}</td><td style={s.td}>{gradeLabel(row)}</td><td style={s.td}>{compactValue(row.missing_inputs)}</td><td style={s.td}>{topReason(row)}</td></tr>} />
+  return <DataTable headers={['Type', 'Pick / Player / Team', 'Source', 'Game', 'Price', 'Result State', 'Missing Inputs', 'Reason']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key}><td style={s.td}>{outputTypeLabel(row)}</td><td style={s.td}>{rowIdentity(row)}</td><td style={s.td}>{row.source || 'Unavailable'}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{rowHasPrice(row) ? 'Available' : 'Unavailable'}</td><td style={s.td}>{gradeLabel(row)}</td><td style={s.td}>{compactValue(row.missing_inputs)}</td><td style={s.td}>{topReason(row)}</td></tr>} />
 }
 
 function DetailsTable({ rows }) {
-  return <DataTable headers={['Date', 'Source', 'Game', 'Type', 'Pick', 'Player / Team', 'Model', 'Score', 'Confidence', 'Line', 'Price', 'Status', 'Grade', 'Reason']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{row.source}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{row.market_type || row.pick_type}</td><td style={s.td}>{row.pick_label}</td><td style={s.td}>{row.player_name || row.team_name}</td><td style={s.td}>{row.model_name}</td><td style={s.td}>{fmt(row.score)}</td><td style={s.td}>{fmt(row.confidence)}</td><td style={s.td}>{fmt(row.line)}</td><td style={s.td}>{fmtPrice(effectivePrice(row))}</td><td style={s.td}>{row.result_status}</td><td style={s.td}>{row.grade}</td><td style={s.td}>{topReason(row)}</td></tr>} />
+  return <DataTable headers={['Date', 'Source', 'Game', 'Type', 'Pick', 'Player / Team', 'Model', 'Signal', 'Line', 'Price', 'Status', 'Grade', 'Reason']} rows={rows} renderRow={row => <tr key={row.id || row.tracker_key}><td style={s.td}>{row.snapshot_date}</td><td style={s.td}>{row.source}</td><td style={s.td}>{gameLabel(row)}</td><td style={s.td}>{row.market_type || row.pick_type}</td><td style={s.td}>{row.pick_label}</td><td style={s.td}>{row.player_name || row.team_name}</td><td style={s.td}>{row.model_name}</td><td style={s.td}>{signalChip(row) || 'Unavailable'}</td><td style={s.td}>{fmt(row.line)}</td><td style={s.td}>{fmtPrice(effectivePrice(row)) || 'Unavailable'}</td><td style={s.td}>{row.result_status}</td><td style={s.td}>{row.grade}</td><td style={s.td}>{topReason(row)}</td></tr>} />
 }
 
 export default function ModelTrackerPage() {
@@ -300,7 +322,7 @@ export default function ModelTrackerPage() {
   const filteredRows = useMemo(() => rows.filter(filterRow).sort(comparePlayRank), [rows, sourceFilter, gradeFilter, gameFilter, bucketFilter, confidenceFilter, priceFilter, edgeFilter, search])
   const periodRows = useMemo(() => cachedRows.filter(filterRow).sort(comparePlayRank), [cachedRows, sourceFilter, gradeFilter, gameFilter, bucketFilter, confidenceFilter, priceFilter, edgeFilter, search])
   const groupedGames = useMemo(() => groupRowsByGame(filteredRows, games), [filteredRows, games])
-  const topRows = useMemo(() => highestConfidenceRows(filteredRows), [filteredRows])
+  const topRows = useMemo(() => topModelProjectionRows(filteredRows), [filteredRows])
   const pnl = useMemo(() => summarizePnl(filteredRows, UNIT_SIZE_DOLLARS), [filteredRows])
   const summary = { total: filteredRows.length, recommended: filteredRows.filter(r => r.bucket === 'recommended').length, lean: filteredRows.filter(r => r.bucket === 'lean').length, low: filteredRows.filter(r => !['recommended', 'lean'].includes(r.bucket)).length, pending: filteredRows.filter(r => r.grade === 'pending').length, graded: filteredRows.filter(r => GRADED.includes(r.grade)).length, price: filteredRows.filter(rowHasPrice).length }
   const qualityRows = filteredRows.filter(row => !['recommended', 'lean'].includes(row.bucket))
@@ -308,9 +330,9 @@ export default function ModelTrackerPage() {
   const filterProps = { options: { sourceOptions, gradeOptions, gameOptions, visibleCount: filteredRows.length }, values: { sourceFilter, gradeFilter, gameFilter, bucketFilter, confidenceFilter, priceFilter, edgeFilter, search }, setters: { setSourceFilter, setGradeFilter, setGameFilter, setBucketFilter, setConfidenceFilter, setPriceFilter, setEdgeFilter, setSearch } }
 
   return <div style={s.page}>
-    <section style={s.hero}><div style={s.header}><div><p className="page-kicker">Model Accountability</p><h1 className="page-title">Model Tracker</h1><p className="page-subtitle">Game-by-game recommendations, leans, low-confidence outputs, and performance analytics in one production dashboard.</p></div><div style={s.controls}><input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} /><button className="button-primary" type="button" onClick={refreshPlays} disabled={refreshing}>{refreshing ? 'Refreshing...' : 'Refresh Model Plays'}</button><button className="button-secondary" type="button" onClick={refreshResults} disabled={resultRefreshing}>{resultRefreshing ? 'Refreshing...' : 'Refresh Results'}</button></div></div><div style={s.tabs}>{TABS.map(key => <button key={key} type="button" style={s.tab(activeTab === key)} onClick={() => setActiveTab(key)}>{TAB_LABELS[key]}</button>)}</div></section>
+    <section style={s.hero}><div style={s.header}><div><p className="page-kicker">Model Accountability</p><h1 className="page-title">Model Tracker</h1><p className="page-subtitle">Sleek slate view for model projections, actionable leans, game breakdowns, and results analytics.</p></div><div style={s.controls}><input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} /><button className="button-primary" type="button" onClick={refreshPlays} disabled={refreshing}>{refreshing ? 'Refreshing...' : 'Refresh Model Plays'}</button><button className="button-secondary" type="button" onClick={refreshResults} disabled={resultRefreshing}>{resultRefreshing ? 'Refreshing...' : 'Refresh Results'}</button></div></div><div style={s.tabs}>{TABS.map(key => <button key={key} type="button" style={s.tab(activeTab === key)} onClick={() => setActiveTab(key)}>{TAB_LABELS[key]}</button>)}</div></section>
     {error && <div className="state-panel error">{error}</div>}{loading && <div className="state-panel">Loading model plays...</div>}
-    <section style={s.statsScroller}><div style={s.statRail}><StatCard label="Visible Outputs" value={summary.total} /><StatCard label="Recommendations" value={summary.recommended} /><StatCard label="Leans" value={summary.lean} /><StatCard label="Low Confidence" value={summary.low} /><StatCard label="Graded" value={summary.graded} /><StatCard label="Pending" value={summary.pending} /><StatCard label="Price Available" value={summary.price} /><StatCard label="Net P&L" value={fmtMoney(pnl.profit)} /></div></section>
+    <section style={s.statsScroller}><div style={s.statRail}><StatCard label="Visible Outputs" value={summary.total} /><StatCard label="Recommendations" value={summary.recommended} /><StatCard label="Model / Lean" value={summary.lean} /><StatCard label="Low Confidence" value={summary.low} /><StatCard label="Graded" value={summary.graded} /><StatCard label="Pending" value={summary.pending} /><StatCard label="Price Available" value={summary.price} /><StatCard label="Net P&L" value={fmtMoney(pnl.profit)} /></div></section>
     <Filters {...filterProps} />
     {activeTab === 'plays' && <PlaysTab groupedGames={groupedGames} topRows={topRows} gameFilter={gameFilter} />}
     {activeTab === 'results' && <ResultsTab rows={periodRows.length ? periodRows : filteredRows} selectedDate={date} period={resultsPeriod} setPeriod={setResultsPeriod} loading={periodLoading} />}


### PR DESCRIPTION
## Summary

Follow-up to #805 based on the latest product screenshots.

This pass fixes the remaining UX/data-presentation problems:

- Makes the entire Game Breakdown section collapsible and collapsed by default.
- Moves the best available model outputs to the top as `Top Model Projections`.
- Stops treating projection values like `10.8301` as `1083.0%` confidence.
- Collapses duplicate projection rows that only differ by result state/watchlist state.
- Hides unavailable metric chips instead of rendering `Edge Unavailable`, `EV Unavailable`, and `Price unavailable` everywhere.
- Renames noisy `Leans` game bucket to `Model Projections / Leans` so projected totals do not look like betting recommendations.
- Limits expanded game bucket rows to keep accordions concise, with Details used for the full slate.
- Adds tests proving projection values are not probability confidence and duplicate projection rows collapse.

## Changed files

- `frontend/src/lib/modelTrackerPnl.mjs`
- `frontend/src/lib/modelTrackerPnl.test.mjs`
- `frontend/src/pages/ModelTrackerPage.jsx`

## Verification

Run from `frontend/`:

```bash
npm test
npm run build
```

## Production QA

On `/model-tracker` verify:

- First content section is `Top Model Projections`, not expanded games.
- Projection totals display as projection values, not confidence percentages.
- Game Breakdown is collapsed by default and can be opened.
- Expanded games are shorter, deduped, and use concise chips.
- The page no longer visually floods the user with unavailable metrics.