### PR TITLE
Implement canonical full-game orchestration

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,0 +1,29 @@
+"""Canonical full-game orchestration."""
+
+from .contracts import (
+    CanonicalGameConfig,
+    CanonicalGameResult,
+    CanonicalLineup,
+    GameCompletionReason,
+    HalfInningRecord,
+)
+from .orchestrator import (
+    PlateAppearanceResolver,
+    simulate_canonical_game,
+)
+from .validation import (
+    CanonicalGameValidation,
+    validate_canonical_game,
+)
+
+__all__ = [
+    "CanonicalGameConfig",
+    "CanonicalGameResult",
+    "CanonicalGameValidation",
+    "CanonicalLineup",
+    "GameCompletionReason",
+    "HalfInningRecord",
+    "PlateAppearanceResolver",
+    "simulate_canonical_game",
+    "validate_canonical_game",
+]

--- a/mlb_app/simulation/game/contracts.py
+++ b/mlb_app/simulation/game/contracts.py
@@ -1,0 +1,252 @@
+"""Canonical full-game orchestration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Tuple
+
+from mlb_app.simulation.events import (
+    GameState,
+    PlayEvent,
+    PlayLedger,
+)
+
+
+class GameCompletionReason(str, Enum):
+    """Reason canonical game orchestration stopped."""
+
+    REGULATION = "regulation"
+    HOME_LEAD_AFTER_TOP = "home_lead_after_top"
+    WALK_OFF = "walk_off"
+    EXTRA_INNINGS = "extra_innings"
+    EXTRA_INNINGS_CAP_TIE = "extra_innings_cap_tie"
+
+
+@dataclass(frozen=True)
+class CanonicalGameConfig:
+    """Rules and safety limits for one canonical game."""
+
+    regulation_innings: int = 9
+    max_extra_innings: int = 6
+    automatic_runner_enabled: bool = True
+    max_plate_appearances_per_half: int = 100
+
+    def __post_init__(self) -> None:
+        if self.regulation_innings < 1:
+            raise ValueError(
+                "regulation_innings must be positive"
+            )
+        if self.max_extra_innings < 0:
+            raise ValueError(
+                "max_extra_innings cannot be negative"
+            )
+        if self.max_plate_appearances_per_half < 1:
+            raise ValueError(
+                "max_plate_appearances_per_half "
+                "must be positive"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalLineup:
+    """Fixed nine-player batting order for one team."""
+
+    team_side: str
+    player_ids: Tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+        if len(self.player_ids) != 9:
+            raise ValueError(
+                "canonical lineup requires nine players"
+            )
+        if any(not player_id for player_id in self.player_ids):
+            raise ValueError(
+                "lineup player identifiers are required"
+            )
+        if len(set(self.player_ids)) != 9:
+            raise ValueError(
+                "lineup player identifiers must be unique"
+            )
+
+    def batter(self, batting_order_index: int) -> str:
+        return self.player_ids[
+            batting_order_index % len(self.player_ids)
+        ]
+
+    def automatic_runner(
+        self,
+        batting_order_index: int,
+    ) -> str:
+        """Return the hitter immediately preceding the leadoff spot."""
+
+        return self.player_ids[
+            (batting_order_index - 1)
+            % len(self.player_ids)
+        ]
+
+
+@dataclass(frozen=True)
+class HalfInningRecord:
+    """One canonical half inning with its own valid play ledger."""
+
+    inning: int
+    half: str
+    initial_state: GameState
+    events: Tuple[PlayEvent, ...]
+    batting_order_start: int
+    batting_order_end: int
+    ended_by_walk_off: bool = False
+    automatic_runner_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.inning < 1:
+            raise ValueError("inning must be positive")
+        if self.half not in {"top", "bottom"}:
+            raise ValueError(
+                "half must be 'top' or 'bottom'"
+            )
+        if self.initial_state.inning != self.inning:
+            raise ValueError(
+                "initial state inning does not match record"
+            )
+        if self.initial_state.half != self.half:
+            raise ValueError(
+                "initial state half does not match record"
+            )
+        if self.initial_state.outs != 0:
+            raise ValueError(
+                "half inning must begin with zero outs"
+            )
+        if (
+            self.initial_state.batting_order_index
+            != self.batting_order_start
+        ):
+            raise ValueError(
+                "batting order start does not match state"
+            )
+
+        ledger = self.ledger
+
+        if (
+            ledger.current_state.batting_order_index
+            != self.batting_order_end
+        ):
+            raise ValueError(
+                "batting order end does not match ledger"
+            )
+
+        if self.ended_by_walk_off:
+            if self.half != "bottom":
+                raise ValueError(
+                    "walk-off must occur in bottom half"
+                )
+            if (
+                ledger.current_state.home_score
+                <= ledger.current_state.away_score
+            ):
+                raise ValueError(
+                    "walk-off requires home team lead"
+                )
+        elif ledger.current_state.outs != 3:
+            raise ValueError(
+                "non-walk-off half inning must end "
+                "with three outs"
+            )
+
+    @property
+    def final_state(self) -> GameState:
+        if not self.events:
+            return self.initial_state
+        return self.events[-1].state_after
+
+    @property
+    def ledger(self) -> PlayLedger:
+        """
+        Return a half-inning-local replay ledger.
+
+        PlayEvent.sequence remains global across the complete game.
+        PlayLedger requires local sequences beginning at zero, so temporary
+        event copies are normalized only for half-inning replay validation.
+        """
+
+        local_events = tuple(
+            replace(event, sequence=index)
+            for index, event in enumerate(self.events)
+        )
+
+        return PlayLedger.from_events(
+            self.initial_state,
+            local_events,
+        )
+
+
+
+@dataclass(frozen=True)
+class CanonicalGameResult:
+    """Complete deterministic result for one canonical game trial."""
+
+    config: CanonicalGameConfig
+    away_lineup: CanonicalLineup
+    home_lineup: CanonicalLineup
+    halves: Tuple[HalfInningRecord, ...]
+    final_state: GameState
+    completion_reason: GameCompletionReason
+    completed: bool = True
+    warnings: Tuple[str, ...] = field(
+        default_factory=tuple
+    )
+
+    def __post_init__(self) -> None:
+        if not self.halves:
+            raise ValueError(
+                "canonical game requires at least one half"
+            )
+        if self.away_lineup.team_side != "away":
+            raise ValueError(
+                "away_lineup must use away team side"
+            )
+        if self.home_lineup.team_side != "home":
+            raise ValueError(
+                "home_lineup must use home team side"
+            )
+        if self.final_state != self.halves[-1].final_state:
+            raise ValueError(
+                "final_state must equal final half state"
+            )
+        if not self.completed:
+            raise ValueError(
+                "canonical game result must be completed"
+            )
+
+    @property
+    def events(self) -> Tuple[PlayEvent, ...]:
+        return tuple(
+            event
+            for half in self.halves
+            for event in half.events
+        )
+
+    @property
+    def away_score(self) -> int:
+        return self.final_state.away_score
+
+    @property
+    def home_score(self) -> int:
+        return self.final_state.home_score
+
+    @property
+    def total_runs(self) -> int:
+        return self.away_score + self.home_score
+
+    @property
+    def went_to_extras(self) -> bool:
+        return any(
+            half.inning
+            > self.config.regulation_innings
+            for half in self.halves
+        )

--- a/mlb_app/simulation/game/orchestrator.py
+++ b/mlb_app/simulation/game/orchestrator.py
@@ -1,0 +1,337 @@
+"""Canonical regulation, extras, and walk-off orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Callable, Tuple
+
+from mlb_app.simulation.events import (
+    GameState,
+    PlayEvent,
+)
+
+from .contracts import (
+    CanonicalGameConfig,
+    CanonicalGameResult,
+    CanonicalLineup,
+    GameCompletionReason,
+    HalfInningRecord,
+)
+
+
+PlateAppearanceResolver = Callable[
+    [GameState, str, int],
+    PlayEvent,
+]
+
+
+def simulate_canonical_game(
+    *,
+    away_lineup: CanonicalLineup,
+    home_lineup: CanonicalLineup,
+    resolve_plate_appearance: PlateAppearanceResolver,
+    config: CanonicalGameConfig | None = None,
+) -> CanonicalGameResult:
+    """
+    Orchestrate one canonical game using an injected PA resolver.
+
+    The resolver receives:
+      state, batter_id, global_event_sequence
+
+    It must return one valid canonical PlayEvent.
+    """
+
+    rules = config or CanonicalGameConfig()
+
+    if away_lineup.team_side != "away":
+        raise ValueError(
+            "away_lineup must use away team side"
+        )
+    if home_lineup.team_side != "home":
+        raise ValueError(
+            "home_lineup must use home team side"
+        )
+    if not callable(resolve_plate_appearance):
+        raise TypeError(
+            "resolve_plate_appearance must be callable"
+        )
+
+    halves = []
+    away_index = 0
+    home_index = 0
+    away_score = 0
+    home_score = 0
+    plate_appearance_number = 0
+    sequence = 0
+    inning = 1
+
+    final_reason = None
+    warnings = []
+
+    maximum_inning = (
+        rules.regulation_innings
+        + rules.max_extra_innings
+    )
+
+    while inning <= maximum_inning:
+        top = _simulate_half(
+            inning=inning,
+            half="top",
+            lineup=away_lineup,
+            batting_order_index=away_index,
+            away_score=away_score,
+            home_score=home_score,
+            plate_appearance_number=(
+                plate_appearance_number
+            ),
+            sequence=sequence,
+            config=rules,
+            resolve_plate_appearance=(
+                resolve_plate_appearance
+            ),
+        )
+        halves.append(top.record)
+
+        away_index = top.record.batting_order_end
+        away_score = top.record.final_state.away_score
+        home_score = top.record.final_state.home_score
+        plate_appearance_number = (
+            top.record.final_state
+            .plate_appearance_number
+        )
+        sequence = top.next_sequence
+
+        if (
+            inning >= rules.regulation_innings
+            and home_score > away_score
+        ):
+            final_reason = (
+                GameCompletionReason
+                .HOME_LEAD_AFTER_TOP
+            )
+            break
+
+        bottom = _simulate_half(
+            inning=inning,
+            half="bottom",
+            lineup=home_lineup,
+            batting_order_index=home_index,
+            away_score=away_score,
+            home_score=home_score,
+            plate_appearance_number=(
+                plate_appearance_number
+            ),
+            sequence=sequence,
+            config=rules,
+            resolve_plate_appearance=(
+                resolve_plate_appearance
+            ),
+            walk_off_eligible=(
+                inning >= rules.regulation_innings
+            ),
+        )
+        halves.append(bottom.record)
+
+        home_index = bottom.record.batting_order_end
+        away_score = bottom.record.final_state.away_score
+        home_score = bottom.record.final_state.home_score
+        plate_appearance_number = (
+            bottom.record.final_state
+            .plate_appearance_number
+        )
+        sequence = bottom.next_sequence
+
+        if bottom.record.ended_by_walk_off:
+            final_reason = (
+                GameCompletionReason.WALK_OFF
+            )
+            break
+
+        if (
+            inning >= rules.regulation_innings
+            and away_score != home_score
+        ):
+            final_reason = (
+                GameCompletionReason.EXTRA_INNINGS
+                if inning
+                > rules.regulation_innings
+                else GameCompletionReason.REGULATION
+            )
+            break
+
+        inning += 1
+
+    if final_reason is None:
+        final_reason = (
+            GameCompletionReason
+            .EXTRA_INNINGS_CAP_TIE
+        )
+        warnings.append(
+            "game_tied_at_extra_innings_cap"
+        )
+
+    final_state = halves[-1].final_state
+
+    return CanonicalGameResult(
+        config=rules,
+        away_lineup=away_lineup,
+        home_lineup=home_lineup,
+        halves=tuple(halves),
+        final_state=final_state,
+        completion_reason=final_reason,
+        warnings=tuple(warnings),
+    )
+
+
+class _HalfSimulation:
+    def __init__(
+        self,
+        *,
+        record: HalfInningRecord,
+        next_sequence: int,
+    ) -> None:
+        self.record = record
+        self.next_sequence = next_sequence
+
+
+def _simulate_half(
+    *,
+    inning: int,
+    half: str,
+    lineup: CanonicalLineup,
+    batting_order_index: int,
+    away_score: int,
+    home_score: int,
+    plate_appearance_number: int,
+    sequence: int,
+    config: CanonicalGameConfig,
+    resolve_plate_appearance: PlateAppearanceResolver,
+    walk_off_eligible: bool = False,
+) -> _HalfSimulation:
+    bases = (None, None, None)
+    automatic_runner_id = None
+
+    if (
+        inning > config.regulation_innings
+        and config.automatic_runner_enabled
+    ):
+        automatic_runner_id = (
+            lineup.automatic_runner(
+                batting_order_index
+            )
+        )
+        bases = (
+            None,
+            automatic_runner_id,
+            None,
+        )
+
+    initial_state = GameState(
+        inning=inning,
+        half=half,
+        outs=0,
+        bases=bases,
+        away_score=away_score,
+        home_score=home_score,
+        batting_order_index=batting_order_index,
+        plate_appearance_number=(
+            plate_appearance_number
+        ),
+    )
+
+    state = initial_state
+    events = []
+    current_sequence = sequence
+    ended_by_walk_off = False
+
+    for _ in range(
+        config.max_plate_appearances_per_half
+    ):
+        if state.outs >= 3:
+            break
+
+        batter_id = lineup.batter(
+            state.batting_order_index
+        )
+
+        event = resolve_plate_appearance(
+            state,
+            batter_id,
+            current_sequence,
+        )
+
+        _validate_resolved_event(
+            event=event,
+            expected_state=state,
+            expected_batter_id=batter_id,
+            expected_sequence=current_sequence,
+        )
+
+        events.append(event)
+        state = event.state_after
+        current_sequence += 1
+
+        if (
+            walk_off_eligible
+            and half == "bottom"
+            and state.home_score
+            > state.away_score
+        ):
+            ended_by_walk_off = True
+            break
+    else:
+        raise RuntimeError(
+            "maximum plate appearances exceeded "
+            f"in inning {inning} {half}"
+        )
+
+    if not ended_by_walk_off and state.outs != 3:
+        raise RuntimeError(
+            "half inning did not terminate with "
+            "three outs"
+        )
+
+    record = HalfInningRecord(
+        inning=inning,
+        half=half,
+        initial_state=initial_state,
+        events=tuple(events),
+        batting_order_start=batting_order_index,
+        batting_order_end=(
+            state.batting_order_index
+        ),
+        ended_by_walk_off=ended_by_walk_off,
+        automatic_runner_id=automatic_runner_id,
+    )
+
+    return _HalfSimulation(
+        record=record,
+        next_sequence=current_sequence,
+    )
+
+
+def _validate_resolved_event(
+    *,
+    event: PlayEvent,
+    expected_state: GameState,
+    expected_batter_id: str,
+    expected_sequence: int,
+) -> None:
+    if not isinstance(event, PlayEvent):
+        raise TypeError(
+            "plate appearance resolver must "
+            "return PlayEvent"
+        )
+    if event.sequence != expected_sequence:
+        raise ValueError(
+            "resolver returned unexpected event sequence"
+        )
+    if event.batter_id != expected_batter_id:
+        raise ValueError(
+            "resolver returned unexpected batter"
+        )
+    if event.state_before != expected_state:
+        raise ValueError(
+            "resolver event state_before does not "
+            "match current game state"
+        )

