### PR TITLE
PR 1: add My Dashboard canonical object schema

### DIFF
--- a/docs/my_dashboard_object_architecture.md
+++ b/docs/my_dashboard_object_architecture.md
@@ -1,0 +1,44 @@
+# My Dashboard canonical object architecture
+
+## Current execution path
+
+`MyDashboardReportBuilderPage.jsx` sends report state to `/my-dashboard/solver` or `/my-dashboard/solver/active-lineups`. Current-date substantive requests use `my_dashboard_dataset_runtime`, which hydrates unfiltered solver output into `my_dashboard_records` and delegates filtering, request-scoped weighting, sorting, counting, and pagination to `my_dashboard_sql_query`. Unfiltered and historical requests retain the legacy solver compatibility path.
+
+`my_dashboard_records` is intentionally keyed by date, component, mode, version, and entity. It is a safe analytical snapshot/compatibility layer, but cannot represent a durable cross-date player population. A missing current-date solver snapshot can therefore yield an empty default object report even when tracked players exist on other dates.
+
+## Verified reusable sources
+
+- Canonical MLB IDs: `StatcastEvent.batter_id` and `pitcher_id`, MLB Stats people responses, active team rosters, probable pitchers, and boxscore lineups.
+- Confirmed lineups: `active_lineup_solver` calls `generate_matchups_for_date` and `lineup_profile.fetch_boxscore_lineup`; ID is preferred and the existing name/team fallback is not accepted as canonical identity for the new object store.
+- Tracked games: `statcast_events` provides `game_date`, `game_pk`, batter ID, and pitcher ID.
+- Current analytics: batter/pitcher aggregates, player splits, pitch arsenal, and batter/pitch-type matchup tables.
+- Active roster source: the verified MLB Stats `/teams/{team_id}/roster?rosterType=active` path already powers the public roster endpoint and matchup fallback. Population ingestion is deferred to PR 2.
+
+## Object boundaries
+
+- `dashboard_players`: one durable identity row per MLB player ID plus deterministic activity facts and resolution state.
+- `dashboard_player_snapshots`: versioned historical analytical facts. A uniqueness constraint prevents duplicate player/date/context/version rows.
+- `dashboard_player_current`: one query-optimized approved projection per player. This becomes the source for default active-player reports after hydration and query migration.
+- Existing one-to-many tables remain related report sources; they are not flattened into the current player row.
+- `my_dashboard_records` remains untouched as the current compatibility and date-specific snapshot layer.
+
+## Active-player contract for PR 2
+
+Default window: 30 days, configured by `DASHBOARD_ACTIVE_PLAYER_WINDOW_DAYS`. A resolved MLB player is eligible when at least one verified fact is true: recent confirmed lineup, recent tracked game, active roster plus usable analytics, or today's confirmed/projected lineup. Rows lacking an MLB ID remain explicitly unresolved and are excluded from canonical/current promotion. Names alone never establish canonical identity.
+
+## Migration and failure safety
+
+PR 1 only registers additive tables and contracts. Later hydration must build candidate rows, validate counts/identity coverage, write a new snapshot version, and promote current rows in one transaction. Empty or failed refreshes must preserve the prior projection. PostgreSQL production uses the same SQLAlchemy indexes defined and tested under SQLite; deployment must measure lock/build time before any larger backfill.
+
+## Report types
+
+The initial registry declares All Active Hitters, All Active Pitchers, Hitters with Current Matchup Metrics, Hitters with Arsenal Splits, Players with Lineup History, Teams with Daily Analysis, and Games with Totals Analysis. Registry presence is not a claim that a related report is queryable yet; query wiring is delivered in later PRs.
+
+## PR sequence
+
+1. Add this contract, canonical/snapshot/current schemas, registry, indexes, and SQLite tests.
+2. Populate identities and deterministic active status from verified sources.
+3. Hydrate snapshots and atomically promote the current projection.
+4. Query default and filtered reports from the current projection.
+5. Migrate the existing Report Builder to report types and server field metadata.
+6. Add the safest related report types, observability, backfill runbook, and production evidence.

--- a/mlb_app/dashboard_object_models.py
+++ b/mlb_app/dashboard_object_models.py
@@ -1,0 +1,130 @@
+"""Canonical object-store schema for Salesforce-style dashboard reports.
+
+This module only defines the durable contract. Population and report routing are
+deliberately implemented in later sprint slices so the existing solver routes
+remain unchanged while the schema is deployed and reviewed.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, Column, Date, DateTime, Float, Index, Integer, JSON, String, Text, UniqueConstraint
+
+from .database import Base
+
+
+class DashboardPlayer(Base):
+    __tablename__ = "dashboard_players"
+
+    mlb_player_id: int = Column(Integer, primary_key=True, autoincrement=False)
+    full_name: str = Column(String(255), nullable=False)
+    current_team_id: Optional[int] = Column(Integer, nullable=True)
+    current_team_name: Optional[str] = Column(String(120), nullable=True)
+    primary_position: Optional[str] = Column(String(16), nullable=True)
+    player_type: str = Column(String(32), nullable=False)
+    bats: Optional[str] = Column(String(8), nullable=True)
+    throws: Optional[str] = Column(String(8), nullable=True)
+    is_active: bool = Column(Boolean, nullable=False, default=False)
+    active_status_reason: Optional[str] = Column(String(80), nullable=True)
+    first_tracked_date: date = Column(Date, nullable=False)
+    last_tracked_date: date = Column(Date, nullable=False)
+    most_recent_lineup_date: Optional[date] = Column(Date, nullable=True)
+    most_recent_game_date: Optional[date] = Column(Date, nullable=True)
+    lineup_appearance_count: int = Column(Integer, nullable=False, default=0)
+    tracked_game_count: int = Column(Integer, nullable=False, default=0)
+    source_provenance_json = Column(JSON, nullable=False, default=dict)
+    identity_resolution_status: str = Column(String(32), nullable=False)
+    created_at: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: datetime = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        Index("ix_dashboard_players_active_type", "is_active", "player_type", "mlb_player_id"),
+        Index("ix_dashboard_players_team_active", "current_team_id", "is_active"),
+        Index("ix_dashboard_players_last_tracked", "last_tracked_date"),
+        Index("ix_dashboard_players_identity_status", "identity_resolution_status"),
+    )
+
+
+class DashboardPlayerSnapshot(Base):
+    __tablename__ = "dashboard_player_snapshots"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    mlb_player_id: int = Column(Integer, nullable=False)
+    snapshot_date: date = Column(Date, nullable=False)
+    analytical_context: str = Column(String(64), nullable=False)
+    snapshot_version: str = Column(String(64), nullable=False)
+    team_id: Optional[int] = Column(Integer, nullable=True)
+    team_name: Optional[str] = Column(String(120), nullable=True)
+    opponent_team_id: Optional[int] = Column(Integer, nullable=True)
+    game_pk: Optional[int] = Column(Integer, nullable=True)
+    lineup_status: Optional[str] = Column(String(32), nullable=True)
+    lineup_position: Optional[int] = Column(Integer, nullable=True)
+    model_score: Optional[float] = Column(Float, nullable=True)
+    confidence: Optional[str] = Column(String(32), nullable=True)
+    xwoba: Optional[float] = Column(Float, nullable=True)
+    xba: Optional[float] = Column(Float, nullable=True)
+    exit_velocity: Optional[float] = Column(Float, nullable=True)
+    launch_angle: Optional[float] = Column(Float, nullable=True)
+    hard_hit_rate: Optional[float] = Column(Float, nullable=True)
+    barrel_rate: Optional[float] = Column(Float, nullable=True)
+    strikeout_rate: Optional[float] = Column(Float, nullable=True)
+    walk_rate: Optional[float] = Column(Float, nullable=True)
+    iso: Optional[float] = Column(Float, nullable=True)
+    obp: Optional[float] = Column(Float, nullable=True)
+    slg: Optional[float] = Column(Float, nullable=True)
+    plate_appearances: Optional[int] = Column(Integer, nullable=True)
+    metrics_json = Column(JSON, nullable=False, default=dict)
+    source_versions_json = Column(JSON, nullable=False, default=dict)
+    provenance_json = Column(JSON, nullable=False, default=dict)
+    generated_at: datetime = Column(DateTime, nullable=False)
+    refreshed_at: datetime = Column(DateTime, nullable=False)
+    is_approved: bool = Column(Boolean, nullable=False, default=False)
+
+    __table_args__ = (
+        UniqueConstraint("mlb_player_id", "snapshot_date", "analytical_context", "snapshot_version", name="uq_dashboard_player_snapshot_version"),
+        Index("ix_dashboard_snapshots_player_date", "mlb_player_id", "snapshot_date"),
+        Index("ix_dashboard_snapshots_context_date", "analytical_context", "snapshot_date"),
+        Index("ix_dashboard_snapshots_approved", "snapshot_date", "analytical_context", "is_approved"),
+    )
+
+
+class DashboardPlayerCurrent(Base):
+    __tablename__ = "dashboard_player_current"
+
+    mlb_player_id: int = Column(Integer, primary_key=True, autoincrement=False)
+    snapshot_id: int = Column(Integer, nullable=False)
+    player_type: str = Column(String(32), nullable=False)
+    full_name: str = Column(String(255), nullable=False)
+    team_id: Optional[int] = Column(Integer, nullable=True)
+    team_name: Optional[str] = Column(String(120), nullable=True)
+    primary_position: Optional[str] = Column(String(16), nullable=True)
+    is_active: bool = Column(Boolean, nullable=False)
+    model_score: Optional[float] = Column(Float, nullable=True)
+    confidence: Optional[str] = Column(String(32), nullable=True)
+    xwoba: Optional[float] = Column(Float, nullable=True)
+    xba: Optional[float] = Column(Float, nullable=True)
+    exit_velocity: Optional[float] = Column(Float, nullable=True)
+    launch_angle: Optional[float] = Column(Float, nullable=True)
+    hard_hit_rate: Optional[float] = Column(Float, nullable=True)
+    barrel_rate: Optional[float] = Column(Float, nullable=True)
+    strikeout_rate: Optional[float] = Column(Float, nullable=True)
+    walk_rate: Optional[float] = Column(Float, nullable=True)
+    iso: Optional[float] = Column(Float, nullable=True)
+    obp: Optional[float] = Column(Float, nullable=True)
+    slg: Optional[float] = Column(Float, nullable=True)
+    plate_appearances: Optional[int] = Column(Integer, nullable=True)
+    metrics_json = Column(JSON, nullable=False, default=dict)
+    projection_version: str = Column(String(64), nullable=False)
+    source_freshness_json = Column(JSON, nullable=False, default=dict)
+    provenance_json = Column(JSON, nullable=False, default=dict)
+    promoted_at: datetime = Column(DateTime, nullable=False)
+    updated_at: datetime = Column(DateTime, nullable=False)
+
+    __table_args__ = (
+        Index("ix_dashboard_current_active_type", "is_active", "player_type", "mlb_player_id"),
+        Index("ix_dashboard_current_team_active", "team_id", "is_active"),
+        Index("ix_dashboard_current_hitter_xwoba", "player_type", "is_active", "xwoba"),
+        Index("ix_dashboard_current_pitcher_score", "player_type", "is_active", "model_score"),
+    )

--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -1,0 +1,31 @@
+"""Explicit report-type contracts for the dashboard object model."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List
+
+
+REPORT_TYPES: Dict[str, Dict[str, Any]] = {
+    "all_active_hitters": {"label": "All Active Hitters", "ui_object": "hitters", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "hitter"}, "relationships": []},
+    "all_active_pitchers": {"label": "All Active Pitchers", "ui_object": "pitchers", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "pitcher"}, "relationships": []},
+    "hitters_current_matchup": {"label": "Hitters with Current Matchup Metrics", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["current_matchup_snapshot"]},
+    "hitters_arsenal_splits": {"label": "Hitters with Arsenal Splits", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["batter_pitch_type_matchups"]},
+    "players_lineup_history": {"label": "Players with Lineup History", "ui_object": "overall_players", "base_object": "dashboard_players", "population": {}, "relationships": ["lineup_appearances"]},
+    "teams_daily_analysis": {"label": "Teams with Daily Analysis", "ui_object": "teams", "base_object": "teams", "population": {}, "relationships": ["daily_analytical_snapshot"]},
+    "games_totals_analysis": {"label": "Games with Totals Analysis", "ui_object": "totals", "base_object": "games", "population": {}, "relationships": ["totals_projection", "run_environment_snapshot"]},
+}
+
+FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {
+    key: [
+        {"name": "mlb_player_id", "label": "MLB Player ID", "data_type": "id", "group": "Identity", "sortable": True, "filterable": True, "nillable": False, "source_object": config["base_object"], "relationship_path": None, "supported_operators": ["eq", "in"], "description": "Canonical MLBAM player identifier.", "freshness": "canonical"},
+        {"name": "full_name", "label": "Player Name", "data_type": "string", "group": "Identity", "sortable": True, "filterable": True, "nillable": False, "source_object": config["base_object"], "relationship_path": None, "supported_operators": ["eq", "contains"], "description": "Resolved canonical player name.", "freshness": "canonical"},
+    ] if config["base_object"] in {"dashboard_players", "dashboard_player_current"} else []
+    for key, config in REPORT_TYPES.items()
+}
+
+
+def describe_report_type(report_type: str) -> Dict[str, Any]:
+    if report_type not in REPORT_TYPES:
+        raise ValueError(f"Unsupported report type: {report_type}")
+    return {**deepcopy(REPORT_TYPES[report_type]), "api_name": report_type, "fields": deepcopy(FIELD_CATALOG[report_type])}

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -390,6 +390,10 @@ def get_engine(database_url: str):
 
 
 def create_tables(engine) -> None:
+    # Register dashboard object tables before metadata creation. Kept local to
+    # avoid a database -> model -> database import cycle at module import time.
+    from . import dashboard_object_models  # noqa: F401
+
     Base.metadata.create_all(engine)
     _ensure_statcast_event_columns(engine)
 

--- a/tests/test_dashboard_object_schema.py
+++ b/tests/test_dashboard_object_schema.py
@@ -1,0 +1,65 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot
+from mlb_app.dashboard_report_types import REPORT_TYPES, describe_report_type
+from mlb_app.database import Base, create_tables
+
+
+def test_object_tables_and_query_indexes_are_sqlite_compatible():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    create_tables(engine)
+    inspector = inspect(engine)
+    assert {"dashboard_players", "dashboard_player_snapshots", "dashboard_player_current"}.issubset(inspector.get_table_names())
+    assert "ix_dashboard_current_active_type" in {row["name"] for row in inspector.get_indexes("dashboard_player_current")}
+
+
+def test_canonical_player_id_is_unique():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    with Session() as session:
+        values = dict(mlb_player_id=123, full_name="One Player", player_type="hitter", is_active=True, first_tracked_date=dt.date(2026, 7, 1), last_tracked_date=dt.date(2026, 7, 15), identity_resolution_status="resolved")
+        session.add(DashboardPlayer(**values))
+        session.commit()
+        session.add(DashboardPlayer(**values))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_snapshot_business_key_is_versioned_and_unique():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    with Session() as session:
+        values = dict(mlb_player_id=123, snapshot_date=dt.date(2026, 7, 15), analytical_context="current_metrics", snapshot_version="v1", generated_at=dt.datetime(2026, 7, 15, 10), refreshed_at=dt.datetime(2026, 7, 15, 10))
+        session.add(DashboardPlayerSnapshot(**values))
+        session.commit()
+        session.add(DashboardPlayerSnapshot(**values))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_current_projection_has_one_row_per_canonical_player():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True)
+    with Session() as session:
+        values = dict(mlb_player_id=123, snapshot_id=1, player_type="hitter", full_name="One Player", is_active=True, projection_version="v1", promoted_at=dt.datetime(2026, 7, 15, 10), updated_at=dt.datetime(2026, 7, 15, 10))
+        session.add(DashboardPlayerCurrent(**values))
+        session.commit()
+        session.add(DashboardPlayerCurrent(**values))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+def test_report_type_registry_is_explicit_and_describable():
+    assert set(REPORT_TYPES) == {"all_active_hitters", "all_active_pitchers", "hitters_current_matchup", "hitters_arsenal_splits", "players_lineup_history", "teams_daily_analysis", "games_totals_analysis"}
+    hitters = describe_report_type("all_active_hitters")
+    assert hitters["population"] == {"is_active": True, "player_type": "hitter"}
+    assert hitters["fields"][0]["name"] == "mlb_player_id"
+    assert hitters["fields"][0]["supported_operators"] == ["eq", "in"]


### PR DESCRIPTION
Closes the first implementation slice of #1055.

## What changed

- Adds `dashboard_players`, keyed by canonical MLB player ID, with identity, activity, provenance, and resolution fields.
- Adds versioned `dashboard_player_snapshots` with a player/date/context/version uniqueness contract.
- Adds one-row-per-player `dashboard_player_current` for the later default-report query path.
- Adds query-oriented active/type, team, freshness, xwOBA, and score indexes compatible with SQLite and PostgreSQL.
- Registers the additive tables before existing `Base.metadata.create_all()`.
- Defines the seven explicit initial report types and a minimal authoritative field-contract shape.
- Documents the verified current execution path, actual lineup/roster/game/player sources, migration boundaries, failure-safety plan, and six-PR sequence.

## Why

The existing `my_dashboard_records` table is intentionally partitioned by date, component, mode, version, and entity. It remains valuable for daily analytical snapshots and current compatibility, but cannot be the durable cross-date population behind “All Active Hitters.” This PR establishes that missing object boundary without changing live report behavior.

## Deliberately unchanged

- `MyDashboardReportBuilderPage.jsx`
- `/my-dashboard/solver` and `/my-dashboard/solver/active-lineups`
- `my_dashboard_records`
- hydration/query route selection
- solver scoring and formulas
- saved report payloads
- Matchups, Matchup Detail, Daily Odds, Model Projections, and AI Data Assistant

No production rows are populated and no report is claimed to use the new tables yet.

## Validation

Passed locally:

`PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest -q tests/test_dashboard_object_schema.py tests/test_my_dashboard_dataset.py`

Result: **10 passed**.

`git diff --check` passed.

The broader existing SQL-query test module could not collect in the minimal local environment because the full application dependency chain was not installed. Repository CI/deployment must run the backend suite. No frontend files changed.

## Review focus

- Canonical MLB ID and uniqueness boundaries
- Snapshot business key and current-projection cardinality
- PostgreSQL index implications before production backfill
- Confirmation that schema registration remains additive
- Registry contracts as declarations only, not premature route support

## Next slice after merge

PR 2 will implement explicit MLB-ID resolution and the configurable active-player policy from verified lineup, tracked-game, and existing active-roster sources. It must report unresolved identities and must not use name-only canonical matching.