### PR TITLE
Implement canonical shadow comparison

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -1,0 +1,25 @@
+"""Canonical production-shadow comparison integration."""
+
+from .comparator import compare_shadow_payloads
+from .contracts import (
+    SHADOW_SCHEMA_VERSION,
+    CanonicalShadowDiagnostics,
+    MetricComparison,
+    RangeComparison,
+    ShadowCoverage,
+)
+from .integration import attach_canonical_shadow
+from .serialization import (
+    shadow_diagnostics_to_dict,
+)
+
+__all__ = [
+    "SHADOW_SCHEMA_VERSION",
+    "CanonicalShadowDiagnostics",
+    "MetricComparison",
+    "RangeComparison",
+    "ShadowCoverage",
+    "attach_canonical_shadow",
+    "compare_shadow_payloads",
+    "shadow_diagnostics_to_dict",
+]

--- a/mlb_app/simulation/shadow/comparator.py
+++ b/mlb_app/simulation/shadow/comparator.py
@@ -1,0 +1,667 @@
+"""Compare legacy simulation output with canonical projections."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from mlb_app.simulation.projections import (
+    CanonicalProjectionPayload,
+    projection_payload_to_dict,
+)
+
+from .contracts import (
+    CanonicalShadowDiagnostics,
+    MetricComparison,
+    RangeComparison,
+    ShadowCoverage,
+)
+
+
+POSSIBLE_COMPARISONS = (
+    "simulation_count",
+    "away_runs_mean",
+    "home_runs_mean",
+    "total_runs_mean",
+    "away_runs_range",
+    "home_runs_range",
+    "total_runs_range",
+    "home_win_probability",
+)
+
+
+def compare_shadow_payloads(
+    *,
+    legacy_result: Dict[str, Any],
+    canonical_payload,
+) -> CanonicalShadowDiagnostics:
+    """Build non-authoritative comparison diagnostics."""
+
+    legacy = _select_legacy_simulation(legacy_result)
+    canonical = _canonical_dict(canonical_payload)
+
+    legacy_count = _as_int(
+        legacy.get("simulations")
+        or _nested_get(
+            legacy,
+            "metadata.simulation_count",
+        )
+    )
+    canonical_count = _as_int(
+        canonical.get("simulation_count")
+    )
+
+    comparisons = (
+        _comparison(
+            "simulation_count",
+            legacy_count,
+            canonical_count,
+        ),
+        _comparison(
+            "away_runs_mean",
+            _as_float(
+                legacy.get("away_expected_runs")
+            ),
+            _canonical_team_metric(
+                canonical,
+                "away",
+                "runs",
+                "mean",
+            ),
+        ),
+        _comparison(
+            "home_runs_mean",
+            _as_float(
+                legacy.get("home_expected_runs")
+            ),
+            _canonical_team_metric(
+                canonical,
+                "home",
+                "runs",
+                "mean",
+            ),
+        ),
+        _comparison(
+            "total_runs_mean",
+            _as_float(
+                legacy.get("total_expected_runs")
+            ),
+            _canonical_total_metric(
+                canonical,
+                "runs",
+                "mean",
+            ),
+        ),
+        _comparison(
+            "home_win_probability",
+            _as_float(
+                legacy.get("home_win_probability")
+            ),
+            _canonical_outcome_probability(
+                canonical,
+                "home_win_probability",
+            ),
+        ),
+    )
+
+    ranges = (
+        _range_comparison(
+            "away_runs_range",
+            _legacy_distribution_range(
+                legacy.get("away_run_distribution")
+            ),
+            _canonical_team_range(
+                canonical,
+                "away",
+                "runs",
+            ),
+        ),
+        _range_comparison(
+            "home_runs_range",
+            _legacy_distribution_range(
+                legacy.get("home_run_distribution")
+            ),
+            _canonical_team_range(
+                canonical,
+                "home",
+                "runs",
+            ),
+        ),
+        _range_comparison(
+            "total_runs_range",
+            _legacy_distribution_range(
+                legacy.get("total_run_distribution")
+            ),
+            _canonical_total_range(
+                canonical,
+                "runs",
+            ),
+        ),
+    )
+
+    compared_count = sum(
+        comparison.available
+        for comparison in comparisons
+    ) + sum(
+        comparison.available
+        for comparison in ranges
+    )
+
+    possible_count = len(POSSIBLE_COMPARISONS)
+    comparison_rate = round(
+        compared_count / possible_count,
+        6,
+    )
+
+    canonical_diagnostics = (
+        canonical.get("diagnostics")
+        if isinstance(
+            canonical.get("diagnostics"),
+            dict,
+        )
+        else {}
+    )
+
+    warnings = set(
+        str(warning)
+        for warning in (
+            canonical_diagnostics.get("warnings")
+            or []
+        )
+    )
+
+    if legacy_count != canonical_count:
+        warnings.add("simulation_count_mismatch")
+
+    unavailable = [
+        item.name
+        for item in comparisons + ranges
+        if not item.available
+    ]
+
+    for name in unavailable:
+        warnings.add(
+            f"comparison_unavailable:{name}"
+        )
+
+    status = (
+        "complete"
+        if compared_count == possible_count
+        else "partial"
+    )
+
+    return CanonicalShadowDiagnostics(
+        status=status,
+        enabled=True,
+        canonical_available=True,
+        authoritative_source="legacy",
+        comparisons=tuple(
+            sorted(
+                comparisons,
+                key=lambda item: item.name,
+            )
+        ),
+        ranges=tuple(
+            sorted(
+                ranges,
+                key=lambda item: item.name,
+            )
+        ),
+        coverage=ShadowCoverage(
+            compared_metric_count=compared_count,
+            possible_metric_count=possible_count,
+            comparison_rate=comparison_rate,
+        ),
+        legacy_simulation_count=legacy_count,
+        canonical_simulation_count=canonical_count,
+        pitcher_attribution_complete_rate=(
+            _as_float(
+                canonical_diagnostics.get(
+                    "pitcher_attribution_complete_rate"
+                )
+            )
+        ),
+        replay_validation_pass_rate=(
+            _as_float(
+                canonical_diagnostics.get(
+                    "replay_validation_pass_rate"
+                )
+            )
+        ),
+        earned_run_status=(
+            canonical_diagnostics.get(
+                "earned_run_status"
+            )
+        ),
+        warnings=tuple(sorted(warnings)),
+    )
+
+
+def _select_legacy_simulation(
+    result: Dict[str, Any],
+) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        raise TypeError(
+            "legacy_result must be a dictionary"
+        )
+
+    if _looks_like_simulation(result):
+        return result
+
+    derived = _nested_get(
+        result,
+        "derived_outputs",
+    )
+
+    if isinstance(derived, dict):
+        bullpen = derived.get(
+            "bullpen_adjusted_game_simulation"
+        )
+        if isinstance(bullpen, dict) and bullpen:
+            return bullpen
+
+        base = derived.get("game_simulation")
+        if isinstance(base, dict) and base:
+            return base
+
+    raise ValueError(
+        "legacy simulation output was not found"
+    )
+
+
+def _canonical_dict(payload) -> Dict[str, Any]:
+    if isinstance(
+        payload,
+        CanonicalProjectionPayload,
+    ):
+        canonical = projection_payload_to_dict(payload)
+    elif isinstance(payload, dict):
+        canonical = payload
+    else:
+        raise TypeError(
+            "canonical_payload must be a canonical "
+            "payload or dictionary"
+        )
+
+    _validate_canonical_payload(canonical)
+    return canonical
+
+
+def _validate_canonical_payload(
+    payload: Dict[str, Any],
+) -> None:
+    simulation_count = _as_int(
+        payload.get("simulation_count")
+    )
+
+    if simulation_count is None or simulation_count <= 0:
+        raise ValueError(
+            "canonical payload requires a positive "
+            "simulation_count"
+        )
+
+    teams = payload.get("teams")
+
+    if not isinstance(teams, list):
+        raise ValueError(
+            "canonical payload requires a teams list"
+        )
+
+    team_sides = tuple(
+        team.get("team_side")
+        for team in teams
+        if isinstance(team, dict)
+    )
+
+    if team_sides != ("away", "home"):
+        raise ValueError(
+            "canonical payload teams must be ordered "
+            "away then home"
+        )
+
+    for team in teams:
+        metrics = team.get("metrics")
+
+        if not isinstance(metrics, list):
+            raise ValueError(
+                "canonical team projection requires "
+                "a metrics list"
+            )
+
+        runs_metric = next(
+            (
+                metric
+                for metric in metrics
+                if (
+                    isinstance(metric, dict)
+                    and metric.get("name") == "runs"
+                )
+            ),
+            None,
+        )
+
+        if not isinstance(runs_metric, dict):
+            raise ValueError(
+                "canonical team projection requires "
+                "a runs metric"
+            )
+
+        summary = runs_metric.get("summary")
+
+        if not isinstance(summary, dict):
+            raise ValueError(
+                "canonical runs metric requires "
+                "a summary"
+            )
+
+        for field in (
+            "mean",
+            "minimum",
+            "maximum",
+        ):
+            if _as_float(summary.get(field)) is None:
+                raise ValueError(
+                    "canonical runs summary requires "
+                    f"{field}"
+                )
+
+    diagnostics = payload.get("diagnostics")
+
+    if not isinstance(diagnostics, dict):
+        raise ValueError(
+            "canonical payload requires diagnostics"
+        )
+
+
+def _looks_like_simulation(
+    value: Dict[str, Any],
+) -> bool:
+    return any(
+        key in value
+        for key in (
+            "away_expected_runs",
+            "home_expected_runs",
+            "total_expected_runs",
+        )
+    )
+
+
+def _comparison(
+    name: str,
+    legacy_value,
+    canonical_value,
+) -> MetricComparison:
+    legacy_number = _as_float(legacy_value)
+    canonical_number = _as_float(canonical_value)
+
+    available = (
+        legacy_number is not None
+        and canonical_number is not None
+    )
+
+    difference = (
+        round(
+            abs(
+                legacy_number
+                - canonical_number
+            ),
+            6,
+        )
+        if available
+        else None
+    )
+
+    return MetricComparison(
+        name=name,
+        legacy_value=legacy_number,
+        canonical_value=canonical_number,
+        absolute_difference=difference,
+        available=available,
+    )
+
+
+def _range_comparison(
+    name: str,
+    legacy_range,
+    canonical_range,
+) -> RangeComparison:
+    available = (
+        legacy_range is not None
+        and canonical_range is not None
+    )
+
+    return RangeComparison(
+        name=name,
+        legacy_minimum=(
+            legacy_range[0]
+            if available
+            else None
+        ),
+        legacy_maximum=(
+            legacy_range[1]
+            if available
+            else None
+        ),
+        canonical_minimum=(
+            canonical_range[0]
+            if available
+            else None
+        ),
+        canonical_maximum=(
+            canonical_range[1]
+            if available
+            else None
+        ),
+        available=available,
+    )
+
+
+def _canonical_team_metric(
+    payload: Dict[str, Any],
+    team_side: str,
+    metric_name: str,
+    summary_name: str,
+) -> Optional[float]:
+    metric = _canonical_metric(
+        payload,
+        team_side,
+        metric_name,
+    )
+
+    if not isinstance(metric, dict):
+        return None
+
+    summary = metric.get("summary")
+
+    if not isinstance(summary, dict):
+        return None
+
+    return _as_float(summary.get(summary_name))
+
+
+def _canonical_team_range(
+    payload: Dict[str, Any],
+    team_side: str,
+    metric_name: str,
+) -> Optional[Tuple[float, float]]:
+    minimum = _canonical_team_metric(
+        payload,
+        team_side,
+        metric_name,
+        "minimum",
+    )
+    maximum = _canonical_team_metric(
+        payload,
+        team_side,
+        metric_name,
+        "maximum",
+    )
+
+    if minimum is None or maximum is None:
+        return None
+
+    return minimum, maximum
+
+
+def _canonical_total_metric(
+    payload: Dict[str, Any],
+    metric_name: str,
+    summary_name: str,
+) -> Optional[float]:
+    away = _canonical_team_metric(
+        payload,
+        "away",
+        metric_name,
+        summary_name,
+    )
+    home = _canonical_team_metric(
+        payload,
+        "home",
+        metric_name,
+        summary_name,
+    )
+
+    if away is None or home is None:
+        return None
+
+    return round(away + home, 6)
+
+
+def _canonical_total_range(
+    payload: Dict[str, Any],
+    metric_name: str,
+) -> Optional[Tuple[float, float]]:
+    away = _canonical_team_range(
+        payload,
+        "away",
+        metric_name,
+    )
+    home = _canonical_team_range(
+        payload,
+        "home",
+        metric_name,
+    )
+
+    if away is None or home is None:
+        return None
+
+    return (
+        round(away[0] + home[0], 6),
+        round(away[1] + home[1], 6),
+    )
+
+
+def _canonical_metric(
+    payload: Dict[str, Any],
+    team_side: str,
+    metric_name: str,
+):
+    teams = payload.get("teams")
+
+    if not isinstance(teams, list):
+        return None
+
+    team = next(
+        (
+            item
+            for item in teams
+            if (
+                isinstance(item, dict)
+                and item.get("team_side")
+                == team_side
+            )
+        ),
+        None,
+    )
+
+    if not isinstance(team, dict):
+        return None
+
+    metrics = team.get("metrics")
+
+    if not isinstance(metrics, list):
+        return None
+
+    return next(
+        (
+            item
+            for item in metrics
+            if (
+                isinstance(item, dict)
+                and item.get("name")
+                == metric_name
+            )
+        ),
+        None,
+    )
+
+
+def _canonical_outcome_probability(
+    payload: Dict[str, Any],
+    name: str,
+) -> Optional[float]:
+    outcomes = payload.get("outcomes")
+
+    if not isinstance(outcomes, dict):
+        return None
+
+    return _as_float(outcomes.get(name))
+
+
+def _legacy_distribution_range(
+    distribution,
+) -> Optional[Tuple[float, float]]:
+    if not isinstance(distribution, dict):
+        return None
+
+    supported = []
+
+    for raw_value, probability in distribution.items():
+        probability_number = _as_float(probability)
+        value_number = _as_float(raw_value)
+
+        if (
+            value_number is not None
+            and probability_number is not None
+            and probability_number > 0.0
+        ):
+            supported.append(value_number)
+
+    if not supported:
+        return None
+
+    return min(supported), max(supported)
+
+
+def _nested_get(
+    value: Dict[str, Any],
+    path: str,
+):
+    current = value
+
+    for key in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+
+    return current
+
+
+def _as_float(value) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return round(number, 6)
+
+
+def _as_int(value) -> Optional[int]:
+    number = _as_float(value)
+
+    if number is None:
+        return None
+
+    return int(number)

--- a/mlb_app/simulation/shadow/contracts.py
+++ b/mlb_app/simulation/shadow/contracts.py
@@ -1,0 +1,156 @@
+"""Immutable canonical-shadow comparison contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+SHADOW_SCHEMA_VERSION = "canonical_shadow_v1"
+
+VALID_SHADOW_STATUSES = frozenset(
+    {
+        "disabled",
+        "unavailable",
+        "partial",
+        "complete",
+        "error",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MetricComparison:
+    """Comparison between one legacy and canonical metric."""
+
+    name: str
+    legacy_value: Optional[float]
+    canonical_value: Optional[float]
+    absolute_difference: Optional[float]
+    available: bool
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError(
+                "comparison metric name is required"
+            )
+
+        if self.available:
+            if (
+                self.legacy_value is None
+                or self.canonical_value is None
+                or self.absolute_difference is None
+            ):
+                raise ValueError(
+                    "available comparisons require both "
+                    "values and a difference"
+                )
+
+
+@dataclass(frozen=True)
+class RangeComparison:
+    """Comparison between legacy and canonical ranges."""
+
+    name: str
+    legacy_minimum: Optional[float]
+    legacy_maximum: Optional[float]
+    canonical_minimum: Optional[float]
+    canonical_maximum: Optional[float]
+    available: bool
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError(
+                "range comparison name is required"
+            )
+
+        if self.available:
+            values = (
+                self.legacy_minimum,
+                self.legacy_maximum,
+                self.canonical_minimum,
+                self.canonical_maximum,
+            )
+            if any(value is None for value in values):
+                raise ValueError(
+                    "available range comparisons require "
+                    "all boundaries"
+                )
+
+
+@dataclass(frozen=True)
+class ShadowCoverage:
+    """Coverage of supported comparison surfaces."""
+
+    compared_metric_count: int
+    possible_metric_count: int
+    comparison_rate: float
+
+    def __post_init__(self) -> None:
+        if self.compared_metric_count < 0:
+            raise ValueError(
+                "compared_metric_count cannot be negative"
+            )
+        if self.possible_metric_count <= 0:
+            raise ValueError(
+                "possible_metric_count must be positive"
+            )
+        if (
+            self.compared_metric_count
+            > self.possible_metric_count
+        ):
+            raise ValueError(
+                "compared count cannot exceed possible count"
+            )
+        if not 0.0 <= self.comparison_rate <= 1.0:
+            raise ValueError(
+                "comparison_rate must be between 0 and 1"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalShadowDiagnostics:
+    """Namespaced non-authoritative shadow diagnostics."""
+
+    status: str
+    enabled: bool
+    canonical_available: bool
+    authoritative_source: str
+    comparisons: Tuple[MetricComparison, ...] = field(
+        default_factory=tuple
+    )
+    ranges: Tuple[RangeComparison, ...] = field(
+        default_factory=tuple
+    )
+    coverage: Optional[ShadowCoverage] = None
+    legacy_simulation_count: Optional[int] = None
+    canonical_simulation_count: Optional[int] = None
+    pitcher_attribution_complete_rate: Optional[float] = None
+    replay_validation_pass_rate: Optional[float] = None
+    earned_run_status: Optional[str] = None
+    warnings: Tuple[str, ...] = field(
+        default_factory=tuple
+    )
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    schema_version: str = SHADOW_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_SHADOW_STATUSES:
+            raise ValueError("invalid shadow status")
+
+        if self.authoritative_source != "legacy":
+            raise ValueError(
+                "legacy must remain authoritative"
+            )
+
+        if self.schema_version != SHADOW_SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported shadow schema version"
+            )
+
+        if self.status == "error":
+            if not self.error_type:
+                raise ValueError(
+                    "error status requires error_type"
+                )

--- a/mlb_app/simulation/shadow/integration.py
+++ b/mlb_app/simulation/shadow/integration.py
@@ -1,0 +1,83 @@
+"""Fail-open canonical-shadow integration."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+from .comparator import compare_shadow_payloads
+from .contracts import CanonicalShadowDiagnostics
+from .serialization import shadow_diagnostics_to_dict
+
+
+def attach_canonical_shadow(
+    *,
+    legacy_result: Dict[str, Any],
+    enabled: bool = False,
+    canonical_payload=None,
+) -> Dict[str, Any]:
+    """Attach shadow diagnostics without mutating legacy data."""
+
+    if not isinstance(legacy_result, dict):
+        raise TypeError(
+            "legacy_result must be a dictionary"
+        )
+
+    output = deepcopy(legacy_result)
+    diagnostics = output.setdefault(
+        "diagnostics",
+        {},
+    )
+
+    if not isinstance(diagnostics, dict):
+        diagnostics = {
+            "legacy_diagnostics": deepcopy(
+                diagnostics
+            )
+        }
+        output["diagnostics"] = diagnostics
+
+    if not enabled:
+        shadow = CanonicalShadowDiagnostics(
+            status="disabled",
+            enabled=False,
+            canonical_available=False,
+            authoritative_source="legacy",
+            warnings=(
+                "canonical_shadow_disabled",
+            ),
+        )
+    elif canonical_payload is None:
+        shadow = CanonicalShadowDiagnostics(
+            status="unavailable",
+            enabled=True,
+            canonical_available=False,
+            authoritative_source="legacy",
+            warnings=(
+                "canonical_payload_unavailable",
+            ),
+        )
+    else:
+        try:
+            shadow = compare_shadow_payloads(
+                legacy_result=legacy_result,
+                canonical_payload=canonical_payload,
+            )
+        except Exception as exc:
+            shadow = CanonicalShadowDiagnostics(
+                status="error",
+                enabled=True,
+                canonical_available=True,
+                authoritative_source="legacy",
+                warnings=(
+                    "canonical_shadow_comparison_failed",
+                ),
+                error_type=exc.__class__.__name__,
+                error_message=str(exc),
+            )
+
+    diagnostics["canonical_shadow"] = (
+        shadow_diagnostics_to_dict(shadow)
+    )
+
+    return output

--- a/mlb_app/simulation/shadow/serialization.py
+++ b/mlb_app/simulation/shadow/serialization.py
@@ -1,0 +1,55 @@
+"""JSON-compatible canonical-shadow serialization."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from typing import Any, Dict
+
+from .contracts import CanonicalShadowDiagnostics
+
+
+def shadow_diagnostics_to_dict(
+    diagnostics: CanonicalShadowDiagnostics,
+) -> Dict[str, Any]:
+    serialized = _serialize(diagnostics)
+
+    if not isinstance(serialized, dict):
+        raise TypeError(
+            "shadow diagnostics must serialize "
+            "to a dictionary"
+        )
+
+    return serialized
+
+
+def _serialize(value):
+    if is_dataclass(value):
+        return {
+            field.name: _serialize(
+                getattr(value, field.name)
+            )
+            for field in fields(value)
+        }
+
+    if isinstance(value, tuple):
+        return [
+            _serialize(item)
+            for item in value
+        ]
+
+    if isinstance(value, list):
+        return [
+            _serialize(item)
+            for item in value
+        ]
+
+    if isinstance(value, dict):
+        return {
+            str(key): _serialize(item)
+            for key, item in sorted(
+                value.items(),
+                key=lambda pair: str(pair[0]),
+            )
+        }
+
+    return value

--- a/tests/test_canonical_shadow_integration.py
+++ b/tests/test_canonical_shadow_integration.py
@@ -1,0 +1,285 @@
+from copy import deepcopy
+import json
+
+from mlb_app.simulation.box_score import (
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.projections import (
+    aggregate_projection_payload,
+)
+from mlb_app.simulation.shadow import (
+    attach_canonical_shadow,
+    compare_shadow_payloads,
+)
+
+
+def canonical_payload():
+    return aggregate_projection_payload(
+        box_scores=(
+            ReducedBoxScore(
+                away=TeamBoxScore(
+                    team_side="away",
+                    runs=3,
+                    hits=7,
+                ),
+                home=TeamBoxScore(
+                    team_side="home",
+                    runs=4,
+                    hits=8,
+                ),
+                pitcher_attribution_complete=True,
+            ),
+            ReducedBoxScore(
+                away=TeamBoxScore(
+                    team_side="away",
+                    runs=5,
+                    hits=9,
+                ),
+                home=TeamBoxScore(
+                    team_side="home",
+                    runs=2,
+                    hits=6,
+                ),
+                pitcher_attribution_complete=False,
+            ),
+        ),
+        model_version="canonical_event_model_v1",
+        replay_validation_passes=(True, True),
+    )
+
+
+def legacy_result():
+    return {
+        "model_version": "full_game_sim_v1",
+        "simulations": 2,
+        "away_expected_runs": 3.5,
+        "home_expected_runs": 3.5,
+        "total_expected_runs": 7.0,
+        "home_win_probability": 0.55,
+        "away_run_distribution": {
+            "2": 0.5,
+            "5": 0.5,
+        },
+        "home_run_distribution": {
+            "1": 0.5,
+            "4": 0.5,
+        },
+        "total_run_distribution": {
+            "6": 0.5,
+            "8": 0.5,
+        },
+        "metadata": {
+            "simulation_count": 2,
+        },
+    }
+
+
+def comparison(diagnostics, name):
+    return next(
+        item
+        for item in diagnostics.comparisons
+        if item.name == name
+    )
+
+
+def range_comparison(diagnostics, name):
+    return next(
+        item
+        for item in diagnostics.ranges
+        if item.name == name
+    )
+
+
+def test_comparator_reports_run_mean_differences():
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=canonical_payload(),
+    )
+
+    away = comparison(
+        diagnostics,
+        "away_runs_mean",
+    )
+    home = comparison(
+        diagnostics,
+        "home_runs_mean",
+    )
+    total = comparison(
+        diagnostics,
+        "total_runs_mean",
+    )
+
+    assert diagnostics.status == "partial"
+    assert away.canonical_value == 4.0
+    assert away.absolute_difference == 0.5
+    assert home.canonical_value == 3.0
+    assert home.absolute_difference == 0.5
+    assert total.canonical_value == 7.0
+    assert total.absolute_difference == 0.0
+
+
+def test_comparator_reports_distribution_ranges():
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=canonical_payload(),
+    )
+
+    away = range_comparison(
+        diagnostics,
+        "away_runs_range",
+    )
+    total = range_comparison(
+        diagnostics,
+        "total_runs_range",
+    )
+
+    assert away.legacy_minimum == 2.0
+    assert away.legacy_maximum == 5.0
+    assert away.canonical_minimum == 3.0
+    assert away.canonical_maximum == 5.0
+    assert total.canonical_minimum == 5.0
+    assert total.canonical_maximum == 9.0
+
+
+def test_missing_canonical_home_win_is_explicit():
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=canonical_payload(),
+    )
+
+    home_win = comparison(
+        diagnostics,
+        "home_win_probability",
+    )
+
+    assert home_win.available is False
+    assert (
+        "comparison_unavailable:"
+        "home_win_probability"
+        in diagnostics.warnings
+    )
+
+
+def test_quality_diagnostics_are_preserved():
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=canonical_payload(),
+    )
+
+    assert (
+        diagnostics
+        .pitcher_attribution_complete_rate
+        == 0.5
+    )
+    assert (
+        diagnostics.replay_validation_pass_rate
+        == 1.0
+    )
+    assert (
+        diagnostics.earned_run_status
+        == "not_reconstructed"
+    )
+
+
+def test_disabled_shadow_preserves_authoritative_result():
+    legacy = legacy_result()
+    original = deepcopy(legacy)
+
+    attached = attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=False,
+    )
+
+    assert legacy == original
+    assert attached is not legacy
+    assert attached["model_version"] == (
+        original["model_version"]
+    )
+    assert attached["away_expected_runs"] == (
+        original["away_expected_runs"]
+    )
+    assert (
+        attached["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "disabled"
+    )
+
+
+def test_missing_payload_is_fail_open():
+    attached = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=None,
+    )
+
+    shadow = attached["diagnostics"][
+        "canonical_shadow"
+    ]
+
+    assert shadow["status"] == "unavailable"
+    assert shadow["authoritative_source"] == "legacy"
+
+
+def test_invalid_payload_is_fail_open_error():
+    legacy = legacy_result()
+
+    attached = attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=True,
+        canonical_payload={"invalid": True},
+    )
+
+    shadow = attached["diagnostics"][
+        "canonical_shadow"
+    ]
+
+    assert shadow["status"] == "error"
+    assert shadow["error_type"] is not None
+    assert attached["away_expected_runs"] == (
+        legacy["away_expected_runs"]
+    )
+
+
+def test_nested_shared_simulation_is_supported():
+    nested = {
+        "derived_outputs": {
+            "bullpen_adjusted_game_simulation": (
+                legacy_result()
+            ),
+        },
+        "diagnostics": {
+            "sources": ["legacy"],
+        },
+    }
+
+    attached = attach_canonical_shadow(
+        legacy_result=nested,
+        enabled=True,
+        canonical_payload=canonical_payload(),
+    )
+
+    assert (
+        attached["diagnostics"]["sources"]
+        == ["legacy"]
+    )
+    assert (
+        attached["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "partial"
+    )
+
+
+def test_output_is_json_serializable():
+    attached = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+    )
+
+    encoded = json.dumps(
+        attached,
+        sort_keys=True,
+    )
+
+    assert "canonical_shadow_v1" in encoded


