### PR TITLE
Add smart decision rules for Model Tracker recommendations

### DIFF
--- a/frontend/src/lib/modelTrackerPnl.mjs
+++ b/frontend/src/lib/modelTrackerPnl.mjs
@@ -98,38 +98,49 @@ export function effectivePrice(row) {
   return toNumber(row?.price) ?? toNumber(row?.provider_price) ?? toNumber(row?.latest_price) ?? toNumber(row?.best_price_seen)
 }
 
-export function recommendationBucket(row) {
-  const status = getRecommendationStatus(row)
-  const score = numericScore(row)
+export function hasNegativeEconomics(row) {
   const edge = toNumber(row?.edge)
   const ev = toNumber(row?.expected_value)
-  const projection = projectionValue(row)
-  const hasIdentity = Boolean(row?.pick_label || row?.player_name || row?.team_name)
-  const hasMetrics = [score, edge, ev, projection].some(v => v !== null)
-  if (!hasIdentity && !hasMetrics) return 'missing_data'
-  if (isRejectedNoBet(row)) return 'rejected'
-  if (status.includes('strong') || status.includes('recommended') || (score !== null && score >= 0.55) || (edge !== null && edge > 0) || (ev !== null && ev > 0)) return 'recommended'
-  if (projection !== null || row?.grade === 'watchlist_only' || row?.grade === 'ungraded' || (score !== null && score >= 0.50)) return 'lean'
-  return 'missing_data'
+  return (edge !== null && edge < 0) || (ev !== null && ev < 0)
 }
 
+export function hasPositiveEconomics(row) {
+  const edge = toNumber(row?.edge)
+  const ev = toNumber(row?.expected_value)
+  return (edge !== null && edge > 0) || (ev !== null && ev > 0)
+}
+
+export function modelDecision(row) {
+  const score = numericScore(row)
+  const projection = projectionValue(row)
+  const edge = toNumber(row?.edge)
+  const ev = toNumber(row?.expected_value)
+  const hasPrice = rowHasPrice(row)
+  const status = getRecommendationStatus(row)
+  const hasIdentity = Boolean(row?.pick_label || row?.player_name || row?.team_name || row?.model_name)
+  const hasMetrics = [score, projection, edge, ev].some(v => v !== null)
+
+  if (!hasIdentity && !hasMetrics) return { bucket: 'missing_data', label: 'Incomplete', posture: 'No decision', action: 'Hold until the model output has a selection and usable market context.' }
+  if (isRejectedNoBet(row) || hasNegativeEconomics(row)) {
+    const reason = edge !== null && edge < 0 ? `negative edge ${edge}` : ev !== null && ev < 0 ? `negative EV ${ev}` : 'model marked no play'
+    return { bucket: 'rejected', label: 'No Play', posture: 'Avoid', action: `Pass. ${reason}; this should not be surfaced as a recommendation.` }
+  }
+  if (projection !== null && !hasPrice && edge === null && ev === null) return { bucket: 'lean', label: 'Model Projection', posture: 'Market intelligence', action: 'Use as the current model number. Wait for a price or market line before action.' }
+  if (hasPositiveEconomics(row) && hasPrice && (score === null || score >= 0.52)) return { bucket: 'recommended', label: 'Recommendation', posture: 'Actionable', action: 'Positive economics with market price available. Candidate for the primary card.' }
+  if (hasPositiveEconomics(row) && !hasPrice) return { bucket: 'lean', label: 'Lean / Watch', posture: 'Price needed', action: 'Good directional signal, but hold until a usable market price is available.' }
+  if (score !== null && score >= 0.57 && hasPrice && status.includes('recommended')) return { bucket: 'lean', label: 'Lean / Watch', posture: 'Needs edge confirmation', action: 'Probability is strong, but edge/EV is missing. Keep it as a watch item until economics are confirmed.' }
+  if (projection !== null || score !== null || status.includes('watch')) return { bucket: 'lean', label: projection !== null ? 'Model Projection' : 'Lean / Watch', posture: 'Monitor', action: projection !== null ? 'Model number is available; compare against market before action.' : 'Directional signal only. Keep on watchlist.' }
+  return { bucket: 'missing_data', label: 'No Play', posture: 'No decision', action: 'Not enough usable signal to recommend.' }
+}
+
+export function recommendationBucket(row) { return modelDecision(row).bucket }
+
 export function recommendationLabel(bucket) {
-  return {
-    recommended: 'Recommended',
-    lean: 'Lean / Watchlist',
-    rejected: 'Rejected / No Bet',
-    missing_data: 'Missing Data / Ungraded',
-  }[bucket] || 'Missing Data / Ungraded'
+  return { recommended: 'Recommended', lean: 'Lean / Watchlist', rejected: 'Rejected / No Bet', missing_data: 'Missing Data / Ungraded' }[bucket] || 'Missing Data / Ungraded'
 }
 
 export function productionBucketLabel(bucket) {
-  return {
-    recommended: 'Recommendation',
-    lean: 'Lean',
-    rejected: 'Low Confidence / No Play',
-    missing_data: 'Low Confidence / No Play',
-    low_confidence: 'Low Confidence / No Play',
-  }[bucket] || 'Low Confidence / No Play'
+  return { recommended: 'Recommendation', lean: 'Lean', rejected: 'Low Confidence / No Play', missing_data: 'Low Confidence / No Play', low_confidence: 'Low Confidence / No Play' }[bucket] || 'Low Confidence / No Play'
 }
 
 export function productionBucket(row) {
@@ -148,16 +159,7 @@ export function summarizePnl(rows = [], unitSize = UNIT_SIZE_DOLLARS) {
   const ledger = rows.map(row => {
     const stake = unitSize
     const profit = gradeProfit(row, stake)
-    return {
-      ...row,
-      bucket: recommendationBucket(row),
-      stake,
-      price_for_pnl: effectivePrice(row),
-      profit,
-      units: resultToUnits(profit, stake),
-      confidence_band: confidenceBand(row?.confidence ?? row?.score ?? row?.model_probability),
-      edge_band: edgeBand(row?.edge),
-    }
+    return { ...row, bucket: recommendationBucket(row), stake, price_for_pnl: effectivePrice(row), profit, units: resultToUnits(profit, stake), confidence_band: confidenceBand(row?.confidence ?? row?.score ?? row?.model_probability), edge_band: edgeBand(row?.edge) }
   })
   const graded = ledger.filter(row => isGradedDecision(row))
   const priced = graded.filter(row => row.profit !== null)
@@ -168,20 +170,7 @@ export function summarizePnl(rows = [], unitSize = UNIT_SIZE_DOLLARS) {
   const profit = priced.reduce((sum, row) => sum + (toNumber(row.profit) ?? 0), 0)
   const units = resultToUnits(profit, unitSize) ?? 0
   const decisions = wins + losses
-  return {
-    rows: ledger,
-    graded_count: graded.length,
-    priced_graded_count: priced.length,
-    pending_count: ledger.filter(isPending).length,
-    wins,
-    losses,
-    pushes,
-    win_rate: decisions ? wins / decisions : null,
-    total_risked: risked,
-    profit,
-    units,
-    roi: risked ? profit / risked : null,
-  }
+  return { rows: ledger, graded_count: graded.length, priced_graded_count: priced.length, pending_count: ledger.filter(isPending).length, wins, losses, pushes, win_rate: decisions ? wins / decisions : null, total_risked: risked, profit, units, roi: risked ? profit / risked : null }
 }
 
 export function groupProfit(rows = [], groupBy = () => 'Unknown') {
@@ -237,234 +226,61 @@ export function maxDrawdown(series = []) {
 export function comparePeriods(currentRows = [], previousRows = [], unitSize = UNIT_SIZE_DOLLARS) {
   const current = summarizePnl(currentRows, unitSize)
   const previous = summarizePnl(previousRows, unitSize)
-  return {
-    current,
-    previous,
-    deltas: {
-      profit: current.profit - previous.profit,
-      units: current.units - previous.units,
-      win_rate: current.win_rate !== null && previous.win_rate !== null ? current.win_rate - previous.win_rate : null,
-      roi: current.roi !== null && previous.roi !== null ? current.roi - previous.roi : null,
-      graded_count: current.graded_count - previous.graded_count,
-      pending_count: current.pending_count - previous.pending_count,
-    },
-  }
+  return { current, previous, deltas: { profit: current.profit - previous.profit, units: current.units - previous.units, win_rate: current.win_rate !== null && previous.win_rate !== null ? current.win_rate - previous.win_rate : null, roi: current.roi !== null && previous.roi !== null ? current.roi - previous.roi : null, graded_count: current.graded_count - previous.graded_count, pending_count: current.pending_count - previous.pending_count } }
 }
 
-function isoDate(date) {
-  return date.toISOString().slice(0, 10)
-}
+function isoDate(date) { return date.toISOString().slice(0, 10) }
+function parseDate(value) { const [year, month, day] = String(value).slice(0, 10).split('-').map(Number); return new Date(Date.UTC(year, month - 1, day)) }
+function addDays(value, days) { const date = parseDate(value); date.setUTCDate(date.getUTCDate() + days); return isoDate(date) }
+function startOfMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1))) }
+function endOfPreviousMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 0))) }
+function startOfPreviousMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))) }
 
