### PR TITLE
Phase 2: add performance, payload, cache, and probability-source instrumentation

### DIFF
--- a/mlb_app/matchup_generator.py
+++ b/mlb_app/matchup_generator.py
@@ -15,6 +15,7 @@ from .canonical_matchup_probability import compute_canonical_matchup_probability
 from .db_utils import get_batter_aggregate, get_pitch_arsenal, get_pitcher_aggregate, get_player_split, get_team_split
 from .etl import fetch_schedule
 from .lineup_profile import build_lineup_offense_diagnostics, build_lineup_offense_inputs
+from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
 from .pitcher_profile_store import get_pitcher_profile_overview
 from .shared_payload_cache import env_ttl, get_cache, make_cache_key, set_cache
 
@@ -250,15 +251,23 @@ def _add_missing_pitcher_diagnostics(base_matchup: Dict) -> None:
 
 
 def _apply_canonical_probability(session: Session, base_matchup: Dict, season: int) -> None:
-    canonical = compute_canonical_matchup_probability(
-        session=session,
-        home_pitcher_id=base_matchup["home_pitcher_id"],
-        away_pitcher_id=base_matchup["away_pitcher_id"],
-        home_team_id=base_matchup["home_team_id"],
-        away_team_id=base_matchup["away_team_id"],
-        season=season,
-        context=base_matchup,
-    )
+    with timing_span(
+        "compute_canonical_matchup_probability",
+        category="probability_resolution",
+        route="/matchups",
+        game_pk=base_matchup.get("game_pk"),
+        date=base_matchup.get("game_date"),
+        probability_source="canonical_matchup_win_probability_v2",
+    ):
+        canonical = compute_canonical_matchup_probability(
+            session=session,
+            home_pitcher_id=base_matchup["home_pitcher_id"],
+            away_pitcher_id=base_matchup["away_pitcher_id"],
+            home_team_id=base_matchup["home_team_id"],
+            away_team_id=base_matchup["away_team_id"],
+            season=season,
+            context=base_matchup,
+        )
     for key in (
         "model_version",
         "legacy_model_version",
@@ -275,6 +284,7 @@ def _apply_canonical_probability(session: Session, base_matchup: Dict, season: i
         "missing_inputs",
     ):
         base_matchup[key] = canonical.get(key)
+    record_probability_source(canonical.get("model_version") or "canonical_matchup_win_probability_v2")
 
 
 def _generate_matchups_for_date_uncached(session: Session, date_str: str) -> List[Dict]:
@@ -283,7 +293,8 @@ def _generate_matchups_for_date_uncached(session: Session, date_str: str) -> Lis
     except ValueError:
         raise ValueError("date_str must be in YYYY-MM-DD format")
 
-    schedule = fetch_schedule(date_str)
+    with timing_span("matchups.fetch_schedule", category="schedule", route="/matchups", date=date_str):
+        schedule = fetch_schedule(date_str)
     season = date_obj.year
     matchups = []
 
@@ -343,8 +354,9 @@ def _generate_matchups_for_date_uncached(session: Session, date_str: str) -> Lis
             continue
 
         try:
-            base_matchup["home_pitcher_features"] = _format_pitcher_features(session, home_pitcher_id)
-            base_matchup["away_pitcher_features"] = _format_pitcher_features(session, away_pitcher_id)
+            with timing_span("matchups.pitcher_features", category="db", route="/matchups", game_pk=game.get("_game_pk"), date=date_str):
+                base_matchup["home_pitcher_features"] = _format_pitcher_features(session, home_pitcher_id)
+                base_matchup["away_pitcher_features"] = _format_pitcher_features(session, away_pitcher_id)
         except Exception:
             log.exception(
                 "Pitcher feature formatting failed for game_pk=%s date=%s home_pitcher_id=%s away_pitcher_id=%s",
@@ -352,8 +364,9 @@ def _generate_matchups_for_date_uncached(session: Session, date_str: str) -> Lis
             )
 
         try:
-            base_matchup["home_pitch_arsenal"] = _format_pitch_arsenal(session, home_pitcher_id, season)
-            base_matchup["away_pitch_arsenal"] = _format_pitch_arsenal(session, away_pitcher_id, season)
+            with timing_span("matchups.pitch_arsenal", category="db", route="/matchups", game_pk=game.get("_game_pk"), date=date_str):
+                base_matchup["home_pitch_arsenal"] = _format_pitch_arsenal(session, home_pitcher_id, season)
+                base_matchup["away_pitch_arsenal"] = _format_pitch_arsenal(session, away_pitcher_id, season)
         except Exception:
             log.exception(
                 "Pitch arsenal formatting failed for game_pk=%s date=%s home_pitcher_id=%s away_pitcher_id=%s season=%s",
@@ -369,48 +382,52 @@ def _generate_matchups_for_date_uncached(session: Session, date_str: str) -> Lis
             base_matchup["away_offense_inputs"] = away_team_fallback
 
             try:
-                home_lineup_diagnostics = build_lineup_offense_diagnostics(
-                    session=session,
-                    game_pk=game.get("_game_pk"),
-                    side="home",
-                    team_id=home_team,
-                    season=season,
-                    split=home_split,
-                    team_fallback=home_team_fallback,
-                )
-                home_lineup_inputs = build_lineup_offense_inputs(
-                    session=session,
-                    game_pk=game.get("_game_pk"),
-                    side="home",
-                    team_id=home_team,
-                    season=season,
-                    split=home_split,
-                    team_fallback=home_team_fallback,
-                )
+                with timing_span("build_lineup_offense_diagnostics", category="formula", route="/matchups", game_pk=game.get("_game_pk"), date=date_str, extra={"side": "home"}):
+                    home_lineup_diagnostics = build_lineup_offense_diagnostics(
+                        session=session,
+                        game_pk=game.get("_game_pk"),
+                        side="home",
+                        team_id=home_team,
+                        season=season,
+                        split=home_split,
+                        team_fallback=home_team_fallback,
+                    )
+                with timing_span("build_lineup_offense_inputs", category="formula", route="/matchups", game_pk=game.get("_game_pk"), date=date_str, extra={"side": "home"}):
+                    home_lineup_inputs = build_lineup_offense_inputs(
+                        session=session,
+                        game_pk=game.get("_game_pk"),
+                        side="home",
+                        team_id=home_team,
+                        season=season,
+                        split=home_split,
+                        team_fallback=home_team_fallback,
+                    )
                 base_matchup["home_offense_inputs"] = home_lineup_inputs or _with_lineup_fallback_diagnostics(base_matchup["home_offense_inputs"], home_lineup_diagnostics)
             except Exception as exc:
                 base_matchup["home_offense_inputs"] = _with_lineup_exception_diagnostics(base_matchup["home_offense_inputs"], exc)
                 log.exception("Confirmed home lineup offense input failed; using fallback for game_pk=%s date=%s home_team_id=%s", game.get("_game_pk"), date_str, home_team)
 
             try:
-                away_lineup_diagnostics = build_lineup_offense_diagnostics(
-                    session=session,
-                    game_pk=game.get("_game_pk"),
-                    side="away",
-                    team_id=away_team,
-                    season=season,
-                    split=away_split,
-                    team_fallback=away_team_fallback,
-                )
-                away_lineup_inputs = build_lineup_offense_inputs(
-                    session=session,
-                    game_pk=game.get("_game_pk"),
-                    side="away",
-                    team_id=away_team,
-                    season=season,
-                    split=away_split,
-                    team_fallback=away_team_fallback,
-                )
+                with timing_span("build_lineup_offense_diagnostics", category="formula", route="/matchups", game_pk=game.get("_game_pk"), date=date_str, extra={"side": "away"}):
+                    away_lineup_diagnostics = build_lineup_offense_diagnostics(
+                        session=session,
+                        game_pk=game.get("_game_pk"),
+                        side="away",
+                        team_id=away_team,
+                        season=season,
+                        split=away_split,
+                        team_fallback=away_team_fallback,
+                    )
+                with timing_span("build_lineup_offense_inputs", category="formula", route="/matchups", game_pk=game.get("_game_pk"), date=date_str, extra={"side": "away"}):
+                    away_lineup_inputs = build_lineup_offense_inputs(
+                        session=session,
+                        game_pk=game.get("_game_pk"),
+                        side="away",
+                        team_id=away_team,
+                        season=season,
+                        split=away_split,
+                        team_fallback=away_team_fallback,
+                    )
                 base_matchup["away_offense_inputs"] = away_lineup_inputs or _with_lineup_fallback_diagnostics(base_matchup["away_offense_inputs"], away_lineup_diagnostics)
             except Exception as exc:
                 base_matchup["away_offense_inputs"] = _with_lineup_exception_diagnostics(base_matchup["away_offense_inputs"], exc)
@@ -444,7 +461,8 @@ def generate_matchups_for_date(session: Session, date_str: str) -> List[Dict]:
     """
     cache_key = make_cache_key("matchups", "date", date_str)
     ttl_seconds = env_ttl("MATCHUPS_CACHE_TTL_SECONDS")
-    cached = get_cache(cache_key, ttl_seconds)
+    with timing_span("generate_matchups_for_date.cache_lookup", category="cache", route="/matchups", date=date_str):
+        cached = get_cache(cache_key, ttl_seconds)
     if cached is not None:
         if isinstance(cached, list):
             for game in cached:
@@ -452,15 +470,36 @@ def generate_matchups_for_date(session: Session, date_str: str) -> List[Dict]:
                     game.setdefault("cache_hit", True)
                     game.setdefault("cache_key", cache_key)
                     game.setdefault("ttl_seconds", ttl_seconds)
+        record_span(
+            "generate_matchups_for_date",
+            category="route",
+            route="/matchups",
+            date=date_str,
+            cache_status="HIT",
+            probability_source="canonical_matchup_win_probability_v2",
+            payload_bytes=estimate_payload_bytes(cached),
+        )
+        record_probability_source("canonical_matchup_win_probability_v2")
         return cached
 
-    matchups = _generate_matchups_for_date_uncached(session, date_str)
+    with timing_span("_generate_matchups_for_date_uncached", category="route", route="/matchups", date=date_str, cache_status="MISS"):
+        matchups = _generate_matchups_for_date_uncached(session, date_str)
     if isinstance(matchups, list):
         for game in matchups:
             if isinstance(game, dict):
                 game.setdefault("cache_hit", False)
                 game.setdefault("cache_key", cache_key)
                 game.setdefault("ttl_seconds", ttl_seconds)
+    record_span(
+        "generate_matchups_for_date",
+        category="route",
+        route="/matchups",
+        date=date_str,
+        cache_status="MISS",
+        probability_source="canonical_matchup_win_probability_v2",
+        payload_bytes=estimate_payload_bytes(matchups),
+    )
+    record_probability_source("canonical_matchup_win_probability_v2")
     return set_cache(cache_key, matchups)
 
 

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 from .database import create_tables, get_engine, get_session
 from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
+from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
 from .shared_payload_cache import env_ttl, get_or_set, make_cache_key
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 
@@ -24,9 +25,27 @@ def _session_factory():
 
 
 def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
-    session_factory = _session_factory()
+    with timing_span("model_projection.session_factory", category="db", route="/models/projections", date=target_date):
+        session_factory = _session_factory()
     with session_factory() as session:
-        return build_model_projection_payload(session, target_date)
+        with timing_span(
+            "build_model_projection_payload",
+            category="projection",
+            route="/models/projections",
+            date=target_date,
+            probability_source="model_projections",
+        ):
+            payload = build_model_projection_payload(session, target_date)
+    record_probability_source("model_projections")
+    record_span(
+        "model_projection.payload_bytes",
+        category="serialization",
+        route="/models/projections",
+        date=target_date,
+        probability_source="model_projections",
+        payload_bytes=estimate_payload_bytes(payload),
+    )
+    return payload
 
 
 @router.get("/models/projections")
@@ -34,11 +53,28 @@ def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
     target_date = date or datetime.date.today().isoformat()
     cache_key = make_cache_key("model_projection", "full", target_date)
     try:
-        return get_or_set(
-            cache_key,
-            env_ttl("MODEL_PROJECTION_CACHE_TTL_SECONDS"),
-            lambda: _build_uncached_projection_payload(target_date),
+        with timing_span(
+            "route.models.projections.resolve",
+            category="route",
+            route="/models/projections",
+            date=target_date,
+            probability_source="model_projections",
+        ):
+            payload = get_or_set(
+                cache_key,
+                env_ttl("MODEL_PROJECTION_CACHE_TTL_SECONDS"),
+                lambda: _build_uncached_projection_payload(target_date),
+            )
+        record_probability_source("model_projections")
+        record_span(
+            "route.models.projections.payload_bytes",
+            category="serialization",
+            route="/models/projections",
+            date=target_date,
+            probability_source="model_projections",
+            payload_bytes=estimate_payload_bytes(payload),
         )
+        return payload
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:

--- a/mlb_app/performance.py
+++ b/mlb_app/performance.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 import contextvars
+import json
 import math
 import time
 from collections import defaultdict, deque
-from typing import Any, Deque, Dict, Iterable, List, Optional
+from typing import Any, Deque, Dict, Iterable, Iterator, List, Optional
 
 try:
     import fastapi as _fastapi
@@ -13,9 +15,19 @@ except Exception:  # pragma: no cover - FastAPI may be absent in narrow unit tes
 
 
 _MAX_SAMPLES = 1000
+_MAX_SPANS = 5000
 _SAMPLES: Deque[Dict[str, Any]] = deque(maxlen=_MAX_SAMPLES)
+_SPANS: Deque[Dict[str, Any]] = deque(maxlen=_MAX_SPANS)
 _CACHE_STATUS: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "mlb_cache_status",
+    default=None,
+)
+_PROBABILITY_SOURCE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "mlb_probability_source",
+    default=None,
+)
+_REQUEST_ROUTE: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "mlb_request_route",
     default=None,
 )
 _PATCHED = False
@@ -26,6 +38,12 @@ def record_cache_status(status: Optional[str]) -> None:
     """Record cache status for the current request context."""
     if status:
         _CACHE_STATUS.set(str(status).upper())
+
+
+def record_probability_source(source: Optional[str]) -> None:
+    """Record probability source metadata for the current request context."""
+    if source:
+        _PROBABILITY_SOURCE.set(str(source))
 
 
 def _percentile(values: List[float], percentile: float) -> float:
@@ -43,6 +61,19 @@ def _route_label(request: Any) -> str:
     return route_path or getattr(getattr(request, "url", None), "path", None) or "unknown"
 
 
+def estimate_payload_bytes(value: Any) -> Optional[int]:
+    """Best-effort JSON payload byte estimate without logging payload contents."""
+    if value is None:
+        return None
+    try:
+        return len(json.dumps(value, default=str, separators=(",", ":")).encode("utf-8"))
+    except Exception:
+        try:
+            return len(str(value).encode("utf-8"))
+        except Exception:
+            return None
+
+
 def _response_size_bytes(response: Any) -> Optional[int]:
     try:
         content_length = response.headers.get("content-length")
@@ -55,9 +86,111 @@ def record_request_sample(sample: Dict[str, Any]) -> None:
     _SAMPLES.append(sample)
 
 
+def record_span(
+    name: str,
+    *,
+    category: str = "custom",
+    route: Optional[str] = None,
+    game_pk: Optional[Any] = None,
+    date: Optional[Any] = None,
+    duration_ms: Optional[float] = None,
+    cache_status: Optional[str] = None,
+    probability_source: Optional[str] = None,
+    payload_bytes: Optional[int] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Record a bounded, non-sensitive performance span."""
+    span: Dict[str, Any] = {
+        "name": str(name),
+        "category": str(category or "custom"),
+        "route": route or _REQUEST_ROUTE.get() or "unknown",
+        "game_pk": game_pk,
+        "date": str(date) if date is not None else None,
+        "duration_ms": round(float(duration_ms or 0.0), 3),
+        "cache_status": cache_status or _CACHE_STATUS.get(),
+        "probability_source": probability_source or _PROBABILITY_SOURCE.get(),
+        "payload_bytes": payload_bytes,
+    }
+    if extra:
+        safe_extra: Dict[str, Any] = {}
+        for key, value in extra.items():
+            if key.lower() in {"token", "authorization", "cookie", "password", "secret"}:
+                continue
+            if isinstance(value, (str, int, float, bool)) or value is None:
+                safe_extra[key] = value
+            else:
+                safe_extra[key] = str(value)[:300]
+        if safe_extra:
+            span["extra"] = safe_extra
+    _SPANS.append(span)
+    return span
+
+
+@contextlib.contextmanager
+def timing_span(
+    name: str,
+    *,
+    category: str = "custom",
+    route: Optional[str] = None,
+    game_pk: Optional[Any] = None,
+    date: Optional[Any] = None,
+    cache_status: Optional[str] = None,
+    probability_source: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Iterator[None]:
+    """Context manager for recording formula/build/cache/simulation timings."""
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        record_span(
+            name,
+            category=category,
+            route=route,
+            game_pk=game_pk,
+            date=date,
+            duration_ms=(time.perf_counter() - started) * 1000,
+            cache_status=cache_status,
+            probability_source=probability_source,
+            extra=extra,
+        )
+
+
+def _group_counts(rows: Iterable[Dict[str, Any]], field: str, default: str = "NONE") -> Dict[str, int]:
+    counts: Dict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[str(row.get(field) or default)] += 1
+    return dict(counts)
+
+
+def _span_summary(spans: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for span in spans:
+        grouped[str(span.get("name") or "unknown")].append(span)
+
+    summary: Dict[str, Dict[str, Any]] = {}
+    for name, rows in grouped.items():
+        durations = [float(row.get("duration_ms") or 0) for row in rows]
+        payloads = [float(row.get("payload_bytes") or 0) for row in rows if row.get("payload_bytes") is not None]
+        categories = _group_counts(rows, "category", "custom")
+        probability_sources = _group_counts(rows, "probability_source", "NONE")
+        summary[name] = {
+            "count": len(rows),
+            "category_counts": categories,
+            "total_ms": round(sum(durations), 3),
+            "p50_ms": _percentile(durations, 50),
+            "p95_ms": _percentile(durations, 95),
+            "max_ms": round(max(durations), 3) if durations else 0.0,
+            "payload_bytes_p95": _percentile(payloads, 95) if payloads else 0.0,
+            "probability_sources": probability_sources,
+        }
+    return summary
+
+
 def performance_snapshot() -> Dict[str, Any]:
     """Return bounded, non-sensitive route timing diagnostics."""
     samples = list(_SAMPLES)
+    spans = list(_SPANS)
     grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for sample in samples:
         grouped[str(sample.get("route") or sample.get("path") or "unknown")].append(sample)
@@ -65,30 +198,62 @@ def performance_snapshot() -> Dict[str, Any]:
     routes: Dict[str, Dict[str, Any]] = {}
     for route, rows in grouped.items():
         durations = [float(row.get("duration_ms") or 0) for row in rows]
+        payloads = [float(row.get("response_size_bytes") or 0) for row in rows if row.get("response_size_bytes") is not None]
         routes[route] = {
             "count": len(rows),
             "p50_ms": _percentile(durations, 50),
             "p95_ms": _percentile(durations, 95),
             "max_ms": round(max(durations), 3) if durations else 0.0,
-            "cache": dict(defaultdict(int, ((str(row.get("cache_status") or "NONE"), 0) for row in []))),
+            "payload_bytes_p50": _percentile(payloads, 50) if payloads else 0.0,
+            "payload_bytes_p95": _percentile(payloads, 95) if payloads else 0.0,
+            "payload_bytes_max": round(max(payloads), 3) if payloads else 0.0,
+            "cache": _group_counts(rows, "cache_status"),
+            "probability_sources": _group_counts(rows, "probability_source"),
         }
-        cache_counts: Dict[str, int] = defaultdict(int)
-        for row in rows:
-            cache_counts[str(row.get("cache_status") or "NONE")] += 1
-        routes[route]["cache"] = dict(cache_counts)
 
     slow_requests = sorted(
         samples,
         key=lambda row: float(row.get("duration_ms") or 0),
         reverse=True,
     )[:20]
+    largest_responses = sorted(
+        [sample for sample in samples if sample.get("response_size_bytes") is not None],
+        key=lambda row: int(row.get("response_size_bytes") or 0),
+        reverse=True,
+    )[:20]
+    span_summary = _span_summary(spans)
+    top_spans_by_total = sorted(
+        span_summary.items(),
+        key=lambda item: float(item[1].get("total_ms") or 0),
+        reverse=True,
+    )[:25]
+    top_spans_by_max = sorted(
+        span_summary.items(),
+        key=lambda item: float(item[1].get("max_ms") or 0),
+        reverse=True,
+    )[:25]
+    slow_spans = sorted(
+        spans,
+        key=lambda row: float(row.get("duration_ms") or 0),
+        reverse=True,
+    )[:50]
+    slow_simulations = [span for span in slow_spans if span.get("category") == "simulation"][:20]
 
     return {
         "status": "ok",
         "sample_count": len(samples),
         "sample_limit": _MAX_SAMPLES,
+        "span_count": len(spans),
+        "span_limit": _MAX_SPANS,
         "routes": routes,
         "slow_requests": slow_requests,
+        "largest_responses": largest_responses,
+        "spans": {
+            "top_by_total_ms": [{"name": name, **data} for name, data in top_spans_by_total],
+            "top_by_max_ms": [{"name": name, **data} for name, data in top_spans_by_max],
+            "slowest": slow_spans,
+            "slowest_simulations": slow_simulations,
+        },
     }
 
 
@@ -112,7 +277,9 @@ def install_fastapi_performance_patch() -> bool:
 
             @self.middleware("http")
             async def _performance_middleware(request: Any, call_next: Any) -> Any:
-                token = _CACHE_STATUS.set(None)
+                cache_token = _CACHE_STATUS.set(None)
+                probability_token = _PROBABILITY_SOURCE.set(None)
+                route_token = _REQUEST_ROUTE.set(_route_label(request))
                 started = time.perf_counter()
                 status_code = 500
                 response = None
@@ -123,28 +290,43 @@ def install_fastapi_performance_patch() -> bool:
                 finally:
                     duration_ms = round((time.perf_counter() - started) * 1000, 3)
                     cache_status = _CACHE_STATUS.get()
+                    probability_source = _PROBABILITY_SOURCE.get()
                     route = _route_label(request)
+                    response_size = _response_size_bytes(response)
                     sample = {
                         "method": getattr(request, "method", None),
                         "path": getattr(getattr(request, "url", None), "path", None),
                         "route": route,
                         "status_code": status_code,
                         "duration_ms": duration_ms,
-                        "response_size_bytes": _response_size_bytes(response),
+                        "response_size_bytes": response_size,
                         "cache_status": cache_status,
+                        "probability_source": probability_source,
                     }
                     record_request_sample(sample)
                     if response is not None:
                         response.headers["X-Response-Time-ms"] = str(duration_ms)
+                        if response_size is not None:
+                            response.headers["X-Payload-Bytes"] = str(response_size)
                         if cache_status:
                             response.headers["X-Cache"] = cache_status
-                    _CACHE_STATUS.reset(token)
+                        if probability_source:
+                            response.headers["X-Probability-Source"] = probability_source
+                    _REQUEST_ROUTE.reset(route_token)
+                    _PROBABILITY_SOURCE.reset(probability_token)
+                    _CACHE_STATUS.reset(cache_token)
 
             async def _debug_performance() -> Dict[str, Any]:
                 return performance_snapshot()
 
             self.add_api_route(
                 "/debug/performance",
+                _debug_performance,
+                methods=["GET"],
+                include_in_schema=False,
+            )
+            self.add_api_route(
+                "/debug/performance/hotspots",
                 _debug_performance,
                 methods=["GET"],
                 include_in_schema=False,
@@ -156,8 +338,12 @@ def install_fastapi_performance_patch() -> bool:
 
 
 __all__ = [
+    "estimate_payload_bytes",
     "install_fastapi_performance_patch",
     "performance_snapshot",
     "record_cache_status",
+    "record_probability_source",
     "record_request_sample",
+    "record_span",
+    "timing_span",
 ]

--- a/mlb_app/shared_payload_cache.py
+++ b/mlb_app/shared_payload_cache.py
@@ -7,7 +7,7 @@ import os
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
-from .performance import record_cache_status
+from .performance import estimate_payload_bytes, record_cache_status, record_span, timing_span
 
 CacheRecord = Tuple[float, Any]
 _CACHE: Dict[str, CacheRecord] = {}
@@ -52,22 +52,78 @@ def make_cache_key(*parts: Any) -> str:
 
 
 def get_cache(key: str, ttl_seconds: int) -> Optional[Any]:
-    record = _CACHE.get(key)
-    if not record:
-        record_cache_status("MISS")
-        return None
-    created_at, value = record
-    if ttl_seconds <= 0 or _now() - created_at > ttl_seconds:
-        _CACHE.pop(key, None)
-        record_cache_status("MISS")
-        return None
-    record_cache_status("HIT")
-    return copy.deepcopy(value)
+    with timing_span(
+        "shared_payload_cache.get_cache",
+        category="cache",
+        cache_status=None,
+        extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
+    ):
+        record = _CACHE.get(key)
+        if not record:
+            record_cache_status("MISS")
+            record_span(
+                "shared_payload_cache.lookup",
+                category="cache",
+                cache_status="MISS",
+                extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
+            )
+            return None
+        created_at, value = record
+        if ttl_seconds <= 0 or _now() - created_at > ttl_seconds:
+            _CACHE.pop(key, None)
+            record_cache_status("MISS")
+            record_span(
+                "shared_payload_cache.lookup",
+                category="cache",
+                cache_status="EXPIRED",
+                payload_bytes=estimate_payload_bytes(value),
+                extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
+            )
+            return None
+        record_cache_status("HIT")
+        payload_bytes = estimate_payload_bytes(value)
+        with timing_span(
+            "shared_payload_cache.deepcopy.get",
+            category="cache",
+            cache_status="HIT",
+            extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+        ):
+            copied = copy.deepcopy(value)
+        record_span(
+            "shared_payload_cache.lookup",
+            category="cache",
+            cache_status="HIT",
+            payload_bytes=payload_bytes,
+            extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
+        )
+        return copied
 
 
 def set_cache(key: str, value: Any) -> Any:
-    _CACHE[key] = (_now(), copy.deepcopy(value))
-    return copy.deepcopy(value)
+    payload_bytes = estimate_payload_bytes(value)
+    with timing_span(
+        "shared_payload_cache.deepcopy.set_store",
+        category="cache",
+        payload_bytes=payload_bytes,
+        extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+    ):
+        stored = copy.deepcopy(value)
+    _CACHE[key] = (_now(), stored)
+    with timing_span(
+        "shared_payload_cache.deepcopy.set_return",
+        category="cache",
+        payload_bytes=payload_bytes,
+        extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+    ):
+        returned = copy.deepcopy(value)
+    record_span(
+        "shared_payload_cache.set_cache",
+        category="cache",
+        cache_status="STORE",
+        payload_bytes=payload_bytes,
+        extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+    )
+    return returned
 
 
 def get_or_set(key: str, ttl_seconds: int, builder: Callable[[], Any]) -> Any:
@@ -79,7 +135,13 @@ def get_or_set(key: str, ttl_seconds: int, builder: Callable[[], Any]) -> Any:
             cached.setdefault("ttl_seconds", ttl_seconds)
         return cached
     started_at = _now()
-    value = builder()
+    with timing_span(
+        "shared_payload_cache.builder",
+        category="cache",
+        cache_status="MISS",
+        extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
+    ):
+        value = builder()
     built_ms = int(round((_now() - started_at) * 1000))
     stored = set_cache(key, value)
     if isinstance(stored, dict):

--- a/tests/test_performance_instrumentation.py
+++ b/tests/test_performance_instrumentation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from mlb_app.performance import (
+    estimate_payload_bytes,
+    performance_snapshot,
+    record_cache_status,
+    record_probability_source,
+    record_request_sample,
+    record_span,
+    timing_span,
+)
+from mlb_app.shared_payload_cache import clear_shared_payload_cache, get_cache, get_or_set, set_cache
+
+
+def test_estimate_payload_bytes_for_json_payload() -> None:
+    payload = {"route": "/matchups", "games": [{"game_pk": 1, "home_win_prob": 0.55}]}
+
+    measured = estimate_payload_bytes(payload)
+
+    assert isinstance(measured, int)
+    assert measured > 0
+
+
+def test_timing_span_records_formula_span() -> None:
+    with timing_span(
+        "unit.formula_span",
+        category="formula",
+        route="/unit-test",
+        game_pk=123,
+        date="2026-07-09",
+        probability_source="model_projections",
+    ):
+        sum(range(5))
+
+    snapshot = performance_snapshot()
+    slowest = snapshot["spans"]["slowest"]
+
+    assert any(span["name"] == "unit.formula_span" for span in slowest)
+    assert any(span.get("category") == "formula" for span in slowest)
+    assert any(span.get("probability_source") == "model_projections" for span in slowest)
+
+
+def test_performance_snapshot_includes_route_cache_payload_and_probability_source() -> None:
+    record_cache_status("HIT")
+    record_probability_source("model_projections")
+    record_request_sample(
+        {
+            "method": "GET",
+            "path": "/models/projections",
+            "route": "/models/projections",
+            "status_code": 200,
+            "duration_ms": 12.5,
+            "response_size_bytes": 2048,
+            "cache_status": "HIT",
+            "probability_source": "model_projections",
+        }
+    )
+
+    snapshot = performance_snapshot()
+    route = snapshot["routes"]["/models/projections"]
+
+    assert route["cache"]["HIT"] >= 1
+    assert route["payload_bytes_p95"] >= 2048
+    assert route["probability_sources"]["model_projections"] >= 1
+
+
+def test_shared_payload_cache_records_cache_and_deepcopy_spans() -> None:
+    clear_shared_payload_cache("unit:cache")
+    set_cache("unit:cache:key", {"value": [1, 2, 3]})
+
+    cached = get_cache("unit:cache:key", 300)
+
+    assert cached == {"value": [1, 2, 3]}
+    snapshot = performance_snapshot()
+    span_names = {span["name"] for span in snapshot["spans"]["slowest"]}
+    assert "shared_payload_cache.lookup" in span_names
+    assert "shared_payload_cache.deepcopy.get" in span_names
+
+
+def test_get_or_set_builder_records_builder_span_on_miss() -> None:
+    clear_shared_payload_cache("unit:builder")
+
+    payload = get_or_set("unit:builder:key", 300, lambda: {"built": True})
+
+    assert payload["built"] is True
+    assert payload["cache_hit"] is False
+    snapshot = performance_snapshot()
+    span_names = {span["name"] for span in snapshot["spans"]["slowest"]}
+    assert "shared_payload_cache.builder" in span_names


### PR DESCRIPTION
## Summary

Implements Phase 2 / Sprint 0 instrumentation without changing page behavior, model semantics, probability values, or visible UI.

## Related issues

- Epic: #944
- Sprint 0: #945
- Phase 1 map PR: #951

## What changed

### `mlb_app/performance.py`

- Adds bounded span samples in addition to route samples.
- Adds `timing_span(...)` context manager.
- Adds `record_span(...)` for non-sensitive formula/build/cache/projection spans.
- Adds `estimate_payload_bytes(...)` for best-effort JSON payload byte measurement.
- Adds `record_probability_source(...)` and `X-Probability-Source` header support.
- Adds `X-Payload-Bytes` header when content length is available.
- Extends `/debug/performance` and adds `/debug/performance/hotspots`.
- Snapshot now includes:
  - route p50/p95/max
  - payload bytes p50/p95/max
  - cache counts
  - probability-source counts
  - slow requests
  - largest responses
  - top spans by total ms
  - top spans by max ms
  - slowest spans
  - slowest simulation spans

### `mlb_app/shared_payload_cache.py`

- Adds cache lookup/store/deepcopy spans.
- Measures cache payload bytes.
- Separates HIT/MISS/EXPIRED/STORE metadata.
- Keeps existing deepcopy behavior unchanged; this PR only measures it.

### `mlb_app/model_projection_routes.py`

- Adds route-level and builder-level spans around `/models/projections`.
- Records `model_projections` probability-source metadata for this route.
- Records projection payload byte estimates.

### `mlb_app/matchup_generator.py`

- Adds spans for:
  - `generate_matchups_for_date`
  - `_generate_matchups_for_date_uncached`
  - `matchups.fetch_schedule`
  - pitcher feature loading
  - pitch arsenal loading
  - `build_lineup_offense_diagnostics`
  - `build_lineup_offense_inputs`
  - `compute_canonical_matchup_probability`
- Records canonical probability-source metadata for the current matchup path.
- Records matchup payload byte estimates.

### Tests

Adds `tests/test_performance_instrumentation.py` covering:

- payload byte helper
- timing span helper
- route snapshot cache/payload/probability metadata
- shared cache lookup/deepcopy spans
- builder span on cache miss

## What did not change

- No frontend pages changed.
- No page content removed.
- No probability migration performed yet.
- No canonical/model projection semantics changed.
- No cache copy strategy changed.
- No performance optimization claimed yet; this PR only makes the hotspots measurable.

## Test command

```bash
pytest tests/test_performance_instrumentation.py
```

Not run in this connector session.

## Next step

After this PR is reviewed/merged, Phase 3 can use the new span and payload data to implement the Model Projections probability contract and begin targeted performance work from measured bottlenecks.