### PR TITLE
Reduce canonical games into coherent box scores

### DIFF
--- a/mlb_app/simulation/box_score/__init__.py
+++ b/mlb_app/simulation/box_score/__init__.py
@@ -31,3 +31,5 @@ __all__ = [
     "score_pitcher",
     "validate_box_score_reconstruction",
 ]
+
+from .merge import merge_reduced_box_scores

--- a/mlb_app/simulation/box_score/merge.py
+++ b/mlb_app/simulation/box_score/merge.py
@@ -1,0 +1,170 @@
+"""Merge canonical box scores reduced from event segments."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Dict, Iterable, Tuple
+
+from .contracts import (
+    BatterBoxScore,
+    PitcherBoxScore,
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+
+
+def merge_reduced_box_scores(
+    box_scores: Iterable[ReducedBoxScore],
+) -> ReducedBoxScore:
+    """Merge independently validated box-score segments."""
+
+    segments = tuple(box_scores)
+
+    if not segments:
+        raise ValueError(
+            "at least one reduced box score is required"
+        )
+
+    away = _merge_team_lines(
+        tuple(segment.away for segment in segments),
+        team_side="away",
+    )
+    home = _merge_team_lines(
+        tuple(segment.home for segment in segments),
+        team_side="home",
+    )
+
+    batters = _merge_batter_lines(
+        tuple(
+            line
+            for segment in segments
+            for line in segment.batters
+        )
+    )
+    pitchers = _merge_pitcher_lines(
+        tuple(
+            line
+            for segment in segments
+            for line in segment.pitchers
+        )
+    )
+
+    return ReducedBoxScore(
+        away=away,
+        home=home,
+        batters=batters,
+        pitchers=pitchers,
+        pitcher_attribution_complete=all(
+            segment.pitcher_attribution_complete
+            for segment in segments
+        ),
+    )
+
+
+def _merge_team_lines(
+    lines: Tuple[TeamBoxScore, ...],
+    *,
+    team_side: str,
+) -> TeamBoxScore:
+    return TeamBoxScore(
+        team_side=team_side,
+        runs=sum(line.runs for line in lines),
+        hits=sum(line.hits for line in lines),
+        errors=sum(line.errors for line in lines),
+        left_on_base=sum(
+            line.left_on_base for line in lines
+        ),
+    )
+
+
+def _merge_batter_lines(
+    lines: Tuple[BatterBoxScore, ...],
+) -> Tuple[BatterBoxScore, ...]:
+    rows: Dict[Tuple[str, str], dict] = {}
+
+    numeric_fields = tuple(
+        field.name
+        for field in fields(BatterBoxScore)
+        if field.name not in {
+            "player_id",
+            "team_side",
+        }
+    )
+
+    for line in lines:
+        key = (line.team_side, line.player_id)
+        row = rows.setdefault(
+            key,
+            {
+                "player_id": line.player_id,
+                "team_side": line.team_side,
+                **{
+                    name: 0
+                    for name in numeric_fields
+                },
+            },
+        )
+
+        for name in numeric_fields:
+            row[name] += getattr(line, name)
+
+    return tuple(
+        BatterBoxScore(**rows[key])
+        for key in sorted(rows)
+    )
+
+
+def _merge_pitcher_lines(
+    lines: Tuple[PitcherBoxScore, ...],
+) -> Tuple[PitcherBoxScore, ...]:
+    rows: Dict[Tuple[str, str], dict] = {}
+
+    numeric_fields = (
+        "batters_faced",
+        "outs_recorded",
+        "hits_allowed",
+        "home_runs_allowed",
+        "walks",
+        "hit_batters",
+        "strikeouts",
+        "runs_allowed",
+    )
+
+    for line in lines:
+        key = (line.team_side, line.player_id)
+        row = rows.setdefault(
+            key,
+            {
+                "player_id": line.player_id,
+                "team_side": line.team_side,
+                **{
+                    name: 0
+                    for name in numeric_fields
+                },
+                "earned_runs": 0,
+                "earned_run_status": "reconstructed",
+            },
+        )
+
+        for name in numeric_fields:
+            row[name] += getattr(line, name)
+
+        if (
+            line.earned_run_status
+            != "reconstructed"
+            or line.earned_runs is None
+        ):
+            row["earned_runs"] = None
+            row["earned_run_status"] = (
+                "not_reconstructed"
+            )
+        elif (
+            row["earned_run_status"]
+            == "reconstructed"
+        ):
+            row["earned_runs"] += line.earned_runs
+
+    return tuple(
+        PitcherBoxScore(**rows[key])
+        for key in sorted(rows)
+    )

--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,5 +1,11 @@
 """Canonical full-game orchestration."""
 
+from .box_score import (
+    CanonicalGameBoxScore,
+    GameBoxScoreReconciliation,
+    reduce_canonical_game_box_score,
+    validate_game_box_score_reconciliation,
+)
 from .contracts import (
     CanonicalGameConfig,
     CanonicalGameResult,
@@ -17,6 +23,8 @@ from .validation import (
 )
 
 __all__ = [
+    "CanonicalGameBoxScore",
+    "GameBoxScoreReconciliation",
     "CanonicalGameConfig",
     "CanonicalGameResult",
     "CanonicalGameValidation",
@@ -25,5 +33,7 @@ __all__ = [
     "HalfInningRecord",
     "PlateAppearanceResolver",
     "simulate_canonical_game",
+    "reduce_canonical_game_box_score",
+    "validate_game_box_score_reconciliation",
     "validate_canonical_game",
 ]

--- a/mlb_app/simulation/game/box_score.py
+++ b/mlb_app/simulation/game/box_score.py
@@ -1,0 +1,234 @@
+"""Reduce a segmented canonical game into one coherent box score."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from mlb_app.simulation.box_score import (
+    ReducedBoxScore,
+    reduce_box_score,
+)
+from mlb_app.simulation.box_score.merge import (
+    merge_reduced_box_scores,
+)
+
+from .contracts import CanonicalGameResult
+from .validation import validate_canonical_game
+
+
+@dataclass(frozen=True)
+class GameBoxScoreReconciliation:
+    """Coherence checks for canonical projected-box-score output."""
+
+    game_validation_passed: bool
+    away_score_matches: bool
+    home_score_matches: bool
+    away_batter_runs_match: bool
+    home_batter_runs_match: bool
+    away_batter_hits_match: bool
+    home_batter_hits_match: bool
+    pitcher_runs_match_when_complete: bool
+    warnings: Tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.game_validation_passed
+            and self.away_score_matches
+            and self.home_score_matches
+            and self.away_batter_runs_match
+            and self.home_batter_runs_match
+            and self.away_batter_hits_match
+            and self.home_batter_hits_match
+            and self.pitcher_runs_match_when_complete
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalGameBoxScore:
+    """Reduced full-game box score and reconciliation report."""
+
+    box_score: ReducedBoxScore
+    reconciliation: GameBoxScoreReconciliation
+
+
+def reduce_canonical_game_box_score(
+    result: CanonicalGameResult,
+) -> CanonicalGameBoxScore:
+    """
+    Reduce each valid half-inning ledger and merge the results.
+
+    This preserves half-inning replay validity while producing one
+    coherent full-game team/player box score.
+    """
+
+    game_validation = validate_canonical_game(result)
+
+    if not game_validation.passed:
+        raise ValueError(
+            "cannot reduce an invalid canonical game"
+        )
+
+    half_box_scores = tuple(
+        reduce_box_score(
+            initial_state=half.initial_state,
+            events=half.ledger.events,
+        )
+        for half in result.halves
+    )
+
+    merged = merge_reduced_box_scores(
+        half_box_scores
+    )
+
+    reconciliation = (
+        validate_game_box_score_reconciliation(
+            result=result,
+            box_score=merged,
+            game_validation_passed=(
+                game_validation.passed
+            ),
+        )
+    )
+
+    if not reconciliation.passed:
+        raise ValueError(
+            "canonical game box score failed "
+            "reconciliation"
+        )
+
+    return CanonicalGameBoxScore(
+        box_score=merged,
+        reconciliation=reconciliation,
+    )
+
+
+def validate_game_box_score_reconciliation(
+    *,
+    result: CanonicalGameResult,
+    box_score: ReducedBoxScore,
+    game_validation_passed: bool = True,
+) -> GameBoxScoreReconciliation:
+    """Validate team, batter, and pitcher game-level coherence."""
+
+    away_batters = tuple(
+        line
+        for line in box_score.batters
+        if line.team_side == "away"
+    )
+    home_batters = tuple(
+        line
+        for line in box_score.batters
+        if line.team_side == "home"
+    )
+
+    away_score_matches = (
+        box_score.away.runs
+        == result.away_score
+    )
+    home_score_matches = (
+        box_score.home.runs
+        == result.home_score
+    )
+
+    away_batter_runs_match = (
+        sum(line.runs for line in away_batters)
+        == box_score.away.runs
+    )
+    home_batter_runs_match = (
+        sum(line.runs for line in home_batters)
+        == box_score.home.runs
+    )
+
+    away_batter_hits_match = (
+        sum(line.hits for line in away_batters)
+        == box_score.away.hits
+    )
+    home_batter_hits_match = (
+        sum(line.hits for line in home_batters)
+        == box_score.home.hits
+    )
+
+    pitcher_runs_match_when_complete = True
+
+    if box_score.pitcher_attribution_complete:
+        away_pitcher_runs = sum(
+            line.runs_allowed
+            for line in box_score.pitchers
+            if line.team_side == "away"
+        )
+        home_pitcher_runs = sum(
+            line.runs_allowed
+            for line in box_score.pitchers
+            if line.team_side == "home"
+        )
+
+        pitcher_runs_match_when_complete = (
+            away_pitcher_runs
+            == box_score.home.runs
+            and home_pitcher_runs
+            == box_score.away.runs
+        )
+
+    warnings = []
+
+    checks = {
+        "game_validation_failed": (
+            game_validation_passed
+        ),
+        "away_score_mismatch": (
+            away_score_matches
+        ),
+        "home_score_mismatch": (
+            home_score_matches
+        ),
+        "away_batter_run_mismatch": (
+            away_batter_runs_match
+        ),
+        "home_batter_run_mismatch": (
+            home_batter_runs_match
+        ),
+        "away_batter_hit_mismatch": (
+            away_batter_hits_match
+        ),
+        "home_batter_hit_mismatch": (
+            home_batter_hits_match
+        ),
+        "pitcher_run_mismatch": (
+            pitcher_runs_match_when_complete
+        ),
+    }
+
+    for warning, passed in checks.items():
+        if not passed:
+            warnings.append(warning)
+
+    if not box_score.pitcher_attribution_complete:
+        warnings.append(
+            "pitcher_attribution_incomplete"
+        )
+
+    return GameBoxScoreReconciliation(
+        game_validation_passed=(
+            game_validation_passed
+        ),
+        away_score_matches=away_score_matches,
+        home_score_matches=home_score_matches,
+        away_batter_runs_match=(
+            away_batter_runs_match
+        ),
+        home_batter_runs_match=(
+            home_batter_runs_match
+        ),
+        away_batter_hits_match=(
+            away_batter_hits_match
+        ),
+        home_batter_hits_match=(
+            home_batter_hits_match
+        ),
+        pitcher_runs_match_when_complete=(
+            pitcher_runs_match_when_complete
+        ),
+        warnings=tuple(warnings),
+    )

