### PR TITLE
Fix batter page data contract and rolling data dedupe

### DIFF
--- a/mlb_app/batter_data_contract.py
+++ b/mlb_app/batter_data_contract.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .database import StatcastEvent
+from .db_utils import (
+    TERMINAL_EVENTS,
+    _calculate_batter_stats,
+    _dedupe_terminal_pas,
+    _is_true_ab_event,
+    _ordered_batter_terminal_query,
+    get_batter_data_quality,
+)
+
+STATCAST_ROLLING_SOURCE = "postgres_statcast_events_deduped_terminal_pa"
+MLB_SEASON_SOURCE = "mlb_stats_api_people_stats_season"
+MLB_SPLITS_SOURCE = "mlb_stats_api_people_stats_stat_splits"
+MLB_YEAR_BY_YEAR_SOURCE = "mlb_stats_api_people_stats_year_by_year"
+LOCAL_SPLITS_SOURCE = "postgres_player_splits"
+
+
+def parse_window_list(raw: Optional[str], defaults: Iterable[int], *, minimum: int = 1, maximum: int = 5000) -> List[int]:
+    """Parse, bound, and de-duplicate requested rolling windows in request order."""
+    values: List[int] = []
+    for token in str(raw or "").split(","):
+        token = token.strip()
+        if not token.isdigit():
+            continue
+        value = int(token)
+        if minimum <= value <= maximum and value not in values:
+            values.append(value)
+    if values:
+        return values
+    out: List[int] = []
+    for value in defaults:
+        if minimum <= int(value) <= maximum and int(value) not in out:
+            out.append(int(value))
+    return out
+
+
+def _quality_with_source(session: Session, batter_id: int, removed: int = 0) -> Dict[str, Any]:
+    quality = dict(get_batter_data_quality(session, batter_id) or {})
+    quality["source"] = STATCAST_ROLLING_SOURCE
+    quality["dedupe_policy"] = "terminal PA identity: game_pk + at_bat_number + pitcher_id + batter_id"
+    quality["duplicate_terminal_pa_rows_removed_in_window"] = removed
+    warnings = list(quality.get("warnings") or [])
+    if removed:
+        warnings.append(f"Removed {removed} duplicate terminal PA row(s) before calculating this rolling window.")
+    quality["warnings"] = warnings
+    return quality
+
+
+def _clean_terminal_events(session: Session, batter_id: int, requested: int, *, multiplier: int = 4) -> Tuple[List[StatcastEvent], int]:
+    raw_limit = max(requested * multiplier, requested + 50)
+    raw_events = _ordered_batter_terminal_query(session, batter_id).limit(raw_limit).all()
+    deduped = _dedupe_terminal_pas(raw_events)
+    removed = max(len(raw_events) - len(deduped), 0)
+    return deduped, removed
+
+
+def clean_rolling_by_pa(session: Session, batter_id: int, n_pa: int) -> Optional[Dict[str, Any]]:
+    events, removed = _clean_terminal_events(session, batter_id, n_pa)
+    window_events = events[:n_pa]
+    if not window_events:
+        return None
+    stats = _calculate_batter_stats(window_events, raw_event_count=len(window_events) + removed)
+    stats.update({
+        "actual_pa": len(window_events),
+        "requested_pa": n_pa,
+        "window_type": "PA",
+        "label": f"Last {n_pa} PA",
+        "source": STATCAST_ROLLING_SOURCE,
+        "deduped": True,
+        "duplicate_rows_removed": removed,
+        "data_quality": _quality_with_source(session, batter_id, removed),
+    })
+    return stats
+
+
+def clean_rolling_by_ab(session: Session, batter_id: int, n_ab: int) -> Optional[Dict[str, Any]]:
+    events, removed = _clean_terminal_events(session, batter_id, n_ab, multiplier=7)
+    ab_events = [event for event in events if _is_true_ab_event(event.events)][:n_ab]
+    if not ab_events:
+        return None
+    stats = _calculate_batter_stats(ab_events, raw_event_count=len(events) + removed)
+    stats.update({
+        "actual_ab": len(ab_events),
+        "requested_ab": n_ab,
+        "window_type": "AB",
+        "label": f"Last {n_ab} AB",
+        "source": STATCAST_ROLLING_SOURCE,
+        "deduped": True,
+        "duplicate_rows_removed": removed,
+        "data_quality": _quality_with_source(session, batter_id, removed),
+    })
+    return stats
+
+
+def clean_rolling_by_games(session: Session, batter_id: int, n_games: int) -> Optional[Dict[str, Any]]:
+    game_rows = (
+        session.query(StatcastEvent.game_pk, func.max(StatcastEvent.game_date).label("game_date"))
+        .filter(
+            StatcastEvent.batter_id == batter_id,
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.events.in_(TERMINAL_EVENTS),
+        )
+        .group_by(StatcastEvent.game_pk)
+        .order_by(func.max(StatcastEvent.game_date).desc(), StatcastEvent.game_pk.desc())
+        .limit(n_games)
+        .all()
+    )
+    if not game_rows:
+        return None
+    game_pks = [row.game_pk for row in game_rows]
+    raw_events = (
+        session.query(StatcastEvent)
+        .filter(
+            StatcastEvent.batter_id == batter_id,
+            StatcastEvent.game_pk.in_(game_pks),
+            StatcastEvent.events.in_(TERMINAL_EVENTS),
+        )
+        .all()
+    )
+    events = _dedupe_terminal_pas(raw_events)
+    removed = max(len(raw_events) - len(events), 0)
+    if not events:
+        return None
+    stats = _calculate_batter_stats(events, raw_event_count=len(raw_events))
+    stats.update({
+        "actual_games": len(game_pks),
+        "requested_games": n_games,
+        "window_type": "games",
+        "source": STATCAST_ROLLING_SOURCE,
+        "deduped": True,
+        "duplicate_rows_removed": removed,
+        "data_quality": _quality_with_source(session, batter_id, removed),
+    })
+    return stats
+
+
+def clean_rolling_splits(session: Session, batter_id: int, n_pa: int = 100) -> Dict[str, Any]:
+    events, removed = _clean_terminal_events(session, batter_id, n_pa)
+    window_events = events[:n_pa]
+    grouped = {"vsL": [], "vsR": [], "unknown": []}
+    for event in window_events:
+        key = "vsL" if event.p_throws == "L" else "vsR" if event.p_throws == "R" else "unknown"
+        grouped[key].append(event)
+    return {
+        "window_type": "PA",
+        "requested_pa": n_pa,
+        "actual_pa": len(window_events),
+        "source": STATCAST_ROLLING_SOURCE,
+        "deduped": True,
+        "duplicate_rows_removed": removed,
+        "splits": {key: ({**_calculate_batter_stats(value), "actual_pa": len(value), "source": STATCAST_ROLLING_SOURCE} if value else None) for key, value in grouped.items()},
+        "data_quality": _quality_with_source(session, batter_id, removed),
+    }
+
+
+def clean_rolling_pitch_types(session: Session, batter_id: int, n_pa: int = 100) -> Dict[str, Any]:
+    events, removed = _clean_terminal_events(session, batter_id, n_pa)
+    window_events = events[:n_pa]
+    grouped: Dict[str, List[StatcastEvent]] = {}
+    for event in window_events:
+        key = event.pitch_type or "unknown"
+        grouped.setdefault(key, []).append(event)
+    return {
+        "window_type": "PA",
+        "requested_pa": n_pa,
+        "actual_pa": len(window_events),
+        "source": STATCAST_ROLLING_SOURCE,
+        "deduped": True,
+        "duplicate_rows_removed": removed,
+        "pitch_types": {key: {**_calculate_batter_stats(value), "actual_pa": len(value), "source": STATCAST_ROLLING_SOURCE} for key, value in sorted(grouped.items(), key=lambda item: len(item[1]), reverse=True)},
+        "data_quality": _quality_with_source(session, batter_id, removed),
+    }
+
+
+def dedupe_rows(rows: Iterable[Dict[str, Any]], keys: Iterable[str]) -> List[Dict[str, Any]]:
+    seen = set()
+    out: List[Dict[str, Any]] = []
+    for row in rows or []:
+        key = tuple(row.get(k) for k in keys)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(row)
+    return out

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -7,6 +7,20 @@ from typing import Any, Dict, Optional, Tuple
 import requests as _req
 from fastapi import APIRouter, Query
 
