### PR TITLE
Implement canonical projection payload

### DIFF
--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -1,0 +1,37 @@
+"""Canonical aggregate projection payloads."""
+
+from .aggregator import (
+    aggregate_projection_payload,
+    summarize_values,
+)
+from .contracts import (
+    CANONICAL_PROJECTION_SCHEMA_VERSION,
+    CanonicalProjectionPayload,
+    MetricProjection,
+    PlayerProjection,
+    ProjectionDiagnostics,
+    StatisticalSummary,
+    TeamProjection,
+)
+from .serialization import (
+    projection_payload_to_dict,
+)
+from .validation import (
+    ProjectionPayloadValidation,
+    validate_projection_payload,
+)
+
+__all__ = [
+    "CANONICAL_PROJECTION_SCHEMA_VERSION",
+    "CanonicalProjectionPayload",
+    "MetricProjection",
+    "PlayerProjection",
+    "ProjectionDiagnostics",
+    "ProjectionPayloadValidation",
+    "StatisticalSummary",
+    "TeamProjection",
+    "aggregate_projection_payload",
+    "projection_payload_to_dict",
+    "summarize_values",
+    "validate_projection_payload",
+]

--- a/mlb_app/simulation/projections/aggregator.py
+++ b/mlb_app/simulation/projections/aggregator.py
@@ -1,0 +1,525 @@
+"""Aggregate canonical box scores into projection distributions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import hashlib
+import json
+import math
+from statistics import fmean, median
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from mlb_app.simulation.box_score import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+    ReducedBoxScore,
+    score_batter,
+    score_pitcher,
+)
+
+from .contracts import (
+    CanonicalProjectionPayload,
+    MetricProjection,
+    PlayerProjection,
+    ProjectionDiagnostics,
+    StatisticalSummary,
+    TeamProjection,
+)
+
+
+TEAM_METRICS = (
+    "errors",
+    "hits",
+    "left_on_base",
+    "runs",
+)
+
+BATTER_METRICS = (
+    "at_bats",
+    "doubles",
+    "hit_by_pitch",
+    "home_runs",
+    "plate_appearances",
+    "rbi",
+    "reached_on_error",
+    "runs",
+    "sacrifice_bunts",
+    "sacrifice_flies",
+    "singles",
+    "strikeouts",
+    "triples",
+    "walks",
+)
+
+PITCHER_METRICS = (
+    "batters_faced",
+    "hit_batters",
+    "hits_allowed",
+    "home_runs_allowed",
+    "outs_recorded",
+    "runs_allowed",
+    "strikeouts",
+    "walks",
+)
+
+
+def summarize_values(
+    values: Sequence[float],
+) -> StatisticalSummary:
+    """Return a deterministic interpolated summary."""
+
+    if not values:
+        raise ValueError(
+            "cannot summarize an empty value sequence"
+        )
+
+    normalized = tuple(float(value) for value in values)
+
+    if any(not math.isfinite(value) for value in normalized):
+        raise ValueError(
+            "summary values must be finite"
+        )
+
+    ordered = tuple(sorted(normalized))
+
+    return StatisticalSummary(
+        count=len(ordered),
+        mean=_round(fmean(ordered)),
+        median=_round(median(ordered)),
+        p10=_round(_percentile(ordered, 0.10)),
+        p25=_round(_percentile(ordered, 0.25)),
+        p75=_round(_percentile(ordered, 0.75)),
+        p90=_round(_percentile(ordered, 0.90)),
+        minimum=_round(ordered[0]),
+        maximum=_round(ordered[-1]),
+    )
+
+
+def aggregate_projection_payload(
+    *,
+    box_scores: Iterable[ReducedBoxScore],
+    model_version: str,
+    replay_validation_passes: Optional[
+        Iterable[bool]
+    ] = None,
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None,
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None,
+) -> CanonicalProjectionPayload:
+    """Aggregate canonical reduced box-score simulations."""
+
+    runs = tuple(box_scores)
+
+    if not runs:
+        raise ValueError(
+            "at least one reduced box score is required"
+        )
+
+    if not model_version:
+        raise ValueError("model_version is required")
+
+    validation_values = (
+        tuple(replay_validation_passes)
+        if replay_validation_passes is not None
+        else tuple(True for _ in runs)
+    )
+
+    if len(validation_values) != len(runs):
+        raise ValueError(
+            "replay validation count must match simulations"
+        )
+
+    team_projections = tuple(
+        _aggregate_team(
+            runs=runs,
+            team_side=team_side,
+        )
+        for team_side in ("away", "home")
+    )
+
+    batter_projections = _aggregate_batters(
+        runs=runs,
+        dfs_rules=batter_dfs_rules,
+    )
+
+    pitcher_projections = _aggregate_pitchers(
+        runs=runs,
+        dfs_rules=pitcher_dfs_rules,
+    )
+
+    complete_pitcher_runs = sum(
+        run.pitcher_attribution_complete
+        for run in runs
+    )
+
+    pitcher_complete_rate = (
+        complete_pitcher_runs / len(runs)
+    )
+
+    replay_pass_rate = (
+        sum(bool(value) for value in validation_values)
+        / len(validation_values)
+    )
+
+    earned_run_status = _earned_run_status(runs)
+
+    warnings = []
+
+    if pitcher_complete_rate < 1.0:
+        warnings.append(
+            "pitcher_attribution_incomplete"
+        )
+
+    if earned_run_status != "reconstructed":
+        warnings.append(
+            "earned_runs_not_fully_reconstructed"
+        )
+
+    if replay_pass_rate < 1.0:
+        warnings.append(
+            "replay_validation_failures_present"
+        )
+
+    if pitcher_dfs_rules is not None and (
+        pitcher_dfs_rules.earned_run != 0.0
+    ):
+        warnings.append(
+            "pitcher_dfs_earned_run_weight_unsupported"
+        )
+
+    run_id = _deterministic_run_id(
+        runs=runs,
+        model_version=model_version,
+        validation_values=validation_values,
+        batter_dfs_rules=batter_dfs_rules,
+        pitcher_dfs_rules=pitcher_dfs_rules,
+    )
+
+    return CanonicalProjectionPayload(
+        run_id=run_id,
+        model_version=model_version,
+        simulation_count=len(runs),
+        teams=team_projections,
+        batters=batter_projections,
+        pitchers=pitcher_projections,
+        diagnostics=ProjectionDiagnostics(
+            pitcher_attribution_complete_rate=(
+                _round(pitcher_complete_rate)
+            ),
+            replay_validation_pass_rate=(
+                _round(replay_pass_rate)
+            ),
+            earned_run_status=earned_run_status,
+            warnings=tuple(sorted(warnings)),
+        ),
+    )
+
+
+def _aggregate_team(
+    *,
+    runs: Tuple[ReducedBoxScore, ...],
+    team_side: str,
+) -> TeamProjection:
+    values = {
+        metric: []
+        for metric in TEAM_METRICS
+    }
+
+    for run in runs:
+        line = getattr(run, team_side)
+
+        for metric in TEAM_METRICS:
+            values[metric].append(
+                float(getattr(line, metric))
+            )
+
+    return TeamProjection(
+        team_side=team_side,
+        metrics=_metric_projections(values),
+    )
+
+
+def _aggregate_batters(
+    *,
+    runs: Tuple[ReducedBoxScore, ...],
+    dfs_rules: Optional[BatterDfsScoringRules],
+) -> Tuple[PlayerProjection, ...]:
+    player_keys = sorted(
+        {
+            (line.team_side, line.player_id)
+            for run in runs
+            for line in run.batters
+        }
+    )
+
+    projections = []
+
+    for team_side, player_id in player_keys:
+        metric_values = {
+            metric: []
+            for metric in BATTER_METRICS
+        }
+
+        if dfs_rules is not None:
+            metric_values["dfs_points"] = []
+
+        for run in runs:
+            line = _find_batter(
+                run=run,
+                team_side=team_side,
+                player_id=player_id,
+            )
+
+            for metric in BATTER_METRICS:
+                metric_values[metric].append(
+                    float(
+                        getattr(line, metric)
+                        if line is not None
+                        else 0
+                    )
+                )
+
+            if dfs_rules is not None:
+                metric_values["dfs_points"].append(
+                    (
+                        score_batter(line, dfs_rules)
+                        if line is not None
+                        else 0.0
+                    )
+                )
+
+        projections.append(
+            PlayerProjection(
+                player_id=player_id,
+                team_side=team_side,
+                metrics=_metric_projections(
+                    metric_values
+                ),
+            )
+        )
+
+    return tuple(projections)
+
+
+def _aggregate_pitchers(
+    *,
+    runs: Tuple[ReducedBoxScore, ...],
+    dfs_rules: Optional[PitcherDfsScoringRules],
+) -> Tuple[PlayerProjection, ...]:
+    player_keys = sorted(
+        {
+            (line.team_side, line.player_id)
+            for run in runs
+            for line in run.pitchers
+        }
+    )
+
+    projections = []
+
+    for team_side, player_id in player_keys:
+        metric_values = {
+            metric: []
+            for metric in PITCHER_METRICS
+        }
+
+        include_dfs = (
+            dfs_rules is not None
+            and dfs_rules.earned_run == 0.0
+        )
+
+        if include_dfs:
+            metric_values["dfs_points"] = []
+
+        for run in runs:
+            line = _find_pitcher(
+                run=run,
+                team_side=team_side,
+                player_id=player_id,
+            )
+
+            for metric in PITCHER_METRICS:
+                metric_values[metric].append(
+                    float(
+                        getattr(line, metric)
+                        if line is not None
+                        else 0
+                    )
+                )
+
+            if include_dfs:
+                metric_values["dfs_points"].append(
+                    (
+                        score_pitcher(line, dfs_rules)
+                        if line is not None
+                        else 0.0
+                    )
+                )
+
+        projections.append(
+            PlayerProjection(
+                player_id=player_id,
+                team_side=team_side,
+                metrics=_metric_projections(
+                    metric_values
+                ),
+            )
+        )
+
+    return tuple(projections)
+
+
+def _metric_projections(
+    values: Mapping[str, Sequence[float]],
+) -> Tuple[MetricProjection, ...]:
+    return tuple(
+        MetricProjection(
+            name=name,
+            summary=summarize_values(values[name]),
+        )
+        for name in sorted(values)
+    )
+
+
+def _find_batter(
+    *,
+    run: ReducedBoxScore,
+    team_side: str,
+    player_id: str,
+):
+    return next(
+        (
+            line
+            for line in run.batters
+            if (
+                line.team_side == team_side
+                and line.player_id == player_id
+            )
+        ),
+        None,
+    )
+
+
+def _find_pitcher(
+    *,
+    run: ReducedBoxScore,
+    team_side: str,
+    player_id: str,
+):
+    return next(
+        (
+            line
+            for line in run.pitchers
+            if (
+                line.team_side == team_side
+                and line.player_id == player_id
+            )
+        ),
+        None,
+    )
+
+
+def _earned_run_status(
+    runs: Tuple[ReducedBoxScore, ...],
+) -> str:
+    statuses = [
+        line.earned_run_status
+        for run in runs
+        for line in run.pitchers
+    ]
+
+    if not statuses:
+        return "not_reconstructed"
+
+    reconstructed = sum(
+        status == "reconstructed"
+        for status in statuses
+    )
+
+    if reconstructed == len(statuses):
+        return "reconstructed"
+
+    if reconstructed:
+        return "partially_reconstructed"
+
+    return "not_reconstructed"
+
+
+def _deterministic_run_id(
+    *,
+    runs: Tuple[ReducedBoxScore, ...],
+    model_version: str,
+    validation_values: Tuple[bool, ...],
+    batter_dfs_rules,
+    pitcher_dfs_rules,
+) -> str:
+    source = {
+        "model_version": model_version,
+        "runs": [asdict(run) for run in runs],
+        "validation_values": validation_values,
+        "batter_dfs_rules": (
+            asdict(batter_dfs_rules)
+            if batter_dfs_rules is not None
+            else None
+        ),
+        "pitcher_dfs_rules": (
+            asdict(pitcher_dfs_rules)
+            if pitcher_dfs_rules is not None
+            else None
+        ),
+    }
+
+    encoded = json.dumps(
+        source,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    digest = hashlib.sha256(encoded).hexdigest()
+
+    return f"canonical-{digest[:24]}"
+
+
+def _percentile(
+    ordered: Sequence[float],
+    probability: float,
+) -> float:
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError(
+            "percentile probability must be between 0 and 1"
+        )
+
+    if len(ordered) == 1:
+        return ordered[0]
+
+    position = probability * (len(ordered) - 1)
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+
+    if lower_index == upper_index:
+        return ordered[lower_index]
+
+    fraction = position - lower_index
+
+    return (
+        ordered[lower_index]
+        + (
+            ordered[upper_index]
+            - ordered[lower_index]
+        )
+        * fraction
+    )
+
+
+def _round(value: float) -> float:
+    return round(float(value), 6)

--- a/mlb_app/simulation/projections/contracts.py
+++ b/mlb_app/simulation/projections/contracts.py
@@ -1,0 +1,194 @@
+"""Immutable canonical projection payload contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+CANONICAL_PROJECTION_SCHEMA_VERSION = (
+    "canonical_projection_payload_v1"
+)
+
+
+@dataclass(frozen=True)
+class StatisticalSummary:
+    """Stable distribution summary for one projected metric."""
+
+    count: int
+    mean: float
+    median: float
+    p10: float
+    p25: float
+    p75: float
+    p90: float
+    minimum: float
+    maximum: float
+
+    def __post_init__(self) -> None:
+        if self.count <= 0:
+            raise ValueError("summary count must be positive")
+        if self.minimum > self.maximum:
+            raise ValueError(
+                "summary minimum cannot exceed maximum"
+            )
+
+
+@dataclass(frozen=True)
+class MetricProjection:
+    """One named projected metric."""
+
+    name: str
+    summary: StatisticalSummary
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("metric name is required")
+
+
+@dataclass(frozen=True)
+class TeamProjection:
+    """Canonical projection for one team side."""
+
+    team_side: str
+    metrics: Tuple[MetricProjection, ...]
+
+    def __post_init__(self) -> None:
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+        _validate_metric_order(self.metrics)
+
+
+@dataclass(frozen=True)
+class PlayerProjection:
+    """Canonical batter or pitcher projection."""
+
+    player_id: str
+    team_side: str
+    metrics: Tuple[MetricProjection, ...]
+
+    def __post_init__(self) -> None:
+        if not self.player_id:
+            raise ValueError("player_id is required")
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+        _validate_metric_order(self.metrics)
+
+
+@dataclass(frozen=True)
+class ProjectionDiagnostics:
+    """Aggregate quality diagnostics for canonical runs."""
+
+    pitcher_attribution_complete_rate: float
+    replay_validation_pass_rate: float
+    earned_run_status: str
+    warnings: Tuple[str, ...] = field(
+        default_factory=tuple
+    )
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            (
+                "pitcher_attribution_complete_rate",
+                self.pitcher_attribution_complete_rate,
+            ),
+            (
+                "replay_validation_pass_rate",
+                self.replay_validation_pass_rate,
+            ),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"{name} must be between 0 and 1"
+                )
+
+        if self.earned_run_status not in {
+            "not_reconstructed",
+            "partially_reconstructed",
+            "reconstructed",
+        }:
+            raise ValueError(
+                "invalid earned_run_status"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalProjectionPayload:
+    """Versioned projection payload from canonical simulations."""
+
+    run_id: str
+    model_version: str
+    simulation_count: int
+    teams: Tuple[TeamProjection, ...]
+    batters: Tuple[PlayerProjection, ...]
+    pitchers: Tuple[PlayerProjection, ...]
+    diagnostics: ProjectionDiagnostics
+    schema_version: str = (
+        CANONICAL_PROJECTION_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise ValueError("run_id is required")
+        if not self.model_version:
+            raise ValueError("model_version is required")
+        if self.simulation_count <= 0:
+            raise ValueError(
+                "simulation_count must be positive"
+            )
+        if self.schema_version != (
+            CANONICAL_PROJECTION_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical projection schema"
+            )
+
+        if tuple(
+            team.team_side for team in self.teams
+        ) != ("away", "home"):
+            raise ValueError(
+                "teams must be ordered away then home"
+            )
+
+        batter_keys = tuple(
+            (player.team_side, player.player_id)
+            for player in self.batters
+        )
+        if batter_keys != tuple(sorted(batter_keys)):
+            raise ValueError(
+                "batters must use deterministic ordering"
+            )
+
+        pitcher_keys = tuple(
+            (player.team_side, player.player_id)
+            for player in self.pitchers
+        )
+        if pitcher_keys != tuple(sorted(pitcher_keys)):
+            raise ValueError(
+                "pitchers must use deterministic ordering"
+            )
+
+
+def _validate_metric_order(
+    metrics: Tuple[MetricProjection, ...],
+) -> None:
+    names = tuple(metric.name for metric in metrics)
+
+    if not names:
+        raise ValueError(
+            "at least one projected metric is required"
+        )
+
+    if len(names) != len(set(names)):
+        raise ValueError(
+            "projected metric names must be unique"
+        )
+
+    if names != tuple(sorted(names)):
+        raise ValueError(
+            "projected metrics must be ordered by name"
+        )

--- a/mlb_app/simulation/projections/serialization.py
+++ b/mlb_app/simulation/projections/serialization.py
@@ -1,0 +1,60 @@
+"""JSON-compatible canonical projection serialization."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from typing import Any, Dict
+
+from .contracts import CanonicalProjectionPayload
+
+
+def projection_payload_to_dict(
+    payload: CanonicalProjectionPayload,
+) -> Dict[str, Any]:
+    """Serialize with lists and deterministic field ordering."""
+
+    serialized = _serialize(payload)
+
+    if not isinstance(serialized, dict):
+        raise TypeError(
+            "canonical payload must serialize to a dictionary"
+        )
+
+    return serialized
+
+
+def _serialize(value):
+    if is_dataclass(value):
+        return {
+            field.name: _serialize(
+                getattr(value, field.name)
+            )
+            for field in fields(value)
+        }
+
+    if isinstance(value, Enum):
+        return value.value
+
+    if isinstance(value, tuple):
+        return [
+            _serialize(item)
+            for item in value
+        ]
+
+    if isinstance(value, list):
+        return [
+            _serialize(item)
+            for item in value
+        ]
+
+    if isinstance(value, dict):
+        return {
+            str(key): _serialize(item)
+            for key, item in sorted(
+                value.items(),
+                key=lambda pair: str(pair[0]),
+            )
+        }
+
+    return value

--- a/mlb_app/simulation/projections/validation.py
+++ b/mlb_app/simulation/projections/validation.py
@@ -1,0 +1,149 @@
+"""Validation for canonical projection payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Tuple
+
+from .contracts import CanonicalProjectionPayload
+from .serialization import projection_payload_to_dict
+
+
+@dataclass(frozen=True)
+class ProjectionPayloadValidation:
+    simulation_counts_match: bool
+    summaries_are_finite: bool
+    deterministic_ordering: bool
+    json_serializable: bool
+    warnings: Tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.simulation_counts_match
+            and self.summaries_are_finite
+            and self.deterministic_ordering
+            and self.json_serializable
+        )
+
+
+def validate_projection_payload(
+    payload: CanonicalProjectionPayload,
+) -> ProjectionPayloadValidation:
+    summaries = [
+        metric.summary
+        for team in payload.teams
+        for metric in team.metrics
+    ] + [
+        metric.summary
+        for player in (
+            payload.batters + payload.pitchers
+        )
+        for metric in player.metrics
+    ]
+
+    simulation_counts_match = all(
+        summary.count == payload.simulation_count
+        for summary in summaries
+    )
+
+    summaries_are_finite = all(
+        _summary_is_finite(summary)
+        for summary in summaries
+    )
+
+    deterministic_ordering = (
+        tuple(
+            team.team_side
+            for team in payload.teams
+        ) == ("away", "home")
+        and tuple(
+            (
+                player.team_side,
+                player.player_id,
+            )
+            for player in payload.batters
+        )
+        == tuple(
+            sorted(
+                (
+                    player.team_side,
+                    player.player_id,
+                )
+                for player in payload.batters
+            )
+        )
+        and tuple(
+            (
+                player.team_side,
+                player.player_id,
+            )
+            for player in payload.pitchers
+        )
+        == tuple(
+            sorted(
+                (
+                    player.team_side,
+                    player.player_id,
+                )
+                for player in payload.pitchers
+            )
+        )
+    )
+
+    try:
+        json.dumps(
+            projection_payload_to_dict(payload),
+            sort_keys=True,
+        )
+        json_serializable = True
+    except (TypeError, ValueError):
+        json_serializable = False
+
+    warnings = []
+
+    if not simulation_counts_match:
+        warnings.append(
+            "summary_simulation_count_mismatch"
+        )
+    if not summaries_are_finite:
+        warnings.append(
+            "nonfinite_summary_value"
+        )
+    if not deterministic_ordering:
+        warnings.append(
+            "nondeterministic_payload_order"
+        )
+    if not json_serializable:
+        warnings.append(
+            "payload_not_json_serializable"
+        )
+
+    return ProjectionPayloadValidation(
+        simulation_counts_match=(
+            simulation_counts_match
+        ),
+        summaries_are_finite=summaries_are_finite,
+        deterministic_ordering=deterministic_ordering,
+        json_serializable=json_serializable,
+        warnings=tuple(warnings),
+    )
+
+
+def _summary_is_finite(summary) -> bool:
+    import math
+
+    return all(
+        math.isfinite(value)
+        for value in (
+            summary.mean,
+            summary.median,
+            summary.p10,
+            summary.p25,
+            summary.p75,
+            summary.p90,
+            summary.minimum,
+            summary.maximum,
+        )
+    )

--- a/tests/test_canonical_projection_payload.py
+++ b/tests/test_canonical_projection_payload.py
@@ -1,0 +1,334 @@
+import json
+
+import pytest
+
+from mlb_app.simulation.box_score import (
+    BatterBoxScore,
+    BatterDfsScoringRules,
+    PitcherBoxScore,
+    PitcherDfsScoringRules,
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.projections import (
+    aggregate_projection_payload,
+    projection_payload_to_dict,
+    summarize_values,
+    validate_projection_payload,
+)
+
+
+def run(
+    *,
+    away_runs,
+    home_runs,
+    batter_runs,
+    pitcher_runs,
+    complete=True,
+):
+    return ReducedBoxScore(
+        away=TeamBoxScore(
+            team_side="away",
+            runs=away_runs,
+            hits=1,
+        ),
+        home=TeamBoxScore(
+            team_side="home",
+            runs=home_runs,
+        ),
+        batters=(
+            BatterBoxScore(
+                player_id="batter",
+                team_side="away",
+                plate_appearances=1,
+                at_bats=1,
+                home_runs=1,
+                runs=batter_runs,
+                rbi=1,
+            ),
+        ),
+        pitchers=(
+            PitcherBoxScore(
+                player_id="pitcher",
+                team_side="home",
+                batters_faced=1,
+                hits_allowed=1,
+                home_runs_allowed=1,
+                runs_allowed=pitcher_runs,
+            ),
+        ),
+        pitcher_attribution_complete=complete,
+    )
+
+
+def metric(projection, name):
+    return next(
+        item
+        for item in projection.metrics
+        if item.name == name
+    )
+
+
+def test_statistical_summary_is_deterministic():
+    summary = summarize_values((4, 1, 3, 2))
+
+    assert summary.count == 4
+    assert summary.mean == 2.5
+    assert summary.median == 2.5
+    assert summary.minimum == 1.0
+    assert summary.maximum == 4.0
+
+
+def test_empty_summary_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="empty value sequence",
+    ):
+        summarize_values(())
+
+
+def test_team_run_distribution_is_aggregated():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=2,
+                home_runs=1,
+                batter_runs=1,
+                pitcher_runs=2,
+            ),
+            run(
+                away_runs=4,
+                home_runs=3,
+                batter_runs=2,
+                pitcher_runs=4,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+    )
+
+    away_runs = metric(
+        payload.teams[0],
+        "runs",
+    ).summary
+
+    assert payload.simulation_count == 2
+    assert away_runs.mean == 3.0
+    assert away_runs.minimum == 2.0
+    assert away_runs.maximum == 4.0
+
+
+def test_batter_metrics_zero_fill_missing_run():
+    first = run(
+        away_runs=1,
+        home_runs=0,
+        batter_runs=1,
+        pitcher_runs=1,
+    )
+    second = ReducedBoxScore(
+        away=TeamBoxScore(team_side="away"),
+        home=TeamBoxScore(team_side="home"),
+    )
+
+    payload = aggregate_projection_payload(
+        box_scores=(first, second),
+        model_version="canonical_event_model_v1",
+    )
+
+    runs = metric(
+        payload.batters[0],
+        "runs",
+    ).summary
+
+    assert runs.count == 2
+    assert runs.mean == 0.5
+
+
+def test_dfs_distributions_are_configurable():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=1,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=1,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+        batter_dfs_rules=BatterDfsScoringRules(
+            home_run=10.0,
+            run=2.0,
+            rbi=2.0,
+        ),
+        pitcher_dfs_rules=PitcherDfsScoringRules(
+            hit_allowed=-1.0,
+            run_allowed=-2.0,
+        ),
+    )
+
+    batter_dfs = metric(
+        payload.batters[0],
+        "dfs_points",
+    ).summary
+    pitcher_dfs = metric(
+        payload.pitchers[0],
+        "dfs_points",
+    ).summary
+
+    assert batter_dfs.mean == 14.0
+    assert pitcher_dfs.mean == -3.0
+
+
+def test_earned_run_weight_is_not_projected():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=1,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=1,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+        pitcher_dfs_rules=PitcherDfsScoringRules(
+            earned_run=-2.0,
+        ),
+    )
+
+    pitcher_metric_names = {
+        item.name
+        for item in payload.pitchers[0].metrics
+    }
+
+    assert "dfs_points" not in pitcher_metric_names
+    assert (
+        "pitcher_dfs_earned_run_weight_unsupported"
+        in payload.diagnostics.warnings
+    )
+
+
+def test_diagnostics_report_incomplete_inputs():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=1,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=1,
+                complete=True,
+            ),
+            run(
+                away_runs=2,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=2,
+                complete=False,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+        replay_validation_passes=(True, False),
+    )
+
+    assert (
+        payload.diagnostics
+        .pitcher_attribution_complete_rate
+        == 0.5
+    )
+    assert (
+        payload.diagnostics
+        .replay_validation_pass_rate
+        == 0.5
+    )
+    assert (
+        "pitcher_attribution_incomplete"
+        in payload.diagnostics.warnings
+    )
+    assert (
+        "replay_validation_failures_present"
+        in payload.diagnostics.warnings
+    )
+
+
+def test_run_identifier_is_deterministic():
+    runs = (
+        run(
+            away_runs=1,
+            home_runs=0,
+            batter_runs=1,
+            pitcher_runs=1,
+        ),
+    )
+
+    first = aggregate_projection_payload(
+        box_scores=runs,
+        model_version="canonical_event_model_v1",
+    )
+    second = aggregate_projection_payload(
+        box_scores=runs,
+        model_version="canonical_event_model_v1",
+    )
+
+    assert first.run_id == second.run_id
+
+
+def test_serialization_is_plain_json_compatible():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=1,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=1,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+    )
+
+    serialized = projection_payload_to_dict(payload)
+    encoded = json.dumps(serialized, sort_keys=True)
+
+    assert isinstance(serialized["teams"], list)
+    assert "canonical_projection_payload_v1" in encoded
+
+
+def test_payload_validation_passes():
+    payload = aggregate_projection_payload(
+        box_scores=(
+            run(
+                away_runs=1,
+                home_runs=0,
+                batter_runs=1,
+                pitcher_runs=1,
+            ),
+            run(
+                away_runs=2,
+                home_runs=1,
+                batter_runs=1,
+                pitcher_runs=2,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+    )
+
+    validation = validate_projection_payload(payload)
+
+    assert validation.passed is True
+    assert validation.warnings == ()
+
+
+def test_validation_count_must_match_simulations():
+    with pytest.raises(
+        ValueError,
+        match="validation count must match",
+    ):
+        aggregate_projection_payload(
+            box_scores=(
+                run(
+                    away_runs=1,
+                    home_runs=0,
+                    batter_runs=1,
+                    pitcher_runs=1,
+                ),
+            ),
+            model_version="canonical_event_model_v1",
+            replay_validation_passes=(True, False),
+        )


### PR DESCRIPTION
## Summary

Implements Layer 10G canonical aggregate projection and diagnostic payloads from canonical `ReducedBoxScore` simulation outputs.

### Added

- Versioned canonical projection payload contracts
- Deterministic statistical summaries
- Team run, hit, error, and left-on-base distributions
- Batter counting-stat distributions
- Pitcher counting-stat distributions
- Configurable batter and pitcher DFS-point distributions
- Zero-filling for players absent from individual simulation runs
- Deterministic player and metric ordering
- Deterministic SHA-256-based run identifiers
- JSON-compatible serialization
- Projection payload validation
- Pitcher-attribution completeness diagnostics
- Replay-validation pass-rate diagnostics
- Explicit earned-run reconstruction warnings

## Architecture

```text
ReducedBoxScore[]
        ↓
aggregate_projection_payload()
        ├─ TeamProjection[]
        ├─ Batter PlayerProjection[]
        ├─ Pitcher PlayerProjection[]
        └─ ProjectionDiagnostics
                ↓
CanonicalProjectionPayload
                ↓
JSON-compatible serialization and validation
```

## Statistical summary contract

Each projected metric exposes:

```text
count
mean
median
p10
p25
p75
p90
minimum
maximum
```

Percentiles use deterministic linear interpolation over sorted values.

## Diagnostics

The payload reports:

- pitcher-attribution completeness rate;
- replay-validation pass rate;
- earned-run reconstruction status;
- explicit warnings for incomplete pitcher attribution;
- explicit warnings for unreconstructed earned runs;
- explicit warnings for replay-validation failures.

## DFS scoring behavior

DFS scoring remains configurable and is calculated only from reduced canonical box-score lines.

Pitcher DFS distributions are omitted when scoring rules require earned runs because Layer 10F intentionally marks earned runs as unreconstructed rather than guessing them.

## Core invariants

- aggregation consumes `ReducedBoxScore` records only;
- output ordering is deterministic;
- every statistical summary contains exactly one observation per simulation;
- absent player outcomes are zero-filled;
- payload serialization is plain JSON-compatible data;
- repeated aggregation of identical inputs produces the same run identifier;
- missing pitcher or earned-run information is surfaced explicitly rather than invented.

## Scope

This layer does not:

- modify existing production projection payloads;
- invoke legacy simulation counters;
- wire canonical projections into production API routes;
- expose UI changes;
- reconstruct earned runs;
- replace the current production simulator.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- Layer 10D tests passed
- Layer 10E tests passed
- Layer 10F tests passed
- New Layer 10G tests passed
- Result: `76 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/projections/__init__.py`
- `mlb_app/simulation/projections/contracts.py`
- `mlb_app/simulation/projections/aggregator.py`
- `mlb_app/simulation/projections/serialization.py`
- `mlb_app/simulation/projections/validation.py`
- `tests/test_canonical_projection_payload.py`

## Next layer

Layer 10H will add production-shadow integration so the canonical event pipeline can run beside the existing simulator, compare outputs, and emit diagnostics without replacing production behavior.