### PR TITLE
Implement Layer 9BN historical outcome field mapping result validation

### DIFF
--- a/scripts/validate_9BN_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field_mapping_result.py
+++ b/scripts/validate_9BN_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field_mapping_result.py
@@ -1,0 +1,1605 @@
+#!/usr/bin/env python3
+"""
+Layer 9BN
+Pitch-Type Matchup Overlay Historical Outcome
+Authoritative Source Endpoint Candidate
+Source Evidence Historical Outcome Field Mapping Result Validation
+
+Implements the deterministic mapping-result validation contract planned by
+Layer 9BM.
+
+No endpoint candidate, validated response, authorized parser execution,
+validated parsed record, mapping submission, mapping execution, mapping-result
+submission, source value, or mapped value exists. This implementation therefore
+emits deterministic fail-closed validation records without inventing evidence.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+LAYER_ID = "9BN"
+
+LAYER_NAME = (
+    "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+    "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+    "result_validation_implementation"
+)
+
+MAPPING_RESULT_VALIDATION_CONTRACT_VERSION = (
+    "layer_9BN_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_result_validation_"
+    "contract_v1"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp"
+    / "layer_9BN_pitch_type_matchup_overlay_historical_outcome_"
+    "authoritative_source_endpoint_candidate_source_evidence_historical_"
+    "outcome_field_mapping_result_validation"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts"
+    / "plan_9BM_pitch_type_matchup_overlay_historical_outcome_authoritative_"
+    "source_endpoint_candidate_source_evidence_historical_outcome_field_"
+    "mapping_result_validation.py"
+)
+
+EXPECTED_PLAN_VERSION = (
+    "layer_9BM_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_result_validation_plan_v1"
+)
+
+EXPECTED_PREDECESSOR_VERSION = (
+    "layer_9BL_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_contract_v1"
+)
+
+EXPECTED_MAPPING_RECORDS = 16
+EXPECTED_VALIDATION_RECORDS = 16
+
+AUTHORITATIVE_FIELD_NAME = "outcome_value"
+
+AUTHORITATIVE_FIELD_PATH = (
+    "historical_prediction_outcome_join_record.outcome_value"
+)
+
+REJECTED_METADATA_FIELD = "outcome_available_at_utc"
+
+VALIDATION_STATUS = "candidate_not_supplied"
+
+VALIDATION_BLOCKER = (
+    "historical_outcome_endpoint_candidate_missing"
+)
+
+SUPPLIED_MAPPING_RESULT_SUBMISSIONS: tuple[
+    dict[str, Any], ...
+] = ()
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def sha256_payload(payload: Any) -> str:
+    return hashlib.sha256(
+        canonical_json(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(
+            character in "0123456789abcdef"
+            for character in value
+        )
+    )
+
+
+def normalized_string(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def load_module(path: Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        path,
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Unable to load module from {path}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def write_csv(
+    path: Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=list(fieldnames),
+            extrasaction="ignore",
+        )
+
+        writer.writeheader()
+
+        for row in rows:
+            serialized: dict[str, Any] = {}
+
+            for field in fieldnames:
+                value = row.get(field)
+
+                serialized[field] = (
+                    canonical_json(value)
+                    if isinstance(
+                        value,
+                        (dict, list, tuple),
+                    )
+                    else value
+                )
+
+            writer.writerow(serialized)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def replay_plan() -> dict[str, Any]:
+    plan = load_module(
+        PLAN_PATH,
+        "layer_9bm_plan",
+    )
+
+    if plan.PLAN_VERSION != EXPECTED_PLAN_VERSION:
+        raise RuntimeError(
+            "Unexpected Layer 9BM plan version: "
+            f"{plan.PLAN_VERSION}"
+        )
+
+    replay = plan.replay_predecessor()
+    predecessor = replay["module"]
+
+    if (
+        predecessor.HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION
+        != EXPECTED_PREDECESSOR_VERSION
+    ):
+        raise RuntimeError(
+            "Unexpected Layer 9BL contract version: "
+            f"{predecessor.HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION}"
+        )
+
+    return {
+        "plan": plan,
+        "predecessor": predecessor,
+        "records": replay["records"],
+        "reverse_records": replay["reverse_records"],
+    }
+
+
+def build_validation_records(
+    plan: Any,
+    mapping_records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    validation_records: list[dict[str, Any]] = []
+
+    for mapping in mapping_records:
+        identity_payload = {
+            "mapping_result_validation_contract_version":
+                MAPPING_RESULT_VALIDATION_CONTRACT_VERSION,
+            "historical_outcome_field_mapping_plan_record_id":
+                mapping.get(
+                    "historical_outcome_field_mapping_plan_record_id"
+                ),
+            "comparison_record_id":
+                mapping.get("comparison_record_id"),
+            "defect_source_record_id":
+                mapping.get("defect_source_record_id"),
+            "candidate_id":
+                mapping.get("candidate_id"),
+            "parsed_record_id":
+                mapping.get("parsed_record_id"),
+            "mapping_id":
+                mapping.get("mapping_id"),
+            "mapping_result_id": None,
+        }
+
+        identity_digest = sha256_payload(
+            identity_payload
+        )
+
+        record = {
+            "historical_outcome_field_mapping_result_validation_plan_contract_version":
+                MAPPING_RESULT_VALIDATION_CONTRACT_VERSION,
+            "historical_outcome_field_mapping_result_validation_plan_record_id":
+                "HOASEHOFMRV-" + identity_digest[:20],
+            "historical_outcome_field_mapping_plan_record_id":
+                mapping.get(
+                    "historical_outcome_field_mapping_plan_record_id"
+                ),
+            "historical_outcome_field_mapping_plan_record_digest":
+                mapping.get(
+                    "historical_outcome_field_mapping_plan_record_digest"
+                ),
+            "source_evidence_parsed_record_validation_plan_record_id":
+                mapping.get(
+                    "source_evidence_parsed_record_validation_plan_record_id"
+                ),
+            "parsed_record_validation_plan_record_digest":
+                mapping.get(
+                    "parsed_record_validation_plan_record_digest"
+                ),
+            "endpoint_candidate_specification_record_id":
+                mapping.get(
+                    "endpoint_candidate_specification_record_id"
+                ),
+            "comparison_record_id":
+                mapping.get("comparison_record_id"),
+            "metric_record_id":
+                mapping.get("metric_record_id"),
+            "metric_name":
+                mapping.get("metric_name"),
+            "aggregation_name":
+                mapping.get("aggregation_name"),
+            "aggregation_key":
+                mapping.get("aggregation_key"),
+            "authoritative_field_name":
+                AUTHORITATIVE_FIELD_NAME,
+            "authoritative_field_path":
+                AUTHORITATIVE_FIELD_PATH,
+            "rejected_metadata_field_name":
+                REJECTED_METADATA_FIELD,
+            "defect_source_path":
+                mapping.get("defect_source_path"),
+            "defect_source_symbol":
+                mapping.get("defect_source_symbol"),
+            "defect_source_record_id":
+                mapping.get("defect_source_record_id"),
+            "defect_source_record_digest":
+                mapping.get("defect_source_record_digest"),
+            "historical_outcome_field_mapping_status":
+                mapping.get(
+                    "historical_outcome_field_mapping_status"
+                ),
+            "historical_outcome_field_mapping_blocker_codes":
+                mapping.get(
+                    "historical_outcome_field_mapping_blocker_codes"
+                ),
+            "candidate_supplied":
+                bool(mapping.get("candidate_supplied")),
+            "candidate_id":
+                mapping.get("candidate_id"),
+            "candidate_version":
+                mapping.get("candidate_version"),
+            "response_artifact_id":
+                mapping.get("response_artifact_id"),
+            "response_sha256":
+                mapping.get("response_sha256"),
+            "parser_id":
+                mapping.get("parser_id"),
+            "parser_version":
+                mapping.get("parser_version"),
+            "parser_code_digest":
+                mapping.get("parser_code_digest"),
+            "parsed_record_id":
+                mapping.get("parsed_record_id"),
+            "parsed_record_version":
+                mapping.get("parsed_record_version"),
+            "parsed_record_digest":
+                mapping.get("parsed_record_digest"),
+            "mapping_submission_supplied":
+                bool(
+                    mapping.get(
+                        "mapping_submission_supplied"
+                    )
+                ),
+            "mapping_id":
+                mapping.get("mapping_id"),
+            "mapping_version":
+                mapping.get("mapping_version"),
+            "mapping_digest":
+                mapping.get("mapping_digest"),
+            "mapping_result_submission_supplied": False,
+            "mapping_result_id": None,
+            "mapping_result_version": None,
+            "mapping_result_digest": None,
+            "source_field_name": None,
+            "source_field_path": None,
+            "source_value": None,
+            "target_field_name":
+                AUTHORITATIVE_FIELD_NAME,
+            "target_field_path":
+                AUTHORITATIVE_FIELD_PATH,
+            "mapped_value": None,
+            "mapped_value_type_valid": None,
+            "mapped_value_domain_valid": None,
+            "source_to_target_provenance": None,
+            "mapping_rule_provenance": None,
+            "rejected_metadata_substitution_detected":
+                False,
+            "coercion_detected":
+                False,
+            "defaulting_inference_or_imputation_detected":
+                False,
+            "mapping_result_ambiguity_detected":
+                False,
+            "mapping_result_malformed_detected":
+                False,
+            "mapping_result_validation_status":
+                VALIDATION_STATUS,
+            "mapping_result_validation_blocker_codes": [
+                VALIDATION_BLOCKER
+            ],
+            "mapping_result_validation_implementation_authority_granted":
+                False,
+            "mapping_result_validation_rationale": (
+                "No endpoint candidate exists. Therefore no validated "
+                "response, authorized parser execution, validated parsed "
+                "record, authorized field-mapping execution, or explicit "
+                "mapping-result submission exists. Mapping-result validation "
+                "cannot proceed without inventing result identity, source "
+                "value, mapped value, provenance, digest, or authority."
+            ),
+            "mapping_result_validation_limitations": [
+                "No endpoint candidate was supplied.",
+                "No validated response artifact exists.",
+                "No authorized parser execution exists.",
+                "No validated parsed record exists.",
+                "No field-mapping submission exists.",
+                "No authorized field-mapping execution exists.",
+                "No mapping-result submission was supplied.",
+                "No mapping-result identity was invented.",
+                "No mapping-result version or digest was invented.",
+                "No source field or source value was invented.",
+                "No mapped value was invented.",
+                "No source-to-target provenance was invented.",
+                "No mapping-rule provenance was invented.",
+                "No rejected metadata substitution was performed.",
+                "No coercion was performed.",
+                "No defaulting, inference, or imputation was performed.",
+                "No mapping result was validated.",
+                "No historical outcome field was mapped.",
+                "No historical outcome value was extracted.",
+                "No canonical source record was mutated.",
+                "No canonical mapping was changed.",
+                "No downstream record was recomputed.",
+            ],
+            "mapping_result_validation_plan_identity_digest":
+                identity_digest,
+        }
+
+        record[
+            "mapping_result_validation_plan_record_digest"
+        ] = sha256_payload(record)
+
+        missing_fields = [
+            field
+            for field in plan.VALIDATION_PLAN_RECORD_FIELDS
+            if field not in record
+        ]
+
+        if missing_fields:
+            raise RuntimeError(
+                "Mapping-result validation record missing fields: "
+                + ", ".join(missing_fields)
+            )
+
+        validation_records.append(
+            {
+                field: record[field]
+                for field in plan.VALIDATION_PLAN_RECORD_FIELDS
+            }
+        )
+
+    validation_records.sort(
+        key=lambda row: (
+            normalized_string(
+                row.get("comparison_record_id")
+            ),
+            normalized_string(
+                row.get("defect_source_record_id")
+            ),
+            normalized_string(
+                row.get("candidate_id")
+            ),
+            normalized_string(
+                row.get("parsed_record_id")
+            ),
+            normalized_string(
+                row.get("mapping_id")
+            ),
+            normalized_string(
+                row.get("mapping_result_id")
+            ),
+            normalized_string(
+                row.get(
+                    "historical_outcome_field_mapping_result_"
+                    "validation_plan_record_id"
+                )
+            ),
+        )
+    )
+
+    return validation_records
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    replay = replay_plan()
+
+    plan = replay["plan"]
+    predecessor = replay["predecessor"]
+    mapping_records = replay["records"]
+    reverse_mapping_records = replay[
+        "reverse_records"
+    ]
+
+    validation_records = build_validation_records(
+        plan,
+        mapping_records,
+    )
+
+    reverse_validation_records = build_validation_records(
+        plan,
+        list(
+            reversed(
+                reverse_mapping_records
+            )
+        ),
+    )
+
+    predecessor_replay_deterministic = (
+        canonical_json(mapping_records)
+        == canonical_json(
+            reverse_mapping_records
+        )
+    )
+
+    validation_replay_deterministic = (
+        canonical_json(validation_records)
+        == canonical_json(
+            reverse_validation_records
+        )
+    )
+
+    validation_digest = sha256_payload(
+        validation_records
+    )
+
+    reverse_validation_digest = sha256_payload(
+        reverse_validation_records
+    )
+
+    comparison_ids = {
+        row["comparison_record_id"]
+        for row in validation_records
+    }
+
+    status_counts = dict(
+        sorted(
+            Counter(
+                row[
+                    "mapping_result_validation_status"
+                ]
+                for row in validation_records
+            ).items()
+        )
+    )
+
+    blocker_counts = dict(
+        sorted(
+            Counter(
+                blocker
+                for row in validation_records
+                for blocker in row[
+                    "mapping_result_validation_blocker_codes"
+                ]
+            ).items()
+        )
+    )
+
+    candidate_presence_counts = dict(
+        sorted(
+            Counter(
+                str(row["candidate_supplied"])
+                for row in validation_records
+            ).items()
+        )
+    )
+
+    mapping_presence_counts = dict(
+        sorted(
+            Counter(
+                str(
+                    row[
+                        "mapping_submission_supplied"
+                    ]
+                )
+                for row in validation_records
+            ).items()
+        )
+    )
+
+    mapping_result_presence_counts = dict(
+        sorted(
+            Counter(
+                str(
+                    row[
+                        "mapping_result_submission_supplied"
+                    ]
+                )
+                for row in validation_records
+            ).items()
+        )
+    )
+
+    authority_records = [
+        row
+        for row in validation_records
+        if row[
+            "mapping_result_validation_"
+            "implementation_authority_granted"
+        ]
+    ]
+
+    checks = [
+        {
+            "check": "nine_bm_plan_version_verified",
+            "actual": plan.PLAN_VERSION,
+            "expected": EXPECTED_PLAN_VERSION,
+            "passed":
+                plan.PLAN_VERSION
+                == EXPECTED_PLAN_VERSION,
+        },
+        {
+            "check": "nine_bl_contract_version_verified",
+            "actual":
+                predecessor.HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION,
+            "expected": EXPECTED_PREDECESSOR_VERSION,
+            "passed": (
+                predecessor.HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION
+                == EXPECTED_PREDECESSOR_VERSION
+            ),
+        },
+        {
+            "check": "predecessor_replay_deterministic",
+            "actual": predecessor_replay_deterministic,
+            "expected": True,
+            "passed": predecessor_replay_deterministic,
+        },
+        {
+            "check": "validation_replay_deterministic",
+            "actual": validation_replay_deterministic,
+            "expected": True,
+            "passed": validation_replay_deterministic,
+        },
+        {
+            "check": "validation_digests_match_reverse_replay",
+            "actual": validation_digest,
+            "expected": reverse_validation_digest,
+            "passed": (
+                validation_digest
+                == reverse_validation_digest
+            ),
+        },
+        {
+            "check": "expected_mapping_records_replayed",
+            "actual": len(mapping_records),
+            "expected": EXPECTED_MAPPING_RECORDS,
+            "passed": (
+                len(mapping_records)
+                == EXPECTED_MAPPING_RECORDS
+            ),
+        },
+        {
+            "check": "expected_validation_records_materialized",
+            "actual": len(validation_records),
+            "expected": EXPECTED_VALIDATION_RECORDS,
+            "passed": (
+                len(validation_records)
+                == EXPECTED_VALIDATION_RECORDS
+            ),
+        },
+        {
+            "check": "one_validation_record_per_comparison",
+            "actual": len(comparison_ids),
+            "expected": EXPECTED_VALIDATION_RECORDS,
+            "passed": (
+                len(comparison_ids)
+                == EXPECTED_VALIDATION_RECORDS
+            ),
+        },
+        {
+            "check": "validation_record_fields_complete",
+            "actual": len(
+                plan.VALIDATION_PLAN_RECORD_FIELDS
+            ),
+            "expected": 62,
+            "passed": all(
+                set(row)
+                == set(
+                    plan.VALIDATION_PLAN_RECORD_FIELDS
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "validation_record_ids_unique",
+            "actual": len(
+                {
+                    row[
+                        "historical_outcome_field_mapping_result_"
+                        "validation_plan_record_id"
+                    ]
+                    for row in validation_records
+                }
+            ),
+            "expected": len(validation_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "historical_outcome_field_mapping_result_"
+                            "validation_plan_record_id"
+                        ]
+                        for row in validation_records
+                    }
+                )
+                == len(validation_records)
+            ),
+        },
+        {
+            "check": "validation_record_digests_unique",
+            "actual": len(
+                {
+                    row[
+                        "mapping_result_validation_plan_record_digest"
+                    ]
+                    for row in validation_records
+                }
+            ),
+            "expected": len(validation_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "mapping_result_validation_plan_record_digest"
+                        ]
+                        for row in validation_records
+                    }
+                )
+                == len(validation_records)
+            ),
+        },
+        {
+            "check": "all_validation_identity_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "mapping_result_validation_plan_identity_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "mapping_result_validation_plan_identity_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_validation_record_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "mapping_result_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "mapping_result_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_mapping_record_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "historical_outcome_field_mapping_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_parsed_record_validation_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "parsed_record_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "parsed_record_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_defect_source_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row["defect_source_record_digest"]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row["defect_source_record_digest"]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "supplied_mapping_result_inventory_empty",
+            "actual": len(
+                SUPPLIED_MAPPING_RESULT_SUBMISSIONS
+            ),
+            "expected": 0,
+            "passed": (
+                len(
+                    SUPPLIED_MAPPING_RESULT_SUBMISSIONS
+                )
+                == 0
+            ),
+        },
+        {
+            "check": "all_candidates_absent",
+            "actual": candidate_presence_counts,
+            "expected": {
+                "False": EXPECTED_VALIDATION_RECORDS
+            },
+            "passed": (
+                candidate_presence_counts
+                == {
+                    "False":
+                        EXPECTED_VALIDATION_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_mapping_submissions_absent",
+            "actual": mapping_presence_counts,
+            "expected": {
+                "False": EXPECTED_VALIDATION_RECORDS
+            },
+            "passed": (
+                mapping_presence_counts
+                == {
+                    "False":
+                        EXPECTED_VALIDATION_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_mapping_result_submissions_absent",
+            "actual": mapping_result_presence_counts,
+            "expected": {
+                "False": EXPECTED_VALIDATION_RECORDS
+            },
+            "passed": (
+                mapping_result_presence_counts
+                == {
+                    "False":
+                        EXPECTED_VALIDATION_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_records_candidate_not_supplied",
+            "actual": status_counts,
+            "expected": {
+                VALIDATION_STATUS:
+                    EXPECTED_VALIDATION_RECORDS
+            },
+            "passed": (
+                status_counts
+                == {
+                    VALIDATION_STATUS:
+                        EXPECTED_VALIDATION_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_candidate_missing_blockers_present",
+            "actual": blocker_counts,
+            "expected": {
+                VALIDATION_BLOCKER:
+                    EXPECTED_VALIDATION_RECORDS
+            },
+            "passed": (
+                blocker_counts
+                == {
+                    VALIDATION_BLOCKER:
+                        EXPECTED_VALIDATION_RECORDS
+                }
+            ),
+        },
+        {
+            "check": "all_candidate_identity_fields_absent",
+            "actual": sum(
+                row["candidate_id"] is None
+                and row["candidate_version"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["candidate_id"] is None
+                and row["candidate_version"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_response_parser_and_record_fields_absent",
+            "actual": sum(
+                row["response_artifact_id"] is None
+                and row["response_sha256"] is None
+                and row["parser_id"] is None
+                and row["parser_version"] is None
+                and row["parser_code_digest"] is None
+                and row["parsed_record_id"] is None
+                and row["parsed_record_version"] is None
+                and row["parsed_record_digest"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["response_artifact_id"] is None
+                and row["response_sha256"] is None
+                and row["parser_id"] is None
+                and row["parser_version"] is None
+                and row["parser_code_digest"] is None
+                and row["parsed_record_id"] is None
+                and row["parsed_record_version"] is None
+                and row["parsed_record_digest"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_mapping_identity_fields_absent",
+            "actual": sum(
+                row["mapping_id"] is None
+                and row["mapping_version"] is None
+                and row["mapping_digest"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["mapping_id"] is None
+                and row["mapping_version"] is None
+                and row["mapping_digest"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_mapping_result_identity_fields_absent",
+            "actual": sum(
+                row["mapping_result_id"] is None
+                and row["mapping_result_version"] is None
+                and row["mapping_result_digest"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["mapping_result_id"] is None
+                and row["mapping_result_version"] is None
+                and row["mapping_result_digest"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_source_and_mapped_values_absent",
+            "actual": sum(
+                row["source_field_name"] is None
+                and row["source_field_path"] is None
+                and row["source_value"] is None
+                and row["mapped_value"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["source_field_name"] is None
+                and row["source_field_path"] is None
+                and row["source_value"] is None
+                and row["mapped_value"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "canonical_target_identity_preserved",
+            "actual": sorted(
+                {
+                    (
+                        row["target_field_name"],
+                        row["target_field_path"],
+                    )
+                    for row in validation_records
+                }
+            ),
+            "expected": [
+                (
+                    AUTHORITATIVE_FIELD_NAME,
+                    AUTHORITATIVE_FIELD_PATH,
+                )
+            ],
+            "passed": all(
+                row["target_field_name"]
+                == AUTHORITATIVE_FIELD_NAME
+                and row["target_field_path"]
+                == AUTHORITATIVE_FIELD_PATH
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "mapped_value_validation_fields_unset",
+            "actual": sum(
+                row["mapped_value_type_valid"] is None
+                and row["mapped_value_domain_valid"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["mapped_value_type_valid"] is None
+                and row["mapped_value_domain_valid"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_mapping_result_provenance_fields_absent",
+            "actual": sum(
+                row["source_to_target_provenance"] is None
+                and row["mapping_rule_provenance"] is None
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                row["source_to_target_provenance"] is None
+                and row["mapping_rule_provenance"] is None
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_prohibited_result_flags_false",
+            "actual": sum(
+                not row[
+                    "rejected_metadata_substitution_detected"
+                ]
+                and not row["coercion_detected"]
+                and not row[
+                    "defaulting_inference_or_imputation_detected"
+                ]
+                and not row[
+                    "mapping_result_ambiguity_detected"
+                ]
+                and not row[
+                    "mapping_result_malformed_detected"
+                ]
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                not row[
+                    "rejected_metadata_substitution_detected"
+                ]
+                and not row["coercion_detected"]
+                and not row[
+                    "defaulting_inference_or_imputation_detected"
+                ]
+                and not row[
+                    "mapping_result_ambiguity_detected"
+                ]
+                and not row[
+                    "mapping_result_malformed_detected"
+                ]
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "no_validation_implementation_authority_granted",
+            "actual": len(authority_records),
+            "expected": 0,
+            "passed":
+                len(authority_records) == 0,
+        },
+        {
+            "check": "authoritative_field_name_preserved",
+            "actual": sorted(
+                {
+                    row["authoritative_field_name"]
+                    for row in validation_records
+                }
+            ),
+            "expected": [AUTHORITATIVE_FIELD_NAME],
+            "passed": all(
+                row["authoritative_field_name"]
+                == AUTHORITATIVE_FIELD_NAME
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "authoritative_field_path_preserved",
+            "actual": sorted(
+                {
+                    row["authoritative_field_path"]
+                    for row in validation_records
+                }
+            ),
+            "expected": [AUTHORITATIVE_FIELD_PATH],
+            "passed": all(
+                row["authoritative_field_path"]
+                == AUTHORITATIVE_FIELD_PATH
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "rejected_metadata_field_preserved",
+            "actual": sorted(
+                {
+                    row["rejected_metadata_field_name"]
+                    for row in validation_records
+                }
+            ),
+            "expected": [REJECTED_METADATA_FIELD],
+            "passed": all(
+                row["rejected_metadata_field_name"]
+                == REJECTED_METADATA_FIELD
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "mapping_result_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "source_or_mapped_value_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "provenance_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "rejected_metadata_substitution_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "coercion_defaulting_inference_imputation_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "mapping_results_validated_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_fields_mapped_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_values_extracted_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "response_bytes_read_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "responses_parsed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "parsed_records_validated_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credentials_stored_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credential_literals_logged_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "network_retrievals_executed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_sources_not_changed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_mappings_not_changed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "candidate_values_not_transformed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "downstream_records_not_recomputed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "quality_and_production_authority_absent",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+    ]
+
+    all_checks_passed = all(
+        bool(row["passed"])
+        for row in checks
+    )
+
+    diagnosis_name = (
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_implementation_complete"
+        if all_checks_passed
+        else
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_implementation_failed"
+    )
+
+    next_layer = (
+        "9BO_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_evidence_package_plan"
+        if all_checks_passed
+        else
+        "9BN_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_implementation_remediation"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR
+        / "historical_outcome_field_mapping_result_validation_records.csv",
+        plan.VALIDATION_PLAN_RECORD_FIELDS,
+        validation_records,
+    )
+
+    write_csv(
+        OUTPUT_DIR / "validation_status_counts.csv",
+        [
+            "validation_status",
+            "count",
+        ],
+        [
+            {
+                "validation_status": key,
+                "count": value,
+            }
+            for key, value in status_counts.items()
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR / "validation_blocker_counts.csv",
+        [
+            "validation_blocker",
+            "count",
+        ],
+        [
+            {
+                "validation_blocker": key,
+                "count": value,
+            }
+            for key, value in blocker_counts.items()
+        ],
+    )
+
+    write_json(
+        OUTPUT_DIR
+        / "supplied_mapping_result_submission_inventory.json",
+        {
+            "layer_id": LAYER_ID,
+            "supplied_mapping_result_submission_count":
+                len(
+                    SUPPLIED_MAPPING_RESULT_SUBMISSIONS
+                ),
+            "supplied_mapping_result_submissions":
+                list(
+                    SUPPLIED_MAPPING_RESULT_SUBMISSIONS
+                ),
+            "inventory_status": (
+                "no_candidate_mapping_execution_or_"
+                "mapping_result_submission_supplied"
+            ),
+        },
+    )
+
+    summary = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "mapping_result_validation_contract_version":
+            MAPPING_RESULT_VALIDATION_CONTRACT_VERSION,
+        "plan_version": plan.PLAN_VERSION,
+        "predecessor_contract_version":
+            predecessor.HISTORICAL_OUTCOME_FIELD_MAPPING_CONTRACT_VERSION,
+        "mapping_records":
+            len(mapping_records),
+        "validation_records":
+            len(validation_records),
+        "validation_comparisons":
+            len(comparison_ids),
+        "supplied_mapping_result_submissions":
+            len(
+                SUPPLIED_MAPPING_RESULT_SUBMISSIONS
+            ),
+        "validation_status_counts":
+            status_counts,
+        "validation_blocker_counts":
+            blocker_counts,
+        "validation_implementation_authorities_granted":
+            len(authority_records),
+        "validation_digest":
+            validation_digest,
+        "reverse_validation_digest":
+            reverse_validation_digest,
+        "implementation_checks_passed": sum(
+            bool(row["passed"])
+            for row in checks
+        ),
+        "implementation_checks_required":
+            len(checks),
+        "mapping_results_validated": 0,
+        "historical_outcome_fields_mapped": 0,
+        "historical_outcome_values_extracted": 0,
+        "response_bytes_read": 0,
+        "responses_parsed": 0,
+        "parsed_records_validated": 0,
+        "credentials_stored": 0,
+        "credential_literals_logged": 0,
+        "network_retrievals_executed": 0,
+        "canonical_source_records_changed": 0,
+        "canonical_mappings_changed": 0,
+        "candidate_values_transformed": 0,
+        "downstream_records_recomputed": 0,
+        "uncertainty_estimates_calculated": 0,
+        "statistical_significance_tests_calculated": 0,
+        "superiority_decisions_emitted": 0,
+        "equivalence_decisions_emitted": 0,
+        "activation_recommendations_emitted": 0,
+        "production_probabilities_changed": 0,
+        "market_comparisons_executed": 0,
+        "betting_edges_calculated": 0,
+        "all_checks_passed":
+            all_checks_passed,
+        "recommended_next_layer":
+            next_layer,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "historical_outcome_field_mapping_result_validation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "all_checks_passed":
+            all_checks_passed,
+        "diagnosis":
+            diagnosis_name,
+        "validation_result":
+            VALIDATION_STATUS,
+        "authority_granted": (
+            "historical_outcome_authoritative_source_endpoint_candidate_"
+            "source_evidence_historical_outcome_field_mapping_result_"
+            "validation_evidence_package_planning"
+            if all_checks_passed
+            else "none"
+        ),
+        "authority_withheld": [
+            "endpoint_candidate_invention",
+            "response_artifact_invention",
+            "parser_submission_invention",
+            "parsed_record_submission_invention",
+            "mapping_submission_invention",
+            "mapping_result_submission_invention",
+            "mapping_result_identity_invention",
+            "mapping_result_content_invention",
+            "mapping_result_digest_invention",
+            "source_field_name_invention",
+            "source_field_path_invention",
+            "source_value_invention",
+            "mapped_value_invention",
+            "source_to_target_provenance_invention",
+            "mapping_rule_provenance_invention",
+            "rejected_metadata_field_substitution",
+            "boolean_to_integer_coercion",
+            "source_value_defaulting",
+            "source_value_inference",
+            "source_value_imputation",
+            "historical_outcome_field_mapping_execution",
+            "historical_outcome_value_extraction",
+            "response_bytes_reading",
+            "source_evidence_parse_execution",
+            "raw_response_parse_execution",
+            "credential_literal_storage",
+            "credential_literal_logging",
+            "dns_resolution_execution",
+            "socket_connection_execution",
+            "http_request_execution",
+            "browser_execution",
+            "api_request_execution",
+            "canonical_source_value_mutation",
+            "canonical_outcome_mapping_change",
+            "canonical_evaluation_row_recomputation",
+            "canonical_join_record_recomputation",
+            "canonical_comparison_record_recomputation",
+            "canonical_metric_recomputation",
+            "uncertainty_estimation",
+            "statistical_significance_testing",
+            "superiority_determination",
+            "equivalence_determination",
+            "activation_recommendation",
+            "production_probability_change",
+            "market_comparison",
+            "pricing_change",
+            "betting_edge_calculation",
+        ],
+        "recommended_next_layer":
+            next_layer,
+        "output_directory":
+            str(
+                OUTPUT_DIR.relative_to(ROOT)
+            ),
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        f"Layer: {LAYER_ID} — {LAYER_NAME}"
+    )
+    print(
+        "Mapping result validation contract version: "
+        f"{MAPPING_RESULT_VALIDATION_CONTRACT_VERSION}"
+    )
+    print(
+        "Implementation checks passed: "
+        f"{summary['implementation_checks_passed']}/"
+        f"{summary['implementation_checks_required']}"
+    )
+    print(
+        "Mapping records replayed: "
+        f"{len(mapping_records)}"
+    )
+    print(
+        "Validation records: "
+        f"{len(validation_records)}"
+    )
+    print(
+        "Validation comparisons: "
+        f"{len(comparison_ids)}"
+    )
+    print(
+        "Supplied mapping result submissions: "
+        f"{len(SUPPLIED_MAPPING_RESULT_SUBMISSIONS)}"
+    )
+    print(
+        "Validation status counts: "
+        f"{status_counts}"
+    )
+    print(
+        "Validation blocker counts: "
+        f"{blocker_counts}"
+    )
+    print(
+        "Validation implementation authorities granted: "
+        f"{len(authority_records)}"
+    )
+    print(
+        f"Validation digest: {validation_digest}"
+    )
+    print(
+        "Reverse validation digest: "
+        f"{reverse_validation_digest}"
+    )
+    print("Mapping results validated: 0")
+    print("Historical outcome fields mapped: 0")
+    print("Historical outcome values extracted: 0")
+    print("Response bytes read: 0")
+    print("Responses parsed: 0")
+    print("Parsed records validated: 0")
+    print("Credentials stored: 0")
+    print("Credential literals logged: 0")
+    print("Network retrievals executed: 0")
+    print("Canonical source records changed: 0")
+    print("Canonical mappings changed: 0")
+    print("Candidate values transformed: 0")
+    print("Downstream records recomputed: 0")
+    print("Uncertainty estimates calculated: 0")
+    print(
+        "Statistical significance tests calculated: 0"
+    )
+    print("Superiority decisions emitted: 0")
+    print("Equivalence decisions emitted: 0")
+    print("Activation recommendations emitted: 0")
+    print("Production probabilities changed: 0")
+    print("Market comparisons executed: 0")
+    print("Betting edges calculated: 0")
+    print(
+        f"Diagnosis: {diagnosis_name}"
+    )
+    print(
+        "Validation result: "
+        f"{diagnosis['validation_result']}"
+    )
+    print(
+        "Authority granted: "
+        f"{diagnosis['authority_granted']}"
+    )
+    print(
+        "Recommended next layer: "
+        f"{next_layer}"
+    )
+    print(
+        "Artifacts: "
+        f"{OUTPUT_DIR.relative_to(ROOT)}"
+    )
+
+    if not all_checks_passed:
+        failed_checks = [
+            row["check"]
+            for row in checks
+            if not row["passed"]
+        ]
+
+        print(
+            "FAILED CHECKS: "
+            + ", ".join(failed_checks)
+        )
+
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the Layer 9BN deterministic historical-outcome field-mapping result-validation contract.

Validation:
- 54/54 implementation checks passed
- 16 Layer 9BL field-mapping records replayed deterministically
- 16 mapping-result validation records materialized, one per comparison
- No endpoint candidate, validated response, authorized parser execution, validated parsed record, mapping submission, mapping execution, or mapping-result submission was supplied or invented
- All records classified as `candidate_not_supplied` with `historical_outcome_endpoint_candidate_missing`
- No mapping-result validation implementation authority granted
- Canonical `outcome_value` target and rejected metadata field preserved
- No candidate/response/parser/parsed-record/mapping/mapping-result/source-value/mapped-value/provenance invention, rejected-metadata substitution, coercion, defaulting, inference, imputation, response-byte reading or parsing, historical-outcome field mapping or value extraction, credential storage or logging, DNS/socket/HTTP/browser/API execution, source mutation, mapping change, transformation, downstream recomputation, production, market, pricing, or betting authority granted

Next layer: 9BO — historical outcome authoritative source endpoint candidate source evidence historical outcome field mapping result validation evidence package plan.