### PR TITLE
PR 3: hydrate player snapshots and current projection

### DIFF
--- a/docs/my_dashboard_projection_hydration.md
+++ b/docs/my_dashboard_projection_hydration.md
@@ -1,0 +1,38 @@
+# My Dashboard snapshot and current-projection hydration
+
+## Boundary
+
+PR 3 creates immutable `dashboard_player_snapshots` and atomically promotes `dashboard_player_current`. It does not route Report Builder requests to the new projection; that remains PR 4.
+
+## Source model
+
+The canonical population always comes from active, resolved `dashboard_players`. Batter and pitcher aggregates provide baseline scalar metrics. The newest compatible current `my_dashboard_records` row may overlay reportable metrics and score, but it cannot add or remove players from the population.
+
+This preserves useful existing dataset work without mistaking a daily component result for the complete player universe.
+
+## Refresh lifecycle
+
+1. Build and validate all candidate rows before writing.
+2. Require unique canonical MLB IDs.
+3. For a full refresh, require exact coverage of the active canonical population.
+4. Derive a deterministic per-player content version and a deterministic batch projection version.
+5. Reuse an identical existing snapshot; create a new snapshot only when that player’s approved reportable content changed.
+6. Flush snapshots and current-row promotion in one transaction.
+7. Run the optional promotion guard after staging and before commit.
+8. Roll back every staged snapshot/current change on any failure.
+
+An empty full refresh is rejected by default. Partial refreshes never delete current rows outside their requested subset. A successful complete refresh removes current rows for players no longer in the active canonical population.
+
+## Failure safety and idempotency
+
+- A builder or source failure occurs before shared rows are changed.
+- A validation, database, or promotion-guard failure rolls back the entire date refresh.
+- Repeating identical inputs reuses snapshots and leaves the current projection unchanged.
+- A one-player metric change creates one new historical snapshot and reuses unchanged player snapshots.
+- User filters and weights are not accepted or persisted by this service.
+
+## Backfill evidence
+
+`backfill_player_projection()` processes dates in order, retains a result per successful date, and promotes current rows only for the final requested date. Its response includes requested/successful/failed date counts, per-date projection versions and row counts, total snapshots created, final current row count, historical snapshot count, and explicit failures.
+
+These counts are execution evidence only. They are not a claim that production backfill has run.