+from .batter_data_contract import (
+    LOCAL_SPLITS_SOURCE,
+    MLB_SEASON_SOURCE,
+    MLB_SPLITS_SOURCE,
+    MLB_YEAR_BY_YEAR_SOURCE,
+    STATCAST_ROLLING_SOURCE,
+    clean_rolling_by_ab,
+    clean_rolling_by_games,
+    clean_rolling_by_pa,
+    clean_rolling_pitch_types,
+    clean_rolling_splits,
+    dedupe_rows,
+    parse_window_list,
+)
 from .database import get_engine, create_tables, get_session
 from .db_utils import (
     get_batter_aggregate_with_fallback,
@@ -14,12 +28,6 @@ from .db_utils import (
     get_batter_data_quality,
     get_batter_leaderboards,
     get_batter_multi_season,
-    get_batter_rolling_by_ab,
-    get_batter_rolling_by_abs,
-    get_batter_rolling_by_games,
-    get_batter_rolling_by_pa,
-    get_batter_rolling_pitch_types,
-    get_batter_rolling_splits,
     get_player_splits_multi_season,
 )
 from .pitcher_intelligence import build_pitcher_intelligence_profile
@@ -28,10 +36,7 @@ from .pitcher_leaderboards import build_pitcher_leaderboards
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 router = APIRouter()
 
-# In-process TTL cache for the leaderboard response.
-# The SQL aggregation queries are bounded and safe, but still touch the full
-# season's terminal-event rows. Caching prevents redundant work across requests.
-_LEADERBOARD_TTL_SECONDS = 3600  # 1 hour
+_LEADERBOARD_TTL_SECONDS = 3600
 _leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
 _pitcher_leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
 _identity_cache: Dict[int, Tuple[float, Dict[str, Any]]] = {}
@@ -59,23 +64,9 @@ def _fetch_player_identity(player_id: int) -> Dict[str, Any]:
         if time.monotonic() - cached_at < _LEADERBOARD_TTL_SECONDS:
             return payload
 
-    payload = {
-        "id": player_id,
-        "name": None,
-        "team": None,
-        "team_abbreviation": None,
-        "position": None,
-        "position_type": None,
-        "throws": None,
-        "bats": None,
-        "source": "fallback",
-    }
+    payload = {"id": player_id, "name": None, "team": None, "team_abbreviation": None, "position": None, "position_type": None, "throws": None, "bats": None, "source": "fallback"}
     try:
-        r = _req.get(
-            f"{MLB_STATS_BASE}/people/{player_id}",
-            params={"hydrate": "currentTeam"},
-            timeout=10,
-        )
+        r = _req.get(f"{MLB_STATS_BASE}/people/{player_id}", params={"hydrate": "currentTeam"}, timeout=10)
         if r.ok:
             p = (r.json().get("people") or [{}])[0]
             team = p.get("currentTeam") or {}
@@ -101,21 +92,17 @@ def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
     out: Dict[str, Any] = {
         "player_info": None,
         "season_stats": None,
+        "season_stats_source": None,
+        "season_stats_warnings": [],
         "splits": {"vsL": None, "vsR": None},
+        "splits_source": None,
         "year_by_year": [],
+        "year_by_year_source": None,
     }
 
     identity = _fetch_player_identity(player_id)
     if identity.get("name"):
-        out["player_info"] = {
-            "name": identity.get("name"),
-            "position": identity.get("position"),
-            "team": identity.get("team"),
-            "bats": identity.get("bats"),
-            "throws": identity.get("throws"),
-            "birth_date": None,
-            "mlb_debut": None,
-        }
+        out["player_info"] = {"name": identity.get("name"), "position": identity.get("position"), "team": identity.get("team"), "bats": identity.get("bats"), "throws": identity.get("throws"), "birth_date": None, "mlb_debut": None, "source": identity.get("source")}
 
     def _parse_stat(s: dict) -> Dict[str, Any]:
         pa = s.get("plateAppearances") or 0
@@ -144,46 +131,42 @@ def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
         }
 
     try:
