### PR TITLE
PR 6: persist scheduled My Dashboard hydration into Workbench datasets

### DIFF
--- a/mlb_app/my_dashboard_hydration_persistence.py
+++ b/mlb_app/my_dashboard_hydration_persistence.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from .database import create_tables, get_engine, get_session
+from .my_dashboard_dataset import dashboard_dataset_status, hydrate_dashboard_dataset
+
+
+def _session_factory():
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    return get_session(engine)
+
+
+def persist_hydration_payload(run: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist completed batch hydration payloads into My Dashboard-owned datasets.
+
+    The route already builds the authoritative, unfiltered component payloads. This
+    function promotes those same rows into the persisted Workbench dataset without
+    rerunning any analytical service. Empty payloads never replace a valid dataset.
+    """
+
+    target_date = str(run.get("target_date") or payload.get("date") or "")[:10]
+    active_lineups = bool(run.get("active_lineups", payload.get("active_lineups", False)))
+    force = bool(run.get("force_requested", False))
+    results = payload.get("results") if isinstance(payload.get("results"), dict) else {}
+    persisted: Dict[str, Any] = {}
+
+    factory = _session_factory()
+    with factory() as session:
+        for component, component_payload in results.items():
+            if not isinstance(component_payload, dict):
+                persisted[component] = {
+                    "hydrated": False,
+                    "skipped": True,
+                    "reason": "invalid_component_payload",
+                }
+                continue
+
+            rows = component_payload.get("items") or component_payload.get("records") or []
+            if not rows:
+                status = dashboard_dataset_status(
+                    session=session,
+                    date=target_date,
+                    component=component,
+                    active_lineups=active_lineups,
+                )
+                persisted[component] = {
+                    **status,
+                    "hydrated": False,
+                    "skipped": True,
+                    "reason": "empty_payload_preserved_previous_dataset",
+                }
+                continue
+
+            status = dashboard_dataset_status(
+                session=session,
+                date=target_date,
+                component=component,
+                active_lineups=active_lineups,
+            )
+            if status.get("ready") and not force:
+                persisted[component] = {
+                    **status,
+                    "hydrated": False,
+                    "skipped": True,
+                    "reason": "current_dataset_already_ready",
+                }
+                continue
+
+            persisted[component] = hydrate_dashboard_dataset(
+                session=session,
+                date=target_date,
+                component=component,
+                payload_builder=lambda value=component_payload: value,
+                active_lineups=active_lineups,
+                force=force,
+                ttl_seconds=None,
+                solver_version="my_dashboard_solver_v1",
+            )
+
+    return {
+        "dataset_source": "my_dashboard_records",
+        "dataset_date": target_date,
+        "dataset_mode": "active_lineups" if active_lineups else "standard",
+        "force_requested": force,
+        "components": persisted,
+        "component_count": len(persisted),
+        "hydrated_component_count": sum(1 for value in persisted.values() if value.get("hydrated")),
+        "skipped_component_count": sum(1 for value in persisted.values() if value.get("skipped")),
+        "dataset_row_count": sum(int(value.get("dataset_row_count") or 0) for value in persisted.values()),
+    }

--- a/mlb_app/my_dashboard_observability.py
+++ b/mlb_app/my_dashboard_observability.py
@@ -8,6 +8,8 @@ import time
 import uuid
 from typing import Any, Dict, Optional
 
+from .my_dashboard_hydration_persistence import persist_hydration_payload
+
 _LOCK = threading.Lock()
 _LATEST: Optional[Dict[str, Any]] = None
 
@@ -83,6 +85,9 @@ def _publish(status: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def complete_hydration(run: Dict[str, Any], payload: Dict[str, Any], cache_mode: str) -> Dict[str, Any]:
+    dataset_hydration = persist_hydration_payload(run, payload)
+    payload["dataset_hydration"] = dataset_hydration
+
     completed = dict(run)
     completed.update(summarize_hydration_payload(payload))
     completed.update({
@@ -90,6 +95,7 @@ def complete_hydration(run: Dict[str, Any], payload: Dict[str, Any], cache_mode:
         "completed_at": utc_now_iso(),
         "duration_ms": round((time.monotonic() - run["_started_monotonic"]) * 1000),
         "cache_mode": cache_mode,
+        "dataset_hydration": dataset_hydration,
         "error": None,
     })
     return _publish(completed)

--- a/tests/test_my_dashboard_hydration_persistence.py
+++ b/tests/test_my_dashboard_hydration_persistence.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from mlb_app import my_dashboard_hydration_persistence as persistence
+from mlb_app import my_dashboard_observability as observability
+
+
+class FakeSession:
+    pass
+
+
+@contextmanager
+def fake_session_context():
+    yield FakeSession()
+
+
+class FakeFactory:
+    def __call__(self):
+        return fake_session_context()
+
+
+def test_persist_hydration_payload_promotes_existing_component_results(monkeypatch):
+    calls = []
+    monkeypatch.setattr(persistence, "_session_factory", lambda: FakeFactory())
+    monkeypatch.setattr(
+        persistence,
+        "dashboard_dataset_status",
+        lambda **kwargs: {"ready": False, "dataset_row_count": 0},
+    )
+
+    def fake_hydrate(**kwargs):
+        calls.append(kwargs)
+        payload = kwargs["payload_builder"]()
+        return {
+            "hydrated": True,
+            "dataset_row_count": len(payload["items"]),
+            "dataset_version": "v1",
+        }
+
+    monkeypatch.setattr(persistence, "hydrate_dashboard_dataset", fake_hydrate)
+
+    result = persistence.persist_hydration_payload(
+        {
+            "target_date": "2026-07-14",
+            "active_lineups": True,
+            "force_requested": True,
+        },
+        {
+            "date": "2026-07-14",
+            "results": {
+                "hitters": {"items": [{"entity_id": "1"}, {"entity_id": "2"}]},
+            },
+        },
+    )
+
+    assert result["dataset_source"] == "my_dashboard_records"
+    assert result["dataset_mode"] == "active_lineups"
+    assert result["hydrated_component_count"] == 1
+    assert result["dataset_row_count"] == 2
+    assert calls[0]["active_lineups"] is True
+    assert calls[0]["force"] is True
+    assert calls[0]["payload_builder"]()["items"][0]["entity_id"] == "1"
+
+
+def test_empty_hydration_payload_never_replaces_previous_dataset(monkeypatch):
+    monkeypatch.setattr(persistence, "_session_factory", lambda: FakeFactory())
+    monkeypatch.setattr(
+        persistence,
+        "dashboard_dataset_status",
+        lambda **kwargs: {
+            "ready": True,
+            "dataset_version": "previous",
+            "dataset_row_count": 12,
+        },
+    )
+    monkeypatch.setattr(
+        persistence,
+        "hydrate_dashboard_dataset",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("empty payload must not hydrate")),
+    )
+
+    result = persistence.persist_hydration_payload(
+        {"target_date": "2026-07-14", "active_lineups": False, "force_requested": True},
+        {"results": {"pitchers": {"items": []}}},
+    )
+
+    component = result["components"]["pitchers"]
+    assert component["dataset_version"] == "previous"
+    assert component["skipped"] is True
+    assert component["reason"] == "empty_payload_preserved_previous_dataset"
+
+
+def test_nonforced_hydration_reuses_ready_historical_dataset(monkeypatch):
+    monkeypatch.setattr(persistence, "_session_factory", lambda: FakeFactory())
+    monkeypatch.setattr(
+        persistence,
+        "dashboard_dataset_status",
+        lambda **kwargs: {
+            "ready": True,
+            "dataset_version": "current",
+            "dataset_row_count": 4,
+        },
+    )
+    monkeypatch.setattr(
+        persistence,
+        "hydrate_dashboard_dataset",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("ready dataset must be reused")),
+    )
+
+    result = persistence.persist_hydration_payload(
+        {"target_date": "2026-07-14", "active_lineups": False, "force_requested": False},
+        {"results": {"teams": {"items": [{"entity_id": "CHC"}]}}},
+    )
+
+    assert result["hydrated_component_count"] == 0
+    assert result["skipped_component_count"] == 1
+    assert result["components"]["teams"]["reason"] == "current_dataset_already_ready"
+
+
+def test_complete_hydration_includes_dataset_persistence_metadata(monkeypatch):
+    monkeypatch.setattr(
+        observability,
+        "persist_hydration_payload",
+        lambda run, payload: {
+            "dataset_source": "my_dashboard_records",
+            "hydrated_component_count": 2,
+            "dataset_row_count": 18,
+        },
+    )
+    run = observability.begin_hydration("2026-07-14", ["hitters", "pitchers"], True, True)
+    payload = {
+        "results": {
+            "hitters": {"items": [{"entity_id": "1"}]},
+            "pitchers": {"items": [{"entity_id": "2"}]},
+        }
+    }
+
+    completed = observability.complete_hydration(run, payload, cache_mode="forced_refresh")
+
+    assert completed["status"] == "success"
+    assert completed["dataset_hydration"]["hydrated_component_count"] == 2
+    assert payload["dataset_hydration"]["dataset_row_count"] == 18


### PR DESCRIPTION
Continues and closes the remaining lifecycle gap in #1043. This stays strictly inside the original Workbench migration scope.

## Original-scope gap
`/my-dashboard/solver/hydrate-yesterday` still warmed the legacy full-result cache but did not populate `my_dashboard_records`. The original sprint required yesterday hydration to warm the persisted My Dashboard dataset, while remaining separate from today’s fallback behavior.

## What changes
- Reuses the exact unfiltered component payloads already built by the existing hydration route
- Persists those payloads into the My Dashboard-owned dataset during the existing hydration completion step
- Does not rerun analytical solvers or duplicate formulas
- Preserves the public hydrate route, response payload, cache keys, cron target, and observability endpoints
- Stores standard and active-lineup hydration in separate dataset modes
- Historical hydrated datasets have no short live-data expiration
- Adds dataset version, row count, component counts, skip reasons, and mode to hydration observability

## Failure safety
- Empty component payloads never replace a previous valid dataset
- Non-forced hydration reuses an already-ready historical dataset
- Forced hydration promotes a new atomic component version through the existing dataset service
- Persistence failures propagate through the existing hydration failure path
- No user filters or weights are persisted

## Runtime behavior
The analytical candidate build still runs once through `_build_batch_payload`. Dataset persistence consumes the completed payload directly, avoiding another Model Projections, Stored 365, lineup, or AI context build.

## Tests
- Existing component payloads are persisted without rebuilding
- Active-lineup mode and force flags are preserved
- Empty payloads preserve the previous dataset
- Non-forced runs reuse ready historical datasets
- Hydration status exposes persisted dataset metadata

## Deliberately unchanged
- `/my-dashboard/solver`
- `/my-dashboard/solver/active-lineups`
- Report Builder UI
- SQL report querying and weighting
- Saved reports
- Scoring formulas
- Matchups, Matchup Detail, Daily Odds, Model Projections, and AI Data Assistant

## Review focus
Run `tests/test_my_dashboard_hydration_persistence.py` plus the existing My Dashboard dataset, route, and SQL query tests. Verify a forced yesterday hydration returns `dataset_hydration.dataset_source = my_dashboard_records` and that each hydrated component has a current persisted version.