### PR TITLE
Phase 7: finalize calendar sequencing and benchmark report path

### DIFF
--- a/docs/phase7_finalization_report.md
+++ b/docs/phase7_finalization_report.md
@@ -1,0 +1,115 @@
+# Phase 7 Finalization Report
+
+Related issue: #958  
+Epic: #944
+
+## Status
+
+Phase 7 is the final EPIC acceptance phase. This report is intentionally checked into the repo so benchmark evidence and probability-source verification have a stable place to land.
+
+Current PR scope:
+
+- Calendar frontend now uses `GET /matchups/calendar/schedule` for initial calendar load.
+- Calendar refresh now warms `POST /matchups/calendar/snapshot` and reloads the lightweight schedule snapshot.
+- `scripts/phase7_benchmark.py` captures cold/warm route timings, payload sizes, cache headers, probability-source headers, and debug hotspot payloads.
+
+## Merged / active sprint phases
+
+| Phase | Scope | PR / Issue | Status |
+|---|---|---:|---|
+| Phase 1 | Probability/performance discovery map | #951 | Merged |
+| Phase 2 | Instrumentation, payload bytes, debug hotspots | #952 | Merged |
+| Phase 3 | Model Projections probability contract | #953 | Merged |
+| Phase 4 | Lightweight calendar + warming routes | #954 | Merged |
+| Phase 5 | Shared artifact metadata | #955 | Merged |
+| Phase 6 | Formula/simulation cache | #957 | Active/merge pending at time this report was created |
+| Phase 7 | Request sequencing, verification, benchmark evidence | #958 | Active |
+
+## Installed routes used by Phase 7
+
+| Route | Purpose | Expected cold path | Expected warm path |
+|---|---|---|---|
+| `GET /matchups/calendar/schedule` | Lightweight calendar/date-selector load | Schedule-only snapshot | Shared calendar artifact/cache |
+| `POST /matchups/calendar/snapshot` | Warm lightweight calendar snapshots | Schedule-only snapshot build | Shared calendar artifact/cache |
+| `GET /matchups?date=<date>` | Daily Matchups | Matchups date cache or build | Matchups cache |
+| `POST /matchups/snapshot/<date>` | Warm Daily Matchups | Matchups build | Matchups cache |
+| `GET /matchup/{game_pk}` | Matchup Detail / Overview | Detail build | Detail/cache path if available |
+| `GET /models/projections?date=<date>` | Model Projections | Projection artifact or build | Model projection artifact/cache |
+| `POST /models/projections/snapshot/{date}` | Warm Model Projections | Projection artifact build | Model projection artifact/cache |
+| `GET /debug/performance` | Runtime performance snapshot | Current process diagnostics | Current process diagnostics |
+| `GET /debug/performance/hotspots` | Runtime hotspot snapshot | Current process diagnostics | Current process diagnostics |
+
+## Frontend/API request sequencing matrix
+
+| Surface | Previous behavior | Phase 7 behavior | Remaining note |
+|---|---|---|---|
+| Calendar / date selector | `GET /matchups/calendar`, which could trigger full `generate_matchups_for_date` for yesterday/today/tomorrow | `GET /matchups/calendar/schedule`, schedule-only initial payload | Implemented in `frontend/src/pages/YesterdayTodayPage.jsx` |
+| Calendar refresh | `POST /matchups/snapshot/{date}` then heavy calendar reload | `POST /matchups/calendar/snapshot` then lightweight calendar reload | Implemented |
+| Daily Matchups / HomePage | Uses `/matchups?date=<date>` | No frontend change in this PR | Should benefit from prior cache/instrumentation; benchmark required |
+| Matchup Detail / Overview | Uses `/matchup/{game_pk}` | No frontend change in this PR | Benchmark required; future reuse of projection artifacts may remain |
+| Model Projections | Uses `/models/projections?date=<date>` | No frontend change in this PR | Route already uses Phase 3 probability contract and Phase 5 artifact keys; Phase 6 adds internal cache wrapper |
+| Daily Odds | Existing Daily Odds API/page flow | No frontend change in this PR | Benchmark/audit required; probability source must be verified |
+
+## Probability-source verification matrix
+
+| Surface | Required source behavior | Phase 7 verification method | Status |
+|---|---|---|---|
+| `/models/projections` | Displayed/default aliases use Model Projections output when available | `scripts/phase7_benchmark.py` reads `model_projection_probability.source` counts | Script added; run required after deploy |
+| Model Projections page | UI uses shared derived simulation / route aliases | Existing frontend already reads shared derived simulation for visible win cards | Needs production verification |
+| Daily Matchups / HomePage | Should display Model Projections where available or explicit fallback | Requires route/component verification | Pending benchmark/audit |
+| Matchup Detail / Overview | Should display Model Projections where available or explicit fallback | Requires route/component verification | Pending benchmark/audit |
+| Daily Odds | Should prefer Model Projection probability where available | Requires route/component verification | Pending benchmark/audit |
+
+## Benchmark command
+
+Run against production or a deployed preview after this PR is deployed:
+
+```bash
+python scripts/phase7_benchmark.py \
+  --base-url https://mlbgpt.com \
+  --date YYYY-MM-DD \
+  --output docs/phase7_benchmark_output.json
+```
+
+The script records:
+
+- cold/warm elapsed ms
+- response payload bytes
+- `X-Response-Time-ms`
+- `X-Payload-Bytes`
+- `X-Cache`
+- `X-Probability-Source`
+- `/debug/performance`
+- `/debug/performance/hotspots`
+- Model Projection probability-source counts
+
+## Benchmark evidence
+
+Paste or commit `docs/phase7_benchmark_output.json` after deployment.
+
+| Route/page | Cold ms | Warm ms | Payload bytes | Cache status | Probability source | Notes |
+|---|---:|---:|---:|---|---|---|
+| `/matchups/calendar/schedule` | Pending | Pending | Pending | Pending | not loaded on initial calendar | Calendar should not trigger heavy matchup build |
+| `/matchups?date=<date>` | Pending | Pending | Pending | Pending | Pending | Daily Matchups |
+| `/matchup/{game_pk}` | Pending | Pending | Pending | Pending | Pending | Matchup Detail |
+| `/models/projections?date=<date>` | Pending | Pending | Pending | Pending | model_projections where available | Model Projections |
+| Daily Matchups frontend waterfall | Pending | Pending | Pending | Pending | Pending | Browser/network capture required if not covered by backend script |
+| Model Projections frontend waterfall | Pending | Pending | Pending | Pending | Pending | Browser/network capture required if not covered by backend script |
+| Daily Odds frontend/API waterfall | Pending | Pending | Pending | Pending | Pending | Browser/network capture required if not covered by backend script |
+
+## EPIC completion checklist
+
+- [x] Phase 7 issue created from final five EPIC acceptance bullets.
+- [x] Calendar initial load switched to installed lightweight route.
+- [x] Calendar refresh switched to installed lightweight snapshot route.
+- [x] Benchmark runner added.
+- [ ] Phase 6 merged/deployed if not already merged.
+- [ ] Phase 7 deployed.
+- [ ] Production or preview benchmark output committed/attached.
+- [ ] Probability-source verification completed for all displayed/default surfaces.
+- [ ] Remaining exceptions documented, or none confirmed.
+- [ ] EPIC #944 closed only after evidence supports completion.
+
+## Final completion statement
+
+Not complete yet. Phase 7 code is in progress; final benchmark output and probability-source verification must be produced after deployment before the EPIC can be closed.

