### PR TITLE
Phase 6: cache projection bullpen schema and simulation cards

### DIFF
--- a/mlb_app/model_projection_performance_cache.py
+++ b/mlb_app/model_projection_performance_cache.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Optional, Tuple
+
+from sqlalchemy import inspect, text
+
+from . import model_projections as raw_model_projections
+from .performance import record_span, timing_span
+from .shared_artifacts import payload_input_hash, simulation_key
+from .shared_payload_cache import env_ttl, get_cache, set_cache
+
+_SCHEMA_CACHE: Dict[str, Dict[str, Any]] = {}
+_RAW_BULLPEN_INPUTS = raw_model_projections._bullpen_inputs
+_RAW_BUILD_PROJECTION_SIMULATION_CARDS = raw_model_projections._build_projection_simulation_cards
+_PATCHED = False
+
+
+def _engine_cache_key(session: Any) -> str:
+    bind = getattr(session, "bind", None)
+    url = getattr(bind, "url", None)
+    return str(url or id(bind))
+
+
+def clear_projection_performance_caches() -> None:
+    _SCHEMA_CACHE.clear()
+
+
+def _discover_bullpen_schema(session: Any) -> Dict[str, Any]:
+    """Discover bullpen table/column mapping once per engine.
+
+    The original `_bullpen_inputs` reflected table names and columns for every
+    team/game. This cache preserves the same lookup semantics while avoiding
+    repeated SQLAlchemy inspection work on hot projection builds.
+    """
+    cache_key = _engine_cache_key(session)
+    if cache_key in _SCHEMA_CACHE:
+        record_span("model_projection.bullpen_schema_cache", category="db", cache_status="HIT")
+        return _SCHEMA_CACHE[cache_key]
+
+    with timing_span("model_projection.bullpen_schema_discovery", category="db", cache_status="MISS"):
+        try:
+            inspector = inspect(session.bind)
+            table_names = set(inspector.get_table_names())
+        except Exception:
+            schema = {"source_table": None, "error": "inspection_failed"}
+            _SCHEMA_CACHE[cache_key] = schema
+            return schema
+
+        table = next(
+            (
+                name
+                for name in [
+                    "bullpen_stats",
+                    "team_bullpen_stats",
+                    "table_layerseven",
+                    "layerseven",
+                    "team_pitching_bullpen",
+                    "team_pitching_stats",
+                ]
+                if name in table_names
+            ),
+            None,
+        )
+        if not table:
+            schema = {"source_table": None}
+            _SCHEMA_CACHE[cache_key] = schema
+            return schema
+
+        try:
+            columns = [col["name"] for col in inspector.get_columns(table)]
+        except Exception as exc:
+            schema = {"source_table": table, "error": str(exc)}
+            _SCHEMA_CACHE[cache_key] = schema
+            return schema
+
+        schema = {
+            "source_table": table,
+            "team_id_col": raw_model_projections._find_column(columns, ["team_id", "teamid", "mlb_team_id"]),
+            "team_name_col": raw_model_projections._find_column(columns, ["team_name", "team", "name"]),
+            "era_col": raw_model_projections._find_column(columns, ["era", "bullpen_era"]),
+            "bb9_col": raw_model_projections._find_column(columns, ["bb_per_9", "bb9", "bb_9", "bb_per_nine", "walks_per_9"]),
+            "whip_col": raw_model_projections._find_column(columns, ["whip", "bullpen_whip"]),
+        }
+        _SCHEMA_CACHE[cache_key] = schema
+        record_span("model_projection.bullpen_schema_cache", category="db", cache_status="STORE")
+        return schema
+
+
+def cached_bullpen_inputs(session: Any, team_id: Optional[int], team_name: Optional[str]) -> Dict[str, Any]:
+    schema = _discover_bullpen_schema(session)
+    table = schema.get("source_table")
+    if not table:
+        return {"source_table": None}
+    if schema.get("error"):
+        return {"source_table": table, "error": schema.get("error")}
+
+    era_col = schema.get("era_col")
+    bb9_col = schema.get("bb9_col")
+    whip_col = schema.get("whip_col")
+    if not all([era_col, bb9_col, whip_col]):
+        return {"source_table": table}
+
+    where = None
+    params: Dict[str, Any] = {}
+    if schema.get("team_id_col") and team_id is not None:
+        where = f"{schema['team_id_col']} = :team_id"
+        params["team_id"] = int(team_id)
+    elif schema.get("team_name_col") and team_name:
+        where = f"lower({schema['team_name_col']}) = lower(:team_name)"
+        params["team_name"] = team_name
+    if not where:
+        return {"source_table": table}
+
+    try:
+        with timing_span("model_projection.bullpen_inputs_query", category="db"):
+            row = session.execute(
+                text(f"SELECT {era_col} AS era, {bb9_col} AS bb_per_9, {whip_col} AS whip FROM {table} WHERE {where} LIMIT 1"),
+                params,
+            ).mappings().first()
+        return {"era": row.get("era"), "bb_per_9": row.get("bb_per_9"), "whip": row.get("whip"), "source_table": table} if row else {"source_table": table}
+    except Exception as exc:
+        return {"source_table": table, "error": str(exc)}
+
+
+def _simulation_cards_cache_key(matchup: Dict[str, Any], away: Dict[str, Any], home: Dict[str, Any]) -> str:
+    date = matchup.get("game_date") or "unknown_date"
+    game_pk = matchup.get("game_pk") or matchup.get("gamePk") or "unknown_game"
+    input_hash = payload_input_hash({
+        "matchup": {
+            "game_pk": game_pk,
+            "game_date": date,
+            "venue": matchup.get("venue"),
+            "weather": matchup.get("weather"),
+            "park_factor": matchup.get("park_factor"),
+        },
+        "away": {
+            "team_id": away.get("team_id"),
+            "team_name": away.get("team_name"),
+            "offense_inputs": away.get("offense_inputs"),
+            "bullpen_inputs": away.get("bullpen_inputs"),
+        },
+        "home": {
+            "team_id": home.get("team_id"),
+            "team_name": home.get("team_name"),
+            "offense_inputs": home.get("offense_inputs"),
+            "bullpen_inputs": home.get("bullpen_inputs"),
+        },
+        "simulation_count": 3000,
+        "seed": 42,
+    })
+    return simulation_key(date=date, game_pk=game_pk, simulation_count=3000, input_hash=input_hash)
+
+
+def cached_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, Any], home: Dict[str, Any]) -> Dict[str, Any]:
+    cache_key = _simulation_cards_cache_key(matchup, away, home)
+    ttl = env_ttl("MODEL_PROJECTION_SIMULATION_CACHE_TTL_SECONDS")
+    cached = get_cache(cache_key, ttl)
+    if isinstance(cached, dict):
+        cached.setdefault("cache_hit", True)
+        cached.setdefault("cache_key", cache_key)
+        return cached
+
+    with timing_span(
+        "model_projection.build_projection_simulation_cards_uncached",
+        category="simulation",
+        game_pk=matchup.get("game_pk") or matchup.get("gamePk"),
+        date=matchup.get("game_date"),
+        cache_status="MISS",
+    ):
+        built = _RAW_BUILD_PROJECTION_SIMULATION_CARDS(matchup, away, home)
+    if isinstance(built, dict):
+        built.setdefault("cache_hit", False)
+        built.setdefault("cache_key", cache_key)
+    return set_cache(cache_key, built)
+
+
+def install_model_projection_performance_cache() -> bool:
+    """Patch targeted hot functions used by build_model_projection_payload.
+
+    This is intentionally narrow: no formulas or model semantics change. It only
+    caches bullpen schema discovery and repeats of deterministic diagnostic
+    simulation-card builds.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return True
+    raw_model_projections._bullpen_inputs = cached_bullpen_inputs
+    raw_model_projections._build_projection_simulation_cards = cached_projection_simulation_cards
+    _PATCHED = True
+    return True
+
+
+def build_model_projection_payload(session: Any, target_date: str) -> Dict[str, Any]:
+    install_model_projection_performance_cache()
+    return raw_model_projections.build_model_projection_payload(session, target_date)
+
+
+__all__ = [
+    "build_model_projection_payload",
+    "cached_bullpen_inputs",
+    "cached_projection_simulation_cards",
+    "clear_projection_performance_caches",
+    "install_model_projection_performance_cache",
+]

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException
 
 from .database import create_tables, get_engine, get_session
+from .model_projection_performance_cache import build_model_projection_payload
 from .model_projection_probability import build_model_projection_probability
-from .model_projections import build_model_projection_payload
 from .model_tracker_routes import router as model_tracker_router
 from .performance import estimate_payload_bytes, record_probability_source, record_span, timing_span
 from .schedule_calendar import build_calendar_window_payload, warm_schedule_calendar_window

--- a/tests/test_model_projection_performance_cache.py
+++ b/tests/test_model_projection_performance_cache.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mlb_app import model_projection_performance_cache as cache
+from mlb_app import model_projections as raw_model_projections
+from mlb_app.shared_payload_cache import clear_shared_payload_cache
+
+
+class FakeResult:
+    def __init__(self, row: Dict[str, Any] | None):
+        self._row = row
+
+    def mappings(self):
+        return self
+
+    def first(self):
+        return self._row
+
+
+class FakeInspector:
+    table_name_calls = 0
+    column_calls = 0
+
+    def __init__(self, _bind):
+        pass
+
+    def get_table_names(self):
+        FakeInspector.table_name_calls += 1
+        return ["bullpen_stats"]
+
+    def get_columns(self, table):
+        FakeInspector.column_calls += 1
+        assert table == "bullpen_stats"
+        return [
+            {"name": "team_id"},
+            {"name": "era"},
+            {"name": "bb_per_9"},
+            {"name": "whip"},
+        ]
+
+
+class FakeBind:
+    url = "sqlite://unit-test"
+
+
+class FakeSession:
+    bind = FakeBind()
+
+    def __init__(self):
+        self.queries = []
+
+    def execute(self, query, params):
+        self.queries.append((str(query), params))
+        return FakeResult({"era": 3.55, "bb_per_9": 3.1, "whip": 1.21})
+
+
+def test_bullpen_schema_discovery_is_cached(monkeypatch) -> None:
+    cache.clear_projection_performance_caches()
+    FakeInspector.table_name_calls = 0
+    FakeInspector.column_calls = 0
+    monkeypatch.setattr(cache, "inspect", FakeInspector)
+    session = FakeSession()
+
+    first = cache.cached_bullpen_inputs(session, team_id=1, team_name="Home Club")
+    second = cache.cached_bullpen_inputs(session, team_id=2, team_name="Away Club")
+
+    assert first["source_table"] == "bullpen_stats"
+    assert second["source_table"] == "bullpen_stats"
+    assert first["era"] == 3.55
+    assert FakeInspector.table_name_calls == 1
+    assert FakeInspector.column_calls == 1
+    assert len(session.queries) == 2
+
+
+def test_install_model_projection_performance_cache_patches_raw_builder_functions() -> None:
+    assert cache.install_model_projection_performance_cache() is True
+    assert raw_model_projections._bullpen_inputs is cache.cached_bullpen_inputs
+    assert raw_model_projections._build_projection_simulation_cards is cache.cached_projection_simulation_cards
+
+
+def test_cached_projection_simulation_cards_reuses_cached_result(monkeypatch) -> None:
+    clear_shared_payload_cache("artifact")
+    calls = []
+
+    def fake_raw(matchup, away, home):
+        calls.append(matchup["game_pk"])
+        return {
+            "away": [{"model_name": "away"}],
+            "home": [{"model_name": "home"}],
+            "workspace": {"built": True},
+        }
+
+    monkeypatch.setattr(cache, "_RAW_BUILD_PROJECTION_SIMULATION_CARDS", fake_raw)
+    matchup = {"game_pk": 123, "game_date": "2026-07-09", "venue": "Test Park"}
+    away = {"team_id": 1, "team_name": "Away", "offense_inputs": {"pa": 500}, "bullpen_inputs": {"era": 3.5}}
+    home = {"team_id": 2, "team_name": "Home", "offense_inputs": {"pa": 505}, "bullpen_inputs": {"era": 3.9}}
+
+    first = cache.cached_projection_simulation_cards(matchup, away, home)
+    second = cache.cached_projection_simulation_cards(matchup, away, home)
+
+    assert calls == [123]
+    assert first["workspace"]["built"] is True
+    assert second["workspace"]["built"] is True
+    assert second["cache_hit"] is True
+    assert first["cache_key"] == second["cache_key"]
+    assert first["cache_key"].startswith("artifact:shared_artifact_v1:simulation")
+
+
+def test_build_model_projection_payload_installs_cache_before_delegating(monkeypatch) -> None:
+    called = {}
+
+    def fake_build(session, target_date):
+        called["session"] = session
+        called["date"] = target_date
+        return {"date": target_date, "games": []}
+
+    monkeypatch.setattr(cache.raw_model_projections, "build_model_projection_payload", fake_build)
+
+    result = cache.build_model_projection_payload(object(), "2026-07-09")
+
+    assert result == {"date": "2026-07-09", "games": []}
+    assert called["date"] == "2026-07-09"
+    assert raw_model_projections._bullpen_inputs is cache.cached_bullpen_inputs


### PR DESCRIPTION
## Summary

Implements Phase 6 formula/simulation optimization in the same staged workflow as the prior phases.

This PR keeps page behavior and model semantics unchanged. It targets two cold-build hotspots identified by the Phase 1/2 work:

1. repeated SQLAlchemy bullpen table/column inspection inside Model Projections side-context building
2. repeated deterministic diagnostic simulation-card builds inside cold Model Projections payload generation

## Related issues

- Epic: #944
- Sprint 4: #949
- Shared artifact metadata: #955
- Calendar/warming routes: #954
- Probability contract: #953
- Instrumentation: #952

## What changed

### New cache wrapper

Adds `mlb_app/model_projection_performance_cache.py`.

It wraps the existing `mlb_app.model_projections.build_model_projection_payload(...)` and patches only targeted hot functions before delegating to the original builder.

### Bullpen schema discovery cache

The original `_bullpen_inputs(...)` reflected table names and columns on each team/game call.

This PR adds per-engine schema discovery caching:

- table-name discovery happens once per engine URL
- column discovery happens once per engine URL
- per-team row queries still execute normally
- returned bullpen inputs keep the same shape
- no formula semantics change

### Diagnostic simulation-card cache

Adds deterministic cache keys for `_build_projection_simulation_cards(...)` using the Phase 5 shared artifact key system:

```text
artifact:shared_artifact_v1:simulation:<date>:<game_pk>:3000:<input_hash>
```

The cache key includes:

- game id/date
- venue/weather/park factor
- away/home team ids and names
- offense inputs
- bullpen inputs
- simulation count
- seed

This avoids rerunning the same deterministic diagnostic 3,000-count simulation-card build across repeated cold projection builds in the same process/cache window.

### Route wiring

Updates `mlb_app/model_projection_routes.py` to import `build_model_projection_payload` from the new cache wrapper:

```python
from .model_projection_performance_cache import build_model_projection_payload
```

The installed routes remain the same:

- `GET /models/projections`
- `POST /models/projections/snapshot/{date_str}`
- `GET /matchups/calendar/schedule`
- `POST /matchups/calendar/snapshot`

### Tests

Adds `tests/test_model_projection_performance_cache.py` covering:

- bullpen schema discovery cache only inspects once per engine
- per-team bullpen queries still execute
- patch installation swaps the targeted raw functions
- deterministic simulation-card cache reuses cached output
- route-level builder delegates through the cached wrapper

## What did not change

- No frontend pages changed.
- No existing route removed.
- No page sections/cards removed.
- No probability semantics changed.
- No formulas changed.
- No simulation count changed.
- No cache deepcopy behavior changed.
- No raw payload fields removed.

## New optional env var

```bash
MODEL_PROJECTION_SIMULATION_CACHE_TTL_SECONDS=300
```

If unset, it falls back through the existing shared cache TTL default behavior.

## Test command

```bash
pytest tests/test_model_projection_performance_cache.py tests/test_shared_artifacts.py tests/test_model_projection_probability.py
```

Not run in this connector session.

## Risk notes

The wrapper patches two internal functions at runtime before delegating to the original builder. The patch is intentionally narrow, idempotent, and covered by tests. It avoids rewriting the large `model_projections.py` file directly while still applying the optimization to the installed `/models/projections` route.

## Next step

After merge, Phase 7 should move to frontend/API request sequencing and final benchmark reporting using the installed lightweight calendar route, warmed projection snapshot route, artifact metadata, and Phase 2 debug performance endpoint.