### PR TITLE
Layer 6PJ: Dynamic Starter-Hook State Contract and Evaluator Implementation

### DIFF
--- a/mlb_app/simulation/starter_hook_evaluator.py
+++ b/mlb_app/simulation/starter_hook_evaluator.py
@@ -1,0 +1,658 @@
+"""
+Pure deterministic starter-hook state evaluator.
+
+This module has no production simulation authority. It evaluates a supplied
+starter/game-state snapshot and returns an auditable recommendation only.
+
+It does not:
+- alter starter innings;
+- select a reliever;
+- change bullpen probabilities;
+- change plate-appearance probabilities;
+- change simulation scores or win probabilities;
+- activate pitching-plan classification behavior.
+"""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from typing import Any, Dict, Iterable
+
+
+STARTER_HOOK_EVALUATOR_VERSION = (
+    "starter-hook-evaluator-v1"
+)
+
+REQUIRED_STATE_FIELDS = (
+    "inning",
+    "outs",
+    "base_state",
+    "batters_faced",
+    "pitch_count_estimate",
+    "times_through_order",
+    "runs_allowed",
+    "recent_traffic_index",
+    "score_margin",
+    "leverage_proxy",
+    "starter_quality_score",
+    "expected_starter_innings",
+    "fatigue_index",
+)
+
+OPTIONAL_STATE_FIELDS = (
+    "bullpen_availability",
+    "pitching_plan",
+)
+
+EVALUATOR_OUTPUT_FIELDS = (
+    "decision",
+    "pull_probability",
+    "trigger_reasons",
+    "state_completeness",
+    "fallback_used",
+    "fallback_reason",
+    "behavioral_effect",
+    "canonical_probability_authority_changed",
+    "production_activation",
+)
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def _clamp(
+    value: float,
+    lower: float,
+    upper: float,
+) -> float:
+    return max(
+        lower,
+        min(upper, value),
+    )
+
+
+def _missing_fields(
+    state: Dict[str, Any],
+    required_fields: Iterable[str],
+) -> list[str]:
+    return [
+        field
+        for field in required_fields
+        if field not in state
+        or state.get(field) is None
+    ]
+
+
+def validate_starter_hook_state(
+    state: Any,
+) -> Dict[str, Any]:
+    """
+    Validate the starter-hook state contract.
+
+    Validation is deterministic and does not mutate the supplied payload.
+    """
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not isinstance(state, dict):
+        return {
+            "valid": False,
+            "errors": [
+                "state_must_be_object",
+            ],
+            "warnings": [],
+            "missing_fields": list(
+                REQUIRED_STATE_FIELDS
+            ),
+            "state_completeness": 0.0,
+        }
+
+    missing = _missing_fields(
+        state,
+        REQUIRED_STATE_FIELDS,
+    )
+
+    for field in missing:
+        errors.append(
+            f"missing_required_field:{field}"
+        )
+
+    numeric_constraints = {
+        "inning": (1.0, 20.0),
+        "outs": (0.0, 2.0),
+        "batters_faced": (0.0, 100.0),
+        "pitch_count_estimate": (
+            0.0,
+            250.0,
+        ),
+        "times_through_order": (
+            0.0,
+            10.0,
+        ),
+        "runs_allowed": (0.0, 30.0),
+        "recent_traffic_index": (
+            0.0,
+            1.0,
+        ),
+        "score_margin": (-30.0, 30.0),
+        "leverage_proxy": (0.0, 1.0),
+        "starter_quality_score": (
+            -1.0,
+            1.0,
+        ),
+        "expected_starter_innings": (
+            0.1,
+            9.0,
+        ),
+        "fatigue_index": (0.0, 1.0),
+    }
+
+    integer_fields = {
+        "inning",
+        "outs",
+        "batters_faced",
+        "runs_allowed",
+        "score_margin",
+    }
+
+    for field, bounds in (
+        numeric_constraints.items()
+    ):
+        if field in missing:
+            continue
+
+        value = state.get(field)
+
+        if not _is_number(value):
+            errors.append(
+                f"field_must_be_numeric:{field}"
+            )
+            continue
+
+        numeric_value = float(value)
+        lower, upper = bounds
+
+        if (
+            numeric_value < lower
+            or numeric_value > upper
+        ):
+            errors.append(
+                f"field_out_of_range:{field}"
+            )
+
+        if (
+            field in integer_fields
+            and not numeric_value.is_integer()
+        ):
+            errors.append(
+                f"field_must_be_integer:{field}"
+            )
+
+    if (
+        "base_state" not in missing
+        and not isinstance(
+            state.get("base_state"),
+            dict,
+        )
+    ):
+        errors.append(
+            "field_must_be_object:base_state"
+        )
+
+    bullpen_availability = state.get(
+        "bullpen_availability"
+    )
+
+    if (
+        bullpen_availability is not None
+        and not isinstance(
+            bullpen_availability,
+            dict,
+        )
+    ):
+        warnings.append(
+            "optional_field_ignored:"
+            "bullpen_availability"
+        )
+
+    pitching_plan = state.get(
+        "pitching_plan"
+    )
+
+    if (
+        pitching_plan is not None
+        and not isinstance(
+            pitching_plan,
+            dict,
+        )
+    ):
+        warnings.append(
+            "optional_field_ignored:"
+            "pitching_plan"
+        )
+
+    present_required = (
+        len(REQUIRED_STATE_FIELDS)
+        - len(missing)
+    )
+
+    completeness = round(
+        present_required
+        / len(REQUIRED_STATE_FIELDS),
+        4,
+    )
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "missing_fields": missing,
+        "state_completeness": completeness,
+    }
+
+
+def _add_reason(
+    reasons: list[str],
+    reason: str,
+) -> None:
+    if reason not in reasons:
+        reasons.append(reason)
+
+
+def evaluate_starter_hook(
+    state: Any,
+) -> Dict[str, Any]:
+    """
+    Return a deterministic, auditable starter-hook recommendation.
+
+    The recommendation is diagnostic only. It is not wired to the production
+    game simulator and cannot alter model outputs.
+    """
+
+    state_snapshot = deepcopy(state)
+
+    validation = validate_starter_hook_state(
+        state_snapshot
+    )
+
+    if validation["valid"] is not True:
+        return {
+            "decision": "insufficient_state",
+            "pull_probability": 0.0,
+            "trigger_reasons": [
+                "insufficient_state",
+            ],
+            "state_completeness": (
+                validation[
+                    "state_completeness"
+                ]
+            ),
+            "fallback_used": True,
+            "fallback_reason": (
+                "invalid_or_incomplete_state"
+            ),
+            "behavioral_effect": "none",
+            (
+                "canonical_probability_"
+                "authority_changed"
+            ): False,
+            "production_activation": False,
+        }
+
+    inning = int(state_snapshot["inning"])
+    batters_faced = int(
+        state_snapshot["batters_faced"]
+    )
+    pitch_count = float(
+        state_snapshot[
+            "pitch_count_estimate"
+        ]
+    )
+    times_through = float(
+        state_snapshot[
+            "times_through_order"
+        ]
+    )
+    runs_allowed = int(
+        state_snapshot["runs_allowed"]
+    )
+    traffic = float(
+        state_snapshot[
+            "recent_traffic_index"
+        ]
+    )
+    score_margin = int(
+        state_snapshot["score_margin"]
+    )
+    leverage = float(
+        state_snapshot["leverage_proxy"]
+    )
+    quality = float(
+        state_snapshot[
+            "starter_quality_score"
+        ]
+    )
+    expected_innings = float(
+        state_snapshot[
+            "expected_starter_innings"
+        ]
+    )
+    fatigue = float(
+        state_snapshot["fatigue_index"]
+    )
+
+    pull_score = 0.05
+    reasons: list[str] = []
+
+    if pitch_count >= 105:
+        pull_score += 0.55
+        _add_reason(
+            reasons,
+            "critical_pitch_count",
+        )
+    elif pitch_count >= 95:
+        pull_score += 0.38
+        _add_reason(
+            reasons,
+            "high_pitch_count",
+        )
+    elif pitch_count >= 85:
+        pull_score += 0.20
+        _add_reason(
+            reasons,
+            "elevated_pitch_count",
+        )
+
+    if batters_faced >= 27:
+        pull_score += 0.25
+        _add_reason(
+            reasons,
+            "high_batters_faced",
+        )
+    elif batters_faced >= 24:
+        pull_score += 0.15
+        _add_reason(
+            reasons,
+            "elevated_batters_faced",
+        )
+
+    if times_through >= 3.0:
+        pull_score += 0.42
+        _add_reason(
+            reasons,
+            "third_time_through_order",
+        )
+    elif times_through >= 2.5:
+        pull_score += 0.20
+        _add_reason(
+            reasons,
+            "approaching_third_time_through",
+        )
+
+    if runs_allowed >= 5:
+        pull_score += 0.45
+        _add_reason(
+            reasons,
+            "five_plus_runs_allowed",
+        )
+    elif runs_allowed >= 4:
+        pull_score += 0.30
+        _add_reason(
+            reasons,
+            "four_runs_allowed",
+        )
+    elif runs_allowed >= 3:
+        pull_score += 0.15
+        _add_reason(
+            reasons,
+            "three_runs_allowed",
+        )
+
+    if traffic >= 0.75:
+        pull_score += 0.35
+        _add_reason(
+            reasons,
+            "heavy_recent_traffic",
+        )
+    elif traffic >= 0.50:
+        pull_score += 0.18
+        _add_reason(
+            reasons,
+            "elevated_recent_traffic",
+        )
+
+    if fatigue >= 0.80:
+        pull_score += 0.38
+        _add_reason(
+            reasons,
+            "critical_fatigue",
+        )
+    elif fatigue >= 0.65:
+        pull_score += 0.22
+        _add_reason(
+            reasons,
+            "high_fatigue",
+        )
+    elif fatigue >= 0.50:
+        pull_score += 0.10
+        _add_reason(
+            reasons,
+            "moderate_fatigue",
+        )
+
+    if inning >= 7:
+        pull_score += 0.18
+        _add_reason(
+            reasons,
+            "late_inning",
+        )
+    elif inning >= 6:
+        pull_score += 0.08
+        _add_reason(
+            reasons,
+            "middle_late_inning",
+        )
+
+    if inning >= math.ceil(
+        expected_innings
+    ):
+        pull_score += 0.12
+        _add_reason(
+            reasons,
+            "expected_innings_reached",
+        )
+
+    if (
+        inning >= 6
+        and abs(score_margin) <= 2
+        and leverage >= 0.75
+    ):
+        pull_score += 0.25
+        _add_reason(
+            reasons,
+            "late_high_leverage_close_game",
+        )
+
+    if (
+        inning >= 6
+        and abs(score_margin) >= 6
+        and leverage <= 0.30
+    ):
+        pull_score -= 0.28
+        _add_reason(
+            reasons,
+            "low_leverage_blowout_extension",
+        )
+
+    if quality >= 0.55:
+        pull_score -= 0.18
+        _add_reason(
+            reasons,
+            "strong_starter_retention",
+        )
+    elif quality <= -0.55:
+        pull_score += 0.20
+        _add_reason(
+            reasons,
+            "weak_starter_short_leash",
+        )
+
+    pull_probability = round(
+        _clamp(
+            pull_score,
+            0.0,
+            1.0,
+        ),
+        4,
+    )
+
+    decision = (
+        "pull"
+        if pull_probability >= 0.50
+        else "keep"
+    )
+
+    if not reasons:
+        reasons = [
+            "no_pull_threshold_reached",
+        ]
+
+    return {
+        "decision": decision,
+        "pull_probability": (
+            pull_probability
+        ),
+        "trigger_reasons": reasons,
+        "state_completeness": (
+            validation[
+                "state_completeness"
+            ]
+        ),
+        "fallback_used": False,
+        "fallback_reason": None,
+        "behavioral_effect": "none",
+        (
+            "canonical_probability_"
+            "authority_changed"
+        ): False,
+        "production_activation": False,
+    }
+
+
+def validate_starter_hook_evaluation(
+    payload: Any,
+) -> Dict[str, Any]:
+    """
+    Validate the evaluator output contract.
+    """
+
+    errors: list[str] = []
+
+    if not isinstance(payload, dict):
+        return {
+            "valid": False,
+            "errors": [
+                "evaluation_must_be_object",
+            ],
+        }
+
+    if set(payload) != set(
+        EVALUATOR_OUTPUT_FIELDS
+    ):
+        errors.append(
+            "evaluation_field_contract_mismatch"
+        )
+
+    if payload.get("decision") not in {
+        "keep",
+        "pull",
+        "insufficient_state",
+    }:
+        errors.append(
+            "invalid_decision"
+        )
+
+    probability = payload.get(
+        "pull_probability"
+    )
+
+    if (
+        not _is_number(probability)
+        or float(probability) < 0.0
+        or float(probability) > 1.0
+    ):
+        errors.append(
+            "invalid_pull_probability"
+        )
+
+    if not isinstance(
+        payload.get("trigger_reasons"),
+        list,
+    ):
+        errors.append(
+            "trigger_reasons_must_be_array"
+        )
+
+    completeness = payload.get(
+        "state_completeness"
+    )
+
+    if (
+        not _is_number(completeness)
+        or float(completeness) < 0.0
+        or float(completeness) > 1.0
+    ):
+        errors.append(
+            "invalid_state_completeness"
+        )
+
+    if not isinstance(
+        payload.get("fallback_used"),
+        bool,
+    ):
+        errors.append(
+            "fallback_used_must_be_boolean"
+        )
+
+    if (
+        payload.get("behavioral_effect")
+        != "none"
+    ):
+        errors.append(
+            "behavioral_effect_must_be_none"
+        )
+
+    if (
+        payload.get(
+            (
+                "canonical_probability_"
+                "authority_changed"
+            )
+        )
+        is not False
+    ):
+        errors.append(
+            "canonical_probability_authority_changed"
+        )
+
+    if (
+        payload.get(
+            "production_activation"
+        )
+        is not False
+    ):
+        errors.append(
+            "production_activation_must_be_false"
+        )
+
+    return {
+        "valid": not errors,
+        "errors": errors,
+    }

