### PR TITLE
Phase 3: make Model Projections probability the projections route source of truth

### DIFF
--- a/mlb_app/model_projection_probability.py
+++ b/mlb_app/model_projection_probability.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, Optional
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_dict(*values: Any) -> Dict[str, Any]:
+    for value in values:
+        if isinstance(value, dict) and value:
+            return value
+    return {}
+
+
+def _derived_outputs(shared_simulation: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(shared_simulation, dict):
+        return {}
+    outputs = shared_simulation.get("derived_outputs")
+    return outputs if isinstance(outputs, dict) else {}
+
+
+def select_model_projection_simulation(shared_simulation: Optional[Dict[str, Any]]) -> tuple[Dict[str, Any], Optional[str]]:
+    """Select the Model Projections simulation output used for displayed win probability.
+
+    This mirrors the frontend ModelProjectionsPage behavior: prefer bullpen-adjusted
+    game simulation, then fall back to the base game simulation. It does not use
+    canonical matchup probability unless the caller explicitly falls back later.
+    """
+    outputs = _derived_outputs(shared_simulation)
+    bullpen_adjusted = outputs.get("bullpen_adjusted_game_simulation")
+    if isinstance(bullpen_adjusted, dict) and bullpen_adjusted:
+        return bullpen_adjusted, "sharedSimulation.derived_outputs.bullpen_adjusted_game_simulation"
+    game_simulation = outputs.get("game_simulation")
+    if isinstance(game_simulation, dict) and game_simulation:
+        return game_simulation, "sharedSimulation.derived_outputs.game_simulation"
+    return {}, None
+
+
+def build_model_projection_probability(
+    *,
+    game_pk: Any = None,
+    date: Optional[str] = None,
+    shared_simulation: Optional[Dict[str, Any]] = None,
+    matchup: Optional[Dict[str, Any]] = None,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the normalized displayed/default win-probability contract.
+
+    Primary source: Model Projections shared derived simulation output.
+    Fallback source: canonical matchup fields, explicitly marked as fallback.
+    """
+    matchup = matchup or {}
+    selected_sim, source_path = select_model_projection_simulation(shared_simulation)
+    home_prob = _safe_float(selected_sim.get("home_win_probability"))
+    away_prob = _safe_float(selected_sim.get("away_win_probability"))
+    if home_prob is not None and away_prob is not None and source_path:
+        source_meta = _first_dict(selected_sim.get("metadata"), selected_sim.get("meta"))
+        model_version = selected_sim.get("model_version") or source_meta.get("model_version") or source_meta.get("simulation_model_version")
+        return {
+            "home_win_probability": home_prob,
+            "away_win_probability": away_prob,
+            "home_win_prob": home_prob,
+            "away_win_prob": away_prob,
+            "source": "model_projections",
+            "source_path": source_path,
+            "model_version": model_version or "model_projections_shared_simulation",
+            "generated_at": generated_at or datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "game_pk": game_pk,
+            "date": date,
+            "fallback_source": None,
+            "is_fallback": False,
+        }
+
+    canonical_home = _safe_float(matchup.get("home_win_prob") or matchup.get("home_win_probability"))
+    canonical_away = _safe_float(matchup.get("away_win_prob") or matchup.get("away_win_probability"))
+    missing_reason = "sharedSimulation derived outputs missing"
+    if source_path and (home_prob is None or away_prob is None):
+        missing_reason = "sharedSimulation derived outputs missing home/away win probability"
+    return {
+        "home_win_probability": canonical_home,
+        "away_win_probability": canonical_away,
+        "home_win_prob": canonical_home,
+        "away_win_prob": canonical_away,
+        "source": "fallback:canonical_matchup_win_probability_v2",
+        "source_path": None,
+        "model_version": matchup.get("model_version") or "canonical_matchup_win_probability_v2",
+        "generated_at": generated_at or datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "game_pk": game_pk,
+        "date": date,
+        "fallback_source": "canonical_matchup_win_probability_v2",
+        "is_fallback": True,
+        "missing_model_projection_reason": missing_reason,
+    }
+
+
+__all__ = [
+    "build_model_projection_probability",
+    "select_model_projection_simulation",
+]

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException
 
 from .database import create_tables, get_engine, get_session
+from .model_projection_probability import build_model_projection_probability
 from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
 from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
@@ -24,6 +25,61 @@ def _session_factory():
     return get_session(engine)
 
 
+def _apply_projection_probability_contract(payload: Dict[str, Any], target_date: str) -> Dict[str, Any]:
+    """Expose Model Projections as the displayed/default probability source.
+
+    Existing canonical/debug objects stay available for compatibility, but
+    top-level probability aliases now resolve from Model Projections shared
+    derived simulation output when available.
+    """
+    games = payload.get("games") if isinstance(payload.get("games"), list) else []
+    for game in games:
+        if not isinstance(game, dict):
+            continue
+        probability = build_model_projection_probability(
+            game_pk=game.get("game_pk"),
+            date=game.get("game_date") or target_date,
+            shared_simulation=game.get("sharedSimulation"),
+            matchup=game,
+            generated_at=payload.get("generated_at"),
+        )
+        game["model_projection_probability"] = probability
+        game["probability"] = probability
+        game["home_win_probability"] = probability.get("home_win_probability")
+        game["away_win_probability"] = probability.get("away_win_probability")
+        game["home_win_prob"] = probability.get("home_win_prob")
+        game["away_win_prob"] = probability.get("away_win_prob")
+        game["probability_source"] = probability.get("source")
+        game["probability_source_path"] = probability.get("source_path")
+        game["probability_is_fallback"] = probability.get("is_fallback")
+
+        workspace = game.get("workspace")
+        if isinstance(workspace, dict):
+            workspace["modelProjectionProbability"] = probability
+            diagnostics = workspace.get("sharedSimulationDiagnostics")
+            if isinstance(diagnostics, dict):
+                diagnostics["displayed_probability_source"] = probability.get("source")
+                diagnostics["displayed_probability_source_path"] = probability.get("source_path")
+                diagnostics["displayed_probability_is_fallback"] = probability.get("is_fallback")
+
+        main = game.get("main_matchup_probabilities")
+        if isinstance(main, dict):
+            main["displayed_probability_source"] = probability.get("source")
+            main["displayed_probability_source_path"] = probability.get("source_path")
+            main["displayed_probability_is_fallback"] = probability.get("is_fallback")
+            main["model_projection_probability"] = probability
+
+    notes = list(payload.get("source_notes") or [])
+    notes = [note for note in notes if "home_win_prob and away_win_prob are canonical v2" not in str(note)]
+    notes = [note for note in notes if "Simulation outputs remain available as diagnostics and do not define final side probability" not in str(note)]
+    notes.append("Displayed/default home_win_prob and away_win_prob are resolved from Model Projections sharedSimulation derived outputs when available.")
+    notes.append("Canonical matchup probability remains available as a compatibility/fallback diagnostic, not the displayed Model Projections source of truth.")
+    payload["source_notes"] = notes
+    payload["probability_contract"] = "model_projection_probability_v1"
+    payload["probability_source"] = "model_projections"
+    return payload
+
+
 def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
     with timing_span("model_projection.session_factory", category="db", route="/models/projections", date=target_date):
         session_factory = _session_factory()
@@ -36,6 +92,7 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
             probability_source="model_projections",
         ):
             payload = build_model_projection_payload(session, target_date)
+    payload = _apply_projection_probability_contract(payload, target_date)
     record_probability_source("model_projections")
     record_span(
         "model_projection.payload_bytes",
@@ -51,7 +108,7 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
 @router.get("/models/projections")
 def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
     target_date = date or datetime.date.today().isoformat()
-    cache_key = make_cache_key("model_projection", "full", target_date)
+    cache_key = make_cache_key("model_projection", "full", "probability_contract_v1", target_date)
     try:
         with timing_span(
             "route.models.projections.resolve",

--- a/tests/test_model_projection_probability.py
+++ b/tests/test_model_projection_probability.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from mlb_app.model_projection_probability import build_model_projection_probability, select_model_projection_simulation
+from mlb_app.model_projection_routes import _apply_projection_probability_contract
+
+
+def test_select_model_projection_simulation_prefers_bullpen_adjusted_output() -> None:
+    shared = {
+        "derived_outputs": {
+            "game_simulation": {
+                "home_win_probability": 0.51,
+                "away_win_probability": 0.49,
+                "model_version": "base",
+            },
+            "bullpen_adjusted_game_simulation": {
+                "home_win_probability": 0.57,
+                "away_win_probability": 0.43,
+                "model_version": "bullpen",
+            },
+        }
+    }
+
+    selected, source_path = select_model_projection_simulation(shared)
+
+    assert selected["home_win_probability"] == 0.57
+    assert selected["away_win_probability"] == 0.43
+    assert source_path == "sharedSimulation.derived_outputs.bullpen_adjusted_game_simulation"
+
+
+def test_build_probability_contract_uses_model_projection_output() -> None:
+    probability = build_model_projection_probability(
+        game_pk=123,
+        date="2026-07-09",
+        shared_simulation={
+            "derived_outputs": {
+                "bullpen_adjusted_game_simulation": {
+                    "home_win_probability": 0.62,
+                    "away_win_probability": 0.38,
+                    "model_version": "shared_game_simulation_v1",
+                }
+            }
+        },
+        matchup={"home_win_prob": 0.51, "away_win_prob": 0.49, "model_version": "canonical_matchup_win_probability_v2"},
+        generated_at="2026-07-09T18:00:00Z",
+    )
+
+    assert probability["source"] == "model_projections"
+    assert probability["is_fallback"] is False
+    assert probability["home_win_prob"] == 0.62
+    assert probability["away_win_prob"] == 0.38
+    assert probability["home_win_probability"] == 0.62
+    assert probability["away_win_probability"] == 0.38
+    assert probability["source_path"] == "sharedSimulation.derived_outputs.bullpen_adjusted_game_simulation"
+    assert probability["model_version"] == "shared_game_simulation_v1"
+
+
+def test_build_probability_contract_marks_canonical_fallback_explicitly() -> None:
+    probability = build_model_projection_probability(
+        game_pk=123,
+        date="2026-07-09",
+        shared_simulation={"derived_outputs": {}},
+        matchup={"home_win_prob": 0.51, "away_win_prob": 0.49, "model_version": "canonical_matchup_win_probability_v2"},
+        generated_at="2026-07-09T18:00:00Z",
+    )
+
+    assert probability["source"] == "fallback:canonical_matchup_win_probability_v2"
+    assert probability["fallback_source"] == "canonical_matchup_win_probability_v2"
+    assert probability["is_fallback"] is True
+    assert probability["missing_model_projection_reason"] == "sharedSimulation derived outputs missing"
+    assert probability["home_win_prob"] == 0.51
+    assert probability["away_win_prob"] == 0.49
+
+
+def test_projection_route_contract_repoints_legacy_aliases_from_model_projection() -> None:
+    payload = {
+        "date": "2026-07-09",
+        "source_notes": [
+            "home_win_prob and away_win_prob are canonical v2 from /matchups.",
+            "Simulation outputs remain available as diagnostics and do not define final side probability.",
+        ],
+        "games": [
+            {
+                "game_pk": 123,
+                "game_date": "2026-07-09",
+                "home_win_prob": 0.51,
+                "away_win_prob": 0.49,
+                "main_matchup_probabilities": {"source": "matchups.canonical_matchup_win_probability_v2"},
+                "workspace": {"sharedSimulationDiagnostics": {"status": "diagnostic_only_not_final_probability"}},
+                "sharedSimulation": {
+                    "derived_outputs": {
+                        "bullpen_adjusted_game_simulation": {
+                            "home_win_probability": 0.64,
+                            "away_win_probability": 0.36,
+                            "model_version": "bullpen_adjusted_v1",
+                        }
+                    }
+                },
+            }
+        ],
+    }
+
+    updated = _apply_projection_probability_contract(payload, "2026-07-09")
+    game = updated["games"][0]
+
+    assert updated["probability_contract"] == "model_projection_probability_v1"
+    assert game["home_win_prob"] == 0.64
+    assert game["away_win_prob"] == 0.36
+    assert game["home_win_probability"] == 0.64
+    assert game["away_win_probability"] == 0.36
+    assert game["probability_source"] == "model_projections"
+    assert game["probability_is_fallback"] is False
+    assert game["model_projection_probability"]["source"] == "model_projections"
+    assert game["workspace"]["modelProjectionProbability"]["home_win_prob"] == 0.64
+    assert game["main_matchup_probabilities"]["displayed_probability_source"] == "model_projections"
+    assert not any("canonical v2 from /matchups" in note for note in updated["source_notes"])
+
+
+def test_projection_route_contract_marks_fallback_when_shared_output_missing() -> None:
+    payload = {
+        "date": "2026-07-09",
+        "games": [
+            {
+                "game_pk": 123,
+                "game_date": "2026-07-09",
+                "home_win_prob": 0.52,
+                "away_win_prob": 0.48,
+                "sharedSimulation": {"derived_outputs": {}},
+            }
+        ],
+    }
+
+    updated = _apply_projection_probability_contract(payload, "2026-07-09")
+    probability = updated["games"][0]["model_projection_probability"]
+
+    assert probability["source"] == "fallback:canonical_matchup_win_probability_v2"
+    assert probability["is_fallback"] is True
+    assert updated["games"][0]["probability_is_fallback"] is True
+    assert updated["games"][0]["home_win_prob"] == 0.52
+    assert updated["games"][0]["away_win_prob"] == 0.48


### PR DESCRIPTION
## Summary

Implements the first Phase 3 probability-source migration step: define a normalized Model Projections probability contract and apply it to `/models/projections` output.

This preserves page content and existing canonical diagnostics, but the displayed/default top-level aliases on the Model Projections route now resolve from the same shared simulation output the Model Projections frontend already displays.

## Related issues

- Epic: #944
- Sprint 1: #946
- Phase 1 map: #951
- Phase 2 instrumentation: #952

## What changed

### New resolver module

Adds `mlb_app/model_projection_probability.py` with:

- `select_model_projection_simulation(...)`
- `build_model_projection_probability(...)`

The resolver mirrors `ModelProjectionsPage.jsx` selection behavior:

1. Primary: `sharedSimulation.derived_outputs.bullpen_adjusted_game_simulation`
2. Fallback inside Model Projections: `sharedSimulation.derived_outputs.game_simulation`
3. Explicit fallback only after that: canonical matchup probability

### `/models/projections` route contract

Updates `mlb_app/model_projection_routes.py` so the route applies `model_projection_probability_v1` after building the existing payload.

For each game, it now adds:

- `model_projection_probability`
- `probability`
- `probability_source`
- `probability_source_path`
- `probability_is_fallback`

And repoints compatibility aliases from the selected Model Projections probability when available:

- `home_win_prob`
- `away_win_prob`
- `home_win_probability`
- `away_win_probability`

Existing objects are preserved:

- `main_matchup_probabilities`
- `canonical_game_context`
- `workspace.canonicalMatchupProbability`
- `workspace.canonicalGameContext`

But they are now annotated with displayed probability source metadata instead of being the displayed/default source.

### Cache key update

Changes `/models/projections` cache key to include `probability_contract_v1` so old cached canonical-alias payloads cannot be served as the new contract.

### Tests

Adds `tests/test_model_projection_probability.py` covering:

- bullpen-adjusted Model Projection output is preferred
- base game simulation is the internal Model Projection fallback
- canonical fallback is explicitly marked
- route-level aliases are repointed from Model Projections output
- route-level fallback is clearly marked when shared output is missing

## What did not change

- No frontend pages changed.
- No sections/cards were removed.
- Matchups and Matchup Detail are not migrated in this PR yet.
- Daily Odds / Model Tracker are not fully migrated in this PR yet.
- Canonical probability internals remain available as diagnostics/fallback.
- This PR does not claim a speed improvement.

## Why this sequencing

Phase 1 found the source-of-truth conflict: backend aliases on `/models/projections` were canonical while the visible Model Projections page displayed `sharedSimulation.derived_outputs`. This PR resolves that route-level conflict first and creates the reusable resolver needed for the next pages.

## Test command

```bash
pytest tests/test_model_projection_probability.py
```

Not run in this connector session.

## Next step

After merge, continue Phase 3 by reusing `build_model_projection_probability(...)` in Matchup Detail, Matchups/Daily Matchups, Daily Odds, and Model Tracker where those routes can access a warmed Model Projections artifact without causing cold recursive projection builds.