### PR TITLE
My Dashboard mobile-first Salesforce workbench foundation

### DIFF
--- a/docs/MY_DASHBOARD_SALESFORCE_WORKBENCH.md
+++ b/docs/MY_DASHBOARD_SALESFORCE_WORKBENCH.md
@@ -1,0 +1,168 @@
+# My Dashboard Salesforce Workbench Architecture
+
+## Purpose
+
+My Dashboard should evolve from a curated card surface into the first Salesforce-style workbench inside MLBGPT.
+
+The goal is not to replace the model formulas. The goal is to expose the formulas through a faster, mobile-stable, metadata-driven interface that behaves like Salesforce Reports/Object Manager:
+
+- choose an object/component
+- inspect available fields
+- apply filters
+- run the query/formula
+- view results in a table
+- save or pin the result
+
+## Current repo foundation
+
+The repo is already close enough to build Workbench v0 without starting from raw SQL.
+
+Existing backend foundation:
+
+- `SUPPORTED_COMPONENTS = {"hitters", "pitchers", "teams", "totals", "overall_players"}` in `mlb_app/my_dashboard_solver.py`
+- `available_filters_for_component()` returns component-level field/filter metadata
+- `normalize_filter_payload()` already supports basic filters, metric min/max filters, and metric weights
+- `AppDashboardItem` persists `payload_json`, `filter_json`, and `sort_json`
+- active-lineup solving exists as an additive wrapper and must stay additive
+- hydration endpoint exists for yesterday confirmed 1-9 lineups
+
+## Salesforce mapping
+
+| Salesforce concept | MLBGPT equivalent |
+| --- | --- |
+| Object | Dashboard component / future workbench object |
+| Field list | Item fields + metrics returned by `available_filters` |
+| Filter | `filters` payload |
+| Filter operator | `equals`, `contains`, `min`, `max`, `in` |
+| Report rows | Solver result `items` |
+| Report builder | Workbench UI |
+| Dashboard component | Saved `AppDashboardItem` |
+| Object Manager | Workbench object/field registry |
+
+## Workbench v0 objects
+
+The first Workbench version should wrap the existing dashboard components:
+
+1. `hitters`
+2. `pitchers`
+3. `teams`
+4. `totals`
+5. `overall_players`
+
+Do not start by exposing arbitrary raw SQL. Raw ORM objects can be promoted later after a formal schema registry is built.
+
+## Required mobile behavior
+
+My Dashboard must work at mobile widths before more features are added.
+
+Requirements:
+
+- page shell renders before formula results finish
+- controls stack vertically below tablet widths
+- filters are reachable with thumb-sized controls
+- cards and tables do not overflow the viewport except controlled horizontal result-grid scrolling
+- each component has its own loading and error state
+- a slow component cannot freeze the entire dashboard
+- primary actions remain visible: refresh, filter, save/pin, inspect fields
+
+## Required performance behavior
+
+The formulas are expensive and should not all block initial page load.
+
+Recommended load model:
+
+1. Fetch `/my-dashboard/health` first for supported components and hydration policy.
+2. Render the dashboard shell immediately.
+3. Load components progressively, one component request at a time or with a low concurrency cap.
+4. Cache component payloads by date, component, active-lineup flag, and normalized filters.
+5. Keep stale component results visible while refreshing.
+6. Avoid running all component formulas inside a single blocking frontend effect.
+
+## Result-size policy
+
+The existing card dashboard can keep a top-10 default.
+
+Workbench/table mode needs an explicit row contract:
+
+- `limit`
+- `offset` or `page`
+- `page_size`
+- `total_count_before_filters`
+- `total_count_after_filters`
+- `returned_count`
+
+Do not silently cap Workbench results to ten rows. The card UI and table UI should have separate result-size expectations.
+
+## Backend contract proposal
+
+Add optional request fields to dashboard solver requests in a backward-compatible way:
+
+```json
+{
+  "date": "2026-07-10",
+  "component": "hitters",
+  "filters": {},
+  "view_mode": "cards",
+  "limit": 10,
+  "offset": 0,
+  "include_available_fields": true
+}
+```
+
+`view_mode = "cards"` keeps current behavior.
+
+`view_mode = "workbench"` returns larger/paginated table-ready results.
+
+## Frontend architecture proposal
+
+The My Dashboard page should be split into smaller units:
+
+- `DashboardShell`
+- `DashboardObjectPicker`
+- `DashboardFilterPanel`
+- `DashboardFieldPanel`
+- `DashboardComponentCard`
+- `DashboardResultsTable`
+- `useDashboardComponentPayload`
+- `useProgressiveDashboardHydration`
+
+The shell should not wait for every component payload before rendering.
+
+## AI role
+
+AI should not produce the final answer first.
+
+AI should translate language into a visible query/filter state:
+
+User says:
+
+> Show me left-handed hitters with strong xwOBA and EV today.
+
+Workbench should populate:
+
+- object: `hitters`
+- metric filters: `xwOBA` minimum, `EV` minimum if supported
+- sort: score or selected metric descending
+- active lineups: true where applicable
+
+Then the user can inspect and run the query.
+
+## Acceptance criteria
+
+Phase 1 is complete when:
+
+- mobile dashboard renders cleanly from 320px width upward
+- first render does not block on all formulas
+- component results load independently
+- filters remain usable on mobile
+- backend remains backward compatible
+- Salesforce-style workbench contract is documented and ready for implementation
+
+Phase 2 is complete when:
+
+- Workbench object picker exists
+- available fields/metrics are visible per object
+- filter builder writes the existing filter contract
+- table results are available with larger/paginated row counts
+- saved dashboard items can store Workbench filters/sorts
+- AI can populate filters instead of merely writing prose


### PR DESCRIPTION
## Summary

Starts the My Dashboard rebuild toward a mobile-first, Salesforce-style Workbench architecture.

This first commit intentionally documents the target contract before touching formula logic:

- My Dashboard becomes the first Workbench surface
- Salesforce Object/Field/Filter/Report/Dashboard concepts are mapped to existing MLBGPT components
- Existing `SUPPORTED_COMPONENTS`, `available_filters_for_component`, filter normalization, saved dashboard items, and active-lineup hydration become Workbench v0 foundation
- Mobile requirements are defined as the first implementation priority
- Progressive component hydration is defined so expensive formulas do not block first render
- Workbench/table mode is separated from the current top-10 dashboard-card behavior

## Why this matters

The current page is too formula-heavy on initial load and not mobile-safe enough. The fix is not to make formulas less useful; it is to expose them through a faster metadata-driven shell that loads progressively and behaves like Salesforce Reports.

## Implementation sequence after this foundation

1. Patch My Dashboard mobile layout.
2. Split initial shell load from component solver calls.
3. Add independent component loading/error states.
4. Add backend `view_mode`/`limit`/pagination contract for Workbench mode while preserving card mode.
5. Build object/field/filter/table UI around existing component metadata.

Issue: #981