### PR TITLE
Hotfix: Model Projections blank page from realism diagnostics render

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -953,7 +953,6 @@ export default function ModelProjectionsPage() {
         <GameProjectionCard key={game.game_pk || `${game.away_team?.name}-${game.home_team?.name}`} game={game} />
       ))}
     
-      {renderGameStateRealismDiagnostics(projection?.game_state_realism || row?.game_state_realism || item?.game_state_realism)}
 </div>
   )
 }


### PR DESCRIPTION
## Summary
- Remove unsafe top-level `renderGameStateRealismDiagnostics(...)` invocation from `ModelProjectionsPage.jsx`
- Fix blank Model Projections page caused by undefined `projection`/`row`/`item` references in the page render scope

## Context
Layer 6OJ added UI helper functions for realism diagnostics, but the automated render insertion placed the diagnostic component call in an unsafe scope. This hotfix removes only that unsafe render invocation while preserving the helper definitions for a safer follow-up implementation.

## Safety
- Frontend hotfix only
- No backend simulation changes
- No final probability changes
- No tuning, validation, joins, pricing, or edge detection