-        r = _req.get(
-            f"{MLB_STATS_BASE}/people/{player_id}/stats",
-            params={"stats": "season", "group": "hitting", "season": season},
-            timeout=10,
-        )
+        r = _req.get(f"{MLB_STATS_BASE}/people/{player_id}/stats", params={"stats": "season", "group": "hitting", "season": season}, timeout=10)
         if r.ok:
             splits = (r.json().get("stats") or [{}])[0].get("splits", [])
             if splits:
                 out["season_stats"] = _parse_stat(splits[0].get("stat", {}))
-    except Exception:
-        pass
+                out["season_stats"]["season"] = season
+                out["season_stats"]["source"] = MLB_SEASON_SOURCE
+                out["season_stats_source"] = MLB_SEASON_SOURCE
+            else:
+                out["season_stats_warnings"].append(f"MLB Stats API returned no season hitting split for {player_id} in {season}.")
+        else:
+            out["season_stats_warnings"].append(f"MLB Stats API season request failed with status {r.status_code}.")
+    except Exception as exc:
+        out["season_stats_warnings"].append(f"MLB Stats API season request failed: {exc}")
 
     for sit, key in [("vl", "vsL"), ("vr", "vsR")]:
         try:
-            r = _req.get(
-                f"{MLB_STATS_BASE}/people/{player_id}/stats",
-                params={"stats": "statSplits", "group": "hitting", "season": season, "sitCodes": sit},
-                timeout=10,
-            )
+            r = _req.get(f"{MLB_STATS_BASE}/people/{player_id}/stats", params={"stats": "statSplits", "group": "hitting", "season": season, "sitCodes": sit}, timeout=10)
             if r.ok:
                 splits = (r.json().get("stats") or [{}])[0].get("splits", [])
                 if splits:
