### PR TITLE
Hotfix: remove payload_bytes kwargs from timing_span call sites

### DIFF
--- a/mlb_app/shared_payload_cache.py
+++ b/mlb_app/shared_payload_cache.py
@@ -86,7 +86,7 @@ def get_cache(key: str, ttl_seconds: int) -> Optional[Any]:
             "shared_payload_cache.deepcopy.get",
             category="cache",
             cache_status="HIT",
-            extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+            extra={"cache_key_prefix": str(key).split(":", 1)[0], "payload_bytes": payload_bytes},
         ):
             copied = copy.deepcopy(value)
         record_span(
@@ -104,16 +104,14 @@ def set_cache(key: str, value: Any) -> Any:
     with timing_span(
         "shared_payload_cache.deepcopy.set_store",
         category="cache",
-        payload_bytes=payload_bytes,
-        extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+        extra={"cache_key_prefix": str(key).split(":", 1)[0], "payload_bytes": payload_bytes},
     ):
         stored = copy.deepcopy(value)
     _CACHE[key] = (_now(), stored)
     with timing_span(
         "shared_payload_cache.deepcopy.set_return",
         category="cache",
-        payload_bytes=payload_bytes,
-        extra={"cache_key_prefix": str(key).split(":", 1)[0]},
+        extra={"cache_key_prefix": str(key).split(":", 1)[0], "payload_bytes": payload_bytes},
     ):
         returned = copy.deepcopy(value)
     record_span(


### PR DESCRIPTION
## Summary

Belt-and-suspenders fix for the repeated production error:

```text
timing_span() got an unexpected keyword argument 'payload_bytes'
```

## Why this PR exists

PR #961 updated `timing_span(...)` on `main` to accept and forward `payload_bytes`, and the current `main` file confirms that signature is present. If production is still showing the same error, Railway is likely running a stale/mixed build or importing an older `performance.py` while newer cache code is calling it.

This PR removes `payload_bytes=` from `timing_span(...)` call sites in `shared_payload_cache.py`, so the error cannot occur even if an older `timing_span` implementation is loaded.

## What changed

- Removed `payload_bytes=payload_bytes` kwargs from cache deepcopy `timing_span(...)` calls.
- Preserved payload byte visibility by putting `payload_bytes` into the safe `extra` metadata on those spans.
- Kept `record_span(..., payload_bytes=payload_bytes)` calls unchanged, so payload bytes still appear in the performance snapshot where supported.

## Scope

- No frontend changes.
- No route changes.
- No probability changes.
- No model changes.
- No cache semantics changes.
- This only makes cache timing instrumentation backward-compatible with older `timing_span` signatures.

## Verification

After merge and Railway redeploy, `/matchups?date=<date>` should no longer be able to throw the `timing_span payload_bytes` keyword error from `shared_payload_cache.py`.