### PR DESCRIPTION
## Summary

Implements Layer 10H canonical production-shadow comparison as a fail-open adapter that compares a prebuilt canonical projection payload with the existing legacy simulation result without replacing or mutating production behavior.

### Added

- Versioned canonical-shadow contracts
- Legacy-versus-canonical metric comparisons
- Away, home, and total expected-run mean comparisons
- Away, home, and total run-range comparisons
- Simulation-count comparison
- Explicit home-win-probability unavailability handling
- Comparison coverage reporting
- Pitcher-attribution completeness diagnostics
- Replay-validation pass-rate diagnostics
- Earned-run reconstruction status propagation
- Deterministic JSON-compatible serialization
- Fail-open disabled, unavailable, partial, complete, and error states
- Input validation for malformed canonical payload dictionaries

## Architecture

```text
legacy simulation result ───────────────┐
                                       ├─ compare_shadow_payloads()
prebuilt canonical projection payload ─┘
                                                ↓
                                CanonicalShadowDiagnostics
                                                ↓
                              attach_canonical_shadow()
                                                ↓
                   result["diagnostics"]["canonical_shadow"]
```

## Safety behavior

- Legacy simulation remains authoritative.
- The legacy input is never mutated.
- Missing canonical data returns `unavailable`.
- Disabled shadow mode returns `disabled`.
- Malformed canonical data returns `error` while preserving the legacy result.
- Partial comparison coverage is explicit.
- Existing production simulator and builder behavior is unchanged.