-                    out["splits"][key] = _parse_stat(splits[0].get("stat", {}))
+                    out["splits"][key] = {**_parse_stat(splits[0].get("stat", {})), "season": season, "source": MLB_SPLITS_SOURCE}
+                    out["splits_source"] = MLB_SPLITS_SOURCE
         except Exception:
             pass
 
     try:
-        r = _req.get(
-            f"{MLB_STATS_BASE}/people/{player_id}/stats",
-            params={"stats": "yearByYear", "group": "hitting"},
-            timeout=15,
-        )
+        r = _req.get(f"{MLB_STATS_BASE}/people/{player_id}/stats", params={"stats": "yearByYear", "group": "hitting"}, timeout=15)
         if r.ok:
+            by_season: Dict[str, Dict[str, Any]] = {}
             for sp in (r.json().get("stats") or [{}])[0].get("splits", []):
                 yr = sp.get("season")
-                if yr:
-                    row = _parse_stat(sp.get("stat", {}))
-                    row["season"] = yr
-                    out["year_by_year"].append(row)
-            out["year_by_year"].sort(key=lambda x: x["season"], reverse=True)
+                if yr and yr not in by_season:
+                    by_season[yr] = {**_parse_stat(sp.get("stat", {})), "season": yr, "source": MLB_YEAR_BY_YEAR_SOURCE}
+            out["year_by_year"] = sorted(by_season.values(), key=lambda x: x["season"], reverse=True)
+            out["year_by_year_source"] = MLB_YEAR_BY_YEAR_SOURCE if out["year_by_year"] else None
     except Exception:
         pass
 
@@ -193,23 +176,12 @@ def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
 def _aggregate_to_dict(agg) -> Optional[Dict[str, Any]]:
     if not agg:
         return None
-    return {
-        "avg_exit_velocity": agg.avg_exit_velocity,
-        "avg_launch_angle": agg.avg_launch_angle,
-        "hard_hit_pct": agg.hard_hit_pct,
-        "barrel_pct": agg.barrel_pct,
-        "k_pct": agg.k_pct,
-        "bb_pct": agg.bb_pct,
-        "batting_avg": agg.batting_avg,
-        "end_date": agg.end_date.isoformat() if agg.end_date else None,
-        "window": agg.window,
-    }
+    return {"avg_exit_velocity": agg.avg_exit_velocity, "avg_launch_angle": agg.avg_launch_angle, "hard_hit_pct": agg.hard_hit_pct, "barrel_pct": agg.barrel_pct, "k_pct": agg.k_pct, "bb_pct": agg.bb_pct, "batting_avg": agg.batting_avg, "end_date": agg.end_date.isoformat() if agg.end_date else None, "window": agg.window, "source": "postgres_batter_aggregates"}
 
 
 @router.get("/data/freshness")
 def data_freshness() -> Dict[str, Any]:
     from .data_freshness import build_data_freshness_payload
-
     Session = _get_session()
     with Session() as session:
         return build_data_freshness_payload(session)
@@ -221,53 +193,37 @@ def player_identity(id: int) -> Dict[str, Any]:
 
 
 @router.get("/batters/leaderboards")
-def batters_leaderboards(
-    season: Optional[int] = None,
-    min_pa: int = Query(25, ge=1),
-    min_bbe: int = Query(100, ge=1),
-    limit: int = Query(10, ge=1, le=50),
-) -> Dict[str, Any]:
+def batters_leaderboards(season: Optional[int] = None, min_pa: int = Query(25, ge=1), min_bbe: int = Query(100, ge=1), limit: int = Query(10, ge=1, le=50)) -> Dict[str, Any]:
     cache_key = f"{season}:{min_pa}:{min_bbe}:{limit}"
     cached = _leaderboard_cache.get(cache_key)
     if cached is not None:
         cached_at, data = cached
         if time.monotonic() - cached_at < _LEADERBOARD_TTL_SECONDS:
             return data
-
     Session = _get_session()
     with Session() as session:
         result = get_batter_leaderboards(session, season=season, min_pa=min_pa, min_bbe=min_bbe, limit=limit)