-function parseDate(value) {
-  const [year, month, day] = String(value).slice(0, 10).split('-').map(Number)
-  return new Date(Date.UTC(year, month - 1, day))
-}
-
-function addDays(value, days) {
-  const date = parseDate(value)
-  date.setUTCDate(date.getUTCDate() + days)
-  return isoDate(date)
-}
-
-function startOfMonth(value) {
-  const date = parseDate(value)
-  return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1)))
-}
-
-function endOfPreviousMonth(value) {
-  const date = parseDate(value)
-  return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 0)))
-}
-
-function startOfPreviousMonth(value) {
-  const date = parseDate(value)
-  return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1)))
-}
-
-export function listDatesBetween(startDate, endDate) {
-  const dates = []
-  let cursor = startDate
-  while (cursor <= endDate) {
-    dates.push(cursor)
-    cursor = addDays(cursor, 1)
-  }
-  return dates
-}
+export function listDatesBetween(startDate, endDate) { const dates = []; let cursor = startDate; while (cursor <= endDate) { dates.push(cursor); cursor = addDays(cursor, 1) } return dates }
 
 export function getPeriodWindows(period, selectedDate) {
   const date = String(selectedDate).slice(0, 10)
-  if (period === 'dod') {
-    return {
-      label: 'DoD',
-      current: { start: date, end: date, label: date },
-      previous: { start: addDays(date, -1), end: addDays(date, -1), label: addDays(date, -1) },
-    }
-  }
-  if (period === 'wow' || period === 'rolling7') {
-    const currentStart = addDays(date, -6)
-    const previousEnd = addDays(currentStart, -1)
-    return {
-      label: period === 'wow' ? 'WoW' : 'Rolling 7',
-      current: { start: currentStart, end: date, label: `${currentStart} to ${date}` },
-      previous: { start: addDays(previousEnd, -6), end: previousEnd, label: `${addDays(previousEnd, -6)} to ${previousEnd}` },
-    }
-  }
-  if (period === 'mom') {
-    const currentStart = startOfMonth(date)
-    const previousStart = startOfPreviousMonth(date)
-    const daysIntoMonth = listDatesBetween(currentStart, date).length - 1
-    const previousEnd = addDays(previousStart, daysIntoMonth)
-    const previousMonthEnd = endOfPreviousMonth(date)
-    return {
-      label: 'MoM',
-      current: { start: currentStart, end: date, label: `${currentStart} to ${date}` },
-      previous: { start: previousStart, end: previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd, label: `${previousStart} to ${previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd}` },
-    }
-  }
-  if (period === 'rolling30') {
-    const currentStart = addDays(date, -29)
-    const previousEnd = addDays(currentStart, -1)
-    return {
-      label: 'Rolling 30',
-      current: { start: currentStart, end: date, label: `${currentStart} to ${date}` },
-      previous: { start: addDays(previousEnd, -29), end: previousEnd, label: `${addDays(previousEnd, -29)} to ${previousEnd}` },
-    }
-  }
+  if (period === 'dod') return { label: 'DoD', current: { start: date, end: date, label: date }, previous: { start: addDays(date, -1), end: addDays(date, -1), label: addDays(date, -1) } }
+  if (period === 'wow' || period === 'rolling7') { const currentStart = addDays(date, -6); const previousEnd = addDays(currentStart, -1); return { label: period === 'wow' ? 'WoW' : 'Rolling 7', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -6), end: previousEnd, label: `${addDays(previousEnd, -6)} to ${previousEnd}` } } }
+  if (period === 'mom') { const currentStart = startOfMonth(date); const previousStart = startOfPreviousMonth(date); const daysIntoMonth = listDatesBetween(currentStart, date).length - 1; const previousEnd = addDays(previousStart, daysIntoMonth); const previousMonthEnd = endOfPreviousMonth(date); return { label: 'MoM', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: previousStart, end: previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd, label: `${previousStart} to ${previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd}` } } }
+  if (period === 'rolling30') { const currentStart = addDays(date, -29); const previousEnd = addDays(currentStart, -1); return { label: 'Rolling 30', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -29), end: previousEnd, label: `${addDays(previousEnd, -29)} to ${previousEnd}` } } }
   const seasonStart = `${date.slice(0, 4)}-03-01`
