### PR TITLE
Phase 4: add lightweight calendar snapshots and projection warming

### DIFF
--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -11,6 +11,7 @@ from .model_projection_probability import build_model_projection_probability
 from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
 from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
+from .schedule_calendar import build_calendar_window_payload, warm_schedule_calendar_window
 from .shared_payload_cache import env_ttl, get_or_set, make_cache_key, set_cache
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 
@@ -153,6 +154,24 @@ def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "Failed to build model projections", "error": str(exc)}) from exc
+
+
+@router.get("/matchups/calendar/schedule")
+def lightweight_matchup_calendar() -> Dict[str, Any]:
+    """Lightweight schedule-only calendar payload for fast initial calendar load."""
+    try:
+        return build_calendar_window_payload()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Failed to build lightweight calendar", "error": str(exc)}) from exc
+
+
+@router.post("/matchups/calendar/snapshot")
+def snapshot_lightweight_matchup_calendar() -> Dict[str, Any]:
+    """Warm schedule-only calendar snapshots without full matchup/model generation."""
+    try:
+        return warm_schedule_calendar_window()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Failed to warm lightweight calendar", "error": str(exc)}) from exc
 
 
 @router.post("/models/projections/snapshot/{date_str}")

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -11,7 +11,7 @@ from .model_projection_probability import build_model_projection_probability
 from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
 from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
-from .shared_payload_cache import env_ttl, get_or_set, make_cache_key
+from .shared_payload_cache import env_ttl, get_or_set, make_cache_key, set_cache
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 
 router = APIRouter()
@@ -23,6 +23,10 @@ def _session_factory():
     engine = get_engine(database_url)
     create_tables(engine)
     return get_session(engine)
+
+
+def _projection_cache_key(target_date: str) -> str:
+    return make_cache_key("model_projection", "full", "probability_contract_v1", target_date)
 
 
 def _apply_projection_probability_contract(payload: Dict[str, Any], target_date: str) -> Dict[str, Any]:
@@ -105,10 +109,23 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
     return payload
 
 
+def warm_model_projection_payload(target_date: str) -> Dict[str, Any]:
+    """Build and store the projection payload explicitly for cron/warm jobs."""
+    payload = _build_uncached_projection_payload(target_date)
+    stored = set_cache(_projection_cache_key(target_date), payload)
+    return {
+        "warmed": True,
+        "date": target_date,
+        "games_cached": len(stored.get("games") or []) if isinstance(stored, dict) else None,
+        "cache_key": _projection_cache_key(target_date),
+        "probability_contract": "model_projection_probability_v1",
+    }
+
+
 @router.get("/models/projections")
 def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
     target_date = date or datetime.date.today().isoformat()
-    cache_key = make_cache_key("model_projection", "full", "probability_contract_v1", target_date)
+    cache_key = _projection_cache_key(target_date)
     try:
         with timing_span(
             "route.models.projections.resolve",
@@ -136,3 +153,15 @@ def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "Failed to build model projections", "error": str(exc)}) from exc
+
+
+@router.post("/models/projections/snapshot/{date_str}")
+def snapshot_model_projections(date_str: str) -> Dict[str, Any]:
+    try:
+        datetime.datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="date_str must be YYYY-MM-DD") from exc
+    try:
+        return warm_model_projection_payload(date_str)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Failed to warm model projections", "error": str(exc)}) from exc