-
     _leaderboard_cache[cache_key] = (time.monotonic(), result)
     return result
 
 
 @router.get("/pitchers/leaderboards")
-def pitchers_leaderboards(
-    season: Optional[int] = None,
-    limit: int = Query(10, ge=1, le=50),
-) -> Dict[str, Any]:
+def pitchers_leaderboards(season: Optional[int] = None, limit: int = Query(10, ge=1, le=50)) -> Dict[str, Any]:
     cache_key = f"pitchers:{season}:{limit}"
     cached = _pitcher_leaderboard_cache.get(cache_key)
     if cached is not None:
         cached_at, data = cached
         if time.monotonic() - cached_at < _LEADERBOARD_TTL_SECONDS:
             return data
-
     Session = _get_session()
     with Session() as session:
         result = build_pitcher_leaderboards(session, season=season, limit=limit)
-
     _pitcher_leaderboard_cache[cache_key] = (time.monotonic(), result)
     return result
 
 
 @router.get("/pitcher/{id}/intelligence")
-def pitcher_intelligence(
-    id: int,
-    season: Optional[int] = None,
-    days_back: int = Query(365, ge=1, le=3650),
-) -> Dict[str, Any]:
+def pitcher_intelligence(id: int, season: Optional[int] = None, days_back: int = Query(365, ge=1, le=3650)) -> Dict[str, Any]:
     if season is None:
         season = datetime.date.today().year
     Session = _get_session()
@@ -284,74 +240,66 @@ def batter_profile(id: int, season: Optional[int] = None) -> Dict[str, Any]:
         agg, agg_label = get_batter_aggregate_with_fallback(session, id, season)
         seasons = [season, season - 1, season - 2]
         live = _fetch_batter_live_data(id, season)
+        local_splits = get_player_splits_multi_season(session, id, seasons)
+        splits = local_splits or live.get("splits")
         return {
             "batter_id": id,
             "season": season,
             "player_info": live.get("player_info"),
             "season_stats": live.get("season_stats"),
+            "season_stats_source": live.get("season_stats_source"),
+            "season_stats_warnings": live.get("season_stats_warnings", []),
+            "season_stats_contract": "Official season hitting line only. Do not replace with local Statcast aggregate semantics.",
             "aggregate_label": agg_label,
             "aggregate": _aggregate_to_dict(agg),
-            "multi_season": get_batter_multi_season(session, id, seasons),
-            "splits": get_player_splits_multi_season(session, id, seasons) or live.get("splits"),
-            "year_by_year": live.get("year_by_year", []),
+            "aggregate_source": "postgres_batter_aggregates",
+            "multi_season": dedupe_rows(get_batter_multi_season(session, id, seasons), ["season", "label"]),
+            "multi_season_source": "postgres_batter_aggregates",
+            "splits": splits,
+            "splits_source": LOCAL_SPLITS_SOURCE if local_splits else live.get("splits_source"),
+            "year_by_year": dedupe_rows(live.get("year_by_year", []), ["season"]),
+            "year_by_year_source": live.get("year_by_year_source"),
+            "rolling_sources": {"pa": STATCAST_ROLLING_SOURCE, "ab": STATCAST_ROLLING_SOURCE, "games": STATCAST_ROLLING_SOURCE, "splits": STATCAST_ROLLING_SOURCE, "pitch_types": STATCAST_ROLLING_SOURCE},
             "data_quality": get_batter_data_quality(session, id),
         }
 
 
 @router.get("/batter/{id}/rolling/pa")
 def batter_rolling_pa(id: int, windows: str = Query("10,25,50,100")) -> Dict[str, Any]:
-    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
-    parsed = parsed or [10, 25, 50, 100]
+    parsed = parse_window_list(windows, [10, 25, 50, 100])
     Session = _get_session()
     with Session() as session:
-        return {
-            "batter_id": id,
-            "window_type": "PA",
-            "windows": {str(w): get_batter_rolling_by_pa(session, id, w) for w in parsed},
-            "data_quality": get_batter_data_quality(session, id),
-        }
+        return {"batter_id": id, "window_type": "PA", "source": STATCAST_ROLLING_SOURCE, "windows": {str(w): clean_rolling_by_pa(session, id, w) for w in parsed}, "data_quality": get_batter_data_quality(session, id)}
 
 
 @router.get("/batter/{id}/rolling/ab")
 def batter_rolling_ab(id: int, windows: str = Query("10,25,50,100")) -> Dict[str, Any]:
