### PR TITLE
Phase 5: formalize shared artifact cache metadata

### DIFF
--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -12,7 +12,15 @@ from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
 from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
 from .schedule_calendar import build_calendar_window_payload, warm_schedule_calendar_window
-from .shared_payload_cache import env_ttl, get_or_set, make_cache_key, set_cache
+from .shared_artifacts import (
+    attach_artifact_metadata,
+    artifact_metadata,
+    cache_artifact,
+    model_projection_date_key,
+    model_projection_probability_key,
+    payload_input_hash,
+)
+from .shared_payload_cache import env_ttl, get_or_set
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 
 router = APIRouter()
@@ -27,7 +35,20 @@ def _session_factory():
 
 
 def _projection_cache_key(target_date: str) -> str:
-    return make_cache_key("model_projection", "full", "probability_contract_v1", target_date)
+    return model_projection_date_key(target_date)
+
+
+def _attach_projection_artifact_metadata(payload: Dict[str, Any], target_date: str) -> Dict[str, Any]:
+    metadata = artifact_metadata(
+        artifact_type="model_projection_date",
+        cache_key=_projection_cache_key(target_date),
+        source_route="/models/projections",
+        source_builder="model_projection_routes._build_uncached_projection_payload",
+        model_version="model_projection_probability_v1",
+        probability_source="model_projections",
+    )
+    attach_artifact_metadata(payload, metadata)
+    return payload
 
 
 def _apply_projection_probability_contract(payload: Dict[str, Any], target_date: str) -> Dict[str, Any]:
@@ -48,6 +69,31 @@ def _apply_projection_probability_contract(payload: Dict[str, Any], target_date:
             matchup=game,
             generated_at=payload.get("generated_at"),
         )
+        probability_hash = payload_input_hash({
+            "game_pk": game.get("game_pk"),
+            "date": game.get("game_date") or target_date,
+            "source_path": probability.get("source_path"),
+            "home_win_probability": probability.get("home_win_probability"),
+            "away_win_probability": probability.get("away_win_probability"),
+        })
+        probability_cache_key = model_projection_probability_key(
+            date=game.get("game_date") or target_date,
+            game_pk=game.get("game_pk"),
+            model_version=probability.get("model_version"),
+            input_hash=probability_hash,
+        )
+        attach_artifact_metadata(
+            probability,
+            artifact_metadata(
+                artifact_type="model_projection_probability",
+                cache_key=probability_cache_key,
+                source_route="/models/projections",
+                source_builder="model_projection_probability.build_model_projection_probability",
+                model_version=probability.get("model_version"),
+                input_hash=probability_hash,
+                probability_source=probability.get("source"),
+            ),
+        )
         game["model_projection_probability"] = probability
         game["probability"] = probability
         game["home_win_probability"] = probability.get("home_win_probability")