--- a/mlb_app/schedule_calendar.py
+++ b/mlb_app/schedule_calendar.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import datetime
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from .etl import fetch_schedule
+from .performance import estimate_payload_bytes, record_span, timing_span
+from .shared_payload_cache import env_ttl, get_cache, make_cache_key, set_cache
+
+ScheduleFetcher = Callable[[str], Iterable[Dict[str, Any]]]
+
+
+def build_date_window(today: Optional[datetime.date] = None) -> Dict[str, str]:
+    base = today or datetime.date.today()
+    return {
+        "yesterday": (base - datetime.timedelta(days=1)).isoformat(),
+        "today": base.isoformat(),
+        "tomorrow": (base + datetime.timedelta(days=1)).isoformat(),
+    }
+
+
+def _team_name(game: Dict[str, Any], side: str) -> Optional[str]:
+    team = game.get(side, {}).get("team", {}) if isinstance(game.get(side), dict) else {}
+    return team.get("name")
+
+
+def _team_id(game: Dict[str, Any], side: str) -> Optional[int]:
+    team = game.get(side, {}).get("team", {}) if isinstance(game.get(side), dict) else {}
+    try:
+        return int(team.get("id")) if team.get("id") is not None else None
+    except Exception:
+        return None
+
+
+def _pitcher(game: Dict[str, Any], side: str) -> Dict[str, Any]:
+    pitcher = game.get(side, {}).get("probablePitcher", {}) if isinstance(game.get(side), dict) else {}
+    if not isinstance(pitcher, dict):
+        pitcher = {}
+    return {
+        "id": pitcher.get("id"),
+        "name": pitcher.get("fullName"),
+        "hand": (pitcher.get("pitchHand") or {}).get("code") if isinstance(pitcher.get("pitchHand"), dict) else None,
+    }
+
+
+def compact_schedule_game(game: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only calendar-visible schedule fields, not heavy matchup/model payloads."""
+    return {
+        "game_pk": game.get("_game_pk") or game.get("gamePk"),
+        "game_date": game.get("_game_date") or game.get("gameDate"),
+        "game_time": game.get("_game_date") or game.get("gameDate"),
+        "venue": game.get("_venue") or ((game.get("venue") or {}).get("name") if isinstance(game.get("venue"), dict) else game.get("venue")),
+        "status": game.get("_status") or ((game.get("status") or {}).get("detailedState") if isinstance(game.get("status"), dict) else game.get("status")),
+        "home_team_id": _team_id(game, "home"),
+        "away_team_id": _team_id(game, "away"),
+        "home_team_name": _team_name(game, "home"),
+        "away_team_name": _team_name(game, "away"),
+        "home_pitcher": _pitcher(game, "home"),
+        "away_pitcher": _pitcher(game, "away"),
+    }
+
+
+def build_schedule_calendar_snapshot(
+    date_str: str,
+    *,
+    fetcher: ScheduleFetcher = fetch_schedule,
+) -> Dict[str, Any]:
+    """Build a lightweight calendar snapshot for one date.
+
+    This deliberately avoids `generate_matchups_for_date`, lineup diagnostics,
+    canonical probability, Model Projection generation, and simulations.
+    """
+    with timing_span("calendar.fetch_schedule", category="schedule", route="/matchups/calendar", date=date_str):
+        schedule = list(fetcher(date_str) or [])
+    games = [compact_schedule_game(game) for game in schedule]
+    payload = {
+        "date": date_str,
+        "count": len(games),
+        "games": games,
+        "calendar_snapshot_version": "schedule_calendar_v1",
+        "source": "schedule_calendar_snapshot",
+        "heavy_matchup_generation": False,
+        "probability_source": "not_loaded_on_calendar_initial_snapshot",
+        "generated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+    }
+    record_span(
+        "calendar.snapshot.payload_bytes",
+        category="serialization",
+        route="/matchups/calendar",
+        date=date_str,
+        payload_bytes=estimate_payload_bytes(payload),
+    )
+    return payload
+
+
+def get_or_build_schedule_calendar_snapshot(
+    date_str: str,
+    *,
+    fetcher: ScheduleFetcher = fetch_schedule,
+    ttl_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    ttl = env_ttl("MATCHUPS_CALENDAR_CACHE_TTL_SECONDS") if ttl_seconds is None else ttl_seconds
+    cache_key = make_cache_key("schedule_calendar", "date", date_str)
+    cached = get_cache(cache_key, ttl)
+    if isinstance(cached, dict):
+        cached.setdefault("cache_hit", True)
+        cached.setdefault("cache_key", cache_key)
+        cached.setdefault("ttl_seconds", ttl)
+        return cached
+    payload = build_schedule_calendar_snapshot(date_str, fetcher=fetcher)
+    payload.setdefault("cache_hit", False)
+    payload.setdefault("cache_key", cache_key)
+    payload.setdefault("ttl_seconds", ttl)
+    return set_cache(cache_key, payload)
+
+
+def build_calendar_window_payload(
+    dates: Optional[Dict[str, str]] = None,
+    *,
+    fetcher: ScheduleFetcher = fetch_schedule,
+    ttl_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    resolved_dates = dates or build_date_window()
+    payload: Dict[str, Any] = {}
+    for key, date_value in resolved_dates.items():
+        payload[key] = get_or_build_schedule_calendar_snapshot(
+            date_value,
+            fetcher=fetcher,
+            ttl_seconds=ttl_seconds,
+        )
+    return payload
+
+
+def warm_schedule_calendar_window(
+    dates: Optional[Dict[str, str]] = None,
+    *,
+    fetcher: ScheduleFetcher = fetch_schedule,
+) -> Dict[str, Any]:
+    payload = build_calendar_window_payload(dates, fetcher=fetcher, ttl_seconds=0)
+    return {
+        "warmed": True,
+        "dates": {key: value.get("date") for key, value in payload.items()},
+        "counts": {key: value.get("count") for key, value in payload.items()},
+        "snapshot_version": "schedule_calendar_v1",
+    }
+
+
+__all__ = [
+    "build_calendar_window_payload",
+    "build_date_window",
+    "build_schedule_calendar_snapshot",
+    "compact_schedule_game",
+    "get_or_build_schedule_calendar_snapshot",
+    "warm_schedule_calendar_window",
+]

--- a/scripts/warm_game_day.py
+++ b/scripts/warm_game_day.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+
+def _request(method: str, url: str, timeout: int) -> Dict[str, Any]:
+    request = urllib.request.Request(url=url, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            return json.loads(raw) if raw else {"status": response.status}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return {"error": f"HTTP {exc.code}", "url": url, "body": body[:500]}
+    except Exception as exc:
+        return {"error": exc.__class__.__name__, "url": url, "message": str(exc)}
+
+
+def _dates(today: datetime.date) -> Dict[str, str]:
+    return {
+        "yesterday": (today - datetime.timedelta(days=1)).isoformat(),
+        "today": today.isoformat(),
+        "tomorrow": (today + datetime.timedelta(days=1)).isoformat(),
+    }
+
+
+def warm(base_url: str, timeout: int = 60) -> Dict[str, Any]:
+    today = datetime.date.today()
+    dates = _dates(today)
+    base = base_url.rstrip("/")
+    actions: List[Dict[str, Any]] = []
+
+    # Calendar should be lightweight and must not force heavy matchup generation.
+    actions.append({
+        "name": "calendar_window",
+        "method": "GET",
+        "url": f"{base}/matchups/calendar",
+    })
+
+    # Explicitly warm heavyweight matchups and projections outside the user path.
+    for label in ("today", "tomorrow", "yesterday"):
+        date_value = dates[label]
+        actions.append({
+            "name": f"matchups_snapshot_{label}",
+            "method": "POST",
+            "url": f"{base}/matchups/snapshot/{date_value}",
+        })
+        actions.append({
+            "name": f"model_projection_snapshot_{label}",
+            "method": "POST",
+            "url": f"{base}/models/projections/snapshot/{date_value}",
+        })
+
+    results = []
+    for action in actions:
+        result = _request(action["method"], action["url"], timeout)
+        results.append({"action": action["name"], "url": action["url"], "result": result})
+
+    return {
+        "status": "ok",
+        "base_url": base,
+        "dates": dates,
+        "results": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Warm MLBGPT game-day schedule, matchup, and projection caches.")
+    parser.add_argument("--base-url", default=os.getenv("MLBGPT_BASE_URL", "http://127.0.0.1:8000"))
+    parser.add_argument("--timeout", type=int, default=int(os.getenv("MLBGPT_WARM_TIMEOUT_SECONDS", "60")))
+    args = parser.parse_args()
+    print(json.dumps(warm(args.base_url, timeout=args.timeout), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_schedule_calendar.py
+++ b/tests/test_schedule_calendar.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import datetime
+
+from mlb_app.schedule_calendar import (
+    build_calendar_window_payload,
+    build_date_window,
+    build_schedule_calendar_snapshot,
+    compact_schedule_game,
+    get_or_build_schedule_calendar_snapshot,
+)
+from mlb_app.shared_payload_cache import clear_shared_payload_cache
+
+
+def _schedule(_date: str):
+    return [
+        {
+            "_game_pk": 123,
+            "_game_date": "2026-07-09T19:05:00Z",
+            "_venue": "Test Park",
+            "_status": "Preview",
+            "home": {
+                "team": {"id": 1, "name": "Home Club"},
+                "probablePitcher": {"id": 11, "fullName": "Home Starter", "pitchHand": {"code": "R"}},
+            },
+            "away": {
+                "team": {"id": 2, "name": "Away Club"},
+                "probablePitcher": {"id": 22, "fullName": "Away Starter", "pitchHand": {"code": "L"}},
+            },
+        }
+    ]
+
+
+def test_compact_schedule_game_omits_heavy_matchup_payload_fields() -> None:
+    row = compact_schedule_game(_schedule("2026-07-09")[0])
+
+    assert row["game_pk"] == 123
+    assert row["home_team_name"] == "Home Club"
+    assert row["away_team_name"] == "Away Club"
+    assert row["home_pitcher"]["name"] == "Home Starter"
+    assert row["away_pitcher"]["hand"] == "L"
+    assert "probability_components" not in row
+    assert "home_pitcher_features" not in row
+    assert "away_pitch_arsenal" not in row
+    assert "sharedSimulation" not in row
+
+
+def test_build_schedule_calendar_snapshot_uses_schedule_fetcher_only() -> None:
+    calls = []
+
+    def fetcher(date: str):
+        calls.append(date)
+        return _schedule(date)
+
+    payload = build_schedule_calendar_snapshot("2026-07-09", fetcher=fetcher)
+
+    assert calls == ["2026-07-09"]
+    assert payload["date"] == "2026-07-09"
+    assert payload["count"] == 1
+    assert payload["calendar_snapshot_version"] == "schedule_calendar_v1"
+    assert payload["heavy_matchup_generation"] is False
+    assert payload["probability_source"] == "not_loaded_on_calendar_initial_snapshot"
+    assert payload["games"][0]["game_pk"] == 123
+
+
+def test_get_or_build_schedule_calendar_snapshot_uses_cache() -> None:
+    clear_shared_payload_cache("schedule_calendar")
+    calls = []
+
+    def fetcher(date: str):
+        calls.append(date)
+        return _schedule(date)
+
+    first = get_or_build_schedule_calendar_snapshot("2026-07-09", fetcher=fetcher, ttl_seconds=300)
+    second = get_or_build_schedule_calendar_snapshot("2026-07-09", fetcher=fetcher, ttl_seconds=300)
+
+    assert calls == ["2026-07-09"]
+    assert first["count"] == 1
+    assert second["count"] == 1
+    assert second["cache_hit"] is True
+
+
+def test_calendar_window_payload_builds_yesterday_today_tomorrow_without_heavy_matchups() -> None:
+    dates = build_date_window(datetime.date(2026, 7, 9))
+    payload = build_calendar_window_payload(dates, fetcher=_schedule, ttl_seconds=0)
+
+    assert set(payload) == {"yesterday", "today", "tomorrow"}
+    assert payload["yesterday"]["date"] == "2026-07-08"
+    assert payload["today"]["date"] == "2026-07-09"
+    assert payload["tomorrow"]["date"] == "2026-07-10"
+    assert all(day["heavy_matchup_generation"] is False for day in payload.values())


### PR DESCRIPTION
## Summary

Implements Phase 4 calendar/warming infrastructure without removing page content or changing model semantics.

This PR introduces a lightweight schedule-only calendar snapshot path and explicit model projection warming endpoints/scripts. The goal is to stop user-facing calendar/date navigation from needing to cold-build full Daily Matchups/model payloads once the frontend is switched to the lightweight endpoint.

## Related issues

- Epic: #944
- Sprint 2: #947
- Prior instrumentation: #952
- Probability contract: #953

## What changed

### Lightweight calendar snapshot builder

Adds `mlb_app/schedule_calendar.py` with:

- `compact_schedule_game(...)`
- `build_schedule_calendar_snapshot(...)`
- `get_or_build_schedule_calendar_snapshot(...)`
- `build_calendar_window_payload(...)`
- `warm_schedule_calendar_window(...)`

The snapshot intentionally avoids:

- `generate_matchups_for_date(...)`
- lineup diagnostics
- canonical probability generation
- Model Projections generation
- simulations
- pitcher arsenal/model cards

It returns calendar-visible schedule fields only:

- date
- count
- game id
- game time
- venue
- status
- home/away team ids and names
- probable pitcher id/name/hand when available

Each snapshot includes:

- `calendar_snapshot_version: schedule_calendar_v1`
- `heavy_matchup_generation: false`
- `probability_source: not_loaded_on_calendar_initial_snapshot`

### New lightweight calendar endpoints

Adds to the already-mounted model projection router:

- `GET /matchups/calendar/schedule`
- `POST /matchups/calendar/snapshot`

These provide and warm the lightweight calendar window without the existing heavy `/matchups/calendar` behavior.

### Projection warming endpoint

Adds:

- `POST /models/projections/snapshot/{date_str}`

This explicitly builds and stores the Phase 3 `probability_contract_v1` projection payload outside the user request path.

### Warming script

Adds `scripts/warm_game_day.py`.

It warms:

- calendar window
- matchups snapshots for yesterday/today/tomorrow
- model projection snapshots for yesterday/today/tomorrow

It uses:

```bash
python scripts/warm_game_day.py --base-url https://mlbgpt.com
```

or env vars:

```bash
MLBGPT_BASE_URL=https://mlbgpt.com
MLBGPT_WARM_TIMEOUT_SECONDS=60
```

### Tests

Adds `tests/test_schedule_calendar.py` covering:

- compact schedule rows omit heavy matchup/model fields
- snapshot builder uses schedule fetcher only
- schedule snapshot cache reuse
- yesterday/today/tomorrow window generation
- `heavy_matchup_generation` remains false

## Important implementation note

This PR does **not** replace the existing `GET /matchups/calendar` route inside `mlb_app/app.py` yet. That route currently still returns the full heavy matchup payload from `MATCHUP_SNAPSHOT_CACHE` and can call `generate_matchups_for_date(...)` for yesterday/today/tomorrow.

I intentionally avoided a risky large `app.py` rewrite in this PR because `app.py` is large and route-dense. This PR creates the tested lightweight replacement endpoint and warming infrastructure first. The next small PR should update the frontend calendar to call `/matchups/calendar/schedule`, or surgically replace the existing `/matchups/calendar` body once safe.

## What did not change

- No frontend pages changed.
- No page sections/cards removed.
- Existing `/matchups/calendar` remains backward compatible.
- No probability semantics changed.
- No model formulas changed.
- No simulation counts changed.

## Test command

```bash
pytest tests/test_schedule_calendar.py tests/test_model_projection_probability.py
```

Not run in this connector session.

## Next step

After merge, switch the frontend calendar/date selector to `/matchups/calendar/schedule` or replace the existing `/matchups/calendar` implementation with `build_calendar_window_payload()` so the visible calendar stops cold-building full Daily Matchups/model payloads.