-    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
-    parsed = parsed or [10, 25, 50, 100]
+    parsed = parse_window_list(windows, [10, 25, 50, 100])
     Session = _get_session()
     with Session() as session:
-        return {
-            "batter_id": id,
-            "window_type": "AB",
-            "windows": {str(w): get_batter_rolling_by_ab(session, id, w) for w in parsed},
-            "data_quality": get_batter_data_quality(session, id),
-        }
+        return {"batter_id": id, "window_type": "AB", "source": STATCAST_ROLLING_SOURCE, "windows": {str(w): clean_rolling_by_ab(session, id, w) for w in parsed}, "data_quality": get_batter_data_quality(session, id)}
 
 
 @router.get("/batter/{id}/rolling/games")
 def batter_rolling_games(id: int, windows: str = Query("5,10,15,30")) -> Dict[str, Any]:
-    parsed = [int(w.strip()) for w in windows.split(",") if w.strip().isdigit()]
-    parsed = parsed or [5, 10, 15, 30]
+    parsed = parse_window_list(windows, [5, 10, 15, 30])
     Session = _get_session()
     with Session() as session:
-        return {
-            "batter_id": id,
-            "window_type": "games",
-            "windows": {str(w): get_batter_rolling_by_games(session, id, w) for w in parsed},
-            "data_quality": get_batter_data_quality(session, id),
-        }
+        return {"batter_id": id, "window_type": "games", "source": STATCAST_ROLLING_SOURCE, "windows": {str(w): clean_rolling_by_games(session, id, w) for w in parsed}, "data_quality": get_batter_data_quality(session, id)}
 
 
 @router.get("/batter/{id}/rolling/splits")
 def batter_rolling_splits(id: int, pa: int = 100) -> Dict[str, Any]:
     Session = _get_session()
     with Session() as session:
-        return {"batter_id": id, **get_batter_rolling_splits(session, id, pa)}
+        return {"batter_id": id, **clean_rolling_splits(session, id, pa)}
 
 
 @router.get("/batter/{id}/rolling/pitch-types")
 def batter_rolling_pitch_types(id: int, pa: int = 100) -> Dict[str, Any]:
     Session = _get_session()
     with Session() as session:
-        return {"batter_id": id, **get_batter_rolling_pitch_types(session, id, pa)}
+        return {"batter_id": id, **clean_rolling_pitch_types(session, id, pa)}
 
 
 @router.get("/batter/{id}/rolling/legacy")
@@ -359,13 +307,7 @@ def batter_rolling_legacy(id: int) -> Dict[str, Any]:
     windows = [10, 25, 50, 100, 200, 400, 1000]
     Session = _get_session()
     with Session() as session:
-        return {
-            "batter_id": id,
-            "window_type": "PA",
-            "legacy_note": "Legacy rolling abs endpoint uses PA-style terminal outcomes. Use /rolling/ab for strict AB windows.",
-            "windows": {str(w): get_batter_rolling_by_abs(session, id, w) for w in windows},
-            "data_quality": get_batter_data_quality(session, id),
-        }
+        return {"batter_id": id, "window_type": "PA", "legacy_note": "Legacy rolling abs endpoint uses PA-style terminal outcomes. Use /rolling/ab for strict AB windows.", "source": STATCAST_ROLLING_SOURCE, "windows": {str(w): clean_rolling_by_pa(session, id, w) for w in windows}, "data_quality": get_batter_data_quality(session, id)}
 
 
 @router.get("/batter/{id}/qa")