--- a/mlb_app/simulation/game/validation.py
+++ b/mlb_app/simulation/game/validation.py
@@ -1,0 +1,188 @@
+"""Validation for canonical full-game orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from .contracts import CanonicalGameResult
+
+
+@dataclass(frozen=True)
+class CanonicalGameValidation:
+    event_sequences_contiguous: bool
+    half_order_valid: bool
+    score_continuity_valid: bool
+    batting_order_continuity_valid: bool
+    final_state_matches: bool
+    completion_rule_valid: bool
+    warnings: Tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.event_sequences_contiguous
+            and self.half_order_valid
+            and self.score_continuity_valid
+            and self.batting_order_continuity_valid
+            and self.final_state_matches
+            and self.completion_rule_valid
+        )
+
+
+def validate_canonical_game(
+    result: CanonicalGameResult,
+) -> CanonicalGameValidation:
+    events = result.events
+
+    event_sequences_contiguous = tuple(
+        event.sequence for event in events
+    ) == tuple(range(len(events)))
+
+    half_order_valid = all(
+        _expected_next_half(previous, current)
+        for previous, current in zip(
+            result.halves,
+            result.halves[1:],
+        )
+    )
+
+    score_continuity_valid = all(
+        (
+            current.initial_state.away_score
+            == previous.final_state.away_score
+            and current.initial_state.home_score
+            == previous.final_state.home_score
+        )
+        for previous, current in zip(
+            result.halves,
+            result.halves[1:],
+        )
+    )
+
+    batting_order_continuity_valid = (
+        _batting_order_continuity(result)
+    )
+
+    final_state_matches = (
+        result.final_state
+        == result.halves[-1].final_state
+    )
+
+    completion_rule_valid = (
+        _completion_rule_valid(result)
+    )
+
+    warnings = []
+
+    if not event_sequences_contiguous:
+        warnings.append(
+            "noncontiguous_event_sequence"
+        )
+    if not half_order_valid:
+        warnings.append("invalid_half_order")
+    if not score_continuity_valid:
+        warnings.append(
+            "score_discontinuity_between_halves"
+        )
+    if not batting_order_continuity_valid:
+        warnings.append(
+            "batting_order_discontinuity"
+        )
+    if not final_state_matches:
+        warnings.append(
+            "final_state_mismatch"
+        )
+    if not completion_rule_valid:
+        warnings.append(
+            "invalid_game_completion"
+        )
+
+    return CanonicalGameValidation(
+        event_sequences_contiguous=(
+            event_sequences_contiguous
+        ),
+        half_order_valid=half_order_valid,
+        score_continuity_valid=(
+            score_continuity_valid
+        ),
+        batting_order_continuity_valid=(
+            batting_order_continuity_valid
+        ),
+        final_state_matches=final_state_matches,
+        completion_rule_valid=completion_rule_valid,
+        warnings=tuple(warnings),
+    )
+
+
+def _expected_next_half(previous, current) -> bool:
+    if previous.half == "top":
+        return (
+            current.inning == previous.inning
+            and current.half == "bottom"
+        )
+
+    return (
+        current.inning == previous.inning + 1
+        and current.half == "top"
+    )
+
+
+def _batting_order_continuity(
+    result: CanonicalGameResult,
+) -> bool:
+    expected = {
+        "away": 0,
+        "home": 0,
+    }
+
+    for half in result.halves:
+        side = (
+            "away"
+            if half.half == "top"
+            else "home"
+        )
+
+        if half.batting_order_start != expected[side]:
+            return False
+
+        expected[side] = half.batting_order_end
+
+    return True
+
+
+def _completion_rule_valid(
+    result: CanonicalGameResult,
+) -> bool:
+    reason = result.completion_reason.value
+    away = result.away_score
+    home = result.home_score
+    final_half = result.halves[-1]
+
+    if reason == "extra_innings_cap_tie":
+        return away == home
+
+    if reason == "home_lead_after_top":
+        return (
+            final_half.half == "top"
+            and home > away
+        )
+
+    if reason == "walk_off":
+        return (
+            final_half.half == "bottom"
+            and final_half.ended_by_walk_off
+            and home > away
+        )
+
+    if reason in {
+        "regulation",
+        "extra_innings",
+    }:
+        return (
+            final_half.half == "bottom"
+            and final_half.final_state.outs == 3
+            and away != home
+        )
+
+    return False

--- a/tests/test_canonical_game_orchestration.py
+++ b/tests/test_canonical_game_orchestration.py
@@ -1,0 +1,365 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+)
+from mlb_app.simulation.game import (
+    CanonicalGameConfig,
+    CanonicalLineup,
+    GameCompletionReason,
+    simulate_canonical_game,
+    validate_canonical_game,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def out_event(state, batter_id, sequence):
+    next_out = state.outs + 1
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="out",
+        batter_id=batter_id,
+        state_before=state,
+        state_after=replace(
+            state,
+            outs=next_out,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id=batter_id,
+                out_number=next_out,
+                reason="test_out",
+            ),
+        ),
+    )
+
+
+def home_run_event(state, batter_id, sequence):
+    scorers = [
+        runner
+        for runner in state.bases
+        if runner is not None
+    ] + [batter_id]
+
+    movements = []
+
+    for base, runner_id in zip(
+        (Base.FIRST, Base.SECOND, Base.THIRD),
+        state.bases,
+    ):
+        if runner_id is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=base,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+    movements.append(
+        RunnerMovement(
+            runner_id=batter_id,
+            start_base=Base.HOME,
+            end_base=Base.HOME,
+            scored=True,
+        )
+    )
+
+    away_score = state.away_score
+    home_score = state.home_score
+
+    if state.half == "top":
+        away_score += len(scorers)
+    else:
+        home_score += len(scorers)
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="hr",
+        batter_id=batter_id,
+        state_before=state,
+        state_after=replace(
+            state,
+            bases=(None, None, None),
+            away_score=away_score,
+            home_score=home_score,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        runner_movements=tuple(movements),
+        runs_scored=tuple(scorers),
+    )
+
+
+def scripted_resolver(scoring_calls):
+    calls = {"count": 0}
+
+    def resolver(state, batter_id, sequence):
+        call = calls["count"]
+        calls["count"] += 1
+
+        if call in scoring_calls:
+            return home_run_event(
+                state,
+                batter_id,
+                sequence,
+            )
+
+        return out_event(
+            state,
+            batter_id,
+            sequence,
+        )
+
+    return resolver
+
+
+def test_scoreless_regulation_reaches_extra_cap():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=out_event,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=1,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    assert (
+        result.completion_reason
+        is GameCompletionReason.EXTRA_INNINGS_CAP_TIE
+    )
+    assert len(result.halves) == 4
+    assert result.away_score == 0
+    assert result.home_score == 0
+    assert result.went_to_extras is True
+    assert validate_canonical_game(result).passed is True
+
+
+def test_bottom_half_is_skipped_when_home_already_leads():
+    # Home scores in bottom first, then the away side is retired
+    # in the top of the next inning.
+    resolver = scripted_resolver({3})
+
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=resolver,
+        config=CanonicalGameConfig(
+            regulation_innings=2,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    assert (
+        result.completion_reason
+        is GameCompletionReason.HOME_LEAD_AFTER_TOP
+    )
+    assert result.halves[-1].inning == 2
+    assert result.halves[-1].half == "top"
+    assert result.home_score == 1
+    assert result.away_score == 0
+    assert validate_canonical_game(result).passed is True
+
+
+def test_bottom_regulation_walkoff_stops_immediately():
+    # Three away outs, then home HR on first bottom PA.
+    resolver = scripted_resolver({3})
+
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=resolver,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    assert (
+        result.completion_reason
+        is GameCompletionReason.WALK_OFF
+    )
+    assert result.home_score == 1
+    assert result.halves[-1].ended_by_walk_off is True
+    assert result.halves[-1].final_state.outs == 0
+    assert validate_canonical_game(result).passed is True
+
+
+def test_away_regulation_win_completes_bottom_half():
+    # Away HR on first call. All remaining PAs are outs.
+    resolver = scripted_resolver({0})
+
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=resolver,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    assert (
+        result.completion_reason
+        is GameCompletionReason.REGULATION
+    )
+    assert result.away_score == 1
+    assert result.home_score == 0
+    assert result.halves[-1].final_state.outs == 3
+    assert validate_canonical_game(result).passed is True
+
+
+def test_batting_orders_persist_between_innings():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=out_event,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=1,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    away_halves = [
+        half
+        for half in result.halves
+        if half.half == "top"
+    ]
+    home_halves = [
+        half
+        for half in result.halves
+        if half.half == "bottom"
+    ]
+
+    assert away_halves[0].batting_order_start == 0
+    assert away_halves[0].batting_order_end == 3
+    assert away_halves[1].batting_order_start == 3
+    assert home_halves[0].batting_order_end == 3
+    assert home_halves[1].batting_order_start == 3
+
+
+def test_event_sequences_are_global_across_halves():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=out_event,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    assert tuple(
+        event.sequence
+        for event in result.events
+    ) == tuple(range(len(result.events)))
+
+
+def test_automatic_runner_is_previous_batter():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=out_event,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=1,
+            automatic_runner_enabled=True,
+        ),
+    )
+
+    extra_top = next(
+        half
+        for half in result.halves
+        if half.inning == 2
+        and half.half == "top"
+    )
+
+    assert (
+        extra_top.automatic_runner_id
+        == "away_2"
+    )
+    assert (
+        extra_top.initial_state.second
+        == "away_2"
+    )
+
+
+def test_resolver_wrong_sequence_is_rejected():
+    def invalid(state, batter_id, sequence):
+        return out_event(
+            state,
+            batter_id,
+            sequence + 1,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="unexpected event sequence",
+    ):
+        simulate_canonical_game(
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            resolve_plate_appearance=invalid,
+            config=CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+            ),
+        )
+
+
+def test_runaway_half_is_safely_bounded():
+    def never_out(state, batter_id, sequence):
+        return home_run_event(
+            state,
+            batter_id,
+            sequence,
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="maximum plate appearances exceeded",
+    ):
+        simulate_canonical_game(
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            resolve_plate_appearance=never_out,
+            config=CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+                max_plate_appearances_per_half=5,
+            ),
+        )


### PR DESCRIPTION
## Summary

Implements the first Layer 10J slice: deterministic canonical full-game orchestration across regulation innings, skipped bottom halves, walk-offs, extra innings, automatic-runner placement, and capped ties.

## Added

- `CanonicalGameConfig`
- `CanonicalLineup`
- `HalfInningRecord`
- `CanonicalGameResult`
- `GameCompletionReason`
- Full-game orchestration through an injected plate-appearance resolver
- Persistent batting-order state for both teams
- Globally contiguous event sequencing across the complete game
- Half-inning-local replay ledgers for compatibility with existing `PlayLedger` contracts
- Optional automatic-runner placement in extra innings
- Bottom-half skipping when the home team already leads after the top half
- Immediate walk-off termination
- Extra-inning safety cap and structured warning
- Canonical full-game validation for half order, score continuity, batting-order continuity, sequence continuity, final-state consistency, and completion rules

## Architecture

```text
CanonicalGameConfig
        ↓
CanonicalLineup (away/home)
        ↓
simulate_canonical_game()
        ↓
HalfInningRecord[]
        ├─ local replay ledger
        ├─ persistent batting-order position
        ├─ global event sequence
        └─ optional automatic runner
        ↓
CanonicalGameResult
        ├─ final score
        ├─ completion reason
        ├─ flattened event stream
        └─ validation
```

## Sequence model

Canonical events retain game-global sequence numbers:

```text
0, 1, 2, 3, 4, 5, ...
```

Each `HalfInningRecord.ledger` creates temporary local copies for replay validation:

```text
0, 1, 2, ...
```

This preserves whole-game ordering without changing the existing `PlayLedger` contract.

## Supported completion behavior

- Regulation away win after completed bottom half
- Regulation home win after completed bottom half
- Skip unnecessary bottom half when home already leads
- Bottom-half walk-off termination
- Extra innings
- Optional automatic runner on second
- Tied game at configured extra-innings cap

## Scope

This slice intentionally does not yet:

- choose real plate-appearance probabilities;
- assign pitchers or relievers;
- reduce the segmented full game into one `ReducedBoxScore`;
- wire canonical game generation into the production builder;
- replace legacy simulation outputs;
- expose a projected box score in the UI;
- reconstruct earned runs.

## Validation

- Python compilation passed
- Layer 10B through Layer 10I regression tests passed
- New Layer 10J orchestration tests passed
- Result: `113 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/contracts.py`
- `mlb_app/simulation/game/orchestrator.py`
- `mlb_app/simulation/game/validation.py`
- `tests/test_canonical_game_orchestration.py`

## Next slice

Add a segmented full-game box-score reducer that combines all half-inning records into one coherent `ReducedBoxScore`, preserving player/team reconciliation for projected box-score output.