### PR TITLE
Implement baseline runner advancement

### DIFF
--- a/mlb_app/simulation/events/__init__.py
+++ b/mlb_app/simulation/events/__init__.py
@@ -1,5 +1,19 @@
 """Canonical event contracts for the MLB simulation engine."""
 
+from .advancement_model import (
+    AdvancementProbability,
+    BaselineRunnerAdvancementModel,
+    validate_baseline_advancement_rates,
+)
+from .advancement_sampler import (
+    BaselineRunnerAdvancementSampler,
+    RunnerAdvancementResult,
+)
+from .advancement_version import (
+    BASELINE_RUNNER_ADVANCEMENT_METADATA,
+    BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION,
+    AdvancementModelMetadata,
+)
 from .batted_ball import (
     BASELINE_BATTED_BALL_MODEL_VERSION,
     BattedBallContext,
@@ -18,24 +32,40 @@ from .contracts import (
     PlayLedger,
     RunnerMovement,
 )
+from .legal_transitions import (
+    LegalRunnerDestinations,
+    enumerate_legal_runner_destinations,
+    validate_runner_movements,
+)
 from .replay import replay_events
 from .resolver import DeterministicPlayResolver
 
 __all__ = [
+    "AdvancementModelMetadata",
+    "AdvancementProbability",
     "BASELINE_BATTED_BALL_MODEL_VERSION",
+    "BASELINE_RUNNER_ADVANCEMENT_METADATA",
+    "BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION",
     "Base",
     "BattedBallContext",
     "BattedBallDepth",
     "BattedBallType",
     "BaselineBattedBallContextProvider",
+    "BaselineRunnerAdvancementModel",
+    "BaselineRunnerAdvancementSampler",
     "ContactQuality",
+    "DeterministicPlayResolver",
     "GameState",
+    "LegalRunnerDestinations",
     "OutRecord",
     "PlayEvent",
     "PlayLedger",
+    "RunnerAdvancementResult",
     "RunnerMovement",
     "SprayDirection",
-    "DeterministicPlayResolver",
+    "enumerate_legal_runner_destinations",
     "replay_events",
+    "validate_baseline_advancement_rates",
     "validate_baseline_batted_ball_distributions",
+    "validate_runner_movements",
 ]

--- a/mlb_app/simulation/events/advancement_model.py
+++ b/mlb_app/simulation/events/advancement_model.py
@@ -1,0 +1,171 @@
+"""Versioned baseline probabilities for runner advancement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from .advancement_version import (
+    BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION,
+)
+from .batted_ball import (
+    BattedBallContext,
+    BattedBallDepth,
+    BattedBallType,
+    ContactQuality,
+)
+
+
+@dataclass(frozen=True)
+class AdvancementProbability:
+    """One named probability used during transition resolution."""
+
+    name: str
+    probability: float
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("probability name is required")
+        if not 0.0 <= self.probability <= 1.0:
+            raise ValueError(
+                "probability must be between 0.0 and 1.0"
+            )
+
+
+BASELINE_ADVANCEMENT_RATES: Mapping[str, float] = {
+    "single_runner_second_scores": 0.62,
+    "single_runner_first_to_third": 0.28,
+    "double_runner_first_scores": 0.42,
+    "groundout_runner_third_scores": 0.25,
+    "groundout_runner_second_to_third": 0.35,
+    "flyout_runner_third_scores_shallow": 0.08,
+    "flyout_runner_third_scores_medium": 0.38,
+    "flyout_runner_third_scores_deep": 0.65,
+    "flyout_runner_second_to_third_shallow": 0.05,
+    "flyout_runner_second_to_third_medium": 0.22,
+    "flyout_runner_second_to_third_deep": 0.35,
+    "line_drive_runner_third_scores": 0.08,
+    "line_drive_runner_second_to_third": 0.08,
+    "popup_runner_third_scores": 0.01,
+    "popup_runner_second_to_third": 0.01,
+}
+
+
+def validate_baseline_advancement_rates(
+    rates: Mapping[str, float] = BASELINE_ADVANCEMENT_RATES,
+) -> None:
+    if not rates:
+        raise ValueError("advancement rates cannot be empty")
+
+    for name, value in rates.items():
+        if not name:
+            raise ValueError("advancement rate name is required")
+        if not isinstance(value, (int, float)):
+            raise TypeError(
+                f"advancement rate must be numeric: {name}"
+            )
+        if not 0.0 <= float(value) <= 1.0:
+            raise ValueError(
+                f"advancement rate out of bounds: {name}"
+            )
+
+
+class BaselineRunnerAdvancementModel:
+    """Resolve context-aware baseline advancement probabilities.
+
+    These values are explicit initial assumptions. They are not
+    represented as calibrated historical MLB rates.
+    """
+
+    model_version = BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION
+
+    def __init__(
+        self,
+        *,
+        rates: Mapping[str, float] | None = None,
+    ) -> None:
+        resolved = dict(BASELINE_ADVANCEMENT_RATES)
+
+        if rates is not None:
+            unknown = set(rates) - set(resolved)
+            if unknown:
+                raise ValueError(
+                    "unknown advancement rates: "
+                    + ", ".join(sorted(unknown))
+                )
+            resolved.update(rates)
+
+        validate_baseline_advancement_rates(resolved)
+        self._rates: Dict[str, float] = resolved
+
+    def probability(
+        self,
+        name: str,
+        *,
+        context: BattedBallContext,
+    ) -> AdvancementProbability:
+        resolved_name = self._resolve_context_key(
+            name=name,
+            context=context,
+        )
+
+        if resolved_name not in self._rates:
+            raise ValueError(
+                f"unsupported advancement probability: {name}"
+            )
+
+        probability = self._rates[resolved_name]
+        probability = self._apply_contact_quality_modifier(
+            probability=probability,
+            context=context,
+        )
+
+        return AdvancementProbability(
+            name=resolved_name,
+            probability=max(0.0, min(1.0, probability)),
+        )
+
+    def _resolve_context_key(
+        self,
+        *,
+        name: str,
+        context: BattedBallContext,
+    ) -> str:
+        if name == "caught_ball_runner_third_scores":
+            if context.batted_ball_type is BattedBallType.FLY_BALL:
+                return (
+                    "flyout_runner_third_scores_"
+                    f"{context.depth.value}"
+                )
+            if context.batted_ball_type is BattedBallType.LINE_DRIVE:
+                return "line_drive_runner_third_scores"
+            if context.batted_ball_type is BattedBallType.POPUP:
+                return "popup_runner_third_scores"
+
+        if name == "caught_ball_runner_second_to_third":
+            if context.batted_ball_type is BattedBallType.FLY_BALL:
+                return (
+                    "flyout_runner_second_to_third_"
+                    f"{context.depth.value}"
+                )
+            if context.batted_ball_type is BattedBallType.LINE_DRIVE:
+                return "line_drive_runner_second_to_third"
+            if context.batted_ball_type is BattedBallType.POPUP:
+                return "popup_runner_second_to_third"
+
+        return name
+
+    @staticmethod
+    def _apply_contact_quality_modifier(
+        *,
+        probability: float,
+        context: BattedBallContext,
+    ) -> float:
+        if context.contact_quality is ContactQuality.HARD:
+            return probability + 0.05
+        if context.contact_quality is ContactQuality.SOFT:
+            return probability - 0.05
+        return probability
+
+
+validate_baseline_advancement_rates()

--- a/mlb_app/simulation/events/advancement_sampler.py
+++ b/mlb_app/simulation/events/advancement_sampler.py
@@ -1,0 +1,364 @@
+"""Sample legal baseline runner advancement decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import random
+from typing import Optional, Tuple
+
+from .advancement_model import (
+    AdvancementProbability,
+    BaselineRunnerAdvancementModel,
+)
+from .advancement_version import (
+    BASELINE_RUNNER_ADVANCEMENT_METADATA,
+    AdvancementModelMetadata,
+)
+from .batted_ball import BattedBallContext, BattedBallType
+from .contracts import Base, GameState, RunnerMovement
+from .legal_transitions import (
+    enumerate_legal_runner_destinations,
+    validate_runner_movements,
+)
+
+
+@dataclass(frozen=True)
+class RunnerAdvancementResult:
+    """Resolved movement decisions plus probability provenance."""
+
+    movements: Tuple[RunnerMovement, ...]
+    probabilities_used: Tuple[
+        AdvancementProbability,
+        ...,
+    ] = field(default_factory=tuple)
+    metadata: AdvancementModelMetadata = (
+        BASELINE_RUNNER_ADVANCEMENT_METADATA
+    )
+
+    def __post_init__(self) -> None:
+        validate_runner_movements(self.movements)
+
+    @property
+    def runs_scored(self) -> Tuple[str, ...]:
+        return tuple(
+            movement.runner_id
+            for movement in self.movements
+            if movement.scored
+        )
+
+
+class BaselineRunnerAdvancementSampler:
+    """Choose among legal baseline runner destinations."""
+
+    def __init__(
+        self,
+        *,
+        rng: Optional[random.Random] = None,
+        model: Optional[
+            BaselineRunnerAdvancementModel
+        ] = None,
+    ) -> None:
+        self._rng = rng or random.Random()
+        self._model = (
+            model
+            or BaselineRunnerAdvancementModel()
+        )
+
+    def sample(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+        primary_outcome: str,
+        context: BattedBallContext,
+    ) -> RunnerAdvancementResult:
+        outcome = primary_outcome.strip().lower()
+
+        enumerate_legal_runner_destinations(
+            state=state,
+            batter_id=batter_id,
+            primary_outcome=outcome,
+            context=context,
+        )
+
+        if outcome == "single":
+            return self._sample_single(
+                state=state,
+                batter_id=batter_id,
+                context=context,
+            )
+
+        if outcome == "double":
+            return self._sample_double(
+                state=state,
+                batter_id=batter_id,
+                context=context,
+            )
+
+        if outcome == "out":
+            return self._sample_out(
+                state=state,
+                context=context,
+            )
+
+        raise RuntimeError(
+            "legal transition enumeration accepted "
+            "an unreachable outcome"
+        )
+
+    def _sample_single(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+        context: BattedBallContext,
+    ) -> RunnerAdvancementResult:
+        movements = []
+        decisions = []
+        third_occupied = False
+
+        if state.third is not None:
+            movements.append(
+                _movement(
+                    runner_id=state.third,
+                    start=Base.THIRD,
+                    end=Base.HOME,
+                )
+            )
+
+        if state.second is not None:
+            decision = self._model.probability(
+                "single_runner_second_scores",
+                context=context,
+            )
+            decisions.append(decision)
+
+            if self._roll(decision):
+                movements.append(
+                    _movement(
+                        runner_id=state.second,
+                        start=Base.SECOND,
+                        end=Base.HOME,
+                    )
+                )
+            else:
+                third_occupied = True
+                movements.append(
+                    _movement(
+                        runner_id=state.second,
+                        start=Base.SECOND,
+                        end=Base.THIRD,
+                    )
+                )
+
+        if state.first is not None:
+            decision = self._model.probability(
+                "single_runner_first_to_third",
+                context=context,
+            )
+            decisions.append(decision)
+
+            if (
+                not third_occupied
+                and self._roll(decision)
+            ):
+                third_occupied = True
+                end_base = Base.THIRD
+            else:
+                end_base = Base.SECOND
+
+            movements.append(
+                _movement(
+                    runner_id=state.first,
+                    start=Base.FIRST,
+                    end=end_base,
+                )
+            )
+
+        movements.append(
+            _movement(
+                runner_id=batter_id,
+                start=Base.HOME,
+                end=Base.FIRST,
+                forced=True,
+            )
+        )
+
+        return RunnerAdvancementResult(
+            movements=tuple(movements),
+            probabilities_used=tuple(decisions),
+        )
+
+    def _sample_double(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+        context: BattedBallContext,
+    ) -> RunnerAdvancementResult:
+        movements = []
+        decisions = []
+
+        if state.third is not None:
+            movements.append(
+                _movement(
+                    runner_id=state.third,
+                    start=Base.THIRD,
+                    end=Base.HOME,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                _movement(
+                    runner_id=state.second,
+                    start=Base.SECOND,
+                    end=Base.HOME,
+                )
+            )
+
+        if state.first is not None:
+            decision = self._model.probability(
+                "double_runner_first_scores",
+                context=context,
+            )
+            decisions.append(decision)
+
+            end_base = (
+                Base.HOME
+                if self._roll(decision)
+                else Base.THIRD
+            )
+            movements.append(
+                _movement(
+                    runner_id=state.first,
+                    start=Base.FIRST,
+                    end=end_base,
+                )
+            )
+
+        movements.append(
+            _movement(
+                runner_id=batter_id,
+                start=Base.HOME,
+                end=Base.SECOND,
+                forced=True,
+            )
+        )
+
+        return RunnerAdvancementResult(
+            movements=tuple(movements),
+            probabilities_used=tuple(decisions),
+        )
+
+    def _sample_out(
+        self,
+        *,
+        state: GameState,
+        context: BattedBallContext,
+    ) -> RunnerAdvancementResult:
+        movements = []
+        decisions = []
+        third_vacated = state.third is None
+
+        if state.third is not None:
+            decision_name = (
+                "groundout_runner_third_scores"
+                if context.batted_ball_type
+                is BattedBallType.GROUND_BALL
+                else "caught_ball_runner_third_scores"
+            )
+            decision = self._model.probability(
+                decision_name,
+                context=context,
+            )
+            decisions.append(decision)
+
+            if (
+                state.outs < 2
+                and self._roll(decision)
+            ):
+                third_vacated = True
+                end_base = Base.HOME
+            else:
+                third_vacated = False
+                end_base = Base.THIRD
+
+            movements.append(
+                _movement(
+                    runner_id=state.third,
+                    start=Base.THIRD,
+                    end=end_base,
+                )
+            )
+
+        if state.second is not None:
+            decision_name = (
+                "groundout_runner_second_to_third"
+                if context.batted_ball_type
+                is BattedBallType.GROUND_BALL
+                else (
+                    "caught_ball_runner_second_to_third"
+                )
+            )
+            decision = self._model.probability(
+                decision_name,
+                context=context,
+            )
+            decisions.append(decision)
+
+            if (
+                state.outs < 2
+                and third_vacated
+                and self._roll(decision)
+            ):
+                end_base = Base.THIRD
+            else:
+                end_base = Base.SECOND
+
+            movements.append(
+                _movement(
+                    runner_id=state.second,
+                    start=Base.SECOND,
+                    end=end_base,
+                )
+            )
+
+        if state.first is not None:
+            movements.append(
+                _movement(
+                    runner_id=state.first,
+                    start=Base.FIRST,
+                    end=Base.FIRST,
+                )
+            )
+
+        return RunnerAdvancementResult(
+            movements=tuple(movements),
+            probabilities_used=tuple(decisions),
+        )
+
+    def _roll(
+        self,
+        decision: AdvancementProbability,
+    ) -> bool:
+        return (
+            self._rng.random()
+            < decision.probability
+        )
+
+
+def _movement(
+    *,
+    runner_id: str,
+    start: Base,
+    end: Base,
+    forced: bool = False,
+) -> RunnerMovement:
+    return RunnerMovement(
+        runner_id=runner_id,
+        start_base=start,
+        end_base=end,
+        scored=end is Base.HOME,
+        is_forced=forced,
+    )

--- a/mlb_app/simulation/events/advancement_version.py
+++ b/mlb_app/simulation/events/advancement_version.py
@@ -1,0 +1,34 @@
+"""Version and provenance contracts for runner advancement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION = (
+    "baseline_runner_advancement_v1"
+)
+
+
+@dataclass(frozen=True)
+class AdvancementModelMetadata:
+    """Stable metadata attached to an advancement result."""
+
+    model_version: str
+    source: str
+    calibrated: bool
+    production_enabled: bool
+
+    def __post_init__(self) -> None:
+        if not self.model_version:
+            raise ValueError("model_version is required")
+        if not self.source:
+            raise ValueError("source is required")
+
+
+BASELINE_RUNNER_ADVANCEMENT_METADATA = AdvancementModelMetadata(
+    model_version=BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION,
+    source="versioned_initial_simulation_assumptions",
+    calibrated=False,
+    production_enabled=False,
+)

--- a/mlb_app/simulation/events/legal_transitions.py
+++ b/mlb_app/simulation/events/legal_transitions.py
@@ -1,0 +1,202 @@
+"""Legal destination enumeration for baseline runner advancement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Tuple
+
+from .batted_ball import BattedBallContext, BattedBallType
+from .contracts import Base, GameState, RunnerMovement
+
+
+SUPPORTED_ADVANCEMENT_OUTCOMES = frozenset(
+    {
+        "single",
+        "double",
+        "out",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LegalRunnerDestinations:
+    """Legal destinations available to one runner."""
+
+    runner_id: str
+    start_base: Base
+    destinations: Tuple[Base, ...]
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+        if not self.destinations:
+            raise ValueError(
+                "at least one legal destination is required"
+            )
+        if len(self.destinations) != len(set(self.destinations)):
+            raise ValueError(
+                "legal destinations cannot contain duplicates"
+            )
+
+
+def enumerate_legal_runner_destinations(
+    *,
+    state: GameState,
+    batter_id: str,
+    primary_outcome: str,
+    context: BattedBallContext,
+) -> Tuple[LegalRunnerDestinations, ...]:
+    """Enumerate destinations without selecting probabilities."""
+
+    if not batter_id:
+        raise ValueError("batter_id is required")
+
+    outcome = primary_outcome.strip().lower()
+    if outcome not in SUPPORTED_ADVANCEMENT_OUTCOMES:
+        raise ValueError(
+            f"unsupported advancement outcome: {primary_outcome}"
+        )
+
+    legal = []
+
+    if state.third is not None:
+        destinations = _third_base_destinations(
+            outcome=outcome,
+            context=context,
+        )
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=state.third,
+                start_base=Base.THIRD,
+                destinations=destinations,
+            )
+        )
+
+    if state.second is not None:
+        destinations = _second_base_destinations(
+            outcome=outcome,
+            context=context,
+        )
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=state.second,
+                start_base=Base.SECOND,
+                destinations=destinations,
+            )
+        )
+
+    if state.first is not None:
+        destinations = _first_base_destinations(
+            outcome=outcome,
+        )
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=state.first,
+                start_base=Base.FIRST,
+                destinations=destinations,
+            )
+        )
+
+    if outcome == "single":
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                destinations=(Base.FIRST,),
+            )
+        )
+    elif outcome == "double":
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                destinations=(Base.SECOND,),
+            )
+        )
+
+    return tuple(legal)
+
+
+def validate_runner_movements(
+    movements: Tuple[RunnerMovement, ...],
+) -> None:
+    """Reject duplicate runners and occupied-base collisions."""
+
+    runner_ids = tuple(
+        movement.runner_id
+        for movement in movements
+    )
+    if len(runner_ids) != len(set(runner_ids)):
+        raise ValueError(
+            "a runner cannot appear in multiple movements"
+        )
+
+    occupied_destinations = tuple(
+        movement.end_base
+        for movement in movements
+        if (
+            movement.end_base is not None
+            and movement.end_base is not Base.HOME
+            and not movement.is_out
+        )
+    )
+
+    if len(occupied_destinations) != len(
+        set(occupied_destinations)
+    ):
+        raise ValueError(
+            "multiple runners cannot occupy the same base"
+        )
+
+
+def _third_base_destinations(
+    *,
+    outcome: str,
+    context: BattedBallContext,
+) -> Tuple[Base, ...]:
+    if outcome in {"single", "double"}:
+        return (Base.HOME,)
+
+    if context.batted_ball_type in {
+        BattedBallType.FLY_BALL,
+        BattedBallType.LINE_DRIVE,
+        BattedBallType.POPUP,
+        BattedBallType.GROUND_BALL,
+    }:
+        return (Base.THIRD, Base.HOME)
+
+    return (Base.THIRD,)
+
+
+def _second_base_destinations(
+    *,
+    outcome: str,
+    context: BattedBallContext,
+) -> Tuple[Base, ...]:
+    if outcome == "single":
+        return (Base.THIRD, Base.HOME)
+    if outcome == "double":
+        return (Base.HOME,)
+
+    if context.batted_ball_type in {
+        BattedBallType.FLY_BALL,
+        BattedBallType.LINE_DRIVE,
+        BattedBallType.POPUP,
+        BattedBallType.GROUND_BALL,
+    }:
+        return (Base.SECOND, Base.THIRD)
+
+    return (Base.SECOND,)
+
+
+def _first_base_destinations(
+    *,
+    outcome: str,
+) -> Tuple[Base, ...]:
+    if outcome == "single":
+        return (Base.SECOND, Base.THIRD)
+    if outcome == "double":
+        return (Base.THIRD, Base.HOME)
+
+    # Force plays and fielder's choices are Layer 10E concerns.
+    return (Base.FIRST,)