@@ -380,11 +322,5 @@ def batter_ordered_at_bats(id: int, limit: int = 50, offset: int = 0) -> Dict[st
     Session = _get_session()
     with Session() as session:
         total, rows = get_batter_at_bats(session, id, n=limit, offset=offset)
-        return {
-            "batter_id": id,
-            "total": total,
-            "limit": limit,
-            "offset": offset,
-            "events": rows,
-            "data_quality": get_batter_data_quality(session, id),
-        }
+        deduped_rows = dedupe_rows(rows, ["game_pk", "at_bat_number", "pitcher_id", "result"])
+        return {"batter_id": id, "total": total, "limit": limit, "offset": offset, "events": deduped_rows, "source": STATCAST_ROLLING_SOURCE, "duplicate_rows_removed": max(len(rows) - len(deduped_rows), 0), "data_quality": get_batter_data_quality(session, id)}

--- a/mlb_app/data_integrity_audit.py
+++ b/mlb_app/data_integrity_audit.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from .database import BatterAggregate, BatterPitchTypeMatchup, PlayerSplit, StatcastEvent, TeamSplit
+from .db_utils import TERMINAL_EVENTS
+
+
+def _row_to_dict(row: Any, columns: Iterable[str]) -> Dict[str, Any]:
+    out = {column: getattr(row, column) for column in columns}
+    out["duplicate_count"] = int(getattr(row, "duplicate_count") or 0)
+    return out
+
+
+def _duplicate_query(session: Session, model: Any, columns: List[Any], limit: int) -> List[Dict[str, Any]]:
+    labels = [column.key for column in columns]
+    rows = (
+        session.query(*columns, func.count().label("duplicate_count"))
+        .group_by(*columns)
+        .having(func.count() > 1)
+        .order_by(func.count().desc())
+        .limit(limit)
+        .all()
+    )
+    return [_row_to_dict(row, labels) for row in rows]
+
+
+def build_duplicate_audit(session: Session, limit: int = 50) -> Dict[str, Any]:
+    limit = max(1, min(int(limit or 50), 500))
+
+    statcast_pitch_rows = (
+        session.query(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+            StatcastEvent.pitcher_id,
+            StatcastEvent.batter_id,
+            func.count().label("duplicate_count"),
+        )
+        .filter(
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+            StatcastEvent.pitcher_id.isnot(None),
+            StatcastEvent.batter_id.isnot(None),
+        )
+        .group_by(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+            StatcastEvent.pitcher_id,
+            StatcastEvent.batter_id,
+        )
+        .having(func.count() > 1)
+        .order_by(func.count().desc())
+        .limit(limit)
+        .all()
+    )
+
+    statcast_pa_rows = (
+        session.query(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitcher_id,
+            StatcastEvent.batter_id,
+            func.count().label("duplicate_count"),
+        )
+        .filter(
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitcher_id.isnot(None),
+            StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.events.in_(TERMINAL_EVENTS),
+        )
+        .group_by(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitcher_id,
+            StatcastEvent.batter_id,
+        )
+        .having(func.count() > 1)
+        .order_by(func.count().desc())
+        .limit(limit)
+        .all()
+    )
+
+    audit = {
+        "statcast_pitch_identity": [
+            {
+                "game_pk": row.game_pk,
+                "at_bat_number": row.at_bat_number,
+                "pitch_number": row.pitch_number,
+                "pitcher_id": row.pitcher_id,
+                "batter_id": row.batter_id,
+                "duplicate_count": int(row.duplicate_count or 0),
+            }
+            for row in statcast_pitch_rows
+        ],
+        "statcast_terminal_pa_identity": [
+            {
+                "game_pk": row.game_pk,
+                "at_bat_number": row.at_bat_number,
+                "pitcher_id": row.pitcher_id,
+                "batter_id": row.batter_id,
+                "duplicate_count": int(row.duplicate_count or 0),
+            }
+            for row in statcast_pa_rows
+        ],
+        "batter_pitch_type_matchups": _duplicate_query(
+            session,
+            BatterPitchTypeMatchup,
+            [
+                BatterPitchTypeMatchup.target_date,
+                BatterPitchTypeMatchup.game_pk,
+                BatterPitchTypeMatchup.batter_id,
+                BatterPitchTypeMatchup.opposing_pitcher_id,
+                BatterPitchTypeMatchup.pitch_type,
+            ],
+            limit,
+        ),
+        "batter_aggregates": _duplicate_query(
+            session,
+            BatterAggregate,
+            [BatterAggregate.batter_id, BatterAggregate.window, BatterAggregate.end_date],
+            limit,
+        ),
+        "player_splits": _duplicate_query(
+            session,
+            PlayerSplit,
+            [PlayerSplit.player_id, PlayerSplit.season, PlayerSplit.split],
+            limit,
+        ),
+        "team_splits": _duplicate_query(
+            session,
+            TeamSplit,
+            [TeamSplit.team_id, TeamSplit.season, TeamSplit.split],
+            limit,
+        ),
+    }
+    audit["has_duplicates"] = any(bool(rows) for rows in audit.values() if isinstance(rows, list))
+    audit["limits"] = {"per_table": limit}
+    audit["recommendation"] = "Clean duplicate keys, then add DB-level uniqueness or conflict-safe upserts for every audited identity."
+    return audit

--- a/scripts/audit_batter_data_integrity.py
+++ b/scripts/audit_batter_data_integrity.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import json
+import os
+
+from mlb_app.database import create_tables, get_engine, get_session
+from mlb_app.data_integrity_audit import build_duplicate_audit
+
+
+def main() -> int:
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    Session = get_session(engine)
+    with Session() as session:
+        payload = build_duplicate_audit(session)
+    print(json.dumps(payload, indent=2, default=str))
+    return 1 if payload.get("has_duplicates") else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_batter_data_contract.py
+++ b/tests/test_batter_data_contract.py
@@ -1,0 +1,50 @@
+import datetime as dt
+
+from mlb_app.batter_data_contract import dedupe_rows, parse_window_list
+from mlb_app.data_integrity_audit import build_duplicate_audit
+from mlb_app.database import Base, StatcastEvent, get_engine, get_session
+
+
+def test_parse_window_list_dedupes_and_bounds_values():
+    assert parse_window_list("10,25,25,0,abc,5001,50", [1, 2], maximum=5000) == [10, 25, 50]
+    assert parse_window_list("", [10, 25, 10]) == [10, 25]
+
+
+def test_dedupe_rows_removes_repeated_source_rows():
+    rows = [
+        {"season": 2026, "label": "YTD"},
+        {"season": 2026, "label": "YTD"},
+        {"season": 2025, "label": "2025"},
+    ]
+
+    assert dedupe_rows(rows, ["season", "label"]) == [rows[0], rows[2]]
+
+
+def test_duplicate_audit_reports_statcast_pitch_and_pa_duplicates():
+    engine = get_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = get_session(engine)
+
+    with Session() as session:
+        base = dict(
+            game_date=dt.date(2026, 7, 8),
+            game_pk=1,
+            at_bat_number=12,
+            pitch_number=4,
+            inning=3,
+            inning_topbot="Top",
+            outs_when_up=1,
+            pitcher_id=111,
+            batter_id=222,
+            pitch_type="FF",
+            events="single",
+        )
+        session.add(StatcastEvent(**base))
+        session.add(StatcastEvent(**base))
+        session.commit()
+
+        audit = build_duplicate_audit(session)
+
+    assert audit["has_duplicates"] is True
+    assert audit["statcast_pitch_identity"][0]["duplicate_count"] == 2
+    assert audit["statcast_terminal_pa_identity"][0]["duplicate_count"] == 2


### PR DESCRIPTION
## Summary
Fixes the batter ID page data contract and rolling-data integrity path for #978.

## What changed
- Adds `mlb_app/batter_data_contract.py` as the explicit batter page contract layer.
- Keeps official season stats from MLB Stats API separate from local Statcast aggregates.
- Adds explicit source metadata for:
  - `season_stats_source = mlb_stats_api_people_stats_season`
  - `aggregate_source = postgres_batter_aggregates`
  - rolling endpoints = `postgres_statcast_events_deduped_terminal_pa`
- Replaces rolling PA/AB/games/splits/pitch-type route calculations with deduped terminal-PA contract helpers.
- Adds duplicate removal counts and dedupe policy into rolling `data_quality`.
- Dedupes `multi_season`, `year_by_year`, and ordered at-bat rows by stable keys before returning the route payload.
- Adds duplicate audit helper for known duplicate-prone tables:
  - `statcast_events` pitch identity
  - `statcast_events` terminal PA identity
  - `batter_pitch_type_matchups`
  - `batter_aggregates`
  - `player_splits`
  - `team_splits`
- Adds `scripts/audit_batter_data_integrity.py` to print exact duplicate keys/counts and exit nonzero when duplicates are present.
- Adds regression tests for window parsing, row dedupe, and duplicate audit detection.

## Why
The previous rolling endpoints could use `.limit(n)` before deduplication, which means duplicate Statcast terminal rows could pollute the requested rolling window. Also, the batter page needed a clear source contract so official MLB season stats never get silently substituted by local Statcast aggregate semantics.

## Verification needed
I could not run tests in this connector session. Please run:

```bash
pytest tests/test_batter_data_contract.py
python scripts/audit_batter_data_integrity.py
```

Then spot-check:

```bash
curl "$BASE_URL/batter/<BATTER_ID>/profile?season=2026"
curl "$BASE_URL/batter/<BATTER_ID>/rolling/pa?windows=10,25,50,100"
curl "$BASE_URL/batter/<BATTER_ID>/rolling/ab?windows=10,25,50,100"
curl "$BASE_URL/batter/<BATTER_ID>/rolling/games?windows=5,10,15,30"
curl "$BASE_URL/batter/<BATTER_ID>/rolling/splits?pa=100"
curl "$BASE_URL/batter/<BATTER_ID>/rolling/pitch-types?pa=100"
```

## Notes
This does not add DB-level unique constraints yet. It adds route-level correctness, rolling dedupe, and an audit to identify existing duplicate keys. After cleaning current duplicate rows, the next step should be DB uniqueness / conflict-safe migration.