### PR TITLE
Implement box score reducer and replay validation

### DIFF
--- a/mlb_app/simulation/box_score/__init__.py
+++ b/mlb_app/simulation/box_score/__init__.py
@@ -1,0 +1,33 @@
+"""Canonical box-score reduction and DFS scoring."""
+
+from .contracts import (
+    BatterBoxScore,
+    PitcherBoxScore,
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from .dfs_scoring import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+    score_batter,
+    score_pitcher,
+)
+from .reducer import reduce_box_score
+from .validation import (
+    BoxScoreValidation,
+    validate_box_score_reconstruction,
+)
+
+__all__ = [
+    "BatterBoxScore",
+    "BatterDfsScoringRules",
+    "BoxScoreValidation",
+    "PitcherBoxScore",
+    "PitcherDfsScoringRules",
+    "ReducedBoxScore",
+    "TeamBoxScore",
+    "reduce_box_score",
+    "score_batter",
+    "score_pitcher",
+    "validate_box_score_reconstruction",
+]

--- a/mlb_app/simulation/box_score/contracts.py
+++ b/mlb_app/simulation/box_score/contracts.py
@@ -1,0 +1,132 @@
+"""Immutable projected box-score contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+VALID_TEAM_SIDES = frozenset({"away", "home"})
+
+
+def _validate_nonnegative(instance) -> None:
+    for name, value in vars(instance).items():
+        if isinstance(value, int) and value < 0:
+            raise ValueError(f"{name} cannot be negative")
+
+
+@dataclass(frozen=True)
+class BatterBoxScore:
+    player_id: str
+    team_side: str
+    plate_appearances: int = 0
+    at_bats: int = 0
+    singles: int = 0
+    doubles: int = 0
+    triples: int = 0
+    home_runs: int = 0
+    walks: int = 0
+    hit_by_pitch: int = 0
+    strikeouts: int = 0
+    runs: int = 0
+    rbi: int = 0
+    reached_on_error: int = 0
+    sacrifice_flies: int = 0
+    sacrifice_bunts: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.player_id:
+            raise ValueError("player_id is required")
+        if self.team_side not in VALID_TEAM_SIDES:
+            raise ValueError("team_side must be 'away' or 'home'")
+        _validate_nonnegative(self)
+
+    @property
+    def hits(self) -> int:
+        return (
+            self.singles
+            + self.doubles
+            + self.triples
+            + self.home_runs
+        )
+
+
+@dataclass(frozen=True)
+class PitcherBoxScore:
+    player_id: str
+    team_side: str
+    batters_faced: int = 0
+    outs_recorded: int = 0
+    hits_allowed: int = 0
+    home_runs_allowed: int = 0
+    walks: int = 0
+    hit_batters: int = 0
+    strikeouts: int = 0
+    runs_allowed: int = 0
+    earned_runs: Optional[int] = None
+    earned_run_status: str = "not_reconstructed"
+
+    def __post_init__(self) -> None:
+        if not self.player_id:
+            raise ValueError("player_id is required")
+        if self.team_side not in VALID_TEAM_SIDES:
+            raise ValueError("team_side must be 'away' or 'home'")
+        if self.earned_run_status not in {
+            "not_reconstructed",
+            "reconstructed",
+        }:
+            raise ValueError("invalid earned_run_status")
+        if (
+            self.earned_run_status == "not_reconstructed"
+            and self.earned_runs is not None
+        ):
+            raise ValueError(
+                "earned_runs must be None when not reconstructed"
+            )
+        _validate_nonnegative(self)
+
+    @property
+    def innings_pitched(self) -> str:
+        return (
+            f"{self.outs_recorded // 3}."
+            f"{self.outs_recorded % 3}"
+        )
+
+
+@dataclass(frozen=True)
+class TeamBoxScore:
+    team_side: str
+    runs: int = 0
+    hits: int = 0
+    errors: int = 0
+    left_on_base: int = 0
+
+    def __post_init__(self) -> None:
+        if self.team_side not in VALID_TEAM_SIDES:
+            raise ValueError("team_side must be 'away' or 'home'")
+        _validate_nonnegative(self)
+
+
+@dataclass(frozen=True)
+class ReducedBoxScore:
+    away: TeamBoxScore
+    home: TeamBoxScore
+    batters: Tuple[BatterBoxScore, ...] = field(
+        default_factory=tuple
+    )
+    pitchers: Tuple[PitcherBoxScore, ...] = field(
+        default_factory=tuple
+    )
+    pitcher_attribution_complete: bool = False
+
+    def batter(self, player_id: str) -> BatterBoxScore:
+        for line in self.batters:
+            if line.player_id == player_id:
+                return line
+        raise KeyError(player_id)
+
+    def pitcher(self, player_id: str) -> PitcherBoxScore:
+        for line in self.pitchers:
+            if line.player_id == player_id:
+                return line
+        raise KeyError(player_id)

--- a/mlb_app/simulation/box_score/dfs_scoring.py
+++ b/mlb_app/simulation/box_score/dfs_scoring.py
@@ -1,0 +1,73 @@
+"""Configurable DFS scoring from reduced box-score lines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .contracts import BatterBoxScore, PitcherBoxScore
+
+
+@dataclass(frozen=True)
+class BatterDfsScoringRules:
+    single: float = 0.0
+    double: float = 0.0
+    triple: float = 0.0
+    home_run: float = 0.0
+    walk: float = 0.0
+    hit_by_pitch: float = 0.0
+    run: float = 0.0
+    rbi: float = 0.0
+
+
+@dataclass(frozen=True)
+class PitcherDfsScoringRules:
+    out_recorded: float = 0.0
+    strikeout: float = 0.0
+    hit_allowed: float = 0.0
+    walk: float = 0.0
+    hit_batter: float = 0.0
+    run_allowed: float = 0.0
+    earned_run: float = 0.0
+
+
+def score_batter(
+    line: BatterBoxScore,
+    rules: BatterDfsScoringRules,
+) -> float:
+    return (
+        line.singles * rules.single
+        + line.doubles * rules.double
+        + line.triples * rules.triple
+        + line.home_runs * rules.home_run
+        + line.walks * rules.walk
+        + line.hit_by_pitch * rules.hit_by_pitch
+        + line.runs * rules.run
+        + line.rbi * rules.rbi
+    )
+
+
+def score_pitcher(
+    line: PitcherBoxScore,
+    rules: PitcherDfsScoringRules,
+) -> float:
+    if (
+        rules.earned_run != 0.0
+        and line.earned_runs is None
+    ):
+        raise ValueError(
+            "earned-run scoring requires reconstructed "
+            "earned runs"
+        )
+
+    earned_runs = line.earned_runs or 0
+
+    return (
+        line.outs_recorded * rules.out_recorded
+        + line.strikeouts * rules.strikeout
+        + line.hits_allowed * rules.hit_allowed
+        + line.walks * rules.walk
+        + line.hit_batters * rules.hit_batter
+        + line.runs_allowed * rules.run_allowed
+        + earned_runs * rules.earned_run
+    )