--- a/tests/test_canonical_game_box_score.py
+++ b/tests/test_canonical_game_box_score.py
@@ -1,0 +1,325 @@
+from dataclasses import replace
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+)
+from mlb_app.simulation.game import (
+    CanonicalGameConfig,
+    CanonicalLineup,
+    simulate_canonical_game,
+)
+from mlb_app.simulation.game.box_score import (
+    reduce_canonical_game_box_score,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def out_event(state, batter_id, sequence):
+    next_out = state.outs + 1
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="out",
+        batter_id=batter_id,
+        state_before=state,
+        state_after=replace(
+            state,
+            outs=next_out,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id=batter_id,
+                out_number=next_out,
+                reason="test_out",
+            ),
+        ),
+    )
+
+
+def home_run_event(
+    state,
+    batter_id,
+    sequence,
+    pitcher_id=None,
+):
+    scorers = [
+        runner
+        for runner in state.bases
+        if runner is not None
+    ] + [batter_id]
+
+    movements = []
+
+    for base, runner_id in zip(
+        (Base.FIRST, Base.SECOND, Base.THIRD),
+        state.bases,
+    ):
+        if runner_id is not None:
+            movements.append(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=base,
+                    end_base=Base.HOME,
+                    scored=True,
+                )
+            )
+
+    movements.append(
+        RunnerMovement(
+            runner_id=batter_id,
+            start_base=Base.HOME,
+            end_base=Base.HOME,
+            scored=True,
+        )
+    )
+
+    away_score = state.away_score
+    home_score = state.home_score
+
+    if state.half == "top":
+        away_score += len(scorers)
+    else:
+        home_score += len(scorers)
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="hr",
+        batter_id=batter_id,
+        state_before=state,
+        state_after=replace(
+            state,
+            bases=(None, None, None),
+            away_score=away_score,
+            home_score=home_score,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        runner_movements=tuple(movements),
+        runs_scored=tuple(scorers),
+        pitcher_id=pitcher_id,
+    )
+
+
+def scripted_resolver(scoring_calls):
+    calls = {"count": 0}
+
+    def resolver(state, batter_id, sequence):
+        call = calls["count"]
+        calls["count"] += 1
+
+        if call in scoring_calls:
+            fielding_side = (
+                "home"
+                if state.half == "top"
+                else "away"
+            )
+            return home_run_event(
+                state,
+                batter_id,
+                sequence,
+                pitcher_id=(
+                    f"{fielding_side}_pitcher"
+                ),
+            )
+
+        fielding_side = (
+            "home"
+            if state.half == "top"
+            else "away"
+        )
+        event = out_event(
+            state,
+            batter_id,
+            sequence,
+        )
+        return replace(
+            event,
+            pitcher_id=(
+                f"{fielding_side}_pitcher"
+            ),
+        )
+
+    return resolver
+
+
+def test_full_game_box_score_reconciles_with_final_score():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=(
+            scripted_resolver({0})
+        ),
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    reduced = reduce_canonical_game_box_score(
+        result
+    )
+
+    assert reduced.box_score.away.runs == 1
+    assert reduced.box_score.home.runs == 0
+    assert reduced.box_score.away.hits == 1
+    assert reduced.reconciliation.passed is True
+
+
+def test_batter_rows_merge_across_half_innings():
+    # Away batting-order progression:
+    # inning 1: away_0 through away_3
+    # inning 2: away_4 through away_6
+    # inning 3: away_7, away_8, away_0
+    #
+    # Calls 0 and 15 therefore belong to away_0 in different
+    # half-inning segments.
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=(
+            scripted_resolver({0, 15})
+        ),
+        config=CanonicalGameConfig(
+            regulation_innings=3,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    reduced = reduce_canonical_game_box_score(
+        result
+    )
+
+    away_zero = reduced.box_score.batter(
+        "away_0"
+    )
+
+    assert away_zero.plate_appearances == 2
+    assert away_zero.home_runs == 2
+    assert away_zero.runs == 2
+
+
+def test_pitcher_runs_match_opponent_when_complete():
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=(
+            scripted_resolver({0})
+        ),
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    reduced = reduce_canonical_game_box_score(
+        result
+    )
+
+    home_pitcher = reduced.box_score.pitcher(
+        "home_pitcher"
+    )
+
+    assert home_pitcher.runs_allowed == 1
+    assert (
+        reduced.box_score
+        .pitcher_attribution_complete
+        is True
+    )
+    assert (
+        reduced.reconciliation
+        .pitcher_runs_match_when_complete
+        is True
+    )
+
+
+def test_automatic_runner_run_is_credited_to_batter():
+    calls = {
+        "count": 0,
+        "extra_run_scored": False,
+    }
+
+    def resolver(state, batter_id, sequence):
+        call = calls["count"]
+        calls["count"] += 1
+
+        # Score the automatic runner exactly once in the top of
+        # the extra inning, then allow the inning to terminate.
+        if (
+            state.inning == 2
+            and state.half == "top"
+            and state.outs == 0
+            and not calls["extra_run_scored"]
+        ):
+            calls["extra_run_scored"] = True
+            return home_run_event(
+                state,
+                batter_id,
+                sequence,
+                pitcher_id="home_pitcher",
+            )
+
+        fielding_side = (
+            "home"
+            if state.half == "top"
+            else "away"
+        )
+        event = out_event(
+            state,
+            batter_id,
+            sequence,
+        )
+        return replace(
+            event,
+            pitcher_id=(
+                f"{fielding_side}_pitcher"
+            ),
+        )
+
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=resolver,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=1,
+            automatic_runner_enabled=True,
+        ),
+    )
+
+    reduced = reduce_canonical_game_box_score(
+        result
+    )
+
+    automatic_runner = (
+        reduced.box_score.batter("away_2")
+    )
+
+    assert automatic_runner.runs == 1
+    assert reduced.box_score.away.runs == 2
+    assert reduced.reconciliation.passed is True


