### PR TITLE
PR 6: harden canonical My Dashboard production lifecycle

### DIFF
--- a/docs/my_dashboard_canonical_production_runbook.md
+++ b/docs/my_dashboard_canonical_production_runbook.md
@@ -1,0 +1,154 @@
+# My Dashboard canonical projection production runbook
+
+## Purpose
+
+The default Hitters and Pitchers reports read `dashboard_player_current`. They do not build a slate population at request time. This runbook is the production procedure for populating, inspecting, refreshing, and verifying that canonical projection.
+
+Do not claim My Dashboard is populated from a successful deploy alone. A successful production refresh and plausible status counts are separate requirements.
+
+## Read-only inspection
+
+From a Railway shell or equivalent environment with the production `DATABASE_URL`:
+
+```bash
+python scripts/refresh_dashboard_player_projection.py
+```
+
+The command is status-only unless `--refresh` or `--backfill-days` is explicitly supplied.
+
+The deployed API also exposes:
+
+```text
+GET /my-dashboard/canonical/status
+GET /my-dashboard/report-types
+```
+
+The status response contains no player names, credentials, connection strings, or source payloads.
+
+## Initial production refresh
+
+Run after the schema-containing deployment is healthy:
+
+```bash
+python scripts/refresh_dashboard_player_projection.py --date YYYY-MM-DD --refresh
+```
+
+The operator command:
+
+1. reads the verified MLB active-team endpoint and refuses fewer than 30 teams;
+2. reads every verified MLB active roster;
+3. reads confirmed boxscore lineups available for the target date;
+4. combines those sources with tracked Statcast game activity and existing aggregate coverage;
+5. populates canonical identities using MLBAM IDs only;
+6. builds one snapshot row for every resolved active canonical player;
+7. atomically promotes the full current projection;
+8. records a durable success or failure row in `dashboard_projection_runs`;
+9. emits before/after status and row-count evidence.
+
+Missing-player deactivation is off by default. Use `--transition-missing-players` only after confirming the team and roster source set is complete. A source or projection failure preserves the previous `dashboard_player_current` projection.
+
+## Optional historical snapshot backfill
+
+After a successful current refresh:
+
+```bash
+python scripts/refresh_dashboard_player_projection.py --date YYYY-MM-DD --backfill-days 30
+```
+
+To perform both operations in one invocation:
+
+```bash
+python scripts/refresh_dashboard_player_projection.py --date YYYY-MM-DD --refresh --backfill-days 30
+```
+
+Backfill retains immutable snapshots. Only the final successful date is promoted as current.
+
+## Plausibility gates
+
+Treat the projection as production-ready only when all of the following are true:
+
+- `status = ready`;
+- `population.canonical_count > 0`;
+- `population.active_hitter_count > 0`;
+- `population.active_pitcher_count > 0`;
+- `current_projection.row_count = population.active_count`;
+- hitter and pitcher current counts match their active canonical counts;
+- `current_projection.stale = false`;
+- a durable `refresh_runs.latest_success` exists;
+- snapshot count is non-zero;
+- field coverage is inspected rather than assumed;
+- default hitter/pitcher reports return the same full-population counts across pagination;
+- changing weights does not change `totalSize`.
+
+The service intentionally does not hard-code a claim such as “200+ hitters” because roster availability, season timing, aggregate coverage, and the active-window policy affect the actual population. Record the observed counts in issue #1055 after the production run.
+
+## Field coverage
+
+The status endpoint reports non-null counts and ratios separately for hitters and pitchers for:
+
+- model score and confidence;
+- xwOBA and xBA;
+- exit velocity and launch angle;
+- hard-hit and barrel rates;
+- strikeout and walk rates;
+- ISO, OBP, and SLG;
+- plate appearances.
+
+A low-coverage field remains visible and nillable. It must not silently remove players from an unfiltered report.
+
+## Related reports
+
+The query endpoint supports these additional validated related reports:
+
+```json
+{"report_type": "players_lineup_history"}
+```
+
+```json
+{"report_type": "hitters_arsenal_splits"}
+```
+
+They use explicit field catalogs from `GET /my-dashboard/report-types`, SQL validation, stable pagination, and canonical-player joins. Arsenal split rows only include active resolved hitters. These one-to-many reports do not redefine the default active-player population.
+
+## Suggested Railway schedule
+
+Keep the command opt-in until the first production run is inspected. After acceptance, schedule the current refresh after the upstream roster, Statcast aggregate, and Stored 365 jobs finish:
+
+```bash
+python scripts/refresh_dashboard_player_projection.py --refresh
+```
+
+Recommended environment controls:
+
+```text
+DASHBOARD_ACTIVE_PLAYER_WINDOW_DAYS=30
+DASHBOARD_PROJECTION_STALE_HOURS=36
+```
+
+Do not run overlapping projection refreshes. The command is idempotent for identical approved content, but simultaneous source collection wastes capacity and makes run evidence harder to interpret.
+
+## Production verification
+
+1. Deploy the merged schema, status endpoint, report queries, and operator command.
+2. Run status-only inspection and save the empty/prior baseline.
+3. Run the explicit current refresh.
+4. Save the emitted JSON counts.
+5. Call `GET /my-dashboard/canonical/status` from production.
+6. Query `all_active_hitters` and `all_active_pitchers` without filters.
+7. Page through results and confirm stable, gap-free totals.
+8. Apply one team filter and one metric filter.
+9. Apply a weight-only change and confirm count stability with ordering change.
+10. Query the two related report types.
+11. Open the Report Builder on desktop and mobile and switch among primary objects.
+12. Smoke-test Matchups, Matchup Detail, Daily Odds, Model Projections, and AI Data Assistant.
+13. Attach counts, versions, timestamps, tests, build result, deployment logs, and smoke-test results to issue #1055.
+
+## Failure and rollback
+
+- If verified team/roster collection fails, the current projection is not promoted.
+- If the snapshot builder returns empty or incomplete coverage, promotion is rejected.
+- If promotion fails after staging, snapshots and current changes roll back.
+- The failure is recorded in `dashboard_projection_runs`.
+- Continue serving the previous current projection while repairing the source.
+- Do not delete `dashboard_players`, `dashboard_player_snapshots`, `dashboard_player_current`, or `my_dashboard_records`.
+- Roll back application code normally if required; the additive tables and immutable snapshots are safe to retain.

--- a/mlb_app/dashboard_canonical_status.py
+++ b/mlb_app/dashboard_canonical_status.py
@@ -111,7 +111,7 @@ def canonical_dashboard_status(
         DashboardProjectionRun.status == "success"
     ).order_by(DashboardProjectionRun.completed_at.desc(), DashboardProjectionRun.id.desc()).first()
     latest_failure = session.query(DashboardProjectionRun).filter(
-        DashboardProjectionRun.status == "failed"
+        DashboardProjectionRun.status.in_(("failed", "partial"))
     ).order_by(DashboardProjectionRun.completed_at.desc(), DashboardProjectionRun.id.desc()).first()
 
     lineup_players = session.query(DashboardPlayer).filter(DashboardPlayer.lineup_appearance_count > 0).count()
