### PR TITLE
Clarify Model Tracker results quality and coverage buckets

### DIFF
--- a/frontend/src/lib/modelTrackerPnl.mjs
+++ b/frontend/src/lib/modelTrackerPnl.mjs
@@ -25,43 +25,17 @@ export function resultToUnits(profit, stake = UNIT_SIZE_DOLLARS) {
   return p / s
 }
 
-export function isGradedDecision(row) {
-  return ['won', 'lost', 'push'].includes(String(row?.grade || '').toLowerCase())
-}
-
-export function isPending(row) {
-  const grade = String(row?.grade || '').toLowerCase()
-  const status = String(row?.result_status || '').toLowerCase()
-  return grade === 'pending' || status === 'pending' || status === 'live'
-}
-
-export function normalizeStatus(value) {
-  return String(value || '').trim().toLowerCase().replace(/\s+/g, '_')
-}
-
-function probabilityCandidate(value) {
-  const n = toNumber(value)
-  return n !== null && n >= 0 && n <= 1 ? n : null
-}
-
-export function numericScore(row) {
-  const candidates = [row?.confidence, row?.score, row?.model_probability].map(probabilityCandidate).filter(v => v !== null)
-  return candidates.length ? Math.max(...candidates) : null
-}
-
-export function projectionValue(row) {
-  const score = toNumber(row?.score)
-  if (score !== null && score > 1) return score
-  return toNumber(row?.projection) ?? toNumber(row?.projected_total) ?? toNumber(row?.raw_payload?.projected_total) ?? toNumber(row?.raw_payload?.projection)
-}
-
-export function signalValue(row) {
-  return numericScore(row) ?? projectionValue(row) ?? toNumber(row?.expected_value) ?? toNumber(row?.edge)
-}
+export function isGradedDecision(row) { return ['won', 'lost', 'push'].includes(String(row?.grade || '').toLowerCase()) }
+export function isPending(row) { const grade = String(row?.grade || '').toLowerCase(); const status = String(row?.result_status || '').toLowerCase(); return grade === 'pending' || status === 'pending' || status === 'live' }
+export function normalizeStatus(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, '_') }
+function probabilityCandidate(value) { const n = toNumber(value); return n !== null && n >= 0 && n <= 1 ? n : null }
+export function numericScore(row) { const candidates = [row?.confidence, row?.score, row?.model_probability].map(probabilityCandidate).filter(v => v !== null); return candidates.length ? Math.max(...candidates) : null }
+export function projectionValue(row) { const score = toNumber(row?.score); if (score !== null && score > 1) return score; return toNumber(row?.projection) ?? toNumber(row?.projected_total) ?? toNumber(row?.raw_payload?.projected_total) ?? toNumber(row?.raw_payload?.projection) }
+export function signalValue(row) { return numericScore(row) ?? projectionValue(row) ?? toNumber(row?.expected_value) ?? toNumber(row?.edge) }
 
 export function confidenceBand(value) {
   const n = probabilityCandidate(value)
-  if (n === null) return 'Unavailable'
+  if (n === null) return null
   if (n >= 0.65) return '.65+'
   if (n >= 0.60) return '.60-.64'
   if (n >= 0.55) return '.55-.59'
@@ -71,7 +45,7 @@ export function confidenceBand(value) {
 
 export function edgeBand(value) {
   const n = toNumber(value)
-  if (n === null) return 'Unavailable'
+  if (n === null) return null
   if (n >= 0.10) return '+10%+'
   if (n >= 0.05) return '+5% to +9.9%'
   if (n > 0) return '+0% to +4.9%'
@@ -79,35 +53,31 @@ export function edgeBand(value) {
   return 'Negative'
 }
 
-export function getRecommendationStatus(row) {
-  const diagnostics = row?.daily_odds_diagnostics || row?.raw_payload?.daily_odds_diagnostics || row?.raw_payload?.diagnostics || {}
-  return normalizeStatus(diagnostics.recommendation_status || row?.recommendation_status || row?.bucket || row?.status)
-}
+export function getRecommendationStatus(row) { const diagnostics = row?.daily_odds_diagnostics || row?.raw_payload?.daily_odds_diagnostics || row?.raw_payload?.diagnostics || {}; return normalizeStatus(diagnostics.recommendation_status || row?.recommendation_status || row?.bucket || row?.status) }
+export function isRejectedNoBet(row) { const status = getRecommendationStatus(row); const reason = normalizeStatus(row?.grade_reason || row?.primary_reason); return ['no_bet', 'rejected', 'suppressed', 'non_positive_edge'].some(token => status.includes(token) || reason.includes(token)) }
+export function rowHasPrice(row) { return toNumber(row?.price) !== null || toNumber(row?.provider_price) !== null || toNumber(row?.latest_price) !== null || toNumber(row?.best_price_seen) !== null }
+export function effectivePrice(row) { return toNumber(row?.price) ?? toNumber(row?.provider_price) ?? toNumber(row?.latest_price) ?? toNumber(row?.best_price_seen) }
+export function hasNegativeEconomics(row) { const edge = toNumber(row?.edge); const ev = toNumber(row?.expected_value); return (edge !== null && edge < 0) || (ev !== null && ev < 0) }
+export function hasPositiveEconomics(row) { const edge = toNumber(row?.edge); const ev = toNumber(row?.expected_value); return (edge !== null && edge > 0) || (ev !== null && ev > 0) }
 
-export function isRejectedNoBet(row) {
-  const status = getRecommendationStatus(row)
-  const reason = normalizeStatus(row?.grade_reason || row?.primary_reason)
-  return ['no_bet', 'rejected', 'suppressed', 'non_positive_edge'].some(token => status.includes(token) || reason.includes(token))
-}
-
-export function rowHasPrice(row) {
-  return toNumber(row?.price) !== null || toNumber(row?.provider_price) !== null || toNumber(row?.latest_price) !== null || toNumber(row?.best_price_seen) !== null
-}
-
-export function effectivePrice(row) {
-  return toNumber(row?.price) ?? toNumber(row?.provider_price) ?? toNumber(row?.latest_price) ?? toNumber(row?.best_price_seen)
-}
-
-export function hasNegativeEconomics(row) {
+export function economicsCoverage(row) {
   const edge = toNumber(row?.edge)
   const ev = toNumber(row?.expected_value)
-  return (edge !== null && edge < 0) || (ev !== null && ev < 0)
+  const price = effectivePrice(row)
+  if (edge === null && ev === null && price === null) return 'No market economics'
+  if (edge === null && ev === null) return 'Priced, no EV/edge'
+  if (price === null) return 'EV/edge, no price'
+  return 'Priced with EV/edge'
 }
 
-export function hasPositiveEconomics(row) {
+export function decisionQualityLabel(row) {
   const edge = toNumber(row?.edge)
   const ev = toNumber(row?.expected_value)
-  return (edge !== null && edge > 0) || (ev !== null && ev > 0)
+  if ((edge !== null && edge < 0) || (ev !== null && ev < 0)) return 'Negative EV / edge'
+  if ((edge !== null && edge > 0) || (ev !== null && ev > 0)) return rowHasPrice(row) ? 'Positive EV priced' : 'Positive EV unpriced'
+  if (projectionValue(row) !== null) return 'Projection only'
+  if (numericScore(row) !== null) return 'Probability only'
+  return 'Insufficient economics'
 }
 
 export function modelDecision(row) {
@@ -134,19 +104,9 @@ export function modelDecision(row) {
 }
 
 export function recommendationBucket(row) { return modelDecision(row).bucket }
-
-export function recommendationLabel(bucket) {
-  return { recommended: 'Recommended', lean: 'Lean / Watchlist', rejected: 'Rejected / No Bet', missing_data: 'Missing Data / Ungraded' }[bucket] || 'Missing Data / Ungraded'
-}
-
-export function productionBucketLabel(bucket) {
-  return { recommended: 'Recommendation', lean: 'Lean', rejected: 'Low Confidence / No Play', missing_data: 'Low Confidence / No Play', low_confidence: 'Low Confidence / No Play' }[bucket] || 'Low Confidence / No Play'
-}
-
-export function productionBucket(row) {
-  const bucket = row?.bucket || recommendationBucket(row)
-  return bucket === 'recommended' || bucket === 'lean' ? bucket : 'low_confidence'
-}
+export function recommendationLabel(bucket) { return { recommended: 'Recommended', lean: 'Lean / Watchlist', rejected: 'Rejected / No Bet', missing_data: 'Missing Data / Ungraded' }[bucket] || 'Missing Data / Ungraded' }
+export function productionBucketLabel(bucket) { return { recommended: 'Recommendation', lean: 'Lean', rejected: 'Low Confidence / No Play', missing_data: 'Low Confidence / No Play', low_confidence: 'Low Confidence / No Play' }[bucket] || 'Low Confidence / No Play' }
+export function productionBucket(row) { const bucket = row?.bucket || recommendationBucket(row); return bucket === 'recommended' || bucket === 'lean' ? bucket : 'low_confidence' }
 
 export function gradeProfit(row, unitSize = UNIT_SIZE_DOLLARS) {
   if (!isGradedDecision(row)) return null
@@ -159,7 +119,7 @@ export function summarizePnl(rows = [], unitSize = UNIT_SIZE_DOLLARS) {
   const ledger = rows.map(row => {
     const stake = unitSize
     const profit = gradeProfit(row, stake)
-    return { ...row, bucket: recommendationBucket(row), stake, price_for_pnl: effectivePrice(row), profit, units: resultToUnits(profit, stake), confidence_band: confidenceBand(row?.confidence ?? row?.score ?? row?.model_probability), edge_band: edgeBand(row?.edge) }
+    return { ...row, bucket: recommendationBucket(row), stake, price_for_pnl: effectivePrice(row), profit, units: resultToUnits(profit, stake), confidence_band: confidenceBand(row?.confidence ?? row?.score ?? row?.model_probability), edge_band: edgeBand(row?.edge), decision_quality: decisionQualityLabel(row), economics_coverage: economicsCoverage(row) }
   })
   const graded = ledger.filter(row => isGradedDecision(row))
   const priced = graded.filter(row => row.profit !== null)
@@ -170,13 +130,16 @@ export function summarizePnl(rows = [], unitSize = UNIT_SIZE_DOLLARS) {
   const profit = priced.reduce((sum, row) => sum + (toNumber(row.profit) ?? 0), 0)
   const units = resultToUnits(profit, unitSize) ?? 0
   const decisions = wins + losses
-  return { rows: ledger, graded_count: graded.length, priced_graded_count: priced.length, pending_count: ledger.filter(isPending).length, wins, losses, pushes, win_rate: decisions ? wins / decisions : null, total_risked: risked, profit, units, roi: risked ? profit / risked : null }
+  const evRows = ledger.filter(row => toNumber(row.edge) !== null || toNumber(row.expected_value) !== null)
+  const pricedRows = ledger.filter(row => rowHasPrice(row))
+  return { rows: ledger, graded_count: graded.length, priced_graded_count: priced.length, pending_count: ledger.filter(isPending).length, wins, losses, pushes, win_rate: decisions ? wins / decisions : null, total_risked: risked, profit, units, roi: risked ? profit / risked : null, ev_coverage: ledger.length ? evRows.length / ledger.length : null, price_coverage: ledger.length ? pricedRows.length / ledger.length : null }
 }
 
 export function groupProfit(rows = [], groupBy = () => 'Unknown') {
   const map = new Map()
   rows.forEach(row => {
-    const key = groupBy(row) || 'Unknown'
+    const key = groupBy(row)
+    if (key === null || key === undefined || key === '' || key === 'Unavailable') return
     const current = map.get(key) || { label: key, count: 0, profit: 0, units: 0, wins: 0, losses: 0, pushes: 0 }
     current.count += 1
     current.profit += toNumber(row.profit) ?? 0
@@ -194,10 +157,7 @@ export function dailySeries(rows = []) {
   rows.forEach(row => {
     const date = String(row.snapshot_date || row.date || '').slice(0, 10) || 'Unknown'
     const current = map.get(date) || { date, profit: 0, units: 0, graded: 0, pending: 0, wins: 0, losses: 0 }
-    if (row.profit !== null && row.profit !== undefined) {
-      current.profit += toNumber(row.profit) ?? 0
-      current.units += toNumber(row.units) ?? 0
-    }
+    if (row.profit !== null && row.profit !== undefined) { current.profit += toNumber(row.profit) ?? 0; current.units += toNumber(row.units) ?? 0 }
     if (isGradedDecision(row)) current.graded += 1
     if (isPending(row)) current.pending += 1
     if (row.grade === 'won') current.wins += 1
@@ -205,29 +165,11 @@ export function dailySeries(rows = []) {
     map.set(date, current)
   })
   let cumulative = 0
-  return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date)).map(row => {
-    cumulative += row.profit
-    const decisions = row.wins + row.losses
-    return { ...row, cumulative, win_rate: decisions ? row.wins / decisions : null, roi: row.graded ? row.profit / (row.graded * UNIT_SIZE_DOLLARS) : null }
-  })
+  return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date)).map(row => { cumulative += row.profit; const decisions = row.wins + row.losses; return { ...row, cumulative, win_rate: decisions ? row.wins / decisions : null, roi: row.graded ? row.profit / (row.graded * UNIT_SIZE_DOLLARS) : null } })
 }
 
-export function maxDrawdown(series = []) {
-  let peak = 0
-  let worst = 0
-  series.forEach(point => {
-    const value = toNumber(point.cumulative) ?? 0
-    peak = Math.max(peak, value)
-    worst = Math.min(worst, value - peak)
-  })
-  return worst
-}
-
-export function comparePeriods(currentRows = [], previousRows = [], unitSize = UNIT_SIZE_DOLLARS) {
-  const current = summarizePnl(currentRows, unitSize)
-  const previous = summarizePnl(previousRows, unitSize)
-  return { current, previous, deltas: { profit: current.profit - previous.profit, units: current.units - previous.units, win_rate: current.win_rate !== null && previous.win_rate !== null ? current.win_rate - previous.win_rate : null, roi: current.roi !== null && previous.roi !== null ? current.roi - previous.roi : null, graded_count: current.graded_count - previous.graded_count, pending_count: current.pending_count - previous.pending_count } }
-}
+export function maxDrawdown(series = []) { let peak = 0; let worst = 0; series.forEach(point => { const value = toNumber(point.cumulative) ?? 0; peak = Math.max(peak, value); worst = Math.min(worst, value - peak) }); return worst }
+export function comparePeriods(currentRows = [], previousRows = [], unitSize = UNIT_SIZE_DOLLARS) { const current = summarizePnl(currentRows, unitSize); const previous = summarizePnl(previousRows, unitSize); return { current, previous, deltas: { profit: current.profit - previous.profit, units: current.units - previous.units, win_rate: current.win_rate !== null && previous.win_rate !== null ? current.win_rate - previous.win_rate : null, roi: current.roi !== null && previous.roi !== null ? current.roi - previous.roi : null, graded_count: current.graded_count - previous.graded_count, pending_count: current.pending_count - previous.pending_count } } }
 
 function isoDate(date) { return date.toISOString().slice(0, 10) }
 function parseDate(value) { const [year, month, day] = String(value).slice(0, 10).split('-').map(Number); return new Date(Date.UTC(year, month - 1, day)) }
@@ -235,67 +177,20 @@ function addDays(value, days) { const date = parseDate(value); date.setUTCDate(d
 function startOfMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1))) }
 function endOfPreviousMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 0))) }
 function startOfPreviousMonth(value) { const date = parseDate(value); return isoDate(new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1))) }