### PR DESCRIPTION
## Summary

Implements the second Layer 10J slice: segmented full-game box-score reduction for canonical game results.

This change reduces each half-inning ledger independently, merges the resulting box-score segments, and validates that the merged player/team output remains coherent with the orchestrated final game score.

## Added

- `merge_reduced_box_scores()` for combining validated box-score segments
- Full-game reduction through `reduce_canonical_game_box_score()`
- `CanonicalGameBoxScore`
- `GameBoxScoreReconciliation`
- Team run reconciliation against the canonical final score
- Batter run reconciliation against team runs
- Batter hit reconciliation against team hits
- Pitcher run reconciliation when attribution is complete
- Cross-half-inning batter and pitcher stat merging
- Automatic-runner scoring attribution in extra innings
- Structured warnings for incomplete pitcher attribution

## Architecture

```text
CanonicalGameResult
        ↓
HalfInningRecord[]
        ↓
reduce_box_score() per half
        ↓
merge_reduced_box_scores()
        ↓
ReducedBoxScore
        ↓
GameBoxScoreReconciliation
```

Each half remains independently replay-valid under the existing `PlayLedger` contract, while the merged artifact provides one coherent full-game projected box score.

## Coherence guarantees

For a valid reduced game:

```text
final away score
= away TeamBoxScore.runs
= sum(away batter runs)
```

```text
final home score
= home TeamBoxScore.runs
= sum(home batter runs)
```

```text
team hits
= sum(batter hits)
```

When pitcher attribution is complete:

```text
away pitcher runs allowed = home team runs
home pitcher runs allowed = away team runs
```

## Scope

This slice intentionally does not yet:

- generate production plate-appearance probabilities;
- choose pitchers or relievers;
- reconstruct earned runs;
- aggregate many canonical games into full outcome distributions;
- wire internally generated canonical payloads into the production builder;
- expose the projected box score in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New segmented game box-score tests passed
- Result: `117 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/box_score/__init__.py`
- `mlb_app/simulation/box_score/merge.py`
- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/box_score.py`
- `tests/test_canonical_game_box_score.py`

## Next slice

Add multi-game canonical trial orchestration and game-outcome aggregation so the same coherent trial set produces win probabilities, run distributions, team totals, and projected player box-score distributions.