### PR TITLE
PR 5: add SQL-native My Dashboard weight ranking

### DIFF
--- a/docs/my_dashboard_sql_weight_ranking.md
+++ b/docs/my_dashboard_sql_weight_ranking.md
@@ -1,0 +1,22 @@
+# My Dashboard SQL weight ranking
+
+Issue: #1048
+
+This slice removes the final current-date filtered-report exception that routed scoring-weight overrides through the legacy in-memory solver.
+
+## Preserved formula
+
+The SQL expression reproduces the existing `my_dashboard_solver.apply_weight_overrides` contract:
+
+`adjusted = base_score + normalized_metric * (weight - 1.0) * 0.25`
+
+Metric normalization uses the same EV, launch-angle, sample-size, total, score/edge/diff, walk-rate, allowed-contact, and generic clamp rules.
+
+## Safety boundary
+
+- User weights are normalized per request and never persisted.
+- Basic and metric filters execute before weight adjustment, matching the current Python behavior.
+- Weighted score is calculated before sorting, offset, and limit.
+- Shared `my_dashboard_records` rows remain unchanged.
+- Unsupported weight metrics are ignored with explicit warnings.
+- Historical and unfiltered reports retain their existing compatibility paths.

--- a/mlb_app/my_dashboard_dataset_runtime.py
+++ b/mlb_app/my_dashboard_dataset_runtime.py
@@ -24,6 +24,7 @@ SUBSTANTIVE_FILTER_KEYS = {
     "max_score",
     "min_confidence",
     "metrics",
+    "weights",
 }
 
 
@@ -47,6 +48,12 @@ def has_substantive_filters(filters: Optional[Dict[str, Any]]) -> bool:
             ):
                 return True
             continue
+        if key == "weights":
+            if isinstance(value, dict) and any(
+                weight not in (None, "", 1, 1.0, "1", "1.0") for weight in value.values()
+            ):
+                return True
+            continue
         if value not in (None, "", {}, []):
             return True
     return False
@@ -64,11 +71,7 @@ def should_use_dataset_query(*, date: str, filters: Optional[Dict[str, Any]]) ->
         requested_date = dt.date.fromisoformat(str(date)[:10])
     except ValueError:
         return False
-    return (
-        requested_date == mlb_business_date()
-        and has_substantive_filters(filters)
-        and not has_weight_overrides(filters)
-    )
+    return requested_date == mlb_business_date() and has_substantive_filters(filters)
 
 
 def _dataset_ttl_seconds(active_lineups: bool) -> int:

--- a/mlb_app/my_dashboard_sql_query.py
+++ b/mlb_app/my_dashboard_sql_query.py
@@ -20,6 +20,7 @@ from .my_dashboard_report_query import (
     field_metadata,
     normalize_query,
 )
+from .my_dashboard_sql_weights import normalize_weights, weight_explanations, weighted_score_expression
 
 
 CONFIDENCE_ORDER = {"low": 1, "medium": 2, "high": 3}
@@ -179,12 +180,12 @@ def _apply_filters(query: Any, component: str, filters: Dict[str, Any]) -> Tuple
             query = query.filter(expression >= rules["min"])
         if rules.get("max") is not None:
             query = query.filter(expression <= rules["max"])
-    if filters.get("weights"):
-        warnings.append("Weight-aware SQL ranking is intentionally deferred; shared dataset rows remain unmodified")
     return query, warnings
 
 
-def _sort_expression(component: str, sort_by: str):
+def _sort_expression(component: str, sort_by: str, weighted_expression=None):
+    if weighted_expression is not None and sort_by in {"rank", "score", "adjusted_score"}:
+        return weighted_expression
     if sort_by == "rank":
         return MyDashboardRecord.score
     if sort_by.startswith("metrics."):
@@ -200,8 +201,16 @@ def _sort_expression(component: str, sort_by: str):
     return expression
 
 
