### PR TITLE
PR 4: query canonical current player reports

### DIFF
--- a/mlb_app/dashboard_player_report_query.py
+++ b/mlb_app/dashboard_player_report_query.py
@@ -1,0 +1,276 @@
+"""Validated SQL report queries over the canonical current-player projection."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from .dashboard_object_models import DashboardPlayerCurrent
+from .dashboard_report_types import FIELD_CATALOG, REPORT_TYPES, describe_report_type
+
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 250
+
+FIELD_COLUMNS = {
+    name: getattr(DashboardPlayerCurrent, name)
+    for name in (
+        "mlb_player_id", "full_name", "player_type", "team_id", "team_name",
+        "primary_position", "model_score", "confidence", "xwoba", "xba",
+        "exit_velocity", "launch_angle", "hard_hit_rate", "barrel_rate",
+        "strikeout_rate", "walk_rate", "iso", "obp", "slg",
+        "plate_appearances", "projection_version", "promoted_at", "updated_at",
+    )
+}
+
+METRIC_ALIASES = {
+    "xwoba": "xwoba", "xwoba allowed": "xwoba", "xba": "xba",
+    "xba allowed": "xba", "ev": "exit_velocity", "exit velocity": "exit_velocity",
+    "la": "launch_angle", "launch angle": "launch_angle", "hardhit": "hard_hit_rate",
+    "hardhit allowed": "hard_hit_rate", "barrel": "barrel_rate", "k%": "strikeout_rate",
+    "bb%": "walk_rate", "iso": "iso", "obp": "obp", "slg": "slg",
+    "pa": "plate_appearances", "pitches seen": "plate_appearances", "score": "model_score",
+}
+
+
+def _field_map(report_type: str) -> Dict[str, Dict[str, Any]]:
+    return {field["name"]: field for field in FIELD_CATALOG[report_type]}
+
+
+def _validate_report_type(report_type: str) -> Dict[str, Any]:
+    if report_type not in REPORT_TYPES or not REPORT_TYPES[report_type].get("queryable"):
+        raise ValueError(f"Unsupported queryable report type: {report_type}")
+    return REPORT_TYPES[report_type]
+
+
+def _conditions(filters: Any) -> List[Dict[str, Any]]:
+    if filters is None:
+        return []
+    if isinstance(filters, list):
+        return filters
+    if not isinstance(filters, dict):
+        raise ValueError("filters must be an object or a list of conditions")
+    result = list(filters.get("conditions") or [])
+    if filters.get("search_text") not in (None, ""):
+        result.append({"field": "full_name", "operator": "contains", "value": filters["search_text"]})
+    if filters.get("team") not in (None, "", "All"):
+        result.append({"field": "team_name", "operator": "eq", "value": filters["team"]})
+    for key, field, operator in (
+        ("team_id", "team_id", "eq"), ("min_score", "model_score", "gte"),
+        ("max_score", "model_score", "lte"), ("min_confidence", "confidence", "gte"),
+    ):
+        if filters.get(key) is not None:
+            result.append({"field": field, "operator": operator, "value": filters[key]})
+    metrics = filters.get("metrics") or {}
+    if not isinstance(metrics, dict):
+        raise ValueError("filters.metrics must be an object")
+    for raw_name, bounds in metrics.items():
+        field = METRIC_ALIASES.get(str(raw_name).strip().lower())
+        if not field:
+            raise ValueError(f"Unsupported metric filter: {raw_name}")
+        if not isinstance(bounds, dict):
+            raise ValueError(f"Metric filter for {raw_name} must be an object")
+        for key, operator in (("min", "gte"), ("max", "lte")):
+            if bounds.get(key) is not None:
+                result.append({"field": field, "operator": operator, "value": bounds[key]})
+    return result
+
+
+def _confidence_expression():
+    return case(
+        (func.lower(DashboardPlayerCurrent.confidence) == "high", 3),
+        (func.lower(DashboardPlayerCurrent.confidence) == "medium", 2),
+        (func.lower(DashboardPlayerCurrent.confidence) == "low", 1),
+        else_=0,
+    )
+
+
+def _apply_filters(query, report_type: str, filters: Any) -> Tuple[Any, List[Dict[str, Any]]]:
+    fields = _field_map(report_type)
+    applied = _conditions(filters)
+    for condition in applied:
+        if not isinstance(condition, dict):
+            raise ValueError("Each filter condition must be an object")
+        field_name = str(condition.get("field") or "")
+        operator = str(condition.get("operator") or "eq").lower()
+        field = fields.get(field_name)
+        if not field or not field.get("filterable") or field_name not in FIELD_COLUMNS:
+            raise ValueError(f"Unsupported filter field: {field_name}")
+        if operator not in field["supported_operators"]:
+            raise ValueError(f"Unsupported operator '{operator}' for field '{field_name}'")
+        column = FIELD_COLUMNS[field_name]
+        value = condition.get("value")
+        comparison = _confidence_expression() if field_name == "confidence" and operator in {"gt", "gte", "lt", "lte"} else column
+        if comparison is not column:
+            ordinal = {"low": 1, "medium": 2, "high": 3}
+            try:
+                value = ordinal[str(value).lower()]
+            except KeyError as exc:
+                raise ValueError("min_confidence must be low, medium, or high") from exc
+        if operator == "eq": expression = column == value
+        elif operator == "neq": expression = column != value
+        elif operator == "in":
+            if not isinstance(value, (list, tuple, set)):
+                raise ValueError(f"Operator 'in' for field '{field_name}' requires a list")
+            expression = column.in_(list(value))
+        elif operator == "contains": expression = func.lower(column).contains(str(value).lower())
+        elif operator == "gt": expression = comparison > value
+        elif operator == "gte": expression = comparison >= value
+        elif operator == "lt": expression = comparison < value
+        elif operator == "lte": expression = comparison <= value
+        elif operator == "is_null": expression = column.is_(None)
+        elif operator == "is_not_null": expression = column.is_not(None)
+        else:  # guarded by field metadata
+            raise ValueError(f"Unsupported operator: {operator}")
+        query = query.filter(expression)
+    return query, applied
+
+
+def _normalize_weights(report_type: str, weights: Any) -> Tuple[Dict[str, float], Dict[str, str]]:
+    if weights is None:
+        return {}, {}
+    if not isinstance(weights, dict):
+        raise ValueError("weights must be an object")
+    aliases: Dict[str, str] = {}
+    for field in FIELD_CATALOG[report_type]:
+        if field["name"] in FIELD_COLUMNS and field.get("weight_aliases"):
+            aliases[field["name"].lower()] = field["name"]
+            for alias in field["weight_aliases"]:
+                aliases[alias.lower()] = field["name"]
+    normalized, labels = {}, {}
+    for raw_name, raw_weight in weights.items():
+        key = str(raw_name).strip().lower()
+        if key not in aliases:
+            raise ValueError(f"Unsupported weight metric: {raw_name}")
+        try:
+            weight = float(raw_weight)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid weight for {raw_name}") from exc
+        if weight < 0.0 or weight > 2.0:
+            raise ValueError(f"Weight for {raw_name} must be between 0 and 2")
+        if abs(weight - 1.0) >= 0.000001:
+            normalized[aliases[key]] = weight
+            labels[aliases[key]] = str(raw_name)
+    return normalized, labels
+
+
+def _clamp(expression):
+    return case((expression < -1.0, -1.0), (expression > 1.0, 1.0), else_=expression)
+
+
+def _normalized_metric(field_name: str, label: str):
+    value = FIELD_COLUMNS[field_name]
+    name = label.lower()
+    if "ev" in name or "velocity" in name: normalized = (value - 88.0) / 12.0
+    elif "la" in name or "launch angle" in name: normalized = 1.0 - func.abs(value - 16.0) / 25.0
+    elif "pitches seen" in name or name == "pa": normalized = value / 60.0
+    elif "total" in name: normalized = (value - 8.5) / 4.0
+    elif "score" in name or "edge" in name or "diff" in name: normalized = value
+    elif "bb" in name: normalized = (0.085 - value) * 8.0
+    elif "allowed" in name and ("xwoba" in name or "hardhit" in name): normalized = (0.34 - value) * 5.0
+    else: normalized = value
+    return case((value.is_(None), 0.0), else_=_clamp(normalized))
+
+
+def _weighted_score(weights: Dict[str, float], labels: Dict[str, str]):
+    score = func.coalesce(DashboardPlayerCurrent.model_score, 0.0)
+    for field_name, weight in weights.items():
+        score = score + _normalized_metric(field_name, labels[field_name]) * (weight - 1.0) * 0.25
+    return score
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, (dt.date, dt.datetime)) else value
+
+
+def _record(row: DashboardPlayerCurrent, effective_score: float, rank: int, explanations: List[str]) -> Dict[str, Any]:
+    values = {name: _iso(getattr(row, name)) for name in FIELD_COLUMNS}
+    values.update({
+        "metrics": row.metrics_json or {}, "entity_id": str(row.mlb_player_id),
+        "entity_name": row.full_name, "entity_type": row.player_type,
+        "team": row.team_name, "base_score": row.model_score or 0.0,
+        "adjusted_score": float(effective_score), "score": float(effective_score),
+        "rank": rank, "weight_explanation": explanations,
+    })
+    return values
+
+
+def query_player_report(
+    session: Session,
+    report_type: str,
+    *,
+    filters: Any = None,
+    weights: Any = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    page_number: int = 1,
+    sort_by: str = "model_score",
+    sort_direction: str = "desc",
+    selected_fields: Optional[Iterable[str]] = None,
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
+    config = _validate_report_type(report_type)
+    if not isinstance(page_size, int) or page_size < 1 or page_size > MAX_PAGE_SIZE:
+        raise ValueError(f"page_size must be between 1 and {MAX_PAGE_SIZE}")
+    if not isinstance(page_number, int) or page_number < 1:
+        raise ValueError("page_number must be at least 1")
+    direction = str(sort_direction).lower()
+    if direction not in {"asc", "desc"}:
+        raise ValueError("sort_direction must be 'asc' or 'desc'")
+
+    field_map = _field_map(report_type)
+    requested_fields = list(selected_fields or [field["name"] for field in FIELD_CATALOG[report_type]])
+    invalid_fields = [name for name in requested_fields if name not in field_map]
+    if invalid_fields:
+        raise ValueError(f"Unsupported selected field(s): {', '.join(invalid_fields)}")
+
+    query = session.query(DashboardPlayerCurrent).filter(
+        DashboardPlayerCurrent.is_active.is_(True),
+        DashboardPlayerCurrent.player_type == config["population"]["player_type"],
+    )
+    query, applied_filters = _apply_filters(query, report_type, filters)
+    total_count = query.count()
+    normalized_weights, weight_labels = _normalize_weights(report_type, weights)
+    score_expression = _weighted_score(normalized_weights, weight_labels)
+
+    sort_alias = "adjusted_score" if sort_by in {"score", "adjusted_score"} else sort_by
+    if sort_alias == "adjusted_score": sort_expression = score_expression
+    else:
+        field = field_map.get(sort_alias)
+        if not field or not field.get("sortable") or sort_alias not in FIELD_COLUMNS:
+            raise ValueError(f"Unsupported sort field: {sort_by}")
+        sort_expression = FIELD_COLUMNS[sort_alias]
+    ordered = query.add_columns(score_expression.label("effective_score"))
+    ordered = ordered.order_by(
+        case((sort_expression.is_(None), 1), else_=0),
+        sort_expression.asc() if direction == "asc" else sort_expression.desc(),
+        DashboardPlayerCurrent.full_name.asc(), DashboardPlayerCurrent.mlb_player_id.asc(),
+    )
+    offset = (page_number - 1) * page_size
+    rows = ordered.offset(offset).limit(page_size).all()
+    explanations = [f"{weight_labels[name]} {'emphasized' if weight > 1 else 'deemphasized'} at {round(weight, 2)}" for name, weight in normalized_weights.items()]
+    records = [_record(row, score, offset + index + 1, explanations) for index, (row, score) in enumerate(rows)]
+
+    versions = [value for (value,) in query.with_entities(DashboardPlayerCurrent.projection_version).distinct().all()]
+    promoted_at, updated_at = query.with_entities(func.max(DashboardPlayerCurrent.promoted_at), func.max(DashboardPlayerCurrent.updated_at)).one()
+    response = {
+        "report_type": report_type, "component": config["ui_object"], "records": records,
+        "items": records, "totalSize": total_count, "total_count": total_count,
+        "done": offset + len(records) >= total_count,
+        "page_info": {"page_number": page_number, "page_size": page_size, "returned": len(records), "has_next_page": offset + len(records) < total_count},
+        "query": {"source": "dashboard_player_current", "sort_by": sort_by, "sort_direction": direction, "selected_fields": requested_fields},
+        "filters_applied": applied_filters, "weights": normalized_weights,
+        "weight_explanation": explanations, "query_source": "dashboard_player_current",
+        "provenance": {
+            "source_object": "dashboard_player_current",
+            "projection_versions": sorted(versions),
+            "promoted_at": _iso(promoted_at),
+            "updated_at": _iso(updated_at),
+            "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        },
+    }
+    if include_metadata:
+        response["object_info"] = describe_report_type(report_type)
+    return response

--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 REPORT_TYPES: Dict[str, Dict[str, Any]] = {
-    "all_active_hitters": {"label": "All Active Hitters", "ui_object": "hitters", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "hitter"}, "relationships": []},
-    "all_active_pitchers": {"label": "All Active Pitchers", "ui_object": "pitchers", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "pitcher"}, "relationships": []},
+    "all_active_hitters": {"label": "All Active Hitters", "ui_object": "hitters", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "hitter"}, "relationships": [], "queryable": True},
+    "all_active_pitchers": {"label": "All Active Pitchers", "ui_object": "pitchers", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "pitcher"}, "relationships": [], "queryable": True},
     "hitters_current_matchup": {"label": "Hitters with Current Matchup Metrics", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["current_matchup_snapshot"]},
     "hitters_arsenal_splits": {"label": "Hitters with Arsenal Splits", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["batter_pitch_type_matchups"]},
     "players_lineup_history": {"label": "Players with Lineup History", "ui_object": "overall_players", "base_object": "dashboard_players", "population": {}, "relationships": ["lineup_appearances"]},
@@ -16,16 +16,88 @@ REPORT_TYPES: Dict[str, Dict[str, Any]] = {
     "games_totals_analysis": {"label": "Games with Totals Analysis", "ui_object": "totals", "base_object": "games", "population": {}, "relationships": ["totals_projection", "run_environment_snapshot"]},
 }
 
-FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {
-    key: [
-        {"name": "mlb_player_id", "label": "MLB Player ID", "data_type": "id", "group": "Identity", "sortable": True, "filterable": True, "nillable": False, "source_object": config["base_object"], "relationship_path": None, "supported_operators": ["eq", "in"], "description": "Canonical MLBAM player identifier.", "freshness": "canonical"},
-        {"name": "full_name", "label": "Player Name", "data_type": "string", "group": "Identity", "sortable": True, "filterable": True, "nillable": False, "source_object": config["base_object"], "relationship_path": None, "supported_operators": ["eq", "contains"], "description": "Resolved canonical player name.", "freshness": "canonical"},
-    ] if config["base_object"] in {"dashboard_players", "dashboard_player_current"} else []
-    for key, config in REPORT_TYPES.items()
-}
+
+def _field(
+    name: str,
+    label: str,
+    data_type: str,
+    group: str,
+    *,
+    sortable: bool = True,
+    filterable: bool = True,
+    nillable: bool = True,
+    operators: Optional[List[str]] = None,
+    description: str,
+    freshness: str = "current_projection",
+    weight_aliases: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "label": label,
+        "data_type": data_type,
+        "group": group,
+        "sortable": sortable,
+        "filterable": filterable,
+        "nillable": nillable,
+        "source_object": "dashboard_player_current",
+        "relationship_path": None,
+        "description": description,
+        "supported_operators": operators or (["eq", "in"] if data_type == "id" else (["eq", "neq", "in"] if data_type == "string" else ["eq", "gt", "gte", "lt", "lte", "is_null", "is_not_null"])),
+        "freshness": freshness,
+        "weight_aliases": weight_aliases or [],
+    }
+
+
+CURRENT_PLAYER_FIELDS: List[Dict[str, Any]] = [
+    _field("mlb_player_id", "MLB Player ID", "id", "Identity", nillable=False, description="Canonical MLBAM player identifier.", freshness="canonical"),
+    _field("full_name", "Player Name", "string", "Identity", nillable=False, operators=["eq", "neq", "contains", "in"], description="Resolved canonical player name.", freshness="canonical"),
+    _field("player_type", "Player Type", "string", "Identity", nillable=False, description="Canonical hitter or pitcher classification.", freshness="canonical"),
+    _field("team_id", "Team ID", "id", "Team", description="Current MLB team identifier.", freshness="canonical"),
+    _field("team_name", "Team", "string", "Team", operators=["eq", "neq", "contains", "in"], description="Current MLB team name or source abbreviation.", freshness="canonical"),
+    _field("primary_position", "Primary Position", "string", "Identity", description="Current primary-position abbreviation.", freshness="canonical"),
+    _field("model_score", "Model Score", "double", "Scoring", description="Approved base model score before request-scoped weights.", weight_aliases=["Score"]),
+    _field("confidence", "Confidence", "string", "Scoring", operators=["eq", "neq", "in", "gt", "gte", "lt", "lte"], description="Approved model confidence label."),
+    _field("xwoba", "xwOBA", "double", "Hitting", description="Current approved expected weighted on-base average.", weight_aliases=["xwOBA", "xwOBA Allowed"]),
+    _field("xba", "xBA", "double", "Hitting", description="Current approved expected batting average.", weight_aliases=["xBA", "xBA Allowed"]),
+    _field("exit_velocity", "Exit Velocity", "double", "Contact", description="Current approved average exit velocity.", weight_aliases=["EV", "Exit Velocity"]),
+    _field("launch_angle", "Launch Angle", "double", "Contact", description="Current approved average launch angle.", weight_aliases=["LA", "Launch Angle"]),
+    _field("hard_hit_rate", "Hard-Hit Rate", "double", "Contact", description="Current approved hard-hit rate.", weight_aliases=["HardHit", "HardHit Allowed"]),
+    _field("barrel_rate", "Barrel Rate", "double", "Contact", description="Current approved barrel rate.", weight_aliases=["Barrel"]),
+    _field("strikeout_rate", "Strikeout Rate", "double", "Discipline", description="Current approved strikeout rate.", weight_aliases=["K%"]),
+    _field("walk_rate", "Walk Rate", "double", "Discipline", description="Current approved walk rate.", weight_aliases=["BB%"]),
+    _field("iso", "ISO", "double", "Production", description="Current approved isolated power.", weight_aliases=["ISO"]),
+    _field("obp", "OBP", "double", "Production", description="Current approved on-base percentage.", weight_aliases=["OBP"]),
+    _field("slg", "SLG", "double", "Production", description="Current approved slugging percentage.", weight_aliases=["SLG"]),
+    _field("plate_appearances", "Plate Appearances", "integer", "Sample", description="Plate appearances for the approved analytical context.", weight_aliases=["PA", "Pitches Seen"]),
+    _field("projection_version", "Projection Version", "string", "Audit", filterable=False, description="Atomic projection batch version."),
+    _field("promoted_at", "Promoted At", "datetime", "Audit", filterable=False, description="Timestamp when this current row was promoted."),
+    _field("updated_at", "Updated At", "datetime", "Audit", filterable=False, description="Timestamp when this current row last changed."),
+    _field("metrics", "Extended Metrics", "json", "Audit", sortable=False, filterable=False, description="Explicitly supported extensible scalar metrics."),
+]
+
+
+FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {}
+for key, config in REPORT_TYPES.items():
+    if config["base_object"] == "dashboard_player_current":
+        FIELD_CATALOG[key] = deepcopy(CURRENT_PLAYER_FIELDS)
+    elif config["base_object"] == "dashboard_players":
+        FIELD_CATALOG[key] = deepcopy(CURRENT_PLAYER_FIELDS[:6])
+        for field in FIELD_CATALOG[key]:
+            field["source_object"] = "dashboard_players"
+    else:
+        FIELD_CATALOG[key] = []
 
 
 def describe_report_type(report_type: str) -> Dict[str, Any]:
     if report_type not in REPORT_TYPES:
         raise ValueError(f"Unsupported report type: {report_type}")
-    return {**deepcopy(REPORT_TYPES[report_type]), "api_name": report_type, "fields": deepcopy(FIELD_CATALOG[report_type])}
+    return {
+        **deepcopy(REPORT_TYPES[report_type]),
+        "api_name": report_type,
+        "queryable": bool(REPORT_TYPES[report_type].get("queryable")),
+        "fields": deepcopy(FIELD_CATALOG[report_type]),
+    }
+
+
+def list_report_types() -> List[Dict[str, Any]]:
+    return [describe_report_type(name) for name in REPORT_TYPES]

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel
 
 from . import my_dashboard_solver as dashboard_solver
 from .active_lineup_solver import build_active_lineup_solver_payload
+from .dashboard_player_report_query import query_player_report
+from .dashboard_report_types import list_report_types
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_context_cache import install_dashboard_context_cache
 from .my_dashboard_dataset_runtime import mlb_business_date, run_dataset_query, should_use_dataset_query
@@ -58,6 +60,18 @@ class MyDashboardHydrateRequest(BaseModel):
     force: bool = False
 
 
+class DashboardPlayerReportRequest(BaseModel):
+    report_type: str
+    filters: Optional[Any] = None
+    weights: Optional[Dict[str, float]] = None
+    page_size: int = DEFAULT_PAGE_SIZE
+    page_number: int = 1
+    sort_by: str = "model_score"
+    sort_direction: str = "desc"
+    selected_fields: Optional[List[str]] = None
+    include_metadata: bool = True
+
+
 def session_factory():
     database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
     engine = get_engine(database_url)
@@ -105,6 +119,27 @@ def my_dashboard_hydration_status() -> Dict[str, Any]:
         "configuration": cron_configuration(),
         "latest": latest_hydration_status(),
     }
+
+
+@router.get("/my-dashboard/report-types")
+def my_dashboard_report_types() -> Dict[str, Any]:
+    report_types = list_report_types()
+    return {"report_types": report_types, "totalSize": len(report_types)}
+
+
+@router.post("/my-dashboard/reports/query")
+def my_dashboard_player_report_query(payload: DashboardPlayerReportRequest) -> Dict[str, Any]:
+    try:
+        factory = session_factory()
+        with factory() as session:
+            return query_player_report(
+                session, payload.report_type, filters=payload.filters, weights=payload.weights,
+                page_size=payload.page_size, page_number=payload.page_number,
+                sort_by=payload.sort_by, sort_direction=payload.sort_direction,
+                selected_fields=payload.selected_fields, include_metadata=payload.include_metadata,
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/my-dashboard/solver")

--- a/tests/test_dashboard_player_report_query.py
+++ b/tests/test_dashboard_player_report_query.py
@@ -1,0 +1,133 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import DashboardPlayerCurrent
+from mlb_app.dashboard_player_report_query import query_player_report
+from mlb_app.dashboard_report_types import describe_report_type, list_report_types
+from mlb_app.database import Base
+
+
+NOW = dt.datetime(2026, 7, 15, 12, 0, 0)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, future=True)()
+    session.add_all([
+        current(1, "Zeta Tie", "hitter", "AAA", 0.70, 0.40, confidence="high", exit_velocity=96.0),
+        current(2, "Alpha Tie", "hitter", "BBB", 0.70, 0.20, confidence="medium", exit_velocity=84.0),
+        current(3, "Beta Bat", "hitter", "AAA", 0.60, None, confidence="low", exit_velocity=None),
+        current(4, "Inactive Bat", "hitter", "AAA", 0.99, 0.50, active=False),
+        current(5, "Gamma Arm", "pitcher", "CCC", 0.80, 0.29, confidence="high"),
+        current(6, "Delta Arm", "pitcher", "DDD", 0.50, 0.34, confidence="low"),
+    ])
+    session.commit()
+    return session
+
+
+def current(player_id, name, player_type, team, score, xwoba, *, active=True, confidence=None, exit_velocity=None):
+    return DashboardPlayerCurrent(
+        mlb_player_id=player_id, snapshot_id=player_id, player_type=player_type,
+        full_name=name, team_id=player_id * 10, team_name=team,
+        primary_position="OF" if player_type == "hitter" else "P", is_active=active,
+        model_score=score, confidence=confidence, xwoba=xwoba,
+        exit_velocity=exit_velocity, metrics_json={"source_metric": player_id},
+        projection_version="projection-v2" if player_id % 2 else "projection-v1",
+        source_freshness_json={"snapshot_date": "2026-07-15"},
+        provenance_json={"sources": ["test"]}, promoted_at=NOW,
+        updated_at=NOW + dt.timedelta(minutes=player_id),
+    )
+
+
+def test_default_reports_use_complete_active_canonical_populations():
+    session = make_session()
+    hitters = query_player_report(session, "all_active_hitters")
+    pitchers = query_player_report(session, "all_active_pitchers")
+    assert hitters["totalSize"] == 3
+    assert [row["mlb_player_id"] for row in hitters["records"]] == [2, 1, 3]
+    assert pitchers["totalSize"] == 2
+    assert hitters["query_source"] == "dashboard_player_current"
+
+
+def test_validated_filters_are_applied_in_sql_before_count_and_page():
+    session = make_session()
+    result = query_player_report(
+        session, "all_active_hitters",
+        filters={"team": "AAA", "metrics": {"xwOBA": {"min": 0.3}}},
+    )
+    assert result["totalSize"] == 1
+    assert result["records"][0]["full_name"] == "Zeta Tie"
+    confidence = query_player_report(session, "all_active_hitters", filters={"min_confidence": "medium"})
+    assert confidence["totalSize"] == 2
+
+
+@pytest.mark.parametrize(
+    "filters, message",
+    [
+        ([{"field": "secret", "operator": "eq", "value": 1}], "Unsupported filter field"),
+        ([{"field": "xwoba", "operator": "contains", "value": "4"}], "Unsupported operator"),
+        ({"metrics": {"Mystery": {"min": 1}}}, "Unsupported metric filter"),
+    ],
+)
+def test_unsupported_filters_fail_explicitly(filters, message):
+    with pytest.raises(ValueError, match=message):
+        query_player_report(make_session(), "all_active_hitters", filters=filters)
+
+
+def test_pagination_and_ties_are_stable_and_disjoint():
+    session = make_session()
+    first = query_player_report(session, "all_active_hitters", page_size=1, page_number=1)
+    second = query_player_report(session, "all_active_hitters", page_size=1, page_number=2)
+    assert first["records"][0]["full_name"] == "Alpha Tie"
+    assert second["records"][0]["full_name"] == "Zeta Tie"
+    assert first["records"][0]["mlb_player_id"] != second["records"][0]["mlb_player_id"]
+    assert first["page_info"]["has_next_page"] is True
+
+
+def test_request_scoped_weights_rerank_without_mutating_base_scores():
+    session = make_session()
+    baseline = query_player_report(session, "all_active_hitters")
+    weighted = query_player_report(session, "all_active_hitters", weights={"xwOBA": 2.0}, sort_by="adjusted_score")
+    assert baseline["records"][0]["full_name"] == "Alpha Tie"
+    assert weighted["records"][0]["full_name"] == "Zeta Tie"
+    assert weighted["totalSize"] == baseline["totalSize"]
+    assert weighted["records"][0]["base_score"] == pytest.approx(0.70)
+    assert session.get(DashboardPlayerCurrent, 1).model_score == pytest.approx(0.70)
+    assert weighted["weight_explanation"] == ["xwOBA emphasized at 2.0"]
+
+
+def test_null_metrics_do_not_change_weighted_score_and_can_be_filtered():
+    session = make_session()
+    weighted = query_player_report(session, "all_active_hitters", weights={"xwOBA": 2.0})
+    beta = next(row for row in weighted["records"] if row["full_name"] == "Beta Bat")
+    assert beta["adjusted_score"] == pytest.approx(beta["base_score"])
+    nulls = query_player_report(session, "all_active_hitters", filters=[{"field": "xwoba", "operator": "is_null"}])
+    assert [row["full_name"] for row in nulls["records"]] == ["Beta Bat"]
+
+
+def test_field_metadata_selection_and_provenance_are_authoritative():
+    session = make_session()
+    info = describe_report_type("all_active_hitters")
+    names = {field["name"] for field in info["fields"]}
+    assert {"mlb_player_id", "model_score", "xwoba", "projection_version", "metrics"}.issubset(names)
+    assert [item["api_name"] for item in list_report_types()[:2]] == ["all_active_hitters", "all_active_pitchers"]
+    result = query_player_report(session, "all_active_hitters", selected_fields=["full_name", "xwoba"])
+    assert result["query"]["selected_fields"] == ["full_name", "xwoba"]
+    assert result["provenance"]["projection_versions"] == ["projection-v1", "projection-v2"]
+    assert result["provenance"]["updated_at"] == (NOW + dt.timedelta(minutes=3)).isoformat()
+    with pytest.raises(ValueError, match="Unsupported selected field"):
+        query_player_report(session, "all_active_hitters", selected_fields=["not_a_field"])
+
+
+def test_sort_validation_and_ascending_sort_cover_the_full_result_set():
+    session = make_session()
+    result = query_player_report(session, "all_active_hitters", sort_by="xwoba", sort_direction="asc")
+    assert [row["xwoba"] for row in result["records"]] == [0.2, 0.4, None]
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        query_player_report(session, "all_active_hitters", sort_by="metrics")
+    with pytest.raises(ValueError, match="Unsupported queryable report type"):
+        query_player_report(session, "teams_daily_analysis")


### PR DESCRIPTION
## Summary

Implements PR4 of #1055 by adding the SQL query layer over the canonical `dashboard_player_current` projection.

- exposes authoritative report-type and field metadata
- adds default All Active Hitters and All Active Pitchers populations
- validates filters, selected fields, sort fields, operators, pagination, and request-scoped weights
- preserves the existing weighting formula while keeping persisted `model_score` immutable
- provides stable tie ordering, full-result counts, freshness, projection-version, and query provenance
- adds additive `GET /my-dashboard/report-types` and `POST /my-dashboard/reports/query` endpoints

## Compatibility

The existing `/my-dashboard/solver`, active-lineup, hydration, saved-report payload, and frontend behavior are unchanged. UI migration and dynamic Field Library work remain scoped to PR5.

## Tests

```
PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest -q \
  tests/test_dashboard_player_report_query.py \
  tests/test_dashboard_player_projection.py \
  tests/test_dashboard_player_population.py \
  tests/test_dashboard_object_schema.py \
  tests/test_my_dashboard_dataset.py
```

43 passed.

Also verified with `git diff --check` and Python bytecode compilation.