### PR TITLE
Start dashboard lineup hydration redesign work

### DIFF
--- a/mlb_app/active_lineup_solver.py
+++ b/mlb_app/active_lineup_solver.py
@@ -90,6 +90,7 @@ def _build_confirmed_lineup_index_uncached(session: Session, target_date: str) -
                 "enabled": True,
                 "source": "matchups_boxscore_lineups",
                 "lineup_status": "unavailable",
+                "confirmed_lineup_date": target_date,
                 "confirmed_batter_count": 0,
                 "games_checked": 0,
                 "games_with_lineups": 0,
@@ -144,6 +145,7 @@ def _build_confirmed_lineup_index_uncached(session: Session, target_date: str) -
             "enabled": True,
             "source": "matchups_boxscore_lineups",
             "lineup_status": lineup_status,
+            "confirmed_lineup_date": target_date,
             "confirmed_batter_count": len(confirmed_ids) or len(confirmed_names),
             "games_checked": games_checked,
             "games_with_lineups": games_with_lineups,
@@ -183,8 +185,13 @@ def _item_confirmed_in_lineup(item: Dict[str, Any], confirmed_ids: Set[str], con
 
 
 def _rerank_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Re-rank every available item after lineup filtering.
+
+    The dashboard UI can paginate or collapse rows, but the backend should not
+    arbitrarily truncate the player universe to ten names.
+    """
     reranked = []
-    for idx, item in enumerate(items[:10], start=1):
+    for idx, item in enumerate(items, start=1):
         updated = dict(item)
         updated["rank"] = idx
         reranked.append(updated)
@@ -222,6 +229,7 @@ def _apply_active_lineup_filter(response: Dict[str, Any], lineup_index: Dict[str
             verified = dict(item)
             verified["lineup_verified"] = True
             verified["lineup_source"] = metadata.get("source")
+            verified["confirmed_lineup_date"] = metadata.get("confirmed_lineup_date")
             kept.append(verified)
         else:
             removed += 1

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -29,11 +29,22 @@ class MyDashboardBatchSolverRequest(BaseModel):
     active_lineups: bool = False
 
 
+class MyDashboardHydrateRequest(BaseModel):
+    date: Optional[str] = None
+    components: Optional[List[str]] = None
+    active_lineups: bool = True
+    force: bool = False
+
+
 def session_factory():
     database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
     engine = get_engine(database_url)
     create_tables(engine)
     return get_session(engine)
+
+
+def _yesterday_iso() -> str:
+    return (dt.date.today() - dt.timedelta(days=1)).isoformat()
 
 
 @router.get("/my-dashboard/health")
@@ -44,6 +55,10 @@ def my_dashboard_health() -> Dict[str, Any]:
         "auth_required": False,
         "persistence": "frontend_localStorage_v1",
         "supported_components": sorted(SUPPORTED_COMPONENTS),
+        "hydration": {
+            "cron_target": "/my-dashboard/solver/hydrate-yesterday",
+            "default_lineup_source": "yesterday_confirmed_1_9",
+        },
     }
 
 
@@ -75,6 +90,32 @@ def my_dashboard_active_lineup_solver_post(payload: MyDashboardSolverRequest) ->
     return _run_active_lineup_solver(date=payload.date, component=payload.component, filters=payload.filters)
 
 
+@router.post("/my-dashboard/solver/hydrate-yesterday")
+def my_dashboard_hydrate_yesterday_post(payload: Optional[MyDashboardHydrateRequest] = None) -> Dict[str, Any]:
+    request = payload or MyDashboardHydrateRequest()
+    target_date = request.date or _yesterday_iso()
+    return _run_hydration(
+        date=target_date,
+        components=request.components,
+        active_lineups=request.active_lineups,
+        force=request.force,
+    )
+
+
+@router.get("/my-dashboard/solver/hydrate-yesterday")
+def my_dashboard_hydrate_yesterday_get(
+    date: Optional[str] = Query(default=None),
+    active_lineups: bool = Query(default=True),
+    force: bool = Query(default=False),
+) -> Dict[str, Any]:
+    return _run_hydration(
+        date=date or _yesterday_iso(),
+        components=None,
+        active_lineups=active_lineups,
+        force=force,
+    )
+
+
 def _normalize_request(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     target_date = (date or dt.date.today().isoformat())[:10]
     try:
@@ -86,6 +127,15 @@ def _normalize_request(date: Optional[str], component: str, filters: Optional[Di
         "component": (component or "").strip().lower(),
         "filters": normalize_filter_payload(filters),
     }
+
+
+def _normalize_component_list(components: Optional[List[str]]) -> List[str]:
+    requested_components = [str(c or "").strip().lower() for c in (components or sorted(SUPPORTED_COMPONENTS))]
+    requested_components = [c for c in requested_components if c]
+    invalid = [c for c in requested_components if c not in SUPPORTED_COMPONENTS]
+    if invalid:
+        raise HTTPException(status_code=400, detail={"message": "Unsupported dashboard component(s)", "components": invalid, "supported_components": sorted(SUPPORTED_COMPONENTS)})
+    return requested_components
 
 
 def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -155,11 +205,7 @@ def _run_batch_solver(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
 
-    requested_components = [str(c or "").strip().lower() for c in (components or sorted(SUPPORTED_COMPONENTS))]
-    requested_components = [c for c in requested_components if c]
-    invalid = [c for c in requested_components if c not in SUPPORTED_COMPONENTS]
-    if invalid:
-        raise HTTPException(status_code=400, detail={"message": "Unsupported dashboard component(s)", "components": invalid, "supported_components": sorted(SUPPORTED_COMPONENTS)})
+    requested_components = _normalize_component_list(components)
 
     normalized_filters_by_component = {
         component: normalize_filter_payload((filters_by_component or {}).get(component))
@@ -176,34 +222,100 @@ def _run_batch_solver(
 
     try:
         def build() -> Dict[str, Any]:
-            results: Dict[str, Any] = {}
-            factory = session_factory()
-            with factory() as session:
-                for component in requested_components:
-                    filters = normalized_filters_by_component.get(component) or {}
-                    if active_lineups:
-                        results[component] = build_active_lineup_solver_payload(
-                            session=session,
-                            date=target_date,
-                            component=component,
-                            filters=filters,
-                        )
-                    else:
-                        results[component] = build_dashboard_solver_payload(
-                            session=session,
-                            date=target_date,
-                            component=component,
-                            filters=filters,
-                        )
-            return {
-                "date": target_date,
-                "components": requested_components,
-                "active_lineups": active_lineups,
-                "results": results,
-            }
+            return _build_batch_payload(
+                target_date=target_date,
+                requested_components=requested_components,
+                normalized_filters_by_component=normalized_filters_by_component,
+                active_lineups=active_lineups,
+                hydration_mode=False,
+            )
 
         return get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
     except HTTPException:
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "My Dashboard batch solver failed", "error": str(exc)}) from exc
+
+
+def _run_hydration(
+    date: str,
+    components: Optional[List[str]],
+    active_lineups: bool = True,
+    force: bool = False,
+) -> Dict[str, Any]:
+    install_dashboard_context_cache()
+    target_date = (date or _yesterday_iso())[:10]
+    try:
+        dt.date.fromisoformat(target_date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
+
+    requested_components = _normalize_component_list(components)
+    normalized_filters_by_component = {component: {} for component in requested_components}
+    cache_key = make_cache_key(
+        "dashboard_solver",
+        "morning_hydration_active_lineups" if active_lineups else "morning_hydration",
+        target_date,
+        ",".join(requested_components),
+    )
+
+    def build() -> Dict[str, Any]:
+        hydrated = _build_batch_payload(
+            target_date=target_date,
+            requested_components=requested_components,
+            normalized_filters_by_component=normalized_filters_by_component,
+            active_lineups=active_lineups,
+            hydration_mode=True,
+        )
+        hydrated.update({
+            "hydration_status": "hydrated",
+            "hydration_target": "yesterday_confirmed_1_9" if active_lineups else "standard_dashboard_solver",
+            "hydrated_at": dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "force_requested": force,
+        })
+        return hydrated
+
+    try:
+        if force:
+            return build()
+        return get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "My Dashboard hydration failed", "error": str(exc)}) from exc
+
+
+def _build_batch_payload(
+    target_date: str,
+    requested_components: List[str],
+    normalized_filters_by_component: Dict[str, Dict[str, Any]],
+    active_lineups: bool,
+    hydration_mode: bool,
+) -> Dict[str, Any]:
+    results: Dict[str, Any] = {}
+    factory = session_factory()
+    with factory() as session:
+        for component in requested_components:
+            filters = normalized_filters_by_component.get(component) or {}
+            if active_lineups:
+                results[component] = build_active_lineup_solver_payload(
+                    session=session,
+                    date=target_date,
+                    component=component,
+                    filters=filters,
+                )
+            else:
+                results[component] = build_dashboard_solver_payload(
+                    session=session,
+                    date=target_date,
+                    component=component,
+                    filters=filters,
+                )
+    return {
+        "date": target_date,
+        "components": requested_components,
+        "active_lineups": active_lineups,
+        "hydration_mode": hydration_mode,
+        "lineup_source_policy": "confirmed_1_9_lineups" if active_lineups else "not_lineup_filtered",
+        "results": results,
+    }

--- a/tests/test_active_lineup_dashboard.py
+++ b/tests/test_active_lineup_dashboard.py
@@ -1,0 +1,46 @@
+from mlb_app.active_lineup_solver import _apply_active_lineup_filter, _rerank_items
+
+
+def test_rerank_items_keeps_every_available_player():
+    items = [{"entity_id": str(idx), "entity_name": f"Player {idx}"} for idx in range(1, 16)]
+
+    reranked = _rerank_items(items)
+
+    assert len(reranked) == 15
+    assert [row["rank"] for row in reranked] == list(range(1, 16))
+    assert reranked[-1]["entity_name"] == "Player 15"
+
+
+def test_active_lineup_filter_preserves_all_confirmed_hitters_and_metadata():
+    response = {
+        "date": "2026-07-08",
+        "component": "hitters",
+        "items": [
+            {"entity_id": str(idx), "entity_name": f"Confirmed {idx}", "entity_type": "hitter", "team": "CHC"}
+            for idx in range(1, 13)
+        ] + [
+            {"entity_id": "99", "entity_name": "Bench Bat", "entity_type": "hitter", "team": "CHC"}
+        ],
+    }
+    lineup_index = {
+        "confirmed_ids": {str(idx) for idx in range(1, 13)},
+        "confirmed_names": set(),
+        "metadata": {
+            "enabled": True,
+            "source": "matchups_boxscore_lineups",
+            "lineup_status": "confirmed",
+            "confirmed_lineup_date": "2026-07-08",
+            "warnings": [],
+        },
+    }
+
+    filtered = _apply_active_lineup_filter(response, lineup_index, "hitters")
+
+    assert len(filtered["items"]) == 12
+    assert filtered["result_count_after_lineup_filter"] == 12
+    assert filtered["lineup_filter"]["removed_unconfirmed_count"] == 1
+    assert filtered["lineup_filter"]["confirmed_lineup_date"] == "2026-07-08"
+    assert filtered["items"][-1]["rank"] == 12
+    assert all(row["lineup_verified"] for row in filtered["items"])
+    assert all(row["lineup_source"] == "matchups_boxscore_lineups" for row in filtered["items"])
+    assert all(row["confirmed_lineup_date"] == "2026-07-08" for row in filtered["items"])


### PR DESCRIPTION
## Summary
Starts #974 with the backend/data-pipeline slice needed before the My Dashboard UI redesign can safely expose larger lineup-derived leaderboards.

## Changes
- Removes the post-active-lineup filter cap that limited reranked hitter rows to 10.
- Adds confirmed lineup metadata to verified rows, including `confirmed_lineup_date`, `lineup_source`, and existing lineup filter status fields.
- Adds `/my-dashboard/solver/hydrate-yesterday` as a cron-callable GET/POST endpoint for morning dashboard hydration from yesterday's confirmed 1–9 lineups.
- Adds hydration metadata: `hydration_status`, `hydration_target`, `hydrated_at`, `lineup_source_policy`, and `hydration_mode`.
- Refactors batch building so normal batch runs and hydration runs share one code path.
- Adds regression tests proving active-lineup reranking keeps every available confirmed hitter, not only 10.

## Why this first
The requested Salesforce-style UI needs to render larger leaderboard tables. Before changing the UI, the backend needs to stop arbitrarily truncating lineup-filtered hitter lists and expose source/date labels so the page can distinguish confirmed, partial, unavailable, and hydrated data.

## Still to do in follow-up commits/PR
- Redesign `MyDashboardWorkspacePage.jsx` into the Salesforce-style tabbed/card/table layout.
- Default the saved shelf to collapsed/inverted on first load.
- Add metric-specific hitter components for xwOBA, batter vs arsenal, hard-hit, exit velocity, and launch angle.
- Wire the UI to hydration status/source labels.
- Add mobile responsive tests or snapshots where the frontend test stack allows it.

## Tests
- Added `tests/test_active_lineup_dashboard.py`.
- Not run in this connector session.