### PR TITLE
Add performance instrumentation and cache matchups

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -2,6 +2,7 @@ const PROD_API_BASE = 'https://mlb-prediction-app-production-732c.up.railway.app
 
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || PROD_API_BASE
 const JSON_CACHE = new Map()
+const IN_FLIGHT_JSON = new Map()
 const STORAGE_PREFIX = 'mlb-json-cache:v1:'
 
 function nowMs() {
@@ -94,17 +95,11 @@ export function writeCachedJson(url, value) {
 export function clearCachedJson(url) {
   const key = String(url || '')
   JSON_CACHE.delete(key)
+  IN_FLIGHT_JSON.delete(key)
   deleteStorageRecord(key)
 }
 
-export async function fetchJson(url, { ttlSeconds = 60, forceRefresh = false, signal } = {}) {
-  if (!forceRefresh) {
-    const cached = readCachedJson(url, ttlSeconds)
-    if (cached != null) return cached
-  } else {
-    clearCachedJson(url)
-  }
-
+async function fetchJsonUncached(url, signal) {
   const response = await fetch(url, { signal })
   if (!response.ok) {
     const body = await response.text()
@@ -120,6 +115,34 @@ export async function fetchJson(url, { ttlSeconds = 60, forceRefresh = false, si
   const json = await response.json()
   writeCachedJson(url, json)
   return cloneJson(json)
+}
+
+export async function fetchJson(url, { ttlSeconds = 60, forceRefresh = false, signal } = {}) {
+  const key = String(url || '')
+  if (!forceRefresh) {
+    const cached = readCachedJson(url, ttlSeconds)
+    if (cached != null) return cached
+  } else {
+    clearCachedJson(url)
+  }
+
+  const canDedupe = !forceRefresh && !signal
+  if (canDedupe && IN_FLIGHT_JSON.has(key)) {
+    return cloneJson(await IN_FLIGHT_JSON.get(key))
+  }
+
+  const requestPromise = fetchJsonUncached(url, signal)
+  if (canDedupe) {
+    IN_FLIGHT_JSON.set(key, requestPromise)
+  }
+
+  try {
+    return cloneJson(await requestPromise)
+  } finally {
+    if (canDedupe) {
+      IN_FLIGHT_JSON.delete(key)
+    }
+  }
 }
 
 export function getMlbToday() {

--- a/mlb_app/__init__.py
+++ b/mlb_app/__init__.py
@@ -1,1 +1,5 @@
+from .performance import install_fastapi_performance_patch
+
+install_fastapi_performance_patch()
+
 from .database import get_engine, create_tables, get_session

--- a/mlb_app/cache.py
+++ b/mlb_app/cache.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import copy
+import time
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class CacheEntry:
+    value: Any
+    created_at: float
+    expires_at: float
+    stale_expires_at: Optional[float] = None
+
+
+_CACHE: Dict[str, CacheEntry] = {}
+_LOCK = RLock()
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _clone(value: Any) -> Any:
+    try:
+        return copy.deepcopy(value)
+    except Exception:
+        return value
+
+
+def cache_key(*parts: Any) -> str:
+    """Build a stable colon-delimited cache key from non-empty key parts."""
+    return ":".join(str(part) for part in parts if part is not None and str(part) != "")
+
+
+def ttl_cache_set(
+    key: str,
+    value: Any,
+    ttl_seconds: int,
+    stale_ttl_seconds: Optional[int] = None,
+) -> Any:
+    """Store a value with a fresh TTL and optional stale-if-error window."""
+    now = _now()
+    fresh_ttl = max(0, int(ttl_seconds or 0))
+    stale_ttl = max(0, int(stale_ttl_seconds or 0)) if stale_ttl_seconds is not None else fresh_ttl
+    entry = CacheEntry(
+        value=_clone(value),
+        created_at=now,
+        expires_at=now + fresh_ttl,
+        stale_expires_at=now + fresh_ttl + stale_ttl if stale_ttl > 0 else None,
+    )
+    with _LOCK:
+        _CACHE[key] = entry
+    return _clone(value)
+
+
+def ttl_cache_get(key: str) -> Optional[Any]:
+    """Return a fresh cached value, or None on miss/expiry."""
+    now = _now()
+    with _LOCK:
+        entry = _CACHE.get(key)
+        if entry is None:
+            return None
+        if now > entry.expires_at:
+            return None
+        return _clone(entry.value)
+
+
+def ttl_cache_get_stale(key: str) -> Optional[Any]:
+    """Return a stale cached value if it is still inside the stale window."""
+    now = _now()
+    with _LOCK:
+        entry = _CACHE.get(key)
+        if entry is None:
+            return None
+        if entry.stale_expires_at is None or now > entry.stale_expires_at:
+            _CACHE.pop(key, None)
+            return None
+        return _clone(entry.value)
+
+
+def ttl_cache_delete(key: str) -> bool:
+    with _LOCK:
+        return _CACHE.pop(key, None) is not None
+
+
+def ttl_cache_clear(prefix: Optional[str] = None) -> int:
+    """Clear all entries or entries matching a prefix. Returns removed count."""
+    with _LOCK:
+        if prefix is None:
+            count = len(_CACHE)
+            _CACHE.clear()
+            return count
+        keys = [key for key in _CACHE if key.startswith(prefix)]
+        for key in keys:
+            _CACHE.pop(key, None)
+        return len(keys)
+
+
+def ttl_cache_snapshot() -> Dict[str, Dict[str, Any]]:
+    """Return non-sensitive cache metadata for diagnostics."""
+    now = _now()
+    with _LOCK:
+        return {
+            key: {
+                "age_seconds": round(now - entry.created_at, 3),
+                "fresh_seconds_remaining": round(max(entry.expires_at - now, 0), 3),
+                "stale_seconds_remaining": round(max((entry.stale_expires_at or entry.expires_at) - now, 0), 3),
+            }
+            for key, entry in _CACHE.items()
+        }

--- a/mlb_app/performance.py
+++ b/mlb_app/performance.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import contextvars
+import math
+import time
+from collections import defaultdict, deque
+from typing import Any, Deque, Dict, Iterable, List, Optional
+
+try:
+    import fastapi as _fastapi
+except Exception:  # pragma: no cover - FastAPI may be absent in narrow unit tests.
+    _fastapi = None
+
+
+_MAX_SAMPLES = 1000
+_SAMPLES: Deque[Dict[str, Any]] = deque(maxlen=_MAX_SAMPLES)
+_CACHE_STATUS: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "mlb_cache_status",
+    default=None,
+)
+_PATCHED = False
+_ORIGINAL_FASTAPI = None
+
+
+def record_cache_status(status: Optional[str]) -> None:
+    """Record cache status for the current request context."""
+    if status:
+        _CACHE_STATUS.set(str(status).upper())
+
+
+def _percentile(values: List[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = int(math.ceil((percentile / 100.0) * len(ordered))) - 1
+    index = min(max(index, 0), len(ordered) - 1)
+    return round(ordered[index], 3)
+
+
+def _route_label(request: Any) -> str:
+    route = request.scope.get("route") if getattr(request, "scope", None) else None
+    route_path = getattr(route, "path", None)
+    return route_path or getattr(getattr(request, "url", None), "path", None) or "unknown"
+
+
+def _response_size_bytes(response: Any) -> Optional[int]:
+    try:
+        content_length = response.headers.get("content-length")
+        return int(content_length) if content_length is not None else None
+    except Exception:
+        return None
+
+
+def record_request_sample(sample: Dict[str, Any]) -> None:
+    _SAMPLES.append(sample)
+
+
+def performance_snapshot() -> Dict[str, Any]:
+    """Return bounded, non-sensitive route timing diagnostics."""
+    samples = list(_SAMPLES)
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for sample in samples:
+        grouped[str(sample.get("route") or sample.get("path") or "unknown")].append(sample)
+
+    routes: Dict[str, Dict[str, Any]] = {}
+    for route, rows in grouped.items():
+        durations = [float(row.get("duration_ms") or 0) for row in rows]
+        routes[route] = {
+            "count": len(rows),
+            "p50_ms": _percentile(durations, 50),
+            "p95_ms": _percentile(durations, 95),
+            "max_ms": round(max(durations), 3) if durations else 0.0,
+            "cache": dict(defaultdict(int, ((str(row.get("cache_status") or "NONE"), 0) for row in []))),
+        }
+        cache_counts: Dict[str, int] = defaultdict(int)
+        for row in rows:
+            cache_counts[str(row.get("cache_status") or "NONE")] += 1
+        routes[route]["cache"] = dict(cache_counts)
+
+    slow_requests = sorted(
+        samples,
+        key=lambda row: float(row.get("duration_ms") or 0),
+        reverse=True,
+    )[:20]
+
+    return {
+        "status": "ok",
+        "sample_count": len(samples),
+        "sample_limit": _MAX_SAMPLES,
+        "routes": routes,
+        "slow_requests": slow_requests,
+    }
+
+
+def install_fastapi_performance_patch() -> bool:
+    """Patch fastapi.FastAPI so app.py gets timing middleware without a large app.py rewrite.
+
+    This is intentionally small and reversible. It only adds response timing
+    headers, bounded in-process samples, and /debug/performance. It does not
+    inspect request bodies or headers.
+    """
+    global _PATCHED, _ORIGINAL_FASTAPI
+    if _PATCHED or _fastapi is None:
+        return _PATCHED
+
+    original_fastapi = _fastapi.FastAPI
+    _ORIGINAL_FASTAPI = original_fastapi
+
+    class InstrumentedFastAPI(original_fastapi):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+
+            @self.middleware("http")
+            async def _performance_middleware(request: Any, call_next: Any) -> Any:
+                token = _CACHE_STATUS.set(None)
+                started = time.perf_counter()
+                status_code = 500
+                response = None
+                try:
+                    response = await call_next(request)
+                    status_code = getattr(response, "status_code", 500)
+                    return response
+                finally:
+                    duration_ms = round((time.perf_counter() - started) * 1000, 3)
+                    cache_status = _CACHE_STATUS.get()
+                    route = _route_label(request)
+                    sample = {
+                        "method": getattr(request, "method", None),
+                        "path": getattr(getattr(request, "url", None), "path", None),
+                        "route": route,
+                        "status_code": status_code,
+                        "duration_ms": duration_ms,
+                        "response_size_bytes": _response_size_bytes(response),
+                        "cache_status": cache_status,
+                    }
+                    record_request_sample(sample)
+                    if response is not None:
+                        response.headers["X-Response-Time-ms"] = str(duration_ms)
+                        if cache_status:
+                            response.headers["X-Cache"] = cache_status
+                    _CACHE_STATUS.reset(token)
+
+            async def _debug_performance() -> Dict[str, Any]:
+                return performance_snapshot()
+
+            self.add_api_route(
+                "/debug/performance",
+                _debug_performance,
+                methods=["GET"],
+                include_in_schema=False,
+            )
+
+    _fastapi.FastAPI = InstrumentedFastAPI
+    _PATCHED = True
+    return True
+
+
+__all__ = [
+    "install_fastapi_performance_patch",
+    "performance_snapshot",
+    "record_cache_status",
+    "record_request_sample",
+]

--- a/mlb_app/shared_payload_cache.py
+++ b/mlb_app/shared_payload_cache.py
@@ -7,6 +7,8 @@ import os
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
+from .performance import record_cache_status
+
 CacheRecord = Tuple[float, Any]
 _CACHE: Dict[str, CacheRecord] = {}
 
@@ -52,11 +54,14 @@ def make_cache_key(*parts: Any) -> str:
 def get_cache(key: str, ttl_seconds: int) -> Optional[Any]:
     record = _CACHE.get(key)
     if not record:
+        record_cache_status("MISS")
         return None
     created_at, value = record
     if ttl_seconds <= 0 or _now() - created_at > ttl_seconds:
         _CACHE.pop(key, None)
+        record_cache_status("MISS")
         return None
+    record_cache_status("HIT")
     return copy.deepcopy(value)
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,50 @@
+from mlb_app.cache import (
+    cache_key,
+    ttl_cache_clear,
+    ttl_cache_delete,
+    ttl_cache_get,
+    ttl_cache_get_stale,
+    ttl_cache_set,
+)
+
+
+def setup_function():
+    ttl_cache_clear()
+
+
+def test_cache_key_skips_empty_parts():
+    assert cache_key("matchups", None, "", "2026-06-18") == "matchups:2026-06-18"
+
+
+def test_ttl_cache_hit_returns_copy():
+    payload = {"games": [{"game_pk": 123}]}
+    ttl_cache_set("matchups:today", payload, ttl_seconds=60)
+
+    cached = ttl_cache_get("matchups:today")
+    assert cached == payload
+    assert cached is not payload
+
+    cached["games"][0]["game_pk"] = 999
+    assert ttl_cache_get("matchups:today") == payload
+
+
+def test_ttl_cache_expired_misses_but_stale_can_be_returned():
+    ttl_cache_set("matchups:stale", [1, 2, 3], ttl_seconds=0, stale_ttl_seconds=60)
+
+    assert ttl_cache_get("matchups:stale") is None
+    assert ttl_cache_get_stale("matchups:stale") == [1, 2, 3]
+
+
+def test_ttl_cache_stale_window_expires_entry():
+    ttl_cache_set("matchups:expired", {"ok": True}, ttl_seconds=0, stale_ttl_seconds=0)
+
+    assert ttl_cache_get("matchups:expired") is None
+    assert ttl_cache_get_stale("matchups:expired") is None
+
+
+def test_ttl_cache_delete():
+    ttl_cache_set("matchups:delete", "value", ttl_seconds=60)
+
+    assert ttl_cache_delete("matchups:delete") is True
+    assert ttl_cache_get("matchups:delete") is None
+    assert ttl_cache_delete("matchups:delete") is False


### PR DESCRIPTION
## Summary
- Adds `mlb_app/cache.py`, a reusable in-process TTL cache helper with stale-window support and metadata snapshots.
- Adds FastAPI performance instrumentation through `mlb_app/performance.py`, including `X-Response-Time-ms`, bounded in-process route samples, and `/debug/performance`.
- Wires shared payload cache hits/misses into the performance middleware so cached routes can surface `X-Cache`.
- Adds in-flight request dedupe to `frontend/src/lib/api.js` without changing UI layout or model math.
- Adds unit coverage for the new TTL cache helper.

## Scope notes
- This PR starts issue #831 and intentionally keeps the change incremental.
- Existing `generate_matchups_for_date()` already uses `shared_payload_cache.py`; this PR instruments that cache path and makes cache status observable.
- This PR does not yet split `/matchup/{game_pk}` or remove the 5,000-run simulations from the initial matchup detail route. That remains the next PR: `perf/split-matchup-detail-heavy-models`.

## Verification
- Reviewed branch diff: 6 files changed.
- Tests/build were not run here because this connector does not provide a checked-out repo workspace or outbound access to clone GitHub.

## Manual verification to run after checkout
```bash
python -m pytest tests/test_cache.py
python -m pytest
cd frontend && npm install && npm run build
```

Then run repeated endpoint checks and record cold/cache-hit timings:
```bash
curl -i http://localhost:8000/health
curl -i 'http://localhost:8000/matchups?date=<today>'
curl -i 'http://localhost:8000/matchups?date=<today>'
curl -i 'http://localhost:8000/matchups/calendar'
curl -s http://localhost:8000/debug/performance | python -m json.tool
```

Expected behavior:
- All API responses include `X-Response-Time-ms`.
- Cached shared-payload routes can include `X-Cache: HIT` or `X-Cache: MISS`.
- `/debug/performance` returns route-level p50/p95/count/max and recent slow requests.
- Frontend duplicate same-URL `fetchJson` calls share one in-flight network request.

## No fake data
No model output was removed, stubbed, or faked. This PR only adds instrumentation, cache primitives, cache observability, and request dedupe.