@@ -127,8 +127,12 @@ def canonical_dashboard_status(
         issues.append("active_population_empty")
     if current_count == 0:
         issues.append("current_projection_empty")
-    if current_count != active_count:
+    if current_count != active_count or current_hitters != active_hitters or current_pitchers != active_pitchers:
         issues.append("current_projection_population_mismatch")
+    if snapshot_count == 0:
+        issues.append("historical_snapshots_empty")
+    if latest_success is None:
+        issues.append("successful_refresh_evidence_missing")
     if stale:
         issues.append("current_projection_stale")
     readiness = "ready" if not issues else "not_ready" if any(item.endswith("_empty") or item.endswith("_mismatch") for item in issues) else "degraded"

--- a/mlb_app/dashboard_canonical_status.py
+++ b/mlb_app/dashboard_canonical_status.py
@@ -1,0 +1,181 @@
+"""Read-only production status for the canonical My Dashboard object model."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import Any, Dict, Optional
+
+from sqlalchemy import func
+
+from .dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot, DashboardProjectionRun
+from .dashboard_player_population import active_player_window_days
+from .database import BatterPitchTypeMatchup
+
+
+COVERAGE_FIELDS = (
+    "model_score", "confidence", "xwoba", "xba", "exit_velocity", "launch_angle",
+    "hard_hit_rate", "barrel_rate", "strikeout_rate", "walk_rate", "iso", "obp",
+    "slg", "plate_appearances",
+)
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, (dt.date, dt.datetime)) else value
+
+
+def _ratio(value: int, total: int) -> float:
+    return round(value / total, 4) if total else 0.0
+
+
+def _run_payload(run: Optional[DashboardProjectionRun]) -> Optional[Dict[str, Any]]:
+    if run is None:
+        return None
+    return {
+        "id": run.id,
+        "run_type": run.run_type,
+        "target_date": _iso(run.target_date),
+        "status": run.status,
+        "started_at": _iso(run.started_at),
+        "completed_at": _iso(run.completed_at),
+        "canonical_count": run.canonical_count,
+        "active_count": run.active_count,
+        "current_count": run.current_count,
+        "snapshot_count": run.snapshot_count,
+        "projection_version": run.projection_version,
+        "error_type": run.error_type,
+        "error_message": run.error_message,
+    }
+
+
+def _field_coverage(session: Any, player_type: str) -> Dict[str, Any]:
+    base = session.query(DashboardPlayerCurrent).filter(
+        DashboardPlayerCurrent.is_active.is_(True),
+        DashboardPlayerCurrent.player_type == player_type,
+    )
+    total = base.count()
+    fields: Dict[str, Any] = {}
+    for name in COVERAGE_FIELDS:
+        count = base.filter(getattr(DashboardPlayerCurrent, name).isnot(None)).count()
+        fields[name] = {"non_null_count": count, "coverage": _ratio(count, total)}
+    return {"row_count": total, "fields": fields}
+
+
+def canonical_dashboard_status(
+    session: Any,
+    *,
+    now: Optional[dt.datetime] = None,
+    stale_after_hours: Optional[int] = None,
+) -> Dict[str, Any]:
+    current_time = now or dt.datetime.utcnow()
+    stale_hours = stale_after_hours or max(1, int(os.getenv("DASHBOARD_PROJECTION_STALE_HOURS", "36")))
+
+    canonical_count = session.query(DashboardPlayer).count()
+    resolved_count = session.query(DashboardPlayer).filter(DashboardPlayer.identity_resolution_status == "resolved").count()
+    unresolved_count = canonical_count - resolved_count
+    active_count = session.query(DashboardPlayer).filter(
+        DashboardPlayer.is_active.is_(True),
+        DashboardPlayer.identity_resolution_status == "resolved",
+    ).count()
+    active_hitters = session.query(DashboardPlayer).filter(
+        DashboardPlayer.is_active.is_(True),
+        DashboardPlayer.identity_resolution_status == "resolved",
+        DashboardPlayer.player_type == "hitter",
+    ).count()
+    active_pitchers = session.query(DashboardPlayer).filter(
+        DashboardPlayer.is_active.is_(True),
+        DashboardPlayer.identity_resolution_status == "resolved",
+        DashboardPlayer.player_type == "pitcher",
+    ).count()
+    current_count = session.query(DashboardPlayerCurrent).filter(DashboardPlayerCurrent.is_active.is_(True)).count()
+    current_hitters = session.query(DashboardPlayerCurrent).filter(
+        DashboardPlayerCurrent.is_active.is_(True), DashboardPlayerCurrent.player_type == "hitter"
+    ).count()
+    current_pitchers = session.query(DashboardPlayerCurrent).filter(
+        DashboardPlayerCurrent.is_active.is_(True), DashboardPlayerCurrent.player_type == "pitcher"
+    ).count()
+    snapshot_count = session.query(DashboardPlayerSnapshot).count()
+    approved_snapshot_count = session.query(DashboardPlayerSnapshot).filter(DashboardPlayerSnapshot.is_approved.is_(True)).count()
+    snapshot_dates = [value for (value,) in session.query(DashboardPlayerSnapshot.snapshot_date).distinct().order_by(DashboardPlayerSnapshot.snapshot_date).all()]
+
+    last_promoted_at, last_updated_at = session.query(
+        func.max(DashboardPlayerCurrent.promoted_at),
+        func.max(DashboardPlayerCurrent.updated_at),
+    ).one()
+    freshness_anchor = last_updated_at or last_promoted_at
+    age_hours = round((current_time - freshness_anchor).total_seconds() / 3600, 2) if freshness_anchor else None
+    stale = freshness_anchor is None or age_hours > stale_hours
+    versions = sorted(value for (value,) in session.query(DashboardPlayerCurrent.projection_version).distinct().all() if value)
+
+    latest_success = session.query(DashboardProjectionRun).filter(
+        DashboardProjectionRun.status == "success"
+    ).order_by(DashboardProjectionRun.completed_at.desc(), DashboardProjectionRun.id.desc()).first()
+    latest_failure = session.query(DashboardProjectionRun).filter(
+        DashboardProjectionRun.status == "failed"
+    ).order_by(DashboardProjectionRun.completed_at.desc(), DashboardProjectionRun.id.desc()).first()
+
+    lineup_players = session.query(DashboardPlayer).filter(DashboardPlayer.lineup_appearance_count > 0).count()
+    lineup_appearances = session.query(func.coalesce(func.sum(DashboardPlayer.lineup_appearance_count), 0)).scalar() or 0
+    arsenal_rows = session.query(BatterPitchTypeMatchup).join(
+        DashboardPlayer, DashboardPlayer.mlb_player_id == BatterPitchTypeMatchup.batter_id
+    ).filter(DashboardPlayer.is_active.is_(True), DashboardPlayer.player_type == "hitter").count()
+
+    issues = []
+    if canonical_count == 0:
+        issues.append("canonical_population_empty")
+    if active_count == 0:
+        issues.append("active_population_empty")
+    if current_count == 0:
+        issues.append("current_projection_empty")
+    if current_count != active_count:
+        issues.append("current_projection_population_mismatch")
+    if stale:
+        issues.append("current_projection_stale")
+    readiness = "ready" if not issues else "not_ready" if any(item.endswith("_empty") or item.endswith("_mismatch") for item in issues) else "degraded"
+
+    return {
+        "status": readiness,
+        "issues": issues,
+        "query_source": "dashboard_player_current",
+        "activity_window_days": active_player_window_days(),
+        "stale_after_hours": stale_hours,
+        "population": {
+            "canonical_count": canonical_count,
+            "resolved_count": resolved_count,
+            "unresolved_count": unresolved_count,
+            "active_count": active_count,
+            "active_hitter_count": active_hitters,
+            "active_pitcher_count": active_pitchers,
+        },
+        "current_projection": {
+            "row_count": current_count,
+            "hitter_count": current_hitters,
+            "pitcher_count": current_pitchers,
+            "projection_versions": versions,
+            "last_promoted_at": _iso(last_promoted_at),
+            "last_updated_at": _iso(last_updated_at),
+            "age_hours": age_hours,
+            "stale": stale,
+        },
+        "snapshots": {
+            "row_count": snapshot_count,
+            "approved_count": approved_snapshot_count,
+            "date_count": len(snapshot_dates),
+            "earliest_date": _iso(snapshot_dates[0]) if snapshot_dates else None,
+            "latest_date": _iso(snapshot_dates[-1]) if snapshot_dates else None,
+        },
+        "field_coverage": {
+            "hitters": _field_coverage(session, "hitter"),
+            "pitchers": _field_coverage(session, "pitcher"),
+        },
+        "related_reports": {
+            "players_with_lineup_history": lineup_players,
+            "confirmed_lineup_appearance_count": int(lineup_appearances),
+            "active_hitter_arsenal_split_rows": arsenal_rows,
+        },
+        "refresh_runs": {
+            "latest_success": _run_payload(latest_success),
+            "latest_failure": _run_payload(latest_failure),
+        },
+        "generated_at": current_time.isoformat(),
+    }

--- a/mlb_app/dashboard_object_models.py
+++ b/mlb_app/dashboard_object_models.py
@@ -47,6 +47,30 @@ class DashboardPlayer(Base):
     )
 
 
+class DashboardProjectionRun(Base):
+    __tablename__ = "dashboard_projection_runs"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    run_type: str = Column(String(32), nullable=False)
+    target_date: date = Column(Date, nullable=False)
+    status: str = Column(String(24), nullable=False)
+    started_at: datetime = Column(DateTime, nullable=False)
+    completed_at: Optional[datetime] = Column(DateTime, nullable=True)
+    canonical_count: int = Column(Integer, nullable=False, default=0)
+    active_count: int = Column(Integer, nullable=False, default=0)
+    current_count: int = Column(Integer, nullable=False, default=0)
+    snapshot_count: int = Column(Integer, nullable=False, default=0)
+    projection_version: Optional[str] = Column(String(64), nullable=True)
+    error_type: Optional[str] = Column(String(120), nullable=True)
+    error_message: Optional[str] = Column(Text, nullable=True)
+    result_json = Column(JSON, nullable=False, default=dict)
+
+    __table_args__ = (
+        Index("ix_dashboard_projection_runs_status_completed", "status", "completed_at"),
+        Index("ix_dashboard_projection_runs_target_type", "target_date", "run_type"),
+    )
+
+
 class DashboardPlayerSnapshot(Base):
     __tablename__ = "dashboard_player_snapshots"
 

--- a/mlb_app/dashboard_projection_operator.py
+++ b/mlb_app/dashboard_projection_operator.py
@@ -1,0 +1,165 @@
+"""Operator-only orchestration for canonical player population and projection refresh."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+import requests
+
+from .dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot, DashboardProjectionRun
+from .dashboard_player_population import fetch_active_roster, fetch_confirmed_lineup_players, populate_dashboard_players
+from .dashboard_player_projection import backfill_player_projection, refresh_player_projection
+from .lineup_data import MLB_STATS_BASE
+
+
+def fetch_active_mlb_teams(
+    season: int,
+    *,
+    request_get: Callable[..., Any] = requests.get,
+) -> List[Dict[str, Any]]:
+    response = request_get(
+        f"{MLB_STATS_BASE}/teams",
+        params={"sportId": 1, "season": int(season), "activeStatus": "Y"},
+        timeout=20,
+    )
+    response.raise_for_status()
+    teams = []
+    for row in response.json().get("teams", []):
+        try:
+            team_id = int(row.get("id"))
+        except (TypeError, ValueError):
+            continue
+        teams.append({"team_id": team_id, "team_name": row.get("name")})
+    if len(teams) < 30:
+        raise RuntimeError(f"Verified MLB team source returned only {len(teams)} active teams")
+    return teams
+
+
+def _counts(session: Any) -> Dict[str, int]:
+    return {
+        "canonical_count": session.query(DashboardPlayer).count(),
+        "active_count": session.query(DashboardPlayer).filter(DashboardPlayer.is_active.is_(True)).count(),
+        "current_count": session.query(DashboardPlayerCurrent).count(),
+        "snapshot_count": session.query(DashboardPlayerSnapshot).count(),
+    }
+
+
+def _begin_run(session: Any, run_type: str, target_date: dt.date, started_at: dt.datetime) -> DashboardProjectionRun:
+    run = DashboardProjectionRun(
+        run_type=run_type,
+        target_date=target_date,
+        status="running",
+        started_at=started_at,
+        **_counts(session),
+    )
+    session.add(run)
+    session.commit()
+    return run
+
+
+def _complete_run(
+    session: Any,
+    run_id: int,
+    *,
+    status: str,
+    completed_at: dt.datetime,
+    result: Optional[Dict[str, Any]] = None,
+    error: Optional[Exception] = None,
+) -> DashboardProjectionRun:
+    run = session.get(DashboardProjectionRun, run_id)
+    if run is None:
+        raise RuntimeError(f"Projection run audit row disappeared: {run_id}")
+    counts = _counts(session)
+    for key, value in counts.items():
+        setattr(run, key, value)
+    run.status = status
+    run.completed_at = completed_at
+    run.result_json = result or {}
+    run.projection_version = (result or {}).get("projection_version")
+    if error is not None:
+        run.error_type = error.__class__.__name__
+        run.error_message = str(error)[:2000]
+    session.commit()
+    return run
+
+
+def run_canonical_projection_refresh(
+    session: Any,
+    *,
+    target_date: dt.date,
+    request_get: Callable[..., Any] = requests.get,
+    matchup_builder: Optional[Callable[..., Any]] = None,
+    lineup_fetcher: Optional[Callable[..., Any]] = None,
+    transition_missing_players: bool = False,
+    now: Optional[dt.datetime] = None,
+) -> Dict[str, Any]:
+    started_at = now or dt.datetime.utcnow()
+    run = _begin_run(session, "canonical_refresh", target_date, started_at)
+    try:
+        teams = fetch_active_mlb_teams(target_date.year, request_get=request_get)
+        roster_rows: List[Dict[str, Any]] = []
+        for team in teams:
+            roster_rows.extend(fetch_active_roster(
+                team["team_id"],
+                target_date.year,
+                team_name=team["team_name"],
+                request_get=request_get,
+            ))
+        lineup = fetch_confirmed_lineup_players(
+            session,
+            target_date,
+            matchup_builder=matchup_builder,
+            lineup_fetcher=lineup_fetcher,
+        )
+        population = populate_dashboard_players(
+            session,
+            as_of=target_date,
+            lineup_rows=lineup["players"],
+            roster_rows=roster_rows,
+            transition_missing_players=transition_missing_players,
+        )
+        projection = refresh_player_projection(session, snapshot_date=target_date, now=started_at)
+        result = {
+            "target_date": target_date.isoformat(),
+            "team_count": len(teams),
+            "roster_row_count": len(roster_rows),
+            "lineup_player_count": len(lineup["players"]),
+            "lineup_unresolved_count": len(lineup["unresolved_identities"]),
+            "lineup_error_count": len(lineup["errors"]),
+            "population": population,
+            "projection": projection,
+            **projection,
+        }
+        _complete_run(session, run.id, status="success", completed_at=dt.datetime.utcnow(), result=result)
+        return {**result, "run_id": run.id, "status": "success"}
+    except Exception as exc:
+        session.rollback()
+        _complete_run(session, run.id, status="failed", completed_at=dt.datetime.utcnow(), error=exc)
+        raise
+
+
+def run_projection_backfill(
+    session: Any,
+    *,
+    dates: Sequence[dt.date],
+    continue_on_error: bool = False,
+    now: Optional[dt.datetime] = None,
+) -> Dict[str, Any]:
+    target_dates = sorted(set(dates))
+    if not target_dates:
+        raise ValueError("At least one backfill date is required")
+    run = _begin_run(session, "projection_backfill", target_dates[-1], now or dt.datetime.utcnow())
+    try:
+        result = backfill_player_projection(
+            session,
+            dates=target_dates,
+            continue_on_error=continue_on_error,
+        )
+        status = "success" if result["failed_date_count"] == 0 else "partial"
+        _complete_run(session, run.id, status=status, completed_at=dt.datetime.utcnow(), result=result)
+        return {**result, "run_id": run.id, "status": status}
+    except Exception as exc:
+        session.rollback()
+        _complete_run(session, run.id, status="failed", completed_at=dt.datetime.utcnow(), error=exc)
+        raise

--- a/mlb_app/dashboard_related_report_query.py
+++ b/mlb_app/dashboard_related_report_query.py
@@ -1,0 +1,211 @@
+"""Validated SQL queries for selected one-to-many dashboard relationships."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import case, func
+
+from .dashboard_object_models import DashboardPlayer
+from .dashboard_report_types import FIELD_CATALOG, REPORT_TYPES, describe_report_type
+from .database import BatterPitchTypeMatchup
+
+
+MODELS = {
+    "players_lineup_history": DashboardPlayer,
+    "hitters_arsenal_splits": BatterPitchTypeMatchup,
+}
+
+COLUMN_NAMES = {
+    "players_lineup_history": (
+        "mlb_player_id", "full_name", "player_type", "current_team_id", "current_team_name",
+        "most_recent_lineup_date", "lineup_appearance_count", "most_recent_game_date",
+        "tracked_game_count", "active_status_reason", "is_active",
+    ),
+    "hitters_arsenal_splits": (
+        "id", "batter_id", "batter_name", "batter_team_id", "opposing_pitcher_id",
+        "pitch_type", "game_pk", "target_date", "date_end", "pitches_seen", "pa_ended",
+        "xwoba", "xba", "avg_exit_velocity", "avg_launch_angle", "hard_hit_pct",
+        "whiff_pct", "k_pct", "source", "refreshed_at",
+    ),
+}
+
+
+def _columns(report_type: str) -> Dict[str, Any]:
+    model = MODELS[report_type]
+    return {name: getattr(model, name) for name in COLUMN_NAMES[report_type]}
+
+
+def _conditions(filters: Any, report_type: str) -> List[Dict[str, Any]]:
+    if filters is None:
+        return []
+    if isinstance(filters, list):
+        return filters
+    if not isinstance(filters, dict):
+        raise ValueError("filters must be an object or list of conditions")
+    conditions = list(filters.get("conditions") or [])
+    aliases = {
+        "players_lineup_history": (
+            ("search_text", "full_name", "contains"),
+            ("team", "current_team_name", "eq"),
+            ("min_lineup_appearances", "lineup_appearance_count", "gte"),
+        ),
+        "hitters_arsenal_splits": (
+            ("search_text", "batter_name", "contains"),
+            ("team_id", "batter_team_id", "eq"),
+            ("pitch_type", "pitch_type", "eq"),
+            ("min_pitches_seen", "pitches_seen", "gte"),
+        ),
+    }[report_type]
+    for key, field, operator in aliases:
+        if filters.get(key) not in (None, "", "All"):
+            conditions.append({"field": field, "operator": operator, "value": filters[key]})
+    return conditions
+
+
+def _apply_filters(query: Any, report_type: str, filters: Any) -> Tuple[Any, List[Dict[str, Any]]]:
+    columns = _columns(report_type)
+    catalog = {field["name"]: field for field in FIELD_CATALOG[report_type]}
+    applied = _conditions(filters, report_type)
+    for condition in applied:
+        if not isinstance(condition, dict):
+            raise ValueError("Each filter condition must be an object")
+        field_name = str(condition.get("field") or "")
+        operator = str(condition.get("operator") or "eq").lower()
+        field = catalog.get(field_name)
+        if not field or not field.get("filterable") or field_name not in columns:
+            raise ValueError(f"Unsupported filter field: {field_name}")
+        if operator not in field["supported_operators"]:
+            raise ValueError(f"Unsupported operator '{operator}' for field '{field_name}'")
+        column, value = columns[field_name], condition.get("value")
+        if operator == "eq": expression = column == value
+        elif operator == "neq": expression = column != value
+        elif operator == "in":
+            if not isinstance(value, (list, tuple, set)):
+                raise ValueError(f"Operator 'in' for field '{field_name}' requires a list")
+            expression = column.in_(list(value))
+        elif operator == "contains": expression = func.lower(column).contains(str(value).lower())
+        elif operator == "gt": expression = column > value
+        elif operator == "gte": expression = column >= value
+        elif operator == "lt": expression = column < value
+        elif operator == "lte": expression = column <= value
+        elif operator == "is_null": expression = column.is_(None)
+        elif operator == "is_not_null": expression = column.is_not(None)
+        else: raise ValueError(f"Unsupported operator: {operator}")
+        query = query.filter(expression)
+    return query, applied
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, (dt.date, dt.datetime)) else value
+
+
+def query_related_report(
+    session: Any,
+    report_type: str,
+    *,
+    filters: Any = None,
+    weights: Any = None,
+    page_size: int = 50,
+    page_number: int = 1,
+    sort_by: Optional[str] = None,
+    sort_direction: str = "desc",
+    selected_fields: Optional[Iterable[str]] = None,
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
+    if report_type not in MODELS or not REPORT_TYPES[report_type].get("queryable"):
+        raise ValueError(f"Unsupported related report type: {report_type}")
+    if weights:
+        raise ValueError(f"Weights are not supported for related report type: {report_type}")
+    if not isinstance(page_size, int) or page_size < 1 or page_size > 250:
+        raise ValueError("page_size must be between 1 and 250")
+    if not isinstance(page_number, int) or page_number < 1:
+        raise ValueError("page_number must be at least 1")
+    direction = str(sort_direction).lower()
+    if direction not in {"asc", "desc"}:
+        raise ValueError("sort_direction must be 'asc' or 'desc'")
+
+    model, columns = MODELS[report_type], _columns(report_type)
+    catalog = {field["name"]: field for field in FIELD_CATALOG[report_type]}
+    requested_fields = list(selected_fields or columns)
+    invalid = [name for name in requested_fields if name not in catalog]
+    if invalid:
+        raise ValueError(f"Unsupported selected field(s): {', '.join(invalid)}")
+
+    if report_type == "players_lineup_history":
+        query = session.query(model).filter(
+            DashboardPlayer.identity_resolution_status == "resolved",
+            DashboardPlayer.lineup_appearance_count > 0,
+        )
+        default_sort = "most_recent_lineup_date"
+        tie_column = DashboardPlayer.mlb_player_id
+    else:
+        query = session.query(model).join(
+            DashboardPlayer, DashboardPlayer.mlb_player_id == BatterPitchTypeMatchup.batter_id
+        ).filter(
+            DashboardPlayer.is_active.is_(True),
+            DashboardPlayer.identity_resolution_status == "resolved",
+            DashboardPlayer.player_type == "hitter",
+        )
+        default_sort = "pitches_seen"
+        tie_column = BatterPitchTypeMatchup.id
+
+    query, applied_filters = _apply_filters(query, report_type, filters)
+    total_count = query.count()
+    sort_name = str(sort_by or default_sort)
+    field = catalog.get(sort_name)
+    if not field or not field.get("sortable") or sort_name not in columns:
+        raise ValueError(f"Unsupported sort field: {sort_name}")
+    sort_column = columns[sort_name]
+    query = query.order_by(
+        case((sort_column.is_(None), 1), else_=0),
+        sort_column.asc() if direction == "asc" else sort_column.desc(),
+        tie_column.asc(),
+    )
+    offset = (page_number - 1) * page_size
+    rows = query.offset(offset).limit(page_size).all()
+    records = []
+    for index, row in enumerate(rows, start=offset + 1):
+        record = {name: _iso(getattr(row, name)) for name in columns}
+        record["rank"] = index
+        records.append(record)
+    page_count = math.ceil(total_count / page_size) if total_count else 0
+    has_next = offset + len(records) < total_count
+    response = {
+        "report_type": report_type,
+        "component": REPORT_TYPES[report_type]["ui_object"],
+        "records": records,
+        "items": records,
+        "totalSize": total_count,
+        "total_count": total_count,
+        "done": not has_next,
+        "query_source": REPORT_TYPES[report_type]["base_object"],
+        "filters_applied": applied_filters,
+        "query": {
+            "source": REPORT_TYPES[report_type]["base_object"],
+            "sort_by": sort_name,
+            "sort_direction": direction,
+            "selected_fields": requested_fields,
+        },
+        "page_info": {
+            "page_number": page_number,
+            "page_size": page_size,
+            "page_count": page_count,
+            "record_count": len(records),
+            "total_count": total_count,
+            "has_next": has_next,
+            "has_previous": page_number > 1 and total_count > 0,
+            "next_page": page_number + 1 if has_next else None,
+            "previous_page": page_number - 1 if page_number > 1 and total_count > 0 else None,
+        },
+        "provenance": {
+            "source_object": REPORT_TYPES[report_type]["base_object"],
+            "relationship_path": REPORT_TYPES[report_type]["relationships"],
+            "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        },
+    }
+    if include_metadata:
+        response["object_info"] = describe_report_type(report_type)
+    return response

--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -10,8 +10,8 @@ REPORT_TYPES: Dict[str, Dict[str, Any]] = {
     "all_active_hitters": {"label": "All Active Hitters", "ui_object": "hitters", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "hitter"}, "relationships": [], "queryable": True},
     "all_active_pitchers": {"label": "All Active Pitchers", "ui_object": "pitchers", "base_object": "dashboard_player_current", "population": {"is_active": True, "player_type": "pitcher"}, "relationships": [], "queryable": True},
     "hitters_current_matchup": {"label": "Hitters with Current Matchup Metrics", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["current_matchup_snapshot"]},
-    "hitters_arsenal_splits": {"label": "Hitters with Arsenal Splits", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["batter_pitch_type_matchups"]},
-    "players_lineup_history": {"label": "Players with Lineup History", "ui_object": "overall_players", "base_object": "dashboard_players", "population": {}, "relationships": ["lineup_appearances"]},
+    "hitters_arsenal_splits": {"label": "Hitters with Arsenal Splits", "ui_object": "hitters", "base_object": "batter_pitch_type_matchups", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["dashboard_players"], "queryable": True},
+    "players_lineup_history": {"label": "Players with Lineup History", "ui_object": "overall_players", "base_object": "dashboard_players", "population": {"lineup_appearance_count": {"gt": 0}}, "relationships": ["lineup_appearances"], "queryable": True},
     "teams_daily_analysis": {"label": "Teams with Daily Analysis", "ui_object": "teams", "base_object": "teams", "population": {}, "relationships": ["daily_analytical_snapshot"]},
     "games_totals_analysis": {"label": "Games with Totals Analysis", "ui_object": "totals", "base_object": "games", "population": {}, "relationships": ["totals_projection", "run_environment_snapshot"]},
 }
@@ -76,10 +76,55 @@ CURRENT_PLAYER_FIELDS: List[Dict[str, Any]] = [
 ]
 
 
+LINEUP_HISTORY_FIELDS: List[Dict[str, Any]] = [
+    _field("mlb_player_id", "MLB Player ID", "id", "Identity", nillable=False, description="Canonical MLBAM player identifier.", freshness="canonical"),
+    _field("full_name", "Player Name", "string", "Identity", nillable=False, operators=["eq", "neq", "contains", "in"], description="Resolved canonical player name.", freshness="canonical"),
+    _field("player_type", "Player Type", "string", "Identity", nillable=False, description="Canonical hitter or pitcher classification.", freshness="canonical"),
+    _field("current_team_id", "Team ID", "id", "Team", description="Current MLB team identifier.", freshness="canonical"),
+    _field("current_team_name", "Team", "string", "Team", operators=["eq", "neq", "contains", "in"], description="Current MLB team name.", freshness="canonical"),
+    _field("most_recent_lineup_date", "Most Recent Lineup Date", "date", "Lineup History", description="Most recent verified confirmed-lineup date.", freshness="canonical"),
+    _field("lineup_appearance_count", "Lineup Appearances", "integer", "Lineup History", description="Count of distinct verified lineup dates retained for this player.", freshness="canonical"),
+    _field("most_recent_game_date", "Most Recent Tracked Game", "date", "Activity", description="Most recent tracked Statcast game date.", freshness="canonical"),
+    _field("tracked_game_count", "Tracked Games", "integer", "Activity", description="Distinct tracked games retained for this player.", freshness="canonical"),
+    _field("active_status_reason", "Active Status Reason", "string", "Activity", description="Verified eligibility path keeping the player active.", freshness="canonical"),
+    _field("is_active", "Active", "boolean", "Activity", description="Whether the canonical player is currently reportable.", freshness="canonical"),
+]
+for field in LINEUP_HISTORY_FIELDS:
+    field["source_object"] = "dashboard_players"
+
+ARSENAL_SPLIT_FIELDS: List[Dict[str, Any]] = [
+    _field("id", "Split Row ID", "id", "Identity", nillable=False, description="Persistent arsenal split row identifier."),
+    _field("batter_id", "Batter MLB ID", "id", "Identity", nillable=False, description="Canonical batter MLBAM identifier."),
+    _field("batter_name", "Batter", "string", "Identity", operators=["eq", "neq", "contains", "in"], description="Stored batter name for this split."),
+    _field("batter_team_id", "Team ID", "id", "Team", description="Stored batter team identifier."),
+    _field("opposing_pitcher_id", "Opposing Pitcher MLB ID", "id", "Matchup", nillable=False, description="Opposing pitcher MLBAM identifier."),
+    _field("pitch_type", "Pitch Type", "string", "Matchup", nillable=False, operators=["eq", "neq", "in"], description="Statcast pitch type code."),
+    _field("game_pk", "Game PK", "id", "Matchup", description="Associated MLB game identifier."),
+    _field("target_date", "Target Date", "date", "Freshness", description="Report target date for the split."),
+    _field("date_end", "Sample End Date", "date", "Freshness", description="Last date included in the analytical sample."),
+    _field("pitches_seen", "Pitches Seen", "integer", "Sample", description="Deduplicated pitch exposure."),
+    _field("pa_ended", "Plate Appearances Ended", "integer", "Sample", description="Plate appearances ending on this pitch type."),
+    _field("xwoba", "xwOBA", "double", "Quality", description="Expected weighted on-base average against the pitch type."),
+    _field("xba", "xBA", "double", "Quality", description="Expected batting average against the pitch type."),
+    _field("avg_exit_velocity", "Exit Velocity", "double", "Contact", description="Average exit velocity against the pitch type."),
+    _field("avg_launch_angle", "Launch Angle", "double", "Contact", description="Average launch angle against the pitch type."),
+    _field("hard_hit_pct", "Hard-Hit Rate", "double", "Contact", description="Hard-hit rate against the pitch type."),
+    _field("whiff_pct", "Whiff Rate", "double", "Discipline", description="Whiff rate against the pitch type."),
+    _field("k_pct", "Strikeout Rate", "double", "Discipline", description="Strikeout rate against the pitch type."),
+    _field("source", "Source", "string", "Audit", description="Materialization source."),
+    _field("refreshed_at", "Refreshed At", "datetime", "Freshness", filterable=False, description="Last refresh timestamp."),
+]
+for field in ARSENAL_SPLIT_FIELDS:
+    field["source_object"] = "batter_pitch_type_matchups"
+
 FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {}
 for key, config in REPORT_TYPES.items():
     if config["base_object"] == "dashboard_player_current":
         FIELD_CATALOG[key] = deepcopy(CURRENT_PLAYER_FIELDS)
+    elif key == "players_lineup_history":
+        FIELD_CATALOG[key] = deepcopy(LINEUP_HISTORY_FIELDS)
+    elif key == "hitters_arsenal_splits":
+        FIELD_CATALOG[key] = deepcopy(ARSENAL_SPLIT_FIELDS)
     elif config["base_object"] == "dashboard_players":
         FIELD_CATALOG[key] = deepcopy(CURRENT_PLAYER_FIELDS[:6])
         for field in FIELD_CATALOG[key]:

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -9,7 +9,9 @@ from pydantic import BaseModel
 
 from . import my_dashboard_solver as dashboard_solver
 from .active_lineup_solver import build_active_lineup_solver_payload
+from .dashboard_canonical_status import canonical_dashboard_status
 from .dashboard_player_report_query import query_player_report
+from .dashboard_related_report_query import query_related_report
 from .dashboard_report_types import list_report_types
 from .database import create_tables, get_engine, get_session
 from .my_dashboard_context_cache import install_dashboard_context_cache
@@ -127,11 +129,26 @@ def my_dashboard_report_types() -> Dict[str, Any]:
     return {"report_types": report_types, "totalSize": len(report_types)}
 
 
+@router.get("/my-dashboard/canonical/status")
+def my_dashboard_canonical_status() -> Dict[str, Any]:
+    factory = session_factory()
+    with factory() as session:
+        return canonical_dashboard_status(session)
+
+
 @router.post("/my-dashboard/reports/query")
 def my_dashboard_player_report_query(payload: DashboardPlayerReportRequest) -> Dict[str, Any]:
     try:
         factory = session_factory()
         with factory() as session:
+            if payload.report_type in {"players_lineup_history", "hitters_arsenal_splits"}:
+                return query_related_report(
+                    session, payload.report_type, filters=payload.filters, weights=payload.weights,
+                    page_size=payload.page_size, page_number=payload.page_number,
+                    sort_by=None if payload.sort_by == "model_score" else payload.sort_by,
+                    sort_direction=payload.sort_direction,
+                    selected_fields=payload.selected_fields, include_metadata=payload.include_metadata,
+                )
             return query_player_report(
                 session, payload.report_type, filters=payload.filters, weights=payload.weights,
                 page_size=payload.page_size, page_number=payload.page_number,

--- a/scripts/refresh_dashboard_player_projection.py
+++ b/scripts/refresh_dashboard_player_projection.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Inspect or refresh the canonical My Dashboard player projection."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from mlb_app.dashboard_canonical_status import canonical_dashboard_status
+from mlb_app.dashboard_projection_operator import run_canonical_projection_refresh, run_projection_backfill
+from mlb_app.database import create_tables, get_engine, get_session
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--date", default=dt.date.today().isoformat(), help="Target MLB date (YYYY-MM-DD)")
+    parser.add_argument("--refresh", action="store_true", help="Gather verified sources and refresh the canonical current projection")
+    parser.add_argument("--backfill-days", type=int, default=0, help="Create projection snapshots for this many days ending on --date")
+    parser.add_argument("--transition-missing-players", action="store_true", help="Deactivate players absent from the verified complete source set")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    target_date = dt.date.fromisoformat(args.date)
+    database_url = os.getenv("DATABASE_URL", "sqlite:///mlb.db")
+    engine = get_engine(database_url)
+    create_tables(engine)
+    factory = get_session(engine)
+
+    with factory() as session:
+        before = canonical_dashboard_status(session)
+        output = {"before": before, "operation": "status_only"}
+        if args.refresh:
+            output["operation"] = "canonical_refresh"
+            output["refresh"] = run_canonical_projection_refresh(
+                session,
+                target_date=target_date,
+                transition_missing_players=args.transition_missing_players,
+            )
+        if args.backfill_days:
+            if args.backfill_days < 1:
+                raise ValueError("--backfill-days must be positive")
+            dates = [target_date - dt.timedelta(days=offset) for offset in reversed(range(args.backfill_days))]
+            output["operation"] = "refresh_and_backfill" if args.refresh else "projection_backfill"
+            output["backfill"] = run_projection_backfill(session, dates=dates)
+        output["after"] = canonical_dashboard_status(session)
+        print(json.dumps(output, indent=2, sort_keys=True, default=str))
+        return 0 if output["after"]["status"] == "ready" or output["operation"] == "status_only" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dashboard_canonical_status.py
+++ b/tests/test_dashboard_canonical_status.py
@@ -1,0 +1,69 @@
+import datetime as dt
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_canonical_status import canonical_dashboard_status
+from mlb_app.dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardProjectionRun
+from mlb_app.database import Base, BatterPitchTypeMatchup
+
+
+NOW = dt.datetime(2026, 7, 16, 12, 0, 0)
+DATE = NOW.date()
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def player(player_id, player_type):
+    return DashboardPlayer(
+        mlb_player_id=player_id, full_name=f"Player {player_id}", player_type=player_type,
+        is_active=True, active_status_reason="recent_confirmed_lineup",
+        first_tracked_date=DATE, last_tracked_date=DATE, most_recent_lineup_date=DATE,
+        lineup_appearance_count=2, tracked_game_count=1, identity_resolution_status="resolved",
+    )
+
+
+def current(player_id, player_type, **values):
+    return DashboardPlayerCurrent(
+        mlb_player_id=player_id, snapshot_id=player_id, player_type=player_type,
+        full_name=f"Player {player_id}", is_active=True, projection_version="v1",
+        source_freshness_json={"snapshot_date": DATE.isoformat()}, provenance_json={},
+        promoted_at=NOW, updated_at=NOW, metrics_json={}, **values,
+    )
+
+
+def test_status_exposes_counts_coverage_related_rows_and_run_evidence():
+    session = make_session()
+    session.add_all([
+        player(1, "hitter"), player(2, "pitcher"),
+        current(1, "hitter", xwoba=0.4, exit_velocity=92.0),
+        current(2, "pitcher", xwoba=0.3, strikeout_rate=0.28),
+        BatterPitchTypeMatchup(batter_id=1, batter_name="Player 1", opposing_pitcher_id=9, pitch_type="FF", target_date=DATE, pitches_seen=50),
+        DashboardProjectionRun(run_type="canonical_refresh", target_date=DATE, status="success", started_at=NOW, completed_at=NOW, canonical_count=2, active_count=2, current_count=2, snapshot_count=2, result_json={}),
+        DashboardProjectionRun(run_type="canonical_refresh", target_date=DATE, status="failed", started_at=NOW, completed_at=NOW, canonical_count=2, active_count=2, current_count=2, snapshot_count=2, error_type="RuntimeError", error_message="source failed", result_json={}),
+    ])
+    session.commit()
+    result = canonical_dashboard_status(session, now=NOW + dt.timedelta(hours=1))
+    assert result["status"] == "ready"
+    assert result["population"]["active_count"] == 2
+    assert result["current_projection"]["row_count"] == 2
+    assert result["field_coverage"]["hitters"]["fields"]["xwoba"]["coverage"] == 1.0
+    assert result["related_reports"]["confirmed_lineup_appearance_count"] == 4
+    assert result["related_reports"]["active_hitter_arsenal_split_rows"] == 1
+    assert result["refresh_runs"]["latest_success"]["status"] == "success"
+    assert result["refresh_runs"]["latest_failure"]["error_type"] == "RuntimeError"
+
+
+def test_status_is_explicitly_not_ready_for_empty_or_mismatched_projection():
+    session = make_session()
+    empty = canonical_dashboard_status(session, now=NOW)
+    assert empty["status"] == "not_ready"
+    assert "canonical_population_empty" in empty["issues"]
+    session.add_all([player(1, "hitter"), player(2, "pitcher"), current(1, "hitter")])
+    session.commit()
+    mismatch = canonical_dashboard_status(session, now=NOW)
+    assert "current_projection_population_mismatch" in mismatch["issues"]

--- a/tests/test_dashboard_canonical_status.py
+++ b/tests/test_dashboard_canonical_status.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from mlb_app.dashboard_canonical_status import canonical_dashboard_status
-from mlb_app.dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardProjectionRun
+from mlb_app.dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, DashboardPlayerSnapshot, DashboardProjectionRun
 from mlb_app.database import Base, BatterPitchTypeMatchup
 
 
@@ -36,12 +36,22 @@ def current(player_id, player_type, **values):
     )
 
 
+def snapshot(player_id):
+    return DashboardPlayerSnapshot(
+        mlb_player_id=player_id, snapshot_date=DATE,
+        analytical_context="current_player_metrics", snapshot_version=f"row-{player_id}",
+        metrics_json={}, source_versions_json={}, provenance_json={},
+        generated_at=NOW, refreshed_at=NOW, is_approved=True,
+    )
+
+
 def test_status_exposes_counts_coverage_related_rows_and_run_evidence():
     session = make_session()
     session.add_all([
         player(1, "hitter"), player(2, "pitcher"),
         current(1, "hitter", xwoba=0.4, exit_velocity=92.0),
         current(2, "pitcher", xwoba=0.3, strikeout_rate=0.28),
+        snapshot(1), snapshot(2),
         BatterPitchTypeMatchup(batter_id=1, batter_name="Player 1", opposing_pitcher_id=9, pitch_type="FF", target_date=DATE, pitches_seen=50),
         DashboardProjectionRun(run_type="canonical_refresh", target_date=DATE, status="success", started_at=NOW, completed_at=NOW, canonical_count=2, active_count=2, current_count=2, snapshot_count=2, result_json={}),
         DashboardProjectionRun(run_type="canonical_refresh", target_date=DATE, status="failed", started_at=NOW, completed_at=NOW, canonical_count=2, active_count=2, current_count=2, snapshot_count=2, error_type="RuntimeError", error_message="source failed", result_json={}),

--- a/tests/test_dashboard_projection_operator.py
+++ b/tests/test_dashboard_projection_operator.py
@@ -1,0 +1,70 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import DashboardPlayerCurrent, DashboardProjectionRun
+from mlb_app.dashboard_projection_operator import run_canonical_projection_refresh
+from mlb_app.database import Base
+
+
+class Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def request_get(url, **kwargs):
+    if url.endswith("/teams"):
+        return Response({"teams": [{"id": index, "name": f"Team {index}"} for index in range(1, 31)]})
+    return Response({"roster": []})
+
+
+def test_operator_refresh_populates_from_verified_sources_and_records_success():
+    session = make_session()
+    today = dt.date.today()
+    result = run_canonical_projection_refresh(
+        session,
+        target_date=today,
+        request_get=request_get,
+        matchup_builder=lambda *_: [{"game_pk": 10, "away_team_id": 1, "away_team_name": "Team 1", "home_team_id": 2, "home_team_name": "Team 2"}],
+        lineup_fetcher=lambda _: {"away": [{"id": 101, "fullName": "Verified Hitter"}], "home": []},
+    )
+    assert result["status"] == "success"
+    assert result["team_count"] == 30
+    assert result["population"]["active_hitter_count"] == 1
+    assert session.query(DashboardPlayerCurrent).count() == 1
+    assert session.query(DashboardProjectionRun).one().status == "success"
+
+
+def test_operator_failure_is_audited_without_erasing_prior_current_projection():
+    session = make_session()
+    today = dt.date.today()
+    run_canonical_projection_refresh(
+        session,
+        target_date=today,
+        request_get=request_get,
+        matchup_builder=lambda *_: [{"game_pk": 10, "away_team_id": 1, "away_team_name": "Team 1", "home_team_id": 2, "home_team_name": "Team 2"}],
+        lineup_fetcher=lambda _: {"away": [{"id": 101, "fullName": "Verified Hitter"}], "home": []},
+    )
+    version = session.query(DashboardPlayerCurrent).one().projection_version
+
+    def incomplete_teams(url, **kwargs):
+        return Response({"teams": [{"id": 1, "name": "Only Team"}]})
+
+    with pytest.raises(RuntimeError, match="only 1 active teams"):
+        run_canonical_projection_refresh(session, target_date=today, request_get=incomplete_teams)
+    assert session.query(DashboardPlayerCurrent).one().projection_version == version
+    assert session.query(DashboardProjectionRun).filter(DashboardProjectionRun.status == "failed").count() == 1

--- a/tests/test_dashboard_related_report_query.py
+++ b/tests/test_dashboard_related_report_query.py
@@ -1,0 +1,72 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import DashboardPlayer
+from mlb_app.dashboard_related_report_query import query_related_report
+from mlb_app.dashboard_report_types import describe_report_type
+from mlb_app.database import Base, BatterPitchTypeMatchup
+
+
+DATE = dt.date(2026, 7, 16)
+
+
+def make_session():
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, future=True)()
+
+
+def player(player_id, name, appearances, player_type="hitter", active=True):
+    return DashboardPlayer(
+        mlb_player_id=player_id, full_name=name, player_type=player_type,
+        is_active=active, active_status_reason="recent_confirmed_lineup",
+        first_tracked_date=DATE - dt.timedelta(days=30), last_tracked_date=DATE,
+        most_recent_lineup_date=DATE, most_recent_game_date=DATE,
+        lineup_appearance_count=appearances, tracked_game_count=10,
+        identity_resolution_status="resolved",
+    )
+
+
+def test_lineup_history_is_a_complete_validated_related_report():
+    session = make_session()
+    session.add_all([player(1, "Alpha", 3), player(2, "Beta", 1), player(3, "None", 0)])
+    session.commit()
+    result = query_related_report(session, "players_lineup_history", page_size=1)
+    assert result["totalSize"] == 2
+    assert result["records"][0]["full_name"] == "Alpha"
+    assert result["query_source"] == "dashboard_players"
+    assert result["page_info"]["has_next"] is True
+    fields = {field["name"] for field in describe_report_type("players_lineup_history")["fields"]}
+    assert {"most_recent_lineup_date", "lineup_appearance_count", "tracked_game_count"}.issubset(fields)
+
+
+def test_arsenal_splits_only_include_active_canonical_hitters_and_filter_in_sql():
+    session = make_session()
+    session.add_all([player(1, "Alpha", 3), player(2, "Inactive", 3, active=False)])
+    session.add_all([
+        BatterPitchTypeMatchup(batter_id=1, batter_name="Alpha", opposing_pitcher_id=9, pitch_type="FF", target_date=DATE, pitches_seen=80, xwoba=0.41),
+        BatterPitchTypeMatchup(batter_id=1, batter_name="Alpha", opposing_pitcher_id=9, pitch_type="SL", target_date=DATE, pitches_seen=20, xwoba=0.31),
+        BatterPitchTypeMatchup(batter_id=2, batter_name="Inactive", opposing_pitcher_id=9, pitch_type="FF", target_date=DATE, pitches_seen=100, xwoba=0.5),
+    ])
+    session.commit()
+    result = query_related_report(
+        session, "hitters_arsenal_splits",
+        filters={"pitch_type": "FF", "min_pitches_seen": 50},
+    )
+    assert result["totalSize"] == 1
+    assert result["records"][0]["batter_id"] == 1
+    assert result["records"][0]["pitches_seen"] == 80
+    assert result["query_source"] == "batter_pitch_type_matchups"
+
+
+def test_related_reports_reject_unsupported_fields_weights_and_filters():
+    session = make_session()
+    with pytest.raises(ValueError, match="Weights are not supported"):
+        query_related_report(session, "players_lineup_history", weights={"Score": 2})
+    with pytest.raises(ValueError, match="Unsupported selected field"):
+        query_related_report(session, "players_lineup_history", selected_fields=["secret"])
+    with pytest.raises(ValueError, match="Unsupported filter field"):
+        query_related_report(session, "hitters_arsenal_splits", filters=[{"field": "secret", "value": 1}])


### PR DESCRIPTION
## Summary

Implements PR 6, the final implementation slice of #1055.

This PR adds production inspection, audited refresh/backfill operations, selected one-to-many reports, and the operator runbook for the canonical My Dashboard player model.

## Canonical production status

Adds read-only:

```text
GET /my-dashboard/canonical/status
```

The response reports:

- canonical, resolved, unresolved, active hitter, and active pitcher counts
- current-projection counts by player type
- exact population mismatch detection
- projection versions, promotion/update timestamps, age, and staleness
- historical and approved snapshot counts/date range
- per-field non-null coverage and ratios for hitters and pitchers
- confirmed-lineup player/appearance counts
- active hitter arsenal-split row count
- latest durable success and failure/partial run evidence
- explicit `ready`, `degraded`, or `not_ready` status and issue codes
- query source and active-window configuration

Readiness now requires non-empty canonical/current/snapshot populations, exact active/current coverage, a non-stale projection, and durable successful-refresh evidence. The endpoint exposes no player names, credentials, connection strings, or raw source payloads.

## Audited operator refresh

Adds:

```bash
python scripts/refresh_dashboard_player_projection.py
python scripts/refresh_dashboard_player_projection.py --date YYYY-MM-DD --refresh
python scripts/refresh_dashboard_player_projection.py --date YYYY-MM-DD --backfill-days 30
```

Status-only is the default. Mutation requires an explicit flag.

The refresh path:

- verifies the MLB active-team source returns at least 30 teams
- fetches every verified active roster
- consumes confirmed boxscore lineups
- combines roster/lineup facts with tracked Statcast games and aggregate availability
- resolves identity only by MLBAM ID
- builds exact full-population snapshots
- atomically promotes `dashboard_player_current`
- records durable `dashboard_projection_runs` evidence
- preserves the prior current projection on source, builder, coverage, or promotion failure
- leaves missing-player deactivation off unless explicitly requested

## Selected related reports

Makes two actual one-to-many report types queryable through the existing validated endpoint:

- `players_lineup_history` from `dashboard_players`
- `hitters_arsenal_splits` from `batter_pitch_type_matchups`, joined to active resolved canonical hitters

Both provide:

- explicit authoritative field catalogs
- SQL filter and sort validation
- stable ordering and pagination
- full-result counts
- selected-field validation
- source/relationship provenance

They do not redefine or shrink the default active-player population. Request-scoped weights are explicitly rejected for related reports because no approved related-report weighting formula exists.

## Runbook

Adds `docs/my_dashboard_canonical_production_runbook.md` with:

- initial refresh and optional backfill commands
- plausibility/readiness gates
- field-coverage interpretation
- recommended environment values
- safe Railway scheduling order
- exact production verification checklist
- failure/rollback procedure
- evidence required before closing #1055

## Validation

```
PYTHONPATH=.venv/lib/python3.12/site-packages python -m pytest -q \
  tests/test_dashboard_related_report_query.py \
  tests/test_dashboard_canonical_status.py \
  tests/test_dashboard_projection_operator.py \
  tests/test_dashboard_player_report_query.py \
  tests/test_dashboard_player_projection.py \
  tests/test_dashboard_player_population.py \
  tests/test_dashboard_object_schema.py
```

Result: **45 passed**.

Also verified Python bytecode compilation for every changed Python module and the operator script.

Coverage includes:

- complete status counts and field-coverage evidence
- explicit empty/mismatch/not-ready behavior
- durable success and failure evidence
- verified 30-team source guard
- successful roster/lineup population and current promotion
- failed source refresh preserving the prior projection
- lineup-history filtering/pagination
- arsenal split canonical-player isolation
- unsupported related fields, filters, and weights
- all prior canonical schema, population, projection, and query tests

## Deliberately not claimed

- No production refresh or backfill was executed from the connector environment.
- No production row count, field coverage, deployment health, or smoke-test success is claimed.
- No automatic Railway schedule is enabled before the first production counts are inspected.
- No existing table or legacy route is removed.
- No solver formula or unrelated product surface changes.

After merge/deploy, run the documented production refresh, attach the observed status/report evidence to #1055, and only then close the parent sprint.