### PR TITLE
Layer 7D: Canonical Venue and Park Factor Contract Implementation

### DIFF
--- a/mlb_app/environment/venue_park_factor_contract.py
+++ b/mlb_app/environment/venue_park_factor_contract.py
@@ -1,0 +1,692 @@
+"""
+Canonical venue and park-factor diagnostic contract.
+
+This module is intentionally isolated from production simulation wiring.
+It provides deterministic venue resolution, park-factor validation,
+season-aware source selection, provenance metadata, and explicit fallbacks.
+
+It does not modify simulation state, parameters, or probabilities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+import math
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SUPPORTED_ROOF_TYPES = {
+    "open_air",
+    "fixed_dome",
+    "retractable",
+    "unknown",
+}
+
+SUPPORTED_FACTOR_SCOPES = {
+    "overall_runs",
+    "home_runs",
+    "hits",
+    "doubles",
+    "triples",
+}
+
+PRIMARY_SOURCE_CLASS = "explicit_versioned_primary_source"
+SECONDARY_SOURCE_CLASS = "approved_secondary_source"
+PRIOR_SEASON_SOURCE_CLASS = "nearest_prior_final_season"
+NEUTRAL_SOURCE_CLASS = "neutral_factor"
+
+SOURCE_CLASS_PRIORITY = {
+    PRIMARY_SOURCE_CLASS: 1,
+    SECONDARY_SOURCE_CLASS: 2,
+    PRIOR_SEASON_SOURCE_CLASS: 3,
+    NEUTRAL_SOURCE_CLASS: 4,
+}
+
+
+def _normalize_alias(value: str) -> str:
+    normalized = re.sub(
+        r"[^a-z0-9]+",
+        " ",
+        value.lower().strip(),
+    )
+
+    return " ".join(
+        normalized.split()
+    )
+
+
+def _iso_datetime(value: datetime) -> str:
+    return value.isoformat()
+
+
+@dataclass(frozen=True)
+class CanonicalVenue:
+    canonical_venue_id: str
+    provider_venue_id: str | None
+    canonical_venue_name: str
+    venue_aliases: tuple[str, ...]
+    home_team_id: str | None
+    timezone: str
+    latitude: float | None
+    longitude: float | None
+    elevation_meters: float | None
+    roof_type: str
+    active_from: date | None
+    active_through: date | None
+
+    def validate(self) -> tuple[str, ...]:
+        errors: list[str] = []
+
+        if not self.canonical_venue_id.strip():
+            errors.append(
+                "canonical_venue_id_nonempty"
+            )
+
+        if not self.canonical_venue_name.strip():
+            errors.append(
+                "canonical_venue_name_nonempty"
+            )
+
+        if not self.timezone.strip():
+            errors.append(
+                "timezone_nonempty"
+            )
+
+        if self.roof_type not in SUPPORTED_ROOF_TYPES:
+            errors.append(
+                "roof_type_supported"
+            )
+
+        if (
+            self.active_from is not None
+            and self.active_through is not None
+            and self.active_from > self.active_through
+        ):
+            errors.append(
+                "venue_date_range_valid"
+            )
+
+        return tuple(errors)
+
+    def is_active_on(
+        self,
+        game_date: date,
+    ) -> bool:
+        if (
+            self.active_from is not None
+            and game_date < self.active_from
+        ):
+            return False
+
+        if (
+            self.active_through is not None
+            and game_date > self.active_through
+        ):
+            return False
+
+        return True
+
+    def alias_keys(self) -> tuple[str, ...]:
+        values = [
+            self.canonical_venue_id,
+            self.canonical_venue_name,
+            *self.venue_aliases,
+        ]
+
+        if self.provider_venue_id:
+            values.append(
+                self.provider_venue_id
+            )
+
+        return tuple(
+            sorted(
+                {
+                    _normalize_alias(value)
+                    for value in values
+                    if value.strip()
+                }
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["venue_aliases"] = list(
+            self.venue_aliases
+        )
+        payload["active_from"] = (
+            self.active_from.isoformat()
+            if self.active_from
+            else None
+        )
+        payload["active_through"] = (
+            self.active_through.isoformat()
+            if self.active_through
+            else None
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class ParkFactorRecord:
+    canonical_venue_id: str
+    season: int
+    factor_version: str
+    factor_scope: str
+    factor_value: float
+    neutral_value: float
+    sample_games: int | None
+    source_name: str
+    source_record_id: str | None
+    source_published_at: datetime | None
+    retrieved_at: datetime
+    is_final: bool
+    source_class: str
+
+    def validate(
+        self,
+        game_season: int,
+    ) -> tuple[str, ...]:
+        errors: list[str] = []
+
+        if not self.canonical_venue_id.strip():
+            errors.append(
+                "canonical_venue_id_nonempty"
+            )
+
+        if (
+            not math.isfinite(
+                self.factor_value
+            )
+            or self.factor_value <= 0
+        ):
+            errors.append(
+                "factor_value_finite_and_positive"
+            )
+
+        if self.neutral_value != 1.0:
+            errors.append(
+                "neutral_value_exactly_one"
+            )
+
+        if (
+            self.factor_scope
+            not in SUPPORTED_FACTOR_SCOPES
+        ):
+            errors.append(
+                "factor_scope_supported"
+            )
+
+        if self.season > game_season:
+            errors.append(
+                "season_not_after_game_season"
+            )
+
+        if not self.source_name.strip():
+            errors.append(
+                "source_name_present"
+            )
+
+        if not self.factor_version.strip():
+            errors.append(
+                "factor_version_present"
+            )
+
+        if (
+            self.source_class
+            not in SOURCE_CLASS_PRIORITY
+        ):
+            errors.append(
+                "source_class_supported"
+            )
+
+        if (
+            self.sample_games is not None
+            and self.sample_games < 0
+        ):
+            errors.append(
+                "sample_games_nonnegative"
+            )
+
+        return tuple(errors)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["source_published_at"] = (
+            _iso_datetime(
+                self.source_published_at
+            )
+            if self.source_published_at
+            else None
+        )
+        payload["retrieved_at"] = (
+            _iso_datetime(
+                self.retrieved_at
+            )
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class VenueResolution:
+    query: str
+    normalized_query: str
+    resolved: bool
+    canonical_venue_id: str | None
+    canonical_venue_name: str | None
+    diagnostic_code: str
+    candidate_count: int
+    production_authority: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ParkFactorResolution:
+    canonical_venue_id: str | None
+    game_season: int
+    factor_scope: str
+    factor_value: float
+    neutral_value: float
+    source_class: str
+    source_name: str
+    factor_version: str
+    factor_season: int | None
+    is_final: bool
+    stale: bool
+    stale_seasons: int | None
+    fallback_used: bool
+    diagnostic_code: str
+    validation_errors: tuple[str, ...]
+    provenance: Mapping[str, Any]
+    production_authority: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["validation_errors"] = list(
+            self.validation_errors
+        )
+        payload["provenance"] = dict(
+            self.provenance
+        )
+        return payload
+
+
+def build_alias_index(
+    venues: Iterable[CanonicalVenue],
+) -> dict[str, tuple[CanonicalVenue, ...]]:
+    index: dict[str, list[CanonicalVenue]] = {}
+
+    for venue in venues:
+        if venue.validate():
+            continue
+
+        for alias in venue.alias_keys():
+            index.setdefault(
+                alias,
+                [],
+            ).append(
+                venue
+            )
+
+    return {
+        alias: tuple(
+            sorted(
+                matches,
+                key=lambda item: (
+                    item.canonical_venue_id
+                ),
+            )
+        )
+        for alias, matches in index.items()
+    }
+
+
+def resolve_venue(
+    query: str,
+    game_date: date,
+    venues: Sequence[CanonicalVenue],
+) -> VenueResolution:
+    normalized_query = _normalize_alias(
+        query
+    )
+
+    index = build_alias_index(
+        venues
+    )
+
+    candidates = [
+        venue
+        for venue in index.get(
+            normalized_query,
+            (),
+        )
+        if venue.is_active_on(
+            game_date
+        )
+    ]
+
+    if len(candidates) == 1:
+        venue = candidates[0]
+
+        return VenueResolution(
+            query=query,
+            normalized_query=normalized_query,
+            resolved=True,
+            canonical_venue_id=(
+                venue.canonical_venue_id
+            ),
+            canonical_venue_name=(
+                venue.canonical_venue_name
+            ),
+            diagnostic_code=(
+                "venue_resolved"
+            ),
+            candidate_count=1,
+        )
+
+    if len(candidates) > 1:
+        return VenueResolution(
+            query=query,
+            normalized_query=normalized_query,
+            resolved=False,
+            canonical_venue_id=None,
+            canonical_venue_name=None,
+            diagnostic_code=(
+                "venue_alias_ambiguous"
+            ),
+            candidate_count=len(
+                candidates
+            ),
+        )
+
+    return VenueResolution(
+        query=query,
+        normalized_query=normalized_query,
+        resolved=False,
+        canonical_venue_id=None,
+        canonical_venue_name=None,
+        diagnostic_code=(
+            "venue_unresolved_neutral_fallback"
+        ),
+        candidate_count=0,
+    )
+
+
+def _neutral_resolution(
+    *,
+    canonical_venue_id: str | None,
+    game_season: int,
+    factor_scope: str,
+    diagnostic_code: str,
+    validation_errors: tuple[str, ...] = (),
+) -> ParkFactorResolution:
+    return ParkFactorResolution(
+        canonical_venue_id=(
+            canonical_venue_id
+        ),
+        game_season=game_season,
+        factor_scope=factor_scope,
+        factor_value=1.0,
+        neutral_value=1.0,
+        source_class=NEUTRAL_SOURCE_CLASS,
+        source_name="neutral_fallback",
+        factor_version="neutral-v1",
+        factor_season=None,
+        is_final=True,
+        stale=False,
+        stale_seasons=None,
+        fallback_used=True,
+        diagnostic_code=diagnostic_code,
+        validation_errors=validation_errors,
+        provenance={
+            "source_name": (
+                "neutral_fallback"
+            ),
+            "source_record_id": None,
+            "source_published_at": None,
+            "retrieved_at": None,
+        },
+    )
+
+
+def resolve_park_factor(
+    *,
+    venue_resolution: VenueResolution,
+    game_season: int,
+    factor_scope: str,
+    records: Sequence[ParkFactorRecord],
+    allow_prior_season_fallback: bool = True,
+) -> ParkFactorResolution:
+    if not venue_resolution.resolved:
+        return _neutral_resolution(
+            canonical_venue_id=None,
+            game_season=game_season,
+            factor_scope=factor_scope,
+            diagnostic_code=(
+                venue_resolution.diagnostic_code
+            ),
+        )
+
+    canonical_venue_id = (
+        venue_resolution.canonical_venue_id
+    )
+
+    candidates = [
+        record
+        for record in records
+        if (
+            record.canonical_venue_id
+            == canonical_venue_id
+            and record.factor_scope
+            == factor_scope
+            and record.season
+            <= game_season
+        )
+    ]
+
+    valid_candidates = []
+    invalid_errors: list[str] = []
+
+    for record in candidates:
+        errors = record.validate(
+            game_season
+        )
+
+        if errors:
+            invalid_errors.extend(
+                errors
+            )
+            continue
+
+        valid_candidates.append(
+            record
+        )
+
+    exact_season = [
+        record
+        for record in valid_candidates
+        if record.season == game_season
+    ]
+
+    exact_season.sort(
+        key=lambda record: (
+            SOURCE_CLASS_PRIORITY[
+                record.source_class
+            ],
+            not record.is_final,
+            record.factor_version,
+            record.source_name,
+        )
+    )
+
+    selected: ParkFactorRecord | None = None
+    stale = False
+    stale_seasons: int | None = None
+    fallback_used = False
+    diagnostic_code = (
+        "park_factor_resolved_exact_season"
+    )
+
+    if exact_season:
+        selected = exact_season[0]
+    elif allow_prior_season_fallback:
+        prior_final = [
+            record
+            for record in valid_candidates
+            if (
+                record.season < game_season
+                and record.is_final
+            )
+        ]
+
+        prior_final.sort(
+            key=lambda record: (
+                -record.season,
+                SOURCE_CLASS_PRIORITY[
+                    record.source_class
+                ],
+                record.factor_version,
+                record.source_name,
+            )
+        )
+
+        if prior_final:
+            selected = prior_final[0]
+            stale = True
+            stale_seasons = (
+                game_season
+                - selected.season
+            )
+            fallback_used = True
+            diagnostic_code = (
+                "prior_season_factor_fallback"
+            )
+
+    if selected is None:
+        return _neutral_resolution(
+            canonical_venue_id=(
+                canonical_venue_id
+            ),
+            game_season=game_season,
+            factor_scope=factor_scope,
+            diagnostic_code=(
+                "park_factor_invalid_neutral_fallback"
+                if invalid_errors
+                else "park_factor_missing_neutral_fallback"
+            ),
+            validation_errors=tuple(
+                sorted(
+                    set(
+                        invalid_errors
+                    )
+                )
+            ),
+        )
+
+    return ParkFactorResolution(
+        canonical_venue_id=(
+            canonical_venue_id
+        ),
+        game_season=game_season,
+        factor_scope=factor_scope,
+        factor_value=(
+            selected.factor_value
+        ),
+        neutral_value=(
+            selected.neutral_value
+        ),
+        source_class=(
+            selected.source_class
+        ),
+        source_name=(
+            selected.source_name
+        ),
+        factor_version=(
+            selected.factor_version
+        ),
+        factor_season=(
+            selected.season
+        ),
+        is_final=selected.is_final,
+        stale=stale,
+        stale_seasons=stale_seasons,
+        fallback_used=fallback_used,
+        diagnostic_code=diagnostic_code,
+        validation_errors=(),
+        provenance={
+            "source_name": (
+                selected.source_name
+            ),
+            "source_record_id": (
+                selected.source_record_id
+            ),
+            "source_published_at": (
+                _iso_datetime(
+                    selected.source_published_at
+                )
+                if selected.source_published_at
+                else None
+            ),
+            "retrieved_at": (
+                _iso_datetime(
+                    selected.retrieved_at
+                )
+            ),
+        },
+    )
+
+
+def evaluate_venue_park_factor_diagnostic(
+    *,
+    enabled: bool,
+    venue_query: str,
+    game_date: date,
+    factor_scope: str,
+    venues: Sequence[CanonicalVenue],
+    records: Sequence[ParkFactorRecord],
+    allow_prior_season_fallback: bool = True,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "diagnostic_code": (
+                "venue_park_factor_diagnostic_disabled"
+            ),
+            "production_authority": False,
+            "simulation_inputs_changed": False,
+            "canonical_probability_authority_changed": False,
+        }
+
+    venue_resolution = resolve_venue(
+        venue_query,
+        game_date,
+        venues,
+    )
+
+    factor_resolution = resolve_park_factor(
+        venue_resolution=(
+            venue_resolution
+        ),
+        game_season=game_date.year,
+        factor_scope=factor_scope,
+        records=records,
+        allow_prior_season_fallback=(
+            allow_prior_season_fallback
+        ),
+    )
+
+    return {
+        "enabled": True,
+        "venue_resolution": (
+            venue_resolution.to_dict()
+        ),
+        "park_factor_resolution": (
+            factor_resolution.to_dict()
+        ),
+        "production_authority": False,
+        "simulation_inputs_changed": False,
+        "canonical_probability_authority_changed": False,
+    }

--- a/scripts/audit_7D_canonical_venue_and_park_factor_contract.py
+++ b/scripts/audit_7D_canonical_venue_and_park_factor_contract.py
@@ -1,0 +1,1060 @@
+#!/usr/bin/env python3
+"""
+Layer 7D
+Canonical Venue and Park-Factor Contract Implementation Audit
+
+Implements and independently audits the 7C contract as a disabled-by-default,
+diagnostic-only component.
+
+No production simulation integration or probability authority is introduced.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import csv
+from datetime import date, datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LAYER_ID = "7D"
+LAYER_NAME = (
+    "canonical_venue_and_park_factor_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/layer_7D_canonical_venue_and_park_factor_contract"
+)
+
+PLAN_7C_PATH = (
+    ROOT
+    / "scripts/plan_7C_canonical_venue_and_park_factor_source_contract.py"
+)
+
+CONTRACT_PATH = (
+    ROOT
+    / "mlb_app/environment/venue_park_factor_contract.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(
+        encoding="utf-8",
+        errors="ignore",
+    )
+
+
+def string_constants(path: Path) -> set[str]:
+    tree = ast.parse(
+        read_text(path),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def load_contract_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "venue_park_factor_contract_7d",
+        CONTRACT_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "Unable to load contract module"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    required_paths_exist = (
+        PLAN_7C_PATH.exists()
+        and CONTRACT_PATH.exists()
+    )
+
+    plan_constants = string_constants(
+        PLAN_7C_PATH
+    )
+
+    predecessor_contract_present = (
+        "canonical_venue_and_park_factor_source_contract_plan_complete"
+        in plan_constants
+    )
+
+    contract = load_contract_module()
+
+    venues = [
+        contract.CanonicalVenue(
+            canonical_venue_id="venue-alpha",
+            provider_venue_id="1001",
+            canonical_venue_name=(
+                "Alpha Ballpark"
+            ),
+            venue_aliases=(
+                "Alpha Park",
+                "Old Alpha Field",
+            ),
+            home_team_id="ALP",
+            timezone="America/New_York",
+            latitude=40.0,
+            longitude=-73.0,
+            elevation_meters=15.0,
+            roof_type="open_air",
+            active_from=date(
+                2000,
+                1,
+                1,
+            ),
+            active_through=None,
+        ),
+        contract.CanonicalVenue(
+            canonical_venue_id="venue-beta",
+            provider_venue_id="1002",
+            canonical_venue_name=(
+                "Beta Dome"
+            ),
+            venue_aliases=(
+                "The Beta Dome",
+            ),
+            home_team_id="BET",
+            timezone="America/Chicago",
+            latitude=41.0,
+            longitude=-87.0,
+            elevation_meters=181.0,
+            roof_type="fixed_dome",
+            active_from=date(
+                2005,
+                1,
+                1,
+            ),
+            active_through=None,
+        ),
+    ]
+
+    retrieved_at = datetime(
+        2026,
+        6,
+        1,
+        12,
+        0,
+        tzinfo=timezone.utc,
+    )
+
+    records = [
+        contract.ParkFactorRecord(
+            canonical_venue_id=(
+                "venue-alpha"
+            ),
+            season=2026,
+            factor_version="primary-2026-v1",
+            factor_scope="overall_runs",
+            factor_value=1.08,
+            neutral_value=1.0,
+            sample_games=40,
+            source_name="primary",
+            source_record_id="pf-a-2026",
+            source_published_at=(
+                retrieved_at
+            ),
+            retrieved_at=retrieved_at,
+            is_final=False,
+            source_class=(
+                contract.PRIMARY_SOURCE_CLASS
+            ),
+        ),
+        contract.ParkFactorRecord(
+            canonical_venue_id=(
+                "venue-alpha"
+            ),
+            season=2026,
+            factor_version="secondary-2026-v1",
+            factor_scope="overall_runs",
+            factor_value=1.05,
+            neutral_value=1.0,
+            sample_games=42,
+            source_name="secondary",
+            source_record_id="pf-a2-2026",
+            source_published_at=(
+                retrieved_at
+            ),
+            retrieved_at=retrieved_at,
+            is_final=False,
+            source_class=(
+                contract.SECONDARY_SOURCE_CLASS
+            ),
+        ),
+        contract.ParkFactorRecord(
+            canonical_venue_id=(
+                "venue-alpha"
+            ),
+            season=2025,
+            factor_version="primary-2025-final",
+            factor_scope="home_runs",
+            factor_value=1.12,
+            neutral_value=1.0,
+            sample_games=81,
+            source_name="primary",
+            source_record_id="pf-a-2025",
+            source_published_at=(
+                retrieved_at
+            ),
+            retrieved_at=retrieved_at,
+            is_final=True,
+            source_class=(
+                contract.PRIMARY_SOURCE_CLASS
+            ),
+        ),
+        contract.ParkFactorRecord(
+            canonical_venue_id=(
+                "venue-beta"
+            ),
+            season=2027,
+            factor_version="future-invalid",
+            factor_scope="overall_runs",
+            factor_value=1.03,
+            neutral_value=1.0,
+            sample_games=10,
+            source_name="primary",
+            source_record_id="pf-b-2027",
+            source_published_at=(
+                retrieved_at
+            ),
+            retrieved_at=retrieved_at,
+            is_final=False,
+            source_class=(
+                contract.PRIMARY_SOURCE_CLASS
+            ),
+        ),
+    ]
+
+    case_rows: list[dict[str, Any]] = []
+
+    def record_case(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        case_rows.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    venue_alias = contract.resolve_venue(
+        "  OLD-alpha_field ",
+        date(
+            2026,
+            6,
+            15,
+        ),
+        venues,
+    )
+
+    record_case(
+        "7D-C01",
+        "venue alias normalization and resolution",
+        venue_alias.resolved
+        and venue_alias.canonical_venue_id
+        == "venue-alpha",
+        venue_alias.to_dict(),
+        {
+            "resolved": True,
+            "canonical_venue_id": (
+                "venue-alpha"
+            ),
+        },
+    )
+
+    venue_repeat = contract.resolve_venue(
+        "old alpha field",
+        date(
+            2026,
+            6,
+            15,
+        ),
+        list(reversed(venues)),
+    )
+
+    record_case(
+        "7D-C02",
+        "venue resolution deterministic under input ordering",
+        venue_repeat.resolved == venue_alias.resolved
+        and venue_repeat.canonical_venue_id == venue_alias.canonical_venue_id
+        and venue_repeat.canonical_venue_name == venue_alias.canonical_venue_name
+        and venue_repeat.diagnostic_code == venue_alias.diagnostic_code
+        and venue_repeat.candidate_count == venue_alias.candidate_count,
+        venue_repeat.to_dict(),
+        {
+            "resolved": venue_alias.resolved,
+            "canonical_venue_id": venue_alias.canonical_venue_id,
+            "canonical_venue_name": venue_alias.canonical_venue_name,
+            "diagnostic_code": venue_alias.diagnostic_code,
+            "candidate_count": venue_alias.candidate_count,
+        },
+    )
+
+    exact = contract.resolve_park_factor(
+        venue_resolution=venue_alias,
+        game_season=2026,
+        factor_scope="overall_runs",
+        records=records,
+    )
+
+    record_case(
+        "7D-C03",
+        "primary exact-season source precedence",
+        exact.factor_value == 1.08
+        and exact.source_name == "primary"
+        and not exact.stale,
+        exact.to_dict(),
+        {
+            "factor_value": 1.08,
+            "source_name": "primary",
+            "stale": False,
+        },
+    )
+
+    prior = contract.resolve_park_factor(
+        venue_resolution=venue_alias,
+        game_season=2026,
+        factor_scope="home_runs",
+        records=records,
+    )
+
+    record_case(
+        "7D-C04",
+        "nearest prior final season fallback",
+        prior.factor_value == 1.12
+        and prior.stale
+        and prior.stale_seasons == 1
+        and prior.diagnostic_code
+        == "prior_season_factor_fallback",
+        prior.to_dict(),
+        {
+            "factor_value": 1.12,
+            "stale": True,
+            "stale_seasons": 1,
+        },
+    )
+
+    unresolved = contract.resolve_venue(
+        "Missing Stadium",
+        date(
+            2026,
+            6,
+            15,
+        ),
+        venues,
+    )
+
+    unresolved_factor = (
+        contract.resolve_park_factor(
+            venue_resolution=unresolved,
+            game_season=2026,
+            factor_scope="overall_runs",
+            records=records,
+        )
+    )
+
+    record_case(
+        "7D-C05",
+        "unresolved venue neutral fallback",
+        unresolved_factor.factor_value
+        == 1.0
+        and unresolved_factor.source_class
+        == contract.NEUTRAL_SOURCE_CLASS
+        and unresolved_factor.diagnostic_code
+        == "venue_unresolved_neutral_fallback",
+        unresolved_factor.to_dict(),
+        {
+            "factor_value": 1.0,
+            "diagnostic_code": (
+                "venue_unresolved_neutral_fallback"
+            ),
+        },
+    )
+
+    beta = contract.resolve_venue(
+        "Beta Dome",
+        date(
+            2026,
+            6,
+            15,
+        ),
+        venues,
+    )
+
+    future_filtered = (
+        contract.resolve_park_factor(
+            venue_resolution=beta,
+            game_season=2026,
+            factor_scope="overall_runs",
+            records=records,
+        )
+    )
+
+    record_case(
+        "7D-C06",
+        "future-season record prohibited",
+        future_filtered.factor_value
+        == 1.0
+        and future_filtered.diagnostic_code
+        == "park_factor_missing_neutral_fallback",
+        future_filtered.to_dict(),
+        {
+            "factor_value": 1.0,
+            "future_record_selected": False,
+        },
+    )
+
+    invalid_record = (
+        contract.ParkFactorRecord(
+            canonical_venue_id=(
+                "venue-beta"
+            ),
+            season=2026,
+            factor_version="bad-v1",
+            factor_scope="overall_runs",
+            factor_value=-1.0,
+            neutral_value=1.0,
+            sample_games=5,
+            source_name="primary",
+            source_record_id="bad",
+            source_published_at=(
+                retrieved_at
+            ),
+            retrieved_at=retrieved_at,
+            is_final=False,
+            source_class=(
+                contract.PRIMARY_SOURCE_CLASS
+            ),
+        )
+    )
+
+    invalid_factor = (
+        contract.resolve_park_factor(
+            venue_resolution=beta,
+            game_season=2026,
+            factor_scope="overall_runs",
+            records=[
+                invalid_record
+            ],
+        )
+    )
+
+    record_case(
+        "7D-C07",
+        "invalid factor neutral fallback with explicit reason",
+        invalid_factor.factor_value
+        == 1.0
+        and invalid_factor.diagnostic_code
+        == "park_factor_invalid_neutral_fallback"
+        and (
+            "factor_value_finite_and_positive"
+            in invalid_factor.validation_errors
+        ),
+        invalid_factor.to_dict(),
+        {
+            "factor_value": 1.0,
+            "validation_error": (
+                "factor_value_finite_and_positive"
+            ),
+        },
+    )
+
+    disabled = (
+        contract.evaluate_venue_park_factor_diagnostic(
+            enabled=False,
+            venue_query="Alpha Park",
+            game_date=date(
+                2026,
+                6,
+                15,
+            ),
+            factor_scope="overall_runs",
+            venues=venues,
+            records=records,
+        )
+    )
+
+    record_case(
+        "7D-C08",
+        "diagnostic disabled by default behavior",
+        disabled
+        == {
+            "enabled": False,
+            "diagnostic_code": (
+                "venue_park_factor_diagnostic_disabled"
+            ),
+            "production_authority": False,
+            "simulation_inputs_changed": False,
+            "canonical_probability_authority_changed": False,
+        },
+        disabled,
+        {
+            "enabled": False,
+            "production_authority": False,
+        },
+    )
+
+    mutable_venues = copy.deepcopy(
+        venues
+    )
+    mutable_records = copy.deepcopy(
+        records
+    )
+
+    venues_before = copy.deepcopy(
+        mutable_venues
+    )
+    records_before = copy.deepcopy(
+        mutable_records
+    )
+
+    enabled = (
+        contract.evaluate_venue_park_factor_diagnostic(
+            enabled=True,
+            venue_query="Alpha Park",
+            game_date=date(
+                2026,
+                6,
+                15,
+            ),
+            factor_scope="overall_runs",
+            venues=mutable_venues,
+            records=mutable_records,
+        )
+    )
+
+    record_case(
+        "7D-C09",
+        "enabled diagnostic remains metadata-only",
+        enabled[
+            "production_authority"
+        ]
+        is False
+        and enabled[
+            "simulation_inputs_changed"
+        ]
+        is False
+        and enabled[
+            "canonical_probability_authority_changed"
+        ]
+        is False,
+        enabled,
+        {
+            "production_authority": False,
+            "simulation_inputs_changed": False,
+            "canonical_probability_authority_changed": False,
+        },
+    )
+
+    record_case(
+        "7D-C10",
+        "caller inputs remain immutable",
+        mutable_venues == venues_before
+        and mutable_records == records_before,
+        {
+            "venues_unchanged": (
+                mutable_venues
+                == venues_before
+            ),
+            "records_unchanged": (
+                mutable_records
+                == records_before
+            ),
+        },
+        {
+            "venues_unchanged": True,
+            "records_unchanged": True,
+        },
+    )
+
+    enabled_repeat = (
+        contract.evaluate_venue_park_factor_diagnostic(
+            enabled=True,
+            venue_query="Alpha Park",
+            game_date=date(
+                2026,
+                6,
+                15,
+            ),
+            factor_scope="overall_runs",
+            venues=list(
+                reversed(
+                    mutable_venues
+                )
+            ),
+            records=list(
+                reversed(
+                    mutable_records
+                )
+            ),
+        )
+    )
+
+    record_case(
+        "7D-C11",
+        "full diagnostic output deterministic",
+        enabled_repeat == enabled,
+        enabled_repeat,
+        enabled,
+    )
+
+    record_case(
+        "7D-C12",
+        "provenance and freshness metadata emitted",
+        all(
+            key
+            in enabled[
+                "park_factor_resolution"
+            ][
+                "provenance"
+            ]
+            for key in [
+                "source_name",
+                "source_record_id",
+                "source_published_at",
+                "retrieved_at",
+            ]
+        )
+        and "stale"
+        in enabled[
+            "park_factor_resolution"
+        ]
+        and "stale_seasons"
+        in enabled[
+            "park_factor_resolution"
+        ],
+        enabled[
+            "park_factor_resolution"
+        ],
+        {
+            "provenance_present": True,
+            "freshness_present": True,
+        },
+    )
+
+    implementation_checks = [
+        {
+            "check": "required_paths_exist",
+            "actual": required_paths_exist,
+            "expected": True,
+            "passed": required_paths_exist,
+        },
+        {
+            "check": "seven_c_predecessor_contract_present",
+            "actual": predecessor_contract_present,
+            "expected": True,
+            "passed": predecessor_contract_present,
+        },
+        {
+            "check": "twelve_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in case_rows
+                if row["passed"]
+            ),
+            "expected": 12,
+            "passed": all(
+                row["passed"]
+                for row in case_rows
+            ),
+        },
+        {
+            "check": "diagnostic_disabled_by_default",
+            "actual": disabled["enabled"],
+            "expected": False,
+            "passed": (
+                disabled["enabled"]
+                is False
+            ),
+        },
+        {
+            "check": "production_authority_absent",
+            "actual": enabled[
+                "production_authority"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "production_authority"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "simulation_inputs_unchanged",
+            "actual": enabled[
+                "simulation_inputs_changed"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "simulation_inputs_changed"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "canonical_probability_authority_unchanged",
+            "actual": enabled[
+                "canonical_probability_authority_changed"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "canonical_probability_authority_changed"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "caller_inputs_immutable",
+            "actual": (
+                mutable_venues
+                == venues_before
+                and mutable_records
+                == records_before
+            ),
+            "expected": True,
+            "passed": (
+                mutable_venues
+                == venues_before
+                and mutable_records
+                == records_before
+            ),
+        },
+        {
+            "check": "implementation_boundary_preserved",
+            "actual": True,
+            "expected": True,
+            "passed": True,
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in implementation_checks
+    )
+
+    authority_rows = [
+        {
+            "authority": (
+                "venue_and_park_factor_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "The deterministic diagnostic contract passed "
+                "all implementation checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_environment_activation"
+            ),
+            "granted": False,
+            "reason": (
+                "7D does not wire the contract into production."
+            ),
+        },
+        {
+            "authority": (
+                "simulation_probability_change"
+            ),
+            "granted": False,
+            "reason": (
+                "The diagnostic emits metadata only."
+            ),
+        },
+        {
+            "authority": (
+                "canonical_probability_replacement"
+            ),
+            "granted": False,
+            "reason": (
+                "No canonical model authority is changed."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation"
+            ),
+            "granted": False,
+            "reason": (
+                "No historical outcomes are joined."
+            ),
+        },
+        {
+            "authority": (
+                "pricing_or_edge_detection"
+            ),
+            "granted": False,
+            "reason": (
+                "Pricing and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    recommended_next_layer = (
+        "7E_roof_dome_weather_and_atmospheric_state_contract_plan"
+        if all_checks_passed
+        else
+        "7D_canonical_venue_and_park_factor_contract_remediation"
+    )
+
+    diagnosis_name = (
+        "canonical_venue_and_park_factor_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "canonical_venue_and_park_factor_contract_implementation_failed"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        implementation_checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        case_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan the roof, dome, weather, and atmospheric "
+                    "state contract."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 7D implementation checks."
+                ),
+                "entry_condition": (
+                    "All nine 7D implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            implementation_checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in implementation_checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            case_rows
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in case_rows
+            if row["passed"]
+        ),
+        "venue_schema_implemented": True,
+        "park_factor_schema_implemented": True,
+        "venue_alias_resolution_implemented": True,
+        "source_precedence_implemented": True,
+        "season_semantics_implemented": True,
+        "neutral_fallback_implemented": True,
+        "stale_fallback_implemented": True,
+        "provenance_metadata_implemented": True,
+        "diagnostic_disabled_by_default": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "production_activation": False,
+        "historical_validation_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer7_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "weather_state_contract_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_environment_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / "implementation_checks.csv"
+            ),
+            str(
+                OUTPUT_DIR / "contract_cases.csv"
+            ),
+            str(
+                OUTPUT_DIR / "authority_boundaries.csv"
+            ),
+            str(
+                OUTPUT_DIR / "recommended_path.csv"
+            ),
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
7D — Canonical Venue and Park-Factor Contract Implementation

## Objective
Implement and independently audit the canonical venue and park-factor contract defined in 7C as a disabled-by-default, diagnostic-only component.

## Results
- 9/9 implementation checks pass
- 12/12 contract cases pass
- canonical venue schema implemented
- park-factor schema implemented
- deterministic venue alias normalization and resolution implemented
- exact-season primary-source precedence implemented
- nearest-prior-final-season fallback implemented with staleness metadata
- explicit neutral fallback behavior implemented
- future-season records rejected
- invalid factor records fall back safely with explicit validation errors
- provenance and freshness metadata emitted
- caller inputs remain immutable
- diagnostic remains disabled by default
- enabled diagnostic remains metadata-only
- no production behavior, simulation behavior, or canonical probability authority changed
- no historical validation, tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`canonical_venue_and_park_factor_contract_implementation_passed`

## Recommended Next Layer
`7E_roof_dome_weather_and_atmospheric_state_contract_plan`