### PR TITLE
Implement deterministic play ledger event contracts

### DIFF
--- a/mlb_app/simulation/events/__init__.py
+++ b/mlb_app/simulation/events/__init__.py
@@ -1,0 +1,23 @@
+"""Canonical event contracts for the MLB simulation engine."""
+
+from .contracts import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    PlayLedger,
+    RunnerMovement,
+)
+from .replay import replay_events
+from .resolver import DeterministicPlayResolver
+
+__all__ = [
+    "Base",
+    "GameState",
+    "OutRecord",
+    "PlayEvent",
+    "PlayLedger",
+    "RunnerMovement",
+    "DeterministicPlayResolver",
+    "replay_events",
+]

--- a/mlb_app/simulation/events/contracts.py
+++ b/mlb_app/simulation/events/contracts.py
@@ -1,0 +1,232 @@
+"""Immutable contracts for event-driven baseball simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Iterable, Optional, Tuple
+
+
+class Base(IntEnum):
+    """Canonical base identifiers used by runner movements."""
+
+    HOME = 0
+    FIRST = 1
+    SECOND = 2
+    THIRD = 3
+
+
+@dataclass(frozen=True)
+class GameState:
+    """Immutable state required to resolve and replay a half-inning.
+
+    Bases are stored in first/second/third order. A value of ``None``
+    means the base is empty. Runner identifiers are intentionally
+    opaque strings so this contract remains independent of player
+    storage and projection models.
+    """
+
+    inning: int = 1
+    half: str = "top"
+    outs: int = 0
+    bases: Tuple[Optional[str], Optional[str], Optional[str]] = (
+        None,
+        None,
+        None,
+    )
+    away_score: int = 0
+    home_score: int = 0
+    batting_order_index: int = 0
+    plate_appearance_number: int = 0
+
+    def __post_init__(self) -> None:
+        if self.inning < 1:
+            raise ValueError("inning must be at least 1")
+        if self.half not in {"top", "bottom"}:
+            raise ValueError("half must be 'top' or 'bottom'")
+        if not 0 <= self.outs <= 3:
+            raise ValueError("outs must be between 0 and 3")
+        if len(self.bases) != 3:
+            raise ValueError("bases must contain first, second, and third")
+        if self.away_score < 0 or self.home_score < 0:
+            raise ValueError("scores cannot be negative")
+        if self.batting_order_index < 0:
+            raise ValueError("batting_order_index cannot be negative")
+        if self.plate_appearance_number < 0:
+            raise ValueError("plate_appearance_number cannot be negative")
+
+        occupied = tuple(runner for runner in self.bases if runner is not None)
+        if len(occupied) != len(set(occupied)):
+            raise ValueError("a runner cannot occupy multiple bases")
+
+    @property
+    def first(self) -> Optional[str]:
+        return self.bases[0]
+
+    @property
+    def second(self) -> Optional[str]:
+        return self.bases[1]
+
+    @property
+    def third(self) -> Optional[str]:
+        return self.bases[2]
+
+    @property
+    def batting_score(self) -> int:
+        return self.away_score if self.half == "top" else self.home_score
+
+    def runner_on(self, base: Base) -> Optional[str]:
+        if base == Base.HOME:
+            raise ValueError("home plate is not an occupiable base")
+        return self.bases[int(base) - 1]
+
+
+@dataclass(frozen=True)
+class RunnerMovement:
+    """One runner's movement caused by a single play."""
+
+    runner_id: str
+    start_base: Base
+    end_base: Optional[Base]
+    scored: bool = False
+    is_out: bool = False
+    is_forced: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+        if self.scored and self.is_out:
+            raise ValueError("a runner cannot both score and be out")
+        if self.scored and self.end_base is not Base.HOME:
+            raise ValueError("a scoring movement must end at home")
+        if self.is_out and self.end_base is not None:
+            raise ValueError("an out movement cannot occupy an ending base")
+        if not self.scored and not self.is_out and self.end_base is None:
+            raise ValueError(
+                "a surviving non-scoring runner requires an ending base"
+            )
+
+
+@dataclass(frozen=True)
+class OutRecord:
+    """An out charged during a play."""
+
+    runner_id: str
+    out_number: int
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+        if not 1 <= self.out_number <= 3:
+            raise ValueError("out_number must be between 1 and 3")
+        if not self.reason:
+            raise ValueError("reason is required")
+
+
+@dataclass(frozen=True)
+class PlayEvent:
+    """Canonical append-only record for one resolved baseball play."""
+
+    sequence: int
+    event_type: str
+    batter_id: str
+    state_before: GameState
+    state_after: GameState
+    runner_movements: Tuple[RunnerMovement, ...] = field(default_factory=tuple)
+    outs_recorded: Tuple[OutRecord, ...] = field(default_factory=tuple)
+    runs_scored: Tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.sequence < 0:
+            raise ValueError("sequence cannot be negative")
+        if not self.event_type:
+            raise ValueError("event_type is required")
+        if not self.batter_id:
+            raise ValueError("batter_id is required")
+
+        if self.state_after.plate_appearance_number != (
+            self.state_before.plate_appearance_number + 1
+        ):
+            raise ValueError(
+                "a plate-appearance event must increment "
+                "plate_appearance_number exactly once"
+            )
+
+        if self.state_after.batting_order_index != (
+            self.state_before.batting_order_index + 1
+        ) % 9:
+            raise ValueError(
+                "a plate-appearance event must advance batting order once"
+            )
+
+        score_delta = (
+            self.state_after.away_score - self.state_before.away_score
+            + self.state_after.home_score - self.state_before.home_score
+        )
+        if score_delta != len(self.runs_scored):
+            raise ValueError(
+                "score change must equal the number of recorded runs"
+            )
+
+        movement_scorers = tuple(
+            movement.runner_id
+            for movement in self.runner_movements
+            if movement.scored
+        )
+        if movement_scorers != self.runs_scored:
+            raise ValueError(
+                "runs_scored must match scoring runner movements in order"
+            )
+
+        expected_outs = (
+            self.state_after.outs - self.state_before.outs
+        )
+        if expected_outs != len(self.outs_recorded):
+            raise ValueError(
+                "outs change must equal the number of out records"
+            )
+
+
+@dataclass(frozen=True)
+class PlayLedger:
+    """Immutable append-only sequence of canonical play events."""
+
+    initial_state: GameState
+    events: Tuple[PlayEvent, ...] = field(default_factory=tuple)
+
+    @property
+    def current_state(self) -> GameState:
+        if not self.events:
+            return self.initial_state
+        return self.events[-1].state_after
+
+    def append(self, event: PlayEvent) -> "PlayLedger":
+        expected_sequence = len(self.events)
+
+        if event.sequence != expected_sequence:
+            raise ValueError(
+                f"expected event sequence {expected_sequence}, "
+                f"received {event.sequence}"
+            )
+
+        if event.state_before != self.current_state:
+            raise ValueError(
+                "event state_before does not match ledger current_state"
+            )
+
+        return PlayLedger(
+            initial_state=self.initial_state,
+            events=self.events + (event,),
+        )
+
+    @classmethod
+    def from_events(
+        cls,
+        initial_state: GameState,
+        events: Iterable[PlayEvent],
+    ) -> "PlayLedger":
+        ledger = cls(initial_state=initial_state)
+        for event in events:
+            ledger = ledger.append(event)
+        return ledger