@@ -57,6 +103,7 @@ def _apply_projection_probability_contract(payload: Dict[str, Any], target_date:
         game["probability_source"] = probability.get("source")
         game["probability_source_path"] = probability.get("source_path")
         game["probability_is_fallback"] = probability.get("is_fallback")
+        game["probability_cache_key"] = probability_cache_key
 
         workspace = game.get("workspace")
         if isinstance(workspace, dict):
@@ -66,6 +113,7 @@ def _apply_projection_probability_contract(payload: Dict[str, Any], target_date:
                 diagnostics["displayed_probability_source"] = probability.get("source")
                 diagnostics["displayed_probability_source_path"] = probability.get("source_path")
                 diagnostics["displayed_probability_is_fallback"] = probability.get("is_fallback")
+                diagnostics["displayed_probability_cache_key"] = probability_cache_key
 
         main = game.get("main_matchup_probabilities")
         if isinstance(main, dict):
@@ -98,6 +146,7 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
         ):
             payload = build_model_projection_payload(session, target_date)
     payload = _apply_projection_probability_contract(payload, target_date)
+    payload = _attach_projection_artifact_metadata(payload, target_date)
     record_probability_source("model_projections")
     record_span(
         "model_projection.payload_bytes",
@@ -113,13 +162,22 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
 def warm_model_projection_payload(target_date: str) -> Dict[str, Any]:
     """Build and store the projection payload explicitly for cron/warm jobs."""
     payload = _build_uncached_projection_payload(target_date)
-    stored = set_cache(_projection_cache_key(target_date), payload)
+    stored = cache_artifact(
+        cache_key=_projection_cache_key(target_date),
+        payload=payload,
+        artifact_type="model_projection_date",
+        source_route="/models/projections",
+        source_builder="model_projection_routes.warm_model_projection_payload",
+        model_version="model_projection_probability_v1",
+        probability_source="model_projections",
+    )
     return {
         "warmed": True,
         "date": target_date,
         "games_cached": len(stored.get("games") or []) if isinstance(stored, dict) else None,
         "cache_key": _projection_cache_key(target_date),
         "probability_contract": "model_projection_probability_v1",
+        "artifact": stored.get("artifact") if isinstance(stored, dict) else None,
     }
 
 

--- a/mlb_app/schedule_calendar.py
+++ b/mlb_app/schedule_calendar.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import datetime
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 from .etl import fetch_schedule
 from .performance import estimate_payload_bytes, record_span, timing_span
-from .shared_payload_cache import env_ttl, get_cache, make_cache_key, set_cache
+from .shared_artifacts import (
+    ARTIFACT_SCHEMA_VERSION,
+    attach_artifact_metadata,
+    artifact_metadata,
+    cache_artifact,
+    get_or_build_artifact,
+    schedule_calendar_key,
+)
+from .shared_payload_cache import env_ttl
 
 ScheduleFetcher = Callable[[str], Iterable[Dict[str, Any]]]
 
@@ -73,6 +81,14 @@ def build_schedule_calendar_snapshot(
     with timing_span("calendar.fetch_schedule", category="schedule", route="/matchups/calendar", date=date_str):
         schedule = list(fetcher(date_str) or [])
     games = [compact_schedule_game(game) for game in schedule]
+    cache_key = schedule_calendar_key(date_str)
+    metadata = artifact_metadata(
+        artifact_type="schedule_calendar",
+        cache_key=cache_key,
+        source_route="/matchups/calendar/schedule",
+        source_builder="schedule_calendar.build_schedule_calendar_snapshot",
+        probability_source="not_loaded_on_calendar_initial_snapshot",
+    )
     payload = {
         "date": date_str,
         "count": len(games),
@@ -81,8 +97,9 @@ def build_schedule_calendar_snapshot(
         "source": "schedule_calendar_snapshot",
         "heavy_matchup_generation": False,
         "probability_source": "not_loaded_on_calendar_initial_snapshot",
-        "generated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "generated_at": metadata["generated_at"],
     }
+    attach_artifact_metadata(payload, metadata)
     record_span(
         "calendar.snapshot.payload_bytes",
         category="serialization",
@@ -100,18 +117,19 @@ def get_or_build_schedule_calendar_snapshot(
     ttl_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
     ttl = env_ttl("MATCHUPS_CALENDAR_CACHE_TTL_SECONDS") if ttl_seconds is None else ttl_seconds
-    cache_key = make_cache_key("schedule_calendar", "date", date_str)
-    cached = get_cache(cache_key, ttl)
-    if isinstance(cached, dict):
-        cached.setdefault("cache_hit", True)
-        cached.setdefault("cache_key", cache_key)
-        cached.setdefault("ttl_seconds", ttl)
-        return cached
-    payload = build_schedule_calendar_snapshot(date_str, fetcher=fetcher)
-    payload.setdefault("cache_hit", False)
-    payload.setdefault("cache_key", cache_key)
-    payload.setdefault("ttl_seconds", ttl)
-    return set_cache(cache_key, payload)
+    cache_key = schedule_calendar_key(date_str)
+    payload = get_or_build_artifact(
+        cache_key=cache_key,
+        ttl_seconds=ttl,
+        artifact_type="schedule_calendar",
+        source_route="/matchups/calendar/schedule",
+        source_builder="schedule_calendar.build_schedule_calendar_snapshot",
+        probability_source="not_loaded_on_calendar_initial_snapshot",
+        builder=lambda: build_schedule_calendar_snapshot(date_str, fetcher=fetcher),
+    )
+    if isinstance(payload, dict):
+        payload.setdefault("ttl_seconds", ttl)
+    return payload
 
 
 def build_calendar_window_payload(
@@ -136,12 +154,24 @@ def warm_schedule_calendar_window(
     *,
     fetcher: ScheduleFetcher = fetch_schedule,
 ) -> Dict[str, Any]:
-    payload = build_calendar_window_payload(dates, fetcher=fetcher, ttl_seconds=0)
+    resolved_dates = dates or build_date_window()
+    payload: Dict[str, Any] = {}
+    for key, date_value in resolved_dates.items():
+        snapshot = build_schedule_calendar_snapshot(date_value, fetcher=fetcher)
+        payload[key] = cache_artifact(
+            cache_key=schedule_calendar_key(date_value),
+            payload=snapshot,
+            artifact_type="schedule_calendar",
+            source_route="/matchups/calendar/schedule",
+            source_builder="schedule_calendar.build_schedule_calendar_snapshot",
+            probability_source="not_loaded_on_calendar_initial_snapshot",
+        )
     return {
         "warmed": True,
         "dates": {key: value.get("date") for key, value in payload.items()},
         "counts": {key: value.get("count") for key, value in payload.items()},
         "snapshot_version": "schedule_calendar_v1",
+        "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
     }
 
 

--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import datetime
+from typing import Any, Callable, Dict, Optional
+
+from .shared_payload_cache import env_ttl, get_cache, make_cache_key, set_cache, stable_hash
+
+ARTIFACT_SCHEMA_VERSION = "shared_artifact_v1"
+
+
+ARTIFACT_TYPES = {
+    "schedule_calendar": "schedule_calendar",
+    "matchups_date": "matchups_date",
+    "model_projection_date": "model_projection_date",
+    "model_projection_probability": "model_projection_probability",
+    "matchup_overview": "matchup_overview",
+    "simulation": "simulation",
+}
+
+
+def utc_timestamp() -> str:
+    return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+
+def artifact_key(artifact_type: str, *parts: Any) -> str:
+    if artifact_type not in ARTIFACT_TYPES.values():
+        raise ValueError(f"Unknown artifact type: {artifact_type}")
+    return make_cache_key("artifact", ARTIFACT_SCHEMA_VERSION, artifact_type, *parts)
+
+
+def schedule_calendar_key(date: str) -> str:
+    return artifact_key("schedule_calendar", date)
+
+
+def matchups_date_key(date: str) -> str:
+    return artifact_key("matchups_date", date)
+
+
+def model_projection_date_key(date: str) -> str:
+    return artifact_key("model_projection_date", "probability_contract_v1", date)
+
+
+def model_projection_probability_key(
+    *,
+    date: str,
+    game_pk: Any,
+    model_version: Optional[str] = None,
+    input_hash: Optional[str] = None,
+) -> str:
+    return artifact_key(
+        "model_projection_probability",
+        date,
+        game_pk,
+        model_version or "unknown_model",
+        input_hash or "no_input_hash",
+    )
+
+
+def matchup_overview_key(date: str, game_pk: Any) -> str:
+    return artifact_key("matchup_overview", date, game_pk)
+
+
+def simulation_key(
+    *,
+    date: str,
+    game_pk: Any,
+    simulation_count: Any,
+    input_hash: Optional[str] = None,
+) -> str:
+    return artifact_key("simulation", date, game_pk, simulation_count, input_hash or "no_input_hash")
+
+
+def artifact_metadata(
+    *,
+    artifact_type: str,
+    cache_key: str,
+    source_route: Optional[str] = None,
+    source_builder: Optional[str] = None,
+    model_version: Optional[str] = None,
+    input_hash: Optional[str] = None,
+    probability_source: Optional[str] = None,
+    generated_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    if artifact_type not in ARTIFACT_TYPES.values():
+        raise ValueError(f"Unknown artifact type: {artifact_type}")
+    return {
+        "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+        "artifact_type": artifact_type,
+        "cache_key": cache_key,
+        "generated_at": generated_at or utc_timestamp(),
+        "source_route": source_route,
+        "source_builder": source_builder,
+        "model_version": model_version,
+        "input_hash": input_hash,
+        "probability_source": probability_source,
+    }
+
+
+def attach_artifact_metadata(payload: Any, metadata: Dict[str, Any]) -> Any:
+    if isinstance(payload, dict):
+        existing = payload.get("artifact") if isinstance(payload.get("artifact"), dict) else {}
+        payload["artifact"] = {**existing, **metadata}
+        payload.setdefault("generated_at", metadata.get("generated_at"))
+        payload.setdefault("cache_key", metadata.get("cache_key"))
+    return payload
+
+
+def cache_artifact(
+    *,
+    cache_key: str,
+    payload: Any,
+    artifact_type: str,
+    source_route: Optional[str] = None,
+    source_builder: Optional[str] = None,
+    model_version: Optional[str] = None,
+    input_hash: Optional[str] = None,
+    probability_source: Optional[str] = None,
+) -> Any:
+    metadata = artifact_metadata(
+        artifact_type=artifact_type,
+        cache_key=cache_key,
+        source_route=source_route,
+        source_builder=source_builder,
+        model_version=model_version,
+        input_hash=input_hash,
+        probability_source=probability_source,
+    )
+    return set_cache(cache_key, attach_artifact_metadata(payload, metadata))
+
+
+def get_or_build_artifact(
+    *,
+    cache_key: str,
+    ttl_seconds: int,
+    builder: Callable[[], Any],
+    artifact_type: str,
+    source_route: Optional[str] = None,
+    source_builder: Optional[str] = None,
+    model_version: Optional[str] = None,
+    input_hash: Optional[str] = None,
+    probability_source: Optional[str] = None,
+) -> Any:
+    cached = get_cache(cache_key, ttl_seconds)
+    if cached is not None:
+        if isinstance(cached, dict):
+            cached.setdefault("cache_hit", True)
+            cached.setdefault("cache_key", cache_key)
+            artifact = cached.get("artifact") if isinstance(cached.get("artifact"), dict) else {}
+            cached["artifact"] = {
+                **artifact,
+                "cache_key": cache_key,
+                "artifact_schema_version": artifact.get("artifact_schema_version") or ARTIFACT_SCHEMA_VERSION,
+                "artifact_type": artifact.get("artifact_type") or artifact_type,
+            }
+        return cached
+
+    payload = builder()
+    return cache_artifact(
+        cache_key=cache_key,
+        payload=payload,
+        artifact_type=artifact_type,
+        source_route=source_route,
+        source_builder=source_builder,
+        model_version=model_version,
+        input_hash=input_hash,
+        probability_source=probability_source,
+    )
+
+
+def payload_input_hash(value: Any) -> str:
+    return stable_hash(value)
+
+
+__all__ = [
+    "ARTIFACT_SCHEMA_VERSION",
+    "ARTIFACT_TYPES",
+    "artifact_key",
+    "artifact_metadata",
+    "attach_artifact_metadata",
+    "cache_artifact",
+    "get_or_build_artifact",
+    "matchup_overview_key",
+    "matchups_date_key",
+    "model_projection_date_key",
+    "model_projection_probability_key",
+    "payload_input_hash",
+    "schedule_calendar_key",
+    "simulation_key",
+    "utc_timestamp",
+]

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from mlb_app.model_projection_routes import _apply_projection_probability_contract, _attach_projection_artifact_metadata, _projection_cache_key
+from mlb_app.schedule_calendar import build_schedule_calendar_snapshot, get_or_build_schedule_calendar_snapshot
+from mlb_app.shared_artifacts import (
+    ARTIFACT_SCHEMA_VERSION,
+    artifact_key,
+    attach_artifact_metadata,
+    artifact_metadata,
+    matchups_date_key,
+    model_projection_date_key,
+    model_projection_probability_key,
+    payload_input_hash,
+    schedule_calendar_key,
+    simulation_key,
+)
+from mlb_app.shared_payload_cache import clear_shared_payload_cache
+
+
+def _schedule(_date: str):
+    return [
+        {
+            "_game_pk": 123,
+            "_game_date": "2026-07-09T19:05:00Z",
+            "_venue": "Test Park",
+            "_status": "Preview",
+            "home": {"team": {"id": 1, "name": "Home Club"}},
+            "away": {"team": {"id": 2, "name": "Away Club"}},
+        }
+    ]
+
+
+def test_artifact_keys_are_separated_by_type_and_model_contract() -> None:
+    date = "2026-07-09"
+
+    keys = {
+        schedule_calendar_key(date),
+        matchups_date_key(date),
+        model_projection_date_key(date),
+        model_projection_probability_key(date=date, game_pk=123, model_version="v1", input_hash="abc"),
+        simulation_key(date=date, game_pk=123, simulation_count=3000, input_hash="abc"),
+    }
+
+    assert len(keys) == 5
+    assert schedule_calendar_key(date).startswith(f"artifact:{ARTIFACT_SCHEMA_VERSION}:schedule_calendar")
+    assert model_projection_date_key(date).startswith(f"artifact:{ARTIFACT_SCHEMA_VERSION}:model_projection_date")
+    assert "probability_contract_v1" in model_projection_date_key(date)
+
+
+def test_unknown_artifact_type_raises() -> None:
+    try:
+        artifact_key("not_real", "2026-07-09")
+    except ValueError as exc:
+        assert "Unknown artifact type" in str(exc)
+    else:
+        raise AssertionError("Expected unknown artifact type to raise")
+
+
+def test_attach_artifact_metadata_preserves_payload_and_adds_artifact_block() -> None:
+    payload = {"date": "2026-07-09", "games": []}
+    metadata = artifact_metadata(
+        artifact_type="model_projection_date",
+        cache_key=model_projection_date_key("2026-07-09"),
+        source_route="/models/projections",
+        source_builder="test_builder",
+        model_version="model_projection_probability_v1",
+        probability_source="model_projections",
+    )
+
+    updated = attach_artifact_metadata(payload, metadata)
+
+    assert updated["date"] == "2026-07-09"
+    assert updated["artifact"]["artifact_type"] == "model_projection_date"
+    assert updated["artifact"]["cache_key"] == model_projection_date_key("2026-07-09")
+    assert updated["artifact"]["source_route"] == "/models/projections"
+    assert updated["artifact"]["probability_source"] == "model_projections"
+
+
+def test_schedule_calendar_snapshot_uses_shared_artifact_metadata() -> None:
+    payload = build_schedule_calendar_snapshot("2026-07-09", fetcher=_schedule)
+
+    assert payload["cache_key"] == schedule_calendar_key("2026-07-09")
+    assert payload["artifact"]["artifact_schema_version"] == ARTIFACT_SCHEMA_VERSION
+    assert payload["artifact"]["artifact_type"] == "schedule_calendar"
+    assert payload["artifact"]["source_route"] == "/matchups/calendar/schedule"
+    assert payload["heavy_matchup_generation"] is False
+
+
+def test_schedule_calendar_artifact_cache_reuse_has_metadata() -> None:
+    clear_shared_payload_cache("artifact")
+
+    first = get_or_build_schedule_calendar_snapshot("2026-07-09", fetcher=_schedule, ttl_seconds=300)
+    second = get_or_build_schedule_calendar_snapshot("2026-07-09", fetcher=_schedule, ttl_seconds=300)
+
+    assert first["artifact"]["cache_key"] == schedule_calendar_key("2026-07-09")
+    assert second["cache_hit"] is True
+    assert second["artifact"]["artifact_type"] == "schedule_calendar"
+
+
+def test_projection_payload_receives_date_artifact_metadata() -> None:
+    payload = {"date": "2026-07-09", "games": []}
+
+    updated = _attach_projection_artifact_metadata(payload, "2026-07-09")
+
+    assert updated["cache_key"] == _projection_cache_key("2026-07-09")
+    assert updated["artifact"]["artifact_type"] == "model_projection_date"
+    assert updated["artifact"]["source_route"] == "/models/projections"
+    assert updated["artifact"]["probability_source"] == "model_projections"
+
+
+def test_projection_probability_artifact_metadata_is_attached_to_game_probability() -> None:
+    payload = {
+        "date": "2026-07-09",
+        "games": [
+            {
+                "game_pk": 123,
+                "game_date": "2026-07-09",
+                "home_win_prob": 0.51,
+                "away_win_prob": 0.49,
+                "sharedSimulation": {
+                    "derived_outputs": {
+                        "bullpen_adjusted_game_simulation": {
+                            "home_win_probability": 0.64,
+                            "away_win_probability": 0.36,
+                            "model_version": "bullpen_adjusted_v1",
+                        }
+                    }
+                },
+            }
+        ],
+    }
+
+    updated = _apply_projection_probability_contract(payload, "2026-07-09")
+    probability = updated["games"][0]["model_projection_probability"]
+    expected_hash = payload_input_hash({
+        "game_pk": 123,
+        "date": "2026-07-09",
+        "source_path": "sharedSimulation.derived_outputs.bullpen_adjusted_game_simulation",
+        "home_win_probability": 0.64,
+        "away_win_probability": 0.36,
+    })
+    expected_key = model_projection_probability_key(
+        date="2026-07-09",
+        game_pk=123,
+        model_version="bullpen_adjusted_v1",
+        input_hash=expected_hash,
+    )
+
+    assert probability["artifact"]["artifact_type"] == "model_projection_probability"
+    assert probability["artifact"]["cache_key"] == expected_key
+    assert probability["artifact"]["input_hash"] == expected_hash
+    assert updated["games"][0]["probability_cache_key"] == expected_key


### PR DESCRIPTION
## Summary

Implements Phase 5 shared artifact cache metadata on top of the Phase 4 installed routes, without changing page behavior or adding new user-facing surfaces.

This PR formalizes cache keys and metadata for the artifacts that the sprint needs to reuse across calendar, matchups, projections, matchup overview, probabilities, and simulations.

## Related issues

- Epic: #944
- Sprint 3: #948
- Calendar/warming routes: #954
- Probability contract: #953
- Instrumentation: #952

## What changed

### New shared artifact helper

Adds `mlb_app/shared_artifacts.py` with:

- `artifact_key(...)`
- `schedule_calendar_key(...)`
- `matchups_date_key(...)`
- `model_projection_date_key(...)`
- `model_projection_probability_key(...)`
- `matchup_overview_key(...)`
- `simulation_key(...)`
- `artifact_metadata(...)`
- `attach_artifact_metadata(...)`
- `cache_artifact(...)`
- `get_or_build_artifact(...)`
- `payload_input_hash(...)`

All artifact cache keys are namespaced by:

```text
artifact:shared_artifact_v1:<artifact_type>:...
```

### Calendar artifacts

Updates `mlb_app/schedule_calendar.py` so the installed lightweight calendar route now uses shared artifact metadata and keys.

Calendar snapshots now include an `artifact` block with:

- `artifact_schema_version`
- `artifact_type: schedule_calendar`
- `cache_key`
- `generated_at`
- `source_route: /matchups/calendar/schedule`
- `source_builder`
- `probability_source: not_loaded_on_calendar_initial_snapshot`

### Model Projection date artifacts

Updates `mlb_app/model_projection_routes.py` so the installed `/models/projections` and `/models/projections/snapshot/{date_str}` paths use the shared `model_projection_date` artifact key.

### Model Projection probability artifacts

Each game-level `model_projection_probability` now gets its own artifact metadata and deterministic probability cache key:

```text
artifact:shared_artifact_v1:model_projection_probability:<date>:<game_pk>:<model_version>:<input_hash>
```

The game also exposes:

- `probability_cache_key`
- `model_projection_probability.artifact`
- `workspace.sharedSimulationDiagnostics.displayed_probability_cache_key`

## What did not change

- No frontend pages changed.
- No existing route removed.
- No model formulas changed.
- No simulation behavior changed.
- No probability semantics changed beyond preserving Phase 3 contract metadata.
- No cache deepcopy behavior changed.
- No new public route added; this uses the Phase 4 installed routes.

## Tests

Adds `tests/test_shared_artifacts.py` covering:

- artifact key separation by type
- model projection contract cache key separation
- unknown artifact type rejection
- metadata attachment
- calendar artifact metadata
- calendar cache reuse metadata
- projection date artifact metadata
- projection probability artifact metadata and deterministic keying

## Test command

```bash
pytest tests/test_shared_artifacts.py tests/test_schedule_calendar.py tests/test_model_projection_probability.py
```

Not run in this connector session.

## Notes

Several empty experimental branch refs were created while confirming branch availability. The active branch for this PR is only:

```text
sprint/phase-5-shared-artifacts-final2
```

## Next step

After merge, Phase 6 can use these artifact keys to optimize formulas/simulations and reuse warmed projection/matchup/probability artifacts instead of recomputing them independently.