-def _record_to_dict(row: MyDashboardRecord, rank: int) -> Dict[str, Any]:
+def _record_to_dict(
+    row: MyDashboardRecord,
+    rank: int,
+    *,
+    adjusted_score: Optional[float] = None,
+    explanations: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     record = dict(row.record_json or {})
+    effective_score = round(float(adjusted_score), 3) if adjusted_score is not None else row.score
+    base_score = row.base_score if row.base_score is not None else row.score
     record.update({
         "rank": rank,
         "entity_id": row.entity_id,
@@ -214,9 +223,9 @@ def _record_to_dict(row: MyDashboardRecord, rank: int) -> Dict[str, Any]:
         "category": row.category,
         "pitch_type": row.pitch_type,
         "pitch_name": row.pitch_name,
-        "score": row.score,
-        "base_score": row.base_score,
-        "adjusted_score": row.adjusted_score,
+        "score": effective_score,
+        "base_score": base_score,
+        "adjusted_score": effective_score if adjusted_score is not None else row.adjusted_score,
         "confidence": row.confidence,
         "primary_reason": row.primary_reason,
         "source": row.source,
@@ -230,6 +239,8 @@ def _record_to_dict(row: MyDashboardRecord, rank: int) -> Dict[str, Any]:
         "lineup_revision": row.lineup_revision,
         "model_state": row.model_state,
     })
+    if adjusted_score is not None:
+        record["weight_explanation"] = list(explanations or [])
     return record
 
 
@@ -252,6 +263,11 @@ def query_dashboard_dataset(
         raise ValueError(f"Unsupported dashboard component: {component}")
     query_contract = normalize_query(page_size, page_number, sort_by, sort_direction)
     normalized_filters = normalize_dataset_filters(filters)
+    weights, weight_warnings = normalize_weights(normalized_component, normalized_filters.get("weights"))
+    if weights:
+        normalized_filters["weights"] = weights
+    else:
+        normalized_filters.pop("weights", None)
     mode = DATASET_MODE_ACTIVE_LINEUPS if active_lineups else DATASET_MODE_STANDARD
     base_query = session.query(MyDashboardRecord).filter(
         and_(
@@ -262,17 +278,27 @@ def query_dashboard_dataset(
         )
     )
     filtered_query, warnings = _apply_filters(base_query, normalized_component, normalized_filters)
+    warnings.extend(weight_warnings)
     total_size = filtered_query.order_by(None).count()
-    sort_expression = _sort_expression(normalized_component, query_contract["sort_by"])
+    weighted_expression = weighted_score_expression(weights) if weights else None
+    sort_expression = _sort_expression(normalized_component, query_contract["sort_by"], weighted_expression)
     primary_order = sort_expression.asc().nullslast() if query_contract["sort_direction"] == "asc" else sort_expression.desc().nullslast()
-    rows = (
-        filtered_query
-        .order_by(primary_order, MyDashboardRecord.entity_key.asc(), MyDashboardRecord.id.asc())
-        .offset(query_contract["offset"])
-        .limit(query_contract["page_size"])
-        .all()
-    )
-    records = [_record_to_dict(row, query_contract["offset"] + index) for index, row in enumerate(rows, start=1)]
+    ordered_query = filtered_query.order_by(primary_order, MyDashboardRecord.entity_key.asc(), MyDashboardRecord.id.asc())
+    if weighted_expression is not None:
+        raw_rows = (
+            ordered_query.add_columns(weighted_expression.label("query_adjusted_score"))
+            .offset(query_contract["offset"])
+            .limit(query_contract["page_size"])
+            .all()
+        )
+        explanations = weight_explanations(weights)
+        records = [
+            _record_to_dict(row, query_contract["offset"] + index, adjusted_score=adjusted, explanations=explanations)
+            for index, (row, adjusted) in enumerate(raw_rows, start=1)
+        ]
+    else:
+        rows = ordered_query.offset(query_contract["offset"]).limit(query_contract["page_size"]).all()
+        records = [_record_to_dict(row, query_contract["offset"] + index) for index, row in enumerate(rows, start=1)]
     page_count = math.ceil(total_size / query_contract["page_size"]) if total_size else 0
     end = query_contract["offset"] + len(records)
     has_next = end < total_size
@@ -294,6 +320,12 @@ def query_dashboard_dataset(
         "query": query_contract,
         "filters_applied": normalized_filters,
         "filter_warnings": warnings,
+        "weight_ranking": {
+            "enabled": bool(weights),
+            "weights": weights,
+            "formula": "base_score + normalized_metric * (weight - 1.0) * 0.25",
+            "persisted": False,
+        },
         "page_info": {
             "page_number": query_contract["page_number"],
             "page_size": query_contract["page_size"],

--- a/mlb_app/my_dashboard_sql_weights.py
+++ b/mlb_app/my_dashboard_sql_weights.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from sqlalchemy import Float, case, cast, func
+
+from .my_dashboard_dataset import MyDashboardRecord
+from .my_dashboard_report_query import METRIC_FIELDS
+
+
+def normalize_weights(component: str, weights: Any) -> Tuple[Dict[str, float], List[str]]:
+    if not isinstance(weights, dict):
+        return {}, []
+    registered = set(METRIC_FIELDS.get(component, []))
+    normalized: Dict[str, float] = {}
+    warnings: List[str] = []
+    for metric, raw_value in weights.items():
+        try:
+            weight = max(0.0, min(2.0, float(raw_value)))
+        except (TypeError, ValueError):
+            warnings.append(f"Invalid weight for {metric}")
+            continue
+        if metric not in registered:
+            warnings.append(f"Unsupported weight metric: {metric}")
+            continue
+        if abs(weight - 1.0) >= 0.000001:
+            normalized[str(metric)] = weight
+    return normalized, warnings
+
+
+def metric_expression(metric: str):
+    return cast(MyDashboardRecord.metrics_json[metric].as_string(), Float)
+
+
+def _clamp(expression, lower: float = -1.0, upper: float = 1.0):
+    return case(
+        (expression < lower, lower),
+        (expression > upper, upper),
+        else_=expression,
+    )
+
+
+def normalized_metric_expression(metric_name: str):
+    value = metric_expression(metric_name)
+    name = metric_name.lower()
+    if "ev" in name or "velocity" in name:
+        normalized = (value - 88.0) / 12.0
+    elif "la" in name or "launch angle" in name:
+        normalized = 1.0 - func.abs(value - 16.0) / 25.0
+    elif "pitches seen" in name or name == "pa":
+        normalized = value / 60.0
+    elif "total" in name:
+        normalized = (value - 8.5) / 4.0
+    elif "score" in name or "edge" in name or "diff" in name:
+        normalized = value
+    elif "bb" in name:
+        normalized = (0.085 - value) * 8.0
+    elif "allowed" in name and ("xwoba" in name or "hardhit" in name):
+        normalized = (0.34 - value) * 5.0
+    else:
+        normalized = value
+    return case((value.is_(None), 0.0), else_=_clamp(normalized))
+
+
+def weighted_score_expression(weights: Dict[str, float]):
+    base = func.coalesce(MyDashboardRecord.base_score, MyDashboardRecord.score, 0.0)
+    adjusted = base
+    for metric_name, weight in weights.items():
+        adjusted = adjusted + normalized_metric_expression(metric_name) * (weight - 1.0) * 0.25
+    return adjusted
+
+
+def weight_explanations(weights: Dict[str, float]) -> List[str]:
+    explanations: List[str] = []
+    for metric_name, weight in weights.items():
+        verb = "emphasized" if weight > 1.0 else "deemphasized"
+        explanations.append(f"{metric_name} {verb} at {round(weight, 2)}")
+    return explanations

--- a/tests/test_my_dashboard_dataset_runtime.py
+++ b/tests/test_my_dashboard_dataset_runtime.py
@@ -9,14 +9,16 @@ def test_substantive_filter_detection():
     assert runtime.has_substantive_filters({"team": "CHC"}) is True
     assert runtime.has_substantive_filters({"metrics": {"EV": {"min": 90}}}) is True
     assert runtime.has_substantive_filters({"metrics": {"EV": {"min": "", "max": ""}}}) is False
-    assert runtime.has_substantive_filters({"weights": {"EV": 1.5}}) is False
+    assert runtime.has_substantive_filters({"weights": {"EV": 1.5}}) is True
+    assert runtime.has_substantive_filters({"weights": {"EV": 1.0}}) is False
     assert runtime.has_substantive_filters({}) is False
 
 
-def test_weight_overrides_stay_on_legacy_path(monkeypatch):
+def test_weight_overrides_use_dataset_path(monkeypatch):
     monkeypatch.setattr(runtime, "mlb_business_date", lambda now=None: dt.date(2026, 7, 15))
     assert runtime.should_use_dataset_query(date="2026-07-15", filters={"team": "CHC"}) is True
-    assert runtime.should_use_dataset_query(date="2026-07-15", filters={"team": "CHC", "weights": {"EV": 1.5}}) is False
+    assert runtime.should_use_dataset_query(date="2026-07-15", filters={"team": "CHC", "weights": {"EV": 1.5}}) is True
+    assert runtime.should_use_dataset_query(date="2026-07-15", filters={"weights": {"EV": 1.5}}) is True
     assert runtime.should_use_dataset_query(date="2026-07-14", filters={"team": "CHC"}) is False
     assert runtime.should_use_dataset_query(date="2026-07-15", filters={}) is False
 
@@ -30,7 +32,6 @@ def test_mlb_business_date_uses_eastern_boundary():
 
 def test_runtime_hydrates_unfiltered_then_queries(monkeypatch):
     events = []
-
     monkeypatch.setattr(runtime, "dashboard_dataset_status", lambda **kwargs: {"ready": False, "stale": False})
 
     def fake_hydrate(**kwargs):
@@ -48,7 +49,7 @@ def test_runtime_hydrates_unfiltered_then_queries(monkeypatch):
         session=object(),
         date="2026-07-15",
         component="hitters",
-        filters={"team": "CHC"},
+        filters={"team": "CHC", "weights": {"EV": 1.5}},
         page_size=50,
         page_number=1,
         sort_by="score",
@@ -60,7 +61,7 @@ def test_runtime_hydrates_unfiltered_then_queries(monkeypatch):
 
     assert events[0][0] == "hydrate"
     assert events[0][1]["items"] == [{"entity_id": "1"}, {"entity_id": "2"}]
-    assert events[1] == ("query", {"team": "CHC"})
+    assert events[1] == ("query", {"team": "CHC", "weights": {"EV": 1.5}})
     assert result["execution_path"] == "my_dashboard_dataset_sql_query"
     assert result["dataset_hydrated_for_request"] is True
 

--- a/tests/test_my_dashboard_sql_query.py
+++ b/tests/test_my_dashboard_sql_query.py
@@ -79,12 +79,12 @@ def rows():
     ]
 
 
-def hydrate(session):
+def hydrate(session, payload_rows=None):
     return hydrate_dashboard_dataset(
         session=session,
         date=DATE,
         component="hitters",
-        payload_builder=lambda: {"items": rows(), "model_state": "projected"},
+        payload_builder=lambda: {"items": payload_rows or rows(), "model_state": "projected"},
         now=dt.datetime(2026, 7, 15, 12, 0, 0),
     )
 
@@ -145,6 +145,67 @@ def test_confidence_and_score_filters_work_together():
             filters={"min_confidence": "medium", "min_score": 0.8},
         )
         assert [row["entity_id"] for row in result["items"]] == ["1", "2"]
+
+
+def test_sql_weight_formula_runs_before_sort_and_pagination():
+    Session = session_factory()
+    weighted_rows = [
+        {
+            "entity_id": "slow",
+            "entity_name": "Slow EV",
+            "entity_type": "hitter",
+            "player_type": "hitter",
+            "score": 0.80,
+            "base_score": 0.80,
+            "confidence": "high",
+            "metrics": {"EV": 76.0},
+        },
+        {
+            "entity_id": "fast",
+            "entity_name": "Fast EV",
+            "entity_type": "hitter",
+            "player_type": "hitter",
+            "score": 0.70,
+            "base_score": 0.70,
+            "confidence": "high",
+            "metrics": {"EV": 100.0},
+        },
+    ]
+    with Session() as session:
+        hydrate(session, weighted_rows)
+        result = query_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="hitters",
+            filters={"weights": {"EV": 2.0}},
+            page_size=1,
+            page_number=1,
+            sort_by="score",
+            sort_direction="desc",
+        )
+        assert result["totalSize"] == 2
+        assert result["items"][0]["entity_id"] == "fast"
+        assert result["items"][0]["base_score"] == pytest.approx(0.70)
+        assert result["items"][0]["adjusted_score"] == pytest.approx(0.95)
+        assert result["items"][0]["score"] == pytest.approx(0.95)
+        assert result["items"][0]["weight_explanation"] == ["EV emphasized at 2.0"]
+        assert result["weight_ranking"]["enabled"] is True
+        assert result["weight_ranking"]["persisted"] is False
+
+
+def test_unsupported_weight_metric_warns_without_changing_score():
+    Session = session_factory()
+    with Session() as session:
+        hydrate(session)
+        result = query_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="hitters",
+            filters={"team": "CHC", "weights": {"Not A Metric": 2.0}},
+        )
+        assert result["items"][0]["score"] == pytest.approx(0.91)
+        assert "Unsupported weight metric: Not A Metric" in result["filter_warnings"]
+        assert result["weight_ranking"]["enabled"] is False
 
 
 def test_invalid_sort_field_is_rejected():


### PR DESCRIPTION
Closes #1048 and continues the My Dashboard Workbench migration from #1043.

## What changes
- Current-date reports with scoring-weight overrides now stay on the persisted My Dashboard dataset path
- Reproduces the authoritative `apply_weight_overrides()` formula as a SQLAlchemy expression
- Applies basic and metric filters before weight adjustment, matching existing behavior
- Applies weighted score before sorting, offset, and limit
- Returns query-time `score`, `adjusted_score`, `base_score`, and `weight_explanation`
- Keeps weights request-scoped and never persists them into `my_dashboard_records`
- Supports the same behavior for standard and active-lineup dataset modes
- Unsupported or invalid weight metrics produce explicit warnings without mutating shared rows

## Exact preserved formula

`adjusted = base_score + normalized_metric * (weight - 1.0) * 0.25`

The SQL normalization mirrors the current Python branches for EV/velocity, launch angle, Pitches Seen/PA, totals, score/edge/diff, BB metrics, allowed xwOBA/HardHit, and generic clamped values.

## Runtime impact
Before this PR, any weight override forced the request back through the legacy in-memory solver. After this PR, a current-date report with weights can reuse the fresh persisted dataset and only execute SQL filtering, weighted calculation, sorting, counting, and pagination.

## Compatibility preserved
- Public solver routes and frontend payloads are unchanged
- Historical reports remain on the compatibility path
- Unfiltered reports remain on the compatibility path unless a non-default weight itself is the report criterion
- Saved reports and snapshots remain compatible
- Existing scoring formula is reused, not redesigned
- No changes to Matchups, Matchup Detail, Daily Odds, Model Projections, or AI Data Assistant

## Tests
- Weight-only requests count as substantive current-date queries
- Weighted reports select the dataset path
- SQL weight calculation changes ordering before pagination
- Returned adjusted scores match formula expectations
- Unsupported weights warn and preserve original scores
- Existing SQL filtering, pagination, sorting, and lineup isolation tests remain

## Review focus
- Run backend test suite, especially `tests/test_my_dashboard_sql_query.py` and `tests/test_my_dashboard_dataset_runtime.py`
- Compare a weighted fixture against `my_dashboard_solver.apply_weight_overrides()`
- Verify a live current-date weighted request returns `execution_path = my_dashboard_dataset_sql_query`
- Confirm database rows remain unchanged after multiple users submit different weights

Connector access does not provide a local test runner, so CI/Railway checks are the execution authority for this draft.