### PR TITLE
Phase 8: shell-first Matchup Detail and persistent browser cache

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -5,7 +5,9 @@ const JSON_CACHE = new Map()
 const IN_FLIGHT_JSON = new Map()
 const STORAGE_PREFIX = 'mlb-json-cache:v2:'
 const CACHE_CHANNEL_NAME = 'mlb-json-cache-updates'
+const RAW_FETCH_TTL_SECONDS = 30 * 60
 let CACHE_CHANNEL = null
+let FETCH_CACHE_INSTALLED = false
 
 function nowMs() {
   return Date.now()
@@ -121,8 +123,71 @@ function publishCacheEvent(type, key) {
   }
 }
 
+function urlString(input) {
+  try {
+    if (typeof input === 'string') return input
+    if (input?.url) return input.url
+    return String(input || '')
+  } catch {
+    return ''
+  }
+}
+
+function isCacheableApiGet(input, init = {}) {
+  const method = String(init?.method || input?.method || 'GET').toUpperCase()
+  if (method !== 'GET') return false
+  if (init?.cache === 'no-store' || init?.cache === 'reload') return false
+  const url = urlString(input)
+  if (!url) return false
+  return url.startsWith(API_BASE) || url.startsWith('/')
+}
+
+function jsonResponseFromCache(value) {
+  return new Response(JSON.stringify(cloneJson(value)), {
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'x-mlbgpt-browser-cache': 'HIT',
+    },
+  })
+}
+
+function installFetchCache() {
+  if (typeof window === 'undefined' || FETCH_CACHE_INSTALLED) return
+  if (typeof window.fetch !== 'function' || typeof window.Response !== 'function') return
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = async (input, init = {}) => {
+    const url = urlString(input)
+    if (!isCacheableApiGet(input, init)) {
+      return originalFetch(input, init)
+    }
+
+    const cached = readCachedJson(url, RAW_FETCH_TTL_SECONDS)
+    if (cached != null) {
+      return jsonResponseFromCache(cached)
+    }
+
+    const response = await originalFetch(input, init)
+    const contentType = response.headers.get('content-type') || ''
+    if (!response.ok || !contentType.includes('application/json')) {
+      return response
+    }
+
+    try {
+      const clone = response.clone()
+      const json = await clone.json()
+      writeCachedJson(url, json)
+    } catch {
+    }
+    return response
+  }
+  FETCH_CACHE_INSTALLED = true
+}
+
 if (typeof window !== 'undefined') {
   cacheChannel()
+  installFetchCache()
   window.addEventListener?.('storage', event => {
     if (!event.key || !event.key.startsWith(STORAGE_PREFIX)) return
     const key = event.key.slice(STORAGE_PREFIX.length)

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -3,7 +3,9 @@ const PROD_API_BASE = 'https://mlb-prediction-app-production-732c.up.railway.app
 export const API_BASE = import.meta.env.VITE_API_BASE_URL || PROD_API_BASE
 const JSON_CACHE = new Map()
 const IN_FLIGHT_JSON = new Map()
-const STORAGE_PREFIX = 'mlb-json-cache:v1:'
+const STORAGE_PREFIX = 'mlb-json-cache:v2:'
+const CACHE_CHANNEL_NAME = 'mlb-json-cache-updates'
+let CACHE_CHANNEL = null
 
 function nowMs() {
   return Date.now()
@@ -22,37 +24,121 @@ function storageKey(key) {
   return `${STORAGE_PREFIX}${String(key || '')}`
 }
 
-function readStorageRecord(key) {
-  if (typeof window === 'undefined' || !window.sessionStorage) return null
+function durableStorage() {
+  if (typeof window === 'undefined') return null
   try {
-    const raw = window.sessionStorage.getItem(storageKey(key))
-    if (!raw) return null
-    const parsed = JSON.parse(raw)
-    if (!parsed || typeof parsed !== 'object') return null
-    if (typeof parsed.createdAt !== 'number') return null
-    return parsed
+    return window.localStorage || null
   } catch {
     return null
   }
 }
 
-function writeStorageRecord(key, value) {
-  if (typeof window === 'undefined' || !window.sessionStorage) return
+function sessionFallbackStorage() {
+  if (typeof window === 'undefined') return null
   try {
-    window.sessionStorage.setItem(storageKey(key), JSON.stringify({
-      createdAt: nowMs(),
-      value: cloneJson(value),
-    }))
+    return window.sessionStorage || null
   } catch {
+    return null
+  }
+}
+
+function readStorageRecord(key) {
+  const stores = [durableStorage(), sessionFallbackStorage()].filter(Boolean)
+  for (const store of stores) {
+    try {
+      const raw = store.getItem(storageKey(key))
+      if (!raw) continue
+      const parsed = JSON.parse(raw)
+      if (!parsed || typeof parsed !== 'object') continue
+      if (typeof parsed.createdAt !== 'number') continue
+      return parsed
+    } catch {
+    }
+  }
+  return null
+}
+
+function writeStorageRecord(key, value) {
+  const record = JSON.stringify({
+    createdAt: nowMs(),
+    value: cloneJson(value),
+  })
+  const stores = [durableStorage(), sessionFallbackStorage()].filter(Boolean)
+  for (const store of stores) {
+    try {
+      store.setItem(storageKey(key), record)
+      return
+    } catch {
+    }
   }
 }
 
 function deleteStorageRecord(key) {
-  if (typeof window === 'undefined' || !window.sessionStorage) return
+  const stores = [durableStorage(), sessionFallbackStorage()].filter(Boolean)
+  for (const store of stores) {
+    try {
+      store.removeItem(storageKey(key))
+    } catch {
+    }
+  }
+}
+
+function cacheChannel() {
+  if (typeof window === 'undefined' || typeof window.BroadcastChannel === 'undefined') return null
+  if (CACHE_CHANNEL) return CACHE_CHANNEL
   try {
-    window.sessionStorage.removeItem(storageKey(key))
+    CACHE_CHANNEL = new window.BroadcastChannel(CACHE_CHANNEL_NAME)
+    CACHE_CHANNEL.onmessage = event => {
+      const msg = event?.data || {}
+      if (!msg.key) return
+      if (msg.type === 'delete') {
+        JSON_CACHE.delete(String(msg.key))
+        IN_FLIGHT_JSON.delete(String(msg.key))
+        return
+      }
+      if (msg.type === 'write') {
+        const record = readStorageRecord(String(msg.key))
+        if (record) {
+          JSON_CACHE.set(String(msg.key), {
+            createdAt: record.createdAt,
+            value: cloneJson(record.value),
+          })
+        }
+      }
+    }
+    return CACHE_CHANNEL
+  } catch {
+    return null
+  }
+}
+
+function publishCacheEvent(type, key) {
+  const channel = cacheChannel()
+  if (!channel) return
+  try {
+    channel.postMessage({ type, key: String(key || '') })
   } catch {
   }
+}
+
+if (typeof window !== 'undefined') {
+  cacheChannel()
+  window.addEventListener?.('storage', event => {
+    if (!event.key || !event.key.startsWith(STORAGE_PREFIX)) return
+    const key = event.key.slice(STORAGE_PREFIX.length)
+    if (!event.newValue) {
+      JSON_CACHE.delete(key)
+      IN_FLIGHT_JSON.delete(key)
+      return
+    }
+    const record = readStorageRecord(key)
+    if (record) {
+      JSON_CACHE.set(key, {
+        createdAt: record.createdAt,
+        value: cloneJson(record.value),
+      })
+    }
+  })
 }
 
 export function readCachedJson(url, ttlSeconds = 60) {
@@ -89,6 +175,7 @@ export function writeCachedJson(url, value) {
   }
   JSON_CACHE.set(key, record)
   writeStorageRecord(key, record.value)
+  publishCacheEvent('write', key)
   return cloneJson(value)
 }
 
@@ -97,6 +184,7 @@ export function clearCachedJson(url) {
   JSON_CACHE.delete(key)
   IN_FLIGHT_JSON.delete(key)
   deleteStorageRecord(key)
+  publishCacheEvent('delete', key)
 }
 
 async function fetchJsonUncached(url, signal) {

--- a/scripts/warm_game_day.py
+++ b/scripts/warm_game_day.py
@@ -37,25 +37,32 @@ def warm(base_url: str, timeout: int = 60) -> Dict[str, Any]:
     base = base_url.rstrip("/")
     actions: List[Dict[str, Any]] = []
 
-    # Calendar should be lightweight and must not force heavy matchup generation.
+    # 1. Warm the lightweight schedule/calendar layer first.
+    # This should be the fastest user-visible path and must not force full matchup generation.
     actions.append({
-        "name": "calendar_window",
+        "name": "calendar_schedule_snapshot",
+        "method": "POST",
+        "url": f"{base}/matchups/calendar/snapshot",
+    })
+    actions.append({
+        "name": "calendar_schedule_read",
         "method": "GET",
-        "url": f"{base}/matchups/calendar",
+        "url": f"{base}/matchups/calendar/schedule",
     })
 
-    # Explicitly warm heavyweight matchups and projections outside the user path.
+    # 2. Explicitly warm heavyweight matchups and projections outside the user path.
+    # User-facing pages should reuse these artifacts instead of cold-building on click.
     for label in ("today", "tomorrow", "yesterday"):
         date_value = dates[label]
-        actions.append({
-            "name": f"matchups_snapshot_{label}",
-            "method": "POST",
-            "url": f"{base}/matchups/snapshot/{date_value}",
-        })
         actions.append({
             "name": f"model_projection_snapshot_{label}",
             "method": "POST",
             "url": f"{base}/models/projections/snapshot/{date_value}",
+        })
+        actions.append({
+            "name": f"matchups_snapshot_{label}",
+            "method": "POST",
+            "url": f"{base}/matchups/snapshot/{date_value}",
         })
 
     results = []


### PR DESCRIPTION
## Summary

Implements the requested Matchup Detail behavior: **Batter vs Arsenal is the default view**, but the page no longer blocks first paint on the heavy detail payload.

This PR also keeps the persistent browser cache and warm-script hierarchy changes already started in Phase 8.

## What changed

### Matchup Detail is now shell-first

Added `frontend/src/pages/MatchupDetailShellFirstPage.jsx` and routed `/matchup/:game_pk` to it from `frontend/src/App.jsx`.

The new page flow is:

1. Load a light game shell from `/matchups/calendar/schedule`.
2. Render header/teams/pitchers/status immediately.
3. Fetch `/models/projections?date=...` for cached Model Projection probability metadata.
4. Default to the **Batter vs Arsenal** tab.
5. Fetch `/matchup/{game_pk}/competitive` independently and show skeleton rows while it hydrates.
6. Fetch `/matchup/{game_pk}` in the background for overview/detail enrichment.

The old `frontend/src/pages/MatchupDetailPage.jsx` remains untouched in the repo as rollback/reference.

### Persistent cross-tab browser cache

Updated `frontend/src/lib/api.js`:

- Durable JSON cache now uses `localStorage` with `sessionStorage` fallback.
- Adds `BroadcastChannel` and `storage` event sync across tabs.
- Keeps in-memory cache and in-flight request dedupe.
- Adds conservative raw API GET fetch caching so pages that bypass `fetchJson` still benefit.
- Cached synthetic responses include `x-mlbgpt-browser-cache: HIT`.

### Warm script hierarchy order

Updated `scripts/warm_game_day.py`:

- `POST /matchups/calendar/snapshot`
- `GET /matchups/calendar/schedule`
- `POST /models/projections/snapshot/{date}`
- `POST /matchups/snapshot/{date}`

for yesterday/today/tomorrow.

## Why this is better

Before, Matchup Detail waited for both heavy calls before showing the page:

```js
Promise.all([
  fetch(`/matchup/${game_pk}`),
  fetch(`/matchup/${game_pk}/competitive`),
])
```

Now the page paints the shell first and hydrates the heavy baseball intelligence independently. Batter vs Arsenal remains the primary/default workflow.

## What this does not do yet

- Does not add backend `/matchup/{game_pk}/shell` yet.
- Does not add lineup-triggered projection reruns yet.
- Does not add Railway 7 AM cron config by itself.
- Does not remove the old detail page file.
- Does not run production benchmarks from the connector.

## Manual verification after deploy

1. Open `/matchup/{game_pk}`.
2. Page should render a header/shell quickly.
3. Batter vs Arsenal tab should be selected by default.
4. Skeleton rows should show while `/competitive` hydrates.
5. Reopening the same matchup in another tab should use browser cache within TTL.
6. Overview tab should not block the initial Batter vs Arsenal experience.