-
 export function listDatesBetween(startDate, endDate) { const dates = []; let cursor = startDate; while (cursor <= endDate) { dates.push(cursor); cursor = addDays(cursor, 1) } return dates }
-
-export function getPeriodWindows(period, selectedDate) {
-  const date = String(selectedDate).slice(0, 10)
-  if (period === 'dod') return { label: 'DoD', current: { start: date, end: date, label: date }, previous: { start: addDays(date, -1), end: addDays(date, -1), label: addDays(date, -1) } }
-  if (period === 'wow' || period === 'rolling7') { const currentStart = addDays(date, -6); const previousEnd = addDays(currentStart, -1); return { label: period === 'wow' ? 'WoW' : 'Rolling 7', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -6), end: previousEnd, label: `${addDays(previousEnd, -6)} to ${previousEnd}` } } }
-  if (period === 'mom') { const currentStart = startOfMonth(date); const previousStart = startOfPreviousMonth(date); const daysIntoMonth = listDatesBetween(currentStart, date).length - 1; const previousEnd = addDays(previousStart, daysIntoMonth); const previousMonthEnd = endOfPreviousMonth(date); return { label: 'MoM', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: previousStart, end: previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd, label: `${previousStart} to ${previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd}` } } }
-  if (period === 'rolling30') { const currentStart = addDays(date, -29); const previousEnd = addDays(currentStart, -1); return { label: 'Rolling 30', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -29), end: previousEnd, label: `${addDays(previousEnd, -29)} to ${previousEnd}` } } }
-  const seasonStart = `${date.slice(0, 4)}-03-01`
-  return { label: 'Season', current: { start: seasonStart, end: date, label: `${seasonStart} to ${date}` }, previous: null }
-}
-
+export function getPeriodWindows(period, selectedDate) { const date = String(selectedDate).slice(0, 10); if (period === 'dod') return { label: 'DoD', current: { start: date, end: date, label: date }, previous: { start: addDays(date, -1), end: addDays(date, -1), label: addDays(date, -1) } }; if (period === 'wow' || period === 'rolling7') { const currentStart = addDays(date, -6); const previousEnd = addDays(currentStart, -1); return { label: period === 'wow' ? 'WoW' : 'Rolling 7', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -6), end: previousEnd, label: `${addDays(previousEnd, -6)} to ${previousEnd}` } } }; if (period === 'mom') { const currentStart = startOfMonth(date); const previousStart = startOfPreviousMonth(date); const daysIntoMonth = listDatesBetween(currentStart, date).length - 1; const previousEnd = addDays(previousStart, daysIntoMonth); const previousMonthEnd = endOfPreviousMonth(date); return { label: 'MoM', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: previousStart, end: previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd, label: `${previousStart} to ${previousEnd > previousMonthEnd ? previousMonthEnd : previousEnd}` } } }; if (period === 'rolling30') { const currentStart = addDays(date, -29); const previousEnd = addDays(currentStart, -1); return { label: 'Rolling 30', current: { start: currentStart, end: date, label: `${currentStart} to ${date}` }, previous: { start: addDays(previousEnd, -29), end: previousEnd, label: `${addDays(previousEnd, -29)} to ${previousEnd}` } } }; const seasonStart = `${date.slice(0, 4)}-03-01`; return { label: 'Season', current: { start: seasonStart, end: date, label: `${seasonStart} to ${date}` }, previous: null } }
 export function periodDateKeys(period, selectedDate) { const windows = getPeriodWindows(period, selectedDate); const keys = listDatesBetween(windows.current.start, windows.current.end); if (windows.previous) keys.push(...listDatesBetween(windows.previous.start, windows.previous.end)); return Array.from(new Set(keys)) }
 export function rowsInRange(rows, range) { if (!range) return []; return rows.filter(row => { const rowDate = String(row.snapshot_date || row.date || '').slice(0, 10); return rowDate >= range.start && rowDate <= range.end }) }
