### PR TITLE
Implement multi-out scoring rule realism

### DIFF
--- a/mlb_app/simulation/events/__init__.py
+++ b/mlb_app/simulation/events/__init__.py
@@ -37,6 +37,19 @@ from .legal_transitions import (
     enumerate_legal_runner_destinations,
     validate_runner_movements,
 )
+
+from .event_validation import validate_resolved_play_components
+from .multi_out_resolver import MultiOutPlayResolver
+from .play_resolution import build_play_event
+from .attribution import (
+    ErrorType,
+    PlayAttribution,
+    SacrificeType,
+)
+from .scoring_rules import (
+    counted_scorers,
+    third_out_is_force_or_batter_runner_out,
+)
 from .replay import replay_events
 from .resolver import DeterministicPlayResolver
 
@@ -64,6 +77,14 @@ __all__ = [
     "RunnerMovement",
     "SprayDirection",
     "enumerate_legal_runner_destinations",
+    "ErrorType",
+    "MultiOutPlayResolver",
+    "PlayAttribution",
+    "SacrificeType",
+    "build_play_event",
+    "counted_scorers",
+    "third_out_is_force_or_batter_runner_out",
+    "validate_resolved_play_components",
     "replay_events",
     "validate_baseline_advancement_rates",
     "validate_baseline_batted_ball_distributions",

--- a/mlb_app/simulation/events/attribution.py
+++ b/mlb_app/simulation/events/attribution.py
@@ -1,0 +1,56 @@
+"""Box-score attribution contracts for canonical play events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class SacrificeType(str, Enum):
+    FLY = "sacrifice_fly"
+    BUNT = "sacrifice_bunt"
+
+
+class ErrorType(str, Enum):
+    FIELDING = "fielding"
+    THROWING = "throwing"
+
+
+@dataclass(frozen=True)
+class PlayAttribution:
+    """Box-score attribution attached to a canonical play."""
+
+    rbi_credited_to: Optional[str] = None
+    rbi_count: int = 0
+    sacrifice_type: Optional[SacrificeType] = None
+    error_fielder_id: Optional[str] = None
+    error_type: Optional[ErrorType] = None
+
+    def __post_init__(self) -> None:
+        if self.rbi_count < 0:
+            raise ValueError("rbi_count cannot be negative")
+
+        if self.rbi_count and not self.rbi_credited_to:
+            raise ValueError(
+                "rbi_credited_to is required when "
+                "rbi_count is positive"
+            )
+
+        if (
+            self.error_type is not None
+            and not self.error_fielder_id
+        ):
+            raise ValueError(
+                "error_fielder_id is required when "
+                "error_type is set"
+            )
+
+        if (
+            self.error_fielder_id is not None
+            and self.error_type is None
+        ):
+            raise ValueError(
+                "error_type is required when "
+                "error_fielder_id is set"
+            )

--- a/mlb_app/simulation/events/contracts.py
+++ b/mlb_app/simulation/events/contracts.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Iterable, Optional, Tuple
 
+from .attribution import PlayAttribution
+
 
 class Base(IntEnum):
     """Canonical base identifiers used by runner movements."""
@@ -136,6 +138,7 @@ class PlayEvent:
     runner_movements: Tuple[RunnerMovement, ...] = field(default_factory=tuple)
     outs_recorded: Tuple[OutRecord, ...] = field(default_factory=tuple)
     runs_scored: Tuple[str, ...] = field(default_factory=tuple)
+    attribution: PlayAttribution = field(default_factory=PlayAttribution)
 
     def __post_init__(self) -> None:
         if self.sequence < 0:

--- a/mlb_app/simulation/events/event_validation.py
+++ b/mlb_app/simulation/events/event_validation.py
@@ -1,0 +1,90 @@
+"""Cross-contract validation for canonical resolved plays."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .contracts import (
+    Base,
+    GameState,
+    OutRecord,
+    RunnerMovement,
+)
+from .legal_transitions import validate_runner_movements
+
+
+def validate_resolved_play_components(
+    *,
+    state_before: GameState,
+    state_after: GameState,
+    runner_movements: Tuple[RunnerMovement, ...],
+    outs_recorded: Tuple[OutRecord, ...],
+    runs_scored: Tuple[str, ...],
+) -> None:
+    """Verify that every base, out, and run change is explained."""
+
+    validate_runner_movements(runner_movements)
+
+    expected_out_delta = state_after.outs - state_before.outs
+    if expected_out_delta != len(outs_recorded):
+        raise ValueError(
+            "outs delta must match explicit out records"
+        )
+
+    scoring_movements = tuple(
+        movement.runner_id
+        for movement in runner_movements
+        if movement.scored
+    )
+
+    if runs_scored != scoring_movements:
+        raise ValueError(
+            "runs_scored must match scoring movements"
+        )
+
+    out_runner_ids = {
+        record.runner_id
+        for record in outs_recorded
+    }
+
+    movement_out_runner_ids = {
+        movement.runner_id
+        for movement in runner_movements
+        if movement.is_out
+    }
+
+    if out_runner_ids != movement_out_runner_ids:
+        raise ValueError(
+            "out movements and out records must identify "
+            "the same runners"
+        )
+
+    expected_bases = [None, None, None]
+
+    for movement in runner_movements:
+        if movement.scored or movement.is_out:
+            continue
+
+        if movement.end_base is Base.HOME:
+            raise ValueError(
+                "non-scoring runner cannot survive at home"
+            )
+
+        if movement.end_base is None:
+            raise ValueError(
+                "surviving runner requires an ending base"
+            )
+
+        index = int(movement.end_base) - 1
+
+        if expected_bases[index] is not None:
+            raise ValueError(
+                "multiple surviving runners occupy one base"
+            )
+
+        expected_bases[index] = movement.runner_id
+
+    if tuple(expected_bases) != state_after.bases:
+        raise ValueError(
+            "state_after bases are not explained by movements"
+        )

