### PR TITLE
Fix stale matchup win probability navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,8 @@ import NewsPage from './pages/NewsPage'
 import MyDashboardWorkspacePage from './pages/MyDashboardWorkspacePage'
 import ModelTrackerPage from './pages/ModelTrackerPage'
 
+// Set VITE_ENABLE_BATTER_PAGE=true in Railway env vars to re-enable the Batter routes.
+// Keep false until the leaderboard endpoint is validated stable in production.
 const ENABLE_BATTER_PAGE = import.meta.env.VITE_ENABLE_BATTER_PAGE === 'true'
 
 const BatterPage = ENABLE_BATTER_PAGE ? React.lazy(() => import('./pages/BatterPage')) : null
@@ -31,7 +33,7 @@ function BatterTemporarilyUnavailable() {
       <div className="status-badge warning" style={{ marginBottom: 12 }}>Temporarily Disabled</div>
       <h1 className="page-title" style={{ fontSize: 24 }}>Batter dashboard validation in progress</h1>
       <p className="page-subtitle" style={{ margin: '10px auto 0' }}>
-        Batter routes are temporarily unavailable while the backend endpoint is validated. Matchups, pitchers, teams, odds, live scores, and model projections remain available.
+        The Batter dashboard is temporarily unavailable while the backend leaderboard endpoint is validated for production stability. Matchups, pitchers, teams, odds, live scores, and model projections remain available.
       </p>
     </section>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, NavLink, useParams } from 'react-router-dom'
 import './styles/bet105-mobile.css'
 import HomePage from './pages/HomePage'
 import LandingV2Page from './pages/LandingV2Page'
@@ -20,8 +20,6 @@ import NewsPage from './pages/NewsPage'
 import MyDashboardWorkspacePage from './pages/MyDashboardWorkspacePage'
 import ModelTrackerPage from './pages/ModelTrackerPage'
 
-// Set VITE_ENABLE_BATTER_PAGE=true in Railway env vars to re-enable the Batter routes.
-// Keep false until the leaderboard endpoint is validated stable in production.
 const ENABLE_BATTER_PAGE = import.meta.env.VITE_ENABLE_BATTER_PAGE === 'true'
 
 const BatterPage = ENABLE_BATTER_PAGE ? React.lazy(() => import('./pages/BatterPage')) : null
@@ -33,10 +31,15 @@ function BatterTemporarilyUnavailable() {
       <div className="status-badge warning" style={{ marginBottom: 12 }}>Temporarily Disabled</div>
       <h1 className="page-title" style={{ fontSize: 24 }}>Batter dashboard validation in progress</h1>
       <p className="page-subtitle" style={{ margin: '10px auto 0' }}>
-        The Batter dashboard is temporarily unavailable while the backend leaderboard endpoint is validated for production stability. Matchups, pitchers, teams, odds, live scores, and model projections remain available.
+        Batter routes are temporarily unavailable while the backend endpoint is validated. Matchups, pitchers, teams, odds, live scores, and model projections remain available.
       </p>
     </section>
   )
+}
+
+function MatchupRoute() {
+  const { game_pk } = useParams()
+  return <MatchupDetailPage key={game_pk} />
 }
 
 const navLinkClass = ({ isActive }) => `app-nav-link${isActive ? ' active' : ''}`
@@ -75,7 +78,7 @@ export default function App() {
             <Route path="/models/projections" element={<ModelProjectionsPage />} />
             <Route path="/model-tracker" element={<ModelTrackerPage />} />
             <Route path="/my-dashboard" element={<MyDashboardWorkspacePage />} />
-            <Route path="/matchup/:game_pk" element={<MatchupDetailPage />} />
+            <Route path="/matchup/:game_pk" element={<MatchupRoute />} />
             <Route path="/matchup/:game_pk/competitive" element={<CompetitiveAnalysisPage />} />
             <Route path="/standings" element={<StandingsPage />} />
             <Route path="/pitcher" element={<PitcherPage />} />

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { API_BASE, fetchJson, getMlbLiveDate, readCachedJson } from '../lib/api'
 
 const API = API_BASE
@@ -249,6 +249,11 @@ function statusClass(status) {
   return 'warning'
 }
 
+function openMatchupDetail(gamePk) {
+  if (!gamePk || typeof window === 'undefined') return
+  window.location.assign(`/matchup/${gamePk}`)
+}
+
 export default function HomePage() {
   const isMobile = useIsMobile()
   const today = getMlbLiveDate()
@@ -267,7 +272,6 @@ export default function HomePage() {
   const [oddsLoading, setOddsLoading] = useState(oddsEvents.length === 0)
   const [error, setError] = useState(null)
   const [oddsError, setOddsError] = useState(null)
-  const navigate = useNavigate()
 
   useEffect(() => {
     let cancelled = false
@@ -372,7 +376,7 @@ export default function HomePage() {
               key={m.game_pk || i}
               className="pro-card pro-card-hover card-pad responsive-matchup-card"
               style={s.card}
-              onClick={() => m.game_pk && navigate(`/matchup/${m.game_pk}`)}
+              onClick={() => openMatchupDetail(m.game_pk)}
             >
               <div style={{ ...s.slateMeta, ...(isMobile ? s.slateMetaMobile : {}) }}>
                 <div style={s.venue}>


### PR DESCRIPTION
## Summary
- Use clean document navigation when opening a matchup from the homepage slate.
- Key the matchup detail route by game_pk so each selected game gets a fresh detail component instance.
- Keeps the diff scoped to matchup navigation/state reset behavior.

## Verification
- Reviewed PR diff after cleanup: changed only frontend/src/pages/HomePage.jsx and frontend/src/App.jsx.
- Branch is ahead of main and PR is open.
- Build was not run here because this connector does not provide a checked-out npm workspace.