### PR TITLE
Wire canonical shadow diagnostics

### DIFF
--- a/mlb_app/simulation/game_simulation_builder.py
+++ b/mlb_app/simulation/game_simulation_builder.py
@@ -12,6 +12,8 @@ slightly different function names while we migrate it into mlb_app/simulation.
 
 from __future__ import annotations
 
+import os
+
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
@@ -681,6 +683,190 @@ def _attach_position_player_substitution_diagnostics(
     return payload
 
 
+CANONICAL_SHADOW_ENABLED_ENV = (
+    "CANONICAL_SIMULATION_SHADOW_ENABLED"
+)
+
+CANONICAL_SHADOW_CONFIG_KEYS = frozenset(
+    {
+        "canonical_shadow_enabled",
+        "canonical_shadow_payload",
+    }
+)
+
+
+def _parse_boolean_flag(
+    value,
+    *,
+    default: bool = False,
+) -> bool:
+    """Parse explicit config or environment boolean values."""
+
+    if value is None:
+        return default
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    normalized = str(value).strip().lower()
+
+    if normalized in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }:
+        return True
+
+    if normalized in {
+        "0",
+        "false",
+        "no",
+        "n",
+        "off",
+        "",
+    }:
+        return False
+
+    return default
+
+
+def _canonical_shadow_requested(
+    config: Optional[Dict[str, Any]],
+) -> bool:
+    """
+    Return whether the integration boundary was explicitly requested.
+
+    An absent config key and absent environment variable preserve the
+    historical payload exactly and do not add disabled diagnostics.
+    """
+
+    config_snapshot = dict(config or {})
+
+    if "canonical_shadow_enabled" in config_snapshot:
+        return True
+
+    return CANONICAL_SHADOW_ENABLED_ENV in os.environ
+
+
+def _canonical_shadow_enabled(
+    config: Optional[Dict[str, Any]],
+) -> bool:
+    """
+    Resolve shadow enablement using explicit config, environment, then
+    the disabled default.
+    """
+
+    config_snapshot = dict(config or {})
+
+    if "canonical_shadow_enabled" in config_snapshot:
+        return _parse_boolean_flag(
+            config_snapshot.get(
+                "canonical_shadow_enabled"
+            ),
+            default=False,
+        )
+
+    return _parse_boolean_flag(
+        os.getenv(CANONICAL_SHADOW_ENABLED_ENV),
+        default=False,
+    )
+
+
+def _canonical_shadow_payload(
+    config: Optional[Dict[str, Any]],
+):
+    """Return the prebuilt canonical payload without copying it."""
+
+    return dict(config or {}).get(
+        "canonical_shadow_payload"
+    )
+
+
+def _attach_canonical_shadow_diagnostics(
+    payload: Dict[str, Any],
+    *,
+    config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Attach fail-open canonical shadow diagnostics when explicitly
+    requested.
+
+    This helper never invokes canonical simulation and never changes the
+    legacy simulation's authoritative values.
+    """
+
+    if not _canonical_shadow_requested(config):
+        return payload
+
+    enabled = False
+    canonical_payload = None
+    canonical_available = False
+
+    try:
+        enabled = _canonical_shadow_enabled(config)
+        canonical_payload = _canonical_shadow_payload(
+            config
+        )
+        canonical_available = (
+            canonical_payload is not None
+        )
+
+        from mlb_app.simulation.shadow import (
+            attach_canonical_shadow,
+        )
+
+        return attach_canonical_shadow(
+            legacy_result=payload,
+            enabled=enabled,
+            canonical_payload=canonical_payload,
+        )
+    except Exception as exc:
+        # Never call shadow config/payload helpers again here. One of those
+        # helpers may be the source of the failure.
+        output = deepcopy(payload)
+
+        diagnostics = output.setdefault(
+            "diagnostics",
+            {},
+        )
+
+        if not isinstance(diagnostics, dict):
+            diagnostics = {
+                "legacy_diagnostics": deepcopy(
+                    diagnostics
+                )
+            }
+            output["diagnostics"] = diagnostics
+
+        diagnostics["canonical_shadow"] = {
+            "status": "error",
+            "enabled": enabled,
+            "canonical_available": canonical_available,
+            "authoritative_source": "legacy",
+            "comparisons": [],
+            "ranges": [],
+            "coverage": None,
+            "legacy_simulation_count": None,
+            "canonical_simulation_count": None,
+            "pitcher_attribution_complete_rate": None,
+            "replay_validation_pass_rate": None,
+            "earned_run_status": None,
+            "warnings": [
+                "canonical_shadow_integration_failed"
+            ],
+            "error_type": exc.__class__.__name__,
+            "error_message": str(exc),
+            "schema_version": "canonical_shadow_v1",
+        }
+
+        return output
+
+
 def build_game_simulation(
     game_pk: int,
     config: Optional[Dict[str, Any]] = None,
@@ -712,6 +898,8 @@ def build_game_simulation(
             "position_player_substitution_diagnostics_enabled",
             "position_player_substitution_diagnostics_version",
             "position_player_substitution_state",
+            "canonical_shadow_enabled",
+            "canonical_shadow_payload",
         }
     }
 
@@ -755,8 +943,15 @@ def build_game_simulation(
             )
         )
 
-        return _attach_position_player_substitution_diagnostics(
-            stolen_base_pickoff_payload,
+        position_player_substitution_payload = (
+            _attach_position_player_substitution_diagnostics(
+                stolen_base_pickoff_payload,
+                config=config_snapshot,
+            )
+        )
+
+        return _attach_canonical_shadow_diagnostics(
+            position_player_substitution_payload,
             config=config_snapshot,
         )
     except Exception as exc:

--- a/tests/test_game_simulation_shadow_wiring.py
+++ b/tests/test_game_simulation_shadow_wiring.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+import mlb_app.simulation.game_simulation_builder as builder
+
+
+def legacy_payload():
+    return {
+        "derived_outputs": {
+            "game_simulation": {
+                "model_version": "full_game_sim_v1",
+                "simulations": 2,
+                "away_expected_runs": 3.5,
+                "home_expected_runs": 3.0,
+                "total_expected_runs": 6.5,
+                "home_win_probability": 0.52,
+                "away_run_distribution": {
+                    "2": 0.5,
+                    "5": 0.5,
+                },
+                "home_run_distribution": {
+                    "1": 0.5,
+                    "5": 0.5,
+                },
+                "total_run_distribution": {
+                    "4": 0.5,
+                    "9": 0.5,
+                },
+                "metadata": {
+                    "simulation_count": 2,
+                },
+            }
+        },
+        "diagnostics": {
+            "sources": ["legacy"],
+        },
+        "meta": {
+            "engine": "legacy",
+        },
+    }
+
+
+def canonical_payload():
+    def summary(mean, minimum, maximum):
+        return {
+            "count": 2,
+            "mean": mean,
+            "median": mean,
+            "p10": minimum,
+            "p25": minimum,
+            "p75": maximum,
+            "p90": maximum,
+            "minimum": minimum,
+            "maximum": maximum,
+        }
+
+    return {
+        "schema_version": "canonical_projection_payload_v1",
+        "run_id": "canonical-test",
+        "model_version": "canonical-event-model-v1",
+        "simulation_count": 2,
+        "teams": [
+            {
+                "team_side": "away",
+                "metrics": [
+                    {
+                        "name": "runs",
+                        "summary": summary(
+                            4.0,
+                            3.0,
+                            5.0,
+                        ),
+                    }
+                ],
+            },
+            {
+                "team_side": "home",
+                "metrics": [
+                    {
+                        "name": "runs",
+                        "summary": summary(
+                            3.0,
+                            2.0,
+                            4.0,
+                        ),
+                    }
+                ],
+            },
+        ],
+        "batters": [],
+        "pitchers": [],
+        "diagnostics": {
+            "pitcher_attribution_complete_rate": 0.5,
+            "replay_validation_pass_rate": 1.0,
+            "earned_run_status": "not_reconstructed",
+            "warnings": [
+                "earned_runs_not_fully_reconstructed"
+            ],
+        },
+    }
+
+
+def install_builder_stubs(monkeypatch, captured):
+    def fake_engine(game_pk, config):
+        captured["game_pk"] = game_pk
+        captured["engine_config"] = deepcopy(config)
+        return legacy_payload()
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: fake_engine,
+    )
+
+    monkeypatch.setattr(
+        builder,
+        "_normalize_metadata",
+        lambda payload, **kwargs: payload,
+    )
+
+    monkeypatch.setattr(
+        builder,
+        "_attach_pitching_plan_diagnostics",
+        lambda payload, **kwargs: payload,
+    )
+    monkeypatch.setattr(
+        builder,
+        "_attach_starter_hook_diagnostics",
+        lambda payload, **kwargs: payload,
+    )
+    monkeypatch.setattr(
+        builder,
+        "_attach_bullpen_sequence_diagnostics",
+        lambda payload, **kwargs: payload,
+    )
+    monkeypatch.setattr(
+        builder,
+        "_attach_stolen_base_pickoff_diagnostics",
+        lambda payload, **kwargs: payload,
+    )
+    monkeypatch.setattr(
+        builder,
+        "_attach_position_player_substitution_diagnostics",
+        lambda payload, **kwargs: payload,
+    )
+
+
+def test_absent_flag_preserves_historical_payload(monkeypatch):
+    monkeypatch.delenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        raising=False,
+    )
+
+    payload = legacy_payload()
+
+    attached = builder._attach_canonical_shadow_diagnostics(
+        payload,
+        config={},
+    )
+
+    assert attached is payload
+    assert "canonical_shadow" not in attached["diagnostics"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_boolean_flag_parsing(value, expected):
+    assert builder._parse_boolean_flag(value) is expected
+
+
+def test_explicit_config_precedes_environment(monkeypatch):
+    monkeypatch.setenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        "true",
+    )
+
+    assert (
+        builder._canonical_shadow_enabled(
+            {"canonical_shadow_enabled": False}
+        )
+        is False
+    )
+
+
+def test_environment_enables_shadow_when_config_absent(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        "true",
+    )
+
+    assert builder._canonical_shadow_requested({}) is True
+    assert builder._canonical_shadow_enabled({}) is True
+
+
+def test_explicit_false_attaches_disabled_diagnostics(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        raising=False,
+    )
+
+    attached = builder._attach_canonical_shadow_diagnostics(
+        legacy_payload(),
+        config={
+            "canonical_shadow_enabled": False,
+        },
+    )
+
+    shadow = attached["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "disabled"
+    assert shadow["enabled"] is False
+    assert shadow["authoritative_source"] == "legacy"
+
+
+def test_enabled_without_payload_is_unavailable(monkeypatch):
+    monkeypatch.delenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        raising=False,
+    )
+
+    attached = builder._attach_canonical_shadow_diagnostics(
+        legacy_payload(),
+        config={
+            "canonical_shadow_enabled": True,
+        },
+    )
+
+    shadow = attached["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "unavailable"
+    assert shadow["canonical_available"] is False
+    assert shadow["authoritative_source"] == "legacy"
+
+
+def test_enabled_payload_attaches_partial_comparison(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        raising=False,
+    )
+
+    original = legacy_payload()
+
+    attached = builder._attach_canonical_shadow_diagnostics(
+        original,
+        config={
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_payload": (
+                canonical_payload()
+            ),
+        },
+    )
+
+    shadow = attached["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "partial"
+    assert shadow["authoritative_source"] == "legacy"
+    assert shadow["canonical_available"] is True
+    assert original["diagnostics"] == {
+        "sources": ["legacy"]
+    }
+    assert attached["derived_outputs"] == (
+        original["derived_outputs"]
+    )
+
+
+def test_shadow_keys_do_not_reach_engine(monkeypatch):
+    captured = {}
+    install_builder_stubs(monkeypatch, captured)
+
+    result = builder.build_game_simulation(
+        123,
+        config={
+            "simulation_count": 25,
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_payload": (
+                canonical_payload()
+            ),
+        },
+    )
+
+    assert captured["game_pk"] == 123
+    assert captured["engine_config"] == {
+        "simulation_count": 25,
+    }
+
+    shadow = result["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "partial"
+    assert shadow["authoritative_source"] == "legacy"
+
+
+def test_builder_default_does_not_add_shadow_block(
+    monkeypatch,
+):
+    captured = {}
+    install_builder_stubs(monkeypatch, captured)
+
+    monkeypatch.delenv(
+        builder.CANONICAL_SHADOW_ENABLED_ENV,
+        raising=False,
+    )
+
+    result = builder.build_game_simulation(
+        123,
+        config={
+            "simulation_count": 25,
+        },
+    )
+
+    assert "canonical_shadow" not in result["diagnostics"]
+
+
+def test_outer_shadow_boundary_is_fail_open(
+    monkeypatch,
+):
+    payload = legacy_payload()
+
+    def fail_import(*args, **kwargs):
+        raise RuntimeError("unexpected shadow failure")
+
+    monkeypatch.setattr(
+        builder,
+        "_canonical_shadow_payload",
+        fail_import,
+    )
+
+    attached = builder._attach_canonical_shadow_diagnostics(
+        payload,
+        config={
+            "canonical_shadow_enabled": True,
+        },
+    )
+
+    shadow = attached["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "error"
+    assert shadow["authoritative_source"] == "legacy"
+    assert shadow["error_type"] == "RuntimeError"
+    assert attached["derived_outputs"] == (
+        payload["derived_outputs"]
+    )


### PR DESCRIPTION
## Summary

Implements Layer 10I shared-builder wiring for canonical shadow diagnostics behind explicit configuration and environment feature flags while preserving all existing authoritative simulation outputs.

### Added

- Canonical shadow enablement through explicit config
- Environment fallback via `CANONICAL_SIMULATION_SHADOW_ENABLED`
- Explicit config precedence over environment configuration
- Historical no-op behavior when neither config nor environment requests shadow diagnostics
- Explicit `disabled` diagnostics when shadow mode is requested but disabled
- `unavailable`, `partial`, `complete`, and `error` propagation through the shared builder
- Shadow-only configuration sanitization before legacy engine execution
- Prebuilt canonical payload support without invoking canonical simulation
- Outer fail-open protection around shadow import and attachment
- Builder-level tests for configuration precedence, engine isolation, and error containment

## Architecture

```text
build_game_simulation()
        ↓
legacy engine receives sanitized config
        ↓
existing diagnostics attachment chain
        ↓
_attach_canonical_shadow_diagnostics()
        ├─ no request → historical payload unchanged
        ├─ explicit false → disabled
        ├─ enabled, no payload → unavailable
        ├─ enabled, valid payload → partial/complete
        └─ failure → error, legacy output preserved
```

## Feature-flag precedence

```text
canonical_shadow_enabled in config
        ↓
CANONICAL_SIMULATION_SHADOW_ENABLED
        ↓
False
```

An absent config key and absent environment variable do not add a shadow diagnostics block, preserving the historical payload shape.

## Engine isolation

The following integration-only keys are removed before invoking the existing engine:

- `canonical_shadow_enabled`
- `canonical_shadow_payload`

The full canonical payload is never added to the returned production result.

## Safety behavior

- Legacy simulation remains authoritative.
- Existing engine inputs and outputs remain unchanged.
- Canonical simulation is not invoked.
- Missing or malformed canonical payloads cannot fail the production builder.
- Unexpected shadow-helper or import failures are converted to structured error diagnostics.
- The original legacy payload remains unmodified by the shadow adapter.

## Scope

This layer does not:

- generate canonical full-game simulations;
- replace legacy expected runs or probabilities;
- alter API or UI contracts by default;
- persist canonical payloads;
- reconstruct earned runs;
- enable shadow mode by default.

## Validation

- Python compilation passed
- Layer 10B tests passed
- Layer 10C tests passed
- Layer 10D tests passed
- Layer 10E tests passed
- Layer 10F tests passed
- Layer 10G tests passed
- Layer 10H tests passed
- New Layer 10I tests passed
- Result: `104 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game_simulation_builder.py`
- `tests/test_game_simulation_shadow_wiring.py`

## Next layer

Layer 10J will introduce canonical full-game orchestration so the shadow payload can be generated internally rather than supplied as a prebuilt input.