### PR TITLE
PR 7: lock My Dashboard Workbench route contracts

### DIFF
--- a/docs/my_dashboard_workbench_acceptance.md
+++ b/docs/my_dashboard_workbench_acceptance.md
@@ -1,0 +1,49 @@
+# My Dashboard Workbench acceptance matrix
+
+Tracks the implementation completed under issue #1043.
+
+## Architecture
+
+`analytical solvers -> My Dashboard-owned persisted dataset -> SQL query/describe layer -> existing Report Builder`
+
+## Completed slices
+
+| Requirement | Implementation |
+| --- | --- |
+| Persist normalized records by date, component, mode, version, and entity | PR #1044 |
+| Atomic promotion and previous-version failure safety | PR #1044 |
+| SQL filtering, counting, sorting, pagination, and object metadata | PR #1045 |
+| Current-date filtered route integration with stale-dataset fallback | PR #1046 |
+| Existing Report Builder server pagination and sorting | PR #1047 |
+| Query-time weight ranking without persisting user configuration | PR #1050 |
+| Scheduled yesterday hydration into persisted Workbench datasets | PR #1051 |
+| Route-selection regression coverage | This PR |
+
+## Preserved compatibility boundaries
+
+- Public `/my-dashboard/solver` and `/my-dashboard/solver/active-lineups` routes remain unchanged.
+- Historical reports remain on the legacy compatibility path.
+- Current-date unfiltered reports remain on the legacy compatibility path.
+- Current-date requests with substantive filters or non-default weights use the persisted SQL path.
+- Standard and active-lineup datasets remain isolated.
+- Saved `report_view`, `workbench_view`, and `dashboard_report` payloads remain readable.
+- Shared dataset rows never contain user filters or weights.
+- Scoring formulas remain authoritative in the existing solver modules.
+- Matchups, Matchup Detail, Daily Odds, Model Projections, and AI Data Assistant are outside this migration and were not changed.
+
+## Production verification checklist
+
+After deployment, verify:
+
+1. A current-date filtered report returns `execution_path = my_dashboard_dataset_sql_query`.
+2. Sorting a column changes server ordering across the full filtered result set.
+3. Page 2 does not repeat page 1 and `totalSize` remains stable.
+4. A weight-only current-date report uses the SQL dataset path and does not alter persisted rows.
+5. Confirmed-lineup reports return the active-lineup dataset mode and current lineup revision.
+6. Forced `/my-dashboard/solver/hydrate-yesterday` reports `dataset_hydration.dataset_source = my_dashboard_records`.
+7. A failed refresh serves the prior valid current dataset only when one exists and emits an explicit warning.
+8. Existing saved reports reopen with their prior columns, filters, sort, and snapshot rows.
+
+## Known operational requirement
+
+GitHub Actions have not consistently appeared for these connector-created PR heads. Backend tests, frontend Node tests, and the frontend production build must be executed by the repository CI or deployment pipeline before production verification is marked complete.

--- a/docs/my_dashboard_workbench_acceptance.md
+++ b/docs/my_dashboard_workbench_acceptance.md
@@ -44,6 +44,7 @@ After deployment, verify:
 7. A failed refresh serves the prior valid current dataset only when one exists and emits an explicit warning.
 8. Existing saved reports reopen with their prior columns, filters, sort, and snapshot rows.
 
-## Known operational requirement
+## Known operational requirements
 
-GitHub Actions have not consistently appeared for these connector-created PR heads. Backend tests, frontend Node tests, and the frontend production build must be executed by the repository CI or deployment pipeline before production verification is marked complete.
+- GitHub Actions have not consistently appeared for these connector-created PR heads. Backend tests, frontend Node tests, and the frontend production build must be executed by the repository CI or deployment pipeline before production verification is marked complete.
+- `/my-dashboard/health` still reports the legacy `frontend_localStorage_v1` persistence label even though filtered Workbench reports now use `my_dashboard_records`. This is inaccurate operational metadata, not a data-path fallback. Correct it in a narrowly scoped metadata-only change after the acceptance tests pass.

--- a/tests/test_my_dashboard_route_contract.py
+++ b/tests/test_my_dashboard_route_contract.py
@@ -1,0 +1,184 @@
+from contextlib import contextmanager
+
+from mlb_app import my_dashboard_routes as routes
+
+
+class FakeSession:
+    pass
+
+
+@contextmanager
+def fake_session_context():
+    yield FakeSession()
+
+
+class FakeFactory:
+    def __call__(self):
+        return fake_session_context()
+
+
+def _dataset_result(**kwargs):
+    return {
+        "execution_path": "my_dashboard_dataset_sql_query",
+        "items": [],
+        "records": [],
+        "totalSize": 0,
+        "page_info": {"page_number": kwargs["page_number"], "page_size": kwargs["page_size"]},
+    }
+
+
+def test_filtered_current_date_standard_route_uses_dataset_query(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(routes, "install_dashboard_context_cache", lambda: None)
+    monkeypatch.setattr(
+        routes,
+        "_normalize_request",
+        lambda date, component, filters: {
+            "target_date": "2026-07-15",
+            "component": "hitters",
+            "filters": {"team": "CHC"},
+        },
+    )
+    monkeypatch.setattr(routes, "should_use_dataset_query", lambda **kwargs: True)
+    monkeypatch.setattr(routes, "session_factory", lambda: FakeFactory())
+
+    def fake_run_dataset_query(**kwargs):
+        captured.update(kwargs)
+        payload = kwargs["payload_builder"]()
+        assert payload == {"items": [{"entity_id": "1"}]}
+        return _dataset_result(**kwargs)
+
+    monkeypatch.setattr(routes, "run_dataset_query", fake_run_dataset_query)
+    monkeypatch.setattr(
+        routes.dashboard_solver,
+        "build_dashboard_solver_payload",
+        lambda **kwargs: {"items": [{"entity_id": "1"}]} if kwargs["filters"] == {} else (_ for _ in ()).throw(AssertionError("hydration must be unfiltered")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "_legacy_solver_response",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("filtered current-date request must not use legacy solver")),
+    )
+
+    result = routes._run_solver(
+        date="2026-07-15",
+        component="hitters",
+        filters={"team": "CHC"},
+        page_size=25,
+        page_number=2,
+        sort_by="metrics.xwOBA",
+        sort_direction="asc",
+        include_metadata=True,
+    )
+
+    assert result["execution_path"] == "my_dashboard_dataset_sql_query"
+    assert captured["filters"] == {"team": "CHC"}
+    assert captured["page_size"] == 25
+    assert captured["page_number"] == 2
+    assert captured["sort_by"] == "metrics.xwOBA"
+    assert captured["sort_direction"] == "asc"
+    assert captured["active_lineups"] is False
+
+
+def test_filtered_current_date_active_lineup_route_uses_isolated_dataset(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(routes, "install_dashboard_context_cache", lambda: None)
+    monkeypatch.setattr(
+        routes,
+        "_normalize_request",
+        lambda date, component, filters: {
+            "target_date": "2026-07-15",
+            "component": "hitters",
+            "filters": {"min_score": 0.8},
+        },
+    )
+    monkeypatch.setattr(routes, "should_use_dataset_query", lambda **kwargs: True)
+    monkeypatch.setattr(routes, "session_factory", lambda: FakeFactory())
+
+    def fake_run_dataset_query(**kwargs):
+        captured.update(kwargs)
+        assert kwargs["payload_builder"]() == {"items": [{"entity_id": "2", "lineup_verified": True}]}
+        return _dataset_result(**kwargs)
+
+    monkeypatch.setattr(routes, "run_dataset_query", fake_run_dataset_query)
+    monkeypatch.setattr(
+        routes,
+        "build_active_lineup_solver_payload",
+        lambda **kwargs: {"items": [{"entity_id": "2", "lineup_verified": True}]} if kwargs["filters"] == {} else (_ for _ in ()).throw(AssertionError("hydration must be unfiltered")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "_legacy_solver_response",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("filtered active-lineup request must not use legacy solver")),
+    )
+
+    result = routes._run_active_lineup_solver(
+        date="2026-07-15",
+        component="hitters",
+        filters={"min_score": 0.8},
+    )
+
+    assert result["execution_path"] == "my_dashboard_dataset_sql_query"
+    assert captured["active_lineups"] is True
+    assert captured["filters"] == {"min_score": 0.8}
+
+
+def test_weight_only_current_date_request_uses_dataset_query(monkeypatch):
+    monkeypatch.setattr(routes, "install_dashboard_context_cache", lambda: None)
+    monkeypatch.setattr(
+        routes,
+        "_normalize_request",
+        lambda date, component, filters: {
+            "target_date": "2026-07-15",
+            "component": "hitters",
+            "filters": {"weights": {"EV": 1.5}},
+        },
+    )
+    monkeypatch.setattr(routes, "should_use_dataset_query", lambda **kwargs: True)
+    monkeypatch.setattr(routes, "session_factory", lambda: FakeFactory())
+    monkeypatch.setattr(routes, "run_dataset_query", lambda **kwargs: _dataset_result(**kwargs))
+    monkeypatch.setattr(
+        routes,
+        "_legacy_solver_response",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("weight-only current-date request must use dataset query")),
+    )
+
+    result = routes._run_solver(date="2026-07-15", component="hitters", filters={"weights": {"EV": 1.5}})
+
+    assert result["execution_path"] == "my_dashboard_dataset_sql_query"
+
+
+def test_historical_and_unfiltered_requests_preserve_legacy_compatibility(monkeypatch):
+    calls = []
+    monkeypatch.setattr(routes, "install_dashboard_context_cache", lambda: None)
+    monkeypatch.setattr(
+        routes,
+        "_normalize_request",
+        lambda date, component, filters: {
+            "target_date": str(date),
+            "component": "hitters",
+            "filters": filters or {},
+        },
+    )
+    monkeypatch.setattr(routes, "should_use_dataset_query", lambda **kwargs: False)
+    monkeypatch.setattr(
+        routes,
+        "run_dataset_query",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("compatibility request must not use dataset query")),
+    )
+
+    def fake_legacy(**kwargs):
+        calls.append(kwargs)
+        return {"execution_path": "legacy_in_memory_solver", "items": []}
+
+    monkeypatch.setattr(routes, "_legacy_solver_response", fake_legacy)
+
+    historical = routes._run_solver(date="2026-07-14", component="hitters", filters={"team": "CHC"})
+    unfiltered = routes._run_solver(date="2026-07-15", component="hitters", filters={})
+
+    assert historical["execution_path"] == "legacy_in_memory_solver"
+    assert unfiltered["execution_path"] == "legacy_in_memory_solver"
+    assert calls[0]["target_date"] == "2026-07-14"
+    assert calls[0]["filters"] == {"team": "CHC"}
+    assert calls[1]["target_date"] == "2026-07-15"
+    assert calls[1]["filters"] == {}


### PR DESCRIPTION
Final hardening slice for #1043. This PR stays strictly inside the original Workbench migration scope and does not change runtime behavior.

## What changes
- Adds route-boundary regression coverage for the existing `/my-dashboard/solver` and `/my-dashboard/solver/active-lineups` execution paths
- Verifies current-date filtered standard reports use the persisted SQL dataset path
- Verifies current-date filtered confirmed-lineup reports use the isolated active-lineup dataset mode
- Verifies weight-only current-date requests remain on the SQL dataset path
- Verifies hydration payload builders are always invoked without user filters
- Verifies historical and current-date unfiltered requests retain the legacy compatibility path
- Adds an acceptance matrix mapping the completed implementation back to PRs #1044, #1045, #1046, #1047, #1050, and #1051
- Documents the exact production verification checklist required before closing #1043

## Deliberately unchanged
- No route signatures or response contracts
- No persistence model changes
- No SQL query or weighting changes
- No solver or scoring changes
- No Report Builder changes
- No saved-report changes
- No Matchups, Matchup Detail, Daily Odds, Model Projections, or AI Data Assistant changes

## Review focus
Run `tests/test_my_dashboard_route_contract.py` together with the existing My Dashboard dataset, SQL query, runtime, hydration, and frontend query-state tests.

After deployment, execute the production verification checklist in `docs/my_dashboard_workbench_acceptance.md`. GitHub Actions have not consistently appeared for connector-created PR heads, so CI/deployment execution remains required before issue #1043 should be marked complete.