### PR TITLE
Implement Layer 9BL historical outcome source evidence field mapping

### DIFF
--- a/scripts/map_9BL_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field.py
+++ b/scripts/map_9BL_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field.py
@@ -1,0 +1,1537 @@
+#!/usr/bin/env python3
+"""
+Layer 9BL
+Pitch-Type Matchup Overlay Historical Outcome
+Authoritative Source Endpoint Candidate
+Source Evidence Historical Outcome Field Mapping Implementation
+
+Implements the deterministic field-mapping contract planned by Layer 9BK.
+
+Layer 9BJ established that no endpoint candidate, validated response,
+authorized parser execution, parsed-record submission, or validated parsed
+record exists. Layer 9BK therefore authorized mapping implementation only.
+
+This implementation:
+- verifies the Layer 9BK plan;
+- replays Layer 9BJ parsed-record validation records deterministically;
+- inventories explicitly supplied field-mapping submissions;
+- emits one deterministic mapping record per comparison;
+- classifies every record as candidate_not_supplied;
+- performs no historical-outcome field mapping or value extraction;
+- grants no canonical mutation or downstream recomputation authority.
+
+No candidate, response, parser, parsed record, mapping submission, source field,
+mapping rule, provenance, mapped value, or authority evidence is invented,
+inferred, defaulted, imputed, coerced, substituted, or fabricated.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+LAYER_ID = "9BL"
+
+LAYER_NAME = (
+    "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+    "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+    "implementation"
+)
+
+HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION = (
+    "layer_9BL_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_contract_v1"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp"
+    / "layer_9BL_pitch_type_matchup_overlay_historical_outcome_"
+    "authoritative_source_endpoint_candidate_source_evidence_historical_"
+    "outcome_field_mapping"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts"
+    / "plan_9BK_pitch_type_matchup_overlay_historical_outcome_authoritative_"
+    "source_endpoint_candidate_source_evidence_historical_outcome_field_"
+    "mapping.py"
+)
+
+EXPECTED_PLAN_VERSION = (
+    "layer_9BK_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_plan_v1"
+)
+
+EXPECTED_PREDECESSOR_VERSION = (
+    "layer_9BJ_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_parsed_record_validation_contract_v1"
+)
+
+EXPECTED_PREDECESSOR_RECORDS = 16
+EXPECTED_MAPPING_RECORDS = 16
+
+AUTHORITATIVE_FIELD_NAME = "outcome_value"
+
+AUTHORITATIVE_FIELD_PATH = (
+    "historical_prediction_outcome_join_record.outcome_value"
+)
+
+REJECTED_METADATA_FIELD = "outcome_available_at_utc"
+
+MAPPING_STATUS = "candidate_not_supplied"
+
+MAPPING_BLOCKER = (
+    "historical_outcome_endpoint_candidate_missing"
+)
+
+SUPPLIED_FIELD_MAPPING_SUBMISSIONS: tuple[
+    dict[str, Any], ...
+] = ()
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def sha256_payload(payload: Any) -> str:
+    return hashlib.sha256(
+        canonical_json(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(
+            character in "0123456789abcdef"
+            for character in value
+        )
+    )
+
+
+def normalized_string(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def load_module(path: Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        path,
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Unable to load module from {path}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def write_csv(
+    path: Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=list(fieldnames),
+            extrasaction="ignore",
+        )
+
+        writer.writeheader()
+
+        for row in rows:
+            serialized: dict[str, Any] = {}
+
+            for field in fieldnames:
+                value = row.get(field)
+
+                serialized[field] = (
+                    canonical_json(value)
+                    if isinstance(
+                        value,
+                        (dict, list, tuple),
+                    )
+                    else value
+                )
+
+            writer.writerow(serialized)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def replay_plan() -> dict[str, Any]:
+    plan = load_module(
+        PLAN_PATH,
+        "layer_9bk_plan",
+    )
+
+    if plan.PLAN_VERSION != EXPECTED_PLAN_VERSION:
+        raise RuntimeError(
+            "Unexpected Layer 9BK plan version: "
+            f"{plan.PLAN_VERSION}"
+        )
+
+    replay = plan.replay_predecessor()
+    predecessor = replay["module"]
+
+    if (
+        predecessor.PARSED_RECORD_VALIDATION_CONTRACT_VERSION
+        != EXPECTED_PREDECESSOR_VERSION
+    ):
+        raise RuntimeError(
+            "Unexpected Layer 9BJ contract version: "
+            f"{predecessor.PARSED_RECORD_VALIDATION_CONTRACT_VERSION}"
+        )
+
+    return {
+        "plan": plan,
+        "predecessor": predecessor,
+        "records": replay["records"],
+        "reverse_records": replay["reverse_records"],
+    }
+
+
+def build_mapping_records(
+    plan: Any,
+    validation_records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    mapping_records: list[dict[str, Any]] = []
+
+    for validation in validation_records:
+        identity_payload = {
+            "mapping_contract_version":
+                HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION,
+            "parsed_record_validation_record_id":
+                validation.get(
+                    "source_evidence_parsed_record_validation_"
+                    "plan_record_id"
+                ),
+            "comparison_record_id":
+                validation.get("comparison_record_id"),
+            "defect_source_record_id":
+                validation.get("defect_source_record_id"),
+            "candidate_id":
+                validation.get("candidate_id"),
+            "response_artifact_id":
+                validation.get("response_artifact_id"),
+            "parser_id":
+                validation.get("parser_id"),
+            "parsed_record_id":
+                validation.get("parsed_record_id"),
+            "mapping_id": None,
+        }
+
+        identity_digest = sha256_payload(
+            identity_payload
+        )
+
+        record = {
+            "historical_outcome_field_mapping_plan_contract_version":
+                HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION,
+            "historical_outcome_field_mapping_plan_record_id":
+                "HOASEHOFM-" + identity_digest[:20],
+            "source_evidence_parsed_record_validation_plan_record_id":
+                validation.get(
+                    "source_evidence_parsed_record_validation_"
+                    "plan_record_id"
+                ),
+            "parsed_record_validation_plan_record_digest":
+                validation.get(
+                    "parsed_record_validation_plan_record_digest"
+                ),
+            "source_evidence_response_parsing_plan_record_id":
+                validation.get(
+                    "source_evidence_response_parsing_plan_record_id"
+                ),
+            "endpoint_candidate_specification_record_id":
+                validation.get(
+                    "endpoint_candidate_specification_record_id"
+                ),
+            "comparison_record_id":
+                validation.get("comparison_record_id"),
+            "metric_record_id":
+                validation.get("metric_record_id"),
+            "metric_name":
+                validation.get("metric_name"),
+            "aggregation_name":
+                validation.get("aggregation_name"),
+            "aggregation_key":
+                validation.get("aggregation_key"),
+            "authoritative_field_name":
+                AUTHORITATIVE_FIELD_NAME,
+            "authoritative_field_path":
+                AUTHORITATIVE_FIELD_PATH,
+            "rejected_metadata_field_name":
+                REJECTED_METADATA_FIELD,
+            "defect_source_path":
+                validation.get("defect_source_path"),
+            "defect_source_symbol":
+                validation.get("defect_source_symbol"),
+            "defect_source_record_id":
+                validation.get("defect_source_record_id"),
+            "defect_source_record_digest":
+                validation.get("defect_source_record_digest"),
+            "parsed_record_validation_status":
+                validation.get(
+                    "parsed_record_validation_status"
+                ),
+            "parsed_record_validation_blocker_codes":
+                validation.get(
+                    "parsed_record_validation_blocker_codes"
+                ),
+            "candidate_supplied":
+                bool(validation.get("candidate_supplied")),
+            "candidate_id":
+                validation.get("candidate_id"),
+            "candidate_version":
+                validation.get("candidate_version"),
+            "response_artifact_id":
+                validation.get("response_artifact_id"),
+            "response_sha256":
+                validation.get("response_sha256"),
+            "parser_id":
+                validation.get("parser_id"),
+            "parser_version":
+                validation.get("parser_version"),
+            "parser_code_digest":
+                validation.get("parser_code_digest"),
+            "parsed_record_submission_supplied":
+                bool(
+                    validation.get(
+                        "parsed_record_submission_supplied"
+                    )
+                ),
+            "parsed_record_id":
+                validation.get("parsed_record_id"),
+            "parsed_record_version":
+                validation.get("parsed_record_version"),
+            "parsed_record_digest":
+                validation.get("parsed_record_digest"),
+            "mapping_submission_supplied": False,
+            "mapping_id": None,
+            "mapping_version": None,
+            "mapping_digest": None,
+            "source_field_name": None,
+            "source_field_path": None,
+            "source_field_type": None,
+            "source_value_domain": None,
+            "target_field_name":
+                AUTHORITATIVE_FIELD_NAME,
+            "target_field_path":
+                AUTHORITATIVE_FIELD_PATH,
+            "target_field_type": None,
+            "target_value_domain": None,
+            "mapping_rule": None,
+            "null_policy": None,
+            "invalid_value_policy": None,
+            "source_field_provenance": None,
+            "mapping_provenance": None,
+            "historical_outcome_field_mapping_status":
+                MAPPING_STATUS,
+            "historical_outcome_field_mapping_blocker_codes": [
+                MAPPING_BLOCKER
+            ],
+            "historical_outcome_field_mapping_implementation_authority_granted":
+                False,
+            "historical_outcome_field_mapping_rationale": (
+                "No endpoint candidate exists, so no validated response, "
+                "authorized parser execution, validated parsed record, or "
+                "explicit field-mapping submission exists. Mapping cannot "
+                "proceed without inventing source-field identity, type, value "
+                "domain, mapping rule, target-type contract, provenance, or "
+                "mapped historical outcome values."
+            ),
+            "historical_outcome_field_mapping_limitations": [
+                "No endpoint candidate was supplied.",
+                "No validated response artifact exists.",
+                "No authorized parser execution exists.",
+                "No validated parsed source-evidence record exists.",
+                "No mapping submission was supplied.",
+                "No mapping identifier was invented.",
+                "No mapping version or digest was invented.",
+                "No source-field name or path was invented.",
+                "No source-field type or value domain was invented.",
+                "No target-field type or value domain was invented.",
+                "No mapping rule was invented.",
+                "No null or invalid-value policy was invented.",
+                "No source-field provenance was invented.",
+                "No mapping provenance was invented.",
+                "The rejected metadata field was not substituted.",
+                "No boolean-to-integer coercion was performed.",
+                "No defaulting, inference, or imputation was performed.",
+                "No historical outcome field was mapped.",
+                "No historical outcome value was extracted.",
+                "No canonical source record was mutated.",
+                "No canonical mapping was changed.",
+                "No downstream record was recomputed.",
+            ],
+            "historical_outcome_field_mapping_plan_identity_digest":
+                identity_digest,
+        }
+
+        record[
+            "historical_outcome_field_mapping_plan_record_digest"
+        ] = sha256_payload(record)
+
+        missing_fields = [
+            field
+            for field in plan.MAPPING_PLAN_RECORD_FIELDS
+            if field not in record
+        ]
+
+        if missing_fields:
+            raise RuntimeError(
+                "Historical-outcome mapping record missing fields: "
+                + ", ".join(missing_fields)
+            )
+
+        mapping_records.append(
+            {
+                field: record[field]
+                for field in plan.MAPPING_PLAN_RECORD_FIELDS
+            }
+        )
+
+    mapping_records.sort(
+        key=lambda row: (
+            normalized_string(
+                row.get("comparison_record_id")
+            ),
+            normalized_string(
+                row.get("defect_source_record_id")
+            ),
+            normalized_string(
+                row.get("candidate_id")
+            ),
+            normalized_string(
+                row.get("response_artifact_id")
+            ),
+            normalized_string(
+                row.get("parser_id")
+            ),
+            normalized_string(
+                row.get("parsed_record_id")
+            ),
+            normalized_string(
+                row.get("mapping_id")
+            ),
+            normalized_string(
+                row.get(
+                    "historical_outcome_field_mapping_"
+                    "plan_record_id"
+                )
+            ),
+        )
+    )
+
+    return mapping_records
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    replay = replay_plan()
+
+    plan = replay["plan"]
+    predecessor = replay["predecessor"]
+    validation_records = replay["records"]
+    reverse_validation_records = replay[
+        "reverse_records"
+    ]
+
+    mapping_records = build_mapping_records(
+        plan,
+        validation_records,
+    )
+
+    reverse_mapping_records = build_mapping_records(
+        plan,
+        list(
+            reversed(
+                reverse_validation_records
+            )
+        ),
+    )
+
+    predecessor_replay_deterministic = (
+        canonical_json(validation_records)
+        == canonical_json(
+            reverse_validation_records
+        )
+    )
+
+    mapping_replay_deterministic = (
+        canonical_json(mapping_records)
+        == canonical_json(
+            reverse_mapping_records
+        )
+    )
+
+    mapping_digest = sha256_payload(
+        mapping_records
+    )
+
+    reverse_mapping_digest = sha256_payload(
+        reverse_mapping_records
+    )
+
+    comparison_ids = {
+        row["comparison_record_id"]
+        for row in mapping_records
+    }
+
+    status_counts = dict(
+        sorted(
+            Counter(
+                row[
+                    "historical_outcome_field_mapping_status"
+                ]
+                for row in mapping_records
+            ).items()
+        )
+    )
+
+    blocker_counts = dict(
+        sorted(
+            Counter(
+                blocker
+                for row in mapping_records
+                for blocker in row[
+                    "historical_outcome_field_mapping_blocker_codes"
+                ]
+            ).items()
+        )
+    )
+
+    candidate_presence_counts = dict(
+        sorted(
+            Counter(
+                str(row["candidate_supplied"])
+                for row in mapping_records
+            ).items()
+        )
+    )
+
+    parsed_record_presence_counts = dict(
+        sorted(
+            Counter(
+                str(
+                    row[
+                        "parsed_record_submission_supplied"
+                    ]
+                )
+                for row in mapping_records
+            ).items()
+        )
+    )
+
+    mapping_presence_counts = dict(
+        sorted(
+            Counter(
+                str(
+                    row[
+                        "mapping_submission_supplied"
+                    ]
+                )
+                for row in mapping_records
+            ).items()
+        )
+    )
+
+    authority_records = [
+        row
+        for row in mapping_records
+        if row[
+            "historical_outcome_field_mapping_"
+            "implementation_authority_granted"
+        ]
+    ]
+
+    checks = [
+        {
+            "check": "nine_bk_plan_version_verified",
+            "actual": plan.PLAN_VERSION,
+            "expected": EXPECTED_PLAN_VERSION,
+            "passed":
+                plan.PLAN_VERSION
+                == EXPECTED_PLAN_VERSION,
+        },
+        {
+            "check": "nine_bj_contract_version_verified",
+            "actual":
+                predecessor.PARSED_RECORD_VALIDATION_CONTRACT_VERSION,
+            "expected": EXPECTED_PREDECESSOR_VERSION,
+            "passed": (
+                predecessor.PARSED_RECORD_VALIDATION_CONTRACT_VERSION
+                == EXPECTED_PREDECESSOR_VERSION
+            ),
+        },
+        {
+            "check": "predecessor_replay_deterministic",
+            "actual": predecessor_replay_deterministic,
+            "expected": True,
+            "passed": predecessor_replay_deterministic,
+        },
+        {
+            "check": "mapping_replay_deterministic",
+            "actual": mapping_replay_deterministic,
+            "expected": True,
+            "passed": mapping_replay_deterministic,
+        },
+        {
+            "check": "mapping_digests_match_reverse_replay",
+            "actual": mapping_digest,
+            "expected": reverse_mapping_digest,
+            "passed":
+                mapping_digest
+                == reverse_mapping_digest,
+        },
+        {
+            "check": "expected_predecessor_records_replayed",
+            "actual": len(validation_records),
+            "expected": EXPECTED_PREDECESSOR_RECORDS,
+            "passed": (
+                len(validation_records)
+                == EXPECTED_PREDECESSOR_RECORDS
+            ),
+        },
+        {
+            "check": "expected_mapping_records_materialized",
+            "actual": len(mapping_records),
+            "expected": EXPECTED_MAPPING_RECORDS,
+            "passed": (
+                len(mapping_records)
+                == EXPECTED_MAPPING_RECORDS
+            ),
+        },
+        {
+            "check": "one_mapping_record_per_comparison",
+            "actual": len(comparison_ids),
+            "expected": EXPECTED_MAPPING_RECORDS,
+            "passed": (
+                len(comparison_ids)
+                == EXPECTED_MAPPING_RECORDS
+            ),
+        },
+        {
+            "check": "mapping_record_fields_complete",
+            "actual": len(
+                plan.MAPPING_PLAN_RECORD_FIELDS
+            ),
+            "expected": 56,
+            "passed": all(
+                set(row)
+                == set(
+                    plan.MAPPING_PLAN_RECORD_FIELDS
+                )
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "mapping_record_ids_unique",
+            "actual": len(
+                {
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_record_id"
+                    ]
+                    for row in mapping_records
+                }
+            ),
+            "expected": len(mapping_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "historical_outcome_field_mapping_"
+                            "plan_record_id"
+                        ]
+                        for row in mapping_records
+                    }
+                )
+                == len(mapping_records)
+            ),
+        },
+        {
+            "check": "mapping_record_digests_unique",
+            "actual": len(
+                {
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_record_digest"
+                    ]
+                    for row in mapping_records
+                }
+            ),
+            "expected": len(mapping_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "historical_outcome_field_mapping_"
+                            "plan_record_digest"
+                        ]
+                        for row in mapping_records
+                    }
+                )
+                == len(mapping_records)
+            ),
+        },
+        {
+            "check": "all_mapping_identity_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_identity_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_identity_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_mapping_record_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_record_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_"
+                        "plan_record_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_parsed_record_validation_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "parsed_record_validation_plan_record_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "parsed_record_validation_plan_record_digest"
+                    ]
+                )
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_defect_source_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row["defect_source_record_digest"]
+                )
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                valid_sha256(
+                    row["defect_source_record_digest"]
+                )
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "supplied_mapping_inventory_empty",
+            "actual": len(
+                SUPPLIED_FIELD_MAPPING_SUBMISSIONS
+            ),
+            "expected": 0,
+            "passed": (
+                len(
+                    SUPPLIED_FIELD_MAPPING_SUBMISSIONS
+                )
+                == 0
+            ),
+        },
+        {
+            "check": "all_candidates_absent",
+            "actual": candidate_presence_counts,
+            "expected": {
+                "False": EXPECTED_MAPPING_RECORDS
+            },
+            "passed": (
+                candidate_presence_counts
+                == {
+                    "False":
+                        EXPECTED_MAPPING_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_parsed_record_submissions_absent",
+            "actual": parsed_record_presence_counts,
+            "expected": {
+                "False": EXPECTED_MAPPING_RECORDS
+            },
+            "passed": (
+                parsed_record_presence_counts
+                == {
+                    "False":
+                        EXPECTED_MAPPING_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_mapping_submissions_absent",
+            "actual": mapping_presence_counts,
+            "expected": {
+                "False": EXPECTED_MAPPING_RECORDS
+            },
+            "passed": (
+                mapping_presence_counts
+                == {
+                    "False":
+                        EXPECTED_MAPPING_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_records_candidate_not_supplied",
+            "actual": status_counts,
+            "expected": {
+                MAPPING_STATUS:
+                    EXPECTED_MAPPING_RECORDS
+            },
+            "passed": (
+                status_counts
+                == {
+                    MAPPING_STATUS:
+                        EXPECTED_MAPPING_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_candidate_missing_blockers_present",
+            "actual": blocker_counts,
+            "expected": {
+                MAPPING_BLOCKER:
+                    EXPECTED_MAPPING_RECORDS
+            },
+            "passed": (
+                blocker_counts
+                == {
+                    MAPPING_BLOCKER:
+                        EXPECTED_MAPPING_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_candidate_identity_fields_absent",
+            "actual": sum(
+                row["candidate_id"] is None
+                and row["candidate_version"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["candidate_id"] is None
+                and row["candidate_version"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_response_parser_and_record_identity_fields_absent",
+            "actual": sum(
+                row["response_artifact_id"] is None
+                and row["response_sha256"] is None
+                and row["parser_id"] is None
+                and row["parser_version"] is None
+                and row["parser_code_digest"] is None
+                and row["parsed_record_id"] is None
+                and row["parsed_record_version"] is None
+                and row["parsed_record_digest"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["response_artifact_id"] is None
+                and row["response_sha256"] is None
+                and row["parser_id"] is None
+                and row["parser_version"] is None
+                and row["parser_code_digest"] is None
+                and row["parsed_record_id"] is None
+                and row["parsed_record_version"] is None
+                and row["parsed_record_digest"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_mapping_identity_fields_absent",
+            "actual": sum(
+                row["mapping_id"] is None
+                and row["mapping_version"] is None
+                and row["mapping_digest"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["mapping_id"] is None
+                and row["mapping_version"] is None
+                and row["mapping_digest"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_source_mapping_contract_fields_absent",
+            "actual": sum(
+                row["source_field_name"] is None
+                and row["source_field_path"] is None
+                and row["source_field_type"] is None
+                and row["source_value_domain"] is None
+                and row["mapping_rule"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["source_field_name"] is None
+                and row["source_field_path"] is None
+                and row["source_field_type"] is None
+                and row["source_value_domain"] is None
+                and row["mapping_rule"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "canonical_target_identity_preserved",
+            "actual": sorted(
+                {
+                    (
+                        row["target_field_name"],
+                        row["target_field_path"],
+                    )
+                    for row in mapping_records
+                }
+            ),
+            "expected": [
+                (
+                    AUTHORITATIVE_FIELD_NAME,
+                    AUTHORITATIVE_FIELD_PATH,
+                )
+            ],
+            "passed": all(
+                row["target_field_name"]
+                == AUTHORITATIVE_FIELD_NAME
+                and row["target_field_path"]
+                == AUTHORITATIVE_FIELD_PATH
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_target_type_and_domain_fields_absent",
+            "actual": sum(
+                row["target_field_type"] is None
+                and row["target_value_domain"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["target_field_type"] is None
+                and row["target_value_domain"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "all_mapping_policy_and_provenance_fields_absent",
+            "actual": sum(
+                row["null_policy"] is None
+                and row["invalid_value_policy"] is None
+                and row["source_field_provenance"] is None
+                and row["mapping_provenance"] is None
+                for row in mapping_records
+            ),
+            "expected": len(mapping_records),
+            "passed": all(
+                row["null_policy"] is None
+                and row["invalid_value_policy"] is None
+                and row["source_field_provenance"] is None
+                and row["mapping_provenance"] is None
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "no_mapping_implementation_authority_granted",
+            "actual": len(authority_records),
+            "expected": 0,
+            "passed":
+                len(authority_records) == 0,
+        },
+        {
+            "check": "authoritative_field_name_preserved",
+            "actual": sorted(
+                {
+                    row["authoritative_field_name"]
+                    for row in mapping_records
+                }
+            ),
+            "expected": [AUTHORITATIVE_FIELD_NAME],
+            "passed": all(
+                row["authoritative_field_name"]
+                == AUTHORITATIVE_FIELD_NAME
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "authoritative_field_path_preserved",
+            "actual": sorted(
+                {
+                    row["authoritative_field_path"]
+                    for row in mapping_records
+                }
+            ),
+            "expected": [AUTHORITATIVE_FIELD_PATH],
+            "passed": all(
+                row["authoritative_field_path"]
+                == AUTHORITATIVE_FIELD_PATH
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "rejected_metadata_field_preserved",
+            "actual": sorted(
+                {
+                    row["rejected_metadata_field_name"]
+                    for row in mapping_records
+                }
+            ),
+            "expected": [REJECTED_METADATA_FIELD],
+            "passed": all(
+                row["rejected_metadata_field_name"]
+                == REJECTED_METADATA_FIELD
+                for row in mapping_records
+            ),
+        },
+        {
+            "check": "mapping_submission_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "source_contract_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "rejected_metadata_substitution_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "coercion_defaulting_inference_imputation_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_fields_mapped_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_values_extracted_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "response_bytes_read_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "responses_parsed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "parsed_records_validated_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credentials_stored_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credential_literals_logged_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "network_retrievals_executed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_sources_not_changed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_mappings_not_changed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "candidate_values_not_transformed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "downstream_records_not_recomputed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "quality_and_production_authority_absent",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+    ]
+
+    all_checks_passed = all(
+        bool(row["passed"])
+        for row in checks
+    )
+
+    diagnosis_name = (
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "implementation_complete"
+        if all_checks_passed
+        else
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "implementation_failed"
+    )
+
+    next_layer = (
+        "9BM_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_plan"
+        if all_checks_passed
+        else
+        "9BL_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR
+        / "historical_outcome_field_mapping_records.csv",
+        plan.MAPPING_PLAN_RECORD_FIELDS,
+        mapping_records,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "mapping_status_counts.csv",
+        [
+            "mapping_status",
+            "count",
+        ],
+        [
+            {
+                "mapping_status": key,
+                "count": value,
+            }
+            for key, value in status_counts.items()
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "mapping_blocker_counts.csv",
+        [
+            "mapping_blocker",
+            "count",
+        ],
+        [
+            {
+                "mapping_blocker": key,
+                "count": value,
+            }
+            for key, value in blocker_counts.items()
+        ],
+    )
+
+    write_json(
+        OUTPUT_DIR
+        / "supplied_field_mapping_submission_inventory.json",
+        {
+            "layer_id": LAYER_ID,
+            "supplied_field_mapping_submission_count":
+                len(
+                    SUPPLIED_FIELD_MAPPING_SUBMISSIONS
+                ),
+            "supplied_field_mapping_submissions":
+                list(
+                    SUPPLIED_FIELD_MAPPING_SUBMISSIONS
+                ),
+            "inventory_status": (
+                "no_candidate_validated_parsed_record_or_"
+                "field_mapping_submission_supplied"
+            ),
+        },
+    )
+
+    summary = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "historical_outcome_field_mapping_contract_version":
+            HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION,
+        "plan_version": plan.PLAN_VERSION,
+        "predecessor_contract_version":
+            predecessor.PARSED_RECORD_VALIDATION_CONTRACT_VERSION,
+        "predecessor_records":
+            len(validation_records),
+        "mapping_records":
+            len(mapping_records),
+        "mapping_comparisons":
+            len(comparison_ids),
+        "supplied_field_mapping_submissions":
+            len(
+                SUPPLIED_FIELD_MAPPING_SUBMISSIONS
+            ),
+        "mapping_status_counts":
+            status_counts,
+        "mapping_blocker_counts":
+            blocker_counts,
+        "mapping_implementation_authorities_granted":
+            len(authority_records),
+        "mapping_digest":
+            mapping_digest,
+        "reverse_mapping_digest":
+            reverse_mapping_digest,
+        "implementation_checks_passed": sum(
+            bool(row["passed"])
+            for row in checks
+        ),
+        "implementation_checks_required":
+            len(checks),
+        "historical_outcome_fields_mapped": 0,
+        "historical_outcome_values_extracted": 0,
+        "response_bytes_read": 0,
+        "responses_parsed": 0,
+        "parsed_records_validated": 0,
+        "credentials_stored": 0,
+        "credential_literals_logged": 0,
+        "network_retrievals_executed": 0,
+        "canonical_source_records_changed": 0,
+        "canonical_mappings_changed": 0,
+        "candidate_values_transformed": 0,
+        "downstream_records_recomputed": 0,
+        "uncertainty_estimates_calculated": 0,
+        "statistical_significance_tests_calculated": 0,
+        "superiority_decisions_emitted": 0,
+        "equivalence_decisions_emitted": 0,
+        "activation_recommendations_emitted": 0,
+        "production_probabilities_changed": 0,
+        "market_comparisons_executed": 0,
+        "betting_edges_calculated": 0,
+        "all_checks_passed":
+            all_checks_passed,
+        "recommended_next_layer":
+            next_layer,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "historical_outcome_field_mapping_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "all_checks_passed":
+            all_checks_passed,
+        "diagnosis":
+            diagnosis_name,
+        "mapping_result":
+            MAPPING_STATUS,
+        "authority_granted": (
+            "historical_outcome_authoritative_source_endpoint_candidate_"
+            "source_evidence_historical_outcome_field_mapping_result_"
+            "validation_planning"
+            if all_checks_passed
+            else "none"
+        ),
+        "authority_withheld": [
+            "endpoint_candidate_invention",
+            "endpoint_candidate_selection_without_submission",
+            "response_artifact_invention",
+            "response_metadata_invention",
+            "parser_submission_invention",
+            "parser_identity_invention",
+            "parser_code_invention",
+            "parsed_record_submission_invention",
+            "parsed_record_identity_invention",
+            "parsed_record_content_invention",
+            "parsed_record_digest_invention",
+            "mapping_submission_invention",
+            "mapping_identity_invention",
+            "mapping_rule_invention",
+            "source_field_name_invention",
+            "source_field_path_invention",
+            "source_field_type_invention",
+            "source_value_domain_invention",
+            "target_field_type_invention",
+            "target_value_domain_invention",
+            "source_field_provenance_invention",
+            "mapping_provenance_invention",
+            "rejected_metadata_field_substitution",
+            "boolean_to_integer_coercion",
+            "source_value_defaulting",
+            "source_value_inference",
+            "source_value_imputation",
+            "historical_outcome_field_mapping_execution",
+            "historical_outcome_value_extraction",
+            "response_bytes_reading",
+            "source_evidence_parse_execution",
+            "raw_response_parse_execution",
+            "credential_literal_storage",
+            "credential_literal_logging",
+            "dns_resolution_execution",
+            "socket_connection_execution",
+            "http_request_execution",
+            "browser_execution",
+            "api_request_execution",
+            "canonical_source_value_mutation",
+            "canonical_outcome_mapping_change",
+            "canonical_evaluation_row_recomputation",
+            "canonical_join_record_recomputation",
+            "canonical_comparison_record_recomputation",
+            "canonical_metric_recomputation",
+            "uncertainty_estimation",
+            "statistical_significance_testing",
+            "superiority_determination",
+            "equivalence_determination",
+            "activation_recommendation",
+            "production_probability_change",
+            "market_comparison",
+            "pricing_change",
+            "betting_edge_calculation",
+        ],
+        "recommended_next_layer":
+            next_layer,
+        "output_directory":
+            str(
+                OUTPUT_DIR.relative_to(ROOT)
+            ),
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        f"Layer: {LAYER_ID} — {LAYER_NAME}"
+    )
+    print(
+        "Historical outcome field mapping contract version: "
+        f"{HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION}"
+    )
+    print(
+        "Implementation checks passed: "
+        f"{summary['implementation_checks_passed']}/"
+        f"{summary['implementation_checks_required']}"
+    )
+    print(
+        "Predecessor records replayed: "
+        f"{len(validation_records)}"
+    )
+    print(
+        "Mapping records: "
+        f"{len(mapping_records)}"
+    )
+    print(
+        "Mapping comparisons: "
+        f"{len(comparison_ids)}"
+    )
+    print(
+        "Supplied field mapping submissions: "
+        f"{len(SUPPLIED_FIELD_MAPPING_SUBMISSIONS)}"
+    )
+    print(
+        "Mapping status counts: "
+        f"{status_counts}"
+    )
+    print(
+        "Mapping blocker counts: "
+        f"{blocker_counts}"
+    )
+    print(
+        "Mapping implementation authorities granted: "
+        f"{len(authority_records)}"
+    )
+    print(
+        f"Mapping digest: {mapping_digest}"
+    )
+    print(
+        "Reverse mapping digest: "
+        f"{reverse_mapping_digest}"
+    )
+    print("Historical outcome fields mapped: 0")
+    print("Historical outcome values extracted: 0")
+    print("Response bytes read: 0")
+    print("Responses parsed: 0")
+    print("Parsed records validated: 0")
+    print("Credentials stored: 0")
+    print("Credential literals logged: 0")
+    print("Network retrievals executed: 0")
+    print("Canonical source records changed: 0")
+    print("Canonical mappings changed: 0")
+    print("Candidate values transformed: 0")
+    print("Downstream records recomputed: 0")
+    print("Uncertainty estimates calculated: 0")
+    print(
+        "Statistical significance tests calculated: 0"
+    )
+    print("Superiority decisions emitted: 0")
+    print("Equivalence decisions emitted: 0")
+    print("Activation recommendations emitted: 0")
+    print("Production probabilities changed: 0")
+    print("Market comparisons executed: 0")
+    print("Betting edges calculated: 0")
+    print(
+        f"Diagnosis: {diagnosis_name}"
+    )
+    print(
+        "Mapping result: "
+        f"{diagnosis['mapping_result']}"
+    )
+    print(
+        "Authority granted: "
+        f"{diagnosis['authority_granted']}"
+    )
+    print(
+        "Recommended next layer: "
+        f"{next_layer}"
+    )
+    print(
+        "Artifacts: "
+        f"{OUTPUT_DIR.relative_to(ROOT)}"
+    )
+
+    if not all_checks_passed:
+        failed_checks = [
+            row["check"]
+            for row in checks
+            if not row["passed"]
+        ]
+
+        print(
+            "FAILED CHECKS: "
+            + ", ".join(failed_checks)
+        )
+
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the Layer 9BL deterministic historical-outcome field-mapping contract for authoritative source-evidence records.

Validation:
- 49/49 implementation checks passed
- 16 Layer 9BJ parsed-record validation records replayed deterministically
- 16 historical-outcome field-mapping records materialized, one per comparison
- No endpoint candidate, validated response, authorized parser execution, validated parsed record, or field-mapping submission was supplied or invented
- All records classified as `candidate_not_supplied` with `historical_outcome_endpoint_candidate_missing`
- No mapping implementation authority granted
- Canonical `outcome_value` target and rejected metadata field preserved
- No candidate/response/parser/parsed-record/mapping/source-field/type/domain/rule/provenance invention, rejected-metadata substitution, coercion, defaulting, inference, imputation, response-byte reading or parsing, historical-outcome field mapping or value extraction, credential storage or logging, DNS/socket/HTTP/browser/API execution, source mutation, mapping change, transformation, downstream recomputation, production, market, pricing, or betting authority granted

Next layer: 9BM — historical outcome authoritative source endpoint candidate source evidence historical outcome field mapping result validation plan.