### PR TITLE
Layer 8G: Batter Pitch-Type Response Profile Contract Implementation

### DIFF
--- a/mlb_app/pitching/batter_pitch_type_response_profile.py
+++ b/mlb_app/pitching/batter_pitch_type_response_profile.py
@@ -1,0 +1,996 @@
+"""
+Diagnostic-only batter pitch-type response profile contract.
+
+Builds deterministic, immutable batter response profiles by canonical pitch
+type, pitcher handedness, and count context.
+
+This module does not:
+- alter pitch selection or sequencing;
+- activate production pitcher-batter matchup adjustments;
+- alter swing, whiff, contact, batted-ball, or plate-appearance probabilities;
+- alter simulation state, parameters, or outcomes;
+- grant production authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+import math
+from typing import Any, Mapping, Sequence
+
+from mlb_app.pitching.canonical_pitch_taxonomy import (
+    CANONICAL_PITCHES,
+    TAXONOMY_VERSION,
+)
+
+
+PROFILE_VERSION = "8G-v1"
+PROFILE_MINIMUM_PITCH_COUNT = 100
+ENTRY_MINIMUM_PITCH_COUNT = 25
+CURRENT_PROFILE_MAXIMUM_AGE_DAYS = 14
+BATTED_BALL_RATE_SUM_TOLERANCE = 0.001
+
+SUPPORTED_BATTER_HANDS = frozenset(
+    {"R", "L", "S", "U"}
+)
+SUPPORTED_PITCHER_HANDS = frozenset(
+    {"R", "L", "U"}
+)
+SUPPORTED_COUNT_CONTEXTS = frozenset(
+    {
+        "all_counts",
+        "ahead",
+        "even",
+        "behind",
+        "two_strike",
+        "first_pitch",
+        "unknown",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BatterPitchTypeResponseEntry:
+    canonical_pitch_id: str
+    canonical_pitch_name: str
+    canonical_family: str
+    pitcher_hand: str
+    count_context: str
+    pitch_count: int
+    swing_count: int | None
+    contact_count: int | None
+    batted_ball_count: int | None
+    swing_rate: float | None
+    chase_rate: float | None
+    zone_swing_rate: float | None
+    whiff_rate: float | None
+    contact_rate: float | None
+    called_strike_plus_whiff_rate: float | None
+    avg_exit_velocity_mph: float | None
+    avg_launch_angle_degrees: float | None
+    hard_hit_rate: float | None
+    barrel_rate: float | None
+    ground_ball_rate: float | None
+    line_drive_rate: float | None
+    fly_ball_rate: float | None
+    popup_rate: float | None
+    response_index: float | None
+    diagnostic_codes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class BatterPitchTypeResponseProfile:
+    emitted: bool
+    reason: str
+    batter_id: str | None
+    batter_name: str | None
+    batter_hand: str | None
+    season: int | None
+    as_of_date_utc: str | None
+    source_name: str | None
+    source_record_id: str | None
+    source_timestamp_utc: str | None
+    source_priority: int | None
+    sample_pitch_count: int
+    sample_plate_appearance_count: int | None
+    profile_status: str
+    response_entries: tuple[
+        BatterPitchTypeResponseEntry,
+        ...,
+    ]
+    taxonomy_version: str
+    profile_version: str
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+    pitch_selection_changed: bool = False
+    pitch_sequence_changed: bool = False
+    matchup_adjustment_activated: bool = False
+    swing_probability_changed: bool = False
+    whiff_probability_changed: bool = False
+    contact_probability_changed: bool = False
+    batted_ball_probability_changed: bool = False
+    contact_quality_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["response_entries"] = [
+            entry.to_dict()
+            for entry in self.response_entries
+        ]
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        payload["validation_errors"] = list(
+            self.validation_errors
+        )
+        return payload
+
+
+def _sorted_unique_strings(
+    values: Sequence[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for value in values
+                if isinstance(value, str)
+                and value
+            }
+        )
+    )
+
+
+def _finite_or_none(
+    value: Any,
+) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        converted = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(converted):
+        return None
+
+    return converted
+
+
+def _rate_or_none(
+    value: Any,
+) -> float | None:
+    converted = _finite_or_none(
+        value
+    )
+
+    if converted is None:
+        return None
+
+    if not 0.0 <= converted <= 1.0:
+        return None
+
+    return converted
+
+
+def _positive_or_none(
+    value: Any,
+) -> float | None:
+    converted = _finite_or_none(
+        value
+    )
+
+    if (
+        converted is None
+        or converted <= 0.0
+    ):
+        return None
+
+    return converted
+
+
+def _nonnegative_int_or_none(
+    value: Any,
+) -> int | None:
+    if value is None:
+        return None
+
+    try:
+        converted = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    if converted < 0:
+        return None
+
+    return converted
+
+
+def _normalize_batter_hand(
+    value: Any,
+) -> str:
+    normalized = str(
+        value or "U"
+    ).strip().upper()
+
+    if normalized not in SUPPORTED_BATTER_HANDS:
+        return "U"
+
+    return normalized
+
+
+def _normalize_pitcher_hand(
+    value: Any,
+) -> str:
+    normalized = str(
+        value or "U"
+    ).strip().upper()
+
+    if normalized not in SUPPORTED_PITCHER_HANDS:
+        return "U"
+
+    return normalized
+
+
+def _normalize_count_context(
+    value: Any,
+) -> str:
+    normalized = str(
+        value or "unknown"
+    ).strip().lower()
+
+    if normalized not in SUPPORTED_COUNT_CONTEXTS:
+        return "unknown"
+
+    return normalized
+
+
+def _parse_date(
+    value: Any,
+) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+
+    if isinstance(value, date):
+        return value
+
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(
+                value[:10]
+            )
+        except ValueError:
+            return None
+
+    return None
+
+
+def _parse_datetime(
+    value: Any,
+) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(
+                value
+            )
+        except ValueError:
+            return None
+
+    return None
+
+
+def _source_priority(
+    source_name: str,
+) -> int:
+    normalized = source_name.strip().lower()
+
+    if normalized in {
+        "statcast",
+        "statcast_pitch_level_batter_aggregate",
+        "baseball_savant",
+        "baseball savant",
+    }:
+        return 1
+
+    if normalized in {
+        "trusted_provider",
+        "trusted_provider_pitch_type_split",
+        "provider",
+    }:
+        return 2
+
+    if normalized in {
+        "repository_cache",
+        "repository_cached_batter_response_profile",
+        "cache",
+    }:
+        return 3
+
+    if normalized in {
+        "season_summary",
+        "season_level_pitch_family_summary",
+    }:
+        return 4
+
+    return 5
+
+
+def _disabled_profile(
+    payload: Mapping[str, Any],
+) -> BatterPitchTypeResponseProfile:
+    return BatterPitchTypeResponseProfile(
+        emitted=False,
+        reason="profile_disabled",
+        batter_id=payload.get(
+            "batter_id"
+        ),
+        batter_name=payload.get(
+            "batter_name"
+        ),
+        batter_hand=None,
+        season=None,
+        as_of_date_utc=None,
+        source_name=payload.get(
+            "source_name"
+        ),
+        source_record_id=payload.get(
+            "source_record_id"
+        ),
+        source_timestamp_utc=None,
+        source_priority=None,
+        sample_pitch_count=0,
+        sample_plate_appearance_count=None,
+        profile_status="disabled",
+        response_entries=(),
+        taxonomy_version=TAXONOMY_VERSION,
+        profile_version=PROFILE_VERSION,
+        diagnostic_codes=(
+            "batter_pitch_response_profile_disabled",
+        ),
+        validation_errors=(),
+    )
+
+
+def build_batter_pitch_type_response_profile(
+    payload: Mapping[str, Any],
+) -> BatterPitchTypeResponseProfile:
+    copied_payload = dict(payload)
+
+    if not bool(
+        copied_payload.get(
+            "enabled",
+            False,
+        )
+    ):
+        return _disabled_profile(
+            copied_payload
+        )
+
+    validation_errors: list[str] = []
+    diagnostic_codes: list[str] = []
+
+    batter_id_raw = copied_payload.get(
+        "batter_id"
+    )
+    batter_id = (
+        str(batter_id_raw).strip()
+        if batter_id_raw is not None
+        else ""
+    )
+
+    if not batter_id:
+        validation_errors.append(
+            "batter_pitch_response_batter_identity_missing"
+        )
+
+    batter_name_raw = copied_payload.get(
+        "batter_name"
+    )
+    batter_name = (
+        str(batter_name_raw).strip()
+        if batter_name_raw is not None
+        else None
+    )
+
+    batter_hand = _normalize_batter_hand(
+        copied_payload.get(
+            "batter_hand"
+        )
+    )
+
+    if batter_hand == "U":
+        diagnostic_codes.append(
+            "batter_pitch_response_batter_hand_unknown"
+        )
+
+    try:
+        season = int(
+            copied_payload.get(
+                "season"
+            )
+        )
+    except (TypeError, ValueError):
+        season = 0
+
+    if season <= 0:
+        validation_errors.append(
+            "batter_pitch_response_season_invalid"
+        )
+
+    as_of_date = _parse_date(
+        copied_payload.get(
+            "as_of_date_utc"
+        )
+    )
+
+    if as_of_date is None:
+        validation_errors.append(
+            "batter_pitch_response_as_of_date_invalid"
+        )
+
+    source_name_raw = copied_payload.get(
+        "source_name"
+    )
+    source_name = (
+        str(source_name_raw).strip()
+        if source_name_raw is not None
+        else ""
+    )
+
+    if not source_name:
+        validation_errors.append(
+            "batter_pitch_response_source_name_missing"
+        )
+
+    source_timestamp = _parse_datetime(
+        copied_payload.get(
+            "source_timestamp_utc"
+        )
+    )
+
+    source_priority = (
+        _source_priority(source_name)
+        if source_name
+        else 5
+    )
+
+    raw_entries = copied_payload.get(
+        "response_entries",
+        [],
+    )
+
+    if not isinstance(
+        raw_entries,
+        Sequence,
+    ) or isinstance(
+        raw_entries,
+        (str, bytes),
+    ):
+        raw_entries = []
+        validation_errors.append(
+            "batter_pitch_response_entries_invalid"
+        )
+
+    parsed_entries: list[
+        BatterPitchTypeResponseEntry
+    ] = []
+
+    seen_keys: set[
+        tuple[str, str, str]
+    ] = set()
+
+    total_pitch_count = 0
+
+    rate_fields = (
+        "swing_rate",
+        "chase_rate",
+        "zone_swing_rate",
+        "whiff_rate",
+        "contact_rate",
+        "called_strike_plus_whiff_rate",
+        "hard_hit_rate",
+        "barrel_rate",
+        "ground_ball_rate",
+        "line_drive_rate",
+        "fly_ball_rate",
+        "popup_rate",
+    )
+
+    for raw_entry in raw_entries:
+        if not isinstance(
+            raw_entry,
+            Mapping,
+        ):
+            validation_errors.append(
+                "batter_pitch_response_entry_invalid"
+            )
+            continue
+
+        canonical_pitch_id = str(
+            raw_entry.get(
+                "canonical_pitch_id",
+                "UN",
+            )
+        ).strip().upper()
+
+        if canonical_pitch_id not in CANONICAL_PITCHES:
+            canonical_pitch_id = "UN"
+            diagnostic_codes.append(
+                "batter_pitch_response_unknown_pitch_retained"
+            )
+
+        pitcher_hand = _normalize_pitcher_hand(
+            raw_entry.get(
+                "pitcher_hand"
+            )
+        )
+        count_context = _normalize_count_context(
+            raw_entry.get(
+                "count_context"
+            )
+        )
+
+        entry_key = (
+            canonical_pitch_id,
+            pitcher_hand,
+            count_context,
+        )
+
+        if entry_key in seen_keys:
+            validation_errors.append(
+                "batter_pitch_response_duplicate_entry"
+            )
+            continue
+
+        seen_keys.add(
+            entry_key
+        )
+
+        canonical = CANONICAL_PITCHES[
+            canonical_pitch_id
+        ]
+
+        try:
+            pitch_count = int(
+                raw_entry.get(
+                    "pitch_count",
+                    0,
+                )
+            )
+        except (TypeError, ValueError):
+            pitch_count = -1
+
+        if pitch_count < 0:
+            validation_errors.append(
+                "batter_pitch_response_pitch_count_invalid"
+            )
+            pitch_count = 0
+
+        total_pitch_count += pitch_count
+
+        swing_count = _nonnegative_int_or_none(
+            raw_entry.get(
+                "swing_count"
+            )
+        )
+        contact_count = _nonnegative_int_or_none(
+            raw_entry.get(
+                "contact_count"
+            )
+        )
+        batted_ball_count = _nonnegative_int_or_none(
+            raw_entry.get(
+                "batted_ball_count"
+            )
+        )
+
+        for field_name, field_value in (
+            (
+                "swing_count",
+                swing_count,
+            ),
+            (
+                "contact_count",
+                contact_count,
+            ),
+            (
+                "batted_ball_count",
+                batted_ball_count,
+            ),
+        ):
+            if (
+                raw_entry.get(field_name)
+                is not None
+                and field_value is None
+            ):
+                validation_errors.append(
+                    f"batter_pitch_response_{field_name}_invalid"
+                )
+
+        if (
+            swing_count is not None
+            and swing_count > pitch_count
+        ):
+            validation_errors.append(
+                "batter_pitch_response_swing_count_exceeds_pitch_count"
+            )
+
+        if (
+            contact_count is not None
+            and swing_count is not None
+            and contact_count > swing_count
+        ):
+            validation_errors.append(
+                "batter_pitch_response_contact_count_exceeds_swing_count"
+            )
+
+        if (
+            batted_ball_count is not None
+            and contact_count is not None
+            and batted_ball_count > contact_count
+        ):
+            validation_errors.append(
+                "batter_pitch_response_batted_ball_count_exceeds_contact_count"
+            )
+
+        parsed_rates: dict[
+            str,
+            float | None,
+        ] = {}
+
+        entry_diagnostics: list[str] = []
+
+        for field_name in rate_fields:
+            parsed_value = _rate_or_none(
+                raw_entry.get(
+                    field_name
+                )
+            )
+            parsed_rates[field_name] = (
+                parsed_value
+            )
+
+            if (
+                raw_entry.get(field_name)
+                is not None
+                and parsed_value is None
+            ):
+                validation_errors.append(
+                    f"batter_pitch_response_{field_name}_invalid"
+                )
+                entry_diagnostics.append(
+                    f"batter_pitch_response_{field_name}_invalid"
+                )
+
+        if (
+            parsed_rates["whiff_rate"]
+            is not None
+            and (
+                swing_count is None
+                or swing_count == 0
+            )
+        ):
+            validation_errors.append(
+                "batter_pitch_response_whiff_without_swing_support"
+            )
+
+        if (
+            parsed_rates["contact_rate"]
+            is not None
+            and (
+                swing_count is None
+                or swing_count == 0
+            )
+        ):
+            validation_errors.append(
+                "batter_pitch_response_contact_without_swing_support"
+            )
+
+        batted_ball_rates = [
+            parsed_rates[
+                "ground_ball_rate"
+            ],
+            parsed_rates[
+                "line_drive_rate"
+            ],
+            parsed_rates[
+                "fly_ball_rate"
+            ],
+            parsed_rates[
+                "popup_rate"
+            ],
+        ]
+
+        if (
+            any(
+                value is not None
+                for value in batted_ball_rates
+            )
+            and (
+                batted_ball_count is None
+                or batted_ball_count == 0
+            )
+        ):
+            validation_errors.append(
+                "batter_pitch_response_batted_ball_rates_without_support"
+            )
+
+        batted_ball_rate_total = sum(
+            value or 0.0
+            for value in batted_ball_rates
+        )
+
+        if (
+            batted_ball_rate_total
+            > 1.0
+            + BATTED_BALL_RATE_SUM_TOLERANCE
+        ):
+            validation_errors.append(
+                "batter_pitch_response_batted_ball_rate_total_invalid"
+            )
+
+        if pitcher_hand == "U":
+            entry_diagnostics.append(
+                "batter_pitch_response_pitcher_hand_unknown"
+            )
+
+        if count_context == "unknown":
+            entry_diagnostics.append(
+                "batter_pitch_response_count_context_unknown"
+            )
+
+        if (
+            pitch_count
+            < ENTRY_MINIMUM_PITCH_COUNT
+        ):
+            entry_diagnostics.append(
+                "batter_pitch_response_entry_sample_sparse"
+            )
+
+        parsed_entries.append(
+            BatterPitchTypeResponseEntry(
+                canonical_pitch_id=canonical.canonical_pitch_id,
+                canonical_pitch_name=canonical.canonical_name,
+                canonical_family=canonical.family,
+                pitcher_hand=pitcher_hand,
+                count_context=count_context,
+                pitch_count=pitch_count,
+                swing_count=swing_count,
+                contact_count=contact_count,
+                batted_ball_count=batted_ball_count,
+                swing_rate=parsed_rates[
+                    "swing_rate"
+                ],
+                chase_rate=parsed_rates[
+                    "chase_rate"
+                ],
+                zone_swing_rate=parsed_rates[
+                    "zone_swing_rate"
+                ],
+                whiff_rate=parsed_rates[
+                    "whiff_rate"
+                ],
+                contact_rate=parsed_rates[
+                    "contact_rate"
+                ],
+                called_strike_plus_whiff_rate=parsed_rates[
+                    "called_strike_plus_whiff_rate"
+                ],
+                avg_exit_velocity_mph=_positive_or_none(
+                    raw_entry.get(
+                        "avg_exit_velocity_mph"
+                    )
+                ),
+                avg_launch_angle_degrees=_finite_or_none(
+                    raw_entry.get(
+                        "avg_launch_angle_degrees"
+                    )
+                ),
+                hard_hit_rate=parsed_rates[
+                    "hard_hit_rate"
+                ],
+                barrel_rate=parsed_rates[
+                    "barrel_rate"
+                ],
+                ground_ball_rate=parsed_rates[
+                    "ground_ball_rate"
+                ],
+                line_drive_rate=parsed_rates[
+                    "line_drive_rate"
+                ],
+                fly_ball_rate=parsed_rates[
+                    "fly_ball_rate"
+                ],
+                popup_rate=parsed_rates[
+                    "popup_rate"
+                ],
+                response_index=_finite_or_none(
+                    raw_entry.get(
+                        "response_index"
+                    )
+                ),
+                diagnostic_codes=_sorted_unique_strings(
+                    entry_diagnostics
+                ),
+            )
+        )
+
+    if not parsed_entries:
+        diagnostic_codes.append(
+            "batter_pitch_response_source_unavailable"
+        )
+
+    parsed_entries.sort(
+        key=lambda entry: (
+            -entry.pitch_count,
+            entry.canonical_pitch_id,
+            entry.pitcher_hand,
+            entry.count_context,
+        )
+    )
+
+    requested_sample_pitch_count = (
+        copied_payload.get(
+            "sample_pitch_count"
+        )
+    )
+
+    if requested_sample_pitch_count is None:
+        sample_pitch_count = total_pitch_count
+    else:
+        try:
+            sample_pitch_count = int(
+                requested_sample_pitch_count
+            )
+        except (TypeError, ValueError):
+            sample_pitch_count = -1
+
+    if sample_pitch_count < 0:
+        validation_errors.append(
+            "batter_pitch_response_sample_pitch_count_invalid"
+        )
+        sample_pitch_count = 0
+
+    sample_pa_raw = copied_payload.get(
+        "sample_plate_appearance_count"
+    )
+
+    if sample_pa_raw is None:
+        sample_pa_count = None
+    else:
+        try:
+            sample_pa_count = int(
+                sample_pa_raw
+            )
+        except (TypeError, ValueError):
+            sample_pa_count = -1
+
+        if sample_pa_count < 0:
+            validation_errors.append(
+                "batter_pitch_response_sample_pa_count_invalid"
+            )
+            sample_pa_count = None
+
+    stale = False
+
+    if (
+        as_of_date is not None
+        and source_timestamp is not None
+    ):
+        age_days = (
+            as_of_date
+            - source_timestamp.date()
+        ).days
+
+        if age_days < 0:
+            validation_errors.append(
+                "batter_pitch_response_source_timestamp_future"
+            )
+        elif (
+            age_days
+            > CURRENT_PROFILE_MAXIMUM_AGE_DAYS
+        ):
+            stale = True
+            diagnostic_codes.append(
+                "batter_pitch_response_profile_stale"
+            )
+    elif source_timestamp is None:
+        diagnostic_codes.append(
+            "batter_pitch_response_source_timestamp_missing"
+        )
+
+    if validation_errors:
+        profile_status = "invalid"
+        reason = "profile_invalid"
+    elif not parsed_entries:
+        profile_status = "unavailable"
+        reason = "profile_unavailable"
+    elif stale:
+        profile_status = "stale"
+        reason = "profile_stale"
+    elif (
+        sample_pitch_count
+        < PROFILE_MINIMUM_PITCH_COUNT
+    ):
+        profile_status = "sparse"
+        reason = "profile_sparse"
+        diagnostic_codes.append(
+            "batter_pitch_response_sample_sparse"
+        )
+    elif any(
+        entry.pitch_count
+        < ENTRY_MINIMUM_PITCH_COUNT
+        for entry in parsed_entries
+    ):
+        profile_status = "partial"
+        reason = "profile_partial"
+    else:
+        profile_status = "resolved"
+        reason = "profile_resolved"
+
+    return BatterPitchTypeResponseProfile(
+        emitted=True,
+        reason=reason,
+        batter_id=(
+            batter_id
+            if batter_id
+            else None
+        ),
+        batter_name=batter_name,
+        batter_hand=batter_hand,
+        season=(
+            season
+            if season > 0
+            else None
+        ),
+        as_of_date_utc=(
+            as_of_date.isoformat()
+            if as_of_date is not None
+            else None
+        ),
+        source_name=(
+            source_name
+            if source_name
+            else None
+        ),
+        source_record_id=copied_payload.get(
+            "source_record_id"
+        ),
+        source_timestamp_utc=(
+            source_timestamp.isoformat()
+            if source_timestamp is not None
+            else None
+        ),
+        source_priority=source_priority,
+        sample_pitch_count=sample_pitch_count,
+        sample_plate_appearance_count=(
+            sample_pa_count
+        ),
+        profile_status=profile_status,
+        response_entries=tuple(
+            parsed_entries
+        ),
+        taxonomy_version=TAXONOMY_VERSION,
+        profile_version=PROFILE_VERSION,
+        diagnostic_codes=_sorted_unique_strings(
+            diagnostic_codes
+        ),
+        validation_errors=_sorted_unique_strings(
+            validation_errors
+        ),
+    )

--- a/scripts/audit_8G_batter_pitch_type_response_profile_contract.py
+++ b/scripts/audit_8G_batter_pitch_type_response_profile_contract.py
@@ -1,0 +1,1280 @@
+#!/usr/bin/env python3
+"""
+Layer 8G batter pitch-type response implementation audit.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import csv
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from mlb_app.pitching.batter_pitch_type_response_profile import (
+    PROFILE_VERSION,
+    build_batter_pitch_type_response_profile,
+)
+
+
+LAYER_ID = "8G"
+LAYER_NAME = (
+    "batter_pitch_type_response_profile_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_8G_batter_pitch_type_response_profile_contract"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_8F_batter_pitch_type_response_profile_contract.py"
+)
+
+IMPLEMENTATION_PATH = (
+    ROOT
+    / "mlb_app/pitching/"
+    "batter_pitch_type_response_profile.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    predecessor_present = (
+        "batter_pitch_type_response_profile_contract_plan_complete"
+        in string_constants(
+            PLAN_PATH
+        )
+    )
+
+    cases: list[dict[str, Any]] = []
+
+    def record(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        cases.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    timestamp = datetime(
+        2026,
+        6,
+        25,
+        tzinfo=timezone.utc,
+    )
+
+    base_payload = {
+        "enabled": True,
+        "batter_id": "batter-1",
+        "batter_name": "Example Batter",
+        "batter_hand": "L",
+        "season": 2026,
+        "as_of_date_utc": "2026-06-30",
+        "source_name": "statcast",
+        "source_record_id": "response-1",
+        "source_timestamp_utc": (
+            timestamp.isoformat()
+        ),
+        "sample_plate_appearance_count": 75,
+        "response_entries": [
+            {
+                "canonical_pitch_id": "FF",
+                "pitcher_hand": "R",
+                "count_context": "all_counts",
+                "pitch_count": 60,
+                "swing_count": 30,
+                "contact_count": 24,
+                "batted_ball_count": 18,
+                "swing_rate": 0.5,
+                "whiff_rate": 0.2,
+                "contact_rate": 0.8,
+                "avg_exit_velocity_mph": 91.4,
+                "avg_launch_angle_degrees": 14.2,
+                "hard_hit_rate": 0.44,
+                "barrel_rate": 0.11,
+                "ground_ball_rate": 0.39,
+                "line_drive_rate": 0.22,
+                "fly_ball_rate": 0.33,
+                "popup_rate": 0.06,
+            },
+            {
+                "canonical_pitch_id": "SL",
+                "pitcher_hand": "R",
+                "count_context": "all_counts",
+                "pitch_count": 40,
+                "swing_count": 24,
+                "contact_count": 15,
+                "batted_ball_count": 10,
+                "swing_rate": 0.6,
+                "whiff_rate": 0.375,
+                "contact_rate": 0.625,
+                "avg_exit_velocity_mph": 87.8,
+                "avg_launch_angle_degrees": 9.3,
+                "hard_hit_rate": 0.30,
+                "barrel_rate": 0.05,
+                "ground_ball_rate": 0.50,
+                "line_drive_rate": 0.20,
+                "fly_ball_rate": 0.25,
+                "popup_rate": 0.05,
+            },
+        ],
+    }
+
+    resolved = (
+        build_batter_pitch_type_response_profile(
+            base_payload
+        )
+    )
+
+    record(
+        "8G-C01",
+        "resolved profile emits",
+        resolved.emitted
+        and resolved.profile_status
+        == "resolved",
+        resolved.to_dict(),
+        {
+            "emitted": True,
+            "profile_status": "resolved",
+        },
+    )
+
+    record(
+        "8G-C02",
+        "entries sort deterministically",
+        [
+            entry.canonical_pitch_id
+            for entry in resolved.response_entries
+        ]
+        == ["FF", "SL"],
+        [
+            entry.canonical_pitch_id
+            for entry in resolved.response_entries
+        ],
+        ["FF", "SL"],
+    )
+
+    disabled = (
+        build_batter_pitch_type_response_profile(
+            {
+                "enabled": False,
+                "batter_id": "batter-1",
+                "source_name": "statcast",
+            }
+        )
+    )
+
+    record(
+        "8G-C03",
+        "disabled profile is non-emitting",
+        disabled.emitted is False
+        and disabled.profile_status
+        == "disabled",
+        disabled.to_dict(),
+        {
+            "emitted": False,
+            "profile_status": "disabled",
+        },
+    )
+
+    sparse_payload = copy.deepcopy(
+        base_payload
+    )
+    sparse_payload["response_entries"] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 30,
+        }
+    ]
+
+    sparse = (
+        build_batter_pitch_type_response_profile(
+            sparse_payload
+        )
+    )
+
+    record(
+        "8G-C04",
+        "sparse profile classified",
+        sparse.profile_status == "sparse",
+        sparse.profile_status,
+        "sparse",
+    )
+
+    partial_payload = copy.deepcopy(
+        base_payload
+    )
+    partial_payload["response_entries"] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 90,
+        },
+        {
+            "canonical_pitch_id": "SL",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 10,
+        },
+    ]
+
+    partial = (
+        build_batter_pitch_type_response_profile(
+            partial_payload
+        )
+    )
+
+    record(
+        "8G-C05",
+        "partial profile classified",
+        partial.profile_status == "partial",
+        partial.profile_status,
+        "partial",
+    )
+
+    stale_payload = copy.deepcopy(
+        base_payload
+    )
+    stale_payload[
+        "source_timestamp_utc"
+    ] = "2026-05-01T00:00:00+00:00"
+
+    stale = (
+        build_batter_pitch_type_response_profile(
+            stale_payload
+        )
+    )
+
+    record(
+        "8G-C06",
+        "stale profile classified",
+        stale.profile_status == "stale",
+        stale.profile_status,
+        "stale",
+    )
+
+    unavailable_payload = copy.deepcopy(
+        base_payload
+    )
+    unavailable_payload[
+        "response_entries"
+    ] = []
+
+    unavailable = (
+        build_batter_pitch_type_response_profile(
+            unavailable_payload
+        )
+    )
+
+    record(
+        "8G-C07",
+        "missing entries yield unavailable",
+        unavailable.profile_status
+        == "unavailable",
+        unavailable.profile_status,
+        "unavailable",
+    )
+
+    unknown_payload = copy.deepcopy(
+        base_payload
+    )
+    unknown_payload["response_entries"] = [
+        {
+            "canonical_pitch_id": "ZZ",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 100,
+        }
+    ]
+
+    unknown = (
+        build_batter_pitch_type_response_profile(
+            unknown_payload
+        )
+    )
+
+    record(
+        "8G-C08",
+        "unknown pitch retained as UN",
+        unknown.response_entries[
+            0
+        ].canonical_pitch_id
+        == "UN",
+        unknown.to_dict(),
+        {
+            "canonical_pitch_id": "UN",
+        },
+    )
+
+    duplicate_payload = copy.deepcopy(
+        base_payload
+    )
+    duplicate_payload[
+        "response_entries"
+    ] = [
+        {
+            "canonical_pitch_id": "FF",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 50,
+        },
+        {
+            "canonical_pitch_id": "FF",
+            "pitcher_hand": "R",
+            "count_context": "all_counts",
+            "pitch_count": 50,
+        },
+    ]
+
+    duplicate = (
+        build_batter_pitch_type_response_profile(
+            duplicate_payload
+        )
+    )
+
+    record(
+        "8G-C09",
+        "duplicate response key invalidates profile",
+        duplicate.profile_status == "invalid"
+        and (
+            "batter_pitch_response_duplicate_entry"
+            in duplicate.validation_errors
+        ),
+        duplicate.to_dict(),
+        {
+            "profile_status": "invalid",
+        },
+    )
+
+    invalid_rate_payload = copy.deepcopy(
+        base_payload
+    )
+    invalid_rate_payload[
+        "response_entries"
+    ][0]["swing_rate"] = 1.2
+
+    invalid_rate = (
+        build_batter_pitch_type_response_profile(
+            invalid_rate_payload
+        )
+    )
+
+    record(
+        "8G-C10",
+        "invalid rate invalidates profile",
+        invalid_rate.profile_status
+        == "invalid",
+        invalid_rate.profile_status,
+        "invalid",
+    )
+
+    invalid_count_payload = copy.deepcopy(
+        base_payload
+    )
+    invalid_count_payload[
+        "response_entries"
+    ][0]["contact_count"] = 35
+
+    invalid_count = (
+        build_batter_pitch_type_response_profile(
+            invalid_count_payload
+        )
+    )
+
+    record(
+        "8G-C11",
+        "invalid count relationship invalidates profile",
+        invalid_count.profile_status
+        == "invalid",
+        invalid_count.profile_status,
+        "invalid",
+    )
+
+    invalid_batted_ball_payload = (
+        copy.deepcopy(
+            base_payload
+        )
+    )
+    invalid_batted_ball_payload[
+        "response_entries"
+    ][0]["ground_ball_rate"] = 0.8
+    invalid_batted_ball_payload[
+        "response_entries"
+    ][0]["line_drive_rate"] = 0.4
+
+    invalid_batted_ball = (
+        build_batter_pitch_type_response_profile(
+            invalid_batted_ball_payload
+        )
+    )
+
+    record(
+        "8G-C12",
+        "invalid batted-ball rate sum invalidates profile",
+        invalid_batted_ball.profile_status
+        == "invalid",
+        invalid_batted_ball.profile_status,
+        "invalid",
+    )
+
+    normalized_context_payload = (
+        copy.deepcopy(
+            base_payload
+        )
+    )
+    normalized_context_payload[
+        "batter_hand"
+    ] = "x"
+    normalized_context_payload[
+        "response_entries"
+    ][0]["pitcher_hand"] = "x"
+    normalized_context_payload[
+        "response_entries"
+    ][0]["count_context"] = "late"
+
+    normalized_context = (
+        build_batter_pitch_type_response_profile(
+            normalized_context_payload
+        )
+    )
+
+    record(
+        "8G-C13",
+        "unsupported context normalizes safely",
+        normalized_context.batter_hand
+        == "U"
+        and normalized_context.response_entries[
+            0
+        ].pitcher_hand
+        == "U"
+        and normalized_context.response_entries[
+            0
+        ].count_context
+        == "unknown",
+        {
+            "batter_hand": (
+                normalized_context.batter_hand
+            ),
+            "pitcher_hand": (
+                normalized_context.response_entries[
+                    0
+                ].pitcher_hand
+            ),
+            "count_context": (
+                normalized_context.response_entries[
+                    0
+                ].count_context
+            ),
+        },
+        {
+            "batter_hand": "U",
+            "pitcher_hand": "U",
+            "count_context": "unknown",
+        },
+    )
+
+    payload_before = copy.deepcopy(
+        base_payload
+    )
+
+    build_batter_pitch_type_response_profile(
+        base_payload
+    )
+
+    record(
+        "8G-C14",
+        "caller payload remains immutable",
+        base_payload == payload_before,
+        base_payload,
+        payload_before,
+    )
+
+    repeated_a = (
+        build_batter_pitch_type_response_profile(
+            base_payload
+        )
+    )
+    repeated_b = (
+        build_batter_pitch_type_response_profile(
+            base_payload
+        )
+    )
+
+    record(
+        "8G-C15",
+        "profile construction deterministic",
+        repeated_a.to_dict()
+        == repeated_b.to_dict(),
+        repeated_a.to_dict(),
+        repeated_b.to_dict(),
+    )
+
+    record(
+        "8G-C16",
+        "provenance retained",
+        resolved.source_record_id
+        == "response-1"
+        and resolved.source_timestamp_utc
+        == timestamp.isoformat(),
+        resolved.to_dict(),
+        {
+            "source_record_id": "response-1",
+        },
+    )
+
+    record(
+        "8G-C17",
+        "source priority resolves",
+        resolved.source_priority == 1,
+        resolved.source_priority,
+        1,
+    )
+
+    record(
+        "8G-C18",
+        "taxonomy and profile versions explicit",
+        bool(resolved.taxonomy_version)
+        and resolved.profile_version
+        == PROFILE_VERSION,
+        {
+            "taxonomy_version": (
+                resolved.taxonomy_version
+            ),
+            "profile_version": (
+                resolved.profile_version
+            ),
+        },
+        {
+            "profile_version": "8G-v1",
+        },
+    )
+
+    record(
+        "8G-C19",
+        "diagnostic codes sorted and unique",
+        resolved.diagnostic_codes
+        == tuple(
+            sorted(
+                set(
+                    resolved.diagnostic_codes
+                )
+            )
+        )
+        and all(
+            entry.diagnostic_codes
+            == tuple(
+                sorted(
+                    set(
+                        entry.diagnostic_codes
+                    )
+                )
+            )
+            for entry in resolved.response_entries
+        ),
+        {
+            "profile": (
+                resolved.diagnostic_codes
+            ),
+            "entries": [
+                entry.diagnostic_codes
+                for entry in resolved.response_entries
+            ],
+        },
+        "sorted_unique",
+    )
+
+    record(
+        "8G-C20",
+        "production and simulation authority remain false",
+        all(
+            value is False
+            for value in [
+                resolved.production_authority,
+                resolved.production_behavior_changed,
+                resolved.simulation_behavior_changed,
+                resolved.pitch_selection_changed,
+                resolved.pitch_sequence_changed,
+                resolved.matchup_adjustment_activated,
+                resolved.swing_probability_changed,
+                resolved.whiff_probability_changed,
+                resolved.contact_probability_changed,
+                resolved.batted_ball_probability_changed,
+                resolved.contact_quality_changed,
+            ]
+        ),
+        resolved.to_dict(),
+        {
+            "all_authority_flags": False,
+        },
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+            "expected": True,
+            "passed": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+        },
+        {
+            "check": "eight_f_predecessor_present",
+            "actual": predecessor_present,
+            "expected": True,
+            "passed": predecessor_present,
+        },
+        {
+            "check": "twenty_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in cases
+                if row["passed"]
+            ),
+            "expected": 20,
+            "passed": all(
+                row["passed"]
+                for row in cases
+            ),
+        },
+        {
+            "check": "resolved_profile_supported",
+            "actual": resolved.profile_status,
+            "expected": "resolved",
+            "passed": (
+                resolved.profile_status
+                == "resolved"
+            ),
+        },
+        {
+            "check": "deterministic_ordering_supported",
+            "actual": [
+                entry.canonical_pitch_id
+                for entry in resolved.response_entries
+            ],
+            "expected": ["FF", "SL"],
+            "passed": [
+                entry.canonical_pitch_id
+                for entry in resolved.response_entries
+            ]
+            == ["FF", "SL"],
+        },
+        {
+            "check": "disabled_path_non_emitting",
+            "actual": disabled.emitted,
+            "expected": False,
+            "passed": disabled.emitted is False,
+        },
+        {
+            "check": "partial_status_supported",
+            "actual": partial.profile_status,
+            "expected": "partial",
+            "passed": (
+                partial.profile_status
+                == "partial"
+            ),
+        },
+        {
+            "check": "sparse_status_supported",
+            "actual": sparse.profile_status,
+            "expected": "sparse",
+            "passed": (
+                sparse.profile_status
+                == "sparse"
+            ),
+        },
+        {
+            "check": "stale_status_supported",
+            "actual": stale.profile_status,
+            "expected": "stale",
+            "passed": (
+                stale.profile_status
+                == "stale"
+            ),
+        },
+        {
+            "check": "unavailable_status_supported",
+            "actual": (
+                unavailable.profile_status
+            ),
+            "expected": "unavailable",
+            "passed": (
+                unavailable.profile_status
+                == "unavailable"
+            ),
+        },
+        {
+            "check": "unknown_pitch_retained_as_UN",
+            "actual": (
+                unknown.response_entries[
+                    0
+                ].canonical_pitch_id
+            ),
+            "expected": "UN",
+            "passed": (
+                unknown.response_entries[
+                    0
+                ].canonical_pitch_id
+                == "UN"
+            ),
+        },
+        {
+            "check": "invalid_profiles_detected",
+            "actual": [
+                duplicate.profile_status,
+                invalid_rate.profile_status,
+                invalid_count.profile_status,
+                invalid_batted_ball.profile_status,
+            ],
+            "expected": [
+                "invalid",
+                "invalid",
+                "invalid",
+                "invalid",
+            ],
+            "passed": [
+                duplicate.profile_status,
+                invalid_rate.profile_status,
+                invalid_count.profile_status,
+                invalid_batted_ball.profile_status,
+            ]
+            == [
+                "invalid",
+                "invalid",
+                "invalid",
+                "invalid",
+            ],
+        },
+        {
+            "check": "context_normalization_supported",
+            "actual": [
+                normalized_context.batter_hand,
+                normalized_context.response_entries[
+                    0
+                ].pitcher_hand,
+                normalized_context.response_entries[
+                    0
+                ].count_context,
+            ],
+            "expected": [
+                "U",
+                "U",
+                "unknown",
+            ],
+            "passed": [
+                normalized_context.batter_hand,
+                normalized_context.response_entries[
+                    0
+                ].pitcher_hand,
+                normalized_context.response_entries[
+                    0
+                ].count_context,
+            ]
+            == [
+                "U",
+                "U",
+                "unknown",
+            ],
+        },
+        {
+            "check": "caller_payload_immutable",
+            "actual": (
+                base_payload
+                == payload_before
+            ),
+            "expected": True,
+            "passed": (
+                base_payload
+                == payload_before
+            ),
+        },
+        {
+            "check": "construction_deterministic",
+            "actual": (
+                repeated_a.to_dict()
+                == repeated_b.to_dict()
+            ),
+            "expected": True,
+            "passed": (
+                repeated_a.to_dict()
+                == repeated_b.to_dict()
+            ),
+        },
+        {
+            "check": "provenance_retained",
+            "actual": (
+                resolved.source_record_id
+                == "response-1"
+            ),
+            "expected": True,
+            "passed": (
+                resolved.source_record_id
+                == "response-1"
+            ),
+        },
+        {
+            "check": "production_behavior_unchanged",
+            "actual": (
+                resolved.production_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                resolved.production_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "simulation_behavior_unchanged",
+            "actual": (
+                resolved.simulation_behavior_changed
+            ),
+            "expected": False,
+            "passed": (
+                resolved.simulation_behavior_changed
+                is False
+            ),
+        },
+        {
+            "check": "matchup_swing_contact_batted_ball_authority_absent",
+            "actual": any(
+                [
+                    resolved.matchup_adjustment_activated,
+                    resolved.swing_probability_changed,
+                    resolved.whiff_probability_changed,
+                    resolved.contact_probability_changed,
+                    resolved.batted_ball_probability_changed,
+                    resolved.contact_quality_changed,
+                ]
+            ),
+            "expected": False,
+            "passed": all(
+                value is False
+                for value in [
+                    resolved.matchup_adjustment_activated,
+                    resolved.swing_probability_changed,
+                    resolved.whiff_probability_changed,
+                    resolved.contact_probability_changed,
+                    resolved.batted_ball_probability_changed,
+                    resolved.contact_quality_changed,
+                ]
+            ),
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    authority_rows = [
+        {
+            "authority": (
+                "batter_pitch_type_response_profile_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "The deterministic diagnostic batter response profile passed all checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_batter_response_integration"
+            ),
+            "granted": False,
+            "reason": (
+                "Batter response profiles remain diagnostic-only."
+            ),
+        },
+        {
+            "authority": (
+                "production_matchup_adjustment"
+            ),
+            "granted": False,
+            "reason": (
+                "No production matchup adjustment is activated."
+            ),
+        },
+        {
+            "authority": (
+                "swing_contact_or_batted_ball_probability_change"
+            ),
+            "granted": False,
+            "reason": (
+                "No swing, contact, or batted-ball probability changes are authorized."
+            ),
+        },
+        {
+            "authority": (
+                "simulation_or_contact_quality_change"
+            ),
+            "granted": False,
+            "reason": (
+                "Simulation and contact-quality behavior remain unchanged."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation_tuning_pricing_edge"
+            ),
+            "granted": False,
+            "reason": (
+                "Validation, tuning, pricing, and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    diagnosis_name = (
+        "batter_pitch_type_response_profile_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "batter_pitch_type_response_profile_contract_implementation_failed"
+    )
+
+    recommended_next_layer = (
+        "8H_pitcher_batter_pitch_type_matchup_overlay_contract_plan"
+        if all_checks_passed
+        else
+        "8G_batter_pitch_type_response_profile_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        cases,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "resolved_response_entries.csv",
+        [
+            "canonical_pitch_id",
+            "canonical_pitch_name",
+            "canonical_family",
+            "pitcher_hand",
+            "count_context",
+            "pitch_count",
+            "swing_count",
+            "contact_count",
+            "batted_ball_count",
+            "swing_rate",
+            "whiff_rate",
+            "contact_rate",
+            "avg_exit_velocity_mph",
+            "hard_hit_rate",
+            "barrel_rate",
+            "diagnostic_codes",
+        ],
+        [
+            {
+                "canonical_pitch_id": (
+                    entry.canonical_pitch_id
+                ),
+                "canonical_pitch_name": (
+                    entry.canonical_pitch_name
+                ),
+                "canonical_family": (
+                    entry.canonical_family
+                ),
+                "pitcher_hand": (
+                    entry.pitcher_hand
+                ),
+                "count_context": (
+                    entry.count_context
+                ),
+                "pitch_count": (
+                    entry.pitch_count
+                ),
+                "swing_count": (
+                    entry.swing_count
+                ),
+                "contact_count": (
+                    entry.contact_count
+                ),
+                "batted_ball_count": (
+                    entry.batted_ball_count
+                ),
+                "swing_rate": (
+                    entry.swing_rate
+                ),
+                "whiff_rate": (
+                    entry.whiff_rate
+                ),
+                "contact_rate": (
+                    entry.contact_rate
+                ),
+                "avg_exit_velocity_mph": (
+                    entry.avg_exit_velocity_mph
+                ),
+                "hard_hit_rate": (
+                    entry.hard_hit_rate
+                ),
+                "barrel_rate": (
+                    entry.barrel_rate
+                ),
+                "diagnostic_codes": "|".join(
+                    entry.diagnostic_codes
+                ),
+            }
+            for entry in resolved.response_entries
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan the bounded pitcher-batter pitch-type matchup overlay contract."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 8G implementation checks."
+                ),
+                "entry_condition": (
+                    "All nineteen 8G implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            cases
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in cases
+            if row["passed"]
+        ),
+        "profile_version": PROFILE_VERSION,
+        "resolved_partial_sparse_stale_unavailable_invalid_supported": True,
+        "deterministic_ordering_implemented": True,
+        "unknown_pitch_retention_implemented": True,
+        "rate_and_count_validation_implemented": True,
+        "batted_ball_validation_implemented": True,
+        "disabled_path_non_emitting": True,
+        "caller_payload_immutable": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "pitch_selection_changed": False,
+        "pitch_sequence_changed": False,
+        "matchup_adjustments_activated": False,
+        "swing_probability_changed": False,
+        "whiff_probability_changed": False,
+        "contact_probability_changed": False,
+        "batted_ball_probability_changed": False,
+        "contact_quality_changed": False,
+        "historical_outcome_joined": False,
+        "historical_validation_executed": False,
+        "tuning_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer8_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "pitcher_batter_pitch_type_matchup_overlay_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_batter_response_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / filename
+            )
+            for filename in [
+                "implementation_checks.csv",
+                "contract_cases.csv",
+                "resolved_response_entries.csv",
+                "authority_boundaries.csv",
+                "recommended_path.csv",
+            ]
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
8G — Batter Pitch-Type Response Profile Contract Implementation

## Objective
Implement and independently audit deterministic, diagnostic-only batter response profiles by canonical pitch type, pitcher handedness, and count context using the Layer 8F contract.

## Results
- 19/19 implementation checks pass
- 20/20 contract cases pass
- profile version `8G-v1`
- deterministic response-entry ordering implemented
- resolved, partial, sparse, stale, unavailable, and invalid statuses supported
- rate, count-relationship, and batted-ball validation implemented
- unknown pitch classifications retained as canonical `UN`
- disabled path is non-emitting
- bounded provenance retained
- caller payload remains immutable
- no production matchup activation
- no swing, whiff, contact, batted-ball, plate-appearance, or simulation probability changes
- no contact-quality changes
- no historical outcome joins or predictive validation
- no tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`batter_pitch_type_response_profile_contract_implementation_passed`

## Recommended Next Layer
`8H_pitcher_batter_pitch_type_matchup_overlay_contract_plan`