--- a/mlb_app/simulation/events/multi_out_resolver.py
+++ b/mlb_app/simulation/events/multi_out_resolver.py
@@ -1,0 +1,486 @@
+"""Deterministic multi-out and scoring-rule play resolution."""
+
+from __future__ import annotations
+
+from .contracts import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+)
+from .play_resolution import build_play_event
+from .attribution import (
+    ErrorType,
+    PlayAttribution,
+    SacrificeType,
+)
+
+
+class MultiOutPlayResolver:
+    """Resolve explicitly selected scoring-rule play families."""
+
+    SUPPORTED_EVENTS = frozenset(
+        {
+            "ground_ball_double_play",
+            "ground_ball_fielders_choice",
+            "caught_fly",
+            "sacrifice_fly",
+            "sacrifice_bunt",
+            "reached_on_error",
+        }
+    )
+
+    def resolve(
+        self,
+        *,
+        state: GameState,
+        event_type: str,
+        batter_id: str,
+        sequence: int,
+        error_fielder_id: str | None = None,
+        error_type: ErrorType | None = None,
+    ) -> PlayEvent:
+        normalized = event_type.strip().lower()
+
+        if normalized not in self.SUPPORTED_EVENTS:
+            raise ValueError(
+                f"unsupported multi-out event_type: {event_type}"
+            )
+
+        if not batter_id:
+            raise ValueError("batter_id is required")
+
+        if state.outs >= 3:
+            raise ValueError(
+                "cannot resolve a play after three outs"
+            )
+
+        if normalized == "ground_ball_double_play":
+            return self._ground_ball_double_play(
+                state=state,
+                batter_id=batter_id,
+                sequence=sequence,
+            )
+
+        if normalized == "ground_ball_fielders_choice":
+            return self._fielders_choice(
+                state=state,
+                batter_id=batter_id,
+                sequence=sequence,
+            )
+
+        if normalized == "caught_fly":
+            return self._caught_fly(
+                state=state,
+                batter_id=batter_id,
+                sequence=sequence,
+                sacrifice=False,
+            )
+
+        if normalized == "sacrifice_fly":
+            return self._caught_fly(
+                state=state,
+                batter_id=batter_id,
+                sequence=sequence,
+                sacrifice=True,
+            )
+
+        if normalized == "sacrifice_bunt":
+            return self._sacrifice_bunt(
+                state=state,
+                batter_id=batter_id,
+                sequence=sequence,
+            )
+
+        return self._reached_on_error(
+            state=state,
+            batter_id=batter_id,
+            sequence=sequence,
+            error_fielder_id=error_fielder_id,
+            error_type=error_type,
+        )
+
+    @staticmethod
+    def _ground_ball_double_play(
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        if state.first is None:
+            raise ValueError(
+                "ground-ball double play requires a runner on first"
+            )
+
+        if state.outs >= 2:
+            raise ValueError(
+                "double play requires fewer than two outs"
+            )
+
+        movements = []
+
+        if state.third is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.third,
+                    start_base=Base.THIRD,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.second,
+                    start_base=Base.SECOND,
+                    end_base=Base.THIRD,
+                )
+            )
+
+        movements.extend(
+            [
+                RunnerMovement(
+                    runner_id=state.first,
+                    start_base=Base.FIRST,
+                    end_base=None,
+                    is_out=True,
+                    is_forced=True,
+                ),
+                RunnerMovement(
+                    runner_id=batter_id,
+                    start_base=Base.HOME,
+                    end_base=None,
+                    is_out=True,
+                ),
+            ]
+        )
+
+        outs = (
+            OutRecord(
+                runner_id=state.first,
+                out_number=state.outs + 1,
+                reason="force_out",
+            ),
+            OutRecord(
+                runner_id=batter_id,
+                out_number=state.outs + 2,
+                reason="batter_runner_out_before_first",
+            ),
+        )
+
+        return build_play_event(
+            sequence=sequence,
+            event_type="ground_ball_double_play",
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=tuple(movements),
+            outs_recorded=outs,
+        )
+
+    @staticmethod
+    def _fielders_choice(
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        if state.first is None:
+            raise ValueError(
+                "fielder's choice requires a runner on first"
+            )
+
+        movements = []
+
+        if state.third is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.third,
+                    start_base=Base.THIRD,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.second,
+                    start_base=Base.SECOND,
+                    end_base=Base.THIRD,
+                    is_forced=True,
+                )
+            )
+
+        movements.extend(
+            [
+                RunnerMovement(
+                    runner_id=state.first,
+                    start_base=Base.FIRST,
+                    end_base=None,
+                    is_out=True,
+                    is_forced=True,
+                ),
+                RunnerMovement(
+                    runner_id=batter_id,
+                    start_base=Base.HOME,
+                    end_base=Base.FIRST,
+                    is_forced=True,
+                ),
+            ]
+        )
+
+        outs = (
+            OutRecord(
+                runner_id=state.first,
+                out_number=state.outs + 1,
+                reason="force_out",
+            ),
+        )
+
+        return build_play_event(
+            sequence=sequence,
+            event_type="ground_ball_fielders_choice",
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=tuple(movements),
+            outs_recorded=outs,
+        )
+
+    @staticmethod
+    def _caught_fly(
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+        sacrifice: bool,
+    ) -> PlayEvent:
+        movements = []
+
+        if state.first is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.first,
+                    start_base=Base.FIRST,
+                    end_base=Base.FIRST,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.second,
+                    start_base=Base.SECOND,
+                    end_base=Base.SECOND,
+                )
+            )
+
+        scoring_runner = (
+            state.third
+            if sacrifice and state.outs < 2
+            else None
+        )
+
+        if state.third is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.third,
+                    start_base=Base.THIRD,
+                    end_base=(
+                        Base.HOME
+                        if scoring_runner
+                        else Base.THIRD
+                    ),
+                    scored=bool(scoring_runner),
+                )
+            )
+
+        movements.append(
+            RunnerMovement(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                end_base=None,
+                is_out=True,
+            )
+        )
+
+        outs = (
+            OutRecord(
+                runner_id=batter_id,
+                out_number=state.outs + 1,
+                reason="caught_fly",
+            ),
+        )
+
+        attribution = PlayAttribution(
+            rbi_credited_to=(
+                batter_id
+                if scoring_runner
+                else None
+            ),
+            rbi_count=1 if scoring_runner else 0,
+            sacrifice_type=(
+                SacrificeType.FLY
+                if sacrifice and scoring_runner
+                else None
+            ),
+        )
+
+        return build_play_event(
+            sequence=sequence,
+            event_type=(
+                "sacrifice_fly"
+                if sacrifice
+                else "caught_fly"
+            ),
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=tuple(movements),
+            outs_recorded=outs,
+            attribution=attribution,
+        )
+
+    @staticmethod
+    def _sacrifice_bunt(
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        if state.outs >= 2:
+            raise ValueError(
+                "sacrifice bunt requires fewer than two outs"
+            )
+
+        movements = []
+
+        if state.third is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.third,
+                    start_base=Base.THIRD,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.second,
+                    start_base=Base.SECOND,
+                    end_base=Base.THIRD,
+                    is_forced=True,
+                )
+            )
+
+        if state.first is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.first,
+                    start_base=Base.FIRST,
+                    end_base=Base.SECOND,
+                    is_forced=True,
+                )
+            )
+
+        movements.append(
+            RunnerMovement(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                end_base=None,
+                is_out=True,
+            )
+        )
+
+        outs = (
+            OutRecord(
+                runner_id=batter_id,
+                out_number=state.outs + 1,
+                reason="sacrifice_bunt",
+            ),
+        )
+
+        scored = state.third is not None
+
+        attribution = PlayAttribution(
+            rbi_credited_to=batter_id if scored else None,
+            rbi_count=1 if scored else 0,
+            sacrifice_type=SacrificeType.BUNT,
+        )
+
+        return build_play_event(
+            sequence=sequence,
+            event_type="sacrifice_bunt",
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=tuple(movements),
+            outs_recorded=outs,
+            attribution=attribution,
+        )
+
+    @staticmethod
+    def _reached_on_error(
+        *,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+        error_fielder_id: str | None,
+        error_type: ErrorType | None,
+    ) -> PlayEvent:
+        if not error_fielder_id or error_type is None:
+            raise ValueError(
+                "reached_on_error requires error attribution"
+            )
+
+        movements = []
+
+        if state.third is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.third,
+                    start_base=Base.THIRD,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+        if state.second is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.second,
+                    start_base=Base.SECOND,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+        if state.first is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=state.first,
+                    start_base=Base.FIRST,
+                    end_base=Base.SECOND,
+                )
+            )
+
+        movements.append(
+            RunnerMovement(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                end_base=Base.FIRST,
+            )
+        )
+
+        return build_play_event(
+            sequence=sequence,
+            event_type="reached_on_error",
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=tuple(movements),
+            attribution=PlayAttribution(
+                error_fielder_id=error_fielder_id,
+                error_type=error_type,
+            ),
+        )