--- a/mlb_app/simulation/events/replay.py
+++ b/mlb_app/simulation/events/replay.py
@@ -1,0 +1,21 @@
+"""Replay validation for canonical play events."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .contracts import GameState, PlayEvent, PlayLedger
+
+
+def replay_events(
+    initial_state: GameState,
+    events: Iterable[PlayEvent],
+) -> GameState:
+    """Replay a sequence and return its final canonical state.
+
+    Replay intentionally consumes the state transitions recorded in each
+    event. The ledger validates event ordering and state continuity.
+    """
+
+    ledger = PlayLedger.from_events(initial_state, events)
+    return ledger.current_state

--- a/mlb_app/simulation/events/resolver.py
+++ b/mlb_app/simulation/events/resolver.py
@@ -1,0 +1,208 @@
+"""Deterministic play resolution for BB, HBP, and HR outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import List, Optional, Tuple
+
+from .contracts import (
+    Base,
+    GameState,
+    PlayEvent,
+    RunnerMovement,
+)
+
+
+class DeterministicPlayResolver:
+    """Resolve plate appearances whose runner movement is deterministic."""
+
+    SUPPORTED_EVENTS = frozenset({"bb", "hbp", "hr"})
+
+    def resolve(
+        self,
+        *,
+        state: GameState,
+        event_type: str,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        normalized_event = event_type.lower().strip()
+
+        if normalized_event not in self.SUPPORTED_EVENTS:
+            raise ValueError(
+                f"unsupported deterministic event_type: {event_type}"
+            )
+        if state.outs >= 3:
+            raise ValueError("cannot resolve a plate appearance with 3 outs")
+        if not batter_id:
+            raise ValueError("batter_id is required")
+        if batter_id in {
+            runner for runner in state.bases if runner is not None
+        }:
+            raise ValueError("batter is already present on base")
+
+        if normalized_event in {"bb", "hbp"}:
+            return self._resolve_forced_award(
+                state=state,
+                event_type=normalized_event,
+                batter_id=batter_id,
+                sequence=sequence,
+            )
+
+        return self._resolve_home_run(
+            state=state,
+            batter_id=batter_id,
+            sequence=sequence,
+        )
+
+    @staticmethod
+    def _next_pa_state(
+        state: GameState,
+        *,
+        bases: Tuple[Optional[str], Optional[str], Optional[str]],
+        runs: int,
+    ) -> GameState:
+        if state.half == "top":
+            away_score = state.away_score + runs
+            home_score = state.home_score
+        else:
+            away_score = state.away_score
+            home_score = state.home_score + runs
+
+        return replace(
+            state,
+            bases=bases,
+            away_score=away_score,
+            home_score=home_score,
+            batting_order_index=(state.batting_order_index + 1) % 9,
+            plate_appearance_number=state.plate_appearance_number + 1,
+        )
+
+    def _resolve_forced_award(
+        self,
+        *,
+        state: GameState,
+        event_type: str,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        first, second, third = state.bases
+        movements: List[RunnerMovement] = []
+        scorers: List[str] = []
+
+        new_first: Optional[str] = batter_id
+        new_second = second
+        new_third = third
+
+        # Only contiguous occupied bases are forced by the batter award.
+        if first is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=first,
+                    start_base=Base.FIRST,
+                    end_base=Base.SECOND,
+                    is_forced=True,
+                )
+            )
+            new_second = first
+
+            if second is not None:
+                movements.append(
+                    RunnerMovement(
+                        runner_id=second,
+                        start_base=Base.SECOND,
+                        end_base=Base.THIRD,
+                        is_forced=True,
+                    )
+                )
+                new_third = second
+
+                if third is not None:
+                    movements.append(
+                        RunnerMovement(
+                            runner_id=third,
+                            start_base=Base.THIRD,
+                            end_base=Base.HOME,
+                            scored=True,
+                            is_forced=True,
+                        )
+                    )
+                    scorers.append(third)
+
+        movements.append(
+            RunnerMovement(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                end_base=Base.FIRST,
+                is_forced=True,
+            )
+        )
+
+        state_after = self._next_pa_state(
+            state,
+            bases=(new_first, new_second, new_third),
+            runs=len(scorers),
+        )
+
+        return PlayEvent(
+            sequence=sequence,
+            event_type=event_type,
+            batter_id=batter_id,
+            state_before=state,
+            state_after=state_after,
+            runner_movements=tuple(movements),
+            runs_scored=tuple(scorers),
+        )
+
+    def _resolve_home_run(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        movements: List[RunnerMovement] = []
+        scorers: List[str] = []
+
+        for base, runner_id in (
+            (Base.FIRST, state.first),
+            (Base.SECOND, state.second),
+            (Base.THIRD, state.third),
+        ):
+            if runner_id is None:
+                continue
+            movements.append(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=base,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+            scorers.append(runner_id)
+
+        movements.append(
+            RunnerMovement(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                end_base=Base.HOME,
+                scored=True,
+            )
+        )
+        scorers.append(batter_id)
+
+        state_after = self._next_pa_state(
+            state,
+            bases=(None, None, None),
+            runs=len(scorers),
+        )
+
+        return PlayEvent(
+            sequence=sequence,
+            event_type="hr",
+            batter_id=batter_id,
+            state_before=state,
+            state_after=state_after,
+            runner_movements=tuple(movements),
+            runs_scored=tuple(scorers),
+        )

--- a/tests/test_simulation_event_contracts.py
+++ b/tests/test_simulation_event_contracts.py
@@ -1,0 +1,235 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    DeterministicPlayResolver,
+    GameState,
+    PlayLedger,
+    replay_events,
+)
+
+
+def test_game_state_is_immutable():
+    state = GameState()
+
+    with pytest.raises(FrozenInstanceError):
+        state.outs = 1
+
+
+def test_game_state_rejects_duplicate_runner_occupancy():
+    with pytest.raises(
+        ValueError,
+        match="runner cannot occupy multiple bases",
+    ):
+        GameState(bases=("runner-1", "runner-1", None))
+
+
+def test_empty_base_walk_only_places_batter_on_first():
+    resolver = DeterministicPlayResolver()
+    state = GameState()
+
+    event = resolver.resolve(
+        state=state,
+        event_type="bb",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_before == state
+    assert event.state_after.bases == ("batter", None, None)
+    assert event.state_after.away_score == 0
+    assert event.state_after.batting_order_index == 1
+    assert event.state_after.plate_appearance_number == 1
+    assert event.runs_scored == ()
+
+
+def test_walk_does_not_move_unforced_second_or_third_base_runners():
+    resolver = DeterministicPlayResolver()
+    state = GameState(
+        bases=(None, "runner-2", "runner-3"),
+    )
+
+    event = resolver.resolve(
+        state=state,
+        event_type="bb",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.bases == (
+        "batter",
+        "runner-2",
+        "runner-3",
+    )
+    assert event.runs_scored == ()
+
+
+def test_bases_loaded_hbp_forces_exactly_one_run():
+    resolver = DeterministicPlayResolver()
+    state = GameState(
+        bases=("runner-1", "runner-2", "runner-3"),
+    )
+
+    event = resolver.resolve(
+        state=state,
+        event_type="hbp",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.bases == (
+        "batter",
+        "runner-1",
+        "runner-2",
+    )
+    assert event.state_after.away_score == 1
+    assert event.runs_scored == ("runner-3",)
+
+    movements = {
+        movement.runner_id: movement
+        for movement in event.runner_movements
+    }
+    assert movements["runner-3"].scored is True
+    assert movements["runner-2"].end_base is Base.THIRD
+    assert movements["runner-1"].end_base is Base.SECOND
+    assert movements["batter"].end_base is Base.FIRST
+
+
+def test_bottom_half_grand_slam_updates_home_score_and_clears_bases():
+    resolver = DeterministicPlayResolver()
+    state = GameState(
+        inning=9,
+        half="bottom",
+        outs=2,
+        bases=("runner-1", "runner-2", "runner-3"),
+        away_score=4,
+        home_score=2,
+        batting_order_index=8,
+        plate_appearance_number=35,
+    )
+
+    event = resolver.resolve(
+        state=state,
+        event_type="hr",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.bases == (None, None, None)
+    assert event.state_after.away_score == 4
+    assert event.state_after.home_score == 6
+    assert event.state_after.outs == 2
+    assert event.state_after.batting_order_index == 0
+    assert event.state_after.plate_appearance_number == 36
+    assert event.runs_scored == (
+        "runner-1",
+        "runner-2",
+        "runner-3",
+        "batter",
+    )
+
+
+def test_ledger_is_append_only_and_validates_sequence():
+    resolver = DeterministicPlayResolver()
+    initial_state = GameState()
+    ledger = PlayLedger(initial_state=initial_state)
+
+    first_event = resolver.resolve(
+        state=initial_state,
+        event_type="bb",
+        batter_id="batter-1",
+        sequence=0,
+    )
+    next_ledger = ledger.append(first_event)
+
+    assert ledger.events == ()
+    assert len(next_ledger.events) == 1
+
+    invalid_event = resolver.resolve(
+        state=next_ledger.current_state,
+        event_type="hr",
+        batter_id="batter-2",
+        sequence=3,
+    )
+
+    with pytest.raises(ValueError, match="expected event sequence 1"):
+        next_ledger.append(invalid_event)
+
+
+def test_ledger_rejects_state_discontinuity():
+    resolver = DeterministicPlayResolver()
+    initial_state = GameState()
+    ledger = PlayLedger(initial_state=initial_state)
+
+    unrelated_state = GameState(bases=("other-runner", None, None))
+    event = resolver.resolve(
+        state=unrelated_state,
+        event_type="hr",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    with pytest.raises(ValueError, match="state_before"):
+        ledger.append(event)
+
+
+def test_replay_matches_live_final_state():
+    resolver = DeterministicPlayResolver()
+    initial_state = GameState()
+
+    event_1 = resolver.resolve(
+        state=initial_state,
+        event_type="bb",
+        batter_id="batter-1",
+        sequence=0,
+    )
+    event_2 = resolver.resolve(
+        state=event_1.state_after,
+        event_type="hbp",
+        batter_id="batter-2",
+        sequence=1,
+    )
+    event_3 = resolver.resolve(
+        state=event_2.state_after,
+        event_type="hr",
+        batter_id="batter-3",
+        sequence=2,
+    )
+
+    events = (event_1, event_2, event_3)
+
+    assert replay_events(initial_state, events) == event_3.state_after
+    assert event_3.state_after.away_score == 3
+    assert event_3.state_after.bases == (None, None, None)
+
+
+def test_resolver_rejects_unsupported_probabilistic_event():
+    resolver = DeterministicPlayResolver()
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported deterministic event_type",
+    ):
+        resolver.resolve(
+            state=GameState(),
+            event_type="single",
+            batter_id="batter",
+            sequence=0,
+        )
+
+
+def test_resolver_rejects_plate_appearance_after_three_outs():
+    resolver = DeterministicPlayResolver()
+
+    with pytest.raises(
+        ValueError,
+        match="cannot resolve a plate appearance with 3 outs",
+    ):
+        resolver.resolve(
+            state=GameState(outs=3),
+            event_type="bb",
+            batter_id="batter",
+            sequence=0,
+        )


### PR DESCRIPTION
## Summary

Implements the foundational Layer 10B event-driven simulation contracts without changing existing production simulation behavior.

### Added

- Immutable `GameState`
- Canonical `RunnerMovement`
- Canonical `OutRecord`
- Canonical `PlayEvent`
- Immutable append-only `PlayLedger`
- Deterministic `PlayResolver` support for:
  - walks
  - hit-by-pitch
  - home runs
- Deterministic event replay validation
- Focused contract and transition tests

## Architecture

This establishes the initial event-driven path:

```text
GameState
    ↓
DeterministicPlayResolver
    ↓
PlayEvent
    ↓
PlayLedger
    ↓
Replay validation