--- a/tests/test_runner_advancement.py
+++ b/tests/test_runner_advancement.py
@@ -1,0 +1,414 @@
+import random
+
+import pytest
+
+from mlb_app.simulation.events import (
+    BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION,
+    Base,
+    BaselineRunnerAdvancementModel,
+    BaselineRunnerAdvancementSampler,
+    BattedBallContext,
+    BattedBallDepth,
+    BattedBallType,
+    ContactQuality,
+    GameState,
+    SprayDirection,
+    enumerate_legal_runner_destinations,
+    validate_baseline_advancement_rates,
+    validate_runner_movements,
+)
+
+
+def context(
+    *,
+    batted_ball_type=BattedBallType.LINE_DRIVE,
+    depth=BattedBallDepth.MEDIUM,
+    contact_quality=ContactQuality.MEDIUM,
+):
+    return BattedBallContext(
+        batted_ball_type=batted_ball_type,
+        direction=SprayDirection.CENTER,
+        depth=depth,
+        contact_quality=contact_quality,
+    )
+
+
+def state(
+    *,
+    outs=0,
+    bases=(None, None, None),
+):
+    return GameState(
+        outs=outs,
+        bases=bases,
+    )
+
+
+def movement_by_runner(result):
+    return {
+        movement.runner_id: movement
+        for movement in result.movements
+    }
+
+
+def test_baseline_rates_validate():
+    validate_baseline_advancement_rates()
+
+
+def test_single_places_batter_on_first():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(1),
+    )
+
+    result = sampler.sample(
+        state=state(),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    batter = movement_by_runner(result)["batter"]
+
+    assert batter.start_base is Base.HOME
+    assert batter.end_base is Base.FIRST
+    assert batter.is_forced is True
+
+
+def test_double_places_batter_on_second():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(2),
+    )
+
+    result = sampler.sample(
+        state=state(),
+        batter_id="batter",
+        primary_outcome="double",
+        context=context(),
+    )
+
+    batter = movement_by_runner(result)["batter"]
+
+    assert batter.end_base is Base.SECOND
+    assert batter.is_forced is True
+
+
+def test_single_scores_runner_from_third():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(3),
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=(None, None, "runner_3"),
+        ),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    runner = movement_by_runner(result)["runner_3"]
+
+    assert runner.end_base is Base.HOME
+    assert runner.scored is True
+    assert result.runs_scored == ("runner_3",)
+
+
+def test_double_scores_runners_from_second_and_third():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(4),
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=(None, "runner_2", "runner_3"),
+        ),
+        batter_id="batter",
+        primary_outcome="double",
+        context=context(),
+    )
+
+    movements = movement_by_runner(result)
+
+    assert movements["runner_2"].scored is True
+    assert movements["runner_3"].scored is True
+    assert result.runs_scored == (
+        "runner_3",
+        "runner_2",
+    )
+
+
+def test_forced_zero_rate_keeps_first_runner_at_second():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "single_runner_first_to_third": 0.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(5),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=("runner_1", None, None),
+        ),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    assert (
+        movement_by_runner(result)["runner_1"].end_base
+        is Base.SECOND
+    )
+
+
+def test_forced_one_rate_sends_first_runner_to_third():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "single_runner_first_to_third": 1.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(6),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=("runner_1", None, None),
+        ),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    assert (
+        movement_by_runner(result)["runner_1"].end_base
+        is Base.THIRD
+    )
+
+
+def test_collision_prevents_two_runners_on_third():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "single_runner_second_scores": 0.0,
+            "single_runner_first_to_third": 1.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(7),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=("runner_1", "runner_2", None),
+        ),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    movements = movement_by_runner(result)
+
+    assert movements["runner_2"].end_base is Base.THIRD
+    assert movements["runner_1"].end_base is Base.SECOND
+    validate_runner_movements(result.movements)
+
+
+def test_deep_fly_can_score_runner_from_third():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "flyout_runner_third_scores_deep": 1.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(8),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=(None, None, "runner_3"),
+        ),
+        batter_id="batter",
+        primary_outcome="out",
+        context=context(
+            batted_ball_type=BattedBallType.FLY_BALL,
+            depth=BattedBallDepth.DEEP,
+        ),
+    )
+
+    assert (
+        movement_by_runner(result)["runner_3"].scored
+        is True
+    )
+
+
+def test_runner_does_not_tag_with_two_outs():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "flyout_runner_third_scores_deep": 1.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(9),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            outs=2,
+            bases=(None, None, "runner_3"),
+        ),
+        batter_id="batter",
+        primary_outcome="out",
+        context=context(
+            batted_ball_type=BattedBallType.FLY_BALL,
+            depth=BattedBallDepth.DEEP,
+        ),
+    )
+
+    runner = movement_by_runner(result)["runner_3"]
+
+    assert runner.end_base is Base.THIRD
+    assert runner.scored is False
+
+
+def test_groundout_can_advance_runner_from_second():
+    model = BaselineRunnerAdvancementModel(
+        rates={
+            "groundout_runner_second_to_third": 1.0,
+        }
+    )
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(10),
+        model=model,
+    )
+
+    result = sampler.sample(
+        state=state(
+            bases=(None, "runner_2", None),
+        ),
+        batter_id="batter",
+        primary_outcome="out",
+        context=context(
+            batted_ball_type=BattedBallType.GROUND_BALL,
+            depth=BattedBallDepth.SHALLOW,
+        ),
+    )
+
+    assert (
+        movement_by_runner(result)["runner_2"].end_base
+        is Base.THIRD
+    )
+
+
+def test_fixed_seed_reproduces_advancement_sequence():
+    sampler_a = BaselineRunnerAdvancementSampler(
+        rng=random.Random(11),
+    )
+    sampler_b = BaselineRunnerAdvancementSampler(
+        rng=random.Random(11),
+    )
+    game_state = state(
+        bases=("runner_1", "runner_2", "runner_3"),
+    )
+    ball_context = context()
+
+    sequence_a = tuple(
+        sampler_a.sample(
+            state=game_state,
+            batter_id=f"batter_{index}",
+            primary_outcome="single",
+            context=ball_context,
+        )
+        for index in range(20)
+    )
+    sequence_b = tuple(
+        sampler_b.sample(
+            state=game_state,
+            batter_id=f"batter_{index}",
+            primary_outcome="single",
+            context=ball_context,
+        )
+        for index in range(20)
+    )
+
+    assert sequence_a == sequence_b
+
+
+def test_result_contains_model_provenance():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(12),
+    )
+
+    result = sampler.sample(
+        state=state(),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    assert (
+        result.metadata.model_version
+        == BASELINE_RUNNER_ADVANCEMENT_MODEL_VERSION
+    )
+    assert result.metadata.calibrated is False
+    assert result.metadata.production_enabled is False
+
+
+def test_legal_enumerator_exposes_single_destinations():
+    legal = enumerate_legal_runner_destinations(
+        state=state(
+            bases=("runner_1", "runner_2", None),
+        ),
+        batter_id="batter",
+        primary_outcome="single",
+        context=context(),
+    )
+
+    by_runner = {
+        item.runner_id: item
+        for item in legal
+    }
+
+    assert by_runner["runner_1"].destinations == (
+        Base.SECOND,
+        Base.THIRD,
+    )
+    assert by_runner["runner_2"].destinations == (
+        Base.THIRD,
+        Base.HOME,
+    )
+    assert by_runner["batter"].destinations == (
+        Base.FIRST,
+    )
+
+
+def test_unsupported_outcome_is_rejected():
+    sampler = BaselineRunnerAdvancementSampler(
+        rng=random.Random(13),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported advancement outcome",
+    ):
+        sampler.sample(
+            state=state(),
+            batter_id="batter",
+            primary_outcome="triple",
+            context=context(),
+        )
+
+
+def test_unknown_model_rate_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="unknown advancement rates",
+    ):
+        BaselineRunnerAdvancementModel(
+            rates={"unknown_rate": 0.5}
+        )