-  return {
-    label: 'Season',
-    current: { start: seasonStart, end: date, label: `${seasonStart} to ${date}` },
-    previous: null,
-  }
+  return { label: 'Season', current: { start: seasonStart, end: date, label: `${seasonStart} to ${date}` }, previous: null }
 }
 
-export function periodDateKeys(period, selectedDate) {
-  const windows = getPeriodWindows(period, selectedDate)
-  const keys = listDatesBetween(windows.current.start, windows.current.end)
-  if (windows.previous) keys.push(...listDatesBetween(windows.previous.start, windows.previous.end))
-  return Array.from(new Set(keys))
-}
-
-export function rowsInRange(rows, range) {
-  if (!range) return []
-  return rows.filter(row => {
-    const rowDate = String(row.snapshot_date || row.date || '').slice(0, 10)
-    return rowDate >= range.start && rowDate <= range.end
-  })
-}
+export function periodDateKeys(period, selectedDate) { const windows = getPeriodWindows(period, selectedDate); const keys = listDatesBetween(windows.current.start, windows.current.end); if (windows.previous) keys.push(...listDatesBetween(windows.previous.start, windows.previous.end)); return Array.from(new Set(keys)) }
+export function rowsInRange(rows, range) { if (!range) return []; return rows.filter(row => { const rowDate = String(row.snapshot_date || row.date || '').slice(0, 10); return rowDate >= range.start && rowDate <= range.end }) }
 
 export function buildPeriodComparison(rows = [], period, selectedDate, unitSize = UNIT_SIZE_DOLLARS) {
   const windows = getPeriodWindows(period, selectedDate)
   const currentRows = rowsInRange(rows, windows.current)
   const previousRows = rowsInRange(rows, windows.previous)
   const comparison = comparePeriods(currentRows, previousRows, unitSize)
-  return {
-    windows,
-    currentRows,
-    previousRows,
-    comparison,
-    currentSeries: indexSeries(dailySeries(summarizePnl(currentRows, unitSize).rows.filter(row => row.profit !== null)), 'current'),
-    previousSeries: indexSeries(dailySeries(summarizePnl(previousRows, unitSize).rows.filter(row => row.profit !== null)), 'previous'),
-  }
+  return { windows, currentRows, previousRows, comparison, currentSeries: indexSeries(dailySeries(summarizePnl(currentRows, unitSize).rows.filter(row => row.profit !== null)), 'current'), previousSeries: indexSeries(dailySeries(summarizePnl(previousRows, unitSize).rows.filter(row => row.profit !== null)), 'previous') }
 }
 
