### PR TITLE
Hotfix: restore chart-rich Matchup Detail route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Routes, Route, NavLink, useParams } from 'react-router-d
 import './styles/bet105-mobile.css'
 import HomePage from './pages/HomePage'
 import LandingV2Page from './pages/LandingV2Page'
-import MatchupDetailPage from './pages/MatchupDetailShellFirstPage'
+import MatchupDetailPage from './pages/MatchupDetailPage'
 import PitcherPage from './pages/PitcherPage'
 import RollingPitcherPage from './pages/RollingPitcherPage'
 import TeamPage from './pages/TeamPage'


### PR DESCRIPTION
## Summary

Restores `/matchup/:game_pk` to the original chart-rich `MatchupDetailPage.jsx` after the shell-first replacement removed the graphs/charts from the live route.

## What changed

- Updates `frontend/src/App.jsx` to import:

```js
import MatchupDetailPage from './pages/MatchupDetailPage'
```

instead of the simplified shell-first page.

## Why

The shell-first page improved perceived speed but removed the rich charts/cards that are core to the Matchup Detail experience. This hotfix restores those charts immediately.

## Notes

- The persistent browser cache and warm-script hierarchy changes from #964 remain in place.
- The shell-first experimental file remains in the repo for reference, but it is no longer used by the live `/matchup/:game_pk` route.
- Next performance work should preserve the existing chart-rich UI and progressively hydrate sections inside it, not replace the UI.

## Verification

After deploy:

1. Open `/matchup/{game_pk}`.
2. Confirm the original chart/card-heavy Matchup Detail page is back.
3. Confirm Batter vs Arsenal charts/cards render as before.