-
-export function buildPeriodComparison(rows = [], period, selectedDate, unitSize = UNIT_SIZE_DOLLARS) {
-  const windows = getPeriodWindows(period, selectedDate)
-  const currentRows = rowsInRange(rows, windows.current)
-  const previousRows = rowsInRange(rows, windows.previous)
-  const comparison = comparePeriods(currentRows, previousRows, unitSize)
-  return { windows, currentRows, previousRows, comparison, currentSeries: indexSeries(dailySeries(summarizePnl(currentRows, unitSize).rows.filter(row => row.profit !== null)), 'current'), previousSeries: indexSeries(dailySeries(summarizePnl(previousRows, unitSize).rows.filter(row => row.profit !== null)), 'previous') }
-}
-
+export function buildPeriodComparison(rows = [], period, selectedDate, unitSize = UNIT_SIZE_DOLLARS) { const windows = getPeriodWindows(period, selectedDate); const currentRows = rowsInRange(rows, windows.current); const previousRows = rowsInRange(rows, windows.previous); const comparison = comparePeriods(currentRows, previousRows, unitSize); return { windows, currentRows, previousRows, comparison, currentSeries: indexSeries(dailySeries(summarizePnl(currentRows, unitSize).rows.filter(row => row.profit !== null)), 'current'), previousSeries: indexSeries(dailySeries(summarizePnl(previousRows, unitSize).rows.filter(row => row.profit !== null)), 'previous') } }
 export function indexSeries(series = [], prefix = 'current') { return series.map((point, index) => ({ ...point, day_index: index + 1, [`${prefix}_cumulative`]: point.cumulative, [`${prefix}_profit`]: point.profit })) }