--- a/mlb_app/simulation/events/play_resolution.py
+++ b/mlb_app/simulation/events/play_resolution.py
@@ -1,0 +1,124 @@
+"""Construct canonical state transitions from explicit play records."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Tuple
+
+from .contracts import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+)
+from .event_validation import (
+    validate_resolved_play_components,
+)
+from .attribution import PlayAttribution
+from .scoring_rules import counted_scorers
+
+
+def build_play_event(
+    *,
+    sequence: int,
+    event_type: str,
+    batter_id: str,
+    state_before: GameState,
+    runner_movements: Tuple[RunnerMovement, ...],
+    outs_recorded: Tuple[OutRecord, ...] = (),
+    attribution: PlayAttribution = PlayAttribution(),
+) -> PlayEvent:
+    """Build and validate a canonical play from explicit records."""
+
+    if state_before.outs >= 3:
+        raise ValueError(
+            "cannot resolve a play after three outs"
+        )
+
+    runs_scored = counted_scorers(
+        outs_before=state_before.outs,
+        outs_recorded=outs_recorded,
+        batter_id=batter_id,
+        runner_movements=runner_movements,
+    )
+
+    counted_movements = tuple(
+        movement
+        for movement in runner_movements
+        if (
+            not movement.scored
+            or movement.runner_id in runs_scored
+        )
+    )
+
+    bases = [None, None, None]
+
+    for movement in counted_movements:
+        if movement.scored or movement.is_out:
+            continue
+
+        if movement.end_base is None:
+            raise ValueError(
+                "surviving movement requires an ending base"
+            )
+
+        if movement.end_base is Base.HOME:
+            raise ValueError(
+                "non-scoring movement cannot end at home"
+            )
+
+        index = int(movement.end_base) - 1
+
+        if bases[index] is not None:
+            raise ValueError(
+                "multiple runners cannot occupy one base"
+            )
+
+        bases[index] = movement.runner_id
+
+    runs = len(runs_scored)
+
+    if state_before.half == "top":
+        away_score = state_before.away_score + runs
+        home_score = state_before.home_score
+    else:
+        away_score = state_before.away_score
+        home_score = state_before.home_score + runs
+
+    state_after = replace(
+        state_before,
+        outs=min(
+            3,
+            state_before.outs + len(outs_recorded),
+        ),
+        bases=tuple(bases),
+        away_score=away_score,
+        home_score=home_score,
+        batting_order_index=(
+            state_before.batting_order_index + 1
+        ) % 9,
+        plate_appearance_number=(
+            state_before.plate_appearance_number + 1
+        ),
+    )
+
+    validate_resolved_play_components(
+        state_before=state_before,
+        state_after=state_after,
+        runner_movements=counted_movements,
+        outs_recorded=outs_recorded,
+        runs_scored=runs_scored,
+    )
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type=event_type,
+        batter_id=batter_id,
+        state_before=state_before,
+        state_after=state_after,
+        runner_movements=counted_movements,
+        outs_recorded=outs_recorded,
+        runs_scored=runs_scored,
+        attribution=attribution,
+    )

--- a/mlb_app/simulation/events/scoring_rules.py
+++ b/mlb_app/simulation/events/scoring_rules.py
@@ -1,0 +1,80 @@
+"""Deterministic scoring-rule contracts for canonical plays."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .attribution import PlayAttribution
+from .contracts import OutRecord, RunnerMovement
+
+
+def third_out_is_force_or_batter_runner_out(
+    *,
+    outs_before: int,
+    outs_recorded: Tuple[OutRecord, ...],
+    batter_id: str,
+    runner_movements: Tuple[RunnerMovement, ...],
+) -> bool:
+    """Return whether timing rules cancel all runs on the play."""
+
+    if outs_before + len(outs_recorded) < 3:
+        return False
+
+    third_out_number = 3
+
+    third_out = next(
+        (
+            record
+            for record in outs_recorded
+            if record.out_number == third_out_number
+        ),
+        None,
+    )
+
+    if third_out is None:
+        return False
+
+    if third_out.reason in {
+        "force_out",
+        "batter_runner_out_before_first",
+    }:
+        return True
+
+    batter_movement = next(
+        (
+            movement
+            for movement in runner_movements
+            if movement.runner_id == batter_id
+        ),
+        None,
+    )
+
+    return bool(
+        batter_movement
+        and batter_movement.is_out
+        and batter_movement.start_base.value == 0
+    )
+
+
+def counted_scorers(
+    *,
+    outs_before: int,
+    outs_recorded: Tuple[OutRecord, ...],
+    batter_id: str,
+    runner_movements: Tuple[RunnerMovement, ...],
+) -> Tuple[str, ...]:
+    """Apply force and batter-runner third-out run rules."""
+
+    if third_out_is_force_or_batter_runner_out(
+        outs_before=outs_before,
+        outs_recorded=outs_recorded,
+        batter_id=batter_id,
+        runner_movements=runner_movements,
+    ):
+        return ()
+
+    return tuple(
+        movement.runner_id
+        for movement in runner_movements
+        if movement.scored
+    )