## Comparison surface

The adapter compares, when available:

- simulation count;
- away expected runs;
- home expected runs;
- total expected runs;
- away run range;
- home run range;
- total run range;
- home-win probability.

The current canonical payload does not yet contain game outcome distributions, so home-win probability is explicitly unavailable and coverage remains partial.

## Core invariants

- shadow diagnostics are non-authoritative;
- no legacy response keys or values are replaced;
- canonical payloads must satisfy a minimum structural contract;
- comparison failures cannot fail the legacy result;
- output serialization is deterministic and JSON-compatible;
- quality limitations are surfaced rather than inferred or hidden.

## Scope

This layer does not:

- modify `game_simulation_builder.py`;
- invoke a canonical full-game simulator;
- replace production simulation results;
- add API or UI exposure;
- reconstruct earned runs;
- generate canonical home-win probabilities.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- Layer 10D tests passed
- Layer 10E tests passed
- Layer 10F tests passed
- Layer 10G tests passed
- New Layer 10H tests passed
- Result: `85 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/contracts.py`
- `mlb_app/simulation/shadow/comparator.py`
- `mlb_app/simulation/shadow/integration.py`
- `mlb_app/simulation/shadow/serialization.py`
- `tests/test_canonical_shadow_integration.py`

## Next layer

The next slice will wire this stable fail-open adapter into the shared simulation builder behind an explicit feature flag while preserving all existing production output behavior.