### PR TITLE
Turn AI Data Assistant into real chat UI with LLM wiring

### DIFF
--- a/frontend/src/pages/AIPage.jsx
+++ b/frontend/src/pages/AIPage.jsx
@@ -1,39 +1,160 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { API_BASE, getMlbLiveDate } from '../lib/api'
 
+const STORAGE_KEY = 'mlbgpt-ai-data-assistant-chat-v2'
 const PROMPT_CHIPS = [
-  "Summarize today's slate",
-  'What is the strongest model edge?',
-  'Which games are missing data?',
-  'Best Stored 365 hitter matchups',
-  'Top pitcher leans',
-  'Explain this matchup',
-  'What does Daily Odds tell us?',
+  "What’s the strongest DK/model edge today?",
   'Which game has the cleanest signal?',
-  'Show me the best hitter vs pitcher spots',
-  'What data is stale or weak?',
+  'Give me 3 angles worth watching tonight.',
+  'Explain why the model likes this side.',
+  'What props look interesting, even if they’re just watchlist spots?',
 ]
+
+const WELCOME_MESSAGE = {
+  id: 'welcome',
+  role: 'assistant',
+  answer:
+    "I’m your MLB analyst for DK + model-projection reads, Daily Odds context, Stored 365 matchup flags, and data-quality checks. Ask me what stands out, what’s thin, or why the model likes a side, and I’ll keep it grounded in the app’s own data.",
+  response: {
+    confidence_note: 'App-owned data only. I can sound conversational, but I do not invent baseball facts.',
+    data_used: ['matchups', 'model_projections', 'daily_odds_models'],
+    primary_recommendations: [],
+    watchlist: [],
+    warnings: [],
+    missing_data: [],
+  },
+  createdAt: Date.now(),
+}
+
+function loadStoredMessages() {
+  if (typeof window === 'undefined') return [WELCOME_MESSAGE]
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return [WELCOME_MESSAGE]
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed) || parsed.length === 0) return [WELCOME_MESSAGE]
+    return parsed
+  } catch {
+    return [WELCOME_MESSAGE]
+  }
+}
+
+function sanitizeMessagesForStorage(messages) {
+  return messages
+    .filter(message => !message.pending)
+    .slice(-24)
+    .map(message => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      answer: message.answer,
+      createdAt: message.createdAt,
+      llmMode: message.llmMode,
+      response: message.response,
+    }))
+}
+
+function messageText(message) {
+  return (message?.role === 'assistant' ? message?.answer : message?.content) || ''
+}
+
+function buildConversationPayload(messages) {
+  return messages
+    .filter(message => !message.pending)
+    .slice(-8)
+    .map(message => ({
+      role: message.role === 'assistant' ? 'assistant' : 'user',
+      content: messageText(message),
+    }))
+    .filter(turn => turn.content)
+}
 
 export default function AIPage() {
   const today = getMlbLiveDate()
-  const [message, setMessage] = useState("Summarize today's slate")
+  const [draft, setDraft] = useState('')
   const [date, setDate] = useState(today)
   const [gamePk, setGamePk] = useState('')
   const [playerId, setPlayerId] = useState('')
-  const [response, setResponse] = useState(null)
+  const [messages, setMessages] = useState(() => loadStoredMessages())
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [llmConfigured, setLlmConfigured] = useState(null)
+  const [useLlm, setUseLlm] = useState(true)
+  const [healthLoaded, setHealthLoaded] = useState(false)
+  const chatEndRef = useRef(null)
 
-  async function ask(nextMessage = message) {
+  useEffect(() => {
+    let ignore = false
+    async function loadHealth() {
+      try {
+        const res = await fetch(`${API_BASE}/ai-data-assistant/health`)
+        const json = await res.json()
+        if (ignore) return
+        setLlmConfigured(Boolean(json.llm_configured))
+        setUseLlm(Boolean(json.default_use_llm))
+      } catch {
+        if (!ignore) {
+          setLlmConfigured(false)
+          setUseLlm(false)
+        }
+      } finally {
+        if (!ignore) setHealthLoaded(true)
+      }
+    }
+    loadHealth()
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizeMessagesForStorage(messages)))
+  }, [messages])
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, loading])
+
+  const llmModeLabel = useMemo(() => {
+    if (!healthLoaded) return 'Checking LLM availability…'
+    if (!llmConfigured) return 'Deterministic mode only'
+    return useLlm ? 'LLM polish on' : 'LLM polish off'
+  }, [healthLoaded, llmConfigured, useLlm])
+
+  async function ask(nextMessage = draft) {
+    const trimmed = (nextMessage || '').trim()
+    if (!trimmed || loading) return
+
+    const userMessage = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: trimmed,
+      createdAt: Date.now(),
+    }
+    const pendingId = `assistant-${Date.now()}`
+    const pendingAssistant = {
+      id: pendingId,
+      role: 'assistant',
+      pending: true,
+      answer: '',
+      createdAt: Date.now(),
+    }
+    const historyForPayload = buildConversationPayload(messages)
+
     setLoading(true)
     setError(null)