--- a/tests/test_multi_out_scoring_rules.py
+++ b/tests/test_multi_out_scoring_rules.py
@@ -1,0 +1,205 @@
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    ErrorType,
+    GameState,
+    MultiOutPlayResolver,
+    SacrificeType,
+)
+
+
+def state(*, outs=0, bases=(None, None, None)):
+    return GameState(
+        outs=outs,
+        bases=bases,
+    )
+
+
+def movements_by_runner(event):
+    return {
+        movement.runner_id: movement
+        for movement in event.runner_movements
+    }
+
+
+def test_ground_ball_double_play_records_two_outs():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            outs=0,
+            bases=("runner_1", None, None),
+        ),
+        event_type="ground_ball_double_play",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.outs == 2
+    assert len(event.outs_recorded) == 2
+    assert event.state_after.bases == (
+        None,
+        None,
+        None,
+    )
+
+
+def test_double_play_with_one_out_ends_inning():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            outs=1,
+            bases=("runner_1", None, None),
+        ),
+        event_type="ground_ball_double_play",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.outs == 3
+
+
+def test_force_third_out_cancels_run():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            outs=1,
+            bases=("runner_1", None, "runner_3"),
+        ),
+        event_type="ground_ball_double_play",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.runs_scored == ()
+    assert event.state_after.away_score == 0
+
+
+def test_fielders_choice_retires_forced_runner():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            bases=("runner_1", None, None),
+        ),
+        event_type="ground_ball_fielders_choice",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    movements = movements_by_runner(event)
+
+    assert movements["runner_1"].is_out is True
+    assert movements["batter"].end_base is Base.FIRST
+    assert event.state_after.outs == 1
+
+
+def test_sacrifice_fly_scores_runner_and_credits_rbi():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            outs=1,
+            bases=(None, None, "runner_3"),
+        ),
+        event_type="sacrifice_fly",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.runs_scored == ("runner_3",)
+    assert event.attribution.rbi_count == 1
+    assert (
+        event.attribution.sacrifice_type
+        is SacrificeType.FLY
+    )
+
+
+def test_sacrifice_fly_does_not_score_with_two_outs():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            outs=2,
+            bases=(None, None, "runner_3"),
+        ),
+        event_type="sacrifice_fly",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.runs_scored == ()
+    assert event.attribution.rbi_count == 0
+    assert event.attribution.sacrifice_type is None
+
+
+def test_sacrifice_bunt_advances_runners():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            bases=("runner_1", "runner_2", None),
+        ),
+        event_type="sacrifice_bunt",
+        batter_id="batter",
+        sequence=0,
+    )
+
+    assert event.state_after.bases == (
+        None,
+        "runner_1",
+        "runner_2",
+    )
+    assert (
+        event.attribution.sacrifice_type
+        is SacrificeType.BUNT
+    )
+
+
+def test_reached_on_error_requires_error_attribution():
+    with pytest.raises(
+        ValueError,
+        match="requires error attribution",
+    ):
+        MultiOutPlayResolver().resolve(
+            state=state(),
+            event_type="reached_on_error",
+            batter_id="batter",
+            sequence=0,
+        )
+
+
+def test_reached_on_error_records_error():
+    event = MultiOutPlayResolver().resolve(
+        state=state(
+            bases=("runner_1", None, None),
+        ),
+        event_type="reached_on_error",
+        batter_id="batter",
+        sequence=0,
+        error_fielder_id="shortstop",
+        error_type=ErrorType.FIELDING,
+    )
+
+    assert event.state_after.bases == (
+        "batter",
+        "runner_1",
+        None,
+    )
+    assert event.attribution.error_fielder_id == "shortstop"
+    assert event.attribution.error_type is ErrorType.FIELDING
+
+
+def test_double_play_requires_runner_on_first():
+    with pytest.raises(
+        ValueError,
+        match="requires a runner on first",
+    ):
+        MultiOutPlayResolver().resolve(
+            state=state(),
+            event_type="ground_ball_double_play",
+            batter_id="batter",
+            sequence=0,
+        )
+
+
+def test_unsupported_multi_out_event_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="unsupported multi-out event_type",
+    ):
+        MultiOutPlayResolver().resolve(
+            state=state(),
+            event_type="triple_play",
+            batter_id="batter",
+            sequence=0,
+        )


