### PR TITLE
PR 3: route filtered My Dashboard reports through persisted datasets

### DIFF
--- a/mlb_app/my_dashboard_dataset_runtime.py
+++ b/mlb_app/my_dashboard_dataset_runtime.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Callable, Dict, Optional
+from zoneinfo import ZoneInfo
+
+from .my_dashboard_dataset import dashboard_dataset_status, hydrate_dashboard_dataset
+from .my_dashboard_sql_query import query_dashboard_dataset
+
+
+MLB_TIMEZONE = ZoneInfo("America/New_York")
+SUBSTANTIVE_FILTER_KEYS = {
+    "search_text",
+    "team",
+    "opponent",
+    "category",
+    "entity_type",
+    "player_type",
+    "pitch_type",
+    "pitch_name",
+    "source",
+    "min_score",
+    "max_score",
+    "min_confidence",
+    "metrics",
+}
+
+
+def mlb_business_date(now: Optional[dt.datetime] = None) -> dt.date:
+    current = now or dt.datetime.now(dt.timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.timezone.utc)
+    return current.astimezone(MLB_TIMEZONE).date()
+
+
+def has_substantive_filters(filters: Optional[Dict[str, Any]]) -> bool:
+    if not isinstance(filters, dict):
+        return False
+    for key in SUBSTANTIVE_FILTER_KEYS:
+        value = filters.get(key)
+        if key == "metrics":
+            if isinstance(value, dict) and any(
+                isinstance(rule, dict)
+                and any(bound not in (None, "") for bound in (rule.get("min"), rule.get("max")))
+                for rule in value.values()
+            ):
+                return True
+            continue
+        if value not in (None, "", {}, []):
+            return True
+    return False
+
+
+def has_weight_overrides(filters: Optional[Dict[str, Any]]) -> bool:
+    weights = filters.get("weights") if isinstance(filters, dict) else None
+    if not isinstance(weights, dict):
+        return False
+    return any(value not in (None, "", 1, 1.0, "1", "1.0") for value in weights.values())
+
+
+def should_use_dataset_query(*, date: str, filters: Optional[Dict[str, Any]]) -> bool:
+    try:
+        requested_date = dt.date.fromisoformat(str(date)[:10])
+    except ValueError:
+        return False
+    return (
+        requested_date == mlb_business_date()
+        and has_substantive_filters(filters)
+        and not has_weight_overrides(filters)
+    )
+
+
+def _dataset_ttl_seconds(active_lineups: bool) -> int:
+    name = "DASHBOARD_ACTIVE_LINEUP_DATASET_TTL_SECONDS" if active_lineups else "DASHBOARD_DATASET_TTL_SECONDS"
+    default = 30 if active_lineups else 300
+    try:
+        return max(1, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def run_dataset_query(
+    *,
+    session: Any,
+    date: str,
+    component: str,
+    filters: Dict[str, Any],
+    page_size: int,
+    page_number: int,
+    sort_by: str,
+    sort_direction: str,
+    include_metadata: bool,
+    payload_builder: Callable[[], Dict[str, Any]],
+    active_lineups: bool = False,
+) -> Dict[str, Any]:
+    status = dashboard_dataset_status(
+        session=session,
+        date=date,
+        component=component,
+        active_lineups=active_lineups,
+    )
+    hydration: Optional[Dict[str, Any]] = None
+    served_stale = False
+
+    if not status.get("ready") or status.get("stale"):
+        try:
+            hydration = hydrate_dashboard_dataset(
+                session=session,
+                date=date,
+                component=component,
+                payload_builder=payload_builder,
+                active_lineups=active_lineups,
+                ttl_seconds=_dataset_ttl_seconds(active_lineups),
+                solver_version="my_dashboard_solver_v1",
+            )
+        except Exception:
+            refreshed_status = dashboard_dataset_status(
+                session=session,
+                date=date,
+                component=component,
+                active_lineups=active_lineups,
+            )
+            if not refreshed_status.get("ready"):
+                raise
+            status = refreshed_status
+            served_stale = True
+
+    result = query_dashboard_dataset(
+        session=session,
+        date=date,
+        component=component,
+        filters=filters,
+        page_size=page_size,
+        page_number=page_number,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
+        include_metadata=include_metadata,
+        active_lineups=active_lineups,
+    )
+    result.update({
+        "execution_path": "my_dashboard_dataset_sql_query",
+        "dataset_hydrated_for_request": bool(hydration),
+        "dataset_hydration": hydration,
+        "served_stale_dataset": served_stale,
+    })
+    if served_stale:
+        warnings = list(result.get("filter_warnings") or [])
+        warnings.append("Dataset refresh failed; previous current dataset was served")
+        result["filter_warnings"] = warnings
+    return result

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -11,6 +11,7 @@ from . import my_dashboard_solver as dashboard_solver
 from .active_lineup_solver import build_active_lineup_solver_payload
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_context_cache import install_dashboard_context_cache
+from .my_dashboard_dataset_runtime import mlb_business_date, run_dataset_query, should_use_dataset_query
 from .my_dashboard_observability import (
     begin_hydration,
     complete_hydration,
@@ -65,7 +66,7 @@ def session_factory():
 
 
 def _yesterday_iso() -> str:
-    return (dt.date.today() - dt.timedelta(days=1)).isoformat()
+    return (mlb_business_date() - dt.timedelta(days=1)).isoformat()
 
 
 @router.get("/my-dashboard/health")
@@ -83,6 +84,7 @@ def my_dashboard_health() -> Dict[str, Any]:
             "full_candidate_universe": True,
             "final_top_ten_cap": False,
             "fields": ["totalSize", "done", "records", "page_info", "object_info"],
+            "filtered_current_date_source": "my_dashboard_records",
         },
         "lineup_policy": {
             "today_confirmed_preferred": True,
@@ -192,7 +194,7 @@ def my_dashboard_hydrate_yesterday_get(
 
 
 def _normalize_request(date: Optional[str], component: str, filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
-    target_date = (date or dt.date.today().isoformat())[:10]
+    target_date = (date or mlb_business_date().isoformat())[:10]
     try:
         dt.date.fromisoformat(target_date)
     except ValueError as exc:
@@ -243,6 +245,50 @@ def _query_response(
     )
 
 
+def _legacy_solver_response(
+    *,
+    target_date: str,
+    component: str,
+    filters: Dict[str, Any],
+    page_size: int,
+    page_number: int,
+    sort_by: str,
+    sort_direction: str,
+    include_metadata: bool,
+    active_lineups: bool,
+) -> Dict[str, Any]:
+    filters_hash = stable_hash(filters)
+    cache_key = make_cache_key(
+        "dashboard_solver",
+        "active_lineups_full_result" if active_lineups else "component_full_result",
+        target_date,
+        component,
+        filters_hash,
+    )
+
+    def build() -> Dict[str, Any]:
+        factory = session_factory()
+        with factory() as session:
+            if active_lineups:
+                return build_active_lineup_solver_payload(
+                    session=session,
+                    date=target_date,
+                    component=component,
+                    filters=filters,
+                )
+            return dashboard_solver.build_dashboard_solver_payload(
+                session=session,
+                date=target_date,
+                component=component,
+                filters=filters,
+            )
+
+    full_payload = get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
+    response = _query_response(full_payload, component, page_size, page_number, sort_by, sort_direction, include_metadata)
+    response.setdefault("execution_path", "legacy_in_memory_solver")
+    return response
+
+
 def _run_solver(
     date: Optional[str],
     component: str,
@@ -258,22 +304,40 @@ def _run_solver(
     target_date = normalized["target_date"]
     normalized_component = normalized["component"]
     normalized_filters = normalized["filters"]
-    filters_hash = stable_hash(normalized_filters)
-    cache_key = make_cache_key("dashboard_solver", "component_full_result", target_date, normalized_component, filters_hash)
 
     try:
-        def build() -> Dict[str, Any]:
+        if should_use_dataset_query(date=target_date, filters=normalized_filters):
             factory = session_factory()
             with factory() as session:
-                return dashboard_solver.build_dashboard_solver_payload(
+                return run_dataset_query(
                     session=session,
                     date=target_date,
                     component=normalized_component,
                     filters=normalized_filters,
+                    page_size=page_size,
+                    page_number=page_number,
+                    sort_by=sort_by,
+                    sort_direction=sort_direction,
+                    include_metadata=include_metadata,
+                    payload_builder=lambda: dashboard_solver.build_dashboard_solver_payload(
+                        session=session,
+                        date=target_date,
+                        component=normalized_component,
+                        filters={},
+                    ),
+                    active_lineups=False,
                 )
-
-        full_payload = get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
-        return _query_response(full_payload, normalized_component, page_size, page_number, sort_by, sort_direction, include_metadata)
+        return _legacy_solver_response(
+            target_date=target_date,
+            component=normalized_component,
+            filters=normalized_filters,
+            page_size=page_size,
+            page_number=page_number,
+            sort_by=sort_by,
+            sort_direction=sort_direction,
+            include_metadata=include_metadata,
+            active_lineups=False,
+        )
     except HTTPException:
         raise
     except Exception as exc:
@@ -295,22 +359,40 @@ def _run_active_lineup_solver(
     target_date = normalized["target_date"]
     normalized_component = normalized["component"]
     normalized_filters = normalized["filters"]
-    filters_hash = stable_hash(normalized_filters)
-    cache_key = make_cache_key("dashboard_solver", "active_lineups_full_result", target_date, normalized_component, filters_hash)
 
     try:
-        def build() -> Dict[str, Any]:
+        if should_use_dataset_query(date=target_date, filters=normalized_filters):
             factory = session_factory()
             with factory() as session:
-                return build_active_lineup_solver_payload(
+                return run_dataset_query(
                     session=session,
                     date=target_date,
                     component=normalized_component,
                     filters=normalized_filters,
+                    page_size=page_size,
+                    page_number=page_number,
+                    sort_by=sort_by,
+                    sort_direction=sort_direction,
+                    include_metadata=include_metadata,
+                    payload_builder=lambda: build_active_lineup_solver_payload(
+                        session=session,
+                        date=target_date,
+                        component=normalized_component,
+                        filters={},
+                    ),
+                    active_lineups=True,
                 )
-
-        full_payload = get_or_set(cache_key, env_ttl("DASHBOARD_SOLVER_CACHE_TTL_SECONDS"), build)
-        return _query_response(full_payload, normalized_component, page_size, page_number, sort_by, sort_direction, include_metadata)
+        return _legacy_solver_response(
+            target_date=target_date,
+            component=normalized_component,
+            filters=normalized_filters,
+            page_size=page_size,
+            page_number=page_number,
+            sort_by=sort_by,
+            sort_direction=sort_direction,
+            include_metadata=include_metadata,
+            active_lineups=True,
+        )
     except HTTPException:
         raise
     except Exception as exc:
@@ -324,7 +406,7 @@ def _run_batch_solver(
     active_lineups: bool = False,
 ) -> Dict[str, Any]:
     install_dashboard_context_cache()
-    target_date = (date or dt.date.today().isoformat())[:10]
+    target_date = (date or mlb_business_date().isoformat())[:10]
     try:
         dt.date.fromisoformat(target_date)
     except ValueError as exc:

--- a/tests/test_my_dashboard_dataset_runtime.py
+++ b/tests/test_my_dashboard_dataset_runtime.py
@@ -1,0 +1,116 @@
+import datetime as dt
+
+import pytest
+
+from mlb_app import my_dashboard_dataset_runtime as runtime
+
+
+def test_substantive_filter_detection():
+    assert runtime.has_substantive_filters({"team": "CHC"}) is True
+    assert runtime.has_substantive_filters({"metrics": {"EV": {"min": 90}}}) is True
+    assert runtime.has_substantive_filters({"metrics": {"EV": {"min": "", "max": ""}}}) is False
+    assert runtime.has_substantive_filters({"weights": {"EV": 1.5}}) is False
+    assert runtime.has_substantive_filters({}) is False
+
+
+def test_weight_overrides_stay_on_legacy_path(monkeypatch):
+    monkeypatch.setattr(runtime, "mlb_business_date", lambda now=None: dt.date(2026, 7, 15))
+    assert runtime.should_use_dataset_query(date="2026-07-15", filters={"team": "CHC"}) is True
+    assert runtime.should_use_dataset_query(date="2026-07-15", filters={"team": "CHC", "weights": {"EV": 1.5}}) is False
+    assert runtime.should_use_dataset_query(date="2026-07-14", filters={"team": "CHC"}) is False
+    assert runtime.should_use_dataset_query(date="2026-07-15", filters={}) is False
+
+
+def test_mlb_business_date_uses_eastern_boundary():
+    before_midnight_eastern = dt.datetime(2026, 7, 15, 3, 30, tzinfo=dt.timezone.utc)
+    after_midnight_eastern = dt.datetime(2026, 7, 15, 4, 30, tzinfo=dt.timezone.utc)
+    assert runtime.mlb_business_date(before_midnight_eastern) == dt.date(2026, 7, 14)
+    assert runtime.mlb_business_date(after_midnight_eastern) == dt.date(2026, 7, 15)
+
+
+def test_runtime_hydrates_unfiltered_then_queries(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(runtime, "dashboard_dataset_status", lambda **kwargs: {"ready": False, "stale": False})
+
+    def fake_hydrate(**kwargs):
+        events.append(("hydrate", kwargs["payload_builder"]()))
+        return {"dataset_version": "v1", "dataset_row_count": 2}
+
+    def fake_query(**kwargs):
+        events.append(("query", kwargs["filters"]))
+        return {"items": [{"entity_id": "1"}], "records": [{"entity_id": "1"}], "totalSize": 1}
+
+    monkeypatch.setattr(runtime, "hydrate_dashboard_dataset", fake_hydrate)
+    monkeypatch.setattr(runtime, "query_dashboard_dataset", fake_query)
+
+    result = runtime.run_dataset_query(
+        session=object(),
+        date="2026-07-15",
+        component="hitters",
+        filters={"team": "CHC"},
+        page_size=50,
+        page_number=1,
+        sort_by="score",
+        sort_direction="desc",
+        include_metadata=True,
+        payload_builder=lambda: {"items": [{"entity_id": "1"}, {"entity_id": "2"}]},
+        active_lineups=False,
+    )
+
+    assert events[0][0] == "hydrate"
+    assert events[0][1]["items"] == [{"entity_id": "1"}, {"entity_id": "2"}]
+    assert events[1] == ("query", {"team": "CHC"})
+    assert result["execution_path"] == "my_dashboard_dataset_sql_query"
+    assert result["dataset_hydrated_for_request"] is True
+
+
+def test_runtime_serves_previous_dataset_when_refresh_fails(monkeypatch):
+    statuses = iter([
+        {"ready": True, "stale": True},
+        {"ready": True, "stale": True, "dataset_version": "old"},
+    ])
+    monkeypatch.setattr(runtime, "dashboard_dataset_status", lambda **kwargs: next(statuses))
+    monkeypatch.setattr(runtime, "hydrate_dashboard_dataset", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("refresh failed")))
+    monkeypatch.setattr(runtime, "query_dashboard_dataset", lambda **kwargs: {"items": [], "records": [], "totalSize": 0})
+
+    result = runtime.run_dataset_query(
+        session=object(),
+        date="2026-07-15",
+        component="hitters",
+        filters={"team": "CHC"},
+        page_size=50,
+        page_number=1,
+        sort_by="score",
+        sort_direction="desc",
+        include_metadata=True,
+        payload_builder=lambda: {"items": []},
+        active_lineups=False,
+    )
+
+    assert result["served_stale_dataset"] is True
+    assert "previous current dataset was served" in result["filter_warnings"][0]
+
+
+def test_runtime_raises_when_no_dataset_and_hydration_fails(monkeypatch):
+    statuses = iter([
+        {"ready": False, "stale": False},
+        {"ready": False, "stale": False},
+    ])
+    monkeypatch.setattr(runtime, "dashboard_dataset_status", lambda **kwargs: next(statuses))
+    monkeypatch.setattr(runtime, "hydrate_dashboard_dataset", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("refresh failed")))
+
+    with pytest.raises(RuntimeError, match="refresh failed"):
+        runtime.run_dataset_query(
+            session=object(),
+            date="2026-07-15",
+            component="hitters",
+            filters={"team": "CHC"},
+            page_size=50,
+            page_number=1,
+            sort_by="score",
+            sort_direction="desc",
+            include_metadata=True,
+            payload_builder=lambda: {"items": []},
+            active_lineups=False,
+        )


### PR DESCRIPTION
Continues #1043 after merged PRs #1044 and #1045.

## What changes
- Preserves the public `/my-dashboard/solver` and `/my-dashboard/solver/active-lineups` contracts
- Uses the persisted `my_dashboard_records` dataset for current MLB-date reports with substantive filters
- Hydrates an unfiltered analytical universe only when the dataset is absent or stale
- Executes the user filter, count, sort, offset, and limit through the SQL query layer
- Uses `America/New_York` for the MLB business-date boundary
- Keeps standard and active-lineup dataset modes isolated
- Adds dataset provenance and execution-path metadata
- Serves the previous current dataset with an explicit warning when refresh fails

## Compatibility guardrails
The following remain on the existing legacy path:
- Unfiltered reports
- Historical-date reports
- Requests containing scoring-weight overrides
- Batch solver behavior
- Existing saved report snapshots and definitions

Weights remain on the legacy solver because SQL-native weight-aware ranking has not yet been implemented. This avoids changing formulas or paginating before weighted ranking.

## Runtime impact
A repeated filtered report for today no longer rebuilds Model Projections, AI Assistant contexts, Stored 365 joins, or arsenal scoring while its persisted dataset is fresh. Standard datasets default to a 300-second TTL; active-lineup datasets default to 30 seconds. Both are configurable through environment variables.

## Failure safety
- Hydration writes and promotes through the dataset foundation transaction
- Failed refreshes do not replace the previous valid dataset
- If no valid dataset exists and hydration fails, the route returns the existing explicit solver failure response rather than fabricated rows

## Tests added
- Substantive filter selection
- Weight-override legacy selection
- Eastern-time business-date boundary
- Hydrate-then-query ordering
- Previous-version stale serving
- No-dataset hydration failure

## Deliberately unchanged
- `MyDashboardReportBuilderPage.jsx`
- Scoring formulas
- Saved report schemas
- Matchups and Matchup Detail
- Daily Odds
- Model Projections
- AI Data Assistant

Next PR: wire the existing Report Builder to send server pagination and sorting, consume `totalSize` and `page_info`, and stop locally sorting a single page.