### PR TITLE
Hotfix: bypass browser cache for My Dashboard auth routes

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -133,12 +133,22 @@ function urlString(input) {
   }
 }
 
+function isDashboardSessionRoute(url) {
+  try {
+    const parsed = new URL(url, API_BASE)
+    return parsed.pathname.startsWith('/my-dashboard')
+  } catch {
+    return String(url || '').startsWith('/my-dashboard')
+  }
+}
+
 function isCacheableApiGet(input, init = {}) {
   const method = String(init?.method || input?.method || 'GET').toUpperCase()
   if (method !== 'GET') return false
   if (init?.cache === 'no-store' || init?.cache === 'reload') return false
   const url = urlString(input)
   if (!url) return false
+  if (isDashboardSessionRoute(url)) return false
   return url.startsWith(API_BASE) || url.startsWith('/')
 }
 


### PR DESCRIPTION
## Summary

Prevents the global raw GET browser cache from caching My Dashboard authenticated/session-specific responses.

## Problem

The My Dashboard page can show:

```text
Dashboard session was not established. Try signing in again.
```

Likely cause: the browser cache wrapper in `frontend/src/lib/api.js` can cache `GET /my-dashboard/profile` when it returns:

```json
{"authenticated": false}
```

Then after POST `/my-dashboard/profile` creates a session, the immediate follow-up GET `/my-dashboard/profile` can be served from that stale browser cache instead of the backend, causing the frontend to think the session was not established.

## Fix

Updated `frontend/src/lib/api.js`:

- Adds `isDashboardSessionRoute(url)`.
- Makes `isCacheableApiGet(...)` return `false` for any `/my-dashboard/*` route.
- Leaves global browser cache behavior intact for non-dashboard public JSON routes.

## Scope

- No backend changes.
- No route changes.
- No merge performed without owner approval.
- This PR is opened for review only.

## Manual verification after merge/deploy if approved

1. Clear browser site data for `mlbgpt.com`, or remove `mlb-json-cache:v2:*` entries.
2. Open `/my-dashboard`.
3. Create/sign into dashboard profile.
4. Confirm POST `/my-dashboard/profile` returns a `session_token`.
5. Confirm the following GET `/my-dashboard/profile` hits network, not browser cache.
6. Confirm dashboard loads instead of showing `Dashboard session was not established. Try signing in again.`
