### PR TITLE
Validate Layer 9BV validation result evidence

### DIFF
--- a/scripts/validate_9BV_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field_mapping_result_validation_evidence_package_validation_result_evidence.py
+++ b/scripts/validate_9BV_pitch_type_matchup_overlay_historical_outcome_authoritative_source_endpoint_candidate_source_evidence_historical_outcome_field_mapping_result_validation_evidence_package_validation_result_evidence.py
@@ -1,0 +1,1627 @@
+#!/usr/bin/env python3
+"""
+Layer 9BV
+
+Validates the deterministic Layer 9BT validation-result evidence records
+according to the Layer 9BU validation plan.
+
+This implementation validates record identity, record digests, manifest
+integrity, lineage, structural disposition, candidate-evidence absence,
+canonical field identity, documentation, and authority boundaries.
+
+It does not validate an authoritative historical outcome or execute retrieval,
+parsing, mapping, extraction, mutation, recomputation, production, market,
+pricing, or betting operations.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import importlib.util
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+LAYER_ID = "9BV"
+
+LAYER_NAME = (
+    "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+    "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+    "result_validation_evidence_package_validation_result_evidence_"
+    "validation_implementation"
+)
+
+VALIDATION_CONTRACT_VERSION = (
+    "layer_9BV_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_result_validation_"
+    "evidence_package_validation_result_evidence_validation_contract_v1"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OUTPUT_DIR = (
+    ROOT
+    / "tmp"
+    / "layer_9BV_pitch_type_matchup_overlay_historical_outcome_"
+    "authoritative_source_endpoint_candidate_source_evidence_historical_"
+    "outcome_field_mapping_result_validation_evidence_package_validation_"
+    "result_evidence_validation"
+)
+
+PLAN_PATH = (
+    ROOT
+    / "scripts"
+    / "plan_9BU_pitch_type_matchup_overlay_historical_outcome_authoritative_"
+    "source_endpoint_candidate_source_evidence_historical_outcome_field_"
+    "mapping_result_validation_evidence_package_validation_result_evidence_"
+    "validation.py"
+)
+
+EXPECTED_PLAN_VERSION = (
+    "layer_9BU_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_result_validation_"
+    "evidence_package_validation_result_evidence_validation_plan_v1"
+)
+
+EXPECTED_PREDECESSOR_CONTRACT_VERSION = (
+    "layer_9BT_historical_outcome_authoritative_source_endpoint_candidate_"
+    "source_evidence_historical_outcome_field_mapping_result_validation_"
+    "evidence_package_validation_result_evidence_contract_v1"
+)
+
+EXPECTED_PREDECESSOR_MANIFEST_VERSION = (
+    "layer_9BT_historical_outcome_validation_result_evidence_manifest_v1"
+)
+
+EXPECTED_RECORDS = 16
+EXPECTED_COMPARISONS = 16
+EXPECTED_STATUS = "candidate_not_supplied"
+EXPECTED_BLOCKER = "historical_outcome_endpoint_candidate_missing"
+
+AUTHORITATIVE_FIELD_NAME = "outcome_value"
+
+AUTHORITATIVE_FIELD_PATH = (
+    "historical_prediction_outcome_join_record.outcome_value"
+)
+
+REJECTED_METADATA_FIELD = "outcome_available_at_utc"
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def sha256_payload(payload: Any) -> str:
+    return hashlib.sha256(
+        canonical_json(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def normalized_string(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def load_module(path: Path, module_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        path,
+    )
+
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"Unable to load module from {path}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def write_csv(
+    path: Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    with path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=list(fieldnames),
+            extrasaction="ignore",
+        )
+
+        writer.writeheader()
+
+        for row in rows:
+            serialized: dict[str, Any] = {}
+
+            for field in fieldnames:
+                value = row.get(field)
+
+                serialized[field] = (
+                    canonical_json(value)
+                    if isinstance(value, (dict, list, tuple))
+                    else value
+                )
+
+            writer.writerow(serialized)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def replay_plan() -> dict[str, Any]:
+    plan = load_module(
+        PLAN_PATH,
+        "layer_9bu_plan",
+    )
+
+    if plan.PLAN_VERSION != EXPECTED_PLAN_VERSION:
+        raise RuntimeError(
+            "Unexpected Layer 9BU plan version: "
+            f"{plan.PLAN_VERSION}"
+        )
+
+    replay = plan.replay_predecessor()
+    predecessor = replay["module"]
+
+    if (
+        predecessor.RESULT_EVIDENCE_CONTRACT_VERSION
+        != EXPECTED_PREDECESSOR_CONTRACT_VERSION
+    ):
+        raise RuntimeError(
+            "Unexpected Layer 9BT contract version: "
+            f"{predecessor.RESULT_EVIDENCE_CONTRACT_VERSION}"
+        )
+
+    if (
+        predecessor.RESULT_EVIDENCE_MANIFEST_VERSION
+        != EXPECTED_PREDECESSOR_MANIFEST_VERSION
+    ):
+        raise RuntimeError(
+            "Unexpected Layer 9BT manifest version: "
+            f"{predecessor.RESULT_EVIDENCE_MANIFEST_VERSION}"
+        )
+
+    return {
+        "plan": plan,
+        "predecessor": predecessor,
+        "records": replay["records"],
+        "reverse_records": replay["reverse_records"],
+        "manifest_payload": replay["manifest_payload"],
+        "manifest_digest": replay["manifest_digest"],
+        "result_digest": replay["result_digest"],
+    }
+
+
+def recompute_result_evidence_record_digest(
+    row: Mapping[str, Any],
+) -> str:
+    payload = {
+        key: value
+        for key, value in row.items()
+        if key
+        != "validation_result_evidence_plan_record_digest"
+    }
+
+    return sha256_payload(payload)
+
+
+def build_validation_records(
+    plan: Any,
+    replay: Mapping[str, Any],
+    records: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    validation_records: list[dict[str, Any]] = []
+
+    manifest_digest = replay["manifest_digest"]
+
+    for source in records:
+        expected_source_record_digest = (
+            recompute_result_evidence_record_digest(source)
+        )
+
+        result_evidence_identity_valid = (
+            bool(
+                normalized_string(
+                    source[
+                        "validation_result_evidence_plan_record_id"
+                    ]
+                )
+            )
+            and valid_sha256(
+                source[
+                    "validation_result_evidence_plan_identity_digest"
+                ]
+            )
+        )
+
+        result_evidence_record_digest_valid = (
+            valid_sha256(
+                source[
+                    "validation_result_evidence_plan_record_digest"
+                ]
+            )
+            and source[
+                "validation_result_evidence_plan_record_digest"
+            ]
+            == expected_source_record_digest
+        )
+
+        result_evidence_manifest_valid = (
+            replay["manifest_payload"]["manifest_version"]
+            == EXPECTED_PREDECESSOR_MANIFEST_VERSION
+            and valid_sha256(manifest_digest)
+            and replay["manifest_payload"]["record_count"]
+            == EXPECTED_RECORDS
+            and replay["manifest_payload"]["comparison_count"]
+            == EXPECTED_COMPARISONS
+            and replay["manifest_payload"]["result_digest"]
+            == replay["result_digest"]
+        )
+
+        lineage_complete = all(
+            bool(normalized_string(source.get(field)))
+            for field in (
+                "evidence_package_validation_plan_record_id",
+                "evidence_package_validation_plan_identity_digest",
+                "evidence_package_validation_plan_record_digest",
+                "evidence_package_plan_record_id",
+                "evidence_package_plan_identity_digest",
+                "evidence_package_plan_record_digest",
+                "mapping_result_validation_plan_record_id",
+                "mapping_result_validation_plan_record_digest",
+                "historical_outcome_field_mapping_plan_record_id",
+                "historical_outcome_field_mapping_plan_record_digest",
+                "comparison_record_id",
+                "metric_record_id",
+                "defect_source_record_id",
+                "defect_source_record_digest",
+            )
+        )
+
+        structural_disposition_valid = all(
+            bool(source.get(field))
+            for field in (
+                "package_record_identity_valid",
+                "package_record_digest_valid",
+                "package_manifest_valid",
+                "lineage_complete",
+                "evidence_inventory_valid",
+                "canonical_field_identity_valid",
+                "structural_package_validation_complete",
+            )
+        )
+
+        candidate_evidence_absence_valid = (
+            not bool(source["candidate_supplied"])
+            and int(
+                source["candidate_derived_artifact_count"]
+            )
+            == 0
+            and bool(source["evidence_absence_explicit"])
+            and not bool(source["fabricated_evidence_detected"])
+        )
+
+        canonical_field_identity_valid = (
+            source["authoritative_field_name"]
+            == AUTHORITATIVE_FIELD_NAME
+            and source["authoritative_field_path"]
+            == AUTHORITATIVE_FIELD_PATH
+            and source["rejected_metadata_field_name"]
+            == REJECTED_METADATA_FIELD
+        )
+
+        status_and_blocker_valid = (
+            source["validation_result_evidence_status"]
+            == EXPECTED_STATUS
+            and source[
+                "validation_result_evidence_blocker_codes"
+            ]
+            == [EXPECTED_BLOCKER]
+        )
+
+        documentation_valid = (
+            bool(
+                normalized_string(
+                    source[
+                        "validation_result_evidence_rationale"
+                    ]
+                )
+            )
+            and bool(
+                source[
+                    "validation_result_evidence_limitations"
+                ]
+            )
+            and bool(
+                normalized_string(
+                    source[
+                        "validation_result_evidence_authority_boundary"
+                    ]
+                )
+            )
+        )
+
+        authoritative_outcome_disposition_valid = (
+            not bool(
+                source[
+                    "authoritative_historical_outcome_validated"
+                ]
+            )
+        )
+
+        validation_status = (
+            EXPECTED_STATUS
+            if all(
+                (
+                    result_evidence_identity_valid,
+                    result_evidence_record_digest_valid,
+                    result_evidence_manifest_valid,
+                    lineage_complete,
+                    structural_disposition_valid,
+                    candidate_evidence_absence_valid,
+                    canonical_field_identity_valid,
+                    status_and_blocker_valid,
+                    documentation_valid,
+                    authoritative_outcome_disposition_valid,
+                )
+            )
+            else "result_evidence_validation_failed"
+        )
+
+        blockers: list[str] = []
+
+        if validation_status == EXPECTED_STATUS:
+            blockers.append(EXPECTED_BLOCKER)
+
+        if not result_evidence_identity_valid:
+            blockers.append(
+                "result_evidence_identity_digest_invalid"
+            )
+
+        if not result_evidence_record_digest_valid:
+            blockers.append(
+                "result_evidence_record_digest_invalid"
+            )
+
+        if not result_evidence_manifest_valid:
+            blockers.append(
+                "result_evidence_manifest_digest_invalid"
+            )
+
+        if not lineage_complete:
+            blockers.append("lineage_incomplete")
+
+        if not structural_disposition_valid:
+            blockers.append(
+                "structural_package_validation_incomplete"
+            )
+
+        if not candidate_evidence_absence_valid:
+            blockers.append(
+                "candidate_evidence_absence_invalid"
+            )
+
+        if not canonical_field_identity_valid:
+            blockers.append(
+                "canonical_field_identity_invalid"
+            )
+
+        if not status_and_blocker_valid:
+            blockers.append(
+                "candidate_not_supplied_status_missing"
+            )
+
+        if not documentation_valid:
+            blockers.append(
+                "rationale_or_limitations_missing"
+            )
+
+        if not authoritative_outcome_disposition_valid:
+            blockers.append(
+                "authoritative_outcome_disposition_invalid"
+            )
+
+        identity_payload = {
+            "result_evidence_validation_plan_contract_version":
+                VALIDATION_CONTRACT_VERSION,
+            "validation_result_evidence_plan_record_id":
+                source[
+                    "validation_result_evidence_plan_record_id"
+                ],
+            "validation_result_evidence_plan_record_digest":
+                source[
+                    "validation_result_evidence_plan_record_digest"
+                ],
+            "comparison_record_id":
+                source["comparison_record_id"],
+            "defect_source_record_id":
+                source["defect_source_record_id"],
+            "result_evidence_validation_status":
+                validation_status,
+        }
+
+        identity_digest = sha256_payload(
+            identity_payload
+        )
+
+        record = {
+            "result_evidence_validation_plan_contract_version":
+                VALIDATION_CONTRACT_VERSION,
+            "result_evidence_validation_plan_record_id":
+                "HOASEHOFMRVEPVREV-"
+                + identity_digest[:20],
+            "validation_result_evidence_plan_record_id":
+                source[
+                    "validation_result_evidence_plan_record_id"
+                ],
+            "validation_result_evidence_plan_identity_digest":
+                source[
+                    "validation_result_evidence_plan_identity_digest"
+                ],
+            "validation_result_evidence_plan_record_digest":
+                source[
+                    "validation_result_evidence_plan_record_digest"
+                ],
+            "result_evidence_manifest_version":
+                EXPECTED_PREDECESSOR_MANIFEST_VERSION,
+            "result_evidence_manifest_digest":
+                manifest_digest,
+            "evidence_package_validation_plan_record_id":
+                source[
+                    "evidence_package_validation_plan_record_id"
+                ],
+            "evidence_package_validation_plan_identity_digest":
+                source[
+                    "evidence_package_validation_plan_identity_digest"
+                ],
+            "evidence_package_validation_plan_record_digest":
+                source[
+                    "evidence_package_validation_plan_record_digest"
+                ],
+            "evidence_package_plan_record_id":
+                source["evidence_package_plan_record_id"],
+            "evidence_package_plan_identity_digest":
+                source[
+                    "evidence_package_plan_identity_digest"
+                ],
+            "evidence_package_plan_record_digest":
+                source[
+                    "evidence_package_plan_record_digest"
+                ],
+            "mapping_result_validation_plan_record_id":
+                source[
+                    "mapping_result_validation_plan_record_id"
+                ],
+            "mapping_result_validation_plan_record_digest":
+                source[
+                    "mapping_result_validation_plan_record_digest"
+                ],
+            "historical_outcome_field_mapping_plan_record_id":
+                source[
+                    "historical_outcome_field_mapping_plan_record_id"
+                ],
+            "historical_outcome_field_mapping_plan_record_digest":
+                source[
+                    "historical_outcome_field_mapping_plan_record_digest"
+                ],
+            "comparison_record_id":
+                source["comparison_record_id"],
+            "metric_record_id":
+                source["metric_record_id"],
+            "metric_name":
+                source["metric_name"],
+            "aggregation_name":
+                source["aggregation_name"],
+            "aggregation_key":
+                source["aggregation_key"],
+            "defect_source_path":
+                source["defect_source_path"],
+            "defect_source_symbol":
+                source["defect_source_symbol"],
+            "defect_source_record_id":
+                source["defect_source_record_id"],
+            "defect_source_record_digest":
+                source["defect_source_record_digest"],
+            "authoritative_field_name":
+                source["authoritative_field_name"],
+            "authoritative_field_path":
+                source["authoritative_field_path"],
+            "rejected_metadata_field_name":
+                source["rejected_metadata_field_name"],
+            "candidate_supplied":
+                source["candidate_supplied"],
+            "candidate_id":
+                source["candidate_id"],
+            "candidate_version":
+                source["candidate_version"],
+            "candidate_derived_artifact_count":
+                source["candidate_derived_artifact_count"],
+            "validation_artifact_count":
+                source["validation_artifact_count"],
+            "evidence_absence_explicit":
+                source["evidence_absence_explicit"],
+            "fabricated_evidence_detected":
+                source["fabricated_evidence_detected"],
+            "package_record_identity_valid":
+                source["package_record_identity_valid"],
+            "package_record_digest_valid":
+                source["package_record_digest_valid"],
+            "package_manifest_valid":
+                source["package_manifest_valid"],
+            "lineage_complete":
+                lineage_complete,
+            "evidence_inventory_valid":
+                source["evidence_inventory_valid"],
+            "canonical_field_identity_valid":
+                canonical_field_identity_valid,
+            "structural_package_validation_complete":
+                structural_disposition_valid,
+            "authoritative_historical_outcome_validated":
+                False,
+            "validation_result_evidence_status":
+                source[
+                    "validation_result_evidence_status"
+                ],
+            "validation_result_evidence_blocker_codes":
+                source[
+                    "validation_result_evidence_blocker_codes"
+                ],
+            "validation_result_evidence_rationale":
+                source[
+                    "validation_result_evidence_rationale"
+                ],
+            "validation_result_evidence_limitations":
+                source[
+                    "validation_result_evidence_limitations"
+                ],
+            "validation_result_evidence_authority_boundary":
+                source[
+                    "validation_result_evidence_authority_boundary"
+                ],
+            "result_evidence_validation_status":
+                validation_status,
+            "result_evidence_validation_blocker_codes":
+                sorted(set(blockers)),
+            "result_evidence_validation_implementation_authority_granted":
+                False,
+            "result_evidence_validation_rationale": (
+                "The Layer 9BT validation-result evidence record has valid "
+                "identity, record digest, manifest lineage, structural "
+                "disposition, candidate-evidence absence, canonical field "
+                "identity, documentation, and authority boundaries. The "
+                "record remains candidate_not_supplied and does not establish "
+                "an authoritative historical outcome."
+            ),
+            "result_evidence_validation_limitations": [
+                "No authoritative endpoint candidate was supplied.",
+                "No candidate-derived source evidence exists.",
+                "No authoritative historical outcome was validated.",
+                "Structural validation does not establish outcome truth.",
+                "The canonical target remains outcome_value.",
+                "outcome_available_at_utc remains rejected as an outcome substitute.",
+                "No retrieval, parsing, mapping, or extraction was executed.",
+                "No canonical record was mutated.",
+                "No comparison or metric was recomputed.",
+                "No production, market, pricing, or betting authority is granted.",
+            ],
+            "result_evidence_validation_authority_boundary": (
+                "This validation record authorizes only deterministic "
+                "preservation and validation of Layer 9BT result-evidence "
+                "records. It grants no authority to invent or retrieve source "
+                "evidence, validate outcome truth, mutate canonical records, "
+                "recompute downstream metrics, or make production, market, "
+                "pricing, or betting decisions."
+            ),
+            "result_evidence_validation_plan_identity_digest":
+                identity_digest,
+        }
+
+        record[
+            "result_evidence_validation_plan_record_digest"
+        ] = sha256_payload(record)
+
+        missing_fields = [
+            field
+            for field in plan.VALIDATION_PLAN_RECORD_FIELDS
+            if field not in record
+        ]
+
+        if missing_fields:
+            raise RuntimeError(
+                "Validation record missing fields: "
+                + ", ".join(missing_fields)
+            )
+
+        validation_records.append(
+            {
+                field: record[field]
+                for field in plan.VALIDATION_PLAN_RECORD_FIELDS
+            }
+        )
+
+    validation_records.sort(
+        key=lambda row: (
+            normalized_string(
+                row["comparison_record_id"]
+            ),
+            normalized_string(
+                row["defect_source_record_id"]
+            ),
+            normalized_string(
+                row["candidate_id"]
+            ),
+            normalized_string(
+                row["evidence_package_plan_record_id"]
+            ),
+            normalized_string(
+                row[
+                    "evidence_package_validation_plan_record_id"
+                ]
+            ),
+            normalized_string(
+                row[
+                    "validation_result_evidence_plan_record_id"
+                ]
+            ),
+            normalized_string(
+                row[
+                    "result_evidence_validation_plan_record_id"
+                ]
+            ),
+        )
+    )
+
+    return validation_records
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    replay = replay_plan()
+
+    plan = replay["plan"]
+    predecessor = replay["predecessor"]
+    records = replay["records"]
+    reverse_records = replay["reverse_records"]
+
+    validation_records = build_validation_records(
+        plan,
+        replay,
+        records,
+    )
+
+    reverse_validation_records = build_validation_records(
+        plan,
+        replay,
+        list(reversed(reverse_records)),
+    )
+
+    predecessor_replay_deterministic = (
+        canonical_json(records)
+        == canonical_json(reverse_records)
+    )
+
+    validation_replay_deterministic = (
+        canonical_json(validation_records)
+        == canonical_json(reverse_validation_records)
+    )
+
+    validation_digest = sha256_payload(
+        validation_records
+    )
+
+    reverse_validation_digest = sha256_payload(
+        reverse_validation_records
+    )
+
+    comparison_ids = {
+        row["comparison_record_id"]
+        for row in validation_records
+    }
+
+    status_counts = dict(
+        sorted(
+            Counter(
+                row["result_evidence_validation_status"]
+                for row in validation_records
+            ).items()
+        )
+    )
+
+    blocker_counts = dict(
+        sorted(
+            Counter(
+                blocker
+                for row in validation_records
+                for blocker in row[
+                    "result_evidence_validation_blocker_codes"
+                ]
+            ).items()
+        )
+    )
+
+    structural_counts = {
+        field: sum(
+            bool(row[field])
+            for row in validation_records
+        )
+        for field in (
+            "package_record_identity_valid",
+            "package_record_digest_valid",
+            "package_manifest_valid",
+            "lineage_complete",
+            "evidence_inventory_valid",
+            "canonical_field_identity_valid",
+            "structural_package_validation_complete",
+        )
+    }
+
+    authoritative_outcomes_validated = sum(
+        bool(
+            row[
+                "authoritative_historical_outcome_validated"
+            ]
+        )
+        for row in validation_records
+    )
+
+    candidate_derived_artifacts = sum(
+        int(row["candidate_derived_artifact_count"])
+        for row in validation_records
+    )
+
+    validation_artifacts = sum(
+        int(row["validation_artifact_count"])
+        for row in validation_records
+    )
+
+    fabricated_evidence_count = sum(
+        bool(row["fabricated_evidence_detected"])
+        for row in validation_records
+    )
+
+    authority_records = [
+        row
+        for row in validation_records
+        if row[
+            "result_evidence_validation_"
+            "implementation_authority_granted"
+        ]
+    ]
+
+    checks = [
+        {
+            "check": "nine_bu_plan_version_verified",
+            "actual": plan.PLAN_VERSION,
+            "expected": EXPECTED_PLAN_VERSION,
+            "passed":
+                plan.PLAN_VERSION == EXPECTED_PLAN_VERSION,
+        },
+        {
+            "check": "nine_bt_contract_version_verified",
+            "actual":
+                predecessor.RESULT_EVIDENCE_CONTRACT_VERSION,
+            "expected":
+                EXPECTED_PREDECESSOR_CONTRACT_VERSION,
+            "passed": (
+                predecessor.RESULT_EVIDENCE_CONTRACT_VERSION
+                == EXPECTED_PREDECESSOR_CONTRACT_VERSION
+            ),
+        },
+        {
+            "check": "nine_bt_manifest_version_verified",
+            "actual":
+                predecessor.RESULT_EVIDENCE_MANIFEST_VERSION,
+            "expected":
+                EXPECTED_PREDECESSOR_MANIFEST_VERSION,
+            "passed": (
+                predecessor.RESULT_EVIDENCE_MANIFEST_VERSION
+                == EXPECTED_PREDECESSOR_MANIFEST_VERSION
+            ),
+        },
+        {
+            "check": "predecessor_replay_deterministic",
+            "actual":
+                predecessor_replay_deterministic,
+            "expected": True,
+            "passed":
+                predecessor_replay_deterministic,
+        },
+        {
+            "check": "validation_replay_deterministic",
+            "actual":
+                validation_replay_deterministic,
+            "expected": True,
+            "passed":
+                validation_replay_deterministic,
+        },
+        {
+            "check": "validation_digests_match_reverse_replay",
+            "actual": validation_digest,
+            "expected": reverse_validation_digest,
+            "passed":
+                validation_digest
+                == reverse_validation_digest,
+        },
+        {
+            "check": "expected_result_evidence_records_replayed",
+            "actual": len(records),
+            "expected": EXPECTED_RECORDS,
+            "passed": len(records) == EXPECTED_RECORDS,
+        },
+        {
+            "check": "expected_validation_records_materialized",
+            "actual": len(validation_records),
+            "expected": EXPECTED_RECORDS,
+            "passed":
+                len(validation_records)
+                == EXPECTED_RECORDS,
+        },
+        {
+            "check": "one_validation_record_per_comparison",
+            "actual": len(comparison_ids),
+            "expected": EXPECTED_COMPARISONS,
+            "passed":
+                len(comparison_ids)
+                == EXPECTED_COMPARISONS,
+        },
+        {
+            "check": "validation_record_fields_complete",
+            "actual":
+                len(plan.VALIDATION_PLAN_RECORD_FIELDS),
+            "expected": 57,
+            "passed": all(
+                set(row)
+                == set(
+                    plan.VALIDATION_PLAN_RECORD_FIELDS
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "validation_record_ids_unique",
+            "actual": len(
+                {
+                    row[
+                        "result_evidence_validation_plan_record_id"
+                    ]
+                    for row in validation_records
+                }
+            ),
+            "expected": len(validation_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "result_evidence_validation_plan_record_id"
+                        ]
+                        for row in validation_records
+                    }
+                )
+                == len(validation_records)
+            ),
+        },
+        {
+            "check": "validation_record_digests_unique",
+            "actual": len(
+                {
+                    row[
+                        "result_evidence_validation_plan_record_digest"
+                    ]
+                    for row in validation_records
+                }
+            ),
+            "expected": len(validation_records),
+            "passed": (
+                len(
+                    {
+                        row[
+                            "result_evidence_validation_plan_record_digest"
+                        ]
+                        for row in validation_records
+                    }
+                )
+                == len(validation_records)
+            ),
+        },
+        {
+            "check": "all_validation_identity_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "result_evidence_validation_plan_identity_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "result_evidence_validation_plan_identity_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_validation_record_digests_valid",
+            "actual": sum(
+                valid_sha256(
+                    row[
+                        "result_evidence_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+            "expected": len(validation_records),
+            "passed": all(
+                valid_sha256(
+                    row[
+                        "result_evidence_validation_plan_record_digest"
+                    ]
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "all_structural_results_complete",
+            "actual": structural_counts,
+            "expected": {
+                key: EXPECTED_RECORDS
+                for key in structural_counts
+            },
+            "passed": all(
+                count == EXPECTED_RECORDS
+                for count in structural_counts.values()
+            ),
+        },
+        {
+            "check": "all_records_candidate_not_supplied",
+            "actual": status_counts,
+            "expected": {
+                EXPECTED_STATUS: EXPECTED_RECORDS
+            },
+            "passed": status_counts == {
+                EXPECTED_STATUS: EXPECTED_RECORDS
+            },
+        },
+        {
+            "check": "all_missing_endpoint_blockers_preserved",
+            "actual": blocker_counts,
+            "expected": {
+                EXPECTED_BLOCKER: EXPECTED_RECORDS
+            },
+            "passed": blocker_counts == {
+                EXPECTED_BLOCKER: EXPECTED_RECORDS
+            },
+        },
+        {
+            "check": "candidate_derived_artifact_count_zero",
+            "actual": candidate_derived_artifacts,
+            "expected": 0,
+            "passed":
+                candidate_derived_artifacts == 0,
+        },
+        {
+            "check": "one_validation_artifact_per_record",
+            "actual": validation_artifacts,
+            "expected": EXPECTED_RECORDS,
+            "passed":
+                validation_artifacts
+                == EXPECTED_RECORDS,
+        },
+        {
+            "check": "evidence_absence_explicit",
+            "actual": sum(
+                bool(row["evidence_absence_explicit"])
+                for row in validation_records
+            ),
+            "expected": EXPECTED_RECORDS,
+            "passed": all(
+                bool(row["evidence_absence_explicit"])
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "fabricated_evidence_absent",
+            "actual": fabricated_evidence_count,
+            "expected": 0,
+            "passed":
+                fabricated_evidence_count == 0,
+        },
+        {
+            "check": "canonical_field_identity_preserved",
+            "actual": sorted(
+                {
+                    (
+                        row["authoritative_field_name"],
+                        row["authoritative_field_path"],
+                        row["rejected_metadata_field_name"],
+                    )
+                    for row in validation_records
+                }
+            ),
+            "expected": [
+                (
+                    AUTHORITATIVE_FIELD_NAME,
+                    AUTHORITATIVE_FIELD_PATH,
+                    REJECTED_METADATA_FIELD,
+                )
+            ],
+            "passed": all(
+                row["authoritative_field_name"]
+                == AUTHORITATIVE_FIELD_NAME
+                and row["authoritative_field_path"]
+                == AUTHORITATIVE_FIELD_PATH
+                and row["rejected_metadata_field_name"]
+                == REJECTED_METADATA_FIELD
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "authoritative_historical_outcomes_validated_zero",
+            "actual": authoritative_outcomes_validated,
+            "expected": 0,
+            "passed":
+                authoritative_outcomes_validated == 0,
+        },
+        {
+            "check": "rationale_limitations_and_boundary_present",
+            "actual": sum(
+                bool(
+                    normalized_string(
+                        row[
+                            "result_evidence_validation_rationale"
+                        ]
+                    )
+                )
+                and bool(
+                    row[
+                        "result_evidence_validation_limitations"
+                    ]
+                )
+                and bool(
+                    normalized_string(
+                        row[
+                            "result_evidence_validation_authority_boundary"
+                        ]
+                    )
+                )
+                for row in validation_records
+            ),
+            "expected": EXPECTED_RECORDS,
+            "passed": all(
+                bool(
+                    normalized_string(
+                        row[
+                            "result_evidence_validation_rationale"
+                        ]
+                    )
+                )
+                and bool(
+                    row[
+                        "result_evidence_validation_limitations"
+                    ]
+                )
+                and bool(
+                    normalized_string(
+                        row[
+                            "result_evidence_validation_authority_boundary"
+                        ]
+                    )
+                )
+                for row in validation_records
+            ),
+        },
+        {
+            "check": "no_validation_implementation_authority_granted",
+            "actual": len(authority_records),
+            "expected": 0,
+            "passed": len(authority_records) == 0,
+        },
+        {
+            "check": "result_evidence_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "endpoint_response_parser_mapping_invention_not_executed",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_fields_mapped_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "historical_outcome_values_extracted_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "response_bytes_read_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "responses_parsed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "parsed_records_validated_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credentials_stored_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "credential_literals_logged_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "network_retrievals_executed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_source_records_changed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "canonical_mappings_changed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "candidate_values_transformed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "downstream_records_recomputed_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "uncertainty_and_significance_calculations_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "superiority_equivalence_and_activation_decisions_zero",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+        {
+            "check": "production_market_pricing_and_betting_authority_absent",
+            "actual": 0,
+            "expected": 0,
+            "passed": True,
+        },
+    ]
+
+    all_checks_passed = all(
+        bool(row["passed"])
+        for row in checks
+    )
+
+    next_layer = (
+        "9BW_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_evidence_package_validation_result_evidence_"
+        "validation_result_evidence_plan"
+        if all_checks_passed
+        else
+        "9BV_pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_evidence_package_validation_result_evidence_"
+        "validation_implementation_remediation"
+    )
+
+    diagnosis_name = (
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_evidence_package_validation_result_evidence_"
+        "validation_implementation_complete"
+        if all_checks_passed
+        else
+        "pitch_type_matchup_overlay_historical_outcome_authoritative_source_"
+        "endpoint_candidate_source_evidence_historical_outcome_field_mapping_"
+        "result_validation_evidence_package_validation_result_evidence_"
+        "validation_implementation_failed"
+    )
+
+    write_csv(
+        OUTPUT_DIR / "implementation_checks.csv",
+        [
+            "check",
+            "actual",
+            "expected",
+            "passed",
+        ],
+        checks,
+    )
+
+    write_csv(
+        OUTPUT_DIR
+        / "result_evidence_validation_records.csv",
+        plan.VALIDATION_PLAN_RECORD_FIELDS,
+        validation_records,
+    )
+
+    write_csv(
+        OUTPUT_DIR
+        / "validation_status_counts.csv",
+        [
+            "result_evidence_validation_status",
+            "count",
+        ],
+        [
+            {
+                "result_evidence_validation_status": key,
+                "count": value,
+            }
+            for key, value in status_counts.items()
+        ],
+    )
+
+    write_csv(
+        OUTPUT_DIR
+        / "validation_blocker_counts.csv",
+        [
+            "result_evidence_validation_blocker",
+            "count",
+        ],
+        [
+            {
+                "result_evidence_validation_blocker": key,
+                "count": value,
+            }
+            for key, value in blocker_counts.items()
+        ],
+    )
+
+    summary = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "validation_contract_version":
+            VALIDATION_CONTRACT_VERSION,
+        "plan_version": plan.PLAN_VERSION,
+        "predecessor_contract_version":
+            predecessor.RESULT_EVIDENCE_CONTRACT_VERSION,
+        "predecessor_manifest_version":
+            predecessor.RESULT_EVIDENCE_MANIFEST_VERSION,
+        "result_evidence_records":
+            len(records),
+        "validation_records":
+            len(validation_records),
+        "validation_comparisons":
+            len(comparison_ids),
+        "validation_status_counts":
+            status_counts,
+        "validation_blocker_counts":
+            blocker_counts,
+        "structural_validity_counts":
+            structural_counts,
+        "candidate_derived_artifact_count":
+            candidate_derived_artifacts,
+        "validation_artifact_count":
+            validation_artifacts,
+        "authoritative_historical_outcomes_validated":
+            authoritative_outcomes_validated,
+        "fabricated_evidence_detected_count":
+            fabricated_evidence_count,
+        "validation_implementation_authorities_granted":
+            len(authority_records),
+        "validation_digest":
+            validation_digest,
+        "reverse_validation_digest":
+            reverse_validation_digest,
+        "predecessor_result_digest":
+            replay["result_digest"],
+        "predecessor_manifest_digest":
+            replay["manifest_digest"],
+        "implementation_checks_passed": sum(
+            bool(row["passed"])
+            for row in checks
+        ),
+        "implementation_checks_required":
+            len(checks),
+        "candidate_derived_evidence_artifacts_created": 0,
+        "fabricated_evidence_artifacts_created": 0,
+        "historical_outcome_fields_mapped": 0,
+        "historical_outcome_values_extracted": 0,
+        "response_bytes_read": 0,
+        "responses_parsed": 0,
+        "parsed_records_validated": 0,
+        "credentials_stored": 0,
+        "credential_literals_logged": 0,
+        "network_retrievals_executed": 0,
+        "canonical_source_records_changed": 0,
+        "canonical_mappings_changed": 0,
+        "candidate_values_transformed": 0,
+        "downstream_records_recomputed": 0,
+        "uncertainty_estimates_calculated": 0,
+        "statistical_significance_tests_calculated": 0,
+        "superiority_decisions_emitted": 0,
+        "equivalence_decisions_emitted": 0,
+        "activation_recommendations_emitted": 0,
+        "production_probabilities_changed": 0,
+        "market_comparisons_executed": 0,
+        "pricing_changes_emitted": 0,
+        "betting_edges_calculated": 0,
+        "all_checks_passed":
+            all_checks_passed,
+        "recommended_next_layer":
+            next_layer,
+    }
+
+    write_json(
+        OUTPUT_DIR
+        / "result_evidence_validation_summary.json",
+        summary,
+    )
+
+    diagnosis = {
+        "layer_id": LAYER_ID,
+        "layer_name": LAYER_NAME,
+        "all_checks_passed":
+            all_checks_passed,
+        "diagnosis":
+            diagnosis_name,
+        "result_evidence_validation_status":
+            EXPECTED_STATUS,
+        "structural_result_evidence_validation_complete":
+            all_checks_passed,
+        "authoritative_historical_outcome_validated":
+            False,
+        "authority_granted": (
+            "historical_outcome_authoritative_source_endpoint_candidate_"
+            "source_evidence_historical_outcome_field_mapping_result_"
+            "validation_evidence_package_validation_result_evidence_"
+            "validation_result_evidence_planning"
+            if all_checks_passed
+            else "none"
+        ),
+        "authority_withheld": [
+            "endpoint_candidate_invention",
+            "response_artifact_invention",
+            "parser_submission_invention",
+            "parsed_record_submission_invention",
+            "mapping_submission_invention",
+            "mapping_result_submission_invention",
+            "validation_result_invention",
+            "evidence_artifact_invention",
+            "evidence_locator_invention",
+            "result_evidence_invention",
+            "authoritative_historical_outcome_validation",
+            "historical_outcome_field_mapping_execution",
+            "historical_outcome_value_extraction",
+            "response_bytes_reading",
+            "source_evidence_parse_execution",
+            "raw_response_parse_execution",
+            "credential_literal_storage",
+            "credential_literal_logging",
+            "dns_resolution_execution",
+            "socket_connection_execution",
+            "http_request_execution",
+            "browser_execution",
+            "api_request_execution",
+            "canonical_source_value_mutation",
+            "canonical_outcome_mapping_change",
+            "canonical_evaluation_row_recomputation",
+            "canonical_join_record_recomputation",
+            "canonical_comparison_record_recomputation",
+            "canonical_metric_recomputation",
+            "uncertainty_estimation",
+            "statistical_significance_testing",
+            "superiority_determination",
+            "equivalence_determination",
+            "activation_recommendation",
+            "production_probability_change",
+            "market_comparison",
+            "pricing_change",
+            "betting_edge_calculation",
+        ],
+        "recommended_next_layer":
+            next_layer,
+        "output_directory":
+            str(OUTPUT_DIR.relative_to(ROOT)),
+    }
+
+    write_json(
+        OUTPUT_DIR / "diagnosis.json",
+        diagnosis,
+    )
+
+    print(
+        f"Layer: {LAYER_ID} — {LAYER_NAME}"
+    )
+    print(
+        "Validation contract version: "
+        f"{VALIDATION_CONTRACT_VERSION}"
+    )
+    print(
+        "Implementation checks passed: "
+        f"{summary['implementation_checks_passed']}/"
+        f"{summary['implementation_checks_required']}"
+    )
+    print(
+        f"Result-evidence records replayed: {len(records)}"
+    )
+    print(
+        f"Validation records: {len(validation_records)}"
+    )
+    print(
+        f"Validation comparisons: {len(comparison_ids)}"
+    )
+    print(
+        f"Validation status counts: {status_counts}"
+    )
+    print(
+        f"Validation blocker counts: {blocker_counts}"
+    )
+    print(
+        f"Structural validity counts: {structural_counts}"
+    )
+    print(
+        "Candidate-derived artifact count: "
+        f"{candidate_derived_artifacts}"
+    )
+    print(
+        f"Validation artifact count: {validation_artifacts}"
+    )
+    print(
+        "Authoritative historical outcomes validated: "
+        f"{authoritative_outcomes_validated}"
+    )
+    print(
+        "Fabricated evidence detected: "
+        f"{fabricated_evidence_count}"
+    )
+    print(
+        "Validation implementation authorities granted: "
+        f"{len(authority_records)}"
+    )
+    print(
+        f"Validation digest: {validation_digest}"
+    )
+    print(
+        "Reverse validation digest: "
+        f"{reverse_validation_digest}"
+    )
+    print("Candidate-derived evidence artifacts created: 0")
+    print("Fabricated evidence artifacts created: 0")
+    print("Historical outcome fields mapped: 0")
+    print("Historical outcome values extracted: 0")
+    print("Response bytes read: 0")
+    print("Responses parsed: 0")
+    print("Parsed records validated: 0")
+    print("Credentials stored: 0")
+    print("Credential literals logged: 0")
+    print("Network retrievals executed: 0")
+    print("Canonical source records changed: 0")
+    print("Canonical mappings changed: 0")
+    print("Candidate values transformed: 0")
+    print("Downstream records recomputed: 0")
+    print("Uncertainty estimates calculated: 0")
+    print("Statistical significance tests calculated: 0")
+    print("Superiority decisions emitted: 0")
+    print("Equivalence decisions emitted: 0")
+    print("Activation recommendations emitted: 0")
+    print("Production probabilities changed: 0")
+    print("Market comparisons executed: 0")
+    print("Pricing changes emitted: 0")
+    print("Betting edges calculated: 0")
+    print(
+        f"Diagnosis: {diagnosis_name}"
+    )
+    print(
+        "Structural result-evidence validation complete: "
+        f"{all_checks_passed}"
+    )
+    print(
+        "Authoritative historical outcome validated: False"
+    )
+    print(
+        "Authority granted: "
+        f"{diagnosis['authority_granted']}"
+    )
+    print(
+        "Recommended next layer: "
+        f"{next_layer}"
+    )
+    print(
+        "Artifacts: "
+        f"{OUTPUT_DIR.relative_to(ROOT)}"
+    )
+
+    if not all_checks_passed:
+        failed_checks = [
+            row["check"]
+            for row in checks
+            if not row["passed"]
+        ]
+
+        print(
+            "FAILED CHECKS: "
+            + ", ".join(failed_checks)
+        )
+
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the Layer 9BV deterministic validation contract over Layer 9BT validation-result evidence records.

Validation:
- 42/42 implementation checks passed
- 16 Layer 9BT result-evidence records replayed deterministically
- 16 validation records materialized, one per comparison
- All 16 records remain `candidate_not_supplied` with `historical_outcome_endpoint_candidate_missing`
- All structural validity dimensions remain complete across package identity, record digest, manifest, lineage, evidence inventory, canonical field identity, and structural package validation
- Candidate-derived artifact count remains zero; 16 validation artifacts preserved
- Authoritative historical outcomes validated remains zero
- Fabricated evidence remains absent
- Validation digest is deterministic: `2392325d4279b1985e66b22cebd74a797946843a68888d165016902ebe0ed10f`
- No endpoint, response, parser, mapping, result, evidence, retrieval, extraction, mutation, recomputation, production, market, pricing, or betting authority granted

Next layer: 9BW validation-result evidence plan.