--- a/frontend/src/pages/YesterdayTodayPage.jsx
+++ b/frontend/src/pages/YesterdayTodayPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { API_BASE } from '../lib/api'
 
 const API = API_BASE
+const CALENDAR_SCHEDULE_URL = `${API}/matchups/calendar/schedule`
 
 const card = { background: '#161b22', border: '1px solid #30363d', borderRadius: '10px', padding: '16px', marginBottom: '16px' }
 
@@ -10,16 +11,21 @@ export default function YesterdayTodayPage() {
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
 
+  async function loadCalendar() {
+    const res = await fetch(CALENDAR_SCHEDULE_URL)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    return res.json()
+  }
+
   useEffect(() => {
-    fetch(`${API}/matchups/calendar`)
-      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+    loadCalendar()
       .then(setData)
       .catch(e => setError(String(e)))
   }, [])
 
-  async function snapshot(date) {
-    await fetch(`${API}/matchups/snapshot/${date}`, { method: 'POST' })
-    const refreshed = await fetch(`${API}/matchups/calendar`).then(r => r.json())
+  async function snapshot() {
+    await fetch(`${API}/matchups/calendar/snapshot`, { method: 'POST' })
+    const refreshed = await loadCalendar()
     setData(refreshed)
   }
 
@@ -33,7 +39,7 @@ export default function YesterdayTodayPage() {
         <div key={k} style={card}>
           <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '10px' }}>
             <strong style={{ textTransform: 'capitalize' }}>{k}: {data[k].date}</strong>
-            <button onClick={() => snapshot(data[k].date)}>Save latest copy</button>
+            <button onClick={snapshot}>Save latest copy</button>
           </div>
           <div style={{ fontSize: '13px', color: '#8b949e', marginBottom: '8px' }}>{data[k].count} games</div>
           {data[k].games.slice(0, 8).map((g) => (

--- a/scripts/phase7_benchmark.py
+++ b/scripts/phase7_benchmark.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _request(method: str, url: str, timeout: int = 60) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    started = time.perf_counter()
+    req = urllib.request.Request(url=url, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as res:
+            body = res.read()
+            elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+            content_type = res.headers.get("content-type") or ""
+            payload: Dict[str, Any]
+            if "application/json" in content_type:
+                payload = json.loads(body.decode("utf-8")) if body else {}
+            else:
+                payload = {"raw_preview": body.decode("utf-8", errors="replace")[:500]}
+            return payload, {
+                "ok": True,
+                "status": res.status,
+                "elapsed_ms": elapsed_ms,
+                "payload_bytes": len(body),
+                "x_response_time_ms": res.headers.get("x-response-time-ms"),
+                "x_payload_bytes": res.headers.get("x-payload-bytes"),
+                "x_cache": res.headers.get("x-cache"),
+                "x_probability_source": res.headers.get("x-probability-source"),
+            }
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+        return {"error_body": body.decode("utf-8", errors="replace")[:1000]}, {
+            "ok": False,
+            "status": exc.code,
+            "elapsed_ms": elapsed_ms,
+            "payload_bytes": len(body),
+            "error": f"HTTP {exc.code}",
+        }
+    except Exception as exc:
+        elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+        return {}, {
+            "ok": False,
+            "status": None,
+            "elapsed_ms": elapsed_ms,
+            "payload_bytes": None,
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+
+
+def _first_game_pk(calendar_payload: Dict[str, Any]) -> Optional[Any]:
+    for key in ("today", "tomorrow", "yesterday"):
+        games = calendar_payload.get(key, {}).get("games") if isinstance(calendar_payload.get(key), dict) else None
+        if isinstance(games, list) and games:
+            return games[0].get("game_pk")
+    return None
+
+
+def _projection_probability_summary(payload: Dict[str, Any]) -> Dict[str, Any]:
+    games = payload.get("games") if isinstance(payload.get("games"), list) else []
+    total = len(games)
+    model_projection = 0
+    fallback = 0
+    missing = 0
+    samples: List[Dict[str, Any]] = []
+    for game in games:
+        if not isinstance(game, dict):
+            continue
+        probability = game.get("model_projection_probability") or game.get("probability") or {}
+        source = probability.get("source") or game.get("probability_source")
+        if source == "model_projections":
+            model_projection += 1
+        elif source:
+            fallback += 1
+        else:
+            missing += 1
+        if len(samples) < 5:
+            samples.append({
+                "game_pk": game.get("game_pk"),
+                "source": source,
+                "source_path": probability.get("source_path") or game.get("probability_source_path"),
+                "home_win_prob": game.get("home_win_prob"),
+                "away_win_prob": game.get("away_win_prob"),
+                "is_fallback": probability.get("is_fallback") or game.get("probability_is_fallback"),
+            })
+    return {
+        "games": total,
+        "model_projection_source_count": model_projection,
+        "fallback_or_other_source_count": fallback,
+        "missing_source_count": missing,
+        "samples": samples,
+    }
+
+
+def _measure_twice(name: str, method: str, url: str, timeout: int) -> Dict[str, Any]:
+    cold_payload, cold = _request(method, url, timeout)
+    warm_payload, warm = _request(method, url, timeout)
+    return {
+        "name": name,
+        "method": method,
+        "url": url,
+        "cold": cold,
+        "warm": warm,
+        "payload_summary": {
+            "cold_keys": sorted(list(cold_payload.keys()))[:20] if isinstance(cold_payload, dict) else [],
+            "warm_keys": sorted(list(warm_payload.keys()))[:20] if isinstance(warm_payload, dict) else [],
+        },
+    }
+
+
+def run(base_url: str, date: Optional[str] = None, timeout: int = 60) -> Dict[str, Any]:
+    target_date = date or datetime.date.today().isoformat()
+    base = base_url.rstrip("/")
+    results: Dict[str, Any] = {
+        "generated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "base_url": base,
+        "date": target_date,
+        "routes": [],
+        "probability_verification": {},
+        "debug": {},
+    }
+
+    calendar_url = f"{base}/matchups/calendar/schedule"
+    calendar_payload, calendar_meta = _request("GET", calendar_url, timeout)
+    calendar_warm_payload, calendar_warm_meta = _request("GET", calendar_url, timeout)
+    results["routes"].append({
+        "name": "lightweight_calendar",
+        "method": "GET",
+        "url": calendar_url,
+        "cold": calendar_meta,
+        "warm": calendar_warm_meta,
+        "heavy_matchup_generation": {
+            key: value.get("heavy_matchup_generation")
+            for key, value in calendar_payload.items()
+            if isinstance(value, dict)
+        } if isinstance(calendar_payload, dict) else {},
+    })
+
+    results["routes"].append(_measure_twice("daily_matchups", "GET", f"{base}/matchups?date={target_date}", timeout))
+
+    game_pk = _first_game_pk(calendar_payload)
+    if game_pk:
+        results["routes"].append(_measure_twice("matchup_detail", "GET", f"{base}/matchup/{game_pk}", timeout))
+    else:
+        results["routes"].append({"name": "matchup_detail", "skipped": True, "reason": "No game_pk found from lightweight calendar"})
+
+    projection_url = f"{base}/models/projections?date={target_date}"
+    projection_cold_payload, projection_cold = _request("GET", projection_url, timeout)
+    projection_warm_payload, projection_warm = _request("GET", projection_url, timeout)
+    results["routes"].append({
+        "name": "model_projections",
+        "method": "GET",
+        "url": projection_url,
+        "cold": projection_cold,
+        "warm": projection_warm,
+    })
+    results["probability_verification"] = _projection_probability_summary(projection_warm_payload)
+
+    for endpoint in ("/debug/performance", "/debug/performance/hotspots"):
+        payload, meta = _request("GET", f"{base}{endpoint}", timeout)
+        results["debug"][endpoint] = {"meta": meta, "payload": payload}
+
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Phase 7 MLBGPT cold/warm route benchmarks and probability-source checks.")
+    parser.add_argument("--base-url", required=True, help="Base URL such as https://mlbgpt.com")
+    parser.add_argument("--date", default=None, help="YYYY-MM-DD. Defaults to today.")
+    parser.add_argument("--timeout", type=int, default=60)
+    parser.add_argument("--output", default=None, help="Optional JSON output path.")
+    args = parser.parse_args()
+
+    report = run(args.base_url, date=args.date, timeout=args.timeout)
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Starts Phase 7 from issue #958 by using the installed Phase 4/5 routes for frontend request sequencing and creating the final benchmark/probability verification path.

This PR does not close the EPIC yet. It moves the sprint into the final acceptance phase and creates the tooling/reporting needed to close #944 after deployment evidence exists.

## Related issues

- Epic: #944
- Phase 7: #958
- Phase 6 optimization: #957
- Shared artifacts: #955
- Calendar/warming routes: #954
- Probability contract: #953
- Instrumentation: #952

## What changed

### Calendar request sequencing

Updates `frontend/src/pages/YesterdayTodayPage.jsx`:

- Initial calendar load now calls `GET /matchups/calendar/schedule`.
- Calendar refresh now calls `POST /matchups/calendar/snapshot`.
- Refresh then reloads the lightweight calendar snapshot.

This stops the calendar/date-selector page from using the heavy `/matchups/calendar` path that can cold-build full matchups for yesterday/today/tomorrow.

### Phase 7 benchmark runner

Adds `scripts/phase7_benchmark.py`.

The script measures cold/warm route behavior and probability-source status using installed routes:

- `GET /matchups/calendar/schedule`
- `GET /matchups?date=<date>`
- `GET /matchup/{game_pk}` using the first game from lightweight calendar
- `GET /models/projections?date=<date>`
- `GET /debug/performance`
- `GET /debug/performance/hotspots`

It records:

- elapsed ms
- payload bytes
- `X-Response-Time-ms`
- `X-Payload-Bytes`
- `X-Cache`
- `X-Probability-Source`
- Model Projection probability-source counts
- debug performance/hotspot payloads

Command:

```bash
python scripts/phase7_benchmark.py \
  --base-url https://mlbgpt.com \
  --date YYYY-MM-DD \
  --output docs/phase7_benchmark_output.json
```

### Finalization report path

Adds `docs/phase7_finalization_report.md` with:

- phase/PR matrix
- installed route matrix
- frontend/API sequencing matrix
- probability-source verification matrix
- benchmark command
- benchmark evidence table
- EPIC completion checklist

## What did not change

- No page sections/cards/formulas/detail panels removed.
- No probability semantics changed.
- No Daily Matchups or Matchup Detail page redesign.
- No new backend routes created.
- No fake benchmark numbers added.
- No claim that the EPIC is complete yet.

## Test / verification commands

Static route/path verification after build/deploy:

```bash
python scripts/phase7_benchmark.py --base-url https://mlbgpt.com --date YYYY-MM-DD
```

Expected calendar result:

- `/matchups/calendar/schedule` returns `heavy_matchup_generation: false` for yesterday/today/tomorrow.
- Calendar frontend no longer calls `/matchups/calendar` for initial load.

## Remaining Phase 7 work after merge/deploy

- Run production/preview benchmark and commit or attach output.
- Verify probability-source matrix across displayed/default surfaces.
- Document any remaining canonical fallback exceptions.
- Close #944 only after evidence supports completion.
