### PR TITLE
Layer 6PA: Pitching-Plan Classification Implementation

### DIFF
--- a/mlb_app/simulation/pitching_plan_classifier.py
+++ b/mlb_app/simulation/pitching_plan_classifier.py
@@ -1,0 +1,748 @@
+"""
+Pure pitching-plan classification.
+
+This module has no production-route side effects. It converts explicit
+pregame pitching-plan evidence into a deterministic diagnostic payload.
+
+Production activation is intentionally outside this module.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+
+PLAN_TRADITIONAL_STARTER = "traditional_starter"
+PLAN_OPENER_BULK = "opener_bulk"
+PLAN_TANDEM = "tandem"
+PLAN_BULLPEN_GAME = "bullpen_game"
+PLAN_WORKLOAD_CAPPED_STARTER = "workload_capped_starter"
+PLAN_UNKNOWN_FALLBACK = "unknown_fallback"
+
+ALLOWED_PLAN_TYPES = {
+    PLAN_TRADITIONAL_STARTER,
+    PLAN_OPENER_BULK,
+    PLAN_TANDEM,
+    PLAN_BULLPEN_GAME,
+    PLAN_WORKLOAD_CAPPED_STARTER,
+    PLAN_UNKNOWN_FALLBACK,
+}
+
+SOURCE_VERIFIED = "verified"
+SOURCE_INFERRED = "inferred"
+SOURCE_FALLBACK = "fallback"
+SOURCE_CONTRADICTORY = "contradictory"
+
+ALLOWED_SOURCE_STATUSES = {
+    SOURCE_VERIFIED,
+    SOURCE_INFERRED,
+    SOURCE_FALLBACK,
+    SOURCE_CONTRADICTORY,
+}
+
+CAP_TYPES = {
+    "pitches",
+    "batters",
+    "innings",
+}
+
+
+def _clean_id(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+
+    cleaned = str(value).strip().lower()
+    return cleaned or None
+
+
+def _clean_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        return value.strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "y",
+        }
+
+    return bool(value)
+
+
+def _clean_availability(
+    value: Any,
+) -> Dict[str, bool]:
+    if not isinstance(value, Mapping):
+        return {}
+
+    cleaned: Dict[str, bool] = {}
+
+    for key, available in value.items():
+        pitcher_id = _clean_id(key)
+        if pitcher_id is None:
+            continue
+
+        cleaned[pitcher_id] = _clean_bool(
+            available
+        )
+
+    return cleaned
+
+
+def _is_available(
+    pitcher_id: Optional[str],
+    availability: Mapping[str, bool],
+) -> bool:
+    if pitcher_id is None:
+        return False
+
+    if pitcher_id not in availability:
+        return True
+
+    return bool(availability[pitcher_id])
+
+
+def _normalize_workload_cap(
+    value: Any,
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        return None
+
+    cap_type = _clean_text(
+        value.get("type")
+        or value.get("cap_type")
+    )
+
+    if cap_type not in CAP_TYPES:
+        return None
+
+    raw_value = (
+        value.get("value")
+        if value.get("value") is not None
+        else value.get("cap")
+    )
+
+    try:
+        cap_value = float(raw_value)
+    except (TypeError, ValueError):
+        return None
+
+    if cap_value <= 0:
+        return None
+
+    source = (
+        _clean_text(value.get("source"))
+        or "unspecified"
+    )
+
+    return {
+        "type": cap_type,
+        "value": cap_value,
+        "source": source,
+    }
+
+
+def _dedupe_sequence(
+    rows: Iterable[Dict[str, Any]],
+) -> list[Dict[str, Any]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[Dict[str, Any]] = []
+
+    for row in rows:
+        role = _clean_text(row.get("role"))
+        pitcher_id = _clean_id(
+            row.get("pitcher_id")
+        )
+
+        if role is None or pitcher_id is None:
+            continue
+
+        key = (role, pitcher_id)
+
+        if key in seen:
+            continue
+
+        seen.add(key)
+
+        result.append(
+            {
+                "order": len(result) + 1,
+                "role": role,
+                "pitcher_id": pitcher_id,
+            }
+        )
+
+    return result
+
+
+def _unknown_payload(
+    *,
+    listed_starter_id: Optional[str],
+    primary_pitcher_id: Optional[str],
+    bulk_pitcher_id: Optional[str],
+    workload_cap: Optional[Dict[str, Any]],
+    source_status: str,
+    reasons: list[str],
+    source_provenance: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "plan_type": PLAN_UNKNOWN_FALLBACK,
+        "confidence": 0.20,
+        "source_status": source_status,
+        "source_provenance": source_provenance,
+        "listed_starter_id": listed_starter_id,
+        "primary_pitcher_id": primary_pitcher_id,
+        "bulk_pitcher_id": bulk_pitcher_id,
+        "planned_sequence": [],
+        "workload_cap": workload_cap,
+        "fallback_used": True,
+        "diagnostics": {
+            "rule_id": "PP-R06",
+            "reasons": sorted(set(reasons)),
+            "classifier_version": (
+                "pitching-plan-classifier-v1"
+            ),
+            "production_activation": False,
+            "canonical_probability_authority_changed": (
+                False
+            ),
+        },
+    }
+
+
+def classify_pitching_plan(
+    evidence: Optional[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Classify a pregame pitching plan using explicit evidence.
+
+    The function is deterministic and side-effect free. It does not
+    alter the supplied mapping.
+    """
+
+    raw = deepcopy(dict(evidence or {}))
+
+    listed_starter_id = _clean_id(
+        raw.get("listed_starter_id")
+    )
+
+    expected_primary_pitcher_id = _clean_id(
+        raw.get("expected_primary_pitcher_id")
+    )
+
+    expected_bulk_pitcher_id = _clean_id(
+        raw.get("expected_bulk_pitcher_id")
+    )
+
+    announced_plan = _clean_text(
+        raw.get("announced_pitching_plan")
+    )
+
+    bullpen_game_indicator = _clean_bool(
+        raw.get("team_bullpen_game_indicator")
+    )
+
+    workload_cap = _normalize_workload_cap(
+        raw.get("workload_cap")
+        or raw.get("starter_recent_workload")
+    )
+
+    availability = _clean_availability(
+        raw.get("roster_and_availability_state")
+    )
+
+    contradictory = _clean_bool(
+        raw.get("contradictory_sources")
+    )
+
+    source_name = (
+        _clean_text(raw.get("source_name"))
+        or "unspecified"
+    )
+
+    source_timestamp = _clean_text(
+        raw.get("source_timestamp")
+    )
+
+    source_provenance = {
+        "source_name": source_name,
+        "source_timestamp": source_timestamp,
+        "availability_supplied": bool(
+            availability
+        ),
+        "announcement_supplied": (
+            announced_plan is not None
+        ),
+    }
+
+    primary_pitcher_id = (
+        expected_primary_pitcher_id
+        or listed_starter_id
+    )
+
+    reasons: list[str] = []
+
+    for label, pitcher_id in [
+        ("listed_starter_unavailable", listed_starter_id),
+        (
+            "primary_pitcher_unavailable",
+            primary_pitcher_id,
+        ),
+        (
+            "bulk_pitcher_unavailable",
+            expected_bulk_pitcher_id,
+        ),
+    ]:
+        if (
+            pitcher_id is not None
+            and not _is_available(
+                pitcher_id,
+                availability,
+            )
+        ):
+            reasons.append(label)
+
+    unavailable_identity = bool(reasons)
+
+    if contradictory:
+        reasons.append(
+            "contradictory_sources"
+        )
+
+    if contradictory or unavailable_identity:
+        return _unknown_payload(
+            listed_starter_id=listed_starter_id,
+            primary_pitcher_id=(
+                primary_pitcher_id
+                if _is_available(
+                    primary_pitcher_id,
+                    availability,
+                )
+                else None
+            ),
+            bulk_pitcher_id=(
+                expected_bulk_pitcher_id
+                if _is_available(
+                    expected_bulk_pitcher_id,
+                    availability,
+                )
+                else None
+            ),
+            workload_cap=workload_cap,
+            source_status=(
+                SOURCE_CONTRADICTORY
+                if contradictory
+                else SOURCE_FALLBACK
+            ),
+            reasons=reasons,
+            source_provenance=source_provenance,
+        )
+
+    if announced_plan in {
+        "opener_bulk",
+        "opener",
+        "opener_and_bulk",
+    }:
+        if (
+            listed_starter_id is None
+            or expected_bulk_pitcher_id is None
+        ):
+            return _unknown_payload(
+                listed_starter_id=(
+                    listed_starter_id
+                ),
+                primary_pitcher_id=(
+                    primary_pitcher_id
+                ),
+                bulk_pitcher_id=(
+                    expected_bulk_pitcher_id
+                ),
+                workload_cap=workload_cap,
+                source_status=SOURCE_FALLBACK,
+                reasons=[
+                    "opener_bulk_identity_incomplete"
+                ],
+                source_provenance=(
+                    source_provenance
+                ),
+            )
+
+        sequence = _dedupe_sequence(
+            [
+                {
+                    "role": "opener",
+                    "pitcher_id": (
+                        listed_starter_id
+                    ),
+                },
+                {
+                    "role": "bulk_follower",
+                    "pitcher_id": (
+                        expected_bulk_pitcher_id
+                    ),
+                },
+            ]
+        )
+
+        return {
+            "plan_type": PLAN_OPENER_BULK,
+            "confidence": 0.95,
+            "source_status": SOURCE_VERIFIED,
+            "source_provenance": source_provenance,
+            "listed_starter_id": (
+                listed_starter_id
+            ),
+            "primary_pitcher_id": (
+                expected_bulk_pitcher_id
+            ),
+            "bulk_pitcher_id": (
+                expected_bulk_pitcher_id
+            ),
+            "planned_sequence": sequence,
+            "workload_cap": workload_cap,
+            "fallback_used": False,
+            "diagnostics": {
+                "rule_id": "PP-R01",
+                "reasons": [
+                    "verified_opener_bulk_plan"
+                ],
+                "classifier_version": (
+                    "pitching-plan-classifier-v1"
+                ),
+                "production_activation": False,
+                (
+                    "canonical_probability_"
+                    "authority_changed"
+                ): False,
+            },
+        }
+
+    if announced_plan in {
+        "tandem",
+        "tandem_starter",
+    }:
+        if (
+            listed_starter_id is None
+            or expected_bulk_pitcher_id is None
+            or (
+                listed_starter_id
+                == expected_bulk_pitcher_id
+            )
+        ):
+            return _unknown_payload(
+                listed_starter_id=(
+                    listed_starter_id
+                ),
+                primary_pitcher_id=(
+                    primary_pitcher_id
+                ),
+                bulk_pitcher_id=(
+                    expected_bulk_pitcher_id
+                ),
+                workload_cap=workload_cap,
+                source_status=SOURCE_FALLBACK,
+                reasons=[
+                    "tandem_identity_incomplete"
+                ],
+                source_provenance=(
+                    source_provenance
+                ),
+            )
+
+        sequence = _dedupe_sequence(
+            [
+                {
+                    "role": "tandem_primary",
+                    "pitcher_id": (
+                        listed_starter_id
+                    ),
+                },
+                {
+                    "role": "tandem_secondary",
+                    "pitcher_id": (
+                        expected_bulk_pitcher_id
+                    ),
+                },
+            ]
+        )
+
+        return {
+            "plan_type": PLAN_TANDEM,
+            "confidence": 0.95,
+            "source_status": SOURCE_VERIFIED,
+            "source_provenance": source_provenance,
+            "listed_starter_id": (
+                listed_starter_id
+            ),
+            "primary_pitcher_id": (
+                listed_starter_id
+            ),
+                     "bulk_pitcher_id": (
+                expected_bulk_pitcher_id
+            ),
+   "planned_sequence": sequence,
+            "workload_cap": workload_cap,
+            "fallback_used": False,
+            "diagnostics": {
+                "rule_id": "PP-R02",
+                "reasons": [
+                    "verified_tandem_plan"
+                ],
+                "classifier_version": (
+                    "pitching-plan-classifier-v1"
+                ),
+                "production_activation": False,
+                (
+                    "canonical_probability_"
+                    "authority_changed"
+                ): False,
+            },
+        }
+
+    if (
+        announced_plan == "bullpen_game"
+        or bullpen_game_indicator
+    ):
+        return {
+            "plan_type": PLAN_BULLPEN_GAME,
+            "confidence": (
+                0.95
+                if announced_plan == "bullpen_game"
+                else 0.75
+            ),
+            "source_status": (
+                SOURCE_VERIFIED
+                if announced_plan == "bullpen_game"
+                else SOURCE_INFERRED
+            ),
+            "source_provenance": source_provenance,
+            "listed_starter_id": (
+                listed_starter_id
+            ),
+            "primary_pitcher_id": None,
+            "bulk_pitcher_id": None,
+            "planned_sequence": [],
+            "workload_cap": workload_cap,
+            "fallback_used": False,
+            "diagnostics": {
+                "rule_id": "PP-R03",
+                "reasons": [
+                    "bullpen_game_indicator"
+                ],
+                "classifier_version": (
+                    "pitching-plan-classifier-v1"
+                ),
+                "production_activation": False,
+                (
+                    "canonical_probability_"
+                    "authority_changed"
+                ): False,
+            },
+        }
+
+    if (
+        listed_starter_id is not None
+        and workload_cap is not None
+    ):
+        sequence = _dedupe_sequence(
+            [
+                {
+                    "role": "starter",
+                    "pitcher_id": (
+                        listed_starter_id
+                    ),
+                }
+            ]
+        )
+
+        return {
+            "plan_type": (
+                PLAN_WORKLOAD_CAPPED_STARTER
+            ),
+            "confidence": 0.85,
+            "source_status": SOURCE_VERIFIED,
+            "source_provenance": source_provenance,
+            "listed_starter_id": (
+                listed_starter_id
+            ),
+            "primary_pitcher_id": (
+                listed_starter_id
+            ),
+            "bulk_pitcher_id": None,
+            "planned_sequence": sequence,
+            "workload_cap": workload_cap,
+            "fallback_used": False,
+            "diagnostics": {
+                "rule_id": "PP-R04",
+                "reasons": [
+                    "verified_workload_cap"
+                ],
+                "classifier_version": (
+                    "pitching-plan-classifier-v1"
+                ),
+                "production_activation": False,
+                (
+                    "canonical_probability_"
+                    "authority_changed"
+                ): False,
+            },
+        }
+
+    if listed_starter_id is not None:
+        sequence = _dedupe_sequence(
+            [
+                {
+                    "role": "starter",
+                    "pitcher_id": (
+                        listed_starter_id
+                    ),
+                }
+            ]
+        )
+
+        return {
+            "plan_type": (
+                PLAN_TRADITIONAL_STARTER
+            ),
+            "confidence": 0.65,
+            "source_status": SOURCE_INFERRED,
+            "source_provenance": source_provenance,
+            "listed_starter_id": (
+                listed_starter_id
+            ),
+            "primary_pitcher_id": (
+                primary_pitcher_id
+            ),
+            "bulk_pitcher_id": None,
+            "planned_sequence": sequence,
+            "workload_cap": None,
+            "fallback_used": False,
+            "diagnostics": {
+                "rule_id": "PP-R05",
+                "reasons": [
+                    "listed_starter_no_conflict"
+                ],
+                "classifier_version": (
+                    "pitching-plan-classifier-v1"
+                ),
+                "production_activation": False,
+                (
+                    "canonical_probability_"
+                    "authority_changed"
+                ): False,
+            },
+        }
+
+    return _unknown_payload(
+        listed_starter_id=None,
+        primary_pitcher_id=None,
+        bulk_pitcher_id=None,
+        workload_cap=workload_cap,
+        source_status=SOURCE_FALLBACK,
+        reasons=[
+            "insufficient_pitching_plan_evidence"
+        ],
+        source_provenance=source_provenance,
+    )
+
+
+def validate_pitching_plan_payload(
+    payload: Mapping[str, Any],
+) -> Dict[str, Any]:
+    required_fields = {
+        "plan_type",
+        "confidence",
+        "source_status",
+        "source_provenance",
+        "listed_starter_id",
+        "primary_pitcher_id",
+        "bulk_pitcher_id",
+        "planned_sequence",
+        "workload_cap",
+        "fallback_used",
+        "diagnostics",
+    }
+
+    missing_fields = sorted(
+        required_fields - set(payload.keys())
+    )
+
+    errors: list[str] = []
+
+    if missing_fields:
+        errors.append(
+            "missing_fields:"
+            + ",".join(missing_fields)
+        )
+
+    if payload.get("plan_type") not in (
+        ALLOWED_PLAN_TYPES
+    ):
+        errors.append("invalid_plan_type")
+
+    if payload.get("source_status") not in (
+        ALLOWED_SOURCE_STATUSES
+    ):
+        errors.append("invalid_source_status")
+
+    confidence = payload.get("confidence")
+
+    if not isinstance(confidence, (int, float)):
+        errors.append("invalid_confidence_type")
+    elif not 0.0 <= float(confidence) <= 1.0:
+        errors.append("invalid_confidence_range")
+
+    sequence = payload.get("planned_sequence")
+
+    if not isinstance(sequence, list):
+        errors.append("invalid_sequence_type")
+    else:
+        expected_order = list(
+            range(1, len(sequence) + 1)
+        )
+        actual_order = [
+            row.get("order")
+            for row in sequence
+            if isinstance(row, Mapping)
+        ]
+
+        if actual_order != expected_order:
+            errors.append(
+                "invalid_sequence_order"
+            )
+
+    diagnostics = payload.get("diagnostics")
+
+    if not isinstance(diagnostics, Mapping):
+        errors.append("invalid_diagnostics")
+    else:
+        if diagnostics.get(
+            "production_activation"
+        ) is not False:
+            errors.append(
+                "production_activation_not_false"
+            )
+
+        if diagnostics.get(
+            "canonical_probability_"
+            "authority_changed"
+        ) is not False:
+            errors.append(
+                "probability_authority_changed"
+            )
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "missing_fields": missing_fields,
+    }