### PR DESCRIPTION
## Summary

Implements Layer 10D baseline runner advancement as a standalone, versioned simulation component built on the Layer 10B event contracts and Layer 10C batted-ball context.

### Added

- Legal runner-destination enumeration
- Versioned baseline advancement probabilities
- Context-aware advancement sampling
- Runner movement collision validation
- Fixed-seed reproducibility
- Explicit probability provenance
- Explicit model metadata and versioning

### Supported outcomes

- Singles
  - batter placement on first
  - runner on third scores
  - runner on second may score or stop at third
  - runner on first may advance to second or third
- Doubles
  - batter placement on second
  - runners on second and third score
  - runner on first may score or stop at third
- Outs
  - runner on third may score on eligible caught balls or groundouts
  - runner on second may advance to third
  - no advancement with two outs

## Architecture

```text
GameState
    +
primary outcome
    +
BattedBallContext
        ↓
enumerate_legal_runner_destinations()
        ↓
BaselineRunnerAdvancementModel
        ↓
BaselineRunnerAdvancementSampler
        ↓
RunnerAdvancementResult
    ├─ RunnerMovement records
    ├─ probabilities used
    └─ versioned provenance
```

## Scope

This layer does not:

- modify `simulate_half_inning()`;
- replace the existing transition functions;
- add double plays;
- add fielder's choices or force-play attribution;
- model runners thrown out advancing;
- add sacrifice attribution;
- add errors;
- implement third-out run timing;
- claim the initial probabilities are historically calibrated.

Those concerns remain reserved for Layer 10E and later integration layers.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- New Layer 10D tests passed
- Result: `46 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/events/advancement_version.py`
- `mlb_app/simulation/events/advancement_model.py`
- `mlb_app/simulation/events/legal_transitions.py`
- `mlb_app/simulation/events/advancement_sampler.py`
- `mlb_app/simulation/events/__init__.py`
- `tests/test_runner_advancement.py`

## Next layer

Layer 10E will add multi-out and scoring-rule realism, including double plays, force plays, fielder's choices, sacrifice attribution, errors, and run-timing rules.