### PR TITLE
Hotfix: Wire game-state realism diagnostics into model projection payload

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -651,6 +651,7 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
 
             games.append({
                 "game_pk": matchup.get("game_pk"),
+                "game_state_realism": _build_game_state_realism_diagnostics(),
                 "sharedSimulation": shared_simulation,
                 "game_date": matchup.get("game_date") or target_date,
                 "game_time": matchup.get("game_time"),


### PR DESCRIPTION
## Summary
- Attach the existing `_build_game_state_realism_diagnostics()` output to each game object returned by `build_model_projection_payload`
- Expose the payload under the exact top-level key `game_state_realism`
- Restore the backend/frontend contract expected by `GameProjectionCard`

## Scope
This is a one-line payload wiring change only.

## Safety
- No simulation behavior changes
- No canonical probability changes
- No final probability replacement
- No tuning, validation, pricing, or edge detection

## Validation
- Python source compilation passed without writing pyc files
- Helper contract contains all 8 required fields
- Exactly one runtime helper call exists
- AST check confirms the helper call is attached to the per-game payload object