### PR TITLE
Hotfix: fix performance span summary syntax error

### DIFF
--- a/mlb_app/performance.py
+++ b/mlb_app/performance.py
@@ -168,7 +168,7 @@ def _group_counts(rows: Iterable[Dict[str, Any]], field: str, default: str = "NO
 def _span_summary(spans: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
     grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for span in spans:
-        grouped[str(span.get("name") or "unknown")).append(span)
+        grouped[str(span.get("name") or "unknown")].append(span)
 
     summary: Dict[str, Dict[str, Any]] = {}
     for name, rows in grouped.items():


### PR DESCRIPTION
## Summary

Fixes the startup-blocking syntax error in `mlb_app/performance.py`.

## Production failure

The app crashes immediately on import/startup because `_span_summary` contains mismatched parentheses:

```python
grouped[str(span.get("name") or "unknown")).append(span)
```

That uses `)` where `]` is needed to close the dictionary subscript. Because this file is imported during app boot, the process never starts and `/health` fails every Railway healthcheck attempt.

## Fix

Replaces the broken line with:

```python
grouped[str(span.get("name") or "unknown")].append(span)
```

## Scope

- No route changes.
- No frontend changes.
- No model/probability changes.
- No cache semantics changes.
- Startup syntax fix only.

## Deploy note

After merge, Railway needs to rebuild/redeploy the Docker image from the merge commit. I do not have direct Railway deploy controls from this connector, but this PR is the repo-side fix required for the image to start and `/health` to pass again.