### PR DESCRIPTION
## Summary

Implements Layer 10E multi-out and scoring-rule realism as a deterministic canonical play-resolution layer built on the event contracts, batted-ball context, and baseline runner advancement layers.

### Added

- Dependency-free attribution contracts
- Explicit RBI attribution
- Sacrifice-fly and sacrifice-bunt attribution
- Error attribution
- Deterministic ground-ball double-play resolution
- Deterministic fielder's-choice resolution
- Caught-fly and sacrifice-fly resolution
- Sacrifice-bunt resolution
- Reached-on-error resolution
- Explicit multiple `OutRecord` entries
- Force/batter-runner third-out run cancellation
- Cross-contract validation for bases, outs, movements, and runs

## Architecture

```text
GameState
    +
explicit play family
    +
canonical runner movements and outs
        ↓
scoring and timing rules
        ↓
build_play_event()
        ↓
validated PlayEvent
    ├─ state_before
    ├─ state_after
    ├─ RunnerMovement[]
    ├─ OutRecord[]
    ├─ runs_scored
    └─ PlayAttribution
```

## Supported play families

- `ground_ball_double_play`
- `ground_ball_fielders_choice`
- `caught_fly`
- `sacrifice_fly`
- `sacrifice_bunt`
- `reached_on_error`

## Core invariants

- outs delta equals explicit out-record count;
- score delta equals counted scoring movements;
- every removed runner is explained by an out movement and out record;
- surviving runners cannot share a base;
- state-after base occupancy is derived from movements;
- runs do not count when the third out is a force out or batter-runner out before first.

## Scope

This layer does not:

- modify `simulate_half_inning()`;
- replace the legacy transition functions;
- choose probabilistically whether a double play or sacrifice occurs;
- model throws, assists, putouts, or fielding positions in detail;
- implement earned-run reconstruction;
- wire canonical events into the production game simulation path.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- Layer 10D tests passed
- New Layer 10E tests passed
- Result: `57 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/events/attribution.py`
- `mlb_app/simulation/events/scoring_rules.py`
- `mlb_app/simulation/events/event_validation.py`
- `mlb_app/simulation/events/play_resolution.py`
- `mlb_app/simulation/events/multi_out_resolver.py`
- `mlb_app/simulation/events/contracts.py`
- `mlb_app/simulation/events/__init__.py`
- `tests/test_multi_out_scoring_rules.py`

## Next layer

Layer 10F will build team, batter, and pitcher box-score reducers from canonical events and validate reconstruction through ledger replay.