### PR TITLE
Hotfix: Safe scoped model projection realism diagnostics render

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -824,6 +824,8 @@ function GameProjectionCard({ game }) {
         ))}
       </div>
 
+      {renderGameStateRealismDiagnostics(game?.game_state_realism)}
+
       {(
         !awayRunModel ||
         !homeRunModel ||


### PR DESCRIPTION
## Summary
- Re-add realism diagnostics rendering in the safe `GameProjectionCard({ game })` scope
- Use `game?.game_state_realism` instead of undefined page-scope variables
- Preserve the prior blank-page fix while restoring intended frontend diagnostic visibility

## Safety
- Frontend-only scoped render change
- No backend simulation changes
- No final probability changes
- No tuning, validation, joins, pricing, or edge detection

## Context
The first 6OJ render insertion used undefined variables (`projection`, `row`, `item`) at page scope and caused a blank page. PR #828 removed that unsafe call. This hotfix restores the diagnostic renderer using the scoped `game` prop inside `GameProjectionCard`.