### PR TITLE
Layer 8C: Canonical Pitch Taxonomy and Source Contract Implementation

### DIFF
--- a/mlb_app/pitching/canonical_pitch_taxonomy.py
+++ b/mlb_app/pitching/canonical_pitch_taxonomy.py
@@ -1,0 +1,633 @@
+"""
+Canonical pitch taxonomy and source-normalization contract.
+
+This module provides deterministic, diagnostic-only normalization of source
+pitch classifications into a bounded canonical taxonomy.
+
+It does not:
+- select production pitches;
+- alter pitch sequencing;
+- modify matchup or plate-appearance probabilities;
+- modify contact quality or batted-ball outcomes;
+- replace canonical simulation probabilities;
+- grant production authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import re
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+TAXONOMY_VERSION = "8C-v1"
+
+
+@dataclass(frozen=True)
+class CanonicalPitch:
+    canonical_pitch_id: str
+    canonical_name: str
+    family: str
+    velocity_band: str
+    movement_profile: str
+    active: bool = True
+
+
+@dataclass(frozen=True)
+class PitchTaxonomyInput:
+    source_name: str | None
+    source_pitch_value: str | None
+    source_record_id: str | None = None
+    source_timestamp_utc: datetime | None = None
+    enabled: bool = False
+
+
+@dataclass(frozen=True)
+class PitchTaxonomyResult:
+    emitted: bool
+    reason: str
+    source_name: str | None
+    source_pitch_value: str | None
+    canonical_pitch_id: str | None
+    canonical_pitch_name: str | None
+    canonical_family: str | None
+    normalization_status: str | None
+    normalization_rule: str | None
+    source_priority: int | None
+    source_record_id: str | None
+    source_timestamp_utc: str | None
+    taxonomy_version: str
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+    pitch_selection_changed: bool = False
+    pitch_sequence_changed: bool = False
+    matchup_adjustment_activated: bool = False
+    contact_quality_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(self.diagnostic_codes)
+        payload["validation_errors"] = list(self.validation_errors)
+        return payload
+
+
+_CANONICAL_PITCHES = (
+    CanonicalPitch(
+        "FF",
+        "four_seam_fastball",
+        "fastball",
+        "high",
+        "ride",
+    ),
+    CanonicalPitch(
+        "SI",
+        "sinker",
+        "fastball",
+        "high",
+        "arm_side_run_sink",
+    ),
+    CanonicalPitch(
+        "FC",
+        "cutter",
+        "fastball",
+        "high",
+        "glove_side_cut",
+    ),
+    CanonicalPitch(
+        "SL",
+        "slider",
+        "breaking",
+        "medium",
+        "glove_side_break",
+    ),
+    CanonicalPitch(
+        "ST",
+        "sweeper",
+        "breaking",
+        "medium",
+        "large_horizontal_break",
+    ),
+    CanonicalPitch(
+        "CU",
+        "curveball",
+        "breaking",
+        "low",
+        "vertical_break",
+    ),
+    CanonicalPitch(
+        "KC",
+        "knuckle_curve",
+        "breaking",
+        "low",
+        "vertical_break",
+    ),
+    CanonicalPitch(
+        "CH",
+        "changeup",
+        "offspeed",
+        "medium",
+        "arm_side_fade",
+    ),
+    CanonicalPitch(
+        "FS",
+        "splitter",
+        "offspeed",
+        "medium",
+        "vertical_drop",
+    ),
+    CanonicalPitch(
+        "FO",
+        "forkball",
+        "offspeed",
+        "low",
+        "vertical_drop",
+    ),
+    CanonicalPitch(
+        "KN",
+        "knuckleball",
+        "specialty",
+        "low",
+        "unstable",
+    ),
+    CanonicalPitch(
+        "EP",
+        "eephus",
+        "specialty",
+        "very_low",
+        "high_arc",
+    ),
+    CanonicalPitch(
+        "SC",
+        "screwball",
+        "specialty",
+        "low",
+        "reverse_break",
+    ),
+    CanonicalPitch(
+        "PO",
+        "pitchout",
+        "non_competitive",
+        "unknown",
+        "not_applicable",
+    ),
+    CanonicalPitch(
+        "IN",
+        "intentional_ball",
+        "non_competitive",
+        "unknown",
+        "not_applicable",
+    ),
+    CanonicalPitch(
+        "UN",
+        "unknown",
+        "unknown",
+        "unknown",
+        "unknown",
+    ),
+)
+
+CANONICAL_PITCHES: Mapping[str, CanonicalPitch] = MappingProxyType(
+    {
+        pitch.canonical_pitch_id: pitch
+        for pitch in _CANONICAL_PITCHES
+    }
+)
+
+
+def _normalize_text(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = normalized.replace("_", " ")
+    normalized = re.sub(r"[\-–—]+", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized
+
+
+_EXACT_STATCAST_ALIASES = MappingProxyType(
+    {
+        "FF": "FF",
+        "SI": "SI",
+        "FC": "FC",
+        "SL": "SL",
+        "ST": "ST",
+        "CU": "CU",
+        "KC": "KC",
+        "CH": "CH",
+        "FS": "FS",
+        "FO": "FO",
+        "KN": "KN",
+        "EP": "EP",
+        "SC": "SC",
+        "PO": "PO",
+        "IN": "IN",
+    }
+)
+
+_LEGACY_STATCAST_ALIASES = MappingProxyType(
+    {
+        "FT": "SI",
+    }
+)
+
+_GENERIC_ALIASES = MappingProxyType(
+    {
+        "four seam fastball": "FF",
+        "four seamer": "FF",
+        "4 seam fastball": "FF",
+        "4 seamer": "FF",
+        "sinker": "SI",
+        "two seam fastball": "SI",
+        "two seamer": "SI",
+        "2 seam fastball": "SI",
+        "2 seamer": "SI",
+        "cutter": "FC",
+        "cut fastball": "FC",
+        "slider": "SL",
+        "sweeper": "ST",
+        "curveball": "CU",
+        "curve": "CU",
+        "knuckle curve": "KC",
+        "knuckle curveball": "KC",
+        "changeup": "CH",
+        "change up": "CH",
+        "splitter": "FS",
+        "split finger": "FS",
+        "split finger fastball": "FS",
+        "forkball": "FO",
+        "knuckleball": "KN",
+        "eephus": "EP",
+        "screwball": "SC",
+        "pitchout": "PO",
+        "intentional ball": "IN",
+        "intentional walk pitch": "IN",
+    }
+)
+
+_AMBIGUOUS_ALIASES = frozenset(
+    {
+        "fastball",
+        "breaking ball",
+        "offspeed",
+        "off speed",
+        "curve",
+    }
+)
+
+_TRUSTED_PROVIDER_NAMES = frozenset(
+    {
+        "statcast",
+        "baseball_savant",
+        "baseball savant",
+        "trusted_provider",
+        "provider",
+        "generic",
+        "repository",
+    }
+)
+
+
+def canonical_pitch_records() -> tuple[CanonicalPitch, ...]:
+    return tuple(_CANONICAL_PITCHES)
+
+
+def canonical_pitch_ids() -> tuple[str, ...]:
+    return tuple(
+        pitch.canonical_pitch_id
+        for pitch in _CANONICAL_PITCHES
+    )
+
+
+def canonical_pitch_names() -> tuple[str, ...]:
+    return tuple(
+        pitch.canonical_name
+        for pitch in _CANONICAL_PITCHES
+    )
+
+
+def _sorted_unique_strings(
+    values: list[str] | tuple[str, ...],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for value in values
+                if isinstance(value, str)
+                and value
+            }
+        )
+    )
+
+
+def _fallback_result(
+    *,
+    taxonomy_input: PitchTaxonomyInput,
+    reason: str,
+    normalization_status: str,
+    normalization_rule: str,
+    source_priority: int,
+    diagnostic_codes: list[str],
+    validation_errors: list[str] | None = None,
+) -> PitchTaxonomyResult:
+    unknown = CANONICAL_PITCHES["UN"]
+
+    return PitchTaxonomyResult(
+        emitted=True,
+        reason=reason,
+        source_name=taxonomy_input.source_name,
+        source_pitch_value=taxonomy_input.source_pitch_value,
+        canonical_pitch_id=unknown.canonical_pitch_id,
+        canonical_pitch_name=unknown.canonical_name,
+        canonical_family=unknown.family,
+        normalization_status=normalization_status,
+        normalization_rule=normalization_rule,
+        source_priority=source_priority,
+        source_record_id=taxonomy_input.source_record_id,
+        source_timestamp_utc=(
+            taxonomy_input.source_timestamp_utc.isoformat()
+            if taxonomy_input.source_timestamp_utc is not None
+            else None
+        ),
+        taxonomy_version=TAXONOMY_VERSION,
+        diagnostic_codes=_sorted_unique_strings(
+            diagnostic_codes
+        ),
+        validation_errors=_sorted_unique_strings(
+            validation_errors or []
+        ),
+    )
+
+
+def normalize_pitch_type(
+    taxonomy_input: PitchTaxonomyInput,
+) -> PitchTaxonomyResult:
+    if not taxonomy_input.enabled:
+        return PitchTaxonomyResult(
+            emitted=False,
+            reason="taxonomy_disabled",
+            source_name=taxonomy_input.source_name,
+            source_pitch_value=taxonomy_input.source_pitch_value,
+            canonical_pitch_id=None,
+            canonical_pitch_name=None,
+            canonical_family=None,
+            normalization_status=None,
+            normalization_rule=None,
+            source_priority=None,
+            source_record_id=taxonomy_input.source_record_id,
+            source_timestamp_utc=(
+                taxonomy_input.source_timestamp_utc.isoformat()
+                if taxonomy_input.source_timestamp_utc is not None
+                else None
+            ),
+            taxonomy_version=TAXONOMY_VERSION,
+            diagnostic_codes=(
+                "pitch_taxonomy_disabled",
+            ),
+            validation_errors=(),
+        )
+
+    source_name = (
+        taxonomy_input.source_name.strip().lower()
+        if isinstance(taxonomy_input.source_name, str)
+        else ""
+    )
+
+    if not source_name:
+        return _fallback_result(
+            taxonomy_input=taxonomy_input,
+            reason="missing_source_name",
+            normalization_status="missing",
+            normalization_rule="unknown_fallback",
+            source_priority=5,
+            diagnostic_codes=[
+                "pitch_taxonomy_source_name_missing",
+            ],
+        )
+
+    raw_value = taxonomy_input.source_pitch_value
+
+    if raw_value is None or not str(raw_value).strip():
+        return _fallback_result(
+            taxonomy_input=taxonomy_input,
+            reason="missing_source_value",
+            normalization_status="missing",
+            normalization_rule="unknown_fallback",
+            source_priority=5,
+            diagnostic_codes=[
+                "pitch_taxonomy_source_value_missing",
+            ],
+        )
+
+    raw_text = str(raw_value).strip()
+    raw_upper = raw_text.upper()
+    normalized = _normalize_text(raw_text)
+
+    if normalized in _AMBIGUOUS_ALIASES:
+        return _fallback_result(
+            taxonomy_input=taxonomy_input,
+            reason="ambiguous_source_value",
+            normalization_status="ambiguous",
+            normalization_rule="unknown_fallback",
+            source_priority=5,
+            diagnostic_codes=[
+                "pitch_taxonomy_source_value_ambiguous",
+            ],
+        )
+
+    if (
+        source_name in {"statcast", "baseball_savant", "baseball savant"}
+        and raw_upper in _EXACT_STATCAST_ALIASES
+    ):
+        canonical_id = _EXACT_STATCAST_ALIASES[
+            raw_upper
+        ]
+        canonical = CANONICAL_PITCHES[
+            canonical_id
+        ]
+
+        return PitchTaxonomyResult(
+            emitted=True,
+            reason="normalized",
+            source_name=taxonomy_input.source_name,
+            source_pitch_value=taxonomy_input.source_pitch_value,
+            canonical_pitch_id=canonical.canonical_pitch_id,
+            canonical_pitch_name=canonical.canonical_name,
+            canonical_family=canonical.family,
+            normalization_status="exact",
+            normalization_rule="statcast_explicit_pitch_type",
+            source_priority=1,
+            source_record_id=taxonomy_input.source_record_id,
+            source_timestamp_utc=(
+                taxonomy_input.source_timestamp_utc.isoformat()
+                if taxonomy_input.source_timestamp_utc is not None
+                else None
+            ),
+            taxonomy_version=TAXONOMY_VERSION,
+            diagnostic_codes=(
+                "pitch_taxonomy_exact_match",
+            ),
+            validation_errors=(),
+        )
+
+    if (
+        source_name in {"statcast", "baseball_savant", "baseball savant"}
+        and raw_upper in _LEGACY_STATCAST_ALIASES
+    ):
+        canonical_id = _LEGACY_STATCAST_ALIASES[
+            raw_upper
+        ]
+        canonical = CANONICAL_PITCHES[
+            canonical_id
+        ]
+
+        return PitchTaxonomyResult(
+            emitted=True,
+            reason="normalized",
+            source_name=taxonomy_input.source_name,
+            source_pitch_value=taxonomy_input.source_pitch_value,
+            canonical_pitch_id=canonical.canonical_pitch_id,
+            canonical_pitch_name=canonical.canonical_name,
+            canonical_family=canonical.family,
+            normalization_status="legacy_alias",
+            normalization_rule="source_specific_legacy_alias",
+            source_priority=4,
+            source_record_id=taxonomy_input.source_record_id,
+            source_timestamp_utc=(
+                taxonomy_input.source_timestamp_utc.isoformat()
+                if taxonomy_input.source_timestamp_utc is not None
+                else None
+            ),
+            taxonomy_version=TAXONOMY_VERSION,
+            diagnostic_codes=(
+                "pitch_taxonomy_legacy_alias_used",
+            ),
+            validation_errors=(),
+        )
+
+    if raw_upper in CANONICAL_PITCHES:
+        canonical = CANONICAL_PITCHES[
+            raw_upper
+        ]
+
+        return PitchTaxonomyResult(
+            emitted=True,
+            reason="normalized",
+            source_name=taxonomy_input.source_name,
+            source_pitch_value=taxonomy_input.source_pitch_value,
+            canonical_pitch_id=canonical.canonical_pitch_id,
+            canonical_pitch_name=canonical.canonical_name,
+            canonical_family=canonical.family,
+            normalization_status="exact",
+            normalization_rule="trusted_provider_explicit_pitch_type",
+            source_priority=2,
+            source_record_id=taxonomy_input.source_record_id,
+            source_timestamp_utc=(
+                taxonomy_input.source_timestamp_utc.isoformat()
+                if taxonomy_input.source_timestamp_utc is not None
+                else None
+            ),
+            taxonomy_version=TAXONOMY_VERSION,
+            diagnostic_codes=(
+                "pitch_taxonomy_trusted_provider_exact_match",
+            ),
+            validation_errors=(),
+        )
+
+    if normalized in _GENERIC_ALIASES:
+        canonical_id = _GENERIC_ALIASES[
+            normalized
+        ]
+        canonical = CANONICAL_PITCHES[
+            canonical_id
+        ]
+
+        return PitchTaxonomyResult(
+            emitted=True,
+            reason="normalized",
+            source_name=taxonomy_input.source_name,
+            source_pitch_value=taxonomy_input.source_pitch_value,
+            canonical_pitch_id=canonical.canonical_pitch_id,
+            canonical_pitch_name=canonical.canonical_name,
+            canonical_family=canonical.family,
+            normalization_status="normalized_alias",
+            normalization_rule="repository_canonical_alias",
+            source_priority=3,
+            source_record_id=taxonomy_input.source_record_id,
+            source_timestamp_utc=(
+                taxonomy_input.source_timestamp_utc.isoformat()
+                if taxonomy_input.source_timestamp_utc is not None
+                else None
+            ),
+            taxonomy_version=TAXONOMY_VERSION,
+            diagnostic_codes=(
+                "pitch_taxonomy_alias_normalized",
+            ),
+            validation_errors=(),
+        )
+
+    diagnostic_codes = [
+        "pitch_taxonomy_source_value_unsupported",
+    ]
+
+    if source_name not in _TRUSTED_PROVIDER_NAMES:
+        diagnostic_codes.append(
+            "pitch_taxonomy_source_name_unrecognized"
+        )
+
+    return _fallback_result(
+        taxonomy_input=taxonomy_input,
+        reason="unsupported_source_value",
+        normalization_status="unsupported",
+        normalization_rule="unknown_fallback",
+        source_priority=5,
+        diagnostic_codes=diagnostic_codes,
+    )
+
+
+def normalize_pitch_payload(
+    payload: Mapping[str, Any],
+) -> PitchTaxonomyResult:
+    copied_payload = dict(payload)
+
+    timestamp = copied_payload.get(
+        "source_timestamp_utc"
+    )
+
+    if isinstance(timestamp, str):
+        try:
+            timestamp = datetime.fromisoformat(
+                timestamp
+            )
+        except ValueError:
+            timestamp = None
+
+    taxonomy_input = PitchTaxonomyInput(
+        source_name=copied_payload.get(
+            "source_name"
+        ),
+        source_pitch_value=copied_payload.get(
+            "source_pitch_value"
+        ),
+        source_record_id=copied_payload.get(
+            "source_record_id"
+        ),
+        source_timestamp_utc=(
+            timestamp
+            if isinstance(timestamp, datetime)
+            else None
+        ),
+        enabled=bool(
+            copied_payload.get(
+                "enabled",
+                False,
+            )
+        ),
+    )
+
+    return normalize_pitch_type(
+        taxonomy_input
+    )

--- a/scripts/audit_8C_canonical_pitch_taxonomy_and_source_contract.py
+++ b/scripts/audit_8C_canonical_pitch_taxonomy_and_source_contract.py
@@ -1,0 +1,1074 @@
+#!/usr/bin/env python3
+"""
+Layer 8C canonical pitch taxonomy implementation audit.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import csv
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+LAYER_ID = "8C"
+LAYER_NAME = (
+    "canonical_pitch_taxonomy_and_source_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_8C_canonical_pitch_taxonomy_and_source_contract"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_8B_canonical_pitch_taxonomy_and_source_contract.py"
+)
+
+CONTRACT_PATH = (
+    ROOT
+    / "mlb_app/pitching/"
+    "canonical_pitch_taxonomy.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def load_contract() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "canonical_pitch_taxonomy_8c",
+        CONTRACT_PATH,
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            "Unable to load 8C contract"
+        )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
+
+    import sys
+
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    contract = load_contract()
+
+    predecessor_present = (
+        "canonical_pitch_taxonomy_and_source_contract_plan_complete"
+        in string_constants(
+            PLAN_PATH
+        )
+    )
+
+    timestamp = datetime(
+        2026,
+        7,
+        1,
+        0,
+        0,
+        tzinfo=timezone.utc,
+    )
+
+    cases: list[dict[str, Any]] = []
+
+    def record(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        cases.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    disabled = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="statcast",
+            source_pitch_value="FF",
+            enabled=False,
+        )
+    )
+
+    record(
+        "8C-C01",
+        "disabled path emits no diagnostic payload",
+        disabled.emitted is False
+        and disabled.canonical_pitch_id is None
+        and disabled.reason == "taxonomy_disabled",
+        disabled.to_dict(),
+        {
+            "emitted": False,
+            "reason": "taxonomy_disabled",
+        },
+    )
+
+    statcast_exact = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="statcast",
+            source_pitch_value="FF",
+            source_record_id="pitch-1",
+            source_timestamp_utc=timestamp,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C02",
+        "Statcast exact code resolves",
+        statcast_exact.canonical_pitch_id == "FF"
+        and statcast_exact.normalization_status == "exact"
+        and statcast_exact.source_priority == 1,
+        statcast_exact.to_dict(),
+        {
+            "canonical_pitch_id": "FF",
+            "status": "exact",
+            "priority": 1,
+        },
+    )
+
+    legacy = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="statcast",
+            source_pitch_value="FT",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C03",
+        "legacy two-seam code resolves to sinker",
+        legacy.canonical_pitch_id == "SI"
+        and legacy.normalization_status == "legacy_alias"
+        and legacy.source_priority == 4,
+        legacy.to_dict(),
+        {
+            "canonical_pitch_id": "SI",
+            "status": "legacy_alias",
+        },
+    )
+
+    generic = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="generic",
+            source_pitch_value="  Four-Seam   Fastball ",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C04",
+        "generic alias normalization is whitespace and case stable",
+        generic.canonical_pitch_id == "FF"
+        and generic.normalization_status == "normalized_alias"
+        and generic.source_priority == 3,
+        generic.to_dict(),
+        {
+            "canonical_pitch_id": "FF",
+            "status": "normalized_alias",
+        },
+    )
+
+    trusted_code = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="provider",
+            source_pitch_value="SL",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C05",
+        "trusted provider canonical code resolves",
+        trusted_code.canonical_pitch_id == "SL"
+        and trusted_code.source_priority == 2,
+        trusted_code.to_dict(),
+        {
+            "canonical_pitch_id": "SL",
+            "priority": 2,
+        },
+    )
+
+    missing_value = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="statcast",
+            source_pitch_value=None,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C06",
+        "missing value resolves to unknown",
+        missing_value.canonical_pitch_id == "UN"
+        and missing_value.normalization_status == "missing",
+        missing_value.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+            "status": "missing",
+        },
+    )
+
+    missing_source = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name=None,
+            source_pitch_value="FF",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C07",
+        "missing source resolves to unknown",
+        missing_source.canonical_pitch_id == "UN"
+        and (
+            "pitch_taxonomy_source_name_missing"
+            in missing_source.diagnostic_codes
+        ),
+        missing_source.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+        },
+    )
+
+    unsupported = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="statcast",
+            source_pitch_value="ZZ",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C08",
+        "unsupported value is observable and not guessed",
+        unsupported.canonical_pitch_id == "UN"
+        and unsupported.normalization_status == "unsupported"
+        and (
+            "pitch_taxonomy_source_value_unsupported"
+            in unsupported.diagnostic_codes
+        ),
+        unsupported.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+            "status": "unsupported",
+        },
+    )
+
+    ambiguous = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="generic",
+            source_pitch_value="fastball",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C09",
+        "ambiguous value is not guessed",
+        ambiguous.canonical_pitch_id == "UN"
+        and ambiguous.normalization_status == "ambiguous",
+        ambiguous.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+            "status": "ambiguous",
+        },
+    )
+
+    unknown_source = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="mystery_provider",
+            source_pitch_value="ZZ",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C10",
+        "unknown source remains observable",
+        unknown_source.canonical_pitch_id == "UN"
+        and (
+            "pitch_taxonomy_source_name_unrecognized"
+            in unknown_source.diagnostic_codes
+        ),
+        unknown_source.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+            "source_warning": True,
+        },
+    )
+
+    repeat_a = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="generic",
+            source_pitch_value="change-up",
+            enabled=True,
+        )
+    )
+
+    repeat_b = contract.normalize_pitch_type(
+        contract.PitchTaxonomyInput(
+            source_name="generic",
+            source_pitch_value="change-up",
+            enabled=True,
+        )
+    )
+
+    record(
+        "8C-C11",
+        "normalization is deterministic",
+        repeat_a.to_dict() == repeat_b.to_dict(),
+        repeat_a.to_dict(),
+        repeat_b.to_dict(),
+    )
+
+    canonical_records = (
+        contract.canonical_pitch_records()
+    )
+
+    record(
+        "8C-C12",
+        "sixteen immutable canonical records exposed",
+        len(canonical_records) == 16
+        and len(
+            {
+                row.canonical_pitch_id
+                for row in canonical_records
+            }
+        )
+        == 16,
+        len(canonical_records),
+        16,
+    )
+
+    record(
+        "8C-C13",
+        "canonical names are unique",
+        len(
+            contract.canonical_pitch_names()
+        )
+        == len(
+            set(
+                contract.canonical_pitch_names()
+            )
+        ),
+        contract.canonical_pitch_names(),
+        "unique",
+    )
+
+    record(
+        "8C-C14",
+        "unknown fallback is present",
+        "UN"
+        in contract.canonical_pitch_ids(),
+        contract.canonical_pitch_ids(),
+        "contains UN",
+    )
+
+    payload = {
+        "source_name": "generic",
+        "source_pitch_value": "split-finger",
+        "source_record_id": "pitch-2",
+        "source_timestamp_utc": (
+            timestamp.isoformat()
+        ),
+        "enabled": True,
+    }
+
+    payload_before = copy.deepcopy(
+        payload
+    )
+
+    payload_result = (
+        contract.normalize_pitch_payload(
+            payload
+        )
+    )
+
+    record(
+        "8C-C15",
+        "payload interface resolves alias",
+        payload_result.canonical_pitch_id
+        == "FS",
+        payload_result.to_dict(),
+        {
+            "canonical_pitch_id": "FS",
+        },
+    )
+
+    record(
+        "8C-C16",
+        "caller payload remains immutable",
+        payload == payload_before,
+        payload,
+        payload_before,
+    )
+
+    record(
+        "8C-C17",
+        "provenance fields retained",
+        statcast_exact.source_record_id
+        == "pitch-1"
+        and statcast_exact.source_timestamp_utc
+        == timestamp.isoformat(),
+        statcast_exact.to_dict(),
+        {
+            "source_record_id": "pitch-1",
+            "source_timestamp_utc": (
+                timestamp.isoformat()
+            ),
+        },
+    )
+
+    record(
+        "8C-C18",
+        "diagnostic codes sorted and unique",
+        unsupported.diagnostic_codes
+        == tuple(
+            sorted(
+                set(
+                    unsupported.diagnostic_codes
+                )
+            )
+        ),
+        unsupported.diagnostic_codes,
+        "sorted_unique",
+    )
+
+    record(
+        "8C-C19",
+        "taxonomy version explicit",
+        all(
+            result.taxonomy_version
+            == contract.TAXONOMY_VERSION
+            for result in [
+                disabled,
+                statcast_exact,
+                legacy,
+                generic,
+                missing_value,
+                unsupported,
+                ambiguous,
+            ]
+        ),
+        contract.TAXONOMY_VERSION,
+        "8C-v1",
+    )
+
+    record(
+        "8C-C20",
+        "production and simulation authority remain false",
+        all(
+            value is False
+            for value in [
+                statcast_exact.production_authority,
+                statcast_exact.production_behavior_changed,
+                statcast_exact.simulation_behavior_changed,
+                statcast_exact.pitch_selection_changed,
+                statcast_exact.pitch_sequence_changed,
+                statcast_exact.matchup_adjustment_activated,
+                statcast_exact.contact_quality_changed,
+            ]
+        ),
+        statcast_exact.to_dict(),
+        {
+            "all_authority_flags": False,
+        },
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": (
+                PLAN_PATH.exists()
+                and CONTRACT_PATH.exists()
+            ),
+            "expected": True,
+            "passed": (
+                PLAN_PATH.exists()
+                and CONTRACT_PATH.exists()
+            ),
+        },
+        {
+            "check": "eight_b_predecessor_present",
+            "actual": predecessor_present,
+            "expected": True,
+            "passed": predecessor_present,
+        },
+        {
+            "check": "twenty_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in cases
+                if row["passed"]
+            ),
+            "expected": 20,
+            "passed": all(
+                row["passed"]
+                for row in cases
+            ),
+        },
+        {
+            "check": "sixteen_canonical_pitches_implemented",
+            "actual": len(
+                contract.canonical_pitch_records()
+            ),
+            "expected": 16,
+            "passed": len(
+                contract.canonical_pitch_records()
+            )
+            == 16,
+        },
+        {
+            "check": "canonical_ids_unique",
+            "actual": len(
+                set(
+                    contract.canonical_pitch_ids()
+                )
+            ),
+            "expected": 16,
+            "passed": len(
+                set(
+                    contract.canonical_pitch_ids()
+                )
+            )
+            == 16,
+        },
+        {
+            "check": "canonical_names_unique",
+            "actual": len(
+                set(
+                    contract.canonical_pitch_names()
+                )
+            ),
+            "expected": 16,
+            "passed": len(
+                set(
+                    contract.canonical_pitch_names()
+                )
+            )
+            == 16,
+        },
+        {
+            "check": "unknown_fallback_implemented",
+            "actual": "UN"
+            in contract.canonical_pitch_ids(),
+            "expected": True,
+            "passed": "UN"
+            in contract.canonical_pitch_ids(),
+        },
+        {
+            "check": "source_precedence_implemented",
+            "actual": [
+                statcast_exact.source_priority,
+                trusted_code.source_priority,
+                generic.source_priority,
+                legacy.source_priority,
+                unsupported.source_priority,
+            ],
+            "expected": [1, 2, 3, 4, 5],
+            "passed": [
+                statcast_exact.source_priority,
+                trusted_code.source_priority,
+                generic.source_priority,
+                legacy.source_priority,
+                unsupported.source_priority,
+            ]
+            == [1, 2, 3, 4, 5],
+        },
+        {
+            "check": "disabled_path_non_emitting",
+            "actual": disabled.emitted,
+            "expected": False,
+            "passed": disabled.emitted is False,
+        },
+        {
+            "check": "missing_unsupported_ambiguous_not_guessed",
+            "actual": [
+                missing_value.canonical_pitch_id,
+                unsupported.canonical_pitch_id,
+                ambiguous.canonical_pitch_id,
+            ],
+            "expected": ["UN", "UN", "UN"],
+            "passed": [
+                missing_value.canonical_pitch_id,
+                unsupported.canonical_pitch_id,
+                ambiguous.canonical_pitch_id,
+            ]
+            == ["UN", "UN", "UN"],
+        },
+        {
+            "check": "normalization_deterministic",
+            "actual": (
+                repeat_a.to_dict()
+                == repeat_b.to_dict()
+            ),
+            "expected": True,
+            "passed": (
+                repeat_a.to_dict()
+                == repeat_b.to_dict()
+            ),
+        },
+        {
+            "check": "caller_payload_immutable",
+            "actual": payload
+            == payload_before,
+            "expected": True,
+            "passed": payload
+            == payload_before,
+        },
+        {
+            "check": "provenance_bounded_and_retained",
+            "actual": (
+                statcast_exact.source_record_id
+                == "pitch-1"
+            ),
+            "expected": True,
+            "passed": (
+                statcast_exact.source_record_id
+                == "pitch-1"
+            ),
+        },
+        {
+            "check": "diagnostic_codes_sorted_unique",
+            "actual": (
+                unsupported.diagnostic_codes
+                == tuple(
+                    sorted(
+                        set(
+                            unsupported.diagnostic_codes
+                        )
+                    )
+                )
+            ),
+            "expected": True,
+            "passed": (
+                unsupported.diagnostic_codes
+                == tuple(
+                    sorted(
+                        set(
+                            unsupported.diagnostic_codes
+                        )
+                    )
+                )
+            ),
+        },
+        {
+            "check": "production_behavior_unchanged",
+            "actual": (
+                statcast_exact.production_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                statcast_exact.production_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "simulation_behavior_unchanged",
+            "actual": (
+                statcast_exact.simulation_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                statcast_exact.simulation_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "pitch_selection_unchanged",
+            "actual": (
+                statcast_exact.pitch_selection_changed
+            ),
+            "expected": False,
+            "passed": (
+                statcast_exact.pitch_selection_changed
+                is False
+            ),
+        },
+        {
+            "check": "matchup_and_contact_authority_absent",
+            "actual": (
+                statcast_exact.matchup_adjustment_activated
+                or statcast_exact.contact_quality_changed
+            ),
+            "expected": False,
+            "passed": (
+                statcast_exact.matchup_adjustment_activated
+                is False
+                and statcast_exact.contact_quality_changed
+                is False
+            ),
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    authority_rows = [
+        {
+            "authority": (
+                "canonical_pitch_taxonomy_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "The deterministic diagnostic taxonomy passed all checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_pitch_taxonomy_integration"
+            ),
+            "granted": False,
+            "reason": (
+                "Taxonomy results remain diagnostic-only."
+            ),
+        },
+        {
+            "authority": (
+                "production_pitch_selection"
+            ),
+            "granted": False,
+            "reason": (
+                "No pitch selection behavior is changed."
+            ),
+        },
+        {
+            "authority": (
+                "pitch_sequence_change"
+            ),
+            "granted": False,
+            "reason": (
+                "No pitch sequencing behavior is changed."
+            ),
+        },
+        {
+            "authority": (
+                "matchup_or_contact_adjustment"
+            ),
+            "granted": False,
+            "reason": (
+                "No matchup or contact-quality authority is granted."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation_tuning_pricing_edge"
+            ),
+            "granted": False,
+            "reason": (
+                "Validation, tuning, pricing, and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    diagnosis_name = (
+        "canonical_pitch_taxonomy_and_source_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "canonical_pitch_taxonomy_and_source_contract_implementation_failed"
+    )
+
+    recommended_next_layer = (
+        "8D_pitcher_arsenal_profile_contract_plan"
+        if all_checks_passed
+        else
+        "8C_canonical_pitch_taxonomy_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        cases,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "canonical_pitch_records.csv",
+        [
+            "canonical_pitch_id",
+            "canonical_name",
+            "family",
+            "velocity_band",
+            "movement_profile",
+            "active",
+        ],
+        [
+            {
+                "canonical_pitch_id": (
+                    row.canonical_pitch_id
+                ),
+                "canonical_name": (
+                    row.canonical_name
+                ),
+                "family": row.family,
+                "velocity_band": (
+                    row.velocity_band
+                ),
+                "movement_profile": (
+                    row.movement_profile
+                ),
+                "active": row.active,
+            }
+            for row in contract.canonical_pitch_records()
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan the bounded pitcher arsenal profile contract."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 8C implementation checks."
+                ),
+                "entry_condition": (
+                    "All eighteen 8C implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            cases
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in cases
+            if row["passed"]
+        ),
+        "canonical_pitches_implemented": len(
+            contract.canonical_pitch_records()
+        ),
+        "taxonomy_version": (
+            contract.TAXONOMY_VERSION
+        ),
+        "deterministic_normalization_implemented": True,
+        "source_precedence_implemented": True,
+        "unknown_fallback_implemented": True,
+        "disabled_path_non_emitting": True,
+        "caller_payload_immutable": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "pitch_selection_changed": False,
+        "pitch_sequence_changed": False,
+        "matchup_adjustments_activated": False,
+        "contact_quality_changed": False,
+        "historical_outcome_joined": False,
+        "historical_validation_executed": False,
+        "tuning_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer8_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "pitcher_arsenal_profile_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_pitch_taxonomy_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / filename
+            )
+            for filename in [
+                "implementation_checks.csv",
+                "contract_cases.csv",
+                "canonical_pitch_records.csv",
+                "authority_boundaries.csv",
+                "recommended_path.csv",
+            ]
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
8C — Canonical Pitch Taxonomy and Source Contract Implementation

## Objective
Implement and independently audit the deterministic, diagnostic-only canonical pitch taxonomy and source-normalization contract defined in Layer 8B.

## Results
- 18/18 implementation checks pass
- 20/20 contract cases pass
- 16 immutable canonical pitch records implemented
- taxonomy version `8C-v1`
- deterministic normalization implemented
- explicit source precedence priorities `1–5` implemented
- exact, trusted-provider, generic-alias, and legacy-alias resolution implemented
- missing, unsupported, and ambiguous values resolve to `UN`
- disabled path emits no taxonomy payload
- bounded provenance retained
- diagnostic codes sorted and unique
- caller payload remains immutable
- no production pitch selection changes
- no pitch sequencing changes
- no matchup adjustments activated
- no contact-quality changes
- no simulation behavior or canonical probability authority changes
- no historical outcome joins or predictive validation
- no tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`canonical_pitch_taxonomy_and_source_contract_implementation_passed`

## Recommended Next Layer
`8D_pitcher_arsenal_profile_contract_plan`