-export function indexSeries(series = [], prefix = 'current') {
-  return series.map((point, index) => ({ ...point, day_index: index + 1, [`${prefix}_cumulative`]: point.cumulative, [`${prefix}_profit`]: point.profit }))
-}
+export function indexSeries(series = [], prefix = 'current') { return series.map((point, index) => ({ ...point, day_index: index + 1, [`${prefix}_cumulative`]: point.cumulative, [`${prefix}_profit`]: point.profit })) }
 
 export function playRank(row) {
-  return {
-    projection: projectionValue(row) ?? -Infinity,
-    score: numericScore(row) ?? -Infinity,
-    edge: toNumber(row?.edge) ?? -Infinity,
-    expected_value: toNumber(row?.expected_value) ?? -Infinity,
-    has_price: rowHasPrice(row) ? 1 : 0,
-  }
+  const decision = modelDecision(row)
+  return { bucket: decision.bucket === 'recommended' ? 3 : decision.bucket === 'lean' ? 2 : 1, projection: projectionValue(row) ?? -Infinity, score: numericScore(row) ?? -Infinity, edge: toNumber(row?.edge) ?? -Infinity, expected_value: toNumber(row?.expected_value) ?? -Infinity, has_price: rowHasPrice(row) ? 1 : 0 }
 }
 