--- a/scripts/implement_6PJ_dynamic_starter_hook_state_contract_and_evaluator.py
+++ b/scripts/implement_6PJ_dynamic_starter_hook_state_contract_and_evaluator.py
@@ -1,0 +1,1170 @@
+#!/usr/bin/env python3
+"""
+Layer 6PJ
+Dynamic Starter-Hook State Contract and Evaluator Implementation
+
+Implements and validates a pure deterministic starter-hook evaluator.
+
+No production simulation wiring is permitted.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+import importlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LAYER_ID = "6PJ"
+LAYER_NAME = (
+    "dynamic_starter_hook_state_contract_"
+    "and_evaluator_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = ROOT / (
+    "tmp/layer_6PJ_dynamic_starter_hook_"
+    "state_contract_and_evaluator_implementation"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/plan_6PI_dynamic_starter_hook_"
+    "inventory_and_implementation.py"
+)
+
+MODULE_PATH = (
+    ROOT
+    / "mlb_app/simulation/"
+    "starter_hook_evaluator.py"
+)
+
+PRODUCTION_PATHS = [
+    ROOT
+    / "mlb_app/simulation/"
+    "game_engine_v2.py",
+    ROOT
+    / "mlb_app/simulation/"
+    "game_simulator.py",
+    ROOT
+    / "mlb_app/simulation/"
+    "game_simulation_builder.py",
+]
+
+EXPECTED_OUTPUT_FIELDS = {
+    "decision",
+    "pull_probability",
+    "trigger_reasons",
+    "state_completeness",
+    "fallback_used",
+    "fallback_reason",
+    "behavioral_effect",
+    "canonical_probability_authority_changed",
+    "production_activation",
+}
+
+PROHIBITED_ACTIONS = [
+    "production_starter_hook_change",
+    "starter_exit_distribution_change",
+    "starter_innings_change",
+    "bullpen_transition_change",
+    "bullpen_sequence_change",
+    "plate_appearance_probability_change",
+    "simulation_parameter_change",
+    "simulation_score_change",
+    "win_probability_change",
+    "canonical_probability_replacement",
+    "pitching_plan_production_activation",
+    "backend_response_change",
+    "frontend_behavior_change",
+    "historical_outcome_join",
+    "accuracy_metric_generation",
+    "parameter_tuning",
+    "backtest_execution",
+    "pricing",
+    "edge_detection",
+    "bet_recommendation",
+    "broad_layer6_exit",
+]
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+
+    return path.read_text(
+        encoding="utf-8",
+        errors="ignore",
+    )
+
+
+def base_state() -> dict[str, Any]:
+    return {
+        "inning": 4,
+        "outs": 0,
+        "base_state": {
+            "first": False,
+            "second": False,
+            "third": False,
+        },
+        "batters_faced": 16,
+        "pitch_count_estimate": 60.0,
+        "times_through_order": 1.8,
+        "runs_allowed": 1,
+        "recent_traffic_index": 0.20,
+        "score_margin": 1,
+        "leverage_proxy": 0.45,
+        "starter_quality_score": 0.0,
+        "expected_starter_innings": 5.6,
+        "fatigue_index": 0.30,
+        "bullpen_availability": {},
+        "pitching_plan": {},
+    }
+
+
+def fixture_matrix() -> list[dict[str, Any]]:
+    fixtures: list[dict[str, Any]] = []
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 1,
+            "batters_faced": 3,
+            "pitch_count_estimate": 12.0,
+            "times_through_order": 0.34,
+            "runs_allowed": 0,
+            "recent_traffic_index": 0.0,
+            "fatigue_index": 0.05,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F01",
+            "scenario": (
+                "first_inning_clean_low_workload"
+            ),
+            "state": state,
+            "expected_decision": "keep",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 5,
+            "pitch_count_estimate": 108.0,
+            "batters_faced": 25,
+            "times_through_order": 2.7,
+            "fatigue_index": 0.88,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F02",
+            "scenario": (
+                "fifth_inning_high_pitch_count"
+            ),
+            "state": state,
+            "expected_decision": "pull",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 6,
+            "batters_faced": 28,
+            "pitch_count_estimate": 88.0,
+            "times_through_order": 3.05,
+            "fatigue_index": 0.58,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F03",
+            "scenario": (
+                "third_time_through_order"
+            ),
+            "state": state,
+            "expected_decision": "pull",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 4,
+            "runs_allowed": 4,
+            "recent_traffic_index": 0.90,
+            "pitch_count_estimate": 78.0,
+            "fatigue_index": 0.55,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F04",
+            "scenario": "heavy_recent_traffic",
+            "state": state,
+            "expected_decision": "pull",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 5,
+            "starter_quality_score": 0.80,
+            "pitch_count_estimate": 76.0,
+            "batters_faced": 20,
+            "times_through_order": 2.2,
+            "runs_allowed": 1,
+            "recent_traffic_index": 0.20,
+            "fatigue_index": 0.38,
+            "expected_starter_innings": 6.4,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F05",
+            "scenario": (
+                "strong_starter_moderate_workload"
+            ),
+            "state": state,
+            "expected_decision": "keep",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 5,
+            "starter_quality_score": -0.80,
+            "pitch_count_estimate": 91.0,
+            "batters_faced": 23,
+            "times_through_order": 2.55,
+            "runs_allowed": 3,
+            "recent_traffic_index": 0.55,
+            "fatigue_index": 0.65,
+            "expected_starter_innings": 4.5,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F06",
+            "scenario": (
+                "weak_starter_moderate_workload"
+            ),
+            "state": state,
+            "expected_decision": "pull",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 7,
+            "score_margin": 1,
+            "leverage_proxy": 0.92,
+            "pitch_count_estimate": 89.0,
+            "batters_faced": 25,
+            "times_through_order": 2.75,
+            "fatigue_index": 0.62,
+            "expected_starter_innings": 6.0,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F07",
+            "scenario": (
+                "late_close_game_high_leverage"
+            ),
+            "state": state,
+            "expected_decision": "pull",
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 7,
+            "score_margin": 8,
+            "leverage_proxy": 0.12,
+            "starter_quality_score": 0.70,
+            "pitch_count_estimate": 78.0,
+            "batters_faced": 22,
+            "times_through_order": 2.35,
+            "runs_allowed": 1,
+            "recent_traffic_index": 0.10,
+            "fatigue_index": 0.42,
+            "expected_starter_innings": 7.2,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F08",
+            "scenario": (
+                "late_blowout_low_leverage"
+            ),
+            "state": state,
+            "expected_decision": "keep",
+        }
+    )
+
+    state = base_state()
+    state.pop("pitch_count_estimate")
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F09",
+            "scenario": "incomplete_state",
+            "state": state,
+            "expected_decision": (
+                "insufficient_state"
+            ),
+        }
+    )
+
+    state = base_state()
+    state.update(
+        {
+            "inning": 6,
+            "pitch_count_estimate": 97.0,
+            "times_through_order": 2.8,
+            "fatigue_index": 0.68,
+        }
+    )
+    fixtures.append(
+        {
+            "fixture_id": "PJ-F10",
+            "scenario": "deterministic_replay",
+            "state": state,
+            "expected_decision": "pull",
+            "deterministic_replay": True,
+        }
+    )
+
+    return fixtures
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    required_files_exist = all(
+        path.exists()
+        for path in [
+            PLAN_PATH,
+            MODULE_PATH,
+            *PRODUCTION_PATHS,
+        ]
+    )
+
+    plan_text = read_text(PLAN_PATH)
+
+    plan_tree = ast.parse(
+        plan_text,
+        filename=str(PLAN_PATH),
+    )
+
+    plan_string_constants = {
+        node.value
+        for node in ast.walk(plan_tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+    plan_contract_present = all(
+        token in plan_string_constants
+        for token in [
+            (
+                "dynamic_starter_hook_inventory_"
+                "and_implementation_plan_complete"
+            ),
+            (
+                "6PJ_dynamic_starter_hook_"
+                "state_contract_and_evaluator_"
+                "implementation"
+            ),
+            (
+                "pure_deterministic_evaluator_only"
+            ),
+        ]
+    )
+
+    module = importlib.import_module(
+        "mlb_app.simulation."
+        "starter_hook_evaluator"
+    )
+
+    required_functions_present = all(
+        callable(getattr(module, name, None))
+        for name in [
+            "validate_starter_hook_state",
+            "evaluate_starter_hook",
+            (
+                "validate_starter_hook_"
+                "evaluation"
+            ),
+        ]
+    )
+
+    required_state_fields = set(
+        module.REQUIRED_STATE_FIELDS
+    )
+
+    required_state_contract_present = (
+        len(required_state_fields) == 13
+        and {
+            "inning",
+            "outs",
+            "base_state",
+            "batters_faced",
+            "pitch_count_estimate",
+            "times_through_order",
+            "runs_allowed",
+            "recent_traffic_index",
+            "score_margin",
+            "leverage_proxy",
+            "starter_quality_score",
+            "expected_starter_innings",
+            "fatigue_index",
+        }
+        == required_state_fields
+    )
+
+    output_contract_present = (
+        set(module.EVALUATOR_OUTPUT_FIELDS)
+        == EXPECTED_OUTPUT_FIELDS
+    )
+
+    fixtures = fixture_matrix()
+    fixture_results: list[
+        dict[str, Any]
+    ] = []
+
+    inputs_unchanged = True
+    all_outputs_valid = True
+    deterministic_replay_passed = True
+
+    for fixture in fixtures:
+        state = deepcopy(fixture["state"])
+        original_state = deepcopy(state)
+
+        evaluation = (
+            module.evaluate_starter_hook(
+                state
+            )
+        )
+
+        validation = (
+            module
+            .validate_starter_hook_evaluation(
+                evaluation
+            )
+        )
+
+        replay = None
+
+        if fixture.get(
+            "deterministic_replay"
+        ):
+            replay = (
+                module.evaluate_starter_hook(
+                    deepcopy(state)
+                )
+            )
+
+            deterministic_replay_passed = (
+                deterministic_replay_passed
+                and replay == evaluation
+            )
+
+        state_unchanged = (
+            state == original_state
+        )
+
+        inputs_unchanged = (
+            inputs_unchanged
+            and state_unchanged
+        )
+
+        output_valid = (
+            validation.get("valid") is True
+        )
+
+        all_outputs_valid = (
+            all_outputs_valid
+            and output_valid
+        )
+
+        passed = all(
+            [
+                evaluation.get("decision")
+                == fixture[
+                    "expected_decision"
+                ],
+                output_valid,
+                state_unchanged,
+                (
+                    evaluation.get(
+                        "behavioral_effect"
+                    )
+                    == "none"
+                ),
+                (
+                    evaluation.get(
+                        "production_activation"
+                    )
+                    is False
+                ),
+                (
+                    evaluation.get(
+                        (
+                            "canonical_probability_"
+                            "authority_changed"
+                        )
+                    )
+                    is False
+                ),
+                (
+                    replay == evaluation
+                    if replay is not None
+                    else True
+                ),
+            ]
+        )
+
+        fixture_results.append(
+            {
+                "fixture_id": (
+                    fixture["fixture_id"]
+                ),
+                "scenario": (
+                    fixture["scenario"]
+                ),
+                "expected_decision": (
+                    fixture[
+                        "expected_decision"
+                    ]
+                ),
+                "actual_decision": (
+                    evaluation.get(
+                        "decision"
+                    )
+                ),
+                "pull_probability": (
+                    evaluation.get(
+                        "pull_probability"
+                    )
+                ),
+                "trigger_reasons": (
+                    evaluation.get(
+                        "trigger_reasons"
+                    )
+                ),
+                "output_valid": output_valid,
+                "state_unchanged": (
+                    state_unchanged
+                ),
+                "passed": passed,
+                "evaluation": evaluation,
+            }
+        )
+
+    fixtures_passed = sum(
+        1
+        for row in fixture_results
+        if row["passed"]
+    )
+
+    production_reference_rows: list[
+        dict[str, Any]
+    ] = []
+
+    for path in PRODUCTION_PATHS:
+        text = read_text(path)
+
+        references_module = any(
+            token in text
+            for token in [
+                "starter_hook_evaluator",
+                "evaluate_starter_hook",
+                (
+                    "validate_starter_hook_"
+                    "state"
+                ),
+            ]
+        )
+
+        production_reference_rows.append(
+            {
+                "path": str(
+                    path.relative_to(ROOT)
+                ),
+                "references_evaluator": (
+                    references_module
+                ),
+            }
+        )
+
+    production_reference_count = sum(
+        1
+        for row in production_reference_rows
+        if row["references_evaluator"]
+    )
+
+    module_tree = ast.parse(
+        read_text(MODULE_PATH),
+        filename=str(MODULE_PATH),
+    )
+
+    forbidden_imports = []
+
+    for node in ast.walk(module_tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in {
+                    "random",
+                    "numpy",
+                    "pandas",
+                    "sqlalchemy",
+                }:
+                    forbidden_imports.append(
+                        alias.name
+                    )
+
+        if isinstance(node, ast.ImportFrom):
+            if node.module in {
+                "random",
+                "numpy",
+                "pandas",
+                "sqlalchemy",
+            }:
+                forbidden_imports.append(
+                    str(node.module)
+                )
+
+    evaluator_is_pure = (
+        not forbidden_imports
+        and production_reference_count == 0
+    )
+
+    invalid_state_result = (
+        module.evaluate_starter_hook({})
+    )
+
+    invalid_state_fallback_passed = all(
+        [
+            invalid_state_result.get(
+                "decision"
+            )
+            == "insufficient_state",
+            invalid_state_result.get(
+                "fallback_used"
+            )
+            is True,
+            invalid_state_result.get(
+                "behavioral_effect"
+            )
+            == "none",
+            invalid_state_result.get(
+                "production_activation"
+            )
+            is False,
+        ]
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": required_files_exist,
+            "expected": True,
+            "passed": required_files_exist,
+        },
+        {
+            "check": (
+                "six_pi_plan_contract_present"
+            ),
+            "actual": plan_contract_present,
+            "expected": True,
+            "passed": plan_contract_present,
+        },
+        {
+            "check": (
+                "required_functions_present"
+            ),
+            "actual": (
+                required_functions_present
+            ),
+            "expected": True,
+            "passed": (
+                required_functions_present
+            ),
+        },
+        {
+            "check": (
+                "required_state_contract_present"
+            ),
+            "actual": sorted(
+                required_state_fields
+            ),
+            "expected": sorted(
+                required_state_fields
+            ),
+            "passed": (
+                required_state_contract_present
+            ),
+        },
+        {
+            "check": (
+                "output_contract_present"
+            ),
+            "actual": sorted(
+                module.EVALUATOR_OUTPUT_FIELDS
+            ),
+            "expected": sorted(
+                EXPECTED_OUTPUT_FIELDS
+            ),
+            "passed": (
+                output_contract_present
+            ),
+        },
+        {
+            "check": (
+                "ten_fixtures_executed"
+            ),
+            "actual": len(
+                fixture_results
+            ),
+            "expected": 10,
+            "passed": (
+                len(fixture_results) == 10
+            ),
+        },
+        {
+            "check": (
+                "all_fixtures_pass"
+            ),
+            "actual": fixtures_passed,
+            "expected": len(
+                fixture_results
+            ),
+            "passed": (
+                fixtures_passed
+                == len(fixture_results)
+            ),
+        },
+        {
+            "check": (
+                "all_outputs_validate"
+            ),
+            "actual": all_outputs_valid,
+            "expected": True,
+            "passed": all_outputs_valid,
+        },
+        {
+            "check": (
+                "deterministic_replay_passes"
+            ),
+            "actual": (
+                deterministic_replay_passed
+            ),
+            "expected": True,
+            "passed": (
+                deterministic_replay_passed
+            ),
+        },
+        {
+            "check": "inputs_unchanged",
+            "actual": inputs_unchanged,
+            "expected": True,
+            "passed": inputs_unchanged,
+        },
+        {
+            "check": (
+                "invalid_state_fallback_passes"
+            ),
+            "actual": (
+                invalid_state_fallback_passed
+            ),
+            "expected": True,
+            "passed": (
+                invalid_state_fallback_passed
+            ),
+        },
+        {
+            "check": (
+                "zero_production_references"
+            ),
+            "actual": (
+                production_reference_count
+            ),
+            "expected": 0,
+            "passed": (
+                production_reference_count == 0
+            ),
+        },
+        {
+            "check": (
+                "evaluator_is_pure"
+            ),
+            "actual": evaluator_is_pure,
+            "expected": True,
+            "passed": evaluator_is_pure,
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    safety_rows = [
+        {
+            "boundary": action,
+            "changed_or_executed": False,
+            "passed": True,
+        }
+        for action in PROHIBITED_ACTIONS
+    ]
+
+    safety_rows.extend(
+        [
+            {
+                "boundary": (
+                    "pure_evaluator_implementation"
+                ),
+                "changed_or_executed": True,
+                "passed": all_checks_passed,
+            },
+            {
+                "boundary": (
+                    "state_contract_validation"
+                ),
+                "changed_or_executed": True,
+                "passed": all_checks_passed,
+            },
+        ]
+    )
+
+    recommended_next_layer = (
+        "6PK_dynamic_starter_hook_"
+        "evaluator_independent_audit"
+        if all_checks_passed
+        else
+        "6PK_dynamic_starter_hook_"
+        "evaluator_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "fixture_results.csv",
+        [
+            "fixture_id",
+            "scenario",
+            "expected_decision",
+            "actual_decision",
+            "pull_probability",
+            "trigger_reasons",
+            "output_valid",
+            "state_unchanged",
+            "passed",
+        ],
+        [
+            {
+                key: row[key]
+                for key in [
+                    "fixture_id",
+                    "scenario",
+                    "expected_decision",
+                    "actual_decision",
+                    "pull_probability",
+                    "trigger_reasons",
+                    "output_valid",
+                    "state_unchanged",
+                    "passed",
+                ]
+            }
+            for row in fixture_results
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "production_reference_scan.csv",
+        [
+            "path",
+            "references_evaluator",
+        ],
+        production_reference_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "safety_audit.csv",
+        [
+            "boundary",
+            "changed_or_executed",
+            "passed",
+        ],
+        safety_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Independently audit the pure "
+                    "starter-hook evaluator without "
+                    "production simulation wiring."
+                ),
+                "entry_condition": (
+                    "All 6PJ implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    write_json(
+        OUTPUT_DIR / "fixture_payloads.json",
+        fixture_results,
+    )
+
+    implementation_summary = {
+        "module": (
+            "mlb_app/simulation/"
+            "starter_hook_evaluator.py"
+        ),
+        "evaluator_version": (
+            module
+            .STARTER_HOOK_EVALUATOR_VERSION
+        ),
+        "required_state_fields": len(
+            module.REQUIRED_STATE_FIELDS
+        ),
+        "optional_state_fields": len(
+            module.OPTIONAL_STATE_FIELDS
+        ),
+        "output_fields": len(
+            module.EVALUATOR_OUTPUT_FIELDS
+        ),
+        "fixtures_executed": len(
+            fixture_results
+        ),
+        "fixtures_passed": (
+            fixtures_passed
+        ),
+        "production_reference_count": (
+            production_reference_count
+        ),
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        (
+            "canonical_probability_"
+            "authority_changed"
+        ): False,
+        "new_authority_granted": False,
+    }
+
+    write_json(
+        OUTPUT_DIR / "implementation_summary.json",
+        implementation_summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": (
+            "dynamic_starter_hook_state_contract_"
+            "and_evaluator_implementation_complete"
+            if all_checks_passed
+            else
+            "dynamic_starter_hook_state_contract_"
+            "and_evaluator_implementation_failed"
+        ),
+        "all_checks_passed": (
+            all_checks_passed
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "implementation_checks_required": len(
+            checks
+        ),
+        "fixtures_executed": len(
+            fixture_results
+        ),
+        "fixtures_passed": (
+            fixtures_passed
+        ),
+        "required_state_fields": len(
+            module.REQUIRED_STATE_FIELDS
+        ),
+        "optional_state_fields": len(
+            module.OPTIONAL_STATE_FIELDS
+        ),
+        "evaluator_output_fields": len(
+            module.EVALUATOR_OUTPUT_FIELDS
+        ),
+        "all_outputs_valid": (
+            all_outputs_valid
+        ),
+        "deterministic_replay_passed": (
+            deterministic_replay_passed
+        ),
+        "inputs_unchanged": (
+            inputs_unchanged
+        ),
+        "invalid_state_fallback_passed": (
+            invalid_state_fallback_passed
+        ),
+        "production_reference_count": (
+            production_reference_count
+        ),
+        "evaluator_is_pure": (
+            evaluator_is_pure
+        ),
+        "production_starter_hook_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": (
+            False
+        ),
+        "production_activation": False,
+        "broad_layer6_exit_paused": True,
+        "layer6_exit_recommended": False,
+        "layer6_exit_finalized": False,
+        "new_authority_granted": False,
+        "backend_behavior_change_allowed_next": False,
+        "frontend_behavior_change_allowed_next": False,
+        "simulation_parameter_change_allowed_next": False,
+        "final_probability_replacement_allowed_next": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "prediction_join_execution_allowed_next": False,
+        "accuracy_metrics_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "independent_evaluator_audit_allowed_next": (
+            all_checks_passed
+        ),
+        "diagnostic_integration_allowed_next": False,
+        "production_behavior_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "implementation_checks.csv"
+            ),
+            str(
+                OUTPUT_DIR
+                / "fixture_results.csv"
+            ),
+            str(
+                OUTPUT_DIR
+                / "production_reference_scan.csv"
+            ),
+            str(
+                OUTPUT_DIR
+                / "safety_audit.csv"
+            ),
+            str(
+                OUTPUT_DIR
+                / "recommended_path.csv"
+            ),
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "fixture_payloads.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(json.dumps(diagnosis, indent=2))
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
6PJ — Dynamic Starter-Hook State Contract and Evaluator Implementation

## Objective
Implement a pure deterministic starter-hook evaluator and state-validation contract with no production simulation wiring or behavioral authority.

## Implementation
- adds `mlb_app/simulation/starter_hook_evaluator.py`
- defines 13 required state fields and 2 optional fields
- defines a 9-field evaluator output contract
- validates incomplete and invalid state through explicit fallback behavior
- returns deterministic `keep`, `pull`, or `insufficient_state` recommendations
- emits auditable trigger reasons
- preserves input immutability
- keeps `behavioral_effect` at `none`
- keeps production activation and canonical probability authority changes false

## Validation
- 13/13 implementation checks pass
- 10/10 fixtures pass
- all outputs validate
- deterministic replay passes
- inputs remain unchanged
- invalid-state fallback passes
- production reference count remains 0
- evaluator purity check passes
- no production starter-hook change
- no simulation behavior change
- no canonical probability authority change

## Diagnosis
`dynamic_starter_hook_state_contract_and_evaluator_implementation_complete`

## Recommended Next Layer
`6PK_dynamic_starter_hook_evaluator_independent_audit`