### PR TITLE
Add Salesforce-style My Dashboard query contract

### DIFF
--- a/mlb_app/my_dashboard_report_query.py
+++ b/mlb_app/my_dashboard_report_query.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Dict, List, Optional
+
+
+MAX_PAGE_SIZE = 250
+DEFAULT_PAGE_SIZE = 50
+SORT_DIRECTIONS = {"asc", "desc"}
+
+OBJECT_METADATA: Dict[str, Dict[str, Any]] = {
+    "hitters": {"label": "Hitters", "label_plural": "Hitters", "entity_type": "hitter", "lineup_scope_supported": True},
+    "pitchers": {"label": "Pitcher", "label_plural": "Pitchers", "entity_type": "pitcher", "lineup_scope_supported": False},
+    "teams": {"label": "Team", "label_plural": "Teams", "entity_type": "team", "lineup_scope_supported": False},
+    "totals": {"label": "Game Total", "label_plural": "Game Totals", "entity_type": "game", "lineup_scope_supported": False},
+    "overall_players": {"label": "Player", "label_plural": "Overall Players", "entity_type": "player", "lineup_scope_supported": True},
+}
+
+BASE_FIELDS: List[Dict[str, Any]] = [
+    {"name": "rank", "label": "Rank", "type": "integer", "sortable": True, "filterable": False, "nillable": False, "group": "Identity"},
+    {"name": "entity_id", "label": "Entity ID", "type": "id", "sortable": True, "filterable": True, "nillable": False, "group": "Identity"},
+    {"name": "entity_name", "label": "Name", "type": "string", "sortable": True, "filterable": True, "nillable": False, "group": "Identity"},
+    {"name": "entity_type", "label": "Entity Type", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Identity"},
+    {"name": "player_type", "label": "Player Type", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Identity"},
+    {"name": "team", "label": "Team", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Matchup"},
+    {"name": "opponent", "label": "Opponent", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Matchup"},
+    {"name": "game_pk", "label": "Game PK", "type": "id", "sortable": True, "filterable": True, "nillable": True, "group": "Matchup"},
+    {"name": "pitch_type", "label": "Pitch Type", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Matchup"},
+    {"name": "pitch_name", "label": "Pitch Name", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Matchup"},
+    {"name": "category", "label": "Category", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Classification"},
+    {"name": "score", "label": "Score", "type": "double", "sortable": True, "filterable": True, "nillable": True, "group": "Scoring"},
+    {"name": "base_score", "label": "Base Score", "type": "double", "sortable": True, "filterable": True, "nillable": True, "group": "Scoring"},
+    {"name": "adjusted_score", "label": "Adjusted Score", "type": "double", "sortable": True, "filterable": True, "nillable": True, "group": "Scoring"},
+    {"name": "confidence", "label": "Confidence", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Scoring"},
+    {"name": "source", "label": "Source", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Audit"},
+    {"name": "primary_reason", "label": "Primary Reason", "type": "textarea", "sortable": False, "filterable": True, "nillable": True, "group": "Audit"},
+    {"name": "lineup_verified", "label": "Lineup Verified", "type": "boolean", "sortable": True, "filterable": True, "nillable": True, "group": "Audit"},
+    {"name": "lineup_source", "label": "Lineup Source", "type": "string", "sortable": True, "filterable": True, "nillable": True, "group": "Audit"},
+    {"name": "confirmed_lineup_date", "label": "Confirmed Lineup Date", "type": "date", "sortable": True, "filterable": True, "nillable": True, "group": "Audit"},
+]
+
+METRIC_FIELDS: Dict[str, List[str]] = {
+    "hitters": ["xwOBA", "xBA", "EV", "LA", "HardHit", "Usage", "Pitcher xwOBA", "Pitches Seen", "PA"],
+    "pitchers": ["K%", "BB%", "xwOBA Allowed", "HardHit Allowed", "Opp K%", "Opp ISO", "Score"],
+    "teams": ["Edge Score", "Win Edge", "Run Diff", "ISO", "OBP", "SLG"],
+    "totals": ["Projected Total", "Raw Total", "Run Index", "Score"],
+    "overall_players": ["Score", "xwOBA", "EV", "K%", "xwOBA Allowed"],
+}
+
+
+def normalize_query(page_size: Any = DEFAULT_PAGE_SIZE, page_number: Any = 1, sort_by: Any = "score", sort_direction: Any = "desc") -> Dict[str, Any]:
+    try:
+        normalized_size = int(page_size)
+    except (TypeError, ValueError):
+        normalized_size = DEFAULT_PAGE_SIZE
+    try:
+        normalized_page = int(page_number)
+    except (TypeError, ValueError):
+        normalized_page = 1
+    normalized_size = max(1, min(MAX_PAGE_SIZE, normalized_size))
+    normalized_page = max(1, normalized_page)
+    normalized_direction = str(sort_direction or "desc").lower()
+    if normalized_direction not in SORT_DIRECTIONS:
+        normalized_direction = "desc"
+    return {
+        "page_size": normalized_size,
+        "page_number": normalized_page,
+        "offset": (normalized_page - 1) * normalized_size,
+        "sort_by": str(sort_by or "score"),
+        "sort_direction": normalized_direction,
+    }
+
+
+def _value_at_path(record: Dict[str, Any], field_name: str) -> Any:
+    if field_name.startswith("metrics."):
+        return (record.get("metrics") or {}).get(field_name[8:])
+    current: Any = record
+    for part in field_name.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _sort_key(value: Any) -> tuple:
+    if value is None or value == "":
+        return (1, 0, "")
+    try:
+        return (0, 0, float(value))
+    except (TypeError, ValueError):
+        return (0, 1, str(value).lower())
+
+
+def field_metadata(component: str, records: Optional[List[Dict[str, Any]]] = None) -> List[Dict[str, Any]]:
+    fields = [dict(field) for field in BASE_FIELDS]
+    known_names = {field["name"] for field in fields}
+    metric_names = set(METRIC_FIELDS.get(component, []))
+    for record in records or []:
+        metric_names.update((record.get("metrics") or {}).keys())
+    for metric_name in sorted(metric_names):
+        name = f"metrics.{metric_name}"
+        if name in known_names:
+            continue
+        fields.append({
+            "name": name,
+            "label": metric_name,
+            "type": "double",
+            "sortable": True,
+            "filterable": True,
+            "nillable": True,
+            "group": "Metrics",
+            "source": "server_metric_registry",
+        })
+        known_names.add(name)
+    return fields
+
+
+def apply_report_query(payload: Dict[str, Any], component: str, page_size: Any = DEFAULT_PAGE_SIZE, page_number: Any = 1, sort_by: Any = "score", sort_direction: Any = "desc", include_metadata: bool = True) -> Dict[str, Any]:
+    query = normalize_query(page_size, page_number, sort_by, sort_direction)
+    all_records = [dict(record) for record in (payload.get("items") or []) if isinstance(record, dict)]
+    reverse = query["sort_direction"] == "desc"
+    all_records.sort(key=lambda record: _sort_key(_value_at_path(record, query["sort_by"])), reverse=reverse)
+    for index, record in enumerate(all_records, start=1):
+        record["rank"] = index
+    total_size = len(all_records)
+    start = query["offset"]
+    end = start + query["page_size"]
+    records = all_records[start:end]
+    page_count = math.ceil(total_size / query["page_size"]) if total_size else 0
+    has_next = end < total_size
+    has_previous = query["page_number"] > 1 and total_size > 0
+    result = dict(payload)
+    result["items"] = records
+    result["records"] = records
+    result["totalSize"] = total_size
+    result["total_count"] = total_size
+    result["done"] = not has_next
+    result["query"] = query
+    result["page_info"] = {
+        "page_number": query["page_number"],
+        "page_size": query["page_size"],
+        "page_count": page_count,
+        "record_count": len(records),
+        "total_count": total_size,
+        "has_next": has_next,
+        "has_previous": has_previous,
+        "next_page": query["page_number"] + 1 if has_next else None,
+        "previous_page": query["page_number"] - 1 if has_previous else None,
+    }
+    if include_metadata:
+        object_metadata = dict(OBJECT_METADATA.get(component, {"label": component.title(), "label_plural": component.title()}))
+        object_metadata.update({
+            "name": component,
+            "queryable": True,
+            "sortable": True,
+            "filterable": True,
+            "fields": field_metadata(component, all_records),
+        })
+        result["object_info"] = object_metadata
+    return result
+
+
+def install_full_result_finalizer(solver_module: Any) -> None:
+    """Install an additive response finalizer that preserves the full candidate universe.
+
+    Existing candidate builders, scoring, filters, and response fields remain unchanged.
+    The only removed behavior is the final arbitrary ten-record truncation.
+    """
+
+    def finalize_component_response(
+        date: str,
+        component: str,
+        candidates: List[Dict[str, Any]],
+        key_fn: Callable[[Dict[str, Any]], str],
+        data_quality: Any = None,
+        missing_data: Any = None,
+        filters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        pool_limit = max(len(candidates), 1)
+        deduped_pool = solver_module.dedupe_ranked_items(candidates, key_fn, limit=pool_limit)
+        filtered, filters_applied, warnings, before, after = solver_module.apply_dashboard_filters(deduped_pool, filters)
+        final_limit = max(len(filtered), 1)
+        final_items = solver_module.dedupe_ranked_items(filtered, key_fn, limit=final_limit) if filtered else []
+        response = solver_module.build_response(date, component, final_items, data_quality, missing_data)
+        response.update({
+            "filters_applied": filters_applied,
+            "available_filters": solver_module.available_filters_for_component(component, deduped_pool),
+            "result_count_before_filters": before,
+            "result_count_after_filters": after,
+            "filter_warnings": warnings,
+            "candidate_universe_count": len(candidates),
+            "deduped_universe_count": len(deduped_pool),
+            "result_cap_applied": False,
+        })
+        return response
+
+    solver_module.finalize_component_response = finalize_component_response

--- a/mlb_app/my_dashboard_report_query.py
+++ b/mlb_app/my_dashboard_report_query.py
@@ -1,15 +1,23 @@
 from __future__ import annotations
 
+import datetime as dt
 import math
+import os
 from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy import or_
+
+from . import ai_data_assistant as assistant
+from .database import BatterPitchTypeMatchup
 
 
 MAX_PAGE_SIZE = 250
 DEFAULT_PAGE_SIZE = 50
 SORT_DIRECTIONS = {"asc", "desc"}
+DEFAULT_HITTER_SOURCE_ROW_LIMIT = 10000
 
 OBJECT_METADATA: Dict[str, Dict[str, Any]] = {
-    "hitters": {"label": "Hitters", "label_plural": "Hitters", "entity_type": "hitter", "lineup_scope_supported": True},
+    "hitters": {"label": "Hitter", "label_plural": "Hitters", "entity_type": "hitter", "lineup_scope_supported": True},
     "pitchers": {"label": "Pitcher", "label_plural": "Pitchers", "entity_type": "pitcher", "lineup_scope_supported": False},
     "teams": {"label": "Team", "label_plural": "Teams", "entity_type": "team", "lineup_scope_supported": False},
     "totals": {"label": "Game Total", "label_plural": "Game Totals", "entity_type": "game", "lineup_scope_supported": False},
@@ -160,12 +168,99 @@ def apply_report_query(payload: Dict[str, Any], component: str, page_size: Any =
     return result
 
 
-def install_full_result_finalizer(solver_module: Any) -> None:
-    """Install an additive response finalizer that preserves the full candidate universe.
+def build_full_stored_365_sweep_context(session: Any, date: str) -> Dict[str, Any]:
+    """Score the complete available Stored 365 row set for the requested date.
 
-    Existing candidate builders, scoring, filters, and response fields remain unchanged.
-    The only removed behavior is the final arbitrary ten-record truncation.
+    The legacy assistant context intentionally returned only its top 25 rows for a
+    chat summary. My Dashboard needs the full report universe, so this adapter
+    keeps the same joins and scoring function while removing that presentation cap.
     """
+    errors: List[str] = []
+    projection_payload: Dict[str, Any] = {}
+    try:
+        projection_payload = assistant.build_model_projection_payload(session, date) or {}
+    except Exception as exc:
+        errors.append(f"projection_payload_unavailable_for_arsenal_join: {exc}")
+    pitch_lookup = assistant.pitch_lookup_from_projection_payload(projection_payload)
+
+    row_limit = max(1, int(os.getenv("DASHBOARD_HITTER_SOURCE_ROW_LIMIT", str(DEFAULT_HITTER_SOURCE_ROW_LIMIT))))
+    rows: List[Any] = []
+    try:
+        parsed = dt.date.fromisoformat(date[:10])
+        rows = (
+            session.query(BatterPitchTypeMatchup)
+            .filter(or_(BatterPitchTypeMatchup.target_date == parsed, BatterPitchTypeMatchup.target_date.is_(None)))
+            .limit(row_limit)
+            .all()
+        )
+    except Exception as exc:
+        errors.append(str(exc))
+
+    scored_rows: List[Dict[str, Any]] = []
+    for row in rows:
+        pitcher_id = assistant.safe_int(assistant.row_value(row, "opposing_pitcher_id"))
+        pitch_type = assistant.row_value(row, "pitch_type")
+        pitcher_pitch = pitch_lookup.get((pitcher_id, str(pitch_type))) or {}
+        score = assistant.score_batter_pitch_matchup(row, pitcher_pitch, target_date=date)
+        scored_rows.append({
+            "rank_score": score.get("score"),
+            "confidence": score.get("confidence"),
+            "confidence_tier": score.get("confidence_tier"),
+            "reasons": score.get("reasons"),
+            "missing_inputs": score.get("missing_inputs"),
+            "sample_size": score.get("sample_size"),
+            "batter_id": assistant.row_value(row, "batter_id"),
+            "batter_name": assistant.row_value(row, "batter_name"),
+            "batter_team_id": assistant.row_value(row, "batter_team_id"),
+            "opposing_pitcher_id": pitcher_id,
+            "opposing_pitcher_name": pitcher_pitch.get("pitcher_name"),
+            "game_pk": assistant.row_value(row, "game_pk") or pitcher_pitch.get("game_pk"),
+            "game_label": pitcher_pitch.get("game_label"),
+            "pitch_type": pitch_type,
+            "pitch_name": pitcher_pitch.get("pitch_name"),
+            "pitcher_usage_pct": pitcher_pitch.get("usage_pct"),
+            "pitcher_xwoba_allowed": pitcher_pitch.get("xwoba_allowed"),
+            "pitcher_hard_hit_allowed": pitcher_pitch.get("hard_hit_pct_allowed"),
+            "pitcher_whiff_pct": pitcher_pitch.get("whiff_pct"),
+            "hitter_xwoba": assistant.safe_float(assistant.row_value(row, "xwoba")),
+            "hitter_xba": assistant.safe_float(assistant.row_value(row, "xba")),
+            "hitter_avg_ev": assistant.safe_float(assistant.row_value(row, "avg_exit_velocity") or assistant.row_value(row, "avg_ev")),
+            "hitter_avg_la": assistant.safe_float(assistant.row_value(row, "avg_launch_angle") or assistant.row_value(row, "avg_la")),
+            "hitter_hard_hit_pct": assistant.normalize_rate(assistant.row_value(row, "hard_hit_pct") or assistant.row_value(row, "hardhit_pct")),
+            "hitter_whiff_pct": assistant.normalize_rate(assistant.row_value(row, "whiff_pct")),
+            "hitter_k_pct": assistant.normalize_rate(assistant.row_value(row, "k_pct")),
+            "pa": assistant.safe_int(assistant.row_value(row, "pa_ended") or assistant.row_value(row, "pa")),
+            "pitches_seen": assistant.safe_int(assistant.row_value(row, "pitches_seen")),
+            "target_date": assistant.row_value(row, "target_date").isoformat() if assistant.row_value(row, "target_date") else None,
+            "date_start": assistant.row_value(row, "date_start").isoformat() if assistant.row_value(row, "date_start") else None,
+            "date_end": assistant.row_value(row, "date_end").isoformat() if assistant.row_value(row, "date_end") else None,
+            "refreshed_at": assistant.row_value(row, "refreshed_at").isoformat() if assistant.row_value(row, "refreshed_at") else None,
+            "source": assistant.row_value(row, "source"),
+            "duplicate_rows_removed": assistant.safe_int(assistant.row_value(row, "duplicate_rows_removed")),
+            "watchlist_note": "player prop watchlist angle only; no sportsbook line assumed",
+        })
+
+    scored_rows.sort(key=lambda item: item.get("rank_score") or -999, reverse=True)
+    missing_name_count = sum(1 for item in scored_rows if not item.get("batter_name"))
+    return {
+        "intent": "stored_365_matchups",
+        "date": date,
+        "sources_used": ["batter_pitch_type_matchups", "model_projections.pitch_arsenal", "pitcher_arsenals"],
+        "top_matchups": scored_rows,
+        "data_quality": {
+            "stored_365_rows_scored": len(scored_rows),
+            "stored_365_source_row_limit": row_limit,
+            "stored_365_source_limit_reached": len(rows) >= row_limit,
+            "pitcher_pitch_join_rows": len(pitch_lookup),
+            "missing_batter_names": missing_name_count,
+            "errors": errors,
+        },
+        "missing_data": errors + ([f"{missing_name_count} rows are missing batter names"] if missing_name_count else []),
+    }
+
+
+def install_full_result_finalizer(solver_module: Any) -> None:
+    """Install the report-oriented full-result contract on the existing solver."""
 
     def finalize_component_response(
         date: str,
@@ -194,4 +289,5 @@ def install_full_result_finalizer(solver_module: Any) -> None:
         })
         return response
 
+    solver_module.build_stored_365_sweep_context = build_full_stored_365_sweep_context
     solver_module.finalize_component_response = finalize_component_response

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -7,19 +7,33 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+from . import my_dashboard_solver as dashboard_solver
 from .active_lineup_solver import build_active_lineup_solver_payload
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_context_cache import install_dashboard_context_cache
-from .my_dashboard_solver import build_dashboard_solver_payload, normalize_filter_payload, SUPPORTED_COMPONENTS
+from .my_dashboard_report_query import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    apply_report_query,
+    install_full_result_finalizer,
+)
 from .shared_payload_cache import env_ttl, get_or_set, make_cache_key, stable_hash
 
+install_full_result_finalizer(dashboard_solver)
+
 router = APIRouter()
+SUPPORTED_COMPONENTS = dashboard_solver.SUPPORTED_COMPONENTS
 
 
 class MyDashboardSolverRequest(BaseModel):
     date: Optional[str] = None
     component: str
     filters: Optional[Dict[str, Any]] = None
+    page_size: int = DEFAULT_PAGE_SIZE
+    page_number: int = 1
+    sort_by: str = "score"
+    sort_direction: str = "desc"
+    include_metadata: bool = True
 
 
 class MyDashboardBatchSolverRequest(BaseModel):
@@ -55,6 +69,14 @@ def my_dashboard_health() -> Dict[str, Any]:
         "auth_required": False,
         "persistence": "frontend_localStorage_v1",
         "supported_components": sorted(SUPPORTED_COMPONENTS),
+        "query_contract": {
+            "style": "salesforce_inspired_query_and_describe",
+            "default_page_size": DEFAULT_PAGE_SIZE,
+            "maximum_page_size": MAX_PAGE_SIZE,
+            "full_candidate_universe": True,
+            "final_top_ten_cap": False,
+            "fields": ["totalSize", "done", "records", "page_info", "object_info"],
+        },
         "hydration": {
             "cron_target": "/my-dashboard/solver/hydrate-yesterday",
             "default_lineup_source": "yesterday_confirmed_1_9",
@@ -66,13 +88,36 @@ def my_dashboard_health() -> Dict[str, Any]:
 def my_dashboard_solver_get(
     date: Optional[str] = Query(default=None),
     component: str = Query(default="hitters"),
+    page_size: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+    page_number: int = Query(default=1, ge=1),
+    sort_by: str = Query(default="score"),
+    sort_direction: str = Query(default="desc"),
+    include_metadata: bool = Query(default=True),
 ) -> Dict[str, Any]:
-    return _run_solver(date=date, component=component, filters=None)
+    return _run_solver(
+        date=date,
+        component=component,
+        filters=None,
+        page_size=page_size,
+        page_number=page_number,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
+        include_metadata=include_metadata,
+    )
 
 
 @router.post("/my-dashboard/solver")
 def my_dashboard_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any]:
-    return _run_solver(date=payload.date, component=payload.component, filters=payload.filters)
+    return _run_solver(
+        date=payload.date,
+        component=payload.component,
+        filters=payload.filters,
+        page_size=payload.page_size,
+        page_number=payload.page_number,
+        sort_by=payload.sort_by,
+        sort_direction=payload.sort_direction,
+        include_metadata=payload.include_metadata,
+    )
 
 
 @router.post("/my-dashboard/solver/batch")
@@ -87,7 +132,16 @@ def my_dashboard_solver_batch_post(payload: MyDashboardBatchSolverRequest) -> Di
 
 @router.post("/my-dashboard/solver/active-lineups")
 def my_dashboard_active_lineup_solver_post(payload: MyDashboardSolverRequest) -> Dict[str, Any]:
-    return _run_active_lineup_solver(date=payload.date, component=payload.component, filters=payload.filters)
+    return _run_active_lineup_solver(
+        date=payload.date,
+        component=payload.component,
+        filters=payload.filters,
+        page_size=payload.page_size,
+        page_number=payload.page_number,
+        sort_by=payload.sort_by,
+        sort_direction=payload.sort_direction,
+        include_metadata=payload.include_metadata,
+    )
 
 
 @router.post("/my-dashboard/solver/hydrate-yesterday")
@@ -122,10 +176,20 @@ def _normalize_request(date: Optional[str], component: str, filters: Optional[Di
         dt.date.fromisoformat(target_date)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
+    normalized_component = (component or "").strip().lower()
+    if normalized_component not in SUPPORTED_COMPONENTS:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "Unsupported dashboard component",
+                "component": normalized_component,
+                "supported_components": sorted(SUPPORTED_COMPONENTS),
+            },
+        )
     return {
         "target_date": target_date,
-        "component": (component or "").strip().lower(),
-        "filters": normalize_filter_payload(filters),
+        "component": normalized_component,
+        "filters": dashboard_solver.normalize_filter_payload(filters),
     }
 
 
@@ -138,41 +202,80 @@ def _normalize_component_list(components: Optional[List[str]]) -> List[str]:
     return requested_components
 
 
-def _run_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _query_response(
+    payload: Dict[str, Any],
+    component: str,
+    page_size: int,
+    page_number: int,
+    sort_by: str,
+    sort_direction: str,
+    include_metadata: bool,
+) -> Dict[str, Any]:
+    return apply_report_query(
+        payload=payload,
+        component=component,
+        page_size=page_size,
+        page_number=page_number,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
+        include_metadata=include_metadata,
+    )
+
+
+def _run_solver(
+    date: Optional[str],
+    component: str,
+    filters: Optional[Dict[str, Any]],
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page_number: int = 1,
+    sort_by: str = "score",
+    sort_direction: str = "desc",
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
     install_dashboard_context_cache()
     normalized = _normalize_request(date, component, filters)
     target_date = normalized["target_date"]
     normalized_component = normalized["component"]
     normalized_filters = normalized["filters"]
     filters_hash = stable_hash(normalized_filters)
-    cache_key = make_cache_key("dashboard_solver", "component", target_date, normalized_component, filters_hash)
+    cache_key = make_cache_key("dashboard_solver", "component_full_result", target_date, normalized_component, filters_hash)
 
     try:
         def build() -> Dict[str, Any]:
             factory = session_factory()
             with factory() as session:
-                return build_dashboard_solver_payload(
+                return dashboard_solver.build_dashboard_solver_payload(
                     session=session,
                     date=target_date,
                     component=normalized_component,
                     filters=normalized_filters,
                 )
 
-        return get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+        full_payload = get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+        return _query_response(full_payload, normalized_component, page_size, page_number, sort_by, sort_direction, include_metadata)
     except HTTPException:
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "My Dashboard solver failed", "error": str(exc)}) from exc
 
 
-def _run_active_lineup_solver(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _run_active_lineup_solver(
+    date: Optional[str],
+    component: str,
+    filters: Optional[Dict[str, Any]],
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page_number: int = 1,
+    sort_by: str = "score",
+    sort_direction: str = "desc",
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
     install_dashboard_context_cache()
     normalized = _normalize_request(date, component, filters)
     target_date = normalized["target_date"]
     normalized_component = normalized["component"]
     normalized_filters = normalized["filters"]
     filters_hash = stable_hash(normalized_filters)
-    cache_key = make_cache_key("dashboard_solver", "active_lineups", target_date, normalized_component, filters_hash)
+    cache_key = make_cache_key("dashboard_solver", "active_lineups_full_result", target_date, normalized_component, filters_hash)
 
     try:
         def build() -> Dict[str, Any]:
@@ -185,7 +288,8 @@ def _run_active_lineup_solver(date: Optional[str], component: str, filters: Opti
                     filters=normalized_filters,
                 )
 
-        return get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+        full_payload = get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+        return _query_response(full_payload, normalized_component, page_size, page_number, sort_by, sort_direction, include_metadata)
     except HTTPException:
         raise
     except Exception as exc:
@@ -206,15 +310,14 @@ def _run_batch_solver(
         raise HTTPException(status_code=400, detail=f"Invalid date: {date}") from exc
 
     requested_components = _normalize_component_list(components)
-
     normalized_filters_by_component = {
-        component: normalize_filter_payload((filters_by_component or {}).get(component))
+        component: dashboard_solver.normalize_filter_payload((filters_by_component or {}).get(component))
         for component in requested_components
     }
     filters_hash = stable_hash(normalized_filters_by_component)
     cache_key = make_cache_key(
         "dashboard_solver",
-        "batch_active_lineups" if active_lineups else "batch",
+        "batch_active_lineups_full_result" if active_lineups else "batch_full_result",
         target_date,
         ",".join(requested_components),
         filters_hash,
@@ -254,7 +357,7 @@ def _run_hydration(
     normalized_filters_by_component = {component: {} for component in requested_components}
     cache_key = make_cache_key(
         "dashboard_solver",
-        "morning_hydration_active_lineups" if active_lineups else "morning_hydration",
+        "morning_hydration_active_lineups_full_result" if active_lineups else "morning_hydration_full_result",
         target_date,
         ",".join(requested_components),
     )
@@ -305,7 +408,7 @@ def _build_batch_payload(
                     filters=filters,
                 )
             else:
-                results[component] = build_dashboard_solver_payload(
+                results[component] = dashboard_solver.build_dashboard_solver_payload(
                     session=session,
                     date=target_date,
                     component=component,

--- a/tests/test_my_dashboard_report_query.py
+++ b/tests/test_my_dashboard_report_query.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mlb_app.my_dashboard_report_query import (
+    MAX_PAGE_SIZE,
+    apply_report_query,
+    field_metadata,
+    install_full_result_finalizer,
+    normalize_query,
+)
+
+
+def _items(count: int):
+    return [
+        {
+            "entity_id": str(index),
+            "entity_name": f"Player {index}",
+            "score": float(index),
+            "metrics": {"xwOBA": round(index / 1000, 3)},
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+def test_normalize_query_clamps_page_size_and_direction():
+    query = normalize_query(page_size=9999, page_number=-4, sort_by="entity_name", sort_direction="sideways")
+    assert query == {
+        "page_size": MAX_PAGE_SIZE,
+        "page_number": 1,
+        "offset": 0,
+        "sort_by": "entity_name",
+        "sort_direction": "desc",
+    }
+
+
+def test_query_envelope_pages_full_universe_without_top_ten_cap():
+    payload = {"items": _items(27), "date": "2026-07-13", "component": "hitters"}
+    page = apply_report_query(payload, "hitters", page_size=10, page_number=2, sort_by="score", sort_direction="desc")
+
+    assert page["totalSize"] == 27
+    assert page["total_count"] == 27
+    assert len(page["records"]) == 10
+    assert page["records"][0]["entity_name"] == "Player 17"
+    assert page["records"][-1]["entity_name"] == "Player 8"
+    assert page["done"] is False
+    assert page["page_info"]["next_page"] == 3
+    assert page["page_info"]["previous_page"] == 1
+
+
+def test_query_can_sort_by_nested_metric():
+    payload = {"items": _items(4)}
+    page = apply_report_query(payload, "hitters", page_size=50, sort_by="metrics.xwOBA", sort_direction="asc")
+    assert [record["entity_id"] for record in page["records"]] == ["1", "2", "3", "4"]
+
+
+def test_field_metadata_is_server_owned_and_describe_like():
+    fields = field_metadata("hitters", _items(2))
+    by_name = {field["name"]: field for field in fields}
+    assert by_name["entity_name"]["type"] == "string"
+    assert by_name["entity_name"]["sortable"] is True
+    assert by_name["metrics.xwOBA"]["filterable"] is True
+    assert by_name["metrics.xwOBA"]["source"] == "server_metric_registry"
+
+
+def test_installed_finalizer_preserves_every_deduped_filtered_record():
+    def dedupe(items, key_fn, limit=10):
+        unique = {}
+        for item in items:
+            unique[key_fn(item)] = dict(item)
+        ranked = sorted(unique.values(), key=lambda item: item["score"], reverse=True)[:limit]
+        for rank, item in enumerate(ranked, start=1):
+            item["rank"] = rank
+        return ranked
+
+    def apply_filters(items, filters):
+        return list(items), filters or {}, [], len(items), len(items)
+
+    def build_response(date, component, items, data_quality, missing_data):
+        return {"date": date, "component": component, "items": items}
+
+    fake_solver = SimpleNamespace(
+        dedupe_ranked_items=dedupe,
+        apply_dashboard_filters=apply_filters,
+        build_response=build_response,
+        available_filters_for_component=lambda component, items: {"metrics": []},
+        finalize_component_response=None,
+    )
+    install_full_result_finalizer(fake_solver)
+    candidates = _items(31)
+    result = fake_solver.finalize_component_response(
+        "2026-07-13",
+        "hitters",
+        candidates,
+        lambda item: item["entity_id"],
+    )
+
+    assert len(result["items"]) == 31
+    assert result["candidate_universe_count"] == 31
+    assert result["deduped_universe_count"] == 31
+    assert result["result_cap_applied"] is False


### PR DESCRIPTION
## Summary

Implements the next My Dashboard backend foundation: full-result querying, server-side pagination, total counts, sorting, and server-owned field metadata.

## Core behavior change

The previous solver had two presentation caps:

1. Stored 365 hitter context scored up to 1,500 database rows but exposed only its top 25 rows.
2. The dashboard finalizer deduplicated/filter-scored the pool and then truncated the final response to 10 records.

This PR removes both report-layer caps for My Dashboard. Pagination now limits only the response page, not the underlying candidate universe.

## What changed

- Adds a Salesforce-inspired query envelope to the existing `/my-dashboard/solver` and `/my-dashboard/solver/active-lineups` endpoints.
- Supports `page_size`, `page_number`, `sort_by`, `sort_direction`, and `include_metadata` in GET and POST requests.
- Returns `totalSize`, `done`, `records`, `items`, `page_info`, `query`, and `object_info`.
- Defaults to 50 rows per page and allows up to 250 rows per page.
- Sorts before pagination, including nested metric fields such as `metrics.xwOBA`.
- Adds server-owned object/field metadata with type, label, group, sortable, filterable, and nillable properties.
- Preserves every deduplicated candidate after filters instead of applying a final top-10 cap.
- Reuses the existing Stored 365 scoring function while exposing the full scored hitter row set to the dashboard.
- Raises the configurable Stored 365 source-row ceiling to 10,000 through `DASHBOARD_HITTER_SOURCE_ROW_LIMIT`.
- Keeps confirmed-lineup filtering after the full hitter universe is built, so the active-lineup endpoint can return every matched confirmed hitter rather than only hitters that happened to appear in the prior top 10/25.
- Updates cache namespaces so older capped payloads are not reused.
- Adds focused tests for pagination, total counts, nested metric sorting, metadata, page-size limits, and full-result finalization.

## Salesforce alignment

This is intentionally Salesforce-inspired rather than wire-compatible.

### Query API concepts mirrored

- `totalSize`: full filtered result count
- `done`: whether another page remains
- `records`: current response page
- query continuation state through `page_info.next_page` / `previous_page`
- server-side sorting and pagination

### Describe API concepts mirrored

- object-level metadata in `object_info`
- server-owned field names and labels
- field types
- `sortable`, `filterable`, and `nillable` capabilities
- report-object identity and lineup-scope support

### MLBGPT-specific additions retained

- scoring and source lineage
- lineup verification/source/date
- missing-data and quality metadata
- metric namespaces such as `metrics.xwOBA`

## Important universe semantics

- Hitters: query the Stored 365 database rows for the requested date, score the available pool, deduplicate to one report row per hitter, then optionally filter against the confirmed 1–9 lineup.
- Pitchers: include every available projected starter/pitcher lean in the requested slate.
- Teams: include both teams from every available projected game.
- Totals: include every available projected game total.
- Overall Players: combine the available hitter and pitcher universes without a final top-10 cap.

The active-lineup endpoint remains the preferred path when today’s lineups are confirmed. Yesterday’s confirmed lineup hydration remains available as the fallback/warm path.

## Scope

- No scoring formulas changed.
- No matchup generation changed.
- No new user-facing route was created.
- Existing endpoints remain backward compatible: `items` still exists, but now contains the requested page and is accompanied by the full count and metadata.

## Validation required before merge

- Run `pytest tests/test_my_dashboard_report_query.py`.
- Run the existing My Dashboard solver and route tests.
- Verify a hitter response can return more than 10 total records.
- Verify active-lineup mode returns all confirmed lineup hitters available in the Stored 365 table.
- Verify page 1/page 2 have stable, non-overlapping records under the same sort.
- Verify sorting by `score`, `entity_name`, and `metrics.xwOBA`.
- Load-test the configured 10,000-row Stored 365 source ceiling against production PostgreSQL.

## Follow-up PR

Wire the Report Workspace UI to `page_info`, `totalSize`, and `object_info`, including Next/Previous controls, page-size selection, and server-owned field rendering.