-
-export function playRank(row) {
-  const decision = modelDecision(row)
-  return { bucket: decision.bucket === 'recommended' ? 3 : decision.bucket === 'lean' ? 2 : 1, projection: projectionValue(row) ?? -Infinity, score: numericScore(row) ?? -Infinity, edge: toNumber(row?.edge) ?? -Infinity, expected_value: toNumber(row?.expected_value) ?? -Infinity, has_price: rowHasPrice(row) ? 1 : 0 }
-}
-
+export function playRank(row) { const decision = modelDecision(row); return { bucket: decision.bucket === 'recommended' ? 3 : decision.bucket === 'lean' ? 2 : 1, projection: projectionValue(row) ?? -Infinity, score: numericScore(row) ?? -Infinity, edge: toNumber(row?.edge) ?? -Infinity, expected_value: toNumber(row?.expected_value) ?? -Infinity, has_price: rowHasPrice(row) ? 1 : 0 } }
 export function comparePlayRank(a, b) { const ar = playRank(a); const br = playRank(b); return (br.bucket - ar.bucket) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.projection - ar.projection) || (br.has_price - ar.has_price) }
 export function compareModelOutputRank(a, b) { const ar = playRank(a); const br = playRank(b); return (br.bucket - ar.bucket) || (br.projection - ar.projection) || (br.score - ar.score) || (br.edge - ar.edge) || (br.expected_value - ar.expected_value) || (br.has_price - ar.has_price) }