--- a/scripts/implement_6PA_pitching_plan_classification.py
+++ b/scripts/implement_6PA_pitching_plan_classification.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+"""
+Layer 6PA
+Pitching-Plan Classification Implementation
+
+Implements and audits the pure disabled-by-default GM-01 classifier.
+
+No production-route wiring or probability changes occur here.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Iterable
+
+from mlb_app.simulation.pitching_plan_classifier import (
+    PLAN_BULLPEN_GAME,
+    PLAN_OPENER_BULK,
+    PLAN_TANDEM,
+    PLAN_TRADITIONAL_STARTER,
+    PLAN_UNKNOWN_FALLBACK,
+    PLAN_WORKLOAD_CAPPED_STARTER,
+    classify_pitching_plan,
+    validate_pitching_plan_payload,
+)
+
+
+LAYER_ID = "6PA"
+LAYER_NAME = (
+    "pitching_plan_classification_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = ROOT / (
+    "tmp/layer_6PA_pitching_plan_"
+    "classification_implementation"
+)
+
+MODULE_PATH = (
+    ROOT
+    / "mlb_app/simulation/"
+    "pitching_plan_classifier.py"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/plan_6OZ_pitching_plan_"
+    "classification_inventory_and_implementation.py"
+)
+
+PROHIBITED_ACTIONS = [
+    "production_route_wiring",
+    "production_classifier_activation",
+    "backend_payload_change",
+    "frontend_behavior_change",
+    "simulation_parameter_change",
+    "simulation_probability_change",
+    "canonical_probability_replacement",
+    "historical_outcome_join",
+    "accuracy_metric_generation",
+    "parameter_tuning",
+    "backtest_execution",
+    "pricing",
+    "edge_detection",
+    "bet_recommendation",
+    "layer6_exit_finalization",
+]
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    fixtures = [
+        {
+            "fixture_id": "PP-F01",
+            "scenario": "traditional_starter",
+            "expected_plan_type": (
+                PLAN_TRADITIONAL_STARTER
+            ),
+            "evidence": {
+                "listed_starter_id": "starter-1",
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F02",
+            "scenario": "verified_opener_and_bulk",
+            "expected_plan_type": (
+                PLAN_OPENER_BULK
+            ),
+            "evidence": {
+                "listed_starter_id": "opener-1",
+                "expected_bulk_pitcher_id": (
+                    "bulk-1"
+                ),
+                "announced_pitching_plan": (
+                    "opener_bulk"
+                ),
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F03",
+            "scenario": "verified_tandem",
+            "expected_plan_type": PLAN_TANDEM,
+            "evidence": {
+                "listed_starter_id": "tandem-1",
+                "expected_bulk_pitcher_id": (
+                    "tandem-2"
+                ),
+                "announced_pitching_plan": (
+                    "tandem"
+                ),
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F04",
+            "scenario": "bullpen_game",
+            "expected_plan_type": (
+                PLAN_BULLPEN_GAME
+            ),
+            "evidence": {
+                "team_bullpen_game_indicator": True,
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F05",
+            "scenario": "workload_capped_starter",
+            "expected_plan_type": (
+                PLAN_WORKLOAD_CAPPED_STARTER
+            ),
+            "evidence": {
+                "listed_starter_id": "starter-2",
+                "workload_cap": {
+                    "type": "pitches",
+                    "value": 70,
+                    "source": "fixture",
+                },
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F06",
+            "scenario": "missing_information",
+            "expected_plan_type": (
+                PLAN_UNKNOWN_FALLBACK
+            ),
+            "evidence": {
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F07",
+            "scenario": "contradictory_sources",
+            "expected_plan_type": (
+                PLAN_UNKNOWN_FALLBACK
+            ),
+            "evidence": {
+                "listed_starter_id": "starter-3",
+                "announced_pitching_plan": (
+                    "bullpen_game"
+                ),
+                "contradictory_sources": True,
+                "source_name": "fixture",
+            },
+        },
+        {
+            "fixture_id": "PP-F08",
+            "scenario": (
+                "inactive_planned_bulk_pitcher"
+            ),
+            "expected_plan_type": (
+                PLAN_UNKNOWN_FALLBACK
+            ),
+            "evidence": {
+                "listed_starter_id": "opener-2",
+                "expected_bulk_pitcher_id": (
+                    "bulk-2"
+                ),
+                "announced_pitching_plan": (
+                    "opener_bulk"
+                ),
+                (
+                    "roster_and_availability_"
+                    "state"
+                ): {
+                    "opener-2": True,
+                    "bulk-2": False,
+                },
+                "source_name": "fixture",
+            },
+        },
+    ]
+
+    fixture_rows = []
+    payload_rows = []
+    deterministic_rows = []
+
+    for fixture in fixtures:
+        original = deepcopy(
+            fixture["evidence"]
+        )
+
+        first = classify_pitching_plan(
+            fixture["evidence"]
+        )
+
+        second = classify_pitching_plan(
+            fixture["evidence"]
+        )
+
+        validation = (
+            validate_pitching_plan_payload(
+                first
+            )
+        )
+
+        expected_type = fixture[
+            "expected_plan_type"
+        ]
+
+        deterministic = first == second
+        input_unchanged = (
+            fixture["evidence"] == original
+        )
+
+        type_passed = (
+            first["plan_type"]
+            == expected_type
+        )
+
+        fixture_passed = all(
+            [
+                type_passed,
+                validation["valid"],
+                deterministic,
+                input_unchanged,
+                first["diagnostics"][
+                    "production_activation"
+                ] is False,
+                first["diagnostics"][
+                    (
+                        "canonical_probability_"
+                        "authority_changed"
+                    )
+                ] is False,
+            ]
+        )
+
+        fixture_rows.append(
+            {
+                "fixture_id": fixture[
+                    "fixture_id"
+                ],
+                "scenario": fixture["scenario"],
+                "expected_plan_type": (
+                    expected_type
+                ),
+                "actual_plan_type": (
+                    first["plan_type"]
+                ),
+                "payload_valid": (
+                    validation["valid"]
+                ),
+                "deterministic": deterministic,
+                "input_unchanged": (
+                    input_unchanged
+                ),
+                "passed": fixture_passed,
+            }
+        )
+
+        deterministic_rows.append(
+            {
+                "fixture_id": fixture[
+                    "fixture_id"
+                ],
+                "first_equals_second": (
+                    deterministic
+                ),
+                "input_unchanged": (
+                    input_unchanged
+                ),
+                "passed": (
+                    deterministic
+                    and input_unchanged
+                ),
+            }
+        )
+
+        payload_rows.append(
+            {
+                "fixture_id": fixture[
+                    "fixture_id"
+                ],
+                "scenario": fixture["scenario"],
+                "payload": first,
+                "validation": validation,
+            }
+        )
+
+    required_output_fields = {
+        "plan_type",
+        "confidence",
+        "source_status",
+        "source_provenance",
+        "listed_starter_id",
+        "primary_pitcher_id",
+        "bulk_pitcher_id",
+        "planned_sequence",
+        "workload_cap",
+        "fallback_used",
+        "diagnostics",
+    }
+
+    sample_payload = (
+        classify_pitching_plan(
+            fixtures[0]["evidence"]
+        )
+    )
+
+    contract_rows = [
+        {
+            "check": "module_exists",
+            "actual": MODULE_PATH.exists(),
+            "expected": True,
+            "passed": MODULE_PATH.exists(),
+        },
+        {
+            "check": "plan_exists",
+            "actual": PLAN_PATH.exists(),
+            "expected": True,
+            "passed": PLAN_PATH.exists(),
+        },
+        {
+            "check": "eight_fixtures",
+            "actual": len(fixtures),
+            "expected": 8,
+            "passed": len(fixtures) == 8,
+        },
+        {
+            "check": "all_fixture_types_match",
+            "actual": sum(
+                1
+                for row in fixture_rows
+                if row["passed"]
+            ),
+            "expected": len(fixtures),
+            "passed": all(
+                row["passed"]
+                for row in fixture_rows
+            ),
+        },
+        {
+            "check": "eleven_output_fields",
+            "actual": len(
+                required_output_fields
+            ),
+            "expected": 11,
+            "passed": (
+                set(sample_payload.keys())
+                == required_output_fields
+            ),
+        },
+        {
+            "check": "deterministic_replay",
+            "actual": sum(
+                1
+                for row in deterministic_rows
+                if row["passed"]
+            ),
+            "expected": len(fixtures),
+            "passed": all(
+                row["passed"]
+                for row in deterministic_rows
+            ),
+        },
+        {
+            "check": "production_activation_false",
+            "actual": any(
+                row["payload"][
+                    "diagnostics"
+                ][
+                    "production_activation"
+                ]
+                for row in payload_rows
+            ),
+            "expected": False,
+            "passed": not any(
+                row["payload"][
+                    "diagnostics"
+                ][
+                    "production_activation"
+                ]
+                for row in payload_rows
+            ),
+        },
+        {
+            "check": (
+                "canonical_probability_"
+                "authority_unchanged"
+            ),
+            "actual": any(
+                row["payload"][
+                    "diagnostics"
+                ][
+                    (
+                        "canonical_probability_"
+                        "authority_changed"
+                    )
+                ]
+                for row in payload_rows
+            ),
+            "expected": False,
+            "passed": not any(
+                row["payload"][
+                    "diagnostics"
+                ][
+                    (
+                        "canonical_probability_"
+                        "authority_changed"
+                    )
+                ]
+                for row in payload_rows
+            ),
+        },
+    ]
+
+    safety_rows = [
+        {
+            "boundary": action,
+            "changed_or_executed": False,
+            "passed": True,
+        }
+        for action in PROHIBITED_ACTIONS
+    ]
+
+    safety_rows.extend(
+        [
+            {
+                "boundary": (
+                    "pure_classifier_implementation"
+                ),
+                "changed_or_executed": True,
+                "passed": True,
+            },
+            {
+                "boundary": (
+                    "deterministic_fixture_audit"
+                ),
+                "changed_or_executed": True,
+                "passed": all(
+                    row["passed"]
+                    for row in fixture_rows
+                ),
+            },
+        ]
+    )
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in contract_rows
+    )
+
+    recommended_next_layer = (
+        "6PB_pitching_plan_classification_"
+        "independent_implementation_audit"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        contract_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "fixture_results.csv",
+        [
+            "fixture_id",
+            "scenario",
+            "expected_plan_type",
+            "actual_plan_type",
+            "payload_valid",
+            "deterministic",
+            "input_unchanged",
+            "passed",
+        ],
+        fixture_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "determinism_audit.csv",
+        [
+            "fixture_id",
+            "first_equals_second",
+            "input_unchanged",
+            "passed",
+        ],
+        deterministic_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "safety_audit.csv",
+        [
+            "boundary",
+            "changed_or_executed",
+            "passed",
+        ],
+        safety_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Independently audit the pure "
+                    "pitching-plan classifier, fixtures, "
+                    "fallbacks, and nonactivation boundary."
+                ),
+                "entry_condition": (
+                    "All 6PA implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    write_json(
+        OUTPUT_DIR / "fixture_payloads.json",
+        payload_rows,
+    )
+
+    implementation_summary = {
+        "module": str(MODULE_PATH),
+        "classifier_function": (
+            "classify_pitching_plan"
+        ),
+        "validator_function": (
+            "validate_pitching_plan_payload"
+        ),
+        "fixtures_executed": len(fixtures),
+        "fixtures_passed": sum(
+            1
+            for row in fixture_rows
+            if row["passed"]
+        ),
+        "production_route_wired": False,
+        "production_classifier_activated": False,
+        (
+            "canonical_probability_"
+            "authority_changed"
+        ): False,
+        "new_authority_granted": False,
+    }
+
+    write_json(
+        OUTPUT_DIR / "implementation_summary.json",
+        implementation_summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": (
+            "pitching_plan_classification_"
+            "implementation_complete"
+            if all_checks_passed
+            else
+            "pitching_plan_classification_"
+            "implementation_failed"
+        ),
+        "all_checks_passed": all_checks_passed,
+        "contract_checks_passed": sum(
+            1
+            for row in contract_rows
+            if row["passed"]
+        ),
+        "contract_checks_required": len(
+            contract_rows
+        ),
+        "fixtures_executed": len(fixtures),
+        "fixtures_passed": sum(
+            1
+            for row in fixture_rows
+            if row["passed"]
+        ),
+        "output_fields_verified": len(
+            required_output_fields
+        ),
+        "deterministic_fixtures_passed": sum(
+            1
+            for row in deterministic_rows
+            if row["passed"]
+        ),
+        "production_route_wired": False,
+        "production_classifier_activated": False,
+        "canonical_probability_authority_changed": (
+            False
+        ),
+        "broad_layer6_exit_paused": True,
+        "layer6_exit_recommended": False,
+        "layer6_exit_finalized": False,
+        "new_authority_granted": False,
+        "backend_behavior_change_allowed_next": False,
+        "frontend_behavior_change_allowed_next": False,
+        "simulation_parameter_change_allowed_next": False,
+        "final_probability_replacement_allowed_next": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "prediction_join_execution_allowed_next": False,
+        "accuracy_metrics_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "independent_audit_allowed_next": (
+            all_checks_passed
+        ),
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / "contract_checks.csv"
+            ),
+            str(
+                OUTPUT_DIR / "fixture_results.csv"
+            ),
+            str(
+                OUTPUT_DIR / "determinism_audit.csv"
+            ),
+            str(OUTPUT_DIR / "safety_audit.csv"),
+            str(
+                OUTPUT_DIR / "recommended_path.csv"
+            ),
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR / "fixture_payloads.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(OUTPUT_DIR / "diagnosis.json"),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(json.dumps(diagnosis, indent=2))
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
6PA — Pitching-Plan Classification Implementation

## Objective
Implement the pure, deterministic, disabled-by-default GM-01 pitching-plan classifier and its fixture audit without wiring it into production simulation behavior.

## Implementation
- adds `mlb_app/simulation/pitching_plan_classifier.py`
- adds deterministic classification for:
  - traditional starter
  - opener/bulk
  - tandem
  - bullpen game
  - workload-capped starter
  - unknown fallback
- validates the full 11-field output contract
- preserves input immutability
- exposes explicit provenance, fallback status, and diagnostics
- keeps production activation false
- keeps canonical probability authority unchanged

## Validation
- 8/8 contract checks pass
- 8/8 fixtures pass
- 8/8 deterministic replay checks pass
- 11 output fields verified
- tandem semantics correctly preserve primary and secondary identities
- no production route wiring
- no backend payload change
- no simulation parameter or probability change
- broad Layer 6 exit remains paused

## Diagnosis
pitching_plan_classification_implementation_complete

## Recommended Next Layer
6PB_pitching_plan_classification_independent_implementation_audit