+    setDraft('')
+    setMessages(prev => [...prev, userMessage, pendingAssistant])
 
     try {
       const payload = {
-        message: nextMessage,
+        message: trimmed,
         date: date || null,
         game_pk: gamePk ? Number(gamePk) : null,
         player_id: playerId ? Number(playerId) : null,
+        use_llm: Boolean(llmConfigured && useLlm),
+        conversation: historyForPayload,
       }
 
       const res = await fetch(`${API_BASE}/ai-data-assistant`, {
@@ -42,183 +163,259 @@ export default function AIPage() {
         body: JSON.stringify(payload),
       })
 
+      const json = await res.json()
       if (!res.ok) {
-        const text = await res.text()
-        throw new Error(text || `Request failed (${res.status})`)
+        throw new Error(typeof json?.detail === 'string' ? json.detail : JSON.stringify(json?.detail || json))
       }
 
-      const json = await res.json()
-      setResponse(json)
+      const assistantMessage = {
+        id: pendingId,
+        role: 'assistant',
+        answer: json.answer || 'No answer returned.',
+        response: json,
+        llmMode: json.llm_mode,
+        createdAt: Date.now(),
+      }
+
+      setMessages(prev => prev.map(message => (message.id === pendingId ? assistantMessage : message)))
     } catch (err) {
-      console.error('AI Data Assistant request failed:', err)
+      const fallbackMessage = {
+        id: pendingId,
+        role: 'assistant',
+        answer: `I hit an error trying to answer that: ${err.message || 'Request failed'}`,
+        response: {
+          warnings: [err.message || 'Request failed'],
+          missing_data: [],
+          primary_recommendations: [],
+          watchlist: [],
+          data_used: [],
+          confidence_note: 'No app response was returned for this turn.',
+        },
+        createdAt: Date.now(),
+      }
       setError(err.message || 'Request failed')
-      setResponse(null)
+      setMessages(prev => prev.map(message => (message.id === pendingId ? fallbackMessage : message)))
     } finally {
       setLoading(false)
     }
   }
 
-  function runChip(chip) {
-    setMessage(chip)
-    ask(chip)
+  function clearChat() {
+    setMessages([WELCOME_MESSAGE])
+    setError(null)
   }
 
-  const dataUsed = response?.data_used || response?.sources_used || []
-  const primaryRecommendations = response?.primary_recommendations || []
-  const watchlist = response?.watchlist || []
-  const warnings = response?.warnings || []
-
   return (
-    <div>
-      <h1 style={{ fontSize: '28px', marginBottom: '8px' }}>AI Data Assistant</h1>
-      <p style={{ color: '#8b949e', marginBottom: '18px', lineHeight: 1.5 }}>
-        Ask the app to explain DK + model-projection edges, Daily Odds, Stored 365 hitter spots, and data quality using only app-owned data.
-      </p>
-
-      <div style={{
-        background: '#161b22',
-        border: '1px solid #30363d',
-        borderRadius: '12px',
-        padding: '16px',
-        marginBottom: '16px'
-      }}>
-        <div style={{ display: 'flex', gap: '10px', marginBottom: '12px', flexWrap: 'wrap' }}>
-          <label style={{ color: '#8b949e', fontSize: '13px' }}>
-            Date
-            <input
-              type="date"
-              value={date}
-              onChange={e => setDate(e.target.value)}
-              style={inputStyle}
-            />
-          </label>
-          <label style={{ color: '#8b949e', fontSize: '13px' }}>
-            Game PK
-            <input
-              value={gamePk}
-              onChange={e => setGamePk(e.target.value)}
-              placeholder="optional"
-              style={{ ...inputStyle, width: '140px' }}
-            />
-          </label>
-          <label style={{ color: '#8b949e', fontSize: '13px' }}>
-            Player ID
-            <input
-              value={playerId}
-              onChange={e => setPlayerId(e.target.value)}
-              placeholder="optional"
-              style={{ ...inputStyle, width: '140px' }}
-            />
-          </label>
+    <div style={pageStyle}>
+      <div style={heroStyle}>
+        <div>
+          <div style={eyebrowStyle}>MLB GPT Analyst Chat</div>
+          <h1 style={titleStyle}>AI Data Assistant</h1>
+          <p style={subtitleStyle}>
+            Real chat UI, DK/model-projection-first reasoning, and app-owned evidence only.
+          </p>
         </div>
+        <div style={heroBadgeRowStyle}>
+          <ModeBadge label={llmModeLabel} active={Boolean(llmConfigured && useLlm)} muted={!llmConfigured} />
+          <ModeBadge label={date} active={false} muted={false} />
+        </div>
+      </div>
 
-        <div style={{ display: 'flex', gap: '8px', marginBottom: '14px' }}>
+      <div style={controlsBarStyle}>
+        <label style={controlLabelStyle}>
+          Date
+          <input type="date" value={date} onChange={e => setDate(e.target.value)} style={controlInputStyle} />
+        </label>
+        <label style={controlLabelStyle}>
+          Game PK
+          <input value={gamePk} onChange={e => setGamePk(e.target.value)} placeholder="optional" style={smallInputStyle} />
+        </label>
+        <label style={controlLabelStyle}>
+          Player ID
+          <input value={playerId} onChange={e => setPlayerId(e.target.value)} placeholder="optional" style={smallInputStyle} />
+        </label>
+        <label style={toggleWrapStyle}>
           <input
-            value={message}
-            onChange={e => setMessage(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') ask() }}
-            style={{
-              flex: 1,
-              background: '#0d1117',
-              color: '#e6edf3',
-              border: '1px solid #30363d',
-              borderRadius: '8px',
-              padding: '12px'
-            }}
+            type="checkbox"
+            checked={Boolean(llmConfigured && useLlm)}
+            disabled={!llmConfigured}
+            onChange={e => setUseLlm(e.target.checked)}
           />
-          <button onClick={() => ask()} disabled={loading}>
-            {loading ? 'Asking...' : 'Ask'}
-          </button>
+          <span>Use LLM polish</span>
+        </label>
+        <button onClick={clearChat} style={secondaryButtonStyle}>Clear chat</button>
+      </div>
+
+      <div style={chatShellStyle}>
+        <div style={chatHeaderStyle}>
+          <div>
+            <div style={chatTitleStyle}>Talk to the MLB analyst</div>
+            <div style={chatSubtitleStyle}>
+              Ask for strongest edges, cleanest signals, watchlist props, or missing-data problems.
+            </div>
+          </div>
+          <div style={statusTextStyle}>
+            {error ? `Last error: ${error}` : 'Ready'}
+          </div>
         </div>
 
-        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+        <div style={starterPromptWrapStyle}>
           {PROMPT_CHIPS.map(chip => (
-            <button key={chip} onClick={() => runChip(chip)} disabled={loading} style={chipStyle}>
+            <button key={chip} onClick={() => ask(chip)} disabled={loading} style={starterChipStyle}>
               {chip}
             </button>
           ))}
         </div>
-      </div>
 
-      {error && (
-        <div style={{
-          background: '#2d1b1b',
-          border: '1px solid #a33',
-          borderRadius: '8px',
-          padding: '14px',
-          marginBottom: '12px'
-        }}>
-          <strong>Error:</strong> {error}
+        <div style={chatHistoryStyle}>
+          {messages.map(message => (
+            <ChatMessage key={message.id} message={message} />
+          ))}
+          {loading && <TypingBubble />}
+          <div ref={chatEndRef} />
         </div>
-      )}
 
-      {response && (
-        <div style={{
-          background: '#161b22',
-          border: '1px solid #30363d',
-          borderRadius: '12px',
-          padding: '16px'
-        }}>
-          <div style={{ fontWeight: 700, marginBottom: '8px' }}>Answer</div>
-          <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.55, marginBottom: '16px' }}>
-            {response.answer}
+        <div style={composerStyle}>
+          <textarea
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                ask()
+              }
+            }}
+            placeholder="Ask what stands out, what the model likes, what props are worth a watch, or where the data is thin…"
+            style={composerInputStyle}
+          />
+          <div style={composerFooterStyle}>
+            <div style={composerHintStyle}>Enter to send • Shift+Enter for a new line</div>
+            <button onClick={() => ask()} disabled={loading || !draft.trim()} style={sendButtonStyle}>
+              {loading ? 'Thinking…' : 'Send'}
+            </button>
           </div>
+        </div>
+      </div>
+    </div>
+  )
+}
 
-          <div style={metaGridStyle}>
-            <MetaCard title="Intent" value={response.intent || 'unknown'} />
-            <MetaCard title="Data used" value={dataUsed.join(', ') || 'None'} />
-            <MetaCard title="Confidence note" value={response.confidence_note || 'None'} />
+function ChatMessage({ message }) {
+  const isUser = message.role === 'user'
+  const response = message.response || {}
+  const primaryRecommendations = response.primary_recommendations || []
+  const watchlist = response.watchlist || []
+  const warnings = response.warnings || []
+  const dataUsed = response.data_used || response.sources_used || []
+  const missingData = response.missing_data || []
+  const llmMode = message.llmMode || response.llm_mode
+
+  return (
+    <div style={{ ...messageRowStyle, justifyContent: isUser ? 'flex-end' : 'flex-start' }}>
+      <div style={{ ...bubbleStyle, ...(isUser ? userBubbleStyle : assistantBubbleStyle) }}>
+        <div style={bubbleMetaStyle}>
+          <span style={bubbleRoleStyle}>{isUser ? 'You' : 'AI Data Assistant'}</span>
+          {!isUser && llmMode && (
+            <span style={bubbleTagStyle}>
+              {llmMode.active ? 'LLM polished' : llmMode.configured ? 'Deterministic reply' : 'LLM unavailable'}
+            </span>
+          )}
+        </div>
+
+        <div style={{ whiteSpace: 'pre-wrap', lineHeight: 1.6, color: isUser ? '#f8fafc' : '#dbe7ff' }}>
+          {isUser ? message.content : message.answer}
+        </div>
+
+        {!isUser && (
+          <div style={assistantSectionsWrapStyle}>
+            <StructuredSection title="Primary recommendations" items={primaryRecommendations} emptyMessage="No actionable recommendations were surfaced for this turn." />
+            <StructuredSection title="Watchlist" items={watchlist} emptyMessage="No extra watchlist angles were surfaced for this turn." />
+            <details style={detailsStyle}>
+              <summary style={detailsSummaryStyle}>Data used, warnings, and confidence</summary>
+              <div style={detailsBodyStyle}>
+                <StructuredInlineList title="Data used" items={dataUsed} emptyMessage="No sources listed." />
+                <StructuredInlineList title="Warnings" items={warnings} emptyMessage="No warnings flagged." />
+                <StructuredInlineList
+                  title="Missing data"
+                  items={missingData.map(item => (typeof item === 'string' ? item : JSON.stringify(item)))}
+                  emptyMessage="No missing-data flags listed."
+                />
+                <div style={confidenceNoteStyle}>{response.confidence_note || 'No confidence note returned.'}</div>
+              </div>
+            </details>
           </div>
+        )}
+      </div>
+    </div>
+  )
+}
 
-          <SectionList
-            title="Primary recommendations"
-            items={primaryRecommendations}
-            emptyMessage="No primary recommendations are currently supported by the app-owned evidence packet."
-          />
+function TypingBubble() {
+  return (
+    <div style={{ ...messageRowStyle, justifyContent: 'flex-start' }}>
+      <div style={{ ...bubbleStyle, ...assistantBubbleStyle, maxWidth: 180 }}>
+        <div style={bubbleMetaStyle}>
+          <span style={bubbleRoleStyle}>AI Data Assistant</span>
+        </div>
+        <div style={typingWrapStyle}>
+          <span style={typingDotStyle}>•</span>
+          <span style={typingDotStyle}>•</span>
+          <span style={typingDotStyle}>•</span>
+        </div>
+      </div>
+    </div>
+  )
+}
 
-          <SectionList
-            title="Watchlist"
-            items={watchlist}
-            emptyMessage="No additional watchlist angles are currently available."
-          />
+function StructuredSection({ title, items, emptyMessage }) {
+  return (
+    <details style={detailsStyle}>
+      <summary style={detailsSummaryStyle}>{title}</summary>
+      <div style={detailsBodyStyle}>
+        {!items?.length ? (
+          <div style={emptyCopyStyle}>{emptyMessage}</div>
+        ) : (
+          <div style={structuredGridStyle}>
+            {items.map((item, index) => (
+              <div key={`${title}-${index}`} style={structuredCardStyle}>
+                {formatStructuredItem(item)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </details>
+  )
+}
 
-          <SectionList
-            title="Warnings"
-            items={warnings}
-            emptyMessage="No warnings were flagged."
-            renderItem={(item) => typeof item === 'string' ? item : JSON.stringify(item)}
-          />
-
-          <details style={{ marginTop: '14px' }}>
-            <summary style={{ cursor: 'pointer', color: '#58a6ff' }}>Data quality and missing data</summary>
-            <pre style={preStyle}>{JSON.stringify({
-              data_quality: response.data_quality,
-              missing_data: response.missing_data,
-              context_preview: response.context_preview,
-              trace_logging: response.trace_logging,
-            }, null, 2)}</pre>
-          </details>
+function StructuredInlineList({ title, items, emptyMessage }) {
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div style={inlineTitleStyle}>{title}</div>
+      {!items?.length ? (
+        <div style={emptyCopyStyle}>{emptyMessage}</div>
+      ) : (
+        <div style={inlineListStyle}>
+          {items.map((item, index) => (
+            <span key={`${title}-${index}`} style={inlineChipStyle}>{String(item)}</span>
+          ))}
         </div>
       )}
     </div>
   )
 }
 
-function SectionList({ title, items, emptyMessage, renderItem }) {
+function ModeBadge({ label, active, muted }) {
   return (
-    <div style={{ marginTop: '16px' }}>
-      <div style={{ fontWeight: 700, marginBottom: '8px' }}>{title}</div>
-      {!items?.length ? (
-        <div style={emptyStateStyle}>{emptyMessage}</div>
-      ) : (
-        <div style={listStyle}>
-          {items.map((item, index) => (
-            <div key={`${title}-${index}`} style={listItemStyle}>
-              {renderItem ? renderItem(item) : formatStructuredItem(item)}
-            </div>
-          ))}
-        </div>
-      )}
+    <div
+      style={{
+        ...modeBadgeStyle,
+        background: active ? 'rgba(34,197,94,0.16)' : muted ? 'rgba(148,163,184,0.12)' : 'rgba(56,189,248,0.12)',
+        borderColor: active ? 'rgba(34,197,94,0.36)' : muted ? 'rgba(148,163,184,0.24)' : 'rgba(56,189,248,0.32)',
+        color: active ? '#bbf7d0' : muted ? '#94a3b8' : '#bae6fd',
+      }}
+    >
+      {label}
     </div>
   )
 }
@@ -227,17 +424,21 @@ function formatStructuredItem(item) {
   if (!item) return 'Unknown item'
   if (typeof item === 'string') return item
 
-  const pieces = []
-  const label = item.label || item.selection || item.player_name || item.team
-  if (label) pieces.push(label)
-  if (item.market) pieces.push(item.market)
-  if (item.score !== undefined && item.score !== null) pieces.push(`score ${formatValue(item.score)}`)
-  if (item.confidence_tier) pieces.push(item.confidence_tier)
-  if (item.expected_value !== undefined && item.expected_value !== null) pieces.push(`EV ${formatValue(item.expected_value)}`)
-  if (item.price !== undefined && item.price !== null && item.price !== '') pieces.push(`price ${item.price}`)
+  const lines = []
+  const head = [item.label || item.selection || item.player_name || item.team, item.market].filter(Boolean).join(' • ')
+  if (head) lines.push(head)
 
-  const reasons = Array.isArray(item.reasons) ? item.reasons.slice(0, 3).join('; ') : ''
-  return reasons ? `${pieces.join(' | ')} - ${reasons}` : pieces.join(' | ')
+  const meta = []
+  if (item.score !== undefined && item.score !== null) meta.push(`score ${formatValue(item.score)}`)
+  if (item.confidence_tier) meta.push(item.confidence_tier)
+  if (item.expected_value !== undefined && item.expected_value !== null) meta.push(`EV ${formatValue(item.expected_value)}`)
+  if (item.price !== undefined && item.price !== null && item.price !== '') meta.push(`price ${item.price}`)
+  if (meta.length) lines.push(meta.join(' | '))
+
+  const reasons = Array.isArray(item.reasons) ? item.reasons.slice(0, 3) : Array.isArray(item.drivers) ? item.drivers.slice(0, 3) : []
+  if (reasons.length) lines.push(reasons.join(' • '))
+
+  return lines.join('\n')
 }
 
 function formatValue(value) {
@@ -247,70 +448,346 @@ function formatValue(value) {
   return String(value)
 }
 
-function MetaCard({ title, value }) {
-  return (
-    <div style={{ background: '#0d1117', border: '1px solid #30363d', borderRadius: '8px', padding: '10px' }}>
-      <div style={{ color: '#8b949e', fontSize: '12px', marginBottom: '6px' }}>{title}</div>
-      <div style={{ color: '#e6edf3', fontSize: '13px', overflowWrap: 'anywhere' }}>{value}</div>
-    </div>
-  )
+const pageStyle = {
+  minHeight: '100vh',
+  background: 'radial-gradient(circle at top, #14213a 0%, #090d18 45%, #060913 100%)',
+  color: '#eef4ff',
+  padding: '28px 18px 36px',
 }
 
-const inputStyle = {
-  display: 'block',
-  marginTop: '6px',
-  background: '#0d1117',
-  color: '#e6edf3',
-  border: '1px solid #30363d',
-  borderRadius: '8px',
-  padding: '9px'
+const heroStyle = {
+  maxWidth: 1200,
+  margin: '0 auto 18px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 18,
+  alignItems: 'flex-start',
+  flexWrap: 'wrap',
 }
 
-const chipStyle = {
-  background: '#0d1117',
-  color: '#58a6ff',
-  border: '1px solid #30363d',
-  borderRadius: '999px',
-  padding: '8px 10px',
-  cursor: 'pointer'
+const eyebrowStyle = {
+  fontSize: 12,
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+  color: '#7dd3fc',
+  marginBottom: 8,
 }
 
-const metaGridStyle = {
+const titleStyle = {
+  margin: 0,
+  fontSize: '34px',
+  lineHeight: 1.05,
+}
+
+const subtitleStyle = {
+  margin: '10px 0 0',
+  maxWidth: 760,
+  color: '#a8b6d9',
+  lineHeight: 1.6,
+}
+
+const heroBadgeRowStyle = {
+  display: 'flex',
+  gap: 10,
+  flexWrap: 'wrap',
+}
+
+const modeBadgeStyle = {
+  padding: '9px 12px',
+  borderRadius: 999,
+  border: '1px solid transparent',
+  fontSize: 12,
+  fontWeight: 700,
+}
+
+const controlsBarStyle = {
+  maxWidth: 1200,
+  margin: '0 auto 18px',
+  display: 'flex',
+  gap: 12,
+  flexWrap: 'wrap',
+  alignItems: 'flex-end',
+  padding: 16,
+  borderRadius: 18,
+  border: '1px solid rgba(148,163,184,0.16)',
+  background: 'rgba(10, 16, 30, 0.78)',
+  boxShadow: '0 20px 60px rgba(0,0,0,0.28)',
+}
+
+const controlLabelStyle = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-  gap: '10px'
+  gap: 6,
+  color: '#9fb0d3',
+  fontSize: 12,
 }
 
-const listStyle = {
+const controlInputStyle = {
+  background: '#07101f',
+  color: '#ecf4ff',
+  border: '1px solid rgba(148,163,184,0.24)',
+  borderRadius: 12,
+  padding: '10px 12px',
+}
+
+const smallInputStyle = {
+  ...controlInputStyle,
+  width: 120,
+}
+
+const toggleWrapStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  color: '#d7e3ff',
+  fontSize: 13,
+  paddingBottom: 10,
+}
+
+const secondaryButtonStyle = {
+  border: '1px solid rgba(148,163,184,0.24)',
+  background: 'rgba(15,23,42,0.82)',
+  color: '#dbeafe',
+  borderRadius: 12,
+  padding: '10px 14px',
+  cursor: 'pointer',
+}
+
+const chatShellStyle = {
+  maxWidth: 1200,
+  margin: '0 auto',
+  borderRadius: 24,
+  border: '1px solid rgba(148,163,184,0.16)',
+  background: 'linear-gradient(180deg, rgba(9, 14, 25, 0.94), rgba(5, 9, 17, 0.98))',
+  boxShadow: '0 28px 90px rgba(0,0,0,0.34)',
+  overflow: 'hidden',
+}
+
+const chatHeaderStyle = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  gap: 16,
+  alignItems: 'center',
+  padding: '20px 22px 14px',
+  borderBottom: '1px solid rgba(148,163,184,0.12)',
+}
+
+const chatTitleStyle = {
+  fontSize: 18,
+  fontWeight: 700,
+  color: '#f5f9ff',
+}
+
+const chatSubtitleStyle = {
+  marginTop: 4,
+  color: '#8fa4ca',
+  fontSize: 13,
+}
+
+const statusTextStyle = {
+  fontSize: 12,
+  color: '#8fa4ca',
+}
+
+const starterPromptWrapStyle = {
+  display: 'flex',
+  gap: 10,
+  flexWrap: 'wrap',
+  padding: '14px 22px 0',
+}
+
+const starterChipStyle = {
+  borderRadius: 999,
+  border: '1px solid rgba(56,189,248,0.22)',
+  background: 'rgba(56,189,248,0.10)',
+  color: '#dff7ff',
+  padding: '9px 12px',
+  cursor: 'pointer',
+  fontSize: 13,
+}
+
+const chatHistoryStyle = {
+  padding: '20px 22px',
+  minHeight: '52vh',
+  maxHeight: '58vh',
+  overflowY: 'auto',
   display: 'grid',
-  gap: '8px'
+  gap: 14,
 }
 
-const listItemStyle = {
-  background: '#0d1117',
-  border: '1px solid #30363d',
-  borderRadius: '8px',
-  padding: '10px',
-  color: '#e6edf3',
-  fontSize: '13px',
+const messageRowStyle = {
+  display: 'flex',
+}
+
+const bubbleStyle = {
+  maxWidth: '78%',
+  borderRadius: 22,
+  padding: '14px 16px',
+  boxShadow: '0 12px 32px rgba(0,0,0,0.22)',
+}
+
+const userBubbleStyle = {
+  background: 'linear-gradient(135deg, #1d4ed8, #2563eb)',
+  border: '1px solid rgba(147,197,253,0.28)',
+}
+
+const assistantBubbleStyle = {
+  background: 'linear-gradient(180deg, rgba(12,21,38,0.96), rgba(8,14,28,0.98))',
+  border: '1px solid rgba(148,163,184,0.16)',
+}
+
+const bubbleMetaStyle = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+  marginBottom: 8,
+  flexWrap: 'wrap',
+}
+
+const bubbleRoleStyle = {
+  fontSize: 12,
+  fontWeight: 700,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+  color: '#9fb7ff',
+}
+
+const bubbleTagStyle = {
+  fontSize: 11,
+  color: '#dff7ff',
+  borderRadius: 999,
+  padding: '4px 8px',
+  background: 'rgba(56,189,248,0.10)',
+  border: '1px solid rgba(56,189,248,0.18)',
+}
+
+const assistantSectionsWrapStyle = {
+  marginTop: 14,
+  display: 'grid',
+  gap: 10,
+}
+
+const detailsStyle = {
+  borderRadius: 16,
+  background: 'rgba(255,255,255,0.02)',
+  border: '1px solid rgba(148,163,184,0.10)',
+}
+
+const detailsSummaryStyle = {
+  cursor: 'pointer',
+  padding: '10px 12px',
+  color: '#dbeafe',
+  fontWeight: 600,
+}
+
+const detailsBodyStyle = {
+  padding: '0 12px 12px',
+}
+
+const structuredGridStyle = {
+  display: 'grid',
+  gap: 8,
+}
+
+const structuredCardStyle = {
+  background: 'rgba(8,14,28,0.9)',
+  border: '1px solid rgba(148,163,184,0.12)',
+  borderRadius: 14,
+  padding: '10px 12px',
+  color: '#dbeafe',
+  whiteSpace: 'pre-wrap',
   lineHeight: 1.5,
-  overflowWrap: 'anywhere'
+  fontSize: 13,
 }
 
-const emptyStateStyle = {
-  background: '#0d1117',
-  border: '1px dashed #30363d',
-  borderRadius: '8px',
-  padding: '10px',
-  color: '#8b949e',
-  fontSize: '13px'
+const inlineTitleStyle = {
+  fontSize: 12,
+  fontWeight: 700,
+  color: '#9fb7ff',
+  marginBottom: 6,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
 }
 
-const preStyle = {
-  marginTop: '12px',
-  background: '#0d1117',
-  borderRadius: '6px',
-  padding: '10px',
-  overflowX: 'auto',
-  fontSize: '12px'
+const inlineListStyle = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+}
+
+const inlineChipStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  borderRadius: 999,
+  padding: '6px 10px',
+  background: 'rgba(148,163,184,0.10)',
+  border: '1px solid rgba(148,163,184,0.16)',
+  color: '#dbeafe',
+  fontSize: 12,
+}
+
+const emptyCopyStyle = {
+  color: '#8fa4ca',
+  fontSize: 13,
+}
+
+const confidenceNoteStyle = {
+  marginTop: 8,
+  color: '#c4d4f4',
+  fontSize: 13,
+  lineHeight: 1.5,
+}
+
+const typingWrapStyle = {
+  display: 'flex',
+  gap: 8,
+  color: '#9fb7ff',
+  fontSize: 20,
+}
+
+const typingDotStyle = {
+  lineHeight: 1,
+}
+
+const composerStyle = {
+  borderTop: '1px solid rgba(148,163,184,0.12)',
+  padding: '16px 18px 18px',
+  background: 'rgba(5, 9, 17, 0.98)',
+}
+
+const composerInputStyle = {
+  width: '100%',
+  minHeight: 86,
+  resize: 'vertical',
+  borderRadius: 18,
+  border: '1px solid rgba(148,163,184,0.16)',
+  background: 'rgba(11, 18, 32, 0.98)',
+  color: '#eff6ff',
+  padding: '14px 16px',
+  boxSizing: 'border-box',
+  fontSize: 15,
+  lineHeight: 1.55,
+}
+
+const composerFooterStyle = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: 12,
+  marginTop: 12,
+  flexWrap: 'wrap',
+}
+
+const composerHintStyle = {
+  color: '#7f93ba',
+  fontSize: 12,
+}
+
+const sendButtonStyle = {
+  borderRadius: 14,
+  border: '1px solid rgba(56,189,248,0.26)',
+  background: 'linear-gradient(135deg, #38bdf8, #60a5fa)',
+  color: '#03121c',
+  padding: '11px 16px',
+  fontWeight: 800,
+  cursor: 'pointer',
 }

--- a/mlb_app/ai_data_assistant_routes.py
+++ b/mlb_app/ai_data_assistant_routes.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from .ai_data_assistant import PROMPT_CHIPS, classify_assistant_intent
+from .ai_data_assistant import AI_DATA_ASSISTANT_SYSTEM_PROMPT, PROMPT_CHIPS, classify_assistant_intent
 from .ai_data_assistant_performance import build_ai_data_assistant_response, clear_ai_data_assistant_caches
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_routes import router as my_dashboard_router
@@ -17,13 +18,19 @@ router = APIRouter()
 router.include_router(my_dashboard_router)
 
 
+class ConversationTurn(BaseModel):
+    role: str
+    content: str
+
+
 class AIDataAssistantRequest(BaseModel):
     message: str
     date: Optional[str] = None
     game_pk: Optional[int] = None
     player_id: Optional[int] = None
     team_id: Optional[int] = None
-    use_llm: bool = False
+    use_llm: Optional[bool] = None
+    conversation: Optional[List[ConversationTurn]] = None
 
 
 def session_factory():
@@ -33,10 +40,104 @@ def session_factory():
     return get_session(engine)
 
 
+def _llm_configured() -> bool:
+    return bool(os.getenv("OPENAI_API_KEY"))
+
+
+def _default_use_llm() -> bool:
+    if not _llm_configured():
+        return False
+    raw = os.getenv("AI_DATA_ASSISTANT_DEFAULT_USE_LLM", "true").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _resolve_use_llm(requested: Optional[bool]) -> bool:
+    if requested is None:
+        return _default_use_llm()
+    if not _llm_configured():
+        return False
+    return bool(requested)
+
+
+def _normalize_conversation(conversation: Optional[List[ConversationTurn]]) -> List[Dict[str, str]]:
+    normalized: List[Dict[str, str]] = []
+    for turn in conversation or []:
+        role = str(turn.role or "").strip().lower()
+        content = str(turn.content or "").strip()
+        if role not in {"user", "assistant"} or not content:
+            continue
+        normalized.append({"role": role, "content": content})
+    return normalized[-8:]
+
+
+def _conversation_transcript(conversation: List[Dict[str, str]]) -> str:
+    if not conversation:
+        return "No prior conversation provided."
+    lines = []
+    for turn in conversation[-6:]:
+        label = "User" if turn["role"] == "user" else "Assistant"
+        lines.append(f"{label}: {turn['content']}")
+    return "\n".join(lines)
+
+
+def _apply_conversational_llm_polish(message: str, result: Dict[str, Any], conversation: List[Dict[str, str]]) -> Dict[str, Any]:
+    if not _llm_configured():
+        return result
+    from openai import OpenAI
+
+    client = OpenAI()
+    packet = result.get("context_preview") or {}
+    transcript = _conversation_transcript(conversation)
+    structured_summary = json.dumps(
+        {
+            "intent": result.get("intent"),
+            "primary_recommendations": result.get("primary_recommendations") or [],
+            "watchlist": result.get("watchlist") or [],
+            "warnings": result.get("warnings") or [],
+            "missing_data": result.get("missing_data") or [],
+            "confidence_note": result.get("confidence_note"),
+        },
+        default=str,
+    )
+    style_prompt = (
+        "You are rewriting the final assistant answer for a chat UI. "
+        "Sound like a sharp, natural MLB analyst. Be conversational, direct, and useful. "
+        "Do not sound like a report template. Do not invent facts. Do not change the underlying recommendations, warnings, or evidence. "
+        "You may reference recent chat context to resolve pronouns or continue the conversation naturally, but app-owned evidence remains the only factual source of truth. "
+        "Keep it concise unless the user asked for detail. Use bullets only when they genuinely help. "
+        "Make the answer feel like a real chatbot reply."
+    )
+    response = client.chat.completions.create(
+        model=os.getenv("AI_DATA_ASSISTANT_MODEL", "gpt-4o-mini"),
+        messages=[
+            {"role": "system", "content": AI_DATA_ASSISTANT_SYSTEM_PROMPT + "\n\n" + style_prompt},
+            {
+                "role": "user",
+                "content": (
+                    f"Recent conversation:\n{transcript}\n\n"
+                    f"Current user question:\n{message}\n\n"
+                    f"Structured response contract JSON:\n{structured_summary}\n\n"
+                    f"Evidence packet preview JSON:\n{json.dumps(packet, default=str)}\n\n"
+                    "Rewrite the answer text only."
+                ),
+            },
+        ],
+        temperature=0.35,
+        max_tokens=700,
+    )
+    answer = response.choices[0].message.content if response.choices else None
+    if answer:
+        result["answer"] = answer
+        result["llm_answer"] = answer
+    return result
+
+
 @router.get("/ai-data-assistant", response_class=HTMLResponse)
 def ai_data_assistant_page() -> str:
     chips = "".join(f'<button class="chip" type="button">{chip}</button>' for chip in PROMPT_CHIPS)
     today = dt.date.today().isoformat()
+    use_llm_checked = "checked" if _default_use_llm() else ""
+    llm_note = "LLM polish available" if _llm_configured() else "Deterministic mode only"
     return f"""
 <!doctype html>
 <html lang="en">
@@ -73,7 +174,8 @@ def ai_data_assistant_page() -> str:
           <label>Date <input id="date" type="date" value="{today}" /></label>
           <label>Game PK <input id="gamePk" type="number" placeholder="optional" /></label>
           <label>Player ID <input id="playerId" type="number" placeholder="optional" /></label>
-          <label><input id="useLlm" type="checkbox" /> Use LLM polish</label>
+          <label><input id="useLlm" type="checkbox" {use_llm_checked} /> Use LLM polish</label>
+          <span class="muted">{llm_note}</span>
           <button id="askBtn" type="button">Ask</button>
         </div>
         <textarea id="message" placeholder="Ask about today's slate, model edges, Daily Odds, Stored 365, missing data, or a specific matchup.">Summarize today's slate</textarea>
@@ -92,7 +194,7 @@ def ai_data_assistant_page() -> str:
   </main>
 <script>
 const $ = (id) => document.getElementById(id);
-document.querySelectorAll('.chip').forEach(btn => btn.addEventListener('click', () => {{ $('message').value = btn.textContent; $('useLlm').checked = false; ask(); }}));
+document.querySelectorAll('.chip').forEach(btn => btn.addEventListener('click', () => {{ $('message').value = btn.textContent; ask(); }}));
 $('askBtn').addEventListener('click', ask);
 async function ask() {{
   $('status').textContent = 'Querying app-owned data...';
@@ -108,7 +210,7 @@ async function ask() {{
     const res = await fetch('/ai-data-assistant', {{ method: 'POST', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify(payload) }});
     const data = await res.json();
     if (!res.ok) throw new Error(JSON.stringify(data.detail || data));
-    $('status').textContent = `Intent: ${{data.intent || 'unknown'}} | Date: ${{data.date || ''}} | Cache: ${{data.cache_status || 'none'}}`;
+    $('status').textContent = `Intent: ${{data.intent || 'unknown'}} | Date: ${{data.date || ''}} | LLM: ${{data.llm_mode?.active ? 'active' : data.llm_mode?.requested ? 'requested' : 'off'}}`;
     $('answer').textContent = data.answer || 'No answer returned.';
     $('sources').textContent = (data.sources_used || []).join(', ') || 'None';
     $('timing').textContent = JSON.stringify(data.timing || {{}}, null, 2);
@@ -131,7 +233,13 @@ def ai_data_assistant_prompts() -> Dict[str, Any]:
 
 @router.get("/ai-data-assistant/health")
 def ai_data_assistant_health() -> Dict[str, Any]:
-    return {"name": "AI Data Assistant", "status": "ok", "llm_configured": bool(os.getenv("OPENAI_API_KEY")), "deterministic_default": True}
+    return {
+        "name": "AI Data Assistant",
+        "status": "ok",
+        "llm_configured": _llm_configured(),
+        "deterministic_default": not _default_use_llm(),
+        "default_use_llm": _default_use_llm(),
+    }
 
 
 @router.post("/ai-data-assistant")
@@ -141,6 +249,8 @@ def ai_data_assistant_query(payload: AIDataAssistantRequest) -> Dict[str, Any]:
     try:
         factory = session_factory()
         with factory() as session:
+            conversation = _normalize_conversation(payload.conversation)
+            resolved_use_llm = _resolve_use_llm(payload.use_llm)
             result = build_ai_data_assistant_response(
                 session=session,
                 message=payload.message,
@@ -148,8 +258,25 @@ def ai_data_assistant_query(payload: AIDataAssistantRequest) -> Dict[str, Any]:
                 game_pk=payload.game_pk,
                 player_id=payload.player_id,
                 team_id=payload.team_id,
-                use_llm=payload.use_llm,
+                use_llm=False,
             )
+            llm_mode = {
+                "requested": bool(payload.use_llm) if payload.use_llm is not None else resolved_use_llm,
+                "configured": _llm_configured(),
+                "active": False,
+                "conversation_turns": len(conversation),
+            }
+            if resolved_use_llm and _llm_configured():
+                result = _apply_conversational_llm_polish(payload.message, result, conversation)
+                llm_mode["active"] = True
+            elif (payload.use_llm or resolved_use_llm) and not _llm_configured():
+                warnings = list(result.get("warnings") or [])
+                warning = "LLM mode was requested but OPENAI_API_KEY is not configured, so deterministic fallback was used."
+                if warning not in warnings:
+                    warnings.append(warning)
+                result["warnings"] = warnings
+                result["confidence_note"] = (result.get("confidence_note") or "") + " Deterministic fallback was used because LLM mode is not configured."
+            result["llm_mode"] = llm_mode
             result["name"] = "AI Data Assistant"
             result["intent"] = result.get("intent") or classify_assistant_intent(payload.message)
             return result

--- a/tests/test_ai_data_assistant_routes.py
+++ b/tests/test_ai_data_assistant_routes.py
@@ -1,0 +1,103 @@
+from mlb_app import ai_data_assistant_routes as routes
+
+
+class DummySession:
+    def __enter__(self):
+        return object()
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyFactory:
+    def __call__(self):
+        return DummySession()
+
+
+def test_resolve_use_llm_defaults_on_when_configured(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AI_DATA_ASSISTANT_DEFAULT_USE_LLM", "true")
+    assert routes._resolve_use_llm(None) is True
+
+
+def test_resolve_use_llm_forces_off_without_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert routes._resolve_use_llm(True) is False
+    assert routes._resolve_use_llm(None) is False
+
+
+def test_query_uses_route_level_llm_polish_and_preserves_backend_contract(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(routes, "session_factory", lambda: DummyFactory())
+
+    captured = {}
+
+    def fake_build(**kwargs):
+        captured.update(kwargs)
+        return {
+            "answer": "Deterministic answer",
+            "intent": "best_model_edges",
+            "primary_recommendations": [{"label": "Cubs ML"}],
+            "watchlist": [],
+            "warnings": [],
+            "missing_data": [],
+            "confidence_note": "Deterministic base.",
+            "data_used": ["model_projections"],
+            "sources_used": ["model_projections"],
+            "context_preview": {"intent": "best_model_edges"},
+            "data_quality": {},
+        }
+
+    def fake_polish(message, result, conversation):
+        assert message == "What stands out today?"
+        assert conversation == [{"role": "user", "content": "Earlier question"}]
+        result = dict(result)
+        result["answer"] = "Here’s what stands out today."
+        result["llm_answer"] = result["answer"]
+        return result
+
+    monkeypatch.setattr(routes, "build_ai_data_assistant_response", fake_build)
+    monkeypatch.setattr(routes, "_apply_conversational_llm_polish", fake_polish)
+
+    payload = routes.AIDataAssistantRequest(
+        message="What stands out today?",
+        use_llm=True,
+        conversation=[routes.ConversationTurn(role="user", content="Earlier question")],
+    )
+    result = routes.ai_data_assistant_query(payload)
+
+    assert captured["use_llm"] is False
+    assert result["answer"] == "Here’s what stands out today."
+    assert result["primary_recommendations"] == [{"label": "Cubs ML"}]
+    assert result["llm_mode"]["active"] is True
+    assert result["llm_mode"]["conversation_turns"] == 1
+
+
+def test_query_warns_when_llm_requested_but_not_configured(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(routes, "session_factory", lambda: DummyFactory())
+    monkeypatch.setattr(
+        routes,
+        "build_ai_data_assistant_response",
+        lambda **kwargs: {
+            "answer": "Deterministic answer",
+            "intent": "daily_slate_summary",
+            "primary_recommendations": [],
+            "watchlist": [],
+            "warnings": [],
+            "missing_data": [],
+            "confidence_note": "Base note.",
+            "data_used": [],
+            "sources_used": [],
+            "context_preview": {},
+            "data_quality": {},
+        },
+    )
+
+    payload = routes.AIDataAssistantRequest(message="Summarize today", use_llm=True)
+    result = routes.ai_data_assistant_query(payload)
+
+    assert result["llm_mode"]["active"] is False
+    assert result["llm_mode"]["configured"] is False
+    assert any("OPENAI_API_KEY" in warning for warning in result["warnings"])
+    assert "Deterministic fallback" in result["confidence_note"]


### PR DESCRIPTION
## Summary
This PR upgrades the existing `/ai-data-assistant` product surface into a real chat-style experience without replacing the endpoint or bypassing the deterministic app-owned evidence pipeline.

### What changed
- Replaced the current AI page form/panel with a real chat UI in `frontend/src/pages/AIPage.jsx`
  - message bubbles
  - chat history
  - typing/loading state
  - starter prompts
  - local session memory via localStorage
  - visible LLM mode toggle/status
  - sends recent conversation turns with each request
- Updated `mlb_app/ai_data_assistant_routes.py`
  - added optional `conversation` turns to the request model
  - added default LLM mode resolution
  - route-level conversational LLM polish on top of the deterministic backend response
  - explicit `llm_mode` metadata in the response
  - preserves `/ai-data-assistant` as the endpoint
- Added route tests in `tests/test_ai_data_assistant_routes.py`
  - LLM mode resolution
  - deterministic fallback when not configured
  - route-level conversational polish preserving structured backend fields

## Why this PR exists
The previous refactor improved backend structure, but the product still did not feel like an actual chatbot:
- the React page was not sending `use_llm`
- the UI was still a form + response panel
- there was no lightweight conversational memory
- the assistant answer did not feel chat-native

## Important notes
- DK/model projections remain the primary reasoning layer
- Bet105 remains secondary
- deterministic backend output remains the source of truth
- LLM polish only rewrites the answer text and uses recent conversation for framing, not as factual evidence

## Still needs verification
I have not run the app locally from this environment.
Please verify:
- `/ai` or `/ai-data-assistant` renders the new chat UI in the frontend build
- LLM mode toggle behaves correctly when `OPENAI_API_KEY` is present/absent
- recent conversation turns are sent and improve follow-up phrasing without changing factual grounding
- structured sections render cleanly inside assistant messages
- no regression to the existing endpoint contract

## Files changed
- `frontend/src/pages/AIPage.jsx`
- `mlb_app/ai_data_assistant_routes.py`
- `tests/test_ai_data_assistant_routes.py`