-export function comparePlayRank(a, b) {
-  const ar = playRank(a)
-  const br = playRank(b)
-  return (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.projection - ar.projection) || (br.has_price - ar.has_price)
-}
+export function comparePlayRank(a, b) { const ar = playRank(a); const br = playRank(b); return (br.bucket - ar.bucket) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.projection - ar.projection) || (br.has_price - ar.has_price) }
+export function compareModelOutputRank(a, b) { const ar = playRank(a); const br = playRank(b); return (br.bucket - ar.bucket) || (br.projection - ar.projection) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.has_price - ar.has_price) }
 
-export function compareModelOutputRank(a, b) {
-  const ar = playRank(a)
-  const br = playRank(b)
-  return (br.projection - ar.projection) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.has_price - ar.has_price)
-}
-
-export function modelOutputKey(row) {
-  return [
-    row?.game_pk || 'ungrouped',
-    row?.away_team || '',
-    row?.home_team || '',
-    row?.market_type || row?.pick_type || '',
-    row?.pick_label || row?.player_name || row?.team_name || row?.model_name || '',
-    toNumber(row?.line) ?? '',
-    projectionValue(row) ?? '',
-    numericScore(row) ?? '',
-    toNumber(row?.edge) ?? '',
-    toNumber(row?.expected_value) ?? '',
-  ].join('|').toLowerCase()
-}
-
-export function uniqueModelOutputs(rows = []) {
-  const seen = new Set()
-  const output = []
-  rows.forEach(row => {
-    const key = modelOutputKey(row)
-    if (seen.has(key)) return
-    seen.add(key)
-    output.push(row)
-  })
-  return output
-}
-
-export function gameFilterValue(value) {
-  return String(value || 'ungrouped')
-}
-
-export function gameLabel(row) {
-  if (row?.away_team || row?.home_team) return `${row.away_team || 'Away'} @ ${row.home_team || 'Home'}`
-  return row?.game_pk ? `Game ${row.game_pk}` : 'Ungrouped'
-}
+function normalizeOutputName(row) { return String(row?.pick_label || row?.player_name || row?.team_name || row?.model_name || '').toLowerCase().replace(/\s+/g, ' ').replace(/\d+\.\d+/g, '#').trim() }
+export function modelOutputKey(row) { return [row?.game_pk || 'ungrouped', row?.away_team || '', row?.home_team || '', row?.market_type || row?.pick_type || '', normalizeOutputName(row), toNumber(row?.line) ?? ''].join('|').toLowerCase() }
+export function uniqueModelOutputs(rows = []) { const map = new Map(); rows.forEach(row => { const key = modelOutputKey(row); const current = map.get(key); if (!current || compareModelOutputRank(row, current) < 0) map.set(key, row) }); return Array.from(map.values()) }
+export function gameFilterValue(value) { return String(value || 'ungrouped') }
+export function gameLabel(row) { if (row?.away_team || row?.home_team) return `${row.away_team || 'Away'} @ ${row.home_team || 'Home'}`; return row?.game_pk ? `Game ${row.game_pk}` : 'Ungrouped' }
 
 export function groupRowsByGame(rows = [], games = []) {
   const map = new Map()
-  games.forEach(game => {
-    const key = gameFilterValue(game.game_pk)
-    map.set(key, {
-      ...game,
-      key,
-      label: gameLabel(game),
-      rows: [],
-      buckets: { recommended: [], lean: [], low_confidence: [] },
-      sources: [],
-      best_score: null,
-      best_projection: null,
-      best_edge: null,
-      price_count: 0,
-    })
-  })
+  games.forEach(game => { const key = gameFilterValue(game.game_pk); map.set(key, { ...game, key, label: gameLabel(game), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }) })
   uniqueModelOutputs(rows).forEach(row => {
     const key = gameFilterValue(row.game_pk)
-    const game = map.get(key) || {
-      key,
-      game_pk: row.game_pk,
-      away_team: row.away_team,
-      home_team: row.home_team,
-      game_time: row.game_time || row.start_time || row.game_datetime,
-      game_status: row.game_status || row.status,
-      label: gameLabel(row),
-      rows: [],
-      buckets: { recommended: [], lean: [], low_confidence: [] },
-      sources: [],
-      best_score: null,
-      best_projection: null,
-      best_edge: null,
-      price_count: 0,
-    }
+    const game = map.get(key) || { key, game_pk: row.game_pk, away_team: row.away_team, home_team: row.home_team, game_time: row.game_time || row.start_time || row.game_datetime, game_status: row.game_status || row.status, label: gameLabel(row), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }
     const bucket = productionBucket(row)
     const score = numericScore(row)
     const projection = projectionValue(row)
@@ -478,26 +294,8 @@ export function groupRowsByGame(rows = [], games = []) {
     if (rowHasPrice(row)) game.price_count += 1
     map.set(key, game)
   })
-  return Array.from(map.values())
-    .filter(game => game.rows.length > 0)
-    .map(game => ({
-      ...game,
-      buckets: {
-        recommended: game.buckets.recommended.sort(comparePlayRank),
-        lean: game.buckets.lean.sort(compareModelOutputRank),
-        low_confidence: game.buckets.low_confidence.sort(comparePlayRank),
-      },
-      rows: game.rows.sort(compareModelOutputRank),
-    }))
-    .sort((a, b) => String(a.game_time || '').localeCompare(String(b.game_time || '')) || a.label.localeCompare(b.label))
+  return Array.from(map.values()).filter(game => game.rows.length > 0).map(game => ({ ...game, buckets: { recommended: game.buckets.recommended.sort(comparePlayRank), lean: game.buckets.lean.sort(compareModelOutputRank), low_confidence: game.buckets.low_confidence.sort(comparePlayRank) }, rows: game.rows.sort(compareModelOutputRank) })).sort((a, b) => String(a.game_time || '').localeCompare(String(b.game_time || '')) || a.label.localeCompare(b.label))
 }
 
-export function highestConfidenceRows(rows = []) {
-  return uniqueModelOutputs(rows).filter(row => productionBucket(row) === 'recommended').sort(comparePlayRank)
-}
-
-export function topModelProjectionRows(rows = []) {
-  return uniqueModelOutputs(rows)
-    .filter(row => projectionValue(row) !== null || numericScore(row) !== null || toNumber(row?.edge) !== null || toNumber(row?.expected_value) !== null)
-    .sort(compareModelOutputRank)
-}
+export function highestConfidenceRows(rows = []) { return uniqueModelOutputs(rows).filter(row => modelDecision(row).bucket === 'recommended').sort(comparePlayRank) }
+export function topModelProjectionRows(rows = []) { return uniqueModelOutputs(rows).filter(row => !['rejected', 'missing_data'].includes(modelDecision(row).bucket)).filter(row => projectionValue(row) !== null || numericScore(row) !== null || hasPositiveEconomics(row)).sort(compareModelOutputRank) }

--- a/frontend/src/lib/modelTrackerPnl.test.mjs
+++ b/frontend/src/lib/modelTrackerPnl.test.mjs
@@ -12,6 +12,7 @@ import {
   groupRowsByGame,
   highestConfidenceRows,
   maxDrawdown,
+  modelDecision,
   numericScore,
   periodDateKeys,
   productionBucketLabel,
@@ -49,6 +50,18 @@ test('projection values are not treated as probability confidence', () => {
   assert.equal(recommendationBucket(row), 'lean')
 })
 
+test('negative EV or edge cannot become a recommendation', () => {
+  const decision = modelDecision({ pick_label: 'Baltimore Orioles 1.5', confidence: 1, edge: -0.121, expected_value: -0.191, price: -171 })
+  assert.equal(decision.bucket, 'rejected')
+  assert.equal(decision.label, 'No Play')
+  assert.equal(recommendationBucket({ pick_label: 'Baltimore Orioles 1.5', confidence: 1, edge: -0.121, expected_value: -0.191, price: -171 }), 'rejected')
+})
+
+test('positive economics require usable price before recommendation', () => {
+  assert.equal(recommendationBucket({ pick_label: 'Over 7.5', confidence: 0.58, edge: 0.183, expected_value: 0.356 }), 'lean')
+  assert.equal(recommendationBucket({ pick_label: 'Over 7.5', confidence: 0.58, edge: 0.183, expected_value: 0.356, price: -106 }), 'recommended')
+})
+
 test('summarizePnl excludes pending rows from realized P&L', () => {
   const summary = summarizePnl([
     { grade: 'won', price: 100, confidence: 0.57, edge: 0.03, pick_label: 'Cubs ML' },
@@ -65,7 +78,7 @@ test('summarizePnl excludes pending rows from realized P&L', () => {
 
 test('recommendationBucket keeps rejected/no-bet separate', () => {
   assert.equal(recommendationBucket({ pick_label: 'No bet', recommendation_status: 'no_bet', confidence: 0.70 }), 'rejected')
-  assert.equal(recommendationBucket({ pick_label: 'Strong play', confidence: 0.56 }), 'recommended')
+  assert.equal(recommendationBucket({ pick_label: 'Strong play', confidence: 0.56, edge: 0.02, expected_value: 0.05, price: 100 }), 'recommended')
   assert.equal(recommendationBucket({ pick_label: 'Watchlist', confidence: 0.51, grade: 'watchlist_only' }), 'lean')
 })
 
@@ -109,7 +122,7 @@ test('uniqueModelOutputs collapses duplicate projection rows', () => {
 test('groupRowsByGame creates production buckets per game', () => {
   const games = [{ game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', game_time: '2026-06-16T18:10:00Z' }]
   const grouped = groupRowsByGame([
-    { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Cubs ML', confidence: 0.61, edge: 0.05, price: 120 },
+    { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Cubs ML', confidence: 0.61, edge: 0.05, expected_value: 0.08, price: 120 },
     { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'Projected total 10.4', score: 10.4, grade: 'watchlist_only' },
     { game_pk: 1, away_team: 'Cubs', home_team: 'Brewers', pick_label: 'No play total', recommendation_status: 'no_bet', confidence: 0.70 },
   ], games)
@@ -124,7 +137,7 @@ test('groupRowsByGame creates production buckets per game', () => {
 test('highestConfidenceRows sorts by probability confidence and excludes no-bet rows', () => {
   const rows = highestConfidenceRows([
     { pick_label: 'Lower score', confidence: 0.56, edge: 0.30, expected_value: 2, price: 100 },
-    { pick_label: 'Top score', confidence: 0.62, edge: 0.01, expected_value: 1 },
+    { pick_label: 'Top score', confidence: 0.62, edge: 0.01, expected_value: 1, price: 100 },
     { pick_label: 'No play', recommendation_status: 'no_bet', confidence: 0.99 },
   ])
   assert.deepEqual(rows.map(row => row.pick_label), ['Top score', 'Lower score'])
@@ -134,7 +147,8 @@ test('topModelProjectionRows showcases projection values first', () => {
   const rows = topModelProjectionRows([
     { pick_label: 'Projected total 10.6', score: 10.6 },
     { pick_label: 'Projected total 10.9', score: 10.9 },
-    { pick_label: 'Probability play', confidence: 0.65 },
+    { pick_label: 'Probability play', confidence: 0.65, edge: 0.02, expected_value: 0.1, price: 100 },
+    { pick_label: 'Bad economics', confidence: 0.90, edge: -0.02, expected_value: -0.1, price: 100 },
   ])
   assert.deepEqual(rows.map(row => row.pick_label), ['Projected total 10.9', 'Projected total 10.6', 'Probability play'])
 })


### PR DESCRIPTION
## Summary

Follow-up to #806. This adds the actual decision layer the board needs so the UI does not promote nonsensical outputs.

Core rules added:

- Negative EV or negative edge can never be classified as `Recommendation`.
- Projection-only outputs are classified as `Model Projection` / watch items, not primary recommendations.
- A primary `Recommendation` now requires positive economics and usable price context.
- Positive signal without price becomes `Lean / Watch`, not a recommendation.
- No-play / rejected diagnostics are removed from the top projection showcase.
- Duplicate outputs are collapsed by game, market, normalized selection, and line, so repeated diagnostic rows do not flood the board.
- Ranking now prioritizes decision quality, then projection, probability, edge, EV, and price availability.

## Tests added

- `negative EV or edge cannot become a recommendation`
- `positive economics require usable price before recommendation`
- top projection rows exclude bad-economics rows

## Why this matters

The page now behaves more like an operator-grade model board:

- A high probability with negative economics becomes a pass.
- A projection with no line/price becomes market intelligence.
- Only outputs with coherent economics are elevated as recommendations.

## Verification

Run from `frontend/`:

```bash
npm test
npm run build
```

## Production QA

On `/model-tracker`, verify examples like `Baltimore Orioles 1.5` with negative EV/edge no longer appear as `Recommendation`. They should be in No Play / low-confidence context, while projected totals remain model projections until paired with actionable market context.