--- a/mlb_app/simulation/box_score/reducer.py
+++ b/mlb_app/simulation/box_score/reducer.py
@@ -1,0 +1,243 @@
+"""Reduce canonical play events into projected box scores."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import fields
+from typing import Dict, Iterable, Tuple
+
+from mlb_app.simulation.events import (
+    PlayEvent,
+    PlayLedger,
+    SacrificeType,
+)
+
+from .contracts import (
+    BatterBoxScore,
+    PitcherBoxScore,
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+
+
+HIT_EVENTS = {
+    "single": "singles",
+    "double": "doubles",
+    "triple": "triples",
+    "hr": "home_runs",
+}
+
+NON_AT_BAT_EVENTS = frozenset(
+    {
+        "bb",
+        "hbp",
+        "sacrifice_fly",
+        "sacrifice_bunt",
+    }
+)
+
+
+def _empty_batter(player_id: str, team_side: str) -> dict:
+    return {
+        field.name: field.default
+        for field in fields(BatterBoxScore)
+        if field.name not in {"player_id", "team_side"}
+    } | {
+        "player_id": player_id,
+        "team_side": team_side,
+    }
+
+
+def _empty_pitcher(player_id: str, team_side: str) -> dict:
+    return {
+        field.name: field.default
+        for field in fields(PitcherBoxScore)
+        if field.name not in {"player_id", "team_side"}
+    } | {
+        "player_id": player_id,
+        "team_side": team_side,
+    }
+
+
+def _batting_side(event: PlayEvent) -> str:
+    return "away" if event.state_before.half == "top" else "home"
+
+
+def _fielding_side(event: PlayEvent) -> str:
+    return "home" if _batting_side(event) == "away" else "away"
+
+
+def reduce_box_score(
+    *,
+    initial_state,
+    events: Iterable[PlayEvent],
+) -> ReducedBoxScore:
+    ledger = PlayLedger.from_events(
+        initial_state,
+        tuple(events),
+    )
+
+    batter_rows: Dict[Tuple[str, str], dict] = {}
+    pitcher_rows: Dict[Tuple[str, str], dict] = {}
+
+    teams = {
+        "away": {
+            "team_side": "away",
+            "runs": 0,
+            "hits": 0,
+            "errors": 0,
+            "left_on_base": 0,
+        },
+        "home": {
+            "team_side": "home",
+            "runs": 0,
+            "hits": 0,
+            "errors": 0,
+            "left_on_base": 0,
+        },
+    }
+
+    pitcher_attribution_complete = True
+
+    for event in ledger.events:
+        batting_side = _batting_side(event)
+        fielding_side = _fielding_side(event)
+        outcome = event.event_type.strip().lower()
+
+        batter_key = (event.batter_id, batting_side)
+        batter = batter_rows.setdefault(
+            batter_key,
+            _empty_batter(
+                event.batter_id,
+                batting_side,
+            ),
+        )
+
+        batter["plate_appearances"] += 1
+
+        if outcome not in NON_AT_BAT_EVENTS:
+            batter["at_bats"] += 1
+
+        hit_field = HIT_EVENTS.get(outcome)
+        if hit_field is not None:
+            batter[hit_field] += 1
+            teams[batting_side]["hits"] += 1
+
+        if outcome == "bb":
+            batter["walks"] += 1
+        elif outcome == "hbp":
+            batter["hit_by_pitch"] += 1
+        elif outcome in {"k", "strikeout"}:
+            batter["strikeouts"] += 1
+        elif outcome == "reached_on_error":
+            batter["reached_on_error"] += 1
+
+        if (
+            event.attribution.sacrifice_type
+            is SacrificeType.FLY
+        ):
+            batter["sacrifice_flies"] += 1
+        elif (
+            event.attribution.sacrifice_type
+            is SacrificeType.BUNT
+        ):
+            batter["sacrifice_bunts"] += 1
+
+        if event.attribution.rbi_count:
+            rbi_player_id = (
+                event.attribution.rbi_credited_to
+            )
+            rbi_key = (rbi_player_id, batting_side)
+            rbi_row = batter_rows.setdefault(
+                rbi_key,
+                _empty_batter(
+                    rbi_player_id,
+                    batting_side,
+                ),
+            )
+            rbi_row["rbi"] += event.attribution.rbi_count
+
+        for scorer_id in event.runs_scored:
+            scorer_key = (scorer_id, batting_side)
+            scorer = batter_rows.setdefault(
+                scorer_key,
+                _empty_batter(
+                    scorer_id,
+                    batting_side,
+                ),
+            )
+            scorer["runs"] += 1
+            teams[batting_side]["runs"] += 1
+
+        if event.attribution.error_fielder_id:
+            teams[fielding_side]["errors"] += 1
+
+        if event.pitcher_id is None:
+            pitcher_attribution_complete = False
+        else:
+            pitcher_key = (
+                event.pitcher_id,
+                fielding_side,
+            )
+            pitcher = pitcher_rows.setdefault(
+                pitcher_key,
+                _empty_pitcher(
+                    event.pitcher_id,
+                    fielding_side,
+                ),
+            )
+
+            pitcher["batters_faced"] += 1
+            pitcher["outs_recorded"] += len(
+                event.outs_recorded
+            )
+            pitcher["runs_allowed"] += len(
+                event.runs_scored
+            )
+
+            if hit_field is not None:
+                pitcher["hits_allowed"] += 1
+            if outcome == "hr":
+                pitcher["home_runs_allowed"] += 1
+            elif outcome == "bb":
+                pitcher["walks"] += 1
+            elif outcome == "hbp":
+                pitcher["hit_batters"] += 1
+            elif outcome in {"k", "strikeout"}:
+                pitcher["strikeouts"] += 1
+
+        if event.state_after.outs == 3:
+            teams[batting_side]["left_on_base"] += sum(
+                runner is not None
+                for runner in event.state_after.bases
+            )
+
+    if ledger.events and ledger.current_state.outs < 3:
+        final_side = (
+            "away"
+            if ledger.current_state.half == "top"
+            else "home"
+        )
+        teams[final_side]["left_on_base"] += sum(
+            runner is not None
+            for runner in ledger.current_state.bases
+        )
+
+    batters = tuple(
+        BatterBoxScore(**row)
+        for _, row in sorted(batter_rows.items())
+    )
+    pitchers = tuple(
+        PitcherBoxScore(**row)
+        for _, row in sorted(pitcher_rows.items())
+    )
+
+    return ReducedBoxScore(
+        away=TeamBoxScore(**teams["away"]),
+        home=TeamBoxScore(**teams["home"]),
+        batters=batters,
+        pitchers=pitchers,
+        pitcher_attribution_complete=(
+            pitcher_attribution_complete
+        ),
+    )

--- a/mlb_app/simulation/box_score/validation.py
+++ b/mlb_app/simulation/box_score/validation.py
@@ -1,0 +1,98 @@
+"""Replay and box-score reconstruction validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from mlb_app.simulation.events import (
+    GameState,
+    PlayEvent,
+    replay_events,
+)
+
+from .contracts import ReducedBoxScore
+from .reducer import reduce_box_score
+
+
+@dataclass(frozen=True)
+class BoxScoreValidation:
+    replay_matches_final_state: bool
+    scoreboard_matches_team_runs: bool
+    batter_runs_match_team_runs: bool
+    deterministic_reduction: bool
+    pitcher_attribution_complete: bool
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.replay_matches_final_state
+            and self.scoreboard_matches_team_runs
+            and self.batter_runs_match_team_runs
+            and self.deterministic_reduction
+        )
+
+
+def validate_box_score_reconstruction(
+    *,
+    initial_state: GameState,
+    events: Iterable[PlayEvent],
+    box_score: ReducedBoxScore,
+) -> BoxScoreValidation:
+    event_tuple = tuple(events)
+
+    replayed = replay_events(
+        initial_state,
+        event_tuple,
+    )
+
+    expected_final = (
+        event_tuple[-1].state_after
+        if event_tuple
+        else initial_state
+    )
+
+    away_delta = (
+        replayed.away_score
+        - initial_state.away_score
+    )
+    home_delta = (
+        replayed.home_score
+        - initial_state.home_score
+    )
+
+    batter_away_runs = sum(
+        line.runs
+        for line in box_score.batters
+        if line.team_side == "away"
+    )
+    batter_home_runs = sum(
+        line.runs
+        for line in box_score.batters
+        if line.team_side == "home"
+    )
+
+    second_reduction = reduce_box_score(
+        initial_state=initial_state,
+        events=event_tuple,
+    )
+
+    return BoxScoreValidation(
+        replay_matches_final_state=(
+            replayed == expected_final
+        ),
+        scoreboard_matches_team_runs=(
+            box_score.away.runs == away_delta
+            and box_score.home.runs == home_delta
+        ),
+        batter_runs_match_team_runs=(
+            batter_away_runs == box_score.away.runs
+            and batter_home_runs == box_score.home.runs
+        ),
+        deterministic_reduction=(
+            second_reduction == box_score
+        ),
+        pitcher_attribution_complete=(
+            box_score.pitcher_attribution_complete
+        ),
+    )

