### PR TITLE
Layer 8M: Pitch-Type Matchup Overlay Shadow Dataset Contract Implementation

### DIFF
--- a/mlb_app/pitching/pitch_type_matchup_overlay_shadow_dataset.py
+++ b/mlb_app/pitching/pitch_type_matchup_overlay_shadow_dataset.py
@@ -1,0 +1,617 @@
+"""
+Append-only diagnostic shadow dataset for Layer 8K matchup observations.
+
+The dataset is deterministic and non-authoritative. It does not join outcomes,
+evaluate predictions, tune parameters, or modify production/simulation behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from typing import Any, Iterable, Sequence
+
+from mlb_app.pitching.pitch_type_matchup_overlay_observability import (
+    MatchupOverlayObservationBundle,
+)
+
+
+SHADOW_DATASET_VERSION = "8M-v1"
+
+SHADOW_ROW_FIELD_ORDER = (
+    "dataset_row_id",
+    "observation_id",
+    "observation_date_utc",
+    "pitcher_id",
+    "batter_id",
+    "pitcher_hand",
+    "batter_hand",
+    "count_context",
+    "overlay_status",
+    "observability_status",
+    "coverage_share",
+    "matched_pitch_count",
+    "unmatched_pitch_count",
+    "overlay_entry_count",
+    "fallback_entry_count",
+    "unknown_pitch_entry_count",
+    "pitcher_only_entry_count",
+    "matched_usage_share",
+    "unmatched_usage_share",
+    "pitcher_profile_version",
+    "batter_profile_version",
+    "overlay_version",
+    "observability_version",
+    "shadow_dataset_version",
+)
+
+SUPPORTED_OBSERVABILITY_STATUSES = frozenset(
+    {
+        "complete",
+        "partial",
+        "empty",
+        "invalid",
+        "disabled",
+    }
+)
+
+SUPPORTED_OVERLAY_STATUSES = frozenset(
+    {
+        "resolved",
+        "partial",
+        "sparse",
+        "stale",
+        "unavailable",
+        "invalid",
+        "disabled",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayShadowRow:
+    dataset_row_id: str
+    observation_id: str
+    observation_date_utc: str
+    pitcher_id: str | None
+    batter_id: str | None
+    pitcher_hand: str | None
+    batter_hand: str | None
+    count_context: str | None
+    overlay_status: str
+    observability_status: str
+    coverage_share: float
+    matched_pitch_count: int
+    unmatched_pitch_count: int
+    overlay_entry_count: int
+    fallback_entry_count: int
+    unknown_pitch_entry_count: int
+    pitcher_only_entry_count: int
+    matched_usage_share: float | None
+    unmatched_usage_share: float | None
+    pitcher_profile_version: str | None
+    batter_profile_version: str | None
+    overlay_version: str
+    observability_version: str
+    shadow_dataset_version: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayShadowPartition:
+    partition_key: str
+    partition_path: str
+    row_count: int
+    minimum_observation_id: str
+    maximum_observation_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayShadowDuplicate:
+    dataset_row_id: str
+    observation_id: str
+    observation_date_utc: str
+    duplicate_type: str
+    duplicate_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayShadowManifest:
+    shadow_dataset_version: str
+    generated_at_utc: str
+    row_count: int
+    unique_observation_count: int
+    duplicate_row_count: int
+    partition_count: int
+    minimum_observation_date_utc: str | None
+    maximum_observation_date_utc: str | None
+    schema_fingerprint: str
+    production_authority: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MatchupOverlayShadowDataset:
+    emitted: bool
+    reason: str
+    dataset_status: str
+    rows: tuple[MatchupOverlayShadowRow, ...]
+    partitions: tuple[MatchupOverlayShadowPartition, ...]
+    duplicates: tuple[MatchupOverlayShadowDuplicate, ...]
+    manifest: MatchupOverlayShadowManifest | None
+    diagnostic_codes: tuple[str, ...]
+    validation_errors: tuple[str, ...]
+    shadow_dataset_version: str
+    append_only: bool = True
+    historical_outcomes_joined: bool = False
+    predictive_evaluation_executed: bool = False
+    production_authority: bool = False
+    production_behavior_changed: bool = False
+    simulation_behavior_changed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "emitted": self.emitted,
+            "reason": self.reason,
+            "dataset_status": self.dataset_status,
+            "rows": [row.to_dict() for row in self.rows],
+            "partitions": [
+                partition.to_dict()
+                for partition in self.partitions
+            ],
+            "duplicates": [
+                duplicate.to_dict()
+                for duplicate in self.duplicates
+            ],
+            "manifest": (
+                self.manifest.to_dict()
+                if self.manifest is not None
+                else None
+            ),
+            "diagnostic_codes": list(self.diagnostic_codes),
+            "validation_errors": list(self.validation_errors),
+            "shadow_dataset_version": (
+                self.shadow_dataset_version
+            ),
+            "append_only": self.append_only,
+            "historical_outcomes_joined": (
+                self.historical_outcomes_joined
+            ),
+            "predictive_evaluation_executed": (
+                self.predictive_evaluation_executed
+            ),
+            "production_authority": self.production_authority,
+            "production_behavior_changed": (
+                self.production_behavior_changed
+            ),
+            "simulation_behavior_changed": (
+                self.simulation_behavior_changed
+            ),
+        }
+
+
+def _sorted_unique_strings(
+    values: Iterable[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for value in values
+                if isinstance(value, str) and value
+            }
+        )
+    )
+
+
+def _schema_fingerprint() -> str:
+    serialized = json.dumps(
+        SHADOW_ROW_FIELD_ORDER,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()
+
+
+def _dataset_row_id(
+    observation_id: str,
+    observation_date_utc: str,
+) -> str:
+    serialized = json.dumps(
+        {
+            "observation_id": observation_id,
+            "observation_date_utc": observation_date_utc,
+            "shadow_dataset_version": SHADOW_DATASET_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()[:20]
+    return f"matchup-shadow-{digest}"
+
+
+def _partition_key(
+    observation_date_utc: str,
+) -> str:
+    return observation_date_utc.replace("-", "_")
+
+
+def _row_signature(
+    row: MatchupOverlayShadowRow,
+) -> str:
+    return json.dumps(
+        row.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def build_pitch_type_matchup_overlay_shadow_dataset(
+    bundles: Sequence[
+        MatchupOverlayObservationBundle | None
+    ],
+    *,
+    enabled: bool = False,
+    generated_at_utc: str | None = None,
+) -> MatchupOverlayShadowDataset:
+    if not enabled:
+        return MatchupOverlayShadowDataset(
+            emitted=False,
+            reason="shadow_dataset_disabled",
+            dataset_status="disabled",
+            rows=(),
+            partitions=(),
+            duplicates=(),
+            manifest=None,
+            diagnostic_codes=(
+                "matchup_shadow_dataset_disabled",
+            ),
+            validation_errors=(),
+            shadow_dataset_version=SHADOW_DATASET_VERSION,
+        )
+
+    diagnostics: list[str] = []
+    validation_errors: list[str] = []
+    candidate_rows: list[MatchupOverlayShadowRow] = []
+
+    for bundle in bundles:
+        if bundle is None:
+            validation_errors.append(
+                "matchup_shadow_observation_missing"
+            )
+            continue
+
+        if not bundle.emitted:
+            diagnostics.append(
+                "matchup_shadow_observation_not_emitted"
+            )
+            continue
+
+        if bundle.summary is None:
+            diagnostics.append(
+                "matchup_shadow_summary_missing"
+            )
+            continue
+
+        summary = bundle.summary
+        observation_date = summary.as_of_date_utc
+
+        if not observation_date:
+            validation_errors.append(
+                "matchup_shadow_date_missing"
+            )
+            continue
+
+        if summary.overlay_status not in SUPPORTED_OVERLAY_STATUSES:
+            validation_errors.append(
+                "matchup_shadow_overlay_status_invalid"
+            )
+
+        if (
+            bundle.observability_status
+            not in SUPPORTED_OBSERVABILITY_STATUSES
+        ):
+            validation_errors.append(
+                "matchup_shadow_observability_status_invalid"
+            )
+
+        if not 0.0 <= summary.coverage_share <= 1.0:
+            validation_errors.append(
+                "matchup_shadow_coverage_invalid"
+            )
+
+        counts = (
+            summary.matched_pitch_count,
+            summary.unmatched_pitch_count,
+            summary.overlay_entry_count,
+            summary.fallback_entry_count,
+            summary.unknown_pitch_entry_count,
+            summary.pitcher_only_entry_count,
+        )
+
+        if any(value < 0 for value in counts):
+            validation_errors.append(
+                "matchup_shadow_count_invalid"
+            )
+
+        usage_values = (
+            summary.matched_usage_share,
+            summary.unmatched_usage_share,
+        )
+
+        numeric_usage = [
+            value
+            for value in usage_values
+            if value is not None
+        ]
+
+        if any(
+            not 0.0 <= value <= 1.0
+            for value in numeric_usage
+        ):
+            validation_errors.append(
+                "matchup_shadow_usage_invalid"
+            )
+
+        if (
+            len(numeric_usage) == 2
+            and sum(numeric_usage) > 1.000001
+        ):
+            validation_errors.append(
+                "matchup_shadow_usage_total_invalid"
+            )
+
+        candidate_rows.append(
+            MatchupOverlayShadowRow(
+                dataset_row_id=_dataset_row_id(
+                    summary.observation_id,
+                    observation_date,
+                ),
+                observation_id=summary.observation_id,
+                observation_date_utc=observation_date,
+                pitcher_id=summary.pitcher_id,
+                batter_id=summary.batter_id,
+                pitcher_hand=summary.pitcher_hand,
+                batter_hand=summary.batter_hand,
+                count_context=summary.count_context,
+                overlay_status=summary.overlay_status,
+                observability_status=(
+                    bundle.observability_status
+                ),
+                coverage_share=round(
+                    summary.coverage_share,
+                    6,
+                ),
+                matched_pitch_count=(
+                    summary.matched_pitch_count
+                ),
+                unmatched_pitch_count=(
+                    summary.unmatched_pitch_count
+                ),
+                overlay_entry_count=(
+                    summary.overlay_entry_count
+                ),
+                fallback_entry_count=(
+                    summary.fallback_entry_count
+                ),
+                unknown_pitch_entry_count=(
+                    summary.unknown_pitch_entry_count
+                ),
+                pitcher_only_entry_count=(
+                    summary.pitcher_only_entry_count
+                ),
+                matched_usage_share=(
+                    summary.matched_usage_share
+                ),
+                unmatched_usage_share=(
+                    summary.unmatched_usage_share
+                ),
+                pitcher_profile_version=(
+                    summary.pitcher_profile_version
+                ),
+                batter_profile_version=(
+                    summary.batter_profile_version
+                ),
+                overlay_version=summary.overlay_version,
+                observability_version=(
+                    summary.observability_version
+                ),
+                shadow_dataset_version=(
+                    SHADOW_DATASET_VERSION
+                ),
+            )
+        )
+
+    grouped: dict[
+        str,
+        list[MatchupOverlayShadowRow],
+    ] = {}
+
+    for row in candidate_rows:
+        grouped.setdefault(
+            row.dataset_row_id,
+            [],
+        ).append(row)
+
+    accepted_rows: list[MatchupOverlayShadowRow] = []
+    duplicates: list[MatchupOverlayShadowDuplicate] = []
+
+    for dataset_row_id in sorted(grouped):
+        group = grouped[dataset_row_id]
+        signatures = {
+            _row_signature(row)
+            for row in group
+        }
+
+        if len(signatures) == 1:
+            accepted_rows.append(group[0])
+
+            if len(group) > 1:
+                diagnostics.append(
+                    "matchup_shadow_exact_duplicate_collapsed"
+                )
+                duplicates.append(
+                    MatchupOverlayShadowDuplicate(
+                        dataset_row_id=dataset_row_id,
+                        observation_id=(
+                            group[0].observation_id
+                        ),
+                        observation_date_utc=(
+                            group[
+                                0
+                            ].observation_date_utc
+                        ),
+                        duplicate_type="exact",
+                        duplicate_count=len(group) - 1,
+                    )
+                )
+        else:
+            validation_errors.append(
+                "matchup_shadow_conflicting_duplicate"
+            )
+            duplicates.append(
+                MatchupOverlayShadowDuplicate(
+                    dataset_row_id=dataset_row_id,
+                    observation_id=(
+                        group[0].observation_id
+                    ),
+                    observation_date_utc=(
+                        group[0].observation_date_utc
+                    ),
+                    duplicate_type="conflicting",
+                    duplicate_count=len(group) - 1,
+                )
+            )
+
+    accepted_rows.sort(
+        key=lambda row: (
+            row.observation_date_utc,
+            row.observation_id,
+            row.dataset_row_id,
+        )
+    )
+
+    partition_groups: dict[
+        str,
+        list[MatchupOverlayShadowRow],
+    ] = {}
+
+    for row in accepted_rows:
+        key = _partition_key(
+            row.observation_date_utc
+        )
+        partition_groups.setdefault(
+            key,
+            [],
+        ).append(row)
+
+    partitions = tuple(
+        MatchupOverlayShadowPartition(
+            partition_key=key,
+            partition_path=(
+                f"observation_date_utc={key}/"
+                "shadow_dataset_rows.csv"
+            ),
+            row_count=len(rows),
+            minimum_observation_id=min(
+                row.observation_id
+                for row in rows
+            ),
+            maximum_observation_id=max(
+                row.observation_id
+                for row in rows
+            ),
+        )
+        for key, rows in sorted(
+            partition_groups.items()
+        )
+    )
+
+    dates = [
+        row.observation_date_utc
+        for row in accepted_rows
+    ]
+
+    generated_at = (
+        generated_at_utc
+        or datetime.now(
+            timezone.utc
+        ).isoformat()
+    )
+
+    manifest = MatchupOverlayShadowManifest(
+        shadow_dataset_version=(
+            SHADOW_DATASET_VERSION
+        ),
+        generated_at_utc=generated_at,
+        row_count=len(accepted_rows),
+        unique_observation_count=len(
+            {
+                row.observation_id
+                for row in accepted_rows
+            }
+        ),
+        duplicate_row_count=sum(
+            duplicate.duplicate_count
+            for duplicate in duplicates
+        ),
+        partition_count=len(partitions),
+        minimum_observation_date_utc=(
+            min(dates) if dates else None
+        ),
+        maximum_observation_date_utc=(
+            max(dates) if dates else None
+        ),
+        schema_fingerprint=_schema_fingerprint(),
+    )
+
+    if validation_errors:
+        dataset_status = "invalid"
+        reason = "shadow_dataset_invalid"
+    elif not accepted_rows:
+        dataset_status = "empty"
+        reason = "shadow_dataset_empty"
+    elif any(
+        row.observability_status
+        in {"partial", "empty", "invalid"}
+        for row in accepted_rows
+    ):
+        dataset_status = "partial"
+        reason = "shadow_dataset_partial"
+    else:
+        dataset_status = "ready"
+        reason = "shadow_dataset_ready"
+
+    return MatchupOverlayShadowDataset(
+        emitted=True,
+        reason=reason,
+        dataset_status=dataset_status,
+        rows=tuple(accepted_rows),
+        partitions=partitions,
+        duplicates=tuple(duplicates),
+        manifest=manifest,
+        diagnostic_codes=_sorted_unique_strings(
+            diagnostics
+        ),
+        validation_errors=_sorted_unique_strings(
+            validation_errors
+        ),
+        shadow_dataset_version=(
+            SHADOW_DATASET_VERSION
+        ),
+    )

--- a/scripts/audit_8M_pitch_type_matchup_overlay_shadow_dataset_contract.py
+++ b/scripts/audit_8M_pitch_type_matchup_overlay_shadow_dataset_contract.py
@@ -1,0 +1,1240 @@
+#!/usr/bin/env python3
+"""
+Layer 8M pitch-type matchup overlay shadow dataset audit.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+from dataclasses import replace
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from mlb_app.pitching.batter_pitch_type_response_profile import (
+    build_batter_pitch_type_response_profile,
+)
+from mlb_app.pitching.pitch_type_matchup_overlay import (
+    build_pitch_type_matchup_overlay,
+)
+from mlb_app.pitching.pitch_type_matchup_overlay_observability import (
+    observe_pitch_type_matchup_overlay,
+)
+from mlb_app.pitching.pitch_type_matchup_overlay_shadow_dataset import (
+    SHADOW_DATASET_VERSION,
+    build_pitch_type_matchup_overlay_shadow_dataset,
+)
+from mlb_app.pitching.pitcher_arsenal_profile import (
+    build_pitcher_arsenal_profile,
+)
+
+
+LAYER_ID = "8M"
+LAYER_NAME = (
+    "pitch_type_matchup_overlay_shadow_dataset_contract_implementation"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp/"
+    "layer_8M_pitch_type_matchup_overlay_shadow_dataset_contract"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts/"
+    "plan_8L_pitch_type_matchup_overlay_shadow_dataset_contract.py"
+)
+
+IMPLEMENTATION_PATH = (
+    ROOT
+    / "mlb_app/pitching/"
+    "pitch_type_matchup_overlay_shadow_dataset.py"
+)
+
+FIXED_GENERATED_AT = "2026-07-01T00:00:00+00:00"
+
+
+def write_csv(
+    path: Path,
+    fieldnames: list[str],
+    rows: Iterable[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(
+    path: Path,
+    payload: Any,
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def string_constants(
+    path: Path,
+) -> set[str]:
+    tree = ast.parse(
+        path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        ),
+        filename=str(path),
+    )
+
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+    }
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    predecessor_present = (
+        "pitch_type_matchup_overlay_shadow_dataset_contract_plan_complete"
+        in string_constants(
+            PLAN_PATH
+        )
+    )
+
+    pitcher_profile = build_pitcher_arsenal_profile(
+        {
+            "enabled": True,
+            "pitcher_id": "pitcher-1",
+            "pitcher_name": "Example Pitcher",
+            "pitcher_hand": "R",
+            "pitcher_role": "starter",
+            "season": 2026,
+            "as_of_date_utc": "2026-06-30",
+            "source_name": "statcast",
+            "source_timestamp_utc": (
+                "2026-06-25T00:00:00+00:00"
+            ),
+            "arsenal_entries": [
+                {
+                    "canonical_pitch_id": "FF",
+                    "pitch_count": 60,
+                    "quality_index": 0.4,
+                    "command_index": 0.2,
+                },
+                {
+                    "canonical_pitch_id": "SL",
+                    "pitch_count": 30,
+                    "quality_index": 0.6,
+                    "command_index": 0.1,
+                },
+                {
+                    "canonical_pitch_id": "CH",
+                    "pitch_count": 10,
+                },
+            ],
+        }
+    )
+
+    batter_profile = (
+        build_batter_pitch_type_response_profile(
+            {
+                "enabled": True,
+                "batter_id": "batter-1",
+                "batter_name": "Example Batter",
+                "batter_hand": "L",
+                "season": 2026,
+                "as_of_date_utc": "2026-06-30",
+                "source_name": "statcast",
+                "source_timestamp_utc": (
+                    "2026-06-25T00:00:00+00:00"
+                ),
+                "response_entries": [
+                    {
+                        "canonical_pitch_id": "FF",
+                        "pitcher_hand": "R",
+                        "count_context": "all_counts",
+                        "pitch_count": 70,
+                        "swing_count": 35,
+                        "contact_count": 28,
+                        "batted_ball_count": 20,
+                        "swing_rate": 0.5,
+                        "whiff_rate": 0.2,
+                        "contact_rate": 0.8,
+                        "hard_hit_rate": 0.4,
+                        "barrel_rate": 0.1,
+                    },
+                    {
+                        "canonical_pitch_id": "SL",
+                        "pitcher_hand": "R",
+                        "count_context": "all_counts",
+                        "pitch_count": 30,
+                        "swing_count": 18,
+                        "contact_count": 12,
+                        "batted_ball_count": 8,
+                        "swing_rate": 0.6,
+                        "whiff_rate": 0.333333,
+                        "contact_rate": 0.666667,
+                        "hard_hit_rate": 0.25,
+                        "barrel_rate": 0.05,
+                    },
+                ],
+            }
+        )
+    )
+
+    overlay = build_pitch_type_matchup_overlay(
+        pitcher_profile,
+        batter_profile,
+        enabled=True,
+    )
+
+    complete_bundle = (
+        observe_pitch_type_matchup_overlay(
+            overlay,
+            enabled=True,
+        )
+    )
+
+    second_bundle = replace(
+        complete_bundle,
+        summary=replace(
+            complete_bundle.summary,
+            observation_id="matchup-overlay-second",
+            as_of_date_utc="2026-07-01",
+        ),
+    )
+
+    ready_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [
+                complete_bundle,
+                second_bundle,
+            ],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    cases: list[dict[str, Any]] = []
+
+    def record(
+        case_id: str,
+        description: str,
+        passed: bool,
+        actual: Any,
+        expected: Any,
+    ) -> None:
+        cases.append(
+            {
+                "case_id": case_id,
+                "description": description,
+                "passed": passed,
+                "actual": json.dumps(
+                    actual,
+                    sort_keys=True,
+                    default=str,
+                ),
+                "expected": json.dumps(
+                    expected,
+                    sort_keys=True,
+                    default=str,
+                ),
+            }
+        )
+
+    record(
+        "8M-C01",
+        "ready dataset emits",
+        ready_dataset.emitted
+        and ready_dataset.dataset_status == "ready",
+        ready_dataset.to_dict(),
+        {
+            "emitted": True,
+            "dataset_status": "ready",
+        },
+    )
+
+    record(
+        "8M-C02",
+        "two rows accepted",
+        len(ready_dataset.rows) == 2,
+        len(ready_dataset.rows),
+        2,
+    )
+
+    record(
+        "8M-C03",
+        "row ids deterministic",
+        all(
+            row.dataset_row_id.startswith(
+                "matchup-shadow-"
+            )
+            for row in ready_dataset.rows
+        ),
+        [
+            row.dataset_row_id
+            for row in ready_dataset.rows
+        ],
+        "matchup-shadow-*",
+    )
+
+    record(
+        "8M-C04",
+        "rows sorted by date",
+        [
+            row.observation_date_utc
+            for row in ready_dataset.rows
+        ]
+        == [
+            "2026-06-30",
+            "2026-07-01",
+        ],
+        [
+            row.observation_date_utc
+            for row in ready_dataset.rows
+        ],
+        [
+            "2026-06-30",
+            "2026-07-01",
+        ],
+    )
+
+    record(
+        "8M-C05",
+        "partitions deterministic",
+        [
+            partition.partition_key
+            for partition in ready_dataset.partitions
+        ]
+        == [
+            "2026_06_30",
+            "2026_07_01",
+        ],
+        [
+            partition.partition_key
+            for partition in ready_dataset.partitions
+        ],
+        [
+            "2026_06_30",
+            "2026_07_01",
+        ],
+    )
+
+    disabled_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [complete_bundle],
+            enabled=False,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C06",
+        "disabled path non-emitting",
+        disabled_dataset.emitted is False
+        and disabled_dataset.manifest is None
+        and not disabled_dataset.rows,
+        disabled_dataset.to_dict(),
+        {
+            "emitted": False,
+            "manifest": None,
+            "rows": [],
+        },
+    )
+
+    empty_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C07",
+        "empty dataset supported",
+        empty_dataset.dataset_status == "empty",
+        empty_dataset.dataset_status,
+        "empty",
+    )
+
+    missing_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [None],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C08",
+        "missing bundle invalid",
+        missing_dataset.dataset_status == "invalid",
+        missing_dataset.to_dict(),
+        {
+            "dataset_status": "invalid",
+        },
+    )
+
+    non_emitted_bundle = (
+        observe_pitch_type_matchup_overlay(
+            overlay,
+            enabled=False,
+        )
+    )
+
+    skipped_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [non_emitted_bundle],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C09",
+        "non-emitted observation skipped",
+        skipped_dataset.dataset_status == "empty"
+        and (
+            "matchup_shadow_observation_not_emitted"
+            in skipped_dataset.diagnostic_codes
+        ),
+        skipped_dataset.to_dict(),
+        {
+            "dataset_status": "empty",
+        },
+    )
+
+    exact_duplicate_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [
+                complete_bundle,
+                complete_bundle,
+            ],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C10",
+        "exact duplicate collapsed",
+        len(exact_duplicate_dataset.rows) == 1
+        and exact_duplicate_dataset.manifest is not None
+        and (
+            exact_duplicate_dataset.manifest.duplicate_row_count
+            == 1
+        ),
+        exact_duplicate_dataset.to_dict(),
+        {
+            "row_count": 1,
+            "duplicate_row_count": 1,
+        },
+    )
+
+    conflicting_bundle = replace(
+        complete_bundle,
+        summary=replace(
+            complete_bundle.summary,
+            coverage_share=0.8,
+        ),
+    )
+
+    conflicting_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [
+                complete_bundle,
+                conflicting_bundle,
+            ],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C11",
+        "conflicting duplicate invalid",
+        conflicting_dataset.dataset_status
+        == "invalid"
+        and (
+            "matchup_shadow_conflicting_duplicate"
+            in conflicting_dataset.validation_errors
+        ),
+        conflicting_dataset.to_dict(),
+        {
+            "dataset_status": "invalid",
+        },
+    )
+
+    partial_bundle = replace(
+        complete_bundle,
+        observability_status="partial",
+    )
+
+    partial_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [partial_bundle],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C12",
+        "partial dataset supported",
+        partial_dataset.dataset_status == "partial",
+        partial_dataset.dataset_status,
+        "partial",
+    )
+
+    record(
+        "8M-C13",
+        "manifest counts reconcile",
+        ready_dataset.manifest is not None
+        and ready_dataset.manifest.row_count
+        == len(ready_dataset.rows)
+        and ready_dataset.manifest.partition_count
+        == len(ready_dataset.partitions),
+        (
+            ready_dataset.manifest.to_dict()
+            if ready_dataset.manifest
+            else None
+        ),
+        {
+            "row_count": 2,
+            "partition_count": 2,
+        },
+    )
+
+    record(
+        "8M-C14",
+        "manifest date bounds reconcile",
+        ready_dataset.manifest is not None
+        and (
+            ready_dataset.manifest.minimum_observation_date_utc
+            == "2026-06-30"
+        )
+        and (
+            ready_dataset.manifest.maximum_observation_date_utc
+            == "2026-07-01"
+        ),
+        (
+            ready_dataset.manifest.to_dict()
+            if ready_dataset.manifest
+            else None
+        ),
+        {
+            "minimum": "2026-06-30",
+            "maximum": "2026-07-01",
+        },
+    )
+
+    record(
+        "8M-C15",
+        "schema fingerprint deterministic",
+        ready_dataset.manifest is not None
+        and len(
+            ready_dataset.manifest.schema_fingerprint
+        )
+        == 64,
+        (
+            ready_dataset.manifest.schema_fingerprint
+            if ready_dataset.manifest
+            else None
+        ),
+        "64_character_sha256",
+    )
+
+    repeated_dataset = (
+        build_pitch_type_matchup_overlay_shadow_dataset(
+            [
+                complete_bundle,
+                second_bundle,
+            ],
+            enabled=True,
+            generated_at_utc=FIXED_GENERATED_AT,
+        )
+    )
+
+    record(
+        "8M-C16",
+        "dataset serialization deterministic",
+        ready_dataset.to_dict()
+        == repeated_dataset.to_dict(),
+        ready_dataset.to_dict(),
+        repeated_dataset.to_dict(),
+    )
+
+    record(
+        "8M-C17",
+        "source versions retained",
+        all(
+            row.overlay_version == "8I-v1"
+            and row.observability_version
+            == "8K-v1"
+            and row.shadow_dataset_version
+            == "8M-v1"
+            for row in ready_dataset.rows
+        ),
+        [
+            row.to_dict()
+            for row in ready_dataset.rows
+        ],
+        {
+            "overlay_version": "8I-v1",
+            "observability_version": "8K-v1",
+            "shadow_dataset_version": "8M-v1",
+        },
+    )
+
+    record(
+        "8M-C18",
+        "append-only flag explicit",
+        ready_dataset.append_only is True,
+        ready_dataset.append_only,
+        True,
+    )
+
+    record(
+        "8M-C19",
+        "manifest production authority false",
+        ready_dataset.manifest is not None
+        and (
+            ready_dataset.manifest.production_authority
+            is False
+        ),
+        (
+            ready_dataset.manifest.production_authority
+            if ready_dataset.manifest
+            else None
+        ),
+        False,
+    )
+
+    record(
+        "8M-C20",
+        "all prohibited authority remains false",
+        all(
+            value is False
+            for value in [
+                ready_dataset.historical_outcomes_joined,
+                ready_dataset.predictive_evaluation_executed,
+                ready_dataset.production_authority,
+                ready_dataset.production_behavior_changed,
+                ready_dataset.simulation_behavior_changed,
+            ]
+        ),
+        ready_dataset.to_dict(),
+        {
+            "all_authority_flags": False,
+        },
+    )
+
+    checks = [
+        {
+            "check": "required_files_exist",
+            "actual": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+            "expected": True,
+            "passed": (
+                PLAN_PATH.exists()
+                and IMPLEMENTATION_PATH.exists()
+            ),
+        },
+        {
+            "check": "eight_l_predecessor_present",
+            "actual": predecessor_present,
+            "expected": True,
+            "passed": predecessor_present,
+        },
+        {
+            "check": "twenty_contract_cases_pass",
+            "actual": sum(
+                1
+                for row in cases
+                if row["passed"]
+            ),
+            "expected": 20,
+            "passed": all(
+                row["passed"]
+                for row in cases
+            ),
+        },
+        {
+            "check": "ready_dataset_supported",
+            "actual": ready_dataset.dataset_status,
+            "expected": "ready",
+            "passed": (
+                ready_dataset.dataset_status == "ready"
+            ),
+        },
+        {
+            "check": "two_rows_accepted",
+            "actual": len(ready_dataset.rows),
+            "expected": 2,
+            "passed": len(ready_dataset.rows) == 2,
+        },
+        {
+            "check": "deterministic_row_ids_supported",
+            "actual": all(
+                row.dataset_row_id.startswith(
+                    "matchup-shadow-"
+                )
+                for row in ready_dataset.rows
+            ),
+            "expected": True,
+            "passed": all(
+                row.dataset_row_id.startswith(
+                    "matchup-shadow-"
+                )
+                for row in ready_dataset.rows
+            ),
+        },
+        {
+            "check": "date_ordering_supported",
+            "actual": [
+                row.observation_date_utc
+                for row in ready_dataset.rows
+            ],
+            "expected": [
+                "2026-06-30",
+                "2026-07-01",
+            ],
+            "passed": [
+                row.observation_date_utc
+                for row in ready_dataset.rows
+            ]
+            == [
+                "2026-06-30",
+                "2026-07-01",
+            ],
+        },
+        {
+            "check": "partitioning_supported",
+            "actual": [
+                partition.partition_key
+                for partition
+                in ready_dataset.partitions
+            ],
+            "expected": [
+                "2026_06_30",
+                "2026_07_01",
+            ],
+            "passed": [
+                partition.partition_key
+                for partition
+                in ready_dataset.partitions
+            ]
+            == [
+                "2026_06_30",
+                "2026_07_01",
+            ],
+        },
+        {
+            "check": "disabled_path_non_emitting",
+            "actual": disabled_dataset.emitted,
+            "expected": False,
+            "passed": disabled_dataset.emitted is False,
+        },
+        {
+            "check": "empty_dataset_supported",
+            "actual": empty_dataset.dataset_status,
+            "expected": "empty",
+            "passed": (
+                empty_dataset.dataset_status == "empty"
+            ),
+        },
+        {
+            "check": "invalid_dataset_supported",
+            "actual": missing_dataset.dataset_status,
+            "expected": "invalid",
+            "passed": (
+                missing_dataset.dataset_status
+                == "invalid"
+            ),
+        },
+        {
+            "check": "partial_dataset_supported",
+            "actual": partial_dataset.dataset_status,
+            "expected": "partial",
+            "passed": (
+                partial_dataset.dataset_status
+                == "partial"
+            ),
+        },
+        {
+            "check": "exact_duplicate_collapsed",
+            "actual": (
+                exact_duplicate_dataset.manifest.duplicate_row_count
+                if exact_duplicate_dataset.manifest
+                else None
+            ),
+            "expected": 1,
+            "passed": (
+                exact_duplicate_dataset.manifest
+                is not None
+                and len(
+                    exact_duplicate_dataset.rows
+                )
+                == 1
+                and (
+                    exact_duplicate_dataset.manifest.duplicate_row_count
+                    == 1
+                )
+            ),
+        },
+        {
+            "check": "conflicting_duplicate_invalid",
+            "actual": (
+                conflicting_dataset.dataset_status
+            ),
+            "expected": "invalid",
+            "passed": (
+                conflicting_dataset.dataset_status
+                == "invalid"
+            ),
+        },
+        {
+            "check": "manifest_counts_reconcile",
+            "actual": (
+                ready_dataset.manifest.to_dict()
+                if ready_dataset.manifest
+                else None
+            ),
+            "expected": {
+                "row_count": 2,
+                "partition_count": 2,
+            },
+            "passed": (
+                ready_dataset.manifest is not None
+                and ready_dataset.manifest.row_count
+                == len(ready_dataset.rows)
+                and ready_dataset.manifest.partition_count
+                == len(ready_dataset.partitions)
+            ),
+        },
+        {
+            "check": "schema_fingerprint_supported",
+            "actual": (
+                ready_dataset.manifest.schema_fingerprint
+                if ready_dataset.manifest
+                else None
+            ),
+            "expected": "64_character_sha256",
+            "passed": (
+                ready_dataset.manifest is not None
+                and len(
+                    ready_dataset.manifest.schema_fingerprint
+                )
+                == 64
+            ),
+        },
+        {
+            "check": "serialization_deterministic",
+            "actual": (
+                ready_dataset.to_dict()
+                == repeated_dataset.to_dict()
+            ),
+            "expected": True,
+            "passed": (
+                ready_dataset.to_dict()
+                == repeated_dataset.to_dict()
+            ),
+        },
+        {
+            "check": "append_only_contract_preserved",
+            "actual": ready_dataset.append_only,
+            "expected": True,
+            "passed": ready_dataset.append_only is True,
+        },
+        {
+            "check": "production_simulation_validation_authority_absent",
+            "actual": any(
+                [
+                    ready_dataset.historical_outcomes_joined,
+                    ready_dataset.predictive_evaluation_executed,
+                    ready_dataset.production_authority,
+                    ready_dataset.production_behavior_changed,
+                    ready_dataset.simulation_behavior_changed,
+                ]
+            ),
+            "expected": False,
+            "passed": all(
+                value is False
+                for value in [
+                    ready_dataset.historical_outcomes_joined,
+                    ready_dataset.predictive_evaluation_executed,
+                    ready_dataset.production_authority,
+                    ready_dataset.production_behavior_changed,
+                    ready_dataset.simulation_behavior_changed,
+                ]
+            ),
+        },
+    ]
+
+    all_checks_passed = all(
+        row["passed"]
+        for row in checks
+    )
+
+    status_order = [
+        "ready",
+        "partial",
+        "empty",
+        "invalid",
+        "disabled",
+    ]
+
+    datasets = [
+        ready_dataset,
+        partial_dataset,
+        empty_dataset,
+        missing_dataset,
+        disabled_dataset,
+    ]
+
+    status_rows = [
+        {
+            "dataset_status": status,
+            "count": sum(
+                1
+                for dataset in datasets
+                if dataset.dataset_status
+                == status
+            ),
+        }
+        for status in status_order
+    ]
+
+    authority_rows = [
+        {
+            "authority": (
+                "pitch_type_matchup_overlay_shadow_dataset_diagnostic"
+            ),
+            "granted": all_checks_passed,
+            "reason": (
+                "Bounded append-only shadow dataset passed all checks."
+            ),
+        },
+        {
+            "authority": (
+                "historical_outcome_enrichment"
+            ),
+            "granted": False,
+            "reason": (
+                "No outcomes are joined."
+            ),
+        },
+        {
+            "authority": (
+                "predictive_evaluation"
+            ),
+            "granted": False,
+            "reason": (
+                "No predictive evaluation is executed."
+            ),
+        },
+        {
+            "authority": (
+                "production_or_simulation_change"
+            ),
+            "granted": False,
+            "reason": (
+                "Production and simulation behavior remain unchanged."
+            ),
+        },
+        {
+            "authority": (
+                "tuning_backtest_pricing_edge"
+            ),
+            "granted": False,
+            "reason": (
+                "Tuning, backtests, pricing, and edge work remain unauthorized."
+            ),
+        },
+    ]
+
+    diagnosis_name = (
+        "pitch_type_matchup_overlay_shadow_dataset_contract_implementation_passed"
+        if all_checks_passed
+        else
+        "pitch_type_matchup_overlay_shadow_dataset_contract_implementation_failed"
+    )
+
+    recommended_next_layer = (
+        "8N_pitch_type_matchup_overlay_shadow_dataset_quality_gate_contract_plan"
+        if all_checks_passed
+        else
+        "8M_pitch_type_matchup_overlay_shadow_dataset_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "contract_cases.csv",
+        [
+            "case_id",
+            "description",
+            "passed",
+            "actual",
+            "expected",
+        ],
+        cases,
+    )
+
+    row_records = [
+        row.to_dict()
+        for row in ready_dataset.rows
+    ]
+
+    write_csv(
+        OUTPUT_DIR / "shadow_dataset_rows.csv",
+        list(row_records[0].keys())
+        if row_records
+        else ["dataset_row_id"],
+        row_records,
+    )
+
+    partition_records = [
+        partition.to_dict()
+        for partition in ready_dataset.partitions
+    ]
+
+    write_csv(
+        OUTPUT_DIR / "partition_manifest.csv",
+        list(partition_records[0].keys())
+        if partition_records
+        else ["partition_key"],
+        partition_records,
+    )
+
+    duplicate_records = [
+        duplicate.to_dict()
+        for duplicate in exact_duplicate_dataset.duplicates
+    ]
+
+    write_csv(
+        OUTPUT_DIR / "duplicate_report.csv",
+        list(duplicate_records[0].keys())
+        if duplicate_records
+        else [
+            "dataset_row_id",
+            "observation_id",
+            "observation_date_utc",
+            "duplicate_type",
+            "duplicate_count",
+        ],
+        duplicate_records,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "status_counts.csv",
+        [
+            "dataset_status",
+            "count",
+        ],
+        status_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "authority_boundaries.csv",
+        [
+            "authority",
+            "granted",
+            "reason",
+        ],
+        authority_rows,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "recommended_path.csv",
+        [
+            "recommended_next_layer",
+            "recommended_action",
+            "entry_condition",
+            "passed",
+        ],
+        [
+            {
+                "recommended_next_layer": (
+                    recommended_next_layer
+                ),
+                "recommended_action": (
+                    "Plan bounded quality gates for the diagnostic shadow dataset."
+                    if all_checks_passed
+                    else
+                    "Remediate failed 8M implementation checks."
+                ),
+                "entry_condition": (
+                    "All nineteen 8M implementation checks pass."
+                ),
+                "passed": all_checks_passed,
+            }
+        ],
+    )
+
+    manifest_payload = (
+        ready_dataset.manifest.to_dict()
+        if ready_dataset.manifest
+        else {}
+    )
+
+    write_json(
+        OUTPUT_DIR
+        / "shadow_dataset_manifest.json",
+        manifest_payload,
+    )
+
+    summary = {
+        "implementation_checks_required": len(
+            checks
+        ),
+        "implementation_checks_passed": sum(
+            1
+            for row in checks
+            if row["passed"]
+        ),
+        "contract_cases_required": len(
+            cases
+        ),
+        "contract_cases_passed": sum(
+            1
+            for row in cases
+            if row["passed"]
+        ),
+        "shadow_dataset_version": (
+            SHADOW_DATASET_VERSION
+        ),
+        "row_serialization_implemented": True,
+        "date_partitioning_implemented": True,
+        "deterministic_row_ids_implemented": True,
+        "exact_duplicate_collapse_implemented": True,
+        "conflicting_duplicate_detection_implemented": True,
+        "schema_fingerprint_implemented": True,
+        "append_only_contract_preserved": True,
+        "disabled_path_non_emitting": True,
+        "historical_outcome_joined": False,
+        "predictive_evaluation_executed": False,
+        "production_behavior_changed": False,
+        "simulation_behavior_changed": False,
+        "canonical_probability_authority_changed": False,
+        "tuning_executed": False,
+        "pricing_or_edge_work_executed": False,
+    }
+
+    write_json(
+        OUTPUT_DIR / "implementation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "diagnosis": diagnosis_name,
+        "all_checks_passed": all_checks_passed,
+        **summary,
+        "layer8_completed": False,
+        "new_production_authority_granted": False,
+        "historical_validation_allowed_next": False,
+        "historical_outcome_enrichment_allowed_next": False,
+        "predictive_evaluation_allowed_next": False,
+        "tuning_allowed_next": False,
+        "backtests_allowed_next": False,
+        "pricing_allowed_next": False,
+        "edge_detection_allowed_next": False,
+        "shadow_dataset_quality_gate_planning_allowed_next": (
+            all_checks_passed
+        ),
+        "production_matchup_overlay_integration_allowed_next": False,
+        "recommended_next_layer": (
+            recommended_next_layer
+        ),
+        "generated_csv_artifacts": [
+            str(
+                OUTPUT_DIR / filename
+            )
+            for filename in [
+                "implementation_checks.csv",
+                "contract_cases.csv",
+                "shadow_dataset_rows.csv",
+                "partition_manifest.csv",
+                "duplicate_report.csv",
+                "status_counts.csv",
+                "authority_boundaries.csv",
+                "recommended_path.csv",
+            ]
+        ],
+        "generated_json_artifacts": [
+            str(
+                OUTPUT_DIR
+                / "shadow_dataset_manifest.json"
+            ),
+            str(
+                OUTPUT_DIR
+                / "implementation_summary.json"
+            ),
+            str(
+                OUTPUT_DIR / "diagnosis.json"
+            ),
+        ],
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        json.dumps(
+            diagnosis,
+            indent=2,
+        )
+    )
+
+    return 0 if all_checks_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Layer
8M — Pitch-Type Matchup Overlay Shadow Dataset Contract Implementation

## Objective
Implement and independently audit a deterministic, append-only diagnostic shadow dataset for Layer 8K pitch-type matchup overlay observations.

## Results
- 19/19 implementation checks pass
- 20/20 contract cases pass
- shadow dataset version `8M-v1`
- deterministic `matchup-shadow-*` row identifiers implemented
- deterministic row serialization and date partitioning implemented
- exact duplicate collapse implemented
- conflicting duplicate detection implemented
- deterministic schema fingerprint implemented
- reconciled dataset and partition manifests implemented
- ready, partial, empty, invalid, and disabled dataset paths supported
- append-only contract preserved
- source version lineage retained
- no historical outcome joins
- no predictive evaluation
- no production overlay integration or matchup activation
- no simulation or canonical probability changes
- no tuning, backtesting, pricing, market comparison, or edge work executed
- no new production authority granted

## Diagnosis
`pitch_type_matchup_overlay_shadow_dataset_contract_implementation_passed`

## Recommended Next Layer
`8N_pitch_type_matchup_overlay_shadow_dataset_quality_gate_contract_plan`