-
 function normalizeOutputName(row) { return String(row?.pick_label || row?.player_name || row?.team_name || row?.model_name || '').toLowerCase().replace(/\s+/g, ' ').replace(/\d+\.\d+/g, '#').trim() }
 export function modelOutputKey(row) { return [row?.game_pk || 'ungrouped', row?.away_team || '', row?.home_team || '', row?.market_type || row?.pick_type || '', normalizeOutputName(row), toNumber(row?.line) ?? ''].join('|').toLowerCase() }
 export function uniqueModelOutputs(rows = []) { const map = new Map(); rows.forEach(row => { const key = modelOutputKey(row); const current = map.get(key); if (!current || compareModelOutputRank(row, current) < 0) map.set(key, row) }); return Array.from(map.values()) }
 export function gameFilterValue(value) { return String(value || 'ungrouped') }
 export function gameLabel(row) { if (row?.away_team || row?.home_team) return `${row.away_team || 'Away'} @ ${row.home_team || 'Home'}`; return row?.game_pk ? `Game ${row.game_pk}` : 'Ungrouped' }
-
-export function groupRowsByGame(rows = [], games = []) {
-  const map = new Map()
-  games.forEach(game => { const key = gameFilterValue(game.game_pk); map.set(key, { ...game, key, label: gameLabel(game), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }) })
-  uniqueModelOutputs(rows).forEach(row => {
-    const key = gameFilterValue(row.game_pk)
-    const game = map.get(key) || { key, game_pk: row.game_pk, away_team: row.away_team, home_team: row.home_team, game_time: row.game_time || row.start_time || row.game_datetime, game_status: row.game_status || row.status, label: gameLabel(row), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }
-    const bucket = productionBucket(row)
-    const score = numericScore(row)
-    const projection = projectionValue(row)
-    const edge = toNumber(row.edge)
-    game.rows.push(row)
-    game.buckets[bucket].push(row)
-    if (row.source && !game.sources.includes(row.source)) game.sources.push(row.source)
-    if (score !== null) game.best_score = game.best_score === null ? score : Math.max(game.best_score, score)
-    if (projection !== null) game.best_projection = game.best_projection === null ? projection : Math.max(game.best_projection, projection)
-    if (edge !== null) game.best_edge = game.best_edge === null ? edge : Math.max(game.best_edge, edge)
-    if (rowHasPrice(row)) game.price_count += 1
-    map.set(key, game)
-  })
-  return Array.from(map.values()).filter(game => game.rows.length > 0).map(game => ({ ...game, buckets: { recommended: game.buckets.recommended.sort(comparePlayRank), lean: game.buckets.lean.sort(compareModelOutputRank), low_confidence: game.buckets.low_confidence.sort(comparePlayRank) }, rows: game.rows.sort(compareModelOutputRank) })).sort((a, b) => String(a.game_time || '').localeCompare(String(b.game_time || '')) || a.label.localeCompare(b.label))
-}
-
+export function groupRowsByGame(rows = [], games = []) { const map = new Map(); games.forEach(game => { const key = gameFilterValue(game.game_pk); map.set(key, { ...game, key, label: gameLabel(game), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }) }); uniqueModelOutputs(rows).forEach(row => { const key = gameFilterValue(row.game_pk); const game = map.get(key) || { key, game_pk: row.game_pk, away_team: row.away_team, home_team: row.home_team, game_time: row.game_time || row.start_time || row.game_datetime, game_status: row.game_status || row.status, label: gameLabel(row), rows: [], buckets: { recommended: [], lean: [], low_confidence: [] }, sources: [], best_score: null, best_projection: null, best_edge: null, price_count: 0 }; const bucket = productionBucket(row); const score = numericScore(row); const projection = projectionValue(row); const edge = toNumber(row.edge); game.rows.push(row); game.buckets[bucket].push(row); if (row.source && !game.sources.includes(row.source)) game.sources.push(row.source); if (score !== null) game.best_score = game.best_score === null ? score : Math.max(game.best_score, score); if (projection !== null) game.best_projection = game.best_projection === null ? projection : Math.max(game.best_projection, projection); if (edge !== null) game.best_edge = game.best_edge === null ? edge : Math.max(game.best_edge, edge); if (rowHasPrice(row)) game.price_count += 1; map.set(key, game) }); return Array.from(map.values()).filter(game => game.rows.length > 0).map(game => ({ ...game, buckets: { recommended: game.buckets.recommended.sort(comparePlayRank), lean: game.buckets.lean.sort(compareModelOutputRank), low_confidence: game.buckets.low_confidence.sort(comparePlayRank) }, rows: game.rows.sort(compareModelOutputRank) })).sort((a, b) => String(a.game_time || '').localeCompare(String(b.game_time || '')) || a.label.localeCompare(b.label)) }
 export function highestConfidenceRows(rows = []) { return uniqueModelOutputs(rows).filter(row => modelDecision(row).bucket === 'recommended').sort(comparePlayRank) }
 export function topModelProjectionRows(rows = []) { return uniqueModelOutputs(rows).filter(row => !['rejected', 'missing_data'].includes(modelDecision(row).bucket)).filter(row => projectionValue(row) !== null || numericScore(row) !== null || hasPositiveEconomics(row)).sort(compareModelOutputRank) }

--- a/frontend/src/lib/modelTrackerPnl.test.mjs
+++ b/frontend/src/lib/modelTrackerPnl.test.mjs
@@ -7,8 +7,11 @@ import {
   comparePeriods,
   confidenceBand,
   dailySeries,
+  decisionQualityLabel,
   edgeBand,
+  economicsCoverage,
   getPeriodWindows,
+  groupProfit,
   groupRowsByGame,
   highestConfidenceRows,
   maxDrawdown,
@@ -23,24 +26,17 @@ import {
   uniqueModelOutputs,
 } from './modelTrackerPnl.mjs'
 
-test('americanOddsToProfit handles positive odds wins', () => {
-  assert.equal(americanOddsToProfit(100, 150, 'won'), 150)
-})
+test('americanOddsToProfit handles positive odds wins', () => { assert.equal(americanOddsToProfit(100, 150, 'won'), 150) })
+test('americanOddsToProfit handles negative odds wins', () => { assert.equal(americanOddsToProfit(100, -200, 'won'), 50) })
+test('americanOddsToProfit handles losses and pushes', () => { assert.equal(americanOddsToProfit(100, -110, 'lost'), -100); assert.equal(americanOddsToProfit(100, -110, 'push'), 0) })
 
-test('americanOddsToProfit handles negative odds wins', () => {
-  assert.equal(americanOddsToProfit(100, -200, 'won'), 50)
-})
-
-test('americanOddsToProfit handles losses and pushes', () => {
-  assert.equal(americanOddsToProfit(100, -110, 'lost'), -100)
-  assert.equal(americanOddsToProfit(100, -110, 'push'), 0)
-})
-
-test('confidenceBand and edgeBand bucket values deterministically', () => {
+test('confidenceBand and edgeBand bucket values deterministically and hide missing values', () => {
   assert.equal(confidenceBand(0.57), '.55-.59')
   assert.equal(confidenceBand(0.66), '.65+')
+  assert.equal(confidenceBand(null), null)
   assert.equal(edgeBand(0.073), '+5% to +9.9%')
   assert.equal(edgeBand(-0.01), 'Negative')
+  assert.equal(edgeBand(null), null)
 })
 
 test('projection values are not treated as probability confidence', () => {
@@ -57,12 +53,22 @@ test('negative EV or edge cannot become a recommendation', () => {
   assert.equal(recommendationBucket({ pick_label: 'Baltimore Orioles 1.5', confidence: 1, edge: -0.121, expected_value: -0.191, price: -171 }), 'rejected')
 })
 
+test('decision quality separates actual result from pre-event economics', () => {
+  assert.equal(decisionQualityLabel({ edge: -0.121, expected_value: -0.191, price: -171 }), 'Negative EV / edge')
+  assert.equal(decisionQualityLabel({ edge: 0.05, expected_value: 0.1, price: -110 }), 'Positive EV priced')
+  assert.equal(decisionQualityLabel({ edge: 0.05, expected_value: 0.1 }), 'Positive EV unpriced')
+  assert.equal(decisionQualityLabel({ score: 10.2 }), 'Projection only')
+  assert.equal(economicsCoverage({ edge: 0.05, price: -110 }), 'Priced with EV/edge')
+  assert.equal(economicsCoverage({ price: -110 }), 'Priced, no EV/edge')
+  assert.equal(economicsCoverage({ score: 10.2 }), 'No market economics')
+})
+
 test('positive economics require usable price before recommendation', () => {
   assert.equal(recommendationBucket({ pick_label: 'Over 7.5', confidence: 0.58, edge: 0.183, expected_value: 0.356 }), 'lean')
   assert.equal(recommendationBucket({ pick_label: 'Over 7.5', confidence: 0.58, edge: 0.183, expected_value: 0.356, price: -106 }), 'recommended')
 })
 
-test('summarizePnl excludes pending rows from realized P&L', () => {
+test('summarizePnl excludes pending rows from realized P&L and reports coverage', () => {
   const summary = summarizePnl([
     { grade: 'won', price: 100, confidence: 0.57, edge: 0.03, pick_label: 'Cubs ML' },
     { grade: 'lost', price: -110, confidence: 0.52, pick_label: 'Yankees TT over' },
@@ -74,6 +80,8 @@ test('summarizePnl excludes pending rows from realized P&L', () => {
   assert.equal(summary.total_risked, 200)
   assert.equal(summary.profit, 0)
   assert.equal(summary.roi, 0)
+  assert.equal(summary.ev_coverage, 0.25)
+  assert.equal(summary.price_coverage, 1)
 })
 
 test('recommendationBucket keeps rejected/no-bet separate', () => {
@@ -102,13 +110,18 @@ test('dailySeries and maxDrawdown are ordered by date', () => {
 })
 
 test('comparePeriods returns current, previous, and deltas', () => {
-  const comparison = comparePeriods(
-    [{ grade: 'won', price: 100, pick_label: 'Current' }],
-    [{ grade: 'lost', price: -110, pick_label: 'Previous' }],
-  )
+  const comparison = comparePeriods([{ grade: 'won', price: 100, pick_label: 'Current' }], [{ grade: 'lost', price: -110, pick_label: 'Previous' }])
   assert.equal(comparison.current.profit, 100)
   assert.equal(comparison.previous.profit, -100)
   assert.equal(comparison.deltas.profit, 200)
+})
+
+test('groupProfit skips unavailable chart buckets', () => {
+  const grouped = groupProfit([
+    { profit: 100, edge_band: null },
+    { profit: -50, edge_band: 'Negative' },
+  ], row => row.edge_band)
+  assert.deepEqual(grouped.map(row => row.label), ['Negative'])
 })
 
 test('uniqueModelOutputs collapses duplicate projection rows', () => {


### PR DESCRIPTION
## Summary

This PR addresses the latest Results tab feedback: the charts were functionally useful, but they made weak/missing data look like meaningful model segments.

Key changes:

- Stops charting `Unavailable` confidence/edge buckets as if they are real model cohorts.
- Adds explicit decision-quality labels:
  - `Positive EV priced`
  - `Positive EV unpriced`
  - `Negative EV / edge`
  - `Projection only`
  - `Probability only`
  - `Insufficient economics`
- Adds economics coverage labels:
  - `Priced with EV/edge`
  - `Priced, no EV/edge`
  - `EV/edge, no price`
  - `No market economics`
- Adds `ev_coverage` and `price_coverage` to P&L summaries so the UI can distinguish real model quality from missing-market context.
- Keeps negative EV/edge rows visible for accountability, but no longer lets missing EV/edge dominate chart buckets.

## Important interpretation

A negative-EV group can still show realized profit over a small sample because actual results are noisy. That does not make the pre-event decision good. This PR gives the frontend the labels and coverage fields needed to separate:

- Actual realized P&L
- Pre-event economics quality
- Missing pricing/EV coverage
- Projection-only intelligence

## Tests added/updated

- Missing confidence/edge buckets return `null`, not `Unavailable` chart labels.
- `groupProfit` skips unavailable chart buckets.
- Summary includes EV coverage and price coverage.
- Decision-quality labels separate negative EV, positive EV, projections, and missing economics.

## Verification

Run from `frontend/`:

```bash
npm test
npm run build
```

## Production QA

On `/model-tracker` Results tab:

- `By Edge` should no longer show a massive `Unavailable` bar.
- `By Confidence` should not chart missing confidence as a real band.
- Negative EV/edge rows can still appear in accounting, but should be understood as decision-quality failures, not profitable recommendation logic.
- Coverage metrics can now be surfaced in a follow-up UI pass if needed.