--- a/mlb_app/simulation/events/contracts.py
+++ b/mlb_app/simulation/events/contracts.py
@@ -139,6 +139,7 @@ class PlayEvent:
     outs_recorded: Tuple[OutRecord, ...] = field(default_factory=tuple)
     runs_scored: Tuple[str, ...] = field(default_factory=tuple)
     attribution: PlayAttribution = field(default_factory=PlayAttribution)
+    pitcher_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.sequence < 0:
@@ -147,6 +148,10 @@ class PlayEvent:
             raise ValueError("event_type is required")
         if not self.batter_id:
             raise ValueError("batter_id is required")
+        if self.pitcher_id == "":
+            raise ValueError(
+                "pitcher_id cannot be an empty string"
+            )
 
         if self.state_after.plate_appearance_number != (
             self.state_before.plate_appearance_number + 1

--- a/tests/test_box_score_reducer.py
+++ b/tests/test_box_score_reducer.py
@@ -1,0 +1,248 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.box_score import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+    reduce_box_score,
+    score_batter,
+    score_pitcher,
+    validate_box_score_reconstruction,
+)
+from mlb_app.simulation.events import (
+    DeterministicPlayResolver,
+    GameState,
+    MultiOutPlayResolver,
+)
+
+
+def with_pitcher(event, pitcher_id="pitcher"):
+    return replace(event, pitcher_id=pitcher_id)
+
+
+def test_home_run_reduces_batter_team_and_pitcher_lines():
+    initial = GameState(
+        bases=("runner_1", None, None),
+    )
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="hr",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    batter = box.batter("batter")
+    pitcher = box.pitcher("pitcher")
+
+    assert batter.plate_appearances == 1
+    assert batter.at_bats == 1
+    assert batter.home_runs == 1
+    assert batter.runs == 1
+    assert box.batter("runner_1").runs == 1
+    assert box.away.runs == 2
+    assert box.away.hits == 1
+    assert pitcher.batters_faced == 1
+    assert pitcher.hits_allowed == 1
+    assert pitcher.home_runs_allowed == 1
+    assert pitcher.runs_allowed == 2
+    assert pitcher.earned_runs is None
+    assert pitcher.innings_pitched == "0.0"
+
+
+def test_walk_is_not_at_bat():
+    initial = GameState()
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="bb",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    batter = box.batter("batter")
+
+    assert batter.plate_appearances == 1
+    assert batter.at_bats == 0
+    assert batter.walks == 1
+    assert box.pitcher("pitcher").walks == 1
+
+
+def test_sacrifice_fly_reduces_rbi_and_sacrifice():
+    initial = GameState(
+        outs=1,
+        bases=(None, None, "runner_3"),
+    )
+
+    event = with_pitcher(
+        MultiOutPlayResolver().resolve(
+            state=initial,
+            event_type="sacrifice_fly",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    batter = box.batter("batter")
+
+    assert batter.plate_appearances == 1
+    assert batter.at_bats == 0
+    assert batter.sacrifice_flies == 1
+    assert batter.rbi == 1
+    assert box.batter("runner_3").runs == 1
+    assert box.pitcher("pitcher").outs_recorded == 1
+
+
+def test_reached_on_error_charges_defensive_error():
+    initial = GameState()
+
+    event = MultiOutPlayResolver().resolve(
+        state=initial,
+        event_type="reached_on_error",
+        batter_id="batter",
+        sequence=0,
+        error_fielder_id="shortstop",
+        error_type=__import__(
+            "mlb_app.simulation.events",
+            fromlist=["ErrorType"],
+        ).ErrorType.FIELDING,
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    assert box.batter("batter").reached_on_error == 1
+    assert box.home.errors == 1
+    assert box.pitcher_attribution_complete is False
+
+
+def test_dfs_scoring_uses_reduced_lines():
+    initial = GameState()
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="hr",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    batter_points = score_batter(
+        box.batter("batter"),
+        BatterDfsScoringRules(
+            home_run=10.0,
+            run=2.0,
+        ),
+    )
+
+    assert batter_points == 12.0
+
+
+def test_pitcher_earned_run_scoring_requires_reconstruction():
+    initial = GameState()
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="hr",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="earned-run scoring requires",
+    ):
+        score_pitcher(
+            box.pitcher("pitcher"),
+            PitcherDfsScoringRules(
+                earned_run=-2.0,
+            ),
+        )
+
+
+def test_replay_and_reduction_validation_pass():
+    initial = GameState()
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="hr",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    events = (event,)
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=events,
+    )
+
+    validation = validate_box_score_reconstruction(
+        initial_state=initial,
+        events=events,
+        box_score=box,
+    )
+
+    assert validation.passed is True
+    assert validation.pitcher_attribution_complete is True
+
+
+def test_reducer_is_deterministic():
+    initial = GameState()
+
+    event = with_pitcher(
+        DeterministicPlayResolver().resolve(
+            state=initial,
+            event_type="hbp",
+            batter_id="batter",
+            sequence=0,
+        )
+    )
+
+    first = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+    second = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    assert first == second


### PR DESCRIPTION
## Summary

Implements Layer 10F box-score reduction and replay validation from canonical event-ledger data.

### Added

- Backward-compatible optional `pitcher_id` on `PlayEvent`
- Immutable batter, pitcher, team, and complete box-score contracts
- Canonical event-to-box-score reduction
- Batter counting statistics for hits, walks, HBP, strikeouts, runs, RBI, reached-on-error, and sacrifices
- Pitcher counting statistics for batters faced, outs, hits, home runs, walks, hit batters, strikeouts, and runs allowed
- Team runs, hits, errors, and left-on-base reduction
- Configurable batter and pitcher DFS scoring rules
- Replay and reconstruction validation
- Explicit pitcher-attribution completeness status
- Explicitly unreconstructed earned-run status

## Architecture

```text
PlayLedger
    ↓
reduce_box_score()
    ├─ TeamBoxScore
    ├─ BatterBoxScore[]
    └─ PitcherBoxScore[]
          ↓
configurable DFS scoring
          ↓
replay/reconstruction validation
```

## Important contract decision

Canonical events previously identified the batter but not the responsible pitcher. This change adds:

```python
pitcher_id: Optional[str] = None
```

The field is backward compatible. Reducers expose `pitcher_attribution_complete=False` when any event lacks pitcher attribution rather than inventing a pitcher.

## Earned runs

This layer does not guess earned runs:

```text
earned_runs = None
earned_run_status = "not_reconstructed"
```

Pitcher DFS scoring rejects nonzero earned-run weights until earned-run reconstruction exists.

## Core invariants

- reduction consumes canonical `PlayEvent` records only;
- replayed score deltas equal reduced team runs;
- batter runs equal reduced team runs;
- repeated reductions are deterministic;
- pitcher statistics are emitted only when pitcher attribution exists;
- earned runs are never presented as authoritative without reconstruction.

## Scope

This layer does not:

- modify the production simulation route;
- inspect legacy simulation counters;
- reconstruct earned versus unearned runs;
- choose active pitchers or substitutions;
- hard-code a sportsbook or DFS site's scoring system;
- expose UI or API payloads.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- Layer 10D tests passed
- Layer 10E tests passed
- New Layer 10F tests passed
- Result: `65 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/events/contracts.py`
- `mlb_app/simulation/box_score/__init__.py`
- `mlb_app/simulation/box_score/contracts.py`
- `mlb_app/simulation/box_score/reducer.py`
- `mlb_app/simulation/box_score/dfs_scoring.py`
- `mlb_app/simulation/box_score/validation.py`
- `tests/test_box_score_reducer.py`

## Next layer

Layer 10G will expose canonical aggregate projection and diagnostic payloads while preserving the event ledger as the source of truth.