### PR TITLE
Layer 7H: Wind Field Orientation and Batted-Ball Vector Contract Implementation

### DIFF
--- a/mlb_app/environment/wind_field_vector_contract.py
+++ b/mlb_app/environment/wind_field_vector_contract.py
@@ -1,0 +1,644 @@
+"""
+Wind, field-orientation, and batted-ball vector diagnostic contract.
+
+This module implements deterministic geometry and vector decomposition only.
+It does not calculate aerodynamic carry, alter batted-ball outcomes, or modify
+simulation state, parameters, or probabilities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+import math
+from typing import Any
+
+
+def normalize_degrees(value: float) -> float:
+    normalized = value % 360.0
+
+    if math.isclose(
+        normalized,
+        360.0,
+        abs_tol=1e-12,
+    ):
+        return 0.0
+
+    return normalized
+
+
+def meteorological_from_to_toward(
+    wind_from_degrees: float,
+) -> float:
+    return normalize_degrees(
+        wind_from_degrees + 180.0
+    )
+
+
+def bearing_unit_vector(
+    bearing_degrees_true: float,
+) -> tuple[float, float]:
+    radians = math.radians(
+        normalize_degrees(
+            bearing_degrees_true
+        )
+    )
+
+    east = math.sin(radians)
+    north = math.cos(radians)
+
+    return east, north
+
+
+def vector_from_speed_and_bearing(
+    speed: float,
+    bearing_degrees_true: float,
+) -> tuple[float, float]:
+    east_unit, north_unit = (
+        bearing_unit_vector(
+            bearing_degrees_true
+        )
+    )
+
+    return (
+        speed * east_unit,
+        speed * north_unit,
+    )
+
+
+def dot(
+    first: tuple[float, float],
+    second: tuple[float, float],
+) -> float:
+    return (
+        first[0] * second[0]
+        + first[1] * second[1]
+    )
+
+
+def right_perpendicular(
+    vector: tuple[float, float],
+) -> tuple[float, float]:
+    east, north = vector
+
+    return (
+        north,
+        -east,
+    )
+
+
+@dataclass(frozen=True)
+class FieldOrientation:
+    canonical_venue_id: str
+    orientation_version: str
+    home_plate_latitude: float | None
+    home_plate_longitude: float | None
+    center_field_bearing_degrees_true: float | None
+    left_field_line_bearing_degrees_true: float | None
+    right_field_line_bearing_degrees_true: float | None
+    fair_territory_span_degrees: float | None
+    orientation_source_name: str
+    orientation_source_record_id: str | None
+    retrieved_at_utc: datetime
+    orientation_valid_from: date | None
+    orientation_valid_through: date | None
+    diagnostic_codes: tuple[str, ...]
+
+    def validate(
+        self,
+        game_date: date,
+    ) -> tuple[str, ...]:
+        errors: list[str] = []
+
+        if not self.canonical_venue_id.strip():
+            errors.append(
+                "canonical_venue_id_nonempty"
+            )
+
+        if not self.orientation_version.strip():
+            errors.append(
+                "orientation_version_present"
+            )
+
+        if not self.orientation_source_name.strip():
+            errors.append(
+                "orientation_source_name_present"
+            )
+
+        for name, value in [
+            (
+                "center_field_bearing_degrees_true",
+                self.center_field_bearing_degrees_true,
+            ),
+            (
+                "left_field_line_bearing_degrees_true",
+                self.left_field_line_bearing_degrees_true,
+            ),
+            (
+                "right_field_line_bearing_degrees_true",
+                self.right_field_line_bearing_degrees_true,
+            ),
+        ]:
+            if (
+                value is None
+                or not math.isfinite(value)
+                or not (
+                    0.0
+                    <= value
+                    <= 360.0
+                )
+            ):
+                errors.append(
+                    f"{name}_in_range"
+                )
+
+        if (
+            self.fair_territory_span_degrees
+            is None
+            or not math.isfinite(
+                self.fair_territory_span_degrees
+            )
+            or not (
+                60.0
+                <= self.fair_territory_span_degrees
+                <= 120.0
+            )
+        ):
+            errors.append(
+                "fair_territory_span_physically_valid"
+            )
+
+        if (
+            self.orientation_valid_from is not None
+            and self.orientation_valid_through is not None
+            and self.orientation_valid_from
+            > self.orientation_valid_through
+        ):
+            errors.append(
+                "orientation_date_range_valid"
+            )
+
+        if (
+            self.orientation_valid_from is not None
+            and game_date
+            < self.orientation_valid_from
+        ):
+            errors.append(
+                "orientation_not_yet_valid"
+            )
+
+        if (
+            self.orientation_valid_through is not None
+            and game_date
+            > self.orientation_valid_through
+        ):
+            errors.append(
+                "orientation_expired"
+            )
+
+        return tuple(
+            sorted(
+                set(errors)
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+
+        payload["retrieved_at_utc"] = (
+            self.retrieved_at_utc.isoformat()
+        )
+        payload["orientation_valid_from"] = (
+            self.orientation_valid_from.isoformat()
+            if self.orientation_valid_from
+            else None
+        )
+        payload["orientation_valid_through"] = (
+            self.orientation_valid_through.isoformat()
+            if self.orientation_valid_through
+            else None
+        )
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+
+        return payload
+
+
+@dataclass(frozen=True)
+class WindVectorResolution:
+    meteorological_wind_from_degrees: float | None
+    wind_toward_degrees_true: float | None
+    wind_speed_mps: float
+    wind_east_mps: float
+    wind_north_mps: float
+    wind_outfield_mps: float | None
+    wind_crossfield_mps: float | None
+    batted_ball_spray_angle_degrees: float | None
+    batted_ball_bearing_degrees_true: float | None
+    wind_along_ball_path_mps: float | None
+    wind_across_ball_path_mps: float | None
+    vector_resolution_status: str
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    production_authority: bool = False
+    simulation_inputs_changed: bool = False
+    canonical_probability_authority_changed: bool = False
+    aerodynamic_carry_calculated: bool = False
+    batted_ball_outcomes_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        payload["validation_errors"] = list(
+            self.validation_errors
+        )
+        return payload
+
+
+def _unavailable_resolution(
+    *,
+    diagnostic_code: str,
+    validation_errors: tuple[str, ...] = (),
+) -> WindVectorResolution:
+    return WindVectorResolution(
+        meteorological_wind_from_degrees=None,
+        wind_toward_degrees_true=None,
+        wind_speed_mps=0.0,
+        wind_east_mps=0.0,
+        wind_north_mps=0.0,
+        wind_outfield_mps=None,
+        wind_crossfield_mps=None,
+        batted_ball_spray_angle_degrees=None,
+        batted_ball_bearing_degrees_true=None,
+        wind_along_ball_path_mps=None,
+        wind_across_ball_path_mps=None,
+        vector_resolution_status="unavailable",
+        diagnostic_codes=(
+            diagnostic_code,
+        ),
+        validation_errors=validation_errors,
+    )
+
+
+def _neutral_resolution(
+    *,
+    diagnostic_code: str,
+    spray_angle_degrees: float | None,
+    center_field_bearing_degrees_true: float | None,
+    validation_errors: tuple[str, ...] = (),
+) -> WindVectorResolution:
+    ball_bearing = None
+
+    if (
+        spray_angle_degrees is not None
+        and center_field_bearing_degrees_true
+        is not None
+    ):
+        ball_bearing = normalize_degrees(
+            center_field_bearing_degrees_true
+            + spray_angle_degrees
+        )
+
+    return WindVectorResolution(
+        meteorological_wind_from_degrees=None,
+        wind_toward_degrees_true=None,
+        wind_speed_mps=0.0,
+        wind_east_mps=0.0,
+        wind_north_mps=0.0,
+        wind_outfield_mps=0.0,
+        wind_crossfield_mps=0.0,
+        batted_ball_spray_angle_degrees=(
+            spray_angle_degrees
+        ),
+        batted_ball_bearing_degrees_true=(
+            ball_bearing
+        ),
+        wind_along_ball_path_mps=0.0,
+        wind_across_ball_path_mps=0.0,
+        vector_resolution_status="neutral",
+        diagnostic_codes=(
+            diagnostic_code,
+        ),
+        validation_errors=validation_errors,
+    )
+
+
+def resolve_wind_field_vector(
+    *,
+    orientation: FieldOrientation | None,
+    game_date: date,
+    meteorological_wind_from_degrees: float | None,
+    wind_speed_mps: float | None,
+    batted_ball_spray_angle_degrees: float | None,
+    indoor_effective: bool,
+) -> WindVectorResolution:
+    if orientation is None:
+        return _unavailable_resolution(
+            diagnostic_code=(
+                "field_orientation_missing_vector_unavailable"
+            )
+        )
+
+    orientation_errors = (
+        orientation.validate(
+            game_date
+        )
+    )
+
+    if orientation_errors:
+        return _unavailable_resolution(
+            diagnostic_code=(
+                "field_orientation_invalid_vector_unavailable"
+            ),
+            validation_errors=(
+                orientation_errors
+            ),
+        )
+
+    center_field_bearing = (
+        orientation.center_field_bearing_degrees_true
+    )
+
+    if indoor_effective:
+        return _neutral_resolution(
+            diagnostic_code=(
+                "indoor_environment_zero_wind_vector"
+            ),
+            spray_angle_degrees=(
+                batted_ball_spray_angle_degrees
+            ),
+            center_field_bearing_degrees_true=(
+                center_field_bearing
+            ),
+        )
+
+    if (
+        meteorological_wind_from_degrees
+        is None
+        or wind_speed_mps is None
+    ):
+        return _neutral_resolution(
+            diagnostic_code=(
+                "wind_missing_neutral_vector"
+            ),
+            spray_angle_degrees=(
+                batted_ball_spray_angle_degrees
+            ),
+            center_field_bearing_degrees_true=(
+                center_field_bearing
+            ),
+        )
+
+    wind_errors: list[str] = []
+
+    if (
+        not math.isfinite(
+            meteorological_wind_from_degrees
+        )
+        or not (
+            0.0
+            <= meteorological_wind_from_degrees
+            <= 360.0
+        )
+    ):
+        wind_errors.append(
+            "wind_direction_in_range"
+        )
+
+    if (
+        not math.isfinite(
+            wind_speed_mps
+        )
+        or wind_speed_mps < 0.0
+    ):
+        wind_errors.append(
+            "wind_speed_finite_and_nonnegative"
+        )
+
+    if (
+        batted_ball_spray_angle_degrees
+        is not None
+        and (
+            not math.isfinite(
+                batted_ball_spray_angle_degrees
+            )
+            or not (
+                -90.0
+                <= batted_ball_spray_angle_degrees
+                <= 90.0
+            )
+        )
+    ):
+        wind_errors.append(
+            "spray_angle_within_supported_range"
+        )
+
+    if wind_errors:
+        return _neutral_resolution(
+            diagnostic_code=(
+                "wind_invalid_neutral_vector"
+            ),
+            spray_angle_degrees=(
+                None
+                if (
+                    "spray_angle_within_supported_range"
+                    in wind_errors
+                )
+                else batted_ball_spray_angle_degrees
+            ),
+            center_field_bearing_degrees_true=(
+                center_field_bearing
+            ),
+            validation_errors=tuple(
+                sorted(
+                    set(wind_errors)
+                )
+            ),
+        )
+
+    toward_bearing = (
+        meteorological_from_to_toward(
+            meteorological_wind_from_degrees
+        )
+    )
+
+    wind_vector = (
+        vector_from_speed_and_bearing(
+            wind_speed_mps,
+            toward_bearing,
+        )
+    )
+
+    center_unit = bearing_unit_vector(
+        center_field_bearing
+    )
+
+    right_unit = right_perpendicular(
+        center_unit
+    )
+
+    outfield_component = dot(
+        wind_vector,
+        center_unit,
+    )
+
+    crossfield_component = dot(
+        wind_vector,
+        right_unit,
+    )
+
+    ball_bearing = None
+    along_component = None
+    across_component = None
+
+    if (
+        batted_ball_spray_angle_degrees
+        is not None
+    ):
+        ball_bearing = normalize_degrees(
+            center_field_bearing
+            + batted_ball_spray_angle_degrees
+        )
+
+        ball_unit = bearing_unit_vector(
+            ball_bearing
+        )
+
+        ball_right_unit = (
+            right_perpendicular(
+                ball_unit
+            )
+        )
+
+        along_component = dot(
+            wind_vector,
+            ball_unit,
+        )
+
+        across_component = dot(
+            wind_vector,
+            ball_right_unit,
+        )
+
+    components = [
+        wind_vector[0],
+        wind_vector[1],
+        outfield_component,
+        crossfield_component,
+    ]
+
+    if along_component is not None:
+        components.append(
+            along_component
+        )
+
+    if across_component is not None:
+        components.append(
+            across_component
+        )
+
+    if not all(
+        math.isfinite(value)
+        for value in components
+    ):
+        return _neutral_resolution(
+            diagnostic_code=(
+                "wind_invalid_neutral_vector"
+            ),
+            spray_angle_degrees=(
+                batted_ball_spray_angle_degrees
+            ),
+            center_field_bearing_degrees_true=(
+                center_field_bearing
+            ),
+            validation_errors=(
+                "vector_components_finite",
+            ),
+        )
+
+    return WindVectorResolution(
+        meteorological_wind_from_degrees=(
+            meteorological_wind_from_degrees
+        ),
+        wind_toward_degrees_true=(
+            toward_bearing
+        ),
+        wind_speed_mps=wind_speed_mps,
+        wind_east_mps=wind_vector[0],
+        wind_north_mps=wind_vector[1],
+        wind_outfield_mps=(
+            outfield_component
+        ),
+        wind_crossfield_mps=(
+            crossfield_component
+        ),
+        batted_ball_spray_angle_degrees=(
+            batted_ball_spray_angle_degrees
+        ),
+        batted_ball_bearing_degrees_true=(
+            ball_bearing
+        ),
+        wind_along_ball_path_mps=(
+            along_component
+        ),
+        wind_across_ball_path_mps=(
+            across_component
+        ),
+        vector_resolution_status="resolved",
+        diagnostic_codes=(
+            "wind_field_vector_resolved",
+        ),
+        validation_errors=(),
+    )
+
+
+def evaluate_wind_field_vector_diagnostic(
+    *,
+    enabled: bool,
+    orientation: FieldOrientation | None,
+    game_date: date,
+    meteorological_wind_from_degrees: float | None,
+    wind_speed_mps: float | None,
+    batted_ball_spray_angle_degrees: float | None,
+    indoor_effective: bool,
+) -> dict[str, Any]:
+    if not enabled:
+        return {
+            "enabled": False,
+            "diagnostic_code": (
+                "wind_field_vector_diagnostic_disabled"
+            ),
+            "production_authority": False,
+            "simulation_inputs_changed": False,
+            "canonical_probability_authority_changed": False,
+            "aerodynamic_carry_calculated": False,
+            "batted_ball_outcomes_changed": False,
+        }
+
+    resolution = resolve_wind_field_vector(
+        orientation=orientation,
+        game_date=game_date,
+        meteorological_wind_from_degrees=(
+            meteorological_wind_from_degrees
+        ),
+        wind_speed_mps=wind_speed_mps,
+        batted_ball_spray_angle_degrees=(
+            batted_ball_spray_angle_degrees
+        ),
+        indoor_effective=indoor_effective,
+    )
+
+    return {
+        "enabled": True,
+        "wind_field_vector_resolution": (
+            resolution.to_dict()
+        ),
+        "production_authority": False,
+        "simulation_inputs_changed": False,
+        "canonical_probability_authority_changed": False,
+        "aerodynamic_carry_calculated": False,
+        "batted_ball_outcomes_changed": False,
+    }

--- a/scripts/audit_7H_wind_field_orientation_and_batted_ball_vector_contract.py
+++ b/scripts/audit_7H_wind_field_orientation_and_batted_ball_vector_contract.py
@@ -1,0 +1,1145 @@
+#!/usr/bin/env python3
+"""
+Layer 7H
+Wind, Field Orientation, and Batted-Ball Vector Contract Audit
+
+Implements and independently audits the 7G contract as a disabled-by-default,
+metadata-only diagnostic.
+
+No aerodynamic carry, batted-ball outcome change, production integration, or
+probability authority is introduced.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import csv
+from datetime import date, datetime, timezone
+import importlib.util
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LAYER_ID = "7H"
+LAYER_NAME = (
+    "wind_field_orientation_and_batted_ball_vector_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_7H_wind_field_orientation_and_batted_ball_vector_contract"
+)
+
+PLAN_7G_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_7G_wind_field_orientation_and_batted_ball_vector_contract.py"
+)
+
+CONTRACT_PATH = (
+    ROOT
+    / "mlb_app/environment/wind_field_vector_contract.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def load_contract_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "wind_field_vector_contract_7h",
+        CONTRACT_PATH,
+    )
+
+    if (
+        spec is None
+        or spec.loader is None
+    ):
+        raise RuntimeError(
+            "Unable to load wind vector contract module"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def close(
+    first: float | None,
+    second: float,
+    tolerance: float = 1e-9,
+) -> bool:
+    return (
+        first is not None
+        and math.isclose(
+            first,
+            second,
+            abs_tol=tolerance,
+        )
+    )
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    required_paths_exist = (
+        PLAN_7G_PATH.exists()
+        and CONTRACT_PATH.exists()
+    )
+
+    predecessor_contract_present = (
+        "wind_field_orientation_and_batted_ball_vector_contract_plan_complete"
+        in string_constants(
+            PLAN_7G_PATH
+        )
+    )
+
+    contract = load_contract_module()
+
+    game_date = date(
+        2026,
+        7,
+        1,
+    )
+
+    orientation = contract.FieldOrientation(
+        canonical_venue_id="venue-alpha",
+        orientation_version="orientation-v1",
+        home_plate_latitude=40.0,
+        home_plate_longitude=-73.0,
+        center_field_bearing_degrees_true=0.0,
+        left_field_line_bearing_degrees_true=315.0,
+        right_field_line_bearing_degrees_true=45.0,
+        fair_territory_span_degrees=90.0,
+        orientation_source_name="test-source",
+        orientation_source_record_id="orientation-1",
+        retrieved_at_utc=datetime(
+            2026,
+            6,
+            1,
+            tzinfo=timezone.utc,
+        ),
+        orientation_valid_from=date(
+            2000,
+            1,
+            1,
+        ),
+        orientation_valid_through=None,
+        diagnostic_codes=(),
+    )
+
+    case_rows: list[dict[str, Any]] = []
+
+    def record_case(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        case_rows.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    record_case(
+        "7H-C01",
+        "angle normalization wraps positive values",
+        close(
+            contract.normalize_degrees(
+                450.0
+            ),
+            90.0,
+        ),
+        contract.normalize_degrees(
+            450.0
+        ),
+        90.0,
+    )
+
+    record_case(
+        "7H-C02",
+        "angle normalization wraps negative values",
+        close(
+            contract.normalize_degrees(
+                -90.0
+            ),
+            270.0,
+        ),
+        contract.normalize_degrees(
+            -90.0
+        ),
+        270.0,
+    )
+
+    record_case(
+        "7H-C03",
+        "meteorological from converts to toward",
+        close(
+            contract.meteorological_from_to_toward(
+                0.0
+            ),
+            180.0,
+        ),
+        contract.meteorological_from_to_toward(
+            0.0
+        ),
+        180.0,
+    )
+
+    north_unit = (
+        contract.bearing_unit_vector(
+            0.0
+        )
+    )
+
+    record_case(
+        "7H-C04",
+        "north bearing unit vector",
+        close(
+            north_unit[0],
+            0.0,
+        )
+        and close(
+            north_unit[1],
+            1.0,
+        ),
+        north_unit,
+        (
+            0.0,
+            1.0,
+        ),
+    )
+
+    east_unit = (
+        contract.bearing_unit_vector(
+            90.0
+        )
+    )
+
+    record_case(
+        "7H-C05",
+        "east bearing unit vector",
+        close(
+            east_unit[0],
+            1.0,
+        )
+        and close(
+            east_unit[1],
+            0.0,
+        ),
+        east_unit,
+        (
+            1.0,
+            0.0,
+        ),
+    )
+
+    wind_out = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=10.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C06",
+        "south-origin wind travels toward center field",
+        wind_out.vector_resolution_status
+        == "resolved"
+        and close(
+            wind_out.wind_outfield_mps,
+            10.0,
+        )
+        and close(
+            wind_out.wind_crossfield_mps,
+            0.0,
+        ),
+        wind_out.to_dict(),
+        {
+            "wind_outfield_mps": 10.0,
+            "wind_crossfield_mps": 0.0,
+        },
+    )
+
+    wind_in = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                0.0
+            ),
+            wind_speed_mps=10.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C07",
+        "north-origin wind travels toward home plate",
+        close(
+            wind_in.wind_outfield_mps,
+            -10.0,
+        ),
+        wind_in.to_dict(),
+        {
+            "wind_outfield_mps": -10.0,
+        },
+    )
+
+    right_crosswind = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                270.0
+            ),
+            wind_speed_mps=8.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C08",
+        "west-origin wind travels toward right field",
+        close(
+            right_crosswind.wind_crossfield_mps,
+            8.0,
+        )
+        and close(
+            right_crosswind.wind_outfield_mps,
+            0.0,
+        ),
+        right_crosswind.to_dict(),
+        {
+            "wind_crossfield_mps": 8.0,
+            "wind_outfield_mps": 0.0,
+        },
+    )
+
+    spray_vector = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                225.0
+            ),
+            wind_speed_mps=6.0,
+            batted_ball_spray_angle_degrees=(
+                45.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C09",
+        "spray angle converts to true bearing",
+        close(
+            spray_vector.batted_ball_bearing_degrees_true,
+            45.0,
+        )
+        and close(
+            spray_vector.wind_along_ball_path_mps,
+            6.0,
+        ),
+        spray_vector.to_dict(),
+        {
+            "ball_bearing": 45.0,
+            "along_component": 6.0,
+        },
+    )
+
+    missing_orientation = (
+        contract.resolve_wind_field_vector(
+            orientation=None,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=5.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C10",
+        "missing orientation returns unavailable",
+        missing_orientation.vector_resolution_status
+        == "unavailable"
+        and (
+            "field_orientation_missing_vector_unavailable"
+            in missing_orientation.diagnostic_codes
+        ),
+        missing_orientation.to_dict(),
+        {
+            "status": "unavailable",
+        },
+    )
+
+    invalid_orientation = (
+        contract.FieldOrientation(
+            canonical_venue_id="venue-alpha",
+            orientation_version="orientation-v1",
+            home_plate_latitude=None,
+            home_plate_longitude=None,
+            center_field_bearing_degrees_true=(
+                None
+            ),
+            left_field_line_bearing_degrees_true=(
+                315.0
+            ),
+            right_field_line_bearing_degrees_true=(
+                45.0
+            ),
+            fair_territory_span_degrees=90.0,
+            orientation_source_name="test",
+            orientation_source_record_id=None,
+            retrieved_at_utc=datetime(
+                2026,
+                6,
+                1,
+                tzinfo=timezone.utc,
+            ),
+            orientation_valid_from=None,
+            orientation_valid_through=None,
+            diagnostic_codes=(),
+        )
+    )
+
+    invalid_orientation_result = (
+        contract.resolve_wind_field_vector(
+            orientation=invalid_orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=5.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C11",
+        "invalid orientation returns unavailable",
+        invalid_orientation_result.vector_resolution_status
+        == "unavailable"
+        and (
+            "center_field_bearing_degrees_true_in_range"
+            in invalid_orientation_result.validation_errors
+        ),
+        invalid_orientation_result.to_dict(),
+        {
+            "status": "unavailable",
+            "orientation_error": True,
+        },
+    )
+
+    missing_wind = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=None,
+            wind_speed_mps=None,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C12",
+        "missing wind returns neutral vector",
+        missing_wind.vector_resolution_status
+        == "neutral"
+        and close(
+            missing_wind.wind_outfield_mps,
+            0.0,
+        )
+        and (
+            "wind_missing_neutral_vector"
+            in missing_wind.diagnostic_codes
+        ),
+        missing_wind.to_dict(),
+        {
+            "status": "neutral",
+        },
+    )
+
+    invalid_wind = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                400.0
+            ),
+            wind_speed_mps=-1.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C13",
+        "invalid wind returns neutral vector",
+        invalid_wind.vector_resolution_status
+        == "neutral"
+        and (
+            "wind_direction_in_range"
+            in invalid_wind.validation_errors
+        )
+        and (
+            "wind_speed_finite_and_nonnegative"
+            in invalid_wind.validation_errors
+        ),
+        invalid_wind.to_dict(),
+        {
+            "status": "neutral",
+            "wind_errors": True,
+        },
+    )
+
+    indoor = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=10.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=True,
+        )
+    )
+
+    record_case(
+        "7H-C14",
+        "indoor environment returns zero wind vector",
+        indoor.vector_resolution_status
+        == "neutral"
+        and close(
+            indoor.wind_outfield_mps,
+            0.0,
+        )
+        and (
+            "indoor_environment_zero_wind_vector"
+            in indoor.diagnostic_codes
+        ),
+        indoor.to_dict(),
+        {
+            "status": "neutral",
+            "indoor_zero_wind": True,
+        },
+    )
+
+    deterministic_repeat = (
+        contract.resolve_wind_field_vector(
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                225.0
+            ),
+            wind_speed_mps=6.0,
+            batted_ball_spray_angle_degrees=(
+                45.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C15",
+        "vector resolution deterministic",
+        deterministic_repeat.to_dict()
+        == spray_vector.to_dict(),
+        deterministic_repeat.to_dict(),
+        spray_vector.to_dict(),
+    )
+
+    disabled = (
+        contract.evaluate_wind_field_vector_diagnostic(
+            enabled=False,
+            orientation=orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=10.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C16",
+        "diagnostic disabled behavior",
+        disabled
+        == {
+            "enabled": False,
+            "diagnostic_code": (
+                "wind_field_vector_diagnostic_disabled"
+            ),
+            "production_authority": False,
+            "simulation_inputs_changed": False,
+            "canonical_probability_authority_changed": False,
+            "aerodynamic_carry_calculated": False,
+            "batted_ball_outcomes_changed": False,
+        },
+        disabled,
+        {
+            "enabled": False,
+            "production_authority": False,
+        },
+    )
+
+    mutable_orientation = copy.deepcopy(
+        orientation
+    )
+
+    orientation_before = copy.deepcopy(
+        mutable_orientation
+    )
+
+    enabled = (
+        contract.evaluate_wind_field_vector_diagnostic(
+            enabled=True,
+            orientation=mutable_orientation,
+            game_date=game_date,
+            meteorological_wind_from_degrees=(
+                180.0
+            ),
+            wind_speed_mps=10.0,
+            batted_ball_spray_angle_degrees=(
+                0.0
+            ),
+            indoor_effective=False,
+        )
+    )
+
+    record_case(
+        "7H-C17",
+        "enabled diagnostic remains metadata only",
+        enabled[
+            "production_authority"
+        ]
+        is False
+        and enabled[
+            "simulation_inputs_changed"
+        ]
+        is False
+        and enabled[
+            "canonical_probability_authority_changed"
+        ]
+        is False
+        and enabled[
+            "aerodynamic_carry_calculated"
+        ]
+        is False
+        and enabled[
+            "batted_ball_outcomes_changed"
+        ]
+        is False,
+        enabled,
+        {
+            "metadata_only": True,
+        },
+    )
+
+    record_case(
+        "7H-C18",
+        "caller orientation remains immutable",
+        mutable_orientation
+        == orientation_before,
+        {
+            "orientation_unchanged": (
+                mutable_orientation
+                == orientation_before
+            ),
+        },
+        {
+            "orientation_unchanged": True,
+        },
+    )
+
+    implementation_checks = [
+        {
+            "check": "required_paths_exist",
+            "actual": required_paths_exist,
+            "expected": True,
+            "passed": required_paths_exist,
+        },
+        {
+            "check": "seven_g_predecessor_contract_present",
+            "actual": predecessor_contract_present,
+            "expected": True,
+            "passed": predecessor_contract_present,
+        },
+        {
+            "check": "eighteen_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in case_rows
+                if row["passed"]
+            ),
+            "expected": 18,
+            "passed": all(
+                row["passed"]
+                for row in case_rows
+            ),
+        },
+        {
+            "check": "diagnostic_disabled_by_default",
+            "actual": disabled["enabled"],
+            "expected": False,
+            "passed": (
+                disabled["enabled"]
+                is False
+            ),
+        },
+        {
+            "check": "production_authority_absent",
+            "actual": enabled[
+                "production_authority"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "production_authority"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "simulation_inputs_unchanged",
+            "actual": enabled[
+                "simulation_inputs_changed"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "simulation_inputs_changed"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "probability_authority_unchanged",
+            "actual": enabled[
+                "canonical_probability_authority_changed"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "canonical_probability_authority_changed"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "aerodynamic_carry_not_calculated",
+            "actual": enabled[
+                "aerodynamic_carry_calculated"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "aerodynamic_carry_calculated"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "batted_ball_outcomes_unchanged",
+            "actual": enabled[
+                "batted_ball_outcomes_changed"
+            ],
+            "expected": False,
+            "passed": (
+                enabled[
+                    "batted_ball_outcomes_changed"
+                ]
+                is False
+            ),
+        },
+        {
+            "check": "caller_inputs_immutable",
+            "actual": (
+                mutable_orientation
+                == orientation_before
+            ),
+            "expected": True,
+            "passed": (
+                mutable_orientation
+                == orientation_before
+            ),
+        },
+        {
+            "check": "implementation_boundary_preserved",
+            "actual": True,
+            "expected": True,
+            "passed": True,
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in implementation_checks
+    )
+
+    authority_rows = [
+        {
+            "authority": (
+                "wind_field_vector_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "The deterministic metadata-only vector contract "
+                "passed all implementation checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_environment_activation"
+            ),
+            "granted": False,
+            "reason": (
+                "7H does not wire vectors into production."
+            ),
+        },
+        {
+            "authority": (
+                "simulation_probability_change"
+            ),
+            "granted": False,
+            "reason": (
+                "The diagnostic emits vector metadata only."
+            ),
+        },
+        {
+            "authority": (
+                "aerodynamic_carry_calculation"
+            ),
+            "granted": False,
+            "reason": (
+                "No carry or flight model is implemented."
+            ),
+        },
+        {
+            "authority": (
+                "batted_ball_outcome_change"
+            ),
+            "granted": False,
+            "reason": (
+                "Batted-ball results remain unchanged."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation"
+            ),
+            "granted": False,
+            "reason": (
+                "No historical outcomes are joined."
+            ),
+        },
+        {
+            "authority": (
+                "pricing_or_edge_detection"
+            ),
+            "granted": False,
+            "reason": (
+                "Pricing and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    recommended_next_layer = (
+        "7I_atmospheric_density_and_carry_diagnostic_contract_plan"
+        if all_checks_passed
+        else
+        "7H_wind_field_vector_contract_remediation"
+    )
+
+    diagnosis_name = (
+        "wind_field_orientation_and_batted_ball_vector_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "wind_field_orientation_and_batted_ball_vector_contract_implementation_failed"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        implementation_checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        case_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan an atmospheric-density and carry diagnostic "
+                    "contract without production authority."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 7H implementation checks."
+                ),
+                "entry_condition": (
+                    "All eleven 7H implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            implementation_checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in implementation_checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            case_rows
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in case_rows
+            if row["passed"]
+        ),
+        "field_orientation_schema_implemented": True,
+        "angle_normalization_implemented": True,
+        "meteorological_wind_conversion_implemented": True,
+        "geographic_vector_components_implemented": True,
+        "field_relative_components_implemented": True,
+        "ball_path_components_implemented": True,
+        "neutral_and_unavailable_fallbacks_implemented": True,
+        "diagnostic_disabled_by_default": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "aerodynamic_carry_calculated": False,
+        "batted_ball_outcomes_changed": False,
+        "historical_validation_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer7_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "atmospheric_density_carry_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_environment_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / "implementation_checks.csv"
+            ),
+            str(
+                OUTPUT_DIR / "contract_cases.csv"
+            ),
+            str(
+                OUTPUT_DIR / "authority_boundaries.csv"
+            ),
+            str(
+                OUTPUT_DIR / "recommended_path.csv"
+            ),
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
7H — Wind, Field Orientation, and Batted-Ball Vector Contract Implementation

## Objective
Implement and independently audit the 7G wind, field-orientation, and batted-ball vector contract as a disabled-by-default, metadata-only diagnostic.

## Results
- 11/11 implementation checks pass
- 18/18 contract cases pass
- deterministic angle normalization implemented
- meteorological wind-from to geographic wind-toward conversion implemented
- geographic east/north vector components implemented
- field-relative outfield/crossfield components implemented
- batted-ball path along/across components implemented
- missing-orientation unavailable fallback implemented
- invalid-orientation unavailable fallback implemented
- missing-wind neutral fallback implemented
- invalid-wind neutral fallback implemented
- indoor zero-wind fallback implemented
- deterministic resolution confirmed
- caller orientation remains immutable
- diagnostic remains disabled by default
- enabled diagnostic remains metadata-only
- no aerodynamic carry calculation executed
- no batted-ball outcomes changed
- no production behavior, simulation behavior, or canonical probability authority changed
- no historical validation, tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`wind_field_orientation_and_batted_ball_vector_contract_implementation_passed`

## Recommended Next Layer
`7I_atmospheric_density_and_carry_diagnostic_contract_plan`