### PR TITLE
Layer 8E: Pitcher Arsenal Profile Contract Implementation

### DIFF
--- a/mlb_app/pitching/pitcher_arsenal_profile.py
+++ b/mlb_app/pitching/pitcher_arsenal_profile.py
@@ -1,0 +1,822 @@
+"""
+Diagnostic-only pitcher arsenal profile contract.
+
+Builds deterministic, immutable pitcher arsenal profiles using the canonical
+pitch taxonomy from Layer 8C.
+
+This module does not:
+- select pitches;
+- alter pitch sequencing;
+- alter matchup or simulation probabilities;
+- alter contact quality or batted-ball outcomes;
+- grant production authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+import math
+from typing import Any, Mapping, Sequence
+
+from mlb_app.pitching.canonical_pitch_taxonomy import (
+    CANONICAL_PITCHES,
+    TAXONOMY_VERSION,
+)
+
+
+PROFILE_VERSION = "8E-v1"
+USAGE_TOTAL_TOLERANCE = 0.001
+PROFILE_MINIMUM_PITCH_COUNT = 50
+ENTRY_MINIMUM_PITCH_COUNT = 10
+CURRENT_PROFILE_MAXIMUM_AGE_DAYS = 14
+
+SUPPORTED_HANDS = frozenset({"R", "L", "U"})
+SUPPORTED_ROLES = frozenset(
+    {
+        "starter",
+        "reliever",
+        "opener",
+        "unknown",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PitcherArsenalEntry:
+    canonical_pitch_id: str
+    canonical_pitch_name: str
+    canonical_family: str
+    available: bool
+    usage_share: float | None
+    pitch_count: int
+    avg_velocity_mph: float | None
+    avg_spin_rpm: float | None
+    avg_horizontal_break_inches: float | None
+    avg_vertical_break_inches: float | None
+    avg_extension_feet: float | None
+    zone_rate: float | None
+    chase_rate: float | None
+    whiff_rate: float | None
+    called_strike_plus_whiff_rate: float | None
+    command_index: float | None
+    quality_index: float | None
+    diagnostic_codes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class PitcherArsenalProfile:
+    emitted: bool
+    reason: str
+    pitcher_id: str | None
+    pitcher_name: str | None
+    pitcher_hand: str | None
+    pitcher_role: str | None
+    season: int | None
+    as_of_date_utc: str | None
+    source_name: str | None
+    source_record_id: str | None
+    source_timestamp_utc: str | None
+    source_priority: int | None
+    sample_pitch_count: int
+    sample_game_count: int | None
+    profile_status: str
+    arsenal_entries: tuple[PitcherArsenalEntry, ...]
+    taxonomy_version: str
+    profile_version: str
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+    pitch_selection_changed: bool = False
+    pitch_sequence_changed: bool = False
+    matchup_adjustment_activated: bool = False
+    contact_quality_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["arsenal_entries"] = [
+            entry.to_dict()
+            for entry in self.arsenal_entries
+        ]
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        payload["validation_errors"] = list(
+            self.validation_errors
+        )
+        return payload
+
+
+def _sorted_unique_strings(
+    values: Sequence[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for value in values
+                if isinstance(value, str)
+                and value
+            }
+        )
+    )
+
+
+def _finite_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(converted):
+        return None
+
+    return converted
+
+
+def _rate_or_none(value: Any) -> float | None:
+    converted = _finite_or_none(value)
+
+    if converted is None:
+        return None
+
+    if not 0.0 <= converted <= 1.0:
+        return None
+
+    return converted
+
+
+def _positive_or_none(value: Any) -> float | None:
+    converted = _finite_or_none(value)
+
+    if converted is None or converted <= 0.0:
+        return None
+
+    return converted
+
+
+def _nonnegative_or_none(
+    value: Any,
+) -> float | None:
+    converted = _finite_or_none(value)
+
+    if converted is None or converted < 0.0:
+        return None
+
+    return converted
+
+
+def _normalize_hand(value: Any) -> str:
+    normalized = str(value or "U").strip().upper()
+
+    if normalized not in SUPPORTED_HANDS:
+        return "U"
+
+    return normalized
+
+
+def _normalize_role(value: Any) -> str:
+    normalized = str(
+        value or "unknown"
+    ).strip().lower()
+
+    if normalized not in SUPPORTED_ROLES:
+        return "unknown"
+
+    return normalized
+
+
+def _parse_date(value: Any) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+
+    if isinstance(value, date):
+        return value
+
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(
+                value[:10]
+            )
+        except ValueError:
+            return None
+
+    return None
+
+
+def _parse_datetime(
+    value: Any,
+) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(
+                value
+            )
+        except ValueError:
+            return None
+
+    return None
+
+
+def _source_priority(source_name: str) -> int:
+    normalized = source_name.strip().lower()
+
+    if normalized in {
+        "statcast",
+        "statcast_pitch_level_aggregate",
+        "baseball_savant",
+        "baseball savant",
+    }:
+        return 1
+
+    if normalized in {
+        "trusted_provider",
+        "trusted_provider_pitch_level_aggregate",
+        "provider",
+    }:
+        return 2
+
+    if normalized in {
+        "repository_cache",
+        "repository_cached_pitch_profile",
+        "cache",
+    }:
+        return 3
+
+    if normalized in {
+        "season_summary",
+        "season_level_pitch_mix_summary",
+    }:
+        return 4
+
+    return 5
+
+
+def _disabled_profile(
+    payload: Mapping[str, Any],
+) -> PitcherArsenalProfile:
+    return PitcherArsenalProfile(
+        emitted=False,
+        reason="profile_disabled",
+        pitcher_id=payload.get("pitcher_id"),
+        pitcher_name=payload.get("pitcher_name"),
+        pitcher_hand=None,
+        pitcher_role=None,
+        season=None,
+        as_of_date_utc=None,
+        source_name=payload.get("source_name"),
+        source_record_id=payload.get(
+            "source_record_id"
+        ),
+        source_timestamp_utc=None,
+        source_priority=None,
+        sample_pitch_count=0,
+        sample_game_count=None,
+        profile_status="disabled",
+        arsenal_entries=(),
+        taxonomy_version=TAXONOMY_VERSION,
+        profile_version=PROFILE_VERSION,
+        diagnostic_codes=(
+            "pitcher_arsenal_profile_disabled",
+        ),
+        validation_errors=(),
+    )
+
+
+def build_pitcher_arsenal_profile(
+    payload: Mapping[str, Any],
+) -> PitcherArsenalProfile:
+    copied_payload = dict(payload)
+
+    if not bool(
+        copied_payload.get(
+            "enabled",
+            False,
+        )
+    ):
+        return _disabled_profile(
+            copied_payload
+        )
+
+    validation_errors: list[str] = []
+    diagnostic_codes: list[str] = []
+
+    pitcher_id_raw = copied_payload.get(
+        "pitcher_id"
+    )
+    pitcher_id = (
+        str(pitcher_id_raw).strip()
+        if pitcher_id_raw is not None
+        else ""
+    )
+
+    if not pitcher_id:
+        validation_errors.append(
+            "pitcher_arsenal_pitcher_identity_missing"
+        )
+
+    pitcher_name_raw = copied_payload.get(
+        "pitcher_name"
+    )
+    pitcher_name = (
+        str(pitcher_name_raw).strip()
+        if pitcher_name_raw is not None
+        else None
+    )
+
+    pitcher_hand = _normalize_hand(
+        copied_payload.get(
+            "pitcher_hand"
+        )
+    )
+
+    if pitcher_hand == "U":
+        diagnostic_codes.append(
+            "pitcher_arsenal_pitcher_hand_unknown"
+        )
+
+    pitcher_role = _normalize_role(
+        copied_payload.get(
+            "pitcher_role"
+        )
+    )
+
+    if pitcher_role == "unknown":
+        diagnostic_codes.append(
+            "pitcher_arsenal_pitcher_role_unknown"
+        )
+
+    try:
+        season = int(
+            copied_payload.get(
+                "season"
+            )
+        )
+    except (TypeError, ValueError):
+        season = 0
+
+    if season <= 0:
+        validation_errors.append(
+            "pitcher_arsenal_season_invalid"
+        )
+
+    as_of_date = _parse_date(
+        copied_payload.get(
+            "as_of_date_utc"
+        )
+    )
+
+    if as_of_date is None:
+        validation_errors.append(
+            "pitcher_arsenal_as_of_date_invalid"
+        )
+
+    source_name_raw = copied_payload.get(
+        "source_name"
+    )
+    source_name = (
+        str(source_name_raw).strip()
+        if source_name_raw is not None
+        else ""
+    )
+
+    if not source_name:
+        validation_errors.append(
+            "pitcher_arsenal_source_name_missing"
+        )
+
+    source_timestamp = _parse_datetime(
+        copied_payload.get(
+            "source_timestamp_utc"
+        )
+    )
+
+    source_priority = (
+        _source_priority(source_name)
+        if source_name
+        else 5
+    )
+
+    raw_entries = copied_payload.get(
+        "arsenal_entries",
+        [],
+    )
+
+    if not isinstance(
+        raw_entries,
+        Sequence,
+    ) or isinstance(
+        raw_entries,
+        (str, bytes),
+    ):
+        raw_entries = []
+        validation_errors.append(
+            "pitcher_arsenal_entries_invalid"
+        )
+
+    parsed_entries: list[
+        PitcherArsenalEntry
+    ] = []
+
+    seen_pitch_ids: set[str] = set()
+    total_pitch_count = 0
+
+    for raw_entry in raw_entries:
+        if not isinstance(
+            raw_entry,
+            Mapping,
+        ):
+            validation_errors.append(
+                "pitcher_arsenal_entry_invalid"
+            )
+            continue
+
+        canonical_pitch_id = str(
+            raw_entry.get(
+                "canonical_pitch_id",
+                "UN",
+            )
+        ).strip().upper()
+
+        if canonical_pitch_id not in CANONICAL_PITCHES:
+            canonical_pitch_id = "UN"
+            diagnostic_codes.append(
+                "pitcher_arsenal_unknown_pitch_retained"
+            )
+
+        if canonical_pitch_id in seen_pitch_ids:
+            validation_errors.append(
+                "pitcher_arsenal_duplicate_pitch"
+            )
+            continue
+
+        seen_pitch_ids.add(
+            canonical_pitch_id
+        )
+
+        canonical = CANONICAL_PITCHES[
+            canonical_pitch_id
+        ]
+
+        try:
+            pitch_count = int(
+                raw_entry.get(
+                    "pitch_count",
+                    0,
+                )
+            )
+        except (TypeError, ValueError):
+            pitch_count = -1
+
+        if pitch_count < 0:
+            validation_errors.append(
+                "pitcher_arsenal_pitch_count_invalid"
+            )
+            pitch_count = 0
+
+        total_pitch_count += pitch_count
+
+        usage_share = _rate_or_none(
+            raw_entry.get(
+                "usage_share"
+            )
+        )
+
+        entry_diagnostics: list[str] = []
+
+        if (
+            raw_entry.get("usage_share")
+            is not None
+            and usage_share is None
+        ):
+            entry_diagnostics.append(
+                "pitcher_arsenal_usage_share_invalid"
+            )
+            validation_errors.append(
+                "pitcher_arsenal_usage_share_invalid"
+            )
+
+        available = bool(
+            raw_entry.get(
+                "available",
+                pitch_count > 0,
+            )
+        )
+
+        if available and pitch_count == 0:
+            entry_diagnostics.append(
+                "pitcher_arsenal_available_without_pitches"
+            )
+            validation_errors.append(
+                "pitcher_arsenal_available_without_pitches"
+            )
+
+        if (
+            pitch_count
+            < ENTRY_MINIMUM_PITCH_COUNT
+        ):
+            entry_diagnostics.append(
+                "pitcher_arsenal_entry_sample_sparse"
+            )
+
+        parsed_entries.append(
+            PitcherArsenalEntry(
+                canonical_pitch_id=canonical.canonical_pitch_id,
+                canonical_pitch_name=canonical.canonical_name,
+                canonical_family=canonical.family,
+                available=available,
+                usage_share=usage_share,
+                pitch_count=pitch_count,
+                avg_velocity_mph=_positive_or_none(
+                    raw_entry.get(
+                        "avg_velocity_mph"
+                    )
+                ),
+                avg_spin_rpm=_nonnegative_or_none(
+                    raw_entry.get(
+                        "avg_spin_rpm"
+                    )
+                ),
+                avg_horizontal_break_inches=_finite_or_none(
+                    raw_entry.get(
+                        "avg_horizontal_break_inches"
+                    )
+                ),
+                avg_vertical_break_inches=_finite_or_none(
+                    raw_entry.get(
+                        "avg_vertical_break_inches"
+                    )
+                ),
+                avg_extension_feet=_positive_or_none(
+                    raw_entry.get(
+                        "avg_extension_feet"
+                    )
+                ),
+                zone_rate=_rate_or_none(
+                    raw_entry.get(
+                        "zone_rate"
+                    )
+                ),
+                chase_rate=_rate_or_none(
+                    raw_entry.get(
+                        "chase_rate"
+                    )
+                ),
+                whiff_rate=_rate_or_none(
+                    raw_entry.get(
+                        "whiff_rate"
+                    )
+                ),
+                called_strike_plus_whiff_rate=_rate_or_none(
+                    raw_entry.get(
+                        "called_strike_plus_whiff_rate"
+                    )
+                ),
+                command_index=_finite_or_none(
+                    raw_entry.get(
+                        "command_index"
+                    )
+                ),
+                quality_index=_finite_or_none(
+                    raw_entry.get(
+                        "quality_index"
+                    )
+                ),
+                diagnostic_codes=_sorted_unique_strings(
+                    entry_diagnostics
+                ),
+            )
+        )
+
+    if not parsed_entries:
+        diagnostic_codes.append(
+            "pitcher_arsenal_source_unavailable"
+        )
+
+    explicit_usage_present = any(
+        entry.usage_share is not None
+        for entry in parsed_entries
+    )
+
+    if (
+        parsed_entries
+        and not explicit_usage_present
+        and total_pitch_count > 0
+    ):
+        parsed_entries = [
+            PitcherArsenalEntry(
+                **{
+                    **entry.__dict__,
+                    "usage_share": round(
+                        entry.pitch_count
+                        / total_pitch_count,
+                        6,
+                    ),
+                }
+            )
+            for entry in parsed_entries
+        ]
+        diagnostic_codes.append(
+            "pitcher_arsenal_usage_derived_from_counts"
+        )
+
+    usage_values = [
+        entry.usage_share
+        for entry in parsed_entries
+        if entry.usage_share is not None
+    ]
+
+    usage_total = sum(
+        usage_values
+    )
+
+    if (
+        usage_values
+        and abs(
+            usage_total - 1.0
+        )
+        > USAGE_TOTAL_TOLERANCE
+    ):
+        validation_errors.append(
+            "pitcher_arsenal_usage_total_invalid"
+        )
+
+    parsed_entries.sort(
+        key=lambda entry: (
+            entry.usage_share is None,
+            -(
+                entry.usage_share
+                if entry.usage_share is not None
+                else 0.0
+            ),
+            -entry.pitch_count,
+            entry.canonical_pitch_id,
+        )
+    )
+
+    requested_sample_pitch_count = (
+        copied_payload.get(
+            "sample_pitch_count"
+        )
+    )
+
+    if requested_sample_pitch_count is None:
+        sample_pitch_count = total_pitch_count
+    else:
+        try:
+            sample_pitch_count = int(
+                requested_sample_pitch_count
+            )
+        except (TypeError, ValueError):
+            sample_pitch_count = -1
+
+    if sample_pitch_count < 0:
+        validation_errors.append(
+            "pitcher_arsenal_sample_pitch_count_invalid"
+        )
+        sample_pitch_count = 0
+
+    sample_game_count_raw = (
+        copied_payload.get(
+            "sample_game_count"
+        )
+    )
+
+    if sample_game_count_raw is None:
+        sample_game_count = None
+    else:
+        try:
+            sample_game_count = int(
+                sample_game_count_raw
+            )
+        except (TypeError, ValueError):
+            sample_game_count = -1
+
+        if sample_game_count < 0:
+            validation_errors.append(
+                "pitcher_arsenal_sample_game_count_invalid"
+            )
+            sample_game_count = None
+
+    stale = False
+
+    if (
+        as_of_date is not None
+        and source_timestamp is not None
+    ):
+        age_days = (
+            as_of_date
+            - source_timestamp.date()
+        ).days
+
+        if age_days < 0:
+            validation_errors.append(
+                "pitcher_arsenal_source_timestamp_future"
+            )
+        elif (
+            age_days
+            > CURRENT_PROFILE_MAXIMUM_AGE_DAYS
+        ):
+            stale = True
+            diagnostic_codes.append(
+                "pitcher_arsenal_profile_stale"
+            )
+    elif source_timestamp is None:
+        diagnostic_codes.append(
+            "pitcher_arsenal_source_timestamp_missing"
+        )
+
+    if validation_errors:
+        profile_status = "invalid"
+        reason = "profile_invalid"
+    elif not parsed_entries:
+        profile_status = "unavailable"
+        reason = "profile_unavailable"
+    elif stale:
+        profile_status = "stale"
+        reason = "profile_stale"
+    elif (
+        sample_pitch_count
+        < PROFILE_MINIMUM_PITCH_COUNT
+    ):
+        profile_status = "sparse"
+        reason = "profile_sparse"
+        diagnostic_codes.append(
+            "pitcher_arsenal_sample_sparse"
+        )
+    elif any(
+        entry.pitch_count
+        < ENTRY_MINIMUM_PITCH_COUNT
+        for entry in parsed_entries
+    ):
+        profile_status = "partial"
+        reason = "profile_partial"
+    else:
+        profile_status = "resolved"
+        reason = "profile_resolved"
+
+    return PitcherArsenalProfile(
+        emitted=True,
+        reason=reason,
+        pitcher_id=(
+            pitcher_id
+            if pitcher_id
+            else None
+        ),
+        pitcher_name=pitcher_name,
+        pitcher_hand=pitcher_hand,
+        pitcher_role=pitcher_role,
+        season=(
+            season
+            if season > 0
+            else None
+        ),
+        as_of_date_utc=(
+            as_of_date.isoformat()
+            if as_of_date is not None
+            else None
+        ),
+        source_name=(
+            source_name
+            if source_name
+            else None
+        ),
+        source_record_id=copied_payload.get(
+            "source_record_id"
+        ),
+        source_timestamp_utc=(
+            source_timestamp.isoformat()
+            if source_timestamp is not None
+            else None
+        ),
+        source_priority=source_priority,
+        sample_pitch_count=sample_pitch_count,
+        sample_game_count=sample_game_count,
+        profile_status=profile_status,
+        arsenal_entries=tuple(
+            parsed_entries
+        ),
+        taxonomy_version=TAXONOMY_VERSION,
+        profile_version=PROFILE_VERSION,
+        diagnostic_codes=_sorted_unique_strings(
+            diagnostic_codes
+        ),
+        validation_errors=_sorted_unique_strings(
+            validation_errors
+        ),
+    )

--- a/scripts/audit_8E_pitcher_arsenal_profile_contract.py
+++ b/scripts/audit_8E_pitcher_arsenal_profile_contract.py
@@ -1,0 +1,1139 @@
+#!/usr/bin/env python3
+"""
+Layer 8E pitcher arsenal profile implementation audit.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import csv
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from mlb_app.pitching.pitcher_arsenal_profile import (
+    PROFILE_VERSION,
+    build_pitcher_arsenal_profile,
+)
+
+
+LAYER_ID = "8E"
+LAYER_NAME = (
+    "pitcher_arsenal_profile_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_8E_pitcher_arsenal_profile_contract"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_8D_pitcher_arsenal_profile_contract.py"
+)
+
+IMPLEMENTATION_PATH = (
+    ROOT
+    / "mlb_app/pitching/"
+    "pitcher_arsenal_profile.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    predecessor_present = (
+        "pitcher_arsenal_profile_contract_plan_complete"
+        in string_constants(
+            PLAN_PATH
+        )
+    )
+
+    cases: list[dict[str, Any]] = []
+
+    def record(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        cases.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    current_timestamp = datetime(
+        2026,
+        6,
+        25,
+        tzinfo=timezone.utc,
+    )
+
+    base_payload = {
+        "enabled": True,
+        "pitcher_id": "pitcher-1",
+        "pitcher_name": "Example Pitcher",
+        "pitcher_hand": "R",
+        "pitcher_role": "starter",
+        "season": 2026,
+        "as_of_date_utc": "2026-06-30",
+        "source_name": "statcast",
+        "source_record_id": "arsenal-1",
+        "source_timestamp_utc": (
+            current_timestamp.isoformat()
+        ),
+        "sample_game_count": 12,
+        "arsenal_entries": [
+            {
+                "canonical_pitch_id": "FF",
+                "pitch_count": 60,
+                "avg_velocity_mph": 95.4,
+                "avg_spin_rpm": 2380,
+                "zone_rate": 0.53,
+                "whiff_rate": 0.24,
+            },
+            {
+                "canonical_pitch_id": "SL",
+                "pitch_count": 30,
+                "avg_velocity_mph": 86.7,
+                "avg_spin_rpm": 2500,
+                "zone_rate": 0.42,
+                "whiff_rate": 0.36,
+            },
+            {
+                "canonical_pitch_id": "CH",
+                "pitch_count": 10,
+                "avg_velocity_mph": 88.1,
+                "zone_rate": 0.47,
+                "whiff_rate": 0.28,
+            },
+        ],
+    }
+
+    resolved = build_pitcher_arsenal_profile(
+        base_payload
+    )
+
+    record(
+        "8E-C01",
+        "resolved profile emits",
+        resolved.emitted
+        and resolved.profile_status == "resolved",
+        resolved.to_dict(),
+        {
+            "emitted": True,
+            "profile_status": "resolved",
+        },
+    )
+
+    record(
+        "8E-C02",
+        "usage shares derive from counts",
+        [
+            entry.usage_share
+            for entry in resolved.arsenal_entries
+        ]
+        == [0.6, 0.3, 0.1],
+        [
+            entry.usage_share
+            for entry in resolved.arsenal_entries
+        ],
+        [0.6, 0.3, 0.1],
+    )
+
+    record(
+        "8E-C03",
+        "entries sort deterministically",
+        [
+            entry.canonical_pitch_id
+            for entry in resolved.arsenal_entries
+        ]
+        == ["FF", "SL", "CH"],
+        [
+            entry.canonical_pitch_id
+            for entry in resolved.arsenal_entries
+        ],
+        ["FF", "SL", "CH"],
+    )
+
+    disabled = build_pitcher_arsenal_profile(
+        {
+            "enabled": False,
+            "pitcher_id": "pitcher-1",
+            "source_name": "statcast",
+        }
+    )
+
+    record(
+        "8E-C04",
+        "disabled profile is non-emitting",
+        disabled.emitted is False
+        and disabled.profile_status == "disabled",
+        disabled.to_dict(),
+        {
+            "emitted": False,
+            "profile_status": "disabled",
+        },
+    )
+
+    sparse_payload = copy.deepcopy(
+        base_payload
+    )
+    sparse_payload["arsenal_entries"] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitch_count": 20,
+        }
+    ]
+
+    sparse = build_pitcher_arsenal_profile(
+        sparse_payload
+    )
+
+    record(
+        "8E-C05",
+        "sparse profile classified",
+        sparse.profile_status == "sparse",
+        sparse.profile_status,
+        "sparse",
+    )
+
+    stale_payload = copy.deepcopy(
+        base_payload
+    )
+    stale_payload[
+        "source_timestamp_utc"
+    ] = "2026-05-01T00:00:00+00:00"
+
+    stale = build_pitcher_arsenal_profile(
+        stale_payload
+    )
+
+    record(
+        "8E-C06",
+        "stale profile classified",
+        stale.profile_status == "stale",
+        stale.profile_status,
+        "stale",
+    )
+
+    unavailable_payload = copy.deepcopy(
+        base_payload
+    )
+    unavailable_payload[
+        "arsenal_entries"
+    ] = []
+
+    unavailable = (
+        build_pitcher_arsenal_profile(
+            unavailable_payload
+        )
+    )
+
+    record(
+        "8E-C07",
+        "missing source entries yield unavailable",
+        unavailable.profile_status
+        == "unavailable",
+        unavailable.profile_status,
+        "unavailable",
+    )
+
+    unknown_payload = copy.deepcopy(
+        base_payload
+    )
+    unknown_payload["arsenal_entries"] = [
+        {
+            "canonical_pitch_id": "ZZ",
+            "pitch_count": 100,
+        }
+    ]
+
+    unknown = build_pitcher_arsenal_profile(
+        unknown_payload
+    )
+
+    record(
+        "8E-C08",
+        "unknown pitch retained as UN",
+        unknown.arsenal_entries[0].canonical_pitch_id
+        == "UN",
+        unknown.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+        },
+    )
+
+    duplicate_payload = copy.deepcopy(
+        base_payload
+    )
+    duplicate_payload["arsenal_entries"] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitch_count": 50,
+        },
+        {
+            "canonical_pitch_id": "FF",
+            "pitch_count": 50,
+        },
+    ]
+
+    duplicate = build_pitcher_arsenal_profile(
+        duplicate_payload
+    )
+
+    record(
+        "8E-C09",
+        "duplicate pitch invalidates profile",
+        duplicate.profile_status == "invalid"
+        and (
+            "pitcher_arsenal_duplicate_pitch"
+            in duplicate.validation_errors
+        ),
+        duplicate.to_dict(),
+        {
+            "profile_status": "invalid",
+        },
+    )
+
+    invalid_usage_payload = copy.deepcopy(
+        base_payload
+    )
+    invalid_usage_payload[
+        "arsenal_entries"
+    ] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitch_count": 60,
+            "usage_share": 0.8,
+        },
+        {
+            "canonical_pitch_id": "SL",
+            "pitch_count": 40,
+            "usage_share": 0.4,
+        },
+    ]
+
+    invalid_usage = (
+        build_pitcher_arsenal_profile(
+            invalid_usage_payload
+        )
+    )
+
+    record(
+        "8E-C10",
+        "invalid usage total invalidates profile",
+        invalid_usage.profile_status
+        == "invalid"
+        and (
+            "pitcher_arsenal_usage_total_invalid"
+            in invalid_usage.validation_errors
+        ),
+        invalid_usage.to_dict(),
+        {
+            "profile_status": "invalid",
+        },
+    )
+
+    missing_identity_payload = (
+        copy.deepcopy(
+            base_payload
+        )
+    )
+    missing_identity_payload[
+        "pitcher_id"
+    ] = ""
+
+    missing_identity = (
+        build_pitcher_arsenal_profile(
+            missing_identity_payload
+        )
+    )
+
+    record(
+        "8E-C11",
+        "missing identity invalidates profile",
+        missing_identity.profile_status
+        == "invalid",
+        missing_identity.profile_status,
+        "invalid",
+    )
+
+    normalized_context_payload = (
+        copy.deepcopy(
+            base_payload
+        )
+    )
+    normalized_context_payload[
+        "pitcher_hand"
+    ] = "x"
+    normalized_context_payload[
+        "pitcher_role"
+    ] = "bulk"
+
+    normalized_context = (
+        build_pitcher_arsenal_profile(
+            normalized_context_payload
+        )
+    )
+
+    record(
+        "8E-C12",
+        "unsupported hand and role normalize safely",
+        normalized_context.pitcher_hand
+        == "U"
+        and normalized_context.pitcher_role
+        == "unknown",
+        {
+            "hand": (
+                normalized_context.pitcher_hand
+            ),
+            "role": (
+                normalized_context.pitcher_role
+            ),
+        },
+        {
+            "hand": "U",
+            "role": "unknown",
+        },
+    )
+
+    payload_before = copy.deepcopy(
+        base_payload
+    )
+
+    build_pitcher_arsenal_profile(
+        base_payload
+    )
+
+    record(
+        "8E-C13",
+        "caller payload remains immutable",
+        base_payload == payload_before,
+        base_payload,
+        payload_before,
+    )
+
+    repeated_a = (
+        build_pitcher_arsenal_profile(
+            base_payload
+        )
+    )
+    repeated_b = (
+        build_pitcher_arsenal_profile(
+            base_payload
+        )
+    )
+
+    record(
+        "8E-C14",
+        "profile construction deterministic",
+        repeated_a.to_dict()
+        == repeated_b.to_dict(),
+        repeated_a.to_dict(),
+        repeated_b.to_dict(),
+    )
+
+    record(
+        "8E-C15",
+        "provenance retained",
+        resolved.source_record_id
+        == "arsenal-1"
+        and resolved.source_timestamp_utc
+        == current_timestamp.isoformat(),
+        resolved.to_dict(),
+        {
+            "source_record_id": "arsenal-1",
+        },
+    )
+
+    record(
+        "8E-C16",
+        "source priority resolves",
+        resolved.source_priority == 1,
+        resolved.source_priority,
+        1,
+    )
+
+    record(
+        "8E-C17",
+        "taxonomy and profile versions explicit",
+        bool(resolved.taxonomy_version)
+        and resolved.profile_version
+        == PROFILE_VERSION,
+        {
+            "taxonomy_version": (
+                resolved.taxonomy_version
+            ),
+            "profile_version": (
+                resolved.profile_version
+            ),
+        },
+        {
+            "profile_version": "8E-v1",
+        },
+    )
+
+    record(
+        "8E-C18",
+        "diagnostic codes sorted and unique",
+        resolved.diagnostic_codes
+        == tuple(
+            sorted(
+                set(
+                    resolved.diagnostic_codes
+                )
+            )
+        ),
+        resolved.diagnostic_codes,
+        "sorted_unique",
+    )
+
+    record(
+        "8E-C19",
+        "entry diagnostic codes sorted and unique",
+        all(
+            entry.diagnostic_codes
+            == tuple(
+                sorted(
+                    set(
+                        entry.diagnostic_codes
+                    )
+                )
+            )
+            for entry in resolved.arsenal_entries
+        ),
+        [
+            entry.diagnostic_codes
+            for entry in resolved.arsenal_entries
+        ],
+        "sorted_unique",
+    )
+
+    record(
+        "8E-C20",
+        "production and simulation authority remain false",
+        all(
+            value is False
+            for value in [
+                resolved.production_authority,
+                resolved.production_behavior_changed,
+                resolved.simulation_behavior_changed,
+                resolved.pitch_selection_changed,
+                resolved.pitch_sequence_changed,
+                resolved.matchup_adjustment_activated,
+                resolved.contact_quality_changed,
+            ]
+        ),
+        resolved.to_dict(),
+        {
+            "all_authority_flags": False,
+        },
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+            "expected": True,
+            "passed": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+        },
+        {
+            "check": "eight_d_predecessor_present",
+            "actual": predecessor_present,
+            "expected": True,
+            "passed": predecessor_present,
+        },
+        {
+            "check": "twenty_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in cases
+                if row["passed"]
+            ),
+            "expected": 20,
+            "passed": all(
+                row["passed"]
+                for row in cases
+            ),
+        },
+        {
+            "check": "resolved_profile_supported",
+            "actual": resolved.profile_status,
+            "expected": "resolved",
+            "passed": (
+                resolved.profile_status
+                == "resolved"
+            ),
+        },
+        {
+            "check": "derived_usage_sums_to_one",
+            "actual": round(
+                sum(
+                    entry.usage_share or 0.0
+                    for entry in resolved.arsenal_entries
+                ),
+                6,
+            ),
+            "expected": 1.0,
+            "passed": abs(
+                sum(
+                    entry.usage_share or 0.0
+                    for entry in resolved.arsenal_entries
+                )
+                - 1.0
+            )
+            <= 0.001,
+        },
+        {
+            "check": "ordering_deterministic",
+            "actual": [
+                entry.canonical_pitch_id
+                for entry in resolved.arsenal_entries
+            ],
+            "expected": [
+                "FF",
+                "SL",
+                "CH",
+            ],
+            "passed": [
+                entry.canonical_pitch_id
+                for entry in resolved.arsenal_entries
+            ]
+            == [
+                "FF",
+                "SL",
+                "CH",
+            ],
+        },
+        {
+            "check": "disabled_path_non_emitting",
+            "actual": disabled.emitted,
+            "expected": False,
+            "passed": disabled.emitted is False,
+        },
+        {
+            "check": "sparse_status_supported",
+            "actual": sparse.profile_status,
+            "expected": "sparse",
+            "passed": (
+                sparse.profile_status
+                == "sparse"
+            ),
+        },
+        {
+            "check": "stale_status_supported",
+            "actual": stale.profile_status,
+            "expected": "stale",
+            "passed": (
+                stale.profile_status
+                == "stale"
+            ),
+        },
+        {
+            "check": "unavailable_status_supported",
+            "actual": (
+                unavailable.profile_status
+            ),
+            "expected": "unavailable",
+            "passed": (
+                unavailable.profile_status
+                == "unavailable"
+            ),
+        },
+        {
+            "check": "unknown_pitch_retained_as_UN",
+            "actual": (
+                unknown.arsenal_entries[
+                    0
+                ].canonical_pitch_id
+            ),
+            "expected": "UN",
+            "passed": (
+                unknown.arsenal_entries[
+                    0
+                ].canonical_pitch_id
+                == "UN"
+            ),
+        },
+        {
+            "check": "invalid_profiles_detected",
+            "actual": [
+                duplicate.profile_status,
+                invalid_usage.profile_status,
+                missing_identity.profile_status,
+            ],
+            "expected": [
+                "invalid",
+                "invalid",
+                "invalid",
+            ],
+            "passed": [
+                duplicate.profile_status,
+                invalid_usage.profile_status,
+                missing_identity.profile_status,
+            ]
+            == [
+                "invalid",
+                "invalid",
+                "invalid",
+            ],
+        },
+        {
+            "check": "caller_payload_immutable",
+            "actual": (
+                base_payload
+                == payload_before
+            ),
+            "expected": True,
+            "passed": (
+                base_payload
+                == payload_before
+            ),
+        },
+        {
+            "check": "construction_deterministic",
+            "actual": (
+                repeated_a.to_dict()
+                == repeated_b.to_dict()
+            ),
+            "expected": True,
+            "passed": (
+                repeated_a.to_dict()
+                == repeated_b.to_dict()
+            ),
+        },
+        {
+            "check": "provenance_retained",
+            "actual": (
+                resolved.source_record_id
+                == "arsenal-1"
+            ),
+            "expected": True,
+            "passed": (
+                resolved.source_record_id
+                == "arsenal-1"
+            ),
+        },
+        {
+            "check": "production_behavior_unchanged",
+            "actual": (
+                resolved.production_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                resolved.production_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "simulation_behavior_unchanged",
+            "actual": (
+                resolved.simulation_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                resolved.simulation_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "pitch_selection_sequence_matchup_contact_authority_absent",
+            "actual": any(
+                [
+                    resolved.pitch_selection_changed,
+                    resolved.pitch_sequence_changed,
+                    resolved.matchup_adjustment_activated,
+                    resolved.contact_quality_changed,
+                ]
+            ),
+            "expected": False,
+            "passed": all(
+                value is False
+                for value in [
+                    resolved.pitch_selection_changed,
+                    resolved.pitch_sequence_changed,
+                    resolved.matchup_adjustment_activated,
+                    resolved.contact_quality_changed,
+                ]
+            ),
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    authority_rows = [
+        {
+            "authority": (
+                "pitcher_arsenal_profile_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "The deterministic diagnostic arsenal profile passed all checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_pitcher_arsenal_integration"
+            ),
+            "granted": False,
+            "reason": (
+                "Arsenal profiles remain diagnostic-only."
+            ),
+        },
+        {
+            "authority": (
+                "production_pitch_selection"
+            ),
+            "granted": False,
+            "reason": (
+                "No production pitch selection is changed."
+            ),
+        },
+        {
+            "authority": (
+                "pitch_sequence_change"
+            ),
+            "granted": False,
+            "reason": (
+                "No pitch sequencing behavior is changed."
+            ),
+        },
+        {
+            "authority": (
+                "matchup_or_contact_adjustment"
+            ),
+            "granted": False,
+            "reason": (
+                "No matchup or contact-quality authority is granted."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation_tuning_pricing_edge"
+            ),
+            "granted": False,
+            "reason": (
+                "Validation, tuning, pricing, and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    diagnosis_name = (
+        "pitcher_arsenal_profile_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "pitcher_arsenal_profile_contract_implementation_failed"
+    )
+
+    recommended_next_layer = (
+        "8F_batter_pitch_type_response_profile_contract_plan"
+        if all_checks_passed
+        else
+        "8E_pitcher_arsenal_profile_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        cases,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "resolved_arsenal_entries.csv",
+        [
+            "canonical_pitch_id",
+            "canonical_pitch_name",
+            "canonical_family",
+            "available",
+            "usage_share",
+            "pitch_count",
+            "avg_velocity_mph",
+            "avg_spin_rpm",
+            "zone_rate",
+            "whiff_rate",
+            "diagnostic_codes",
+        ],
+        [
+            {
+                "canonical_pitch_id": (
+                    entry.canonical_pitch_id
+                ),
+                "canonical_pitch_name": (
+                    entry.canonical_pitch_name
+                ),
+                "canonical_family": (
+                    entry.canonical_family
+                ),
+                "available": entry.available,
+                "usage_share": entry.usage_share,
+                "pitch_count": entry.pitch_count,
+                "avg_velocity_mph": (
+                    entry.avg_velocity_mph
+                ),
+                "avg_spin_rpm": (
+                    entry.avg_spin_rpm
+                ),
+                "zone_rate": entry.zone_rate,
+                "whiff_rate": entry.whiff_rate,
+                "diagnostic_codes": "|".join(
+                    entry.diagnostic_codes
+                ),
+            }
+            for entry in resolved.arsenal_entries
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan the bounded batter pitch-type response profile contract."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 8E implementation checks."
+                ),
+                "entry_condition": (
+                    "All eighteen 8E implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            cases
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in cases
+            if row["passed"]
+        ),
+        "profile_version": PROFILE_VERSION,
+        "resolved_profile_supported": True,
+        "partial_sparse_stale_unavailable_invalid_supported": True,
+        "deterministic_usage_derivation_implemented": True,
+        "deterministic_ordering_implemented": True,
+        "unknown_pitch_retention_implemented": True,
+        "disabled_path_non_emitting": True,
+        "caller_payload_immutable": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "pitch_selection_changed": False,
+        "pitch_sequence_changed": False,
+        "matchup_adjustments_activated": False,
+        "contact_quality_changed": False,
+        "historical_outcome_joined": False,
+        "historical_validation_executed": False,
+        "tuning_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer8_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "batter_pitch_type_response_profile_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_pitcher_arsenal_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / filename
+            )
+            for filename in [
+                "implementation_checks.csv",
+                "contract_cases.csv",
+                "resolved_arsenal_entries.csv",
+                "authority_boundaries.csv",
+                "recommended_path.csv",
+            ]
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
8E — Pitcher Arsenal Profile Contract Implementation

## Objective
Implement and audit deterministic diagnostic pitcher arsenal profiles using the Layer 8C taxonomy and Layer 8D contract.

## Results
- 18/18 implementation checks pass
- 20/20 contract cases pass
- profile version `8E-v1`
- deterministic usage derivation and ordering implemented
- resolved, partial, sparse, stale, unavailable, and invalid statuses supported
- unknown pitch classifications retained as canonical `UN`
- disabled path is non-emitting
- bounded provenance retained
- caller payload remains immutable
- production and simulation behavior remain unchanged
- no new production authority granted

## Diagnosis
`pitcher_arsenal_profile_contract_implementation_passed`

## Recommended Next Layer
`8F_batter_pitch_type_response_profile_contract_plan`