--- a/mlb_app/dashboard_player_projection.py
+++ b/mlb_app/dashboard_player_projection.py
@@ -1,0 +1,517 @@
+"""Versioned player snapshots and atomic current-projection promotion."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+from .dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot
+from .database import BatterAggregate, PitcherAggregate
+from .my_dashboard_dataset import MyDashboardRecord
+
+
+SNAPSHOT_CONTEXT_CURRENT = "current_player_metrics"
+HITTER_COMPONENTS = {"hitters", "overall_players"}
+PITCHER_COMPONENTS = {"pitchers", "overall_players"}
+SNAPSHOT_SCALARS = (
+    "model_score",
+    "confidence",
+    "xwoba",
+    "xba",
+    "exit_velocity",
+    "launch_angle",
+    "hard_hit_rate",
+    "barrel_rate",
+    "strikeout_rate",
+    "walk_rate",
+    "iso",
+    "obp",
+    "slg",
+    "plate_appearances",
+)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, (dt.date, dt.datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _hash(value: Any) -> str:
+    encoded = json.dumps(_json_safe(value), sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _metric(metrics: Dict[str, Any], *names: str) -> Optional[float]:
+    for name in names:
+        value = _safe_float(metrics.get(name))
+        if value is not None:
+            return value
+    return None
+
+
+def _coalesce(*values: Any) -> Any:
+    return next((value for value in values if value is not None), None)
+
+
+def _choose_latest(rows: Iterable[Any], id_attribute: str, snapshot_date: dt.date) -> Dict[int, Any]:
+    selected: Dict[int, Any] = {}
+    window_priority = {"season": 1, "365d": 2, "90d": 3, "30d": 4, "15d": 5}
+    for row in rows:
+        player_id = int(getattr(row, id_attribute))
+        end_date = getattr(row, "end_date", None)
+        if end_date and end_date > snapshot_date:
+            continue
+        current = selected.get(player_id)
+        row_key = (end_date or dt.date.min, window_priority.get(str(getattr(row, "window", "")).lower(), 0), getattr(row, "id", 0))
+        if current is None:
+            selected[player_id] = row
+            continue
+        current_key = (
+            getattr(current, "end_date", None) or dt.date.min,
+            window_priority.get(str(getattr(current, "window", "")).lower(), 0),
+            getattr(current, "id", 0),
+        )
+        if row_key > current_key:
+            selected[player_id] = row
+    return selected
+
+
+def _latest_dashboard_overlays(session: Any, snapshot_date: dt.date, player_types: Dict[int, str]) -> Dict[int, MyDashboardRecord]:
+    if not player_types:
+        return {}
+    player_ids = set(player_types)
+    rows = (
+        session.query(MyDashboardRecord)
+        .filter(
+            MyDashboardRecord.is_current.is_(True),
+            MyDashboardRecord.dataset_date <= snapshot_date,
+            MyDashboardRecord.entity_id.isnot(None),
+            MyDashboardRecord.entity_id.in_([str(value) for value in sorted(player_ids)]),
+            MyDashboardRecord.component.in_(sorted(HITTER_COMPONENTS | PITCHER_COMPONENTS)),
+        )
+        .order_by(MyDashboardRecord.refreshed_at.desc(), MyDashboardRecord.id.desc())
+        .all()
+    )
+    overlays: Dict[int, MyDashboardRecord] = {}
+    for row in rows:
+        player_id = _safe_int(row.entity_id)
+        expected_type = player_types.get(player_id)
+        compatible_components = HITTER_COMPONENTS if expected_type == "hitter" else PITCHER_COMPONENTS
+        compatible_type = not row.player_type or str(row.player_type).lower() in {expected_type, "player"}
+        if player_id in player_ids and player_id not in overlays and row.component in compatible_components and compatible_type:
+            overlays[player_id] = row
+    return overlays
+
+
+def build_player_snapshot_rows(
+    session: Any,
+    snapshot_date: dt.date,
+    *,
+    player_ids: Optional[Sequence[int]] = None,
+) -> List[Dict[str, Any]]:
+    """Build one reportable row for every requested active canonical player.
+
+    Existing date-partitioned dashboard records are metric overlays only; they
+    never define the player population.
+    """
+
+    query = session.query(DashboardPlayer).filter(
+        DashboardPlayer.is_active.is_(True),
+        DashboardPlayer.identity_resolution_status == "resolved",
+    )
+    if player_ids is not None:
+        query = query.filter(DashboardPlayer.mlb_player_id.in_([int(value) for value in player_ids]))
+    players = query.order_by(DashboardPlayer.mlb_player_id.asc()).all()
+    ids = {player.mlb_player_id for player in players}
+    hitter_aggregates = _choose_latest(
+        session.query(BatterAggregate).filter(BatterAggregate.batter_id.in_(ids)).all() if ids else [],
+        "batter_id",
+        snapshot_date,
+    )
+    pitcher_aggregates = _choose_latest(
+        session.query(PitcherAggregate).filter(PitcherAggregate.pitcher_id.in_(ids)).all() if ids else [],
+        "pitcher_id",
+        snapshot_date,
+    )
+    overlays = _latest_dashboard_overlays(session, snapshot_date, {player.mlb_player_id: player.player_type for player in players})
+    output: List[Dict[str, Any]] = []
+
+    for player in players:
+        sources = ["dashboard_players"]
+        metrics: Dict[str, Any] = {}
+        source_versions: Dict[str, Any] = {}
+        row: Dict[str, Any] = {
+            "mlb_player_id": player.mlb_player_id,
+            "full_name": player.full_name,
+            "player_type": player.player_type,
+            "team_id": player.current_team_id,
+            "team_name": player.current_team_name,
+            "primary_position": player.primary_position,
+            "is_active": True,
+            "lineup_status": player.active_status_reason,
+        }
+        row.update({field: None for field in SNAPSHOT_SCALARS})
+        aggregate = hitter_aggregates.get(player.mlb_player_id) if player.player_type == "hitter" else pitcher_aggregates.get(player.mlb_player_id)
+        if isinstance(aggregate, BatterAggregate):
+            row.update(
+                exit_velocity=aggregate.avg_exit_velocity,
+                launch_angle=aggregate.avg_launch_angle,
+                hard_hit_rate=aggregate.hard_hit_pct,
+                barrel_rate=aggregate.barrel_pct,
+                strikeout_rate=aggregate.k_pct,
+                walk_rate=aggregate.bb_pct,
+            )
+            metrics.update({
+                "AVG": aggregate.batting_avg,
+                "EV": aggregate.avg_exit_velocity,
+                "LA": aggregate.avg_launch_angle,
+                "HardHit": aggregate.hard_hit_pct,
+                "Barrel": aggregate.barrel_pct,
+                "K%": aggregate.k_pct,
+                "BB%": aggregate.bb_pct,
+            })
+            sources.append("batter_aggregates")
+        elif isinstance(aggregate, PitcherAggregate):
+            row.update(
+                xwoba=aggregate.xwoba,
+                xba=aggregate.xba,
+                hard_hit_rate=aggregate.hard_hit_pct,
+                strikeout_rate=aggregate.k_pct,
+                walk_rate=aggregate.bb_pct,
+            )
+            metrics.update({
+                "Velocity": aggregate.avg_velocity,
+                "Spin Rate": aggregate.avg_spin_rate,
+                "xwOBA Allowed": aggregate.xwoba,
+                "xBA Allowed": aggregate.xba,
+                "HardHit Allowed": aggregate.hard_hit_pct,
+                "K%": aggregate.k_pct,
+                "BB%": aggregate.bb_pct,
+            })
+            sources.append("pitcher_aggregates")
+        if aggregate is not None:
+            source_versions["aggregate"] = {"window": aggregate.window, "end_date": aggregate.end_date.isoformat()}
+
+        overlay = overlays.get(player.mlb_player_id)
+        if overlay is not None:
+            overlay_metrics = dict(overlay.metrics_json or {})
+            compatible = overlay.component in (HITTER_COMPONENTS if player.player_type == "hitter" else PITCHER_COMPONENTS)
+            if compatible:
+                row.update(
+                    model_score=overlay.adjusted_score if overlay.adjusted_score is not None else overlay.score,
+                    confidence=overlay.confidence,
+                    xwoba=_coalesce(_metric(overlay_metrics, "xwOBA", "xwoba", "xwOBA Allowed"), row.get("xwoba")),
+                    xba=_coalesce(_metric(overlay_metrics, "xBA", "xba", "xBA Allowed"), row.get("xba")),
+                    exit_velocity=_coalesce(_metric(overlay_metrics, "EV", "Exit Velocity", "avg_exit_velocity"), row.get("exit_velocity")),
+                    launch_angle=_coalesce(_metric(overlay_metrics, "LA", "Launch Angle", "avg_launch_angle"), row.get("launch_angle")),
+                    hard_hit_rate=_coalesce(_metric(overlay_metrics, "HardHit", "HardHit%", "Hard Hit %", "HardHit Allowed"), row.get("hard_hit_rate")),
+                    barrel_rate=_coalesce(_metric(overlay_metrics, "Barrel", "Barrel%", "barrel_pct"), row.get("barrel_rate")),
+                    strikeout_rate=_coalesce(_metric(overlay_metrics, "K%", "k_pct"), row.get("strikeout_rate")),
+                    walk_rate=_coalesce(_metric(overlay_metrics, "BB%", "bb_pct"), row.get("walk_rate")),
+                    iso=_metric(overlay_metrics, "ISO"),
+                    obp=_metric(overlay_metrics, "OBP"),
+                    slg=_metric(overlay_metrics, "SLG"),
+                    plate_appearances=_safe_int(overlay_metrics.get("PA")),
+                )
+                metrics.update(overlay_metrics)
+                source_versions["my_dashboard_records"] = {
+                    "dataset_date": overlay.dataset_date.isoformat(),
+                    "dataset_version": overlay.dataset_version,
+                    "component": overlay.component,
+                }
+                sources.append("my_dashboard_records_metric_overlay")
+
+        row["metrics"] = metrics
+        row["source_versions"] = source_versions
+        row["provenance"] = {"sources": sources, "population_source": "dashboard_players", "metrics_overlay_only": True}
+        output.append(row)
+    return output
+
+
+def _normalize_snapshot_row(row: Dict[str, Any], active_players: Dict[int, DashboardPlayer]) -> Dict[str, Any]:
+    player_id = _safe_int(row.get("mlb_player_id") or row.get("player_id") or row.get("entity_id"))
+    if player_id is None or player_id not in active_players:
+        raise ValueError(f"Snapshot row has no active canonical player: {player_id}")
+    player = active_players[player_id]
+    normalized = {
+        "mlb_player_id": player_id,
+        "full_name": str(row.get("full_name") or player.full_name).strip(),
+        "player_type": str(row.get("player_type") or player.player_type).strip().lower(),
+        "team_id": _safe_int(row.get("team_id") or player.current_team_id),
+        "team_name": row.get("team_name") or player.current_team_name,
+        "primary_position": row.get("primary_position") or player.primary_position,
+        "is_active": True,
+        "opponent_team_id": _safe_int(row.get("opponent_team_id")),
+        "game_pk": _safe_int(row.get("game_pk")),
+        "lineup_status": row.get("lineup_status") or player.active_status_reason,
+        "lineup_position": _safe_int(row.get("lineup_position")),
+        "metrics": _json_safe(dict(row.get("metrics") or {})),
+        "source_versions": _json_safe(dict(row.get("source_versions") or {})),
+        "provenance": _json_safe(dict(row.get("provenance") or {})),
+    }
+    for field in SNAPSHOT_SCALARS:
+        if field == "confidence":
+            normalized[field] = row.get(field)
+        elif field == "plate_appearances":
+            normalized[field] = _safe_int(row.get(field))
+        else:
+            normalized[field] = _safe_float(row.get(field))
+    return normalized
+
+
+def _snapshot_values(
+    row: Dict[str, Any],
+    *,
+    snapshot_date: dt.date,
+    context: str,
+    snapshot_version: str,
+    batch_version: str,
+    now: dt.datetime,
+) -> Dict[str, Any]:
+    return {
+        "mlb_player_id": row["mlb_player_id"],
+        "snapshot_date": snapshot_date,
+        "analytical_context": context,
+        "snapshot_version": snapshot_version,
+        "team_id": row.get("team_id"),
+        "team_name": row.get("team_name"),
+        "opponent_team_id": row.get("opponent_team_id"),
+        "game_pk": row.get("game_pk"),
+        "lineup_status": row.get("lineup_status"),
+        "lineup_position": row.get("lineup_position"),
+        "model_score": row.get("model_score"),
+        "confidence": row.get("confidence"),
+        "xwoba": row.get("xwoba"),
+        "xba": row.get("xba"),
+        "exit_velocity": row.get("exit_velocity"),
+        "launch_angle": row.get("launch_angle"),
+        "hard_hit_rate": row.get("hard_hit_rate"),
+        "barrel_rate": row.get("barrel_rate"),
+        "strikeout_rate": row.get("strikeout_rate"),
+        "walk_rate": row.get("walk_rate"),
+        "iso": row.get("iso"),
+        "obp": row.get("obp"),
+        "slg": row.get("slg"),
+        "plate_appearances": _safe_int(row.get("plate_appearances")),
+        "metrics_json": row.get("metrics") or {},
+        "source_versions_json": {**(row.get("source_versions") or {}), "projection_batch_version": batch_version},
+        "provenance_json": row.get("provenance") or {},
+        "generated_at": now,
+        "refreshed_at": now,
+        "is_approved": True,
+    }
+
+
+def _promote_current_values(
+    row: Dict[str, Any],
+    snapshot: DashboardPlayerSnapshot,
+    *,
+    batch_version: str,
+    snapshot_date: dt.date,
+    now: dt.datetime,
+) -> Dict[str, Any]:
+    values = {
+        "snapshot_id": snapshot.id,
+        "player_type": row["player_type"],
+        "full_name": row["full_name"],
+        "team_id": row.get("team_id"),
+        "team_name": row.get("team_name"),
+        "primary_position": row.get("primary_position"),
+        "is_active": True,
+        "metrics_json": row.get("metrics") or {},
+        "projection_version": batch_version,
+        "source_freshness_json": {
+            "snapshot_date": snapshot_date.isoformat(),
+            "snapshot_refreshed_at": now.isoformat(),
+            "source_versions": row.get("source_versions") or {},
+        },
+        "provenance_json": row.get("provenance") or {},
+        "promoted_at": now,
+        "updated_at": now,
+    }
+    for field in SNAPSHOT_SCALARS:
+        values[field] = row.get(field)
+    return values
+
+
+def refresh_player_projection(
+    session: Any,
+    *,
+    snapshot_date: dt.date,
+    row_builder: Optional[Callable[[], Sequence[Dict[str, Any]]]] = None,
+    context: str = SNAPSHOT_CONTEXT_CURRENT,
+    full_refresh: bool = True,
+    promote_current: bool = True,
+    allow_empty_population: bool = False,
+    promotion_guard: Optional[Callable[[Dict[str, Any]], None]] = None,
+    now: Optional[dt.datetime] = None,
+) -> Dict[str, Any]:
+    """Persist immutable snapshots and atomically promote the current object."""
+
+    current_time = now or dt.datetime.utcnow()
+    active_players = {
+        row.mlb_player_id: row
+        for row in session.query(DashboardPlayer).filter(
+            DashboardPlayer.is_active.is_(True),
+            DashboardPlayer.identity_resolution_status == "resolved",
+        ).all()
+    }
+    built_rows = list(row_builder() if row_builder is not None else build_player_snapshot_rows(session, snapshot_date))
+    normalized_rows: List[Dict[str, Any]] = []
+    seen: set[int] = set()
+    for raw in built_rows:
+        normalized = _normalize_snapshot_row(dict(raw), active_players)
+        if normalized["mlb_player_id"] in seen:
+            raise ValueError(f"Duplicate snapshot player ID: {normalized['mlb_player_id']}")
+        seen.add(normalized["mlb_player_id"])
+        normalized_rows.append(normalized)
+    expected_ids = set(active_players)
+    if not normalized_rows and not allow_empty_population:
+        raise ValueError("Refusing to promote an empty player projection")
+    if full_refresh and seen != expected_ids:
+        missing = sorted(expected_ids - seen)
+        extra = sorted(seen - expected_ids)
+        raise ValueError(f"Full projection coverage mismatch; missing={missing[:10]} extra={extra[:10]}")
+
+    row_versions = {row["mlb_player_id"]: _hash(row) for row in normalized_rows}
+    batch_version = _hash({"snapshot_date": snapshot_date, "context": context, "rows": row_versions})
+    snapshots_created = snapshots_reused = current_created = current_updated = current_removed = 0
+    staged_snapshots: Dict[int, DashboardPlayerSnapshot] = {}
+    try:
+        for row in normalized_rows:
+            player_id = row["mlb_player_id"]
+            version = row_versions[player_id]
+            snapshot = session.query(DashboardPlayerSnapshot).filter(
+                DashboardPlayerSnapshot.mlb_player_id == player_id,
+                DashboardPlayerSnapshot.snapshot_date == snapshot_date,
+                DashboardPlayerSnapshot.analytical_context == context,
+                DashboardPlayerSnapshot.snapshot_version == version,
+            ).one_or_none()
+            if snapshot is None:
+                snapshot = DashboardPlayerSnapshot(**_snapshot_values(
+                    row,
+                    snapshot_date=snapshot_date,
+                    context=context,
+                    snapshot_version=version,
+                    batch_version=batch_version,
+                    now=current_time,
+                ))
+                session.add(snapshot)
+                snapshots_created += 1
+            else:
+                snapshots_reused += 1
+            staged_snapshots[player_id] = snapshot
+        session.flush()
+
+        if promote_current:
+            for row in normalized_rows:
+                player_id = row["mlb_player_id"]
+                snapshot = staged_snapshots[player_id]
+                current = session.get(DashboardPlayerCurrent, player_id)
+                values = _promote_current_values(
+                    row,
+                    snapshot,
+                    batch_version=batch_version,
+                    snapshot_date=snapshot_date,
+                    now=current_time,
+                )
+                if current is None:
+                    session.add(DashboardPlayerCurrent(mlb_player_id=player_id, **values))
+                    current_created += 1
+                elif current.snapshot_id != snapshot.id or current.projection_version != batch_version:
+                    for key, value in values.items():
+                        setattr(current, key, value)
+                    current_updated += 1
+            if full_refresh:
+                current_removed = session.query(DashboardPlayerCurrent).filter(
+                    DashboardPlayerCurrent.mlb_player_id.notin_(seen) if seen else True
+                ).delete(synchronize_session=False)
+        session.flush()
+        staged_status = {
+            "snapshot_date": snapshot_date.isoformat(),
+            "context": context,
+            "projection_version": batch_version,
+            "row_count": len(normalized_rows),
+            "snapshots_created": snapshots_created,
+            "snapshots_reused": snapshots_reused,
+            "current_created": current_created,
+            "current_updated": current_updated,
+            "current_removed": current_removed,
+            "promote_current": promote_current,
+            "full_refresh": full_refresh,
+        }
+        if promotion_guard is not None:
+            promotion_guard(dict(staged_status))
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    return {
+        **staged_status,
+        "current_row_count": session.query(DashboardPlayerCurrent).count(),
+        "historical_snapshot_count": session.query(DashboardPlayerSnapshot).count(),
+        "refreshed_at": current_time.isoformat(),
+        "query_source": "dashboard_player_current",
+    }
+
+
+def backfill_player_projection(
+    session: Any,
+    *,
+    dates: Sequence[dt.date],
+    row_builder: Optional[Callable[[dt.date], Sequence[Dict[str, Any]]]] = None,
+    context: str = SNAPSHOT_CONTEXT_CURRENT,
+    continue_on_error: bool = False,
+) -> Dict[str, Any]:
+    target_dates = sorted(set(dates))
+    results: List[Dict[str, Any]] = []
+    failures: List[Dict[str, Any]] = []
+    for index, target_date in enumerate(target_dates):
+        try:
+            result = refresh_player_projection(
+                session,
+                snapshot_date=target_date,
+                row_builder=(lambda value=target_date: row_builder(value)) if row_builder is not None else None,
+                context=context,
+                promote_current=index == len(target_dates) - 1,
+            )
+            results.append(result)
+        except Exception as exc:
+            failures.append({"snapshot_date": target_date.isoformat(), "error": str(exc), "error_type": exc.__class__.__name__})
+            if not continue_on_error:
+                break
+    return {
+        "requested_date_count": len(target_dates),
+        "successful_date_count": len(results),
+        "failed_date_count": len(failures),
+        "results": results,
+        "failures": failures,
+        "snapshot_rows_created": sum(item["snapshots_created"] for item in results),
+        "final_current_row_count": session.query(DashboardPlayerCurrent).count(),
+        "historical_snapshot_count": session.query(DashboardPlayerSnapshot).count(),
+    }

--- a/tests/test_dashboard_player_projection.py
+++ b/tests/test_dashboard_player_projection.py
@@ -1,0 +1,225 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot
+from mlb_app.dashboard_player_projection import backfill_player_projection, build_player_snapshot_rows, refresh_player_projection
+from mlb_app.database import Base, BatterAggregate, PitcherAggregate
+from mlb_app.my_dashboard_dataset import hydrate_dashboard_dataset
+
+
+DATE = dt.date(2026, 7, 15)
+NOW = dt.datetime(2026, 7, 15, 12, 0, 0)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def player(player_id, name, player_type="hitter", active=True):
+    return DashboardPlayer(
+        mlb_player_id=player_id,
+        full_name=name,
+        player_type=player_type,
+        is_active=active,
+        active_status_reason="recent_tracked_game",
+        first_tracked_date=DATE - dt.timedelta(days=20),
+        last_tracked_date=DATE,
+        most_recent_game_date=DATE,
+        identity_resolution_status="resolved",
+    )
+
+
+def row(player_id, name, player_type="hitter", **metrics):
+    value = {"mlb_player_id": player_id, "full_name": name, "player_type": player_type, "metrics": {}, "provenance": {"sources": ["test"]}}
+    value.update(metrics)
+    return value
+
+
+def test_default_builder_returns_every_active_resolved_player_and_aggregate_metrics():
+    session = make_session()
+    session.add_all([
+        player(1, "Hitter"),
+        player(2, "Pitcher", "pitcher"),
+        player(3, "Inactive", active=False),
+        BatterAggregate(batter_id=1, window="90d", end_date=DATE, avg_exit_velocity=92.1, avg_launch_angle=14.2, hard_hit_pct=0.46),
+        PitcherAggregate(pitcher_id=2, window="90d", end_date=DATE, xwoba=0.301, xba=0.229, k_pct=0.28),
+    ])
+    session.commit()
+    rows = build_player_snapshot_rows(session, DATE)
+    assert [item["mlb_player_id"] for item in rows] == [1, 2]
+    assert rows[0]["exit_velocity"] == pytest.approx(92.1)
+    assert rows[1]["xwoba"] == pytest.approx(0.301)
+
+
+def test_date_partitioned_records_overlay_metrics_but_do_not_define_population():
+    session = make_session()
+    session.add_all([player(1, "With Overlay"), player(2, "Without Overlay")])
+    session.commit()
+    hydrate_dashboard_dataset(
+        session=session,
+        date=DATE.isoformat(),
+        component="hitters",
+        payload_builder=lambda: {"items": [{"entity_id": "1", "entity_name": "With Overlay", "entity_type": "hitter", "player_type": "hitter", "score": 0.8, "metrics": {"xwOBA": 0.401}}]},
+        now=NOW,
+    )
+    rows = build_player_snapshot_rows(session, DATE)
+    assert len(rows) == 2
+    assert rows[0]["xwoba"] == pytest.approx(0.401)
+    assert rows[1]["xwoba"] is None
+
+
+def test_refresh_creates_historical_snapshots_and_current_projection_atomically():
+    session = make_session()
+    session.add_all([player(1, "One"), player(2, "Two", "pitcher")])
+    session.commit()
+    result = refresh_player_projection(
+        session,
+        snapshot_date=DATE,
+        row_builder=lambda: [row(1, "One", xwoba=0.4), row(2, "Two", "pitcher", xwoba=0.3)],
+        now=NOW,
+    )
+    assert result["row_count"] == 2
+    assert result["snapshots_created"] == 2
+    assert session.query(DashboardPlayerSnapshot).count() == 2
+    assert session.query(DashboardPlayerCurrent).count() == 2
+    assert session.get(DashboardPlayerCurrent, 1).xwoba == pytest.approx(0.4)
+
+
+def test_identical_refresh_is_idempotent():
+    session = make_session()
+    session.add(player(1, "One"))
+    session.commit()
+    builder = lambda: [row(1, "One", xwoba=0.4)]
+    first = refresh_player_projection(session, snapshot_date=DATE, row_builder=builder, now=NOW)
+    second = refresh_player_projection(session, snapshot_date=DATE, row_builder=builder, now=NOW)
+    assert first["snapshots_created"] == 1
+    assert second["snapshots_created"] == 0
+    assert second["snapshots_reused"] == 1
+    assert second["current_created"] == second["current_updated"] == 0
+    assert session.query(DashboardPlayerSnapshot).count() == 1
+
+
+def test_incremental_change_creates_only_changed_player_snapshot():
+    session = make_session()
+    session.add_all([player(1, "One"), player(2, "Two")])
+    session.commit()
+    refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One", xwoba=0.4), row(2, "Two", xwoba=0.3)], now=NOW)
+    changed = refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One", xwoba=0.41), row(2, "Two", xwoba=0.3)], now=NOW + dt.timedelta(minutes=5))
+    assert changed["snapshots_created"] == 1
+    assert changed["snapshots_reused"] == 1
+    assert session.query(DashboardPlayerSnapshot).count() == 3
+
+
+def test_builder_failure_preserves_prior_current_projection():
+    session = make_session()
+    session.add(player(1, "One"))
+    session.commit()
+    refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One", xwoba=0.4)], now=NOW)
+    previous = session.get(DashboardPlayerCurrent, 1).projection_version
+
+    def fail():
+        raise RuntimeError("source failed")
+
+    with pytest.raises(RuntimeError, match="source failed"):
+        refresh_player_projection(session, snapshot_date=DATE, row_builder=fail)
+    assert session.get(DashboardPlayerCurrent, 1).projection_version == previous
+    assert session.get(DashboardPlayerCurrent, 1).xwoba == pytest.approx(0.4)
+
+
+def test_failure_after_staging_rolls_back_snapshots_and_current_changes():
+    session = make_session()
+    session.add(player(1, "One"))
+    session.commit()
+    refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One", xwoba=0.4)], now=NOW)
+
+    def reject(_):
+        raise RuntimeError("promotion rejected")
+
+    with pytest.raises(RuntimeError, match="promotion rejected"):
+        refresh_player_projection(
+            session,
+            snapshot_date=DATE,
+            row_builder=lambda: [row(1, "One", xwoba=0.5)],
+            promotion_guard=reject,
+            now=NOW + dt.timedelta(minutes=5),
+        )
+    assert session.query(DashboardPlayerSnapshot).count() == 1
+    assert session.get(DashboardPlayerCurrent, 1).xwoba == pytest.approx(0.4)
+
+
+def test_empty_or_incomplete_full_refresh_is_rejected_before_promotion():
+    session = make_session()
+    session.add_all([player(1, "One"), player(2, "Two")])
+    session.commit()
+    with pytest.raises(ValueError, match="empty"):
+        refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [])
+    with pytest.raises(ValueError, match="coverage mismatch"):
+        refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One")])
+    assert session.query(DashboardPlayerCurrent).count() == 0
+
+
+def test_partial_refresh_updates_requested_player_without_removing_other_current_rows():
+    session = make_session()
+    session.add_all([player(1, "One"), player(2, "Two")])
+    session.commit()
+    refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One", xwoba=0.4), row(2, "Two", xwoba=0.3)], now=NOW)
+    refresh_player_projection(
+        session,
+        snapshot_date=DATE,
+        row_builder=lambda: [row(1, "One", xwoba=0.5)],
+        full_refresh=False,
+        now=NOW + dt.timedelta(minutes=5),
+    )
+    assert session.query(DashboardPlayerCurrent).count() == 2
+    assert session.get(DashboardPlayerCurrent, 1).xwoba == pytest.approx(0.5)
+    assert session.get(DashboardPlayerCurrent, 2).xwoba == pytest.approx(0.3)
+
+
+def test_successful_full_refresh_removes_projection_for_now_inactive_player():
+    session = make_session()
+    first, second = player(1, "One"), player(2, "Two")
+    session.add_all([first, second])
+    session.commit()
+    refresh_player_projection(session, snapshot_date=DATE, row_builder=lambda: [row(1, "One"), row(2, "Two")], now=NOW)
+    second.is_active = False
+    session.commit()
+    result = refresh_player_projection(session, snapshot_date=DATE + dt.timedelta(days=1), row_builder=lambda: [row(1, "One")], now=NOW + dt.timedelta(days=1))
+    assert result["current_removed"] == 1
+    assert session.get(DashboardPlayerCurrent, 2) is None
+
+
+def test_projection_exposes_freshness_provenance_and_versions():
+    session = make_session()
+    session.add(player(1, "One"))
+    session.commit()
+    refresh_player_projection(
+        session,
+        snapshot_date=DATE,
+        row_builder=lambda: [row(1, "One", source_versions={"solver": "v7"}, provenance={"sources": ["solver"]})],
+        now=NOW,
+    )
+    current = session.get(DashboardPlayerCurrent, 1)
+    assert current.source_freshness_json["snapshot_date"] == DATE.isoformat()
+    assert current.source_freshness_json["source_versions"] == {"solver": "v7"}
+    assert current.provenance_json["sources"] == ["solver"]
+
+
+def test_backfill_retains_each_date_and_promotes_only_final_successful_date():
+    session = make_session()
+    session.add(player(1, "One"))
+    session.commit()
+    result = backfill_player_projection(
+        session,
+        dates=[DATE - dt.timedelta(days=1), DATE],
+        row_builder=lambda target: [row(1, "One", xwoba=0.39 if target < DATE else 0.4)],
+    )
+    assert result["successful_date_count"] == 2
+    assert result["snapshot_rows_created"] == 2
+    assert result["historical_snapshot_count"] == 2
+    assert result["final_current_row_count"] == 1
+    assert session.get(DashboardPlayerCurrent, 1).xwoba == pytest.approx(0.4)


### PR DESCRIPTION
Continues #1055 after merged PRs #1056 and #1058.

## What changed

- Adds daily, immutable `dashboard_player_snapshots` hydration.
- Adds atomic upsert/promotion into `dashboard_player_current`.
- Builds the population exclusively from active, resolved `dashboard_players`.
- Uses batter/pitcher aggregates as baseline current metrics.
- Reuses compatible current `my_dashboard_records` rows as metric overlays only; those date-partitioned rows cannot add or remove players.
- Adds deterministic per-player content versions and a deterministic batch projection version.
- Reuses identical snapshots and creates a new historical snapshot only when that player’s approved content changes.
- Supports full and explicit partial refreshes.
- Adds source versions, freshness, provenance, projection version, and query-source metadata.
- Adds a multi-date backfill service with explicit row-count/failure evidence.

## Atomic safety

A full refresh must exactly cover the active resolved canonical population. Empty refreshes are rejected by default.

Snapshots and current projection changes are staged in one transaction. The optional promotion guard runs after staging and before commit. Any builder, validation, database, or guard failure rolls back both new snapshots and current-row changes.

Partial refreshes never delete current rows outside the supplied subset. Only a successful complete refresh removes current rows for players no longer active.

## Idempotency and incrementality

- Identical input reuses existing snapshots and leaves the current projection unchanged.
- If one player changes, one new snapshot is created and unchanged player snapshots are reused.
- Historical snapshots are retained.
- User filters and weights are not accepted or persisted.

## Deliberately unchanged

- No My Dashboard route uses `dashboard_player_current` yet.
- No default All Active Hitters/Pitchers query behavior changes.
- No frontend or saved-report changes.
- No solver/formula changes.
- No changes to existing `my_dashboard_records` hydration/query behavior.
- No Matchups, Matchup Detail, Daily Odds, Model Projections, or AI Data Assistant changes.
- No claim that a production backfill has executed.

## Validation

Passed locally:

`PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest -q tests/test_dashboard_player_projection.py tests/test_dashboard_player_population.py tests/test_dashboard_object_schema.py tests/test_my_dashboard_dataset.py`

Result: **33 passed**.

`git diff --check` passed.

Focused coverage includes:

- complete active-population snapshot creation
- aggregate baseline metrics
- date-partitioned metric overlays without population leakage
- snapshot/current promotion
- identical-run idempotency
- one-player incremental changes
- builder-failure preservation
- post-staging transactional rollback
- empty/incomplete refresh rejection
- partial refresh isolation
- inactive-player removal after complete refresh
- freshness/provenance/version metadata
- multi-date backfill evidence and final-date promotion

## Review focus

- Exact-coverage validation for complete refreshes
- Transaction boundaries and rollback behavior
- Per-player versus batch version semantics
- Overlay compatibility and population isolation
- Partial-refresh non-deletion behavior
- Backfill evidence without production-success claims

## Next slice after merge

PR 4 will add the SQL report query layer over `dashboard_player_current`: default All Active Hitters/Pitchers, filters, request-scoped weights, stable sorting, counts, pagination, dynamic metadata, validation, and query provenance. Existing public routes remain compatible during that migration.