### PR TITLE
Layer 8K: Pitch-Type Matchup Overlay Observability Contract Implementation

### DIFF
--- a/mlb_app/pitching/pitch_type_matchup_overlay_observability.py
+++ b/mlb_app/pitching/pitch_type_matchup_overlay_observability.py
@@ -1,0 +1,793 @@
+"""
+Diagnostic-only observability for Layer 8I pitch-type matchup overlays.
+
+Creates deterministic immutable summary, entry, and aggregate records without
+changing production, probability, matchup, or simulation behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+from typing import Any, Iterable, Sequence
+
+from mlb_app.pitching.pitch_type_matchup_overlay import (
+    PitchTypeMatchupOverlay,
+)
+
+
+OBSERVABILITY_VERSION = "8K-v1"
+
+SUPPORTED_OVERLAY_STATUSES = frozenset(
+    {
+        "resolved",
+        "partial",
+        "sparse",
+        "stale",
+        "unavailable",
+        "invalid",
+        "disabled",
+    }
+)
+
+SUPPORTED_COVERAGE_STATUSES = frozenset(
+    {
+        "matched",
+        "pitcher_only",
+        "batter_only",
+        "unknown_pitch",
+        "context_fallback",
+        "hand_fallback",
+        "unavailable",
+    }
+)
+
+TRACKED_FALLBACK_CODES = (
+    "pitch_type_matchup_count_context_fallback",
+    "pitch_type_matchup_pitcher_hand_fallback",
+    "pitch_type_matchup_batter_response_missing",
+    "pitch_type_matchup_unknown_pitch_retained",
+    "pitch_type_matchup_profile_dates_disagree",
+)
+
+FALLBACK_ENTRY_CODES = frozenset(
+    {
+        "pitch_type_matchup_count_context_fallback",
+        "pitch_type_matchup_pitcher_hand_fallback",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayObservation:
+    observation_id: str
+    pitcher_id: str | None
+    batter_id: str | None
+    pitcher_hand: str | None
+    batter_hand: str | None
+    count_context: str | None
+    as_of_date_utc: str | None
+    overlay_status: str
+    coverage_share: float
+    matched_pitch_count: int
+    unmatched_pitch_count: int
+    overlay_entry_count: int
+    matched_usage_share: float | None
+    unmatched_usage_share: float | None
+    fallback_entry_count: int
+    unknown_pitch_entry_count: int
+    pitcher_only_entry_count: int
+    pitcher_profile_status: str | None
+    batter_profile_status: str | None
+    pitcher_profile_version: str | None
+    batter_profile_version: str | None
+    overlay_version: str
+    observability_version: str
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+    historical_outcomes_joined: bool = False
+    predictive_evaluation_executed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        payload["validation_errors"] = list(
+            self.validation_errors
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class MatchupOverlayEntryObservation:
+    observation_id: str
+    entry_ordinal: int
+    canonical_pitch_id: str
+    canonical_pitch_name: str
+    canonical_family: str
+    coverage_status: str
+    pitch_usage_share: float | None
+    pitcher_pitch_count: int
+    batter_pitch_count: int
+    fallback_used: bool
+    response_available: bool
+    unknown_pitch: bool
+    swing_rate_present: bool
+    whiff_rate_present: bool
+    contact_rate_present: bool
+    hard_hit_rate_present: bool
+    barrel_rate_present: bool
+    command_index_present: bool
+    pitch_quality_index_present: bool
+    batter_response_index_present: bool
+    diagnostic_matchup_index_present: bool
+    diagnostic_codes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["diagnostic_codes"] = list(
+            self.diagnostic_codes
+        )
+        return payload
+
+
+@dataclass(frozen=True)
+class MatchupOverlayObservationBundle:
+    emitted: bool
+    reason: str
+    observability_status: str
+    summary: MatchupOverlayObservation | None
+    entries: tuple[
+        MatchupOverlayEntryObservation,
+        ...,
+    ]
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    observability_version: str
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "emitted": self.emitted,
+            "reason": self.reason,
+            "observability_status": (
+                self.observability_status
+            ),
+            "summary": (
+                self.summary.to_dict()
+                if self.summary is not None
+                else None
+            ),
+            "entries": [
+                entry.to_dict()
+                for entry in self.entries
+            ],
+            "diagnostic_codes": list(
+                self.diagnostic_codes
+            ),
+            "validation_errors": list(
+                self.validation_errors
+            ),
+            "observability_version": (
+                self.observability_version
+            ),
+            "production_authority": (
+                self.production_authority
+            ),
+            "production_behavior_changed": (
+                self.production_behavior_changed
+            ),
+            "simulation_behavior_changed": (
+                self.simulation_behavior_changed
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class MatchupOverlayObservationAggregate:
+    overlay_count: int
+    emitted_overlay_count: int
+    disabled_overlay_count: int
+    resolved_overlay_count: int
+    partial_overlay_count: int
+    sparse_overlay_count: int
+    stale_overlay_count: int
+    unavailable_overlay_count: int
+    invalid_overlay_count: int
+    mean_coverage_share: float | None
+    minimum_coverage_share: float | None
+    maximum_coverage_share: float | None
+    fallback_overlay_count: int
+    pitcher_only_overlay_count: int
+    unknown_pitch_overlay_count: int
+    observability_version: str
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _sorted_unique_strings(
+    values: Iterable[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for value in values
+                if isinstance(value, str)
+                and value
+            }
+        )
+    )
+
+
+def _observation_id(
+    overlay: PitchTypeMatchupOverlay,
+) -> str:
+    identity = {
+        "pitcher_id": overlay.pitcher_id,
+        "batter_id": overlay.batter_id,
+        "pitcher_hand": overlay.pitcher_hand,
+        "batter_hand": overlay.batter_hand,
+        "count_context": overlay.count_context,
+        "as_of_date_utc": overlay.as_of_date_utc,
+        "overlay_version": overlay.overlay_version,
+    }
+
+    serialized = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+    digest = hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()[:20]
+
+    return f"matchup-overlay-{digest}"
+
+
+def _usage_shares(
+    overlay: PitchTypeMatchupOverlay,
+) -> tuple[float | None, float | None]:
+    numeric_entries = [
+        entry
+        for entry in overlay.overlay_entries
+        if entry.pitch_usage_share is not None
+    ]
+
+    if not numeric_entries:
+        return None, None
+
+    matched = sum(
+        entry.pitch_usage_share or 0.0
+        for entry in numeric_entries
+        if entry.coverage_status
+        not in {
+            "pitcher_only",
+            "unavailable",
+        }
+    )
+
+    unmatched = sum(
+        entry.pitch_usage_share or 0.0
+        for entry in numeric_entries
+        if entry.coverage_status
+        in {
+            "pitcher_only",
+            "unavailable",
+        }
+    )
+
+    return (
+        round(matched, 6),
+        round(unmatched, 6),
+    )
+
+
+def observe_pitch_type_matchup_overlay(
+    overlay: PitchTypeMatchupOverlay | None,
+    *,
+    enabled: bool = False,
+) -> MatchupOverlayObservationBundle:
+    if not enabled:
+        return MatchupOverlayObservationBundle(
+            emitted=False,
+            reason="observability_disabled",
+            observability_status="disabled",
+            summary=None,
+            entries=(),
+            diagnostic_codes=(
+                "matchup_overlay_observability_disabled",
+            ),
+            validation_errors=(),
+            observability_version=(
+                OBSERVABILITY_VERSION
+            ),
+        )
+
+    if overlay is None:
+        return MatchupOverlayObservationBundle(
+            emitted=True,
+            reason="observation_invalid",
+            observability_status="invalid",
+            summary=None,
+            entries=(),
+            diagnostic_codes=(
+                "matchup_overlay_observation_missing",
+            ),
+            validation_errors=(
+                "matchup_overlay_observation_missing",
+            ),
+            observability_version=(
+                OBSERVABILITY_VERSION
+            ),
+        )
+
+    validation_errors: list[str] = []
+    diagnostic_codes: list[str] = list(
+        overlay.diagnostic_codes
+    )
+
+    if (
+        overlay.overlay_status
+        not in SUPPORTED_OVERLAY_STATUSES
+    ):
+        validation_errors.append(
+            "matchup_overlay_status_invalid"
+        )
+
+    if not 0.0 <= overlay.coverage_share <= 1.0:
+        validation_errors.append(
+            "matchup_overlay_coverage_invalid"
+        )
+
+    if overlay.matched_pitch_count < 0:
+        validation_errors.append(
+            "matchup_overlay_matched_count_invalid"
+        )
+
+    if overlay.unmatched_pitch_count < 0:
+        validation_errors.append(
+            "matchup_overlay_unmatched_count_invalid"
+        )
+
+    observation_id = _observation_id(
+        overlay
+    )
+
+    entry_records: list[
+        MatchupOverlayEntryObservation
+    ] = []
+
+    fallback_entry_count = 0
+    unknown_pitch_entry_count = 0
+    pitcher_only_entry_count = 0
+
+    for ordinal, entry in enumerate(
+        overlay.overlay_entries
+    ):
+        entry_diagnostics = (
+            _sorted_unique_strings(
+                entry.diagnostic_codes
+            )
+        )
+
+        fallback_used = any(
+            code in FALLBACK_ENTRY_CODES
+            for code in entry_diagnostics
+        )
+
+        if fallback_used:
+            fallback_entry_count += 1
+
+        unknown_pitch = (
+            entry.canonical_pitch_id == "UN"
+        )
+
+        if unknown_pitch:
+            unknown_pitch_entry_count += 1
+
+        if entry.coverage_status == "pitcher_only":
+            pitcher_only_entry_count += 1
+
+        if (
+            entry.coverage_status
+            not in SUPPORTED_COVERAGE_STATUSES
+        ):
+            validation_errors.append(
+                "matchup_overlay_coverage_status_invalid"
+            )
+
+        if entry.pitcher_pitch_count < 0:
+            validation_errors.append(
+                "matchup_overlay_pitcher_pitch_count_invalid"
+            )
+
+        if entry.batter_pitch_count < 0:
+            validation_errors.append(
+                "matchup_overlay_batter_pitch_count_invalid"
+            )
+
+        if (
+            entry.pitch_usage_share is not None
+            and not (
+                0.0
+                <= entry.pitch_usage_share
+                <= 1.0
+            )
+        ):
+            validation_errors.append(
+                "matchup_overlay_usage_share_invalid"
+            )
+
+        response_available = (
+            entry.batter_pitch_count > 0
+            or any(
+                value is not None
+                for value in (
+                    entry.swing_rate,
+                    entry.whiff_rate,
+                    entry.contact_rate,
+                    entry.hard_hit_rate,
+                    entry.barrel_rate,
+                    entry.batter_response_index,
+                )
+            )
+        )
+
+        entry_records.append(
+            MatchupOverlayEntryObservation(
+                observation_id=observation_id,
+                entry_ordinal=ordinal,
+                canonical_pitch_id=(
+                    entry.canonical_pitch_id
+                ),
+                canonical_pitch_name=(
+                    entry.canonical_pitch_name
+                ),
+                canonical_family=(
+                    entry.canonical_family
+                ),
+                coverage_status=(
+                    entry.coverage_status
+                ),
+                pitch_usage_share=(
+                    entry.pitch_usage_share
+                ),
+                pitcher_pitch_count=(
+                    entry.pitcher_pitch_count
+                ),
+                batter_pitch_count=(
+                    entry.batter_pitch_count
+                ),
+                fallback_used=fallback_used,
+                response_available=(
+                    response_available
+                ),
+                unknown_pitch=unknown_pitch,
+                swing_rate_present=(
+                    entry.swing_rate is not None
+                ),
+                whiff_rate_present=(
+                    entry.whiff_rate is not None
+                ),
+                contact_rate_present=(
+                    entry.contact_rate is not None
+                ),
+                hard_hit_rate_present=(
+                    entry.hard_hit_rate is not None
+                ),
+                barrel_rate_present=(
+                    entry.barrel_rate is not None
+                ),
+                command_index_present=(
+                    entry.command_index is not None
+                ),
+                pitch_quality_index_present=(
+                    entry.pitch_quality_index
+                    is not None
+                ),
+                batter_response_index_present=(
+                    entry.batter_response_index
+                    is not None
+                ),
+                diagnostic_matchup_index_present=(
+                    entry.diagnostic_matchup_index
+                    is not None
+                ),
+                diagnostic_codes=entry_diagnostics,
+            )
+        )
+
+    matched_usage, unmatched_usage = (
+        _usage_shares(
+            overlay
+        )
+    )
+
+    if (
+        matched_usage is not None
+        and unmatched_usage is not None
+        and matched_usage + unmatched_usage
+        > 1.000001
+    ):
+        validation_errors.append(
+            "matchup_overlay_usage_total_invalid"
+        )
+
+    if not overlay.emitted:
+        diagnostic_codes.append(
+            "matchup_overlay_not_emitted"
+        )
+
+    if not overlay.overlay_entries:
+        diagnostic_codes.append(
+            "matchup_overlay_entries_empty"
+        )
+
+    if validation_errors:
+        observability_status = "invalid"
+        reason = "observation_invalid"
+    elif not overlay.emitted:
+        observability_status = "partial"
+        reason = "observation_status_only"
+    elif not overlay.overlay_entries:
+        observability_status = "empty"
+        reason = "observation_empty"
+    elif (
+        overlay.pitcher_id is None
+        or overlay.batter_id is None
+        or overlay.as_of_date_utc is None
+    ):
+        observability_status = "partial"
+        reason = "observation_partial"
+    else:
+        observability_status = "complete"
+        reason = "observation_complete"
+
+    summary = MatchupOverlayObservation(
+        observation_id=observation_id,
+        pitcher_id=overlay.pitcher_id,
+        batter_id=overlay.batter_id,
+        pitcher_hand=overlay.pitcher_hand,
+        batter_hand=overlay.batter_hand,
+        count_context=overlay.count_context,
+        as_of_date_utc=overlay.as_of_date_utc,
+        overlay_status=overlay.overlay_status,
+        coverage_share=round(
+            overlay.coverage_share,
+            6,
+        ),
+        matched_pitch_count=(
+            overlay.matched_pitch_count
+        ),
+        unmatched_pitch_count=(
+            overlay.unmatched_pitch_count
+        ),
+        overlay_entry_count=len(
+            entry_records
+        ),
+        matched_usage_share=matched_usage,
+        unmatched_usage_share=unmatched_usage,
+        fallback_entry_count=(
+            fallback_entry_count
+        ),
+        unknown_pitch_entry_count=(
+            unknown_pitch_entry_count
+        ),
+        pitcher_only_entry_count=(
+            pitcher_only_entry_count
+        ),
+        pitcher_profile_status=(
+            overlay.pitcher_profile_status
+        ),
+        batter_profile_status=(
+            overlay.batter_profile_status
+        ),
+        pitcher_profile_version=(
+            overlay.pitcher_profile_version
+        ),
+        batter_profile_version=(
+            overlay.batter_profile_version
+        ),
+        overlay_version=overlay.overlay_version,
+        observability_version=(
+            OBSERVABILITY_VERSION
+        ),
+        diagnostic_codes=(
+            _sorted_unique_strings(
+                diagnostic_codes
+            )
+        ),
+        validation_errors=(
+            _sorted_unique_strings(
+                validation_errors
+            )
+        ),
+    )
+
+    return MatchupOverlayObservationBundle(
+        emitted=True,
+        reason=reason,
+        observability_status=(
+            observability_status
+        ),
+        summary=summary,
+        entries=tuple(entry_records),
+        diagnostic_codes=(
+            summary.diagnostic_codes
+        ),
+        validation_errors=(
+            summary.validation_errors
+        ),
+        observability_version=(
+            OBSERVABILITY_VERSION
+        ),
+    )
+
+
+def aggregate_matchup_overlay_observations(
+    bundles: Sequence[
+        MatchupOverlayObservationBundle
+    ],
+) -> MatchupOverlayObservationAggregate:
+    overlay_count = len(bundles)
+
+    summaries = [
+        bundle.summary
+        for bundle in bundles
+        if bundle.summary is not None
+    ]
+
+    emitted_overlay_count = sum(
+        1
+        for bundle in bundles
+        if bundle.emitted
+    )
+
+    disabled_overlay_count = sum(
+        1
+        for bundle in bundles
+        if bundle.observability_status
+        == "disabled"
+    )
+
+    status_counts = {
+        status: sum(
+            1
+            for summary in summaries
+            if summary.overlay_status
+            == status
+        )
+        for status in (
+            "resolved",
+            "partial",
+            "sparse",
+            "stale",
+            "unavailable",
+            "invalid",
+        )
+    }
+
+    coverage_values = [
+        summary.coverage_share
+        for summary in summaries
+    ]
+
+    if coverage_values:
+        mean_coverage = round(
+            sum(coverage_values)
+            / len(coverage_values),
+            6,
+        )
+        minimum_coverage = min(
+            coverage_values
+        )
+        maximum_coverage = max(
+            coverage_values
+        )
+    else:
+        mean_coverage = None
+        minimum_coverage = None
+        maximum_coverage = None
+
+    fallback_overlay_count = sum(
+        1
+        for summary in summaries
+        if summary.fallback_entry_count > 0
+        or any(
+            code
+            in summary.diagnostic_codes
+            for code in TRACKED_FALLBACK_CODES
+        )
+    )
+
+    pitcher_only_overlay_count = sum(
+        1
+        for summary in summaries
+        if summary.pitcher_only_entry_count
+        > 0
+    )
+
+    unknown_pitch_overlay_count = sum(
+        1
+        for summary in summaries
+        if summary.unknown_pitch_entry_count
+        > 0
+    )
+
+    return MatchupOverlayObservationAggregate(
+        overlay_count=overlay_count,
+        emitted_overlay_count=(
+            emitted_overlay_count
+        ),
+        disabled_overlay_count=(
+            disabled_overlay_count
+        ),
+        resolved_overlay_count=(
+            status_counts["resolved"]
+        ),
+        partial_overlay_count=(
+            status_counts["partial"]
+        ),
+        sparse_overlay_count=(
+            status_counts["sparse"]
+        ),
+        stale_overlay_count=(
+            status_counts["stale"]
+        ),
+        unavailable_overlay_count=(
+            status_counts["unavailable"]
+        ),
+        invalid_overlay_count=(
+            status_counts["invalid"]
+        ),
+        mean_coverage_share=mean_coverage,
+        minimum_coverage_share=(
+            minimum_coverage
+        ),
+        maximum_coverage_share=(
+            maximum_coverage
+        ),
+        fallback_overlay_count=(
+            fallback_overlay_count
+        ),
+        pitcher_only_overlay_count=(
+            pitcher_only_overlay_count
+        ),
+        unknown_pitch_overlay_count=(
+            unknown_pitch_overlay_count
+        ),
+        observability_version=(
+            OBSERVABILITY_VERSION
+        ),
+    )
+
+
+def coverage_bucket(
+    coverage_share: float,
+) -> str:
+    if coverage_share == 0.0:
+        return "coverage_0"
+
+    if 0.0 < coverage_share < 0.5:
+        return "coverage_gt_0_lt_0_5"
+
+    if 0.5 <= coverage_share < 0.8:
+        return "coverage_gte_0_5_lt_0_8"
+
+    if 0.8 <= coverage_share < 1.0:
+        return "coverage_gte_0_8_lt_1"
+
+    return "coverage_1"

--- a/scripts/audit_8K_pitch_type_matchup_overlay_observability_contract.py
+++ b/scripts/audit_8K_pitch_type_matchup_overlay_observability_contract.py
@@ -1,0 +1,1370 @@
+#!/usr/bin/env python3
+"""
+Layer 8K pitch-type matchup overlay observability audit.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+from dataclasses import replace
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from mlb_app.pitching.batter_pitch_type_response_profile import (
+    build_batter_pitch_type_response_profile,
+)
+from mlb_app.pitching.pitch_type_matchup_overlay import (
+    build_pitch_type_matchup_overlay,
+)
+from mlb_app.pitching.pitch_type_matchup_overlay_observability import (
+    OBSERVABILITY_VERSION,
+    aggregate_matchup_overlay_observations,
+    coverage_bucket,
+    observe_pitch_type_matchup_overlay,
+)
+from mlb_app.pitching.pitcher_arsenal_profile import (
+    build_pitcher_arsenal_profile,
+)
+
+
+LAYER_ID = "8K"
+LAYER_NAME = (
+    "pitch_type_matchup_overlay_observability_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_8K_pitch_type_matchup_overlay_observability_contract"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_8J_pitch_type_matchup_overlay_observability_contract.py"
+)
+
+IMPLEMENTATION_PATH = (
+    ROOT
+    / "mlb_app/pitching/"
+    "pitch_type_matchup_overlay_observability.py"
+)
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    predecessor_present = (
+        "pitch_type_matchup_overlay_observability_contract_plan_complete"
+        in string_constants(
+            PLAN_PATH
+        )
+    )
+
+    pitcher_profile = (
+        build_pitcher_arsenal_profile(
+            {
+                "enabled": True,
+                "pitcher_id": "pitcher-1",
+                "pitcher_name": "Example Pitcher",
+                "pitcher_hand": "R",
+                "pitcher_role": "starter",
+                "season": 2026,
+                "as_of_date_utc": "2026-06-30",
+                "source_name": "statcast",
+                "source_timestamp_utc": (
+                    "2026-06-25T00:00:00+00:00"
+                ),
+                "arsenal_entries": [
+                    {
+                        "canonical_pitch_id": "FF",
+                        "pitch_count": 60,
+                        "quality_index": 0.4,
+                        "command_index": 0.2,
+                    },
+                    {
+                        "canonical_pitch_id": "SL",
+                        "pitch_count": 30,
+                        "quality_index": 0.6,
+                        "command_index": 0.1,
+                    },
+                    {
+                        "canonical_pitch_id": "CH",
+                        "pitch_count": 10,
+                    },
+                ],
+            }
+        )
+    )
+
+    batter_profile = (
+        build_batter_pitch_type_response_profile(
+            {
+                "enabled": True,
+                "batter_id": "batter-1",
+                "batter_name": "Example Batter",
+                "batter_hand": "L",
+                "season": 2026,
+                "as_of_date_utc": "2026-06-30",
+                "source_name": "statcast",
+                "source_timestamp_utc": (
+                    "2026-06-25T00:00:00+00:00"
+                ),
+                "response_entries": [
+                    {
+                        "canonical_pitch_id": "FF",
+                        "pitcher_hand": "R",
+                        "count_context": "all_counts",
+                        "pitch_count": 70,
+                        "swing_count": 35,
+                        "contact_count": 28,
+                        "batted_ball_count": 20,
+                        "swing_rate": 0.5,
+                        "whiff_rate": 0.2,
+                        "contact_rate": 0.8,
+                        "hard_hit_rate": 0.4,
+                        "barrel_rate": 0.1,
+                    },
+                    {
+                        "canonical_pitch_id": "SL",
+                        "pitcher_hand": "R",
+                        "count_context": "all_counts",
+                        "pitch_count": 30,
+                        "swing_count": 18,
+                        "contact_count": 12,
+                        "batted_ball_count": 8,
+                        "swing_rate": 0.6,
+                        "whiff_rate": 0.333333,
+                        "contact_rate": 0.666667,
+                        "hard_hit_rate": 0.25,
+                        "barrel_rate": 0.05,
+                    },
+                ],
+            }
+        )
+    )
+
+    resolved_overlay = (
+        build_pitch_type_matchup_overlay(
+            pitcher_profile,
+            batter_profile,
+            enabled=True,
+        )
+    )
+
+    resolved_bundle = (
+        observe_pitch_type_matchup_overlay(
+            resolved_overlay,
+            enabled=True,
+        )
+    )
+
+    cases: list[dict[str, Any]] = []
+
+    def record(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        cases.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    record(
+        "8K-C01",
+        "resolved observability emits",
+        resolved_bundle.emitted
+        and resolved_bundle.observability_status
+        == "complete",
+        resolved_bundle.to_dict(),
+        {
+            "emitted": True,
+            "observability_status": "complete",
+        },
+    )
+
+    record(
+        "8K-C02",
+        "deterministic observation id emitted",
+        resolved_bundle.summary is not None
+        and resolved_bundle.summary.observation_id.startswith(
+            "matchup-overlay-"
+        ),
+        (
+            resolved_bundle.summary.observation_id
+            if resolved_bundle.summary
+            else None
+        ),
+        "matchup-overlay-*",
+    )
+
+    record(
+        "8K-C03",
+        "summary entry count reconciles",
+        resolved_bundle.summary is not None
+        and (
+            resolved_bundle.summary.overlay_entry_count
+            == len(resolved_bundle.entries)
+            == 3
+        ),
+        {
+            "summary_count": (
+                resolved_bundle.summary.overlay_entry_count
+                if resolved_bundle.summary
+                else None
+            ),
+            "entry_count": len(
+                resolved_bundle.entries
+            ),
+        },
+        {
+            "summary_count": 3,
+            "entry_count": 3,
+        },
+    )
+
+    record(
+        "8K-C04",
+        "pitcher-only count observed",
+        resolved_bundle.summary is not None
+        and (
+            resolved_bundle.summary.pitcher_only_entry_count
+            == 1
+        ),
+        (
+            resolved_bundle.summary.pitcher_only_entry_count
+            if resolved_bundle.summary
+            else None
+        ),
+        1,
+    )
+
+    record(
+        "8K-C05",
+        "matched and unmatched usage observed",
+        resolved_bundle.summary is not None
+        and (
+            resolved_bundle.summary.matched_usage_share
+            == 0.9
+        )
+        and (
+            resolved_bundle.summary.unmatched_usage_share
+            == 0.1
+        ),
+        (
+            resolved_bundle.summary.to_dict()
+            if resolved_bundle.summary
+            else None
+        ),
+        {
+            "matched_usage_share": 0.9,
+            "unmatched_usage_share": 0.1,
+        },
+    )
+
+    disabled_bundle = (
+        observe_pitch_type_matchup_overlay(
+            resolved_overlay,
+            enabled=False,
+        )
+    )
+
+    record(
+        "8K-C06",
+        "disabled path non-emitting",
+        disabled_bundle.emitted is False
+        and disabled_bundle.summary is None
+        and not disabled_bundle.entries,
+        disabled_bundle.to_dict(),
+        {
+            "emitted": False,
+            "summary": None,
+            "entries": [],
+        },
+    )
+
+    missing_bundle = (
+        observe_pitch_type_matchup_overlay(
+            None,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C07",
+        "missing overlay invalid",
+        missing_bundle.observability_status
+        == "invalid",
+        missing_bundle.observability_status,
+        "invalid",
+    )
+
+    empty_overlay = replace(
+        resolved_overlay,
+        overlay_entries=(),
+        matched_pitch_count=0,
+        unmatched_pitch_count=0,
+        coverage_share=0.0,
+    )
+
+    empty_bundle = (
+        observe_pitch_type_matchup_overlay(
+            empty_overlay,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C08",
+        "empty overlay observed",
+        empty_bundle.observability_status
+        == "empty",
+        empty_bundle.observability_status,
+        "empty",
+    )
+
+    partial_overlay = replace(
+        resolved_overlay,
+        pitcher_id=None,
+    )
+
+    partial_bundle = (
+        observe_pitch_type_matchup_overlay(
+            partial_overlay,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C09",
+        "missing optional identity yields partial",
+        partial_bundle.observability_status
+        == "partial",
+        partial_bundle.observability_status,
+        "partial",
+    )
+
+    invalid_overlay = replace(
+        resolved_overlay,
+        coverage_share=1.5,
+    )
+
+    invalid_bundle = (
+        observe_pitch_type_matchup_overlay(
+            invalid_overlay,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C10",
+        "invalid coverage detected",
+        invalid_bundle.observability_status
+        == "invalid",
+        invalid_bundle.to_dict(),
+        {
+            "observability_status": "invalid",
+        },
+    )
+
+    fallback_overlay = (
+        build_pitch_type_matchup_overlay(
+            pitcher_profile,
+            batter_profile,
+            count_context="two_strike",
+            enabled=True,
+        )
+    )
+
+    fallback_bundle = (
+        observe_pitch_type_matchup_overlay(
+            fallback_overlay,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C11",
+        "fallback entries counted",
+        fallback_bundle.summary is not None
+        and (
+            fallback_bundle.summary.fallback_entry_count
+            == 2
+        ),
+        (
+            fallback_bundle.summary.fallback_entry_count
+            if fallback_bundle.summary
+            else None
+        ),
+        2,
+    )
+
+    record(
+        "8K-C12",
+        "entry ordinals contiguous",
+        [
+            entry.entry_ordinal
+            for entry in resolved_bundle.entries
+        ]
+        == [0, 1, 2],
+        [
+            entry.entry_ordinal
+            for entry in resolved_bundle.entries
+        ],
+        [0, 1, 2],
+    )
+
+    record(
+        "8K-C13",
+        "response presence flags correct",
+        [
+            entry.response_available
+            for entry in resolved_bundle.entries
+        ]
+        == [True, True, False],
+        [
+            entry.response_available
+            for entry in resolved_bundle.entries
+        ],
+        [True, True, False],
+    )
+
+    record(
+        "8K-C14",
+        "metric presence flags correct",
+        resolved_bundle.entries[
+            0
+        ].swing_rate_present
+        and resolved_bundle.entries[
+            0
+        ].whiff_rate_present
+        and resolved_bundle.entries[
+            0
+        ].contact_rate_present
+        and not resolved_bundle.entries[
+            2
+        ].swing_rate_present,
+        [
+            entry.to_dict()
+            for entry in resolved_bundle.entries
+        ],
+        "presence_flags_match_fixture",
+    )
+
+    repeated_bundle = (
+        observe_pitch_type_matchup_overlay(
+            resolved_overlay,
+            enabled=True,
+        )
+    )
+
+    record(
+        "8K-C15",
+        "serialization deterministic",
+        resolved_bundle.to_dict()
+        == repeated_bundle.to_dict(),
+        resolved_bundle.to_dict(),
+        repeated_bundle.to_dict(),
+    )
+
+    record(
+        "8K-C16",
+        "coverage buckets deterministic",
+        [
+            coverage_bucket(value)
+            for value in (
+                0.0,
+                0.2,
+                0.6,
+                0.9,
+                1.0,
+            )
+        ]
+        == [
+            "coverage_0",
+            "coverage_gt_0_lt_0_5",
+            "coverage_gte_0_5_lt_0_8",
+            "coverage_gte_0_8_lt_1",
+            "coverage_1",
+        ],
+        [
+            coverage_bucket(value)
+            for value in (
+                0.0,
+                0.2,
+                0.6,
+                0.9,
+                1.0,
+            )
+        ],
+        [
+            "coverage_0",
+            "coverage_gt_0_lt_0_5",
+            "coverage_gte_0_5_lt_0_8",
+            "coverage_gte_0_8_lt_1",
+            "coverage_1",
+        ],
+    )
+
+    aggregate = (
+        aggregate_matchup_overlay_observations(
+            [
+                resolved_bundle,
+                fallback_bundle,
+                empty_bundle,
+                disabled_bundle,
+            ]
+        )
+    )
+
+    record(
+        "8K-C17",
+        "aggregate counts overlays",
+        aggregate.overlay_count == 4
+        and aggregate.emitted_overlay_count
+        == 3
+        and aggregate.disabled_overlay_count
+        == 1,
+        aggregate.to_dict(),
+        {
+            "overlay_count": 4,
+            "emitted_overlay_count": 3,
+            "disabled_overlay_count": 1,
+        },
+    )
+
+    record(
+        "8K-C18",
+        "aggregate coverage bounds ordered",
+        aggregate.minimum_coverage_share
+        is not None
+        and aggregate.maximum_coverage_share
+        is not None
+        and (
+            aggregate.minimum_coverage_share
+            <= aggregate.mean_coverage_share
+            <= aggregate.maximum_coverage_share
+        ),
+        aggregate.to_dict(),
+        "min_lte_mean_lte_max",
+    )
+
+    record(
+        "8K-C19",
+        "versions retained",
+        resolved_bundle.summary is not None
+        and (
+            resolved_bundle.summary.overlay_version
+            == resolved_overlay.overlay_version
+        )
+        and (
+            resolved_bundle.summary.observability_version
+            == OBSERVABILITY_VERSION
+        ),
+        (
+            resolved_bundle.summary.to_dict()
+            if resolved_bundle.summary
+            else None
+        ),
+        {
+            "observability_version": "8K-v1",
+        },
+    )
+
+    record(
+        "8K-C20",
+        "production and simulation authority remain false",
+        resolved_bundle.summary is not None
+        and all(
+            value is False
+            for value in [
+                resolved_bundle.production_authority,
+                resolved_bundle.production_behavior_changed,
+                resolved_bundle.simulation_behavior_changed,
+                resolved_bundle.summary.production_authority,
+                resolved_bundle.summary.production_behavior_changed,
+                resolved_bundle.summary.simulation_behavior_changed,
+                resolved_bundle.summary.historical_outcomes_joined,
+                resolved_bundle.summary.predictive_evaluation_executed,
+            ]
+        ),
+        resolved_bundle.to_dict(),
+        {
+            "all_authority_flags": False,
+        },
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+            "expected": True,
+            "passed": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+        },
+        {
+            "check": "eight_j_predecessor_present",
+            "actual": predecessor_present,
+            "expected": True,
+            "passed": predecessor_present,
+        },
+        {
+            "check": "twenty_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in cases
+                if row["passed"]
+            ),
+            "expected": 20,
+            "passed": all(
+                row["passed"]
+                for row in cases
+            ),
+        },
+        {
+            "check": "complete_observation_supported",
+            "actual": (
+                resolved_bundle.observability_status
+            ),
+            "expected": "complete",
+            "passed": (
+                resolved_bundle.observability_status
+                == "complete"
+            ),
+        },
+        {
+            "check": "deterministic_observation_id_supported",
+            "actual": (
+                resolved_bundle.summary.observation_id
+                if resolved_bundle.summary
+                else None
+            ),
+            "expected": "matchup-overlay-*",
+            "passed": (
+                resolved_bundle.summary is not None
+                and resolved_bundle.summary.observation_id.startswith(
+                    "matchup-overlay-"
+                )
+            ),
+        },
+        {
+            "check": "summary_entry_count_reconciles",
+            "actual": (
+                resolved_bundle.summary.overlay_entry_count
+                if resolved_bundle.summary
+                else None
+            ),
+            "expected": 3,
+            "passed": (
+                resolved_bundle.summary is not None
+                and resolved_bundle.summary.overlay_entry_count
+                == len(resolved_bundle.entries)
+                == 3
+            ),
+        },
+        {
+            "check": "usage_shares_reconcile",
+            "actual": [
+                (
+                    resolved_bundle.summary.matched_usage_share
+                    if resolved_bundle.summary
+                    else None
+                ),
+                (
+                    resolved_bundle.summary.unmatched_usage_share
+                    if resolved_bundle.summary
+                    else None
+                ),
+            ],
+            "expected": [0.9, 0.1],
+            "passed": (
+                resolved_bundle.summary is not None
+                and resolved_bundle.summary.matched_usage_share
+                == 0.9
+                and resolved_bundle.summary.unmatched_usage_share
+                == 0.1
+            ),
+        },
+        {
+            "check": "disabled_path_non_emitting",
+            "actual": disabled_bundle.emitted,
+            "expected": False,
+            "passed": (
+                disabled_bundle.emitted is False
+            ),
+        },
+        {
+            "check": "missing_overlay_invalid",
+            "actual": (
+                missing_bundle.observability_status
+            ),
+            "expected": "invalid",
+            "passed": (
+                missing_bundle.observability_status
+                == "invalid"
+            ),
+        },
+        {
+            "check": "empty_observation_supported",
+            "actual": (
+                empty_bundle.observability_status
+            ),
+            "expected": "empty",
+            "passed": (
+                empty_bundle.observability_status
+                == "empty"
+            ),
+        },
+        {
+            "check": "partial_observation_supported",
+            "actual": (
+                partial_bundle.observability_status
+            ),
+            "expected": "partial",
+            "passed": (
+                partial_bundle.observability_status
+                == "partial"
+            ),
+        },
+        {
+            "check": "invalid_observation_supported",
+            "actual": (
+                invalid_bundle.observability_status
+            ),
+            "expected": "invalid",
+            "passed": (
+                invalid_bundle.observability_status
+                == "invalid"
+            ),
+        },
+        {
+            "check": "fallback_counts_supported",
+            "actual": (
+                fallback_bundle.summary.fallback_entry_count
+                if fallback_bundle.summary
+                else None
+            ),
+            "expected": 2,
+            "passed": (
+                fallback_bundle.summary is not None
+                and fallback_bundle.summary.fallback_entry_count
+                == 2
+            ),
+        },
+        {
+            "check": "entry_ordinals_contiguous",
+            "actual": [
+                entry.entry_ordinal
+                for entry in resolved_bundle.entries
+            ],
+            "expected": [0, 1, 2],
+            "passed": [
+                entry.entry_ordinal
+                for entry in resolved_bundle.entries
+            ]
+            == [0, 1, 2],
+        },
+        {
+            "check": "presence_flags_supported",
+            "actual": [
+                entry.response_available
+                for entry in resolved_bundle.entries
+            ],
+            "expected": [
+                True,
+                True,
+                False,
+            ],
+            "passed": [
+                entry.response_available
+                for entry in resolved_bundle.entries
+            ]
+            == [
+                True,
+                True,
+                False,
+            ],
+        },
+        {
+            "check": "serialization_deterministic",
+            "actual": (
+                resolved_bundle.to_dict()
+                == repeated_bundle.to_dict()
+            ),
+            "expected": True,
+            "passed": (
+                resolved_bundle.to_dict()
+                == repeated_bundle.to_dict()
+            ),
+        },
+        {
+            "check": "coverage_buckets_supported",
+            "actual": [
+                coverage_bucket(value)
+                for value in (
+                    0.0,
+                    0.2,
+                    0.6,
+                    0.9,
+                    1.0,
+                )
+            ],
+            "expected": [
+                "coverage_0",
+                "coverage_gt_0_lt_0_5",
+                "coverage_gte_0_5_lt_0_8",
+                "coverage_gte_0_8_lt_1",
+                "coverage_1",
+            ],
+            "passed": [
+                coverage_bucket(value)
+                for value in (
+                    0.0,
+                    0.2,
+                    0.6,
+                    0.9,
+                    1.0,
+                )
+            ]
+            == [
+                "coverage_0",
+                "coverage_gt_0_lt_0_5",
+                "coverage_gte_0_5_lt_0_8",
+                "coverage_gte_0_8_lt_1",
+                "coverage_1",
+            ],
+        },
+        {
+            "check": "aggregate_counts_supported",
+            "actual": aggregate.overlay_count,
+            "expected": 4,
+            "passed": (
+                aggregate.overlay_count == 4
+                and aggregate.emitted_overlay_count
+                == 3
+                and aggregate.disabled_overlay_count
+                == 1
+            ),
+        },
+        {
+            "check": "production_simulation_validation_authority_absent",
+            "actual": (
+                resolved_bundle.production_authority
+                or resolved_bundle.production_behavior_changed
+                or resolved_bundle.simulation_behavior_changed
+                or (
+                    resolved_bundle.summary.production_authority
+                    if resolved_bundle.summary
+                    else True
+                )
+                or (
+                    resolved_bundle.summary.historical_outcomes_joined
+                    if resolved_bundle.summary
+                    else True
+                )
+                or (
+                    resolved_bundle.summary.predictive_evaluation_executed
+                    if resolved_bundle.summary
+                    else True
+                )
+            ),
+            "expected": False,
+            "passed": (
+                resolved_bundle.summary is not None
+                and all(
+                    value is False
+                    for value in [
+                        resolved_bundle.production_authority,
+                        resolved_bundle.production_behavior_changed,
+                        resolved_bundle.simulation_behavior_changed,
+                        resolved_bundle.summary.production_authority,
+                        resolved_bundle.summary.production_behavior_changed,
+                        resolved_bundle.summary.simulation_behavior_changed,
+                        resolved_bundle.summary.historical_outcomes_joined,
+                        resolved_bundle.summary.predictive_evaluation_executed,
+                    ]
+                )
+            ),
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    status_order = [
+        "resolved",
+        "partial",
+        "sparse",
+        "stale",
+        "unavailable",
+        "invalid",
+        "disabled",
+    ]
+
+    status_rows = [
+        {
+            "overlay_status": status,
+            "count": (
+                aggregate.disabled_overlay_count
+                if status == "disabled"
+                else getattr(
+                    aggregate,
+                    f"{status}_overlay_count",
+                )
+            ),
+        }
+        for status in status_order
+    ]
+
+    coverage_values = [
+        bundle.summary.coverage_share
+        for bundle in (
+            resolved_bundle,
+            fallback_bundle,
+            empty_bundle,
+        )
+        if bundle.summary is not None
+    ]
+
+    coverage_bucket_order = [
+        "coverage_0",
+        "coverage_gt_0_lt_0_5",
+        "coverage_gte_0_5_lt_0_8",
+        "coverage_gte_0_8_lt_1",
+        "coverage_1",
+    ]
+
+    coverage_rows = [
+        {
+            "coverage_bucket": bucket,
+            "count": sum(
+                1
+                for value in coverage_values
+                if coverage_bucket(value)
+                == bucket
+            ),
+        }
+        for bucket in coverage_bucket_order
+    ]
+
+    fallback_codes = [
+        "pitch_type_matchup_count_context_fallback",
+        "pitch_type_matchup_pitcher_hand_fallback",
+        "pitch_type_matchup_batter_response_missing",
+        "pitch_type_matchup_unknown_pitch_retained",
+        "pitch_type_matchup_profile_dates_disagree",
+    ]
+
+    all_diagnostic_codes = [
+        code
+        for bundle in (
+            resolved_bundle,
+            fallback_bundle,
+            empty_bundle,
+            disabled_bundle,
+        )
+        for code in bundle.diagnostic_codes
+    ]
+
+    all_diagnostic_codes.extend(
+        code
+        for bundle in (
+            resolved_bundle,
+            fallback_bundle,
+            empty_bundle,
+        )
+        for entry in bundle.entries
+        for code in entry.diagnostic_codes
+    )
+
+    fallback_rows = [
+        {
+            "diagnostic_code": code,
+            "count": all_diagnostic_codes.count(
+                code
+            ),
+        }
+        for code in fallback_codes
+    ]
+
+    authority_rows = [
+        {
+            "authority": (
+                "pitch_type_matchup_overlay_observability_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "Bounded deterministic observability passed all checks."
+            ),
+        },
+        {
+            "authority": (
+                "production_matchup_overlay_integration"
+            ),
+            "granted": False,
+            "reason": (
+                "Observability remains diagnostic-only."
+            ),
+        },
+        {
+            "authority": (
+                "simulation_or_probability_change"
+            ),
+            "granted": False,
+            "reason": (
+                "Simulation and probability behavior remain unchanged."
+            ),
+        },
+        {
+            "authority": (
+                "historical_validation_or_predictive_evaluation"
+            ),
+            "granted": False,
+            "reason": (
+                "No outcomes are joined and no predictive evaluation occurs."
+            ),
+        },
+        {
+            "authority": (
+                "tuning_backtest_pricing_edge"
+            ),
+            "granted": False,
+            "reason": (
+                "Tuning, backtests, pricing, and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    diagnosis_name = (
+        "pitch_type_matchup_overlay_observability_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "pitch_type_matchup_overlay_observability_contract_implementation_failed"
+    )
+
+    recommended_next_layer = (
+        "8L_pitch_type_matchup_overlay_shadow_dataset_contract_plan"
+        if all_checks_passed
+        else
+        "8K_pitch_type_matchup_overlay_observability_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        cases,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "overlay_observations.csv",
+        list(
+            resolved_bundle.summary.to_dict().keys()
+        )
+        if resolved_bundle.summary
+        else ["observation_id"],
+        [
+            resolved_bundle.summary.to_dict()
+        ]
+        if resolved_bundle.summary
+        else [],
+    )
+
+    entry_rows = [
+        entry.to_dict()
+        for entry in resolved_bundle.entries
+    ]
+
+    write_csv(
+        OUTPUT_DIR
+        / "overlay_entry_observations.csv",
+        list(entry_rows[0].keys())
+        if entry_rows
+        else ["observation_id"],
+        entry_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "overlay_status_counts.csv",
+        [
+            "overlay_status",
+            "count",
+        ],
+        status_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "coverage_distribution.csv",
+        [
+            "coverage_bucket",
+            "count",
+        ],
+        coverage_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "fallback_counts.csv",
+        [
+            "diagnostic_code",
+            "count",
+        ],
+        fallback_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan a bounded shadow dataset contract for observable matchup overlays."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 8K implementation checks."
+                ),
+                "entry_condition": (
+                    "All nineteen 8K implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            cases
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in cases
+            if row["passed"]
+        ),
+        "observability_version": (
+            OBSERVABILITY_VERSION
+        ),
+        "summary_serialization_implemented": True,
+        "entry_serialization_implemented": True,
+        "aggregate_status_counts_implemented": True,
+        "coverage_distribution_implemented": True,
+        "fallback_counts_implemented": True,
+        "deterministic_observation_ids_implemented": True,
+        "deterministic_serialization_implemented": True,
+        "presence_flags_implemented": True,
+        "disabled_path_non_emitting": True,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "matchup_adjustments_activated": False,
+        "historical_outcome_joined": False,
+        "predictive_evaluation_executed": False,
+        "tuning_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "observability_summary.json",
+        {
+            **summary,
+            "aggregate": aggregate.to_dict(),
+        },
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer8_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "shadow_dataset_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_matchup_overlay_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / filename
+            )
+            for filename in [
+                "implementation_checks.csv",
+                "contract_cases.csv",
+                "overlay_observations.csv",
+                "overlay_entry_observations.csv",
+                "overlay_status_counts.csv",
+                "coverage_distribution.csv",
+                "fallback_counts.csv",
+                "authority_boundaries.csv",
+                "recommended_path.csv",
+            ]
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "observability_summary.json"
+            ),
+            str(
+                OUTPUT_DIR / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
8K — Pitch-Type Matchup Overlay Observability Contract Implementation

## Objective
Implement and independently audit bounded, deterministic, diagnostic-only observability for Layer 8I pitch-type matchup overlays.

## Results
- 19/19 implementation checks pass
- 20/20 contract cases pass
- observability version `8K-v1`
- deterministic observation IDs implemented
- summary and entry serialization implemented
- status counts, coverage distribution, and fallback counts implemented
- matched usage `0.9` and unmatched usage `0.1` in the fixture
- complete, partial, empty, invalid, and disabled observability paths supported
- disabled path is non-emitting
- presence flags implemented
- no production overlay integration or matchup activation
- no pitch selection or sequencing changes
- no simulation or canonical probability changes
- no historical outcome joins or predictive evaluation
- no tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`pitch_type_matchup_overlay_observability_contract_implementation_passed`

## Recommended Next Layer
`8L_pitch_type_matchup_overlay_shadow_dataset_contract_plan`