### PR TITLE
Adapt canonical trial batches for shadow comparison

### DIFF
--- a/mlb_app/simulation/game_simulation_builder.py
+++ b/mlb_app/simulation/game_simulation_builder.py
@@ -780,10 +780,35 @@ def _canonical_shadow_enabled(
 def _canonical_shadow_payload(
     config: Optional[Dict[str, Any]],
 ):
-    """Return the prebuilt canonical payload without copying it."""
+    """
+    Resolve a prebuilt payload or adapt a canonical trial batch.
 
-    return dict(config or {}).get(
+    An explicit canonical_shadow_payload takes precedence for backward
+    compatibility. This helper does not run canonical simulation.
+    """
+
+    config_snapshot = dict(config or {})
+
+    explicit_payload = config_snapshot.get(
         "canonical_shadow_payload"
+    )
+
+    if explicit_payload is not None:
+        return explicit_payload
+
+    trial_batch = config_snapshot.get(
+        "canonical_shadow_trial_batch"
+    )
+
+    if trial_batch is None:
+        return None
+
+    from mlb_app.simulation.shadow import (
+        canonical_trial_batch_to_shadow_payload,
+    )
+
+    return canonical_trial_batch_to_shadow_payload(
+        trial_batch
     )
 
 
@@ -900,6 +925,7 @@ def build_game_simulation(
             "position_player_substitution_state",
             "canonical_shadow_enabled",
             "canonical_shadow_payload",
+            "canonical_shadow_trial_batch",
         }
     }
 

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -9,6 +9,7 @@ from .contracts import (
     ShadowCoverage,
 )
 from .integration import attach_canonical_shadow
+from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
     shadow_diagnostics_to_dict,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "RangeComparison",
     "ShadowCoverage",
     "attach_canonical_shadow",
+    "canonical_trial_batch_to_shadow_payload",
     "compare_shadow_payloads",
     "shadow_diagnostics_to_dict",
 ]

--- a/mlb_app/simulation/shadow/trial_adapter.py
+++ b/mlb_app/simulation/shadow/trial_adapter.py
@@ -1,0 +1,106 @@
+"""Adapt canonical trial batches to the shadow payload boundary."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mlb_app.simulation.game import (
+    CanonicalTrialBatch,
+)
+from mlb_app.simulation.projections import (
+    projection_payload_to_dict,
+)
+
+
+def canonical_trial_batch_to_shadow_payload(
+    batch: CanonicalTrialBatch,
+) -> Dict[str, Any]:
+    """
+    Serialize one canonical trial batch for shadow comparison.
+
+    The existing canonical projection payload remains intact.
+    Game-level outcomes and trial diagnostics are attached as
+    additive, non-authoritative shadow fields.
+    """
+
+    if not isinstance(batch, CanonicalTrialBatch):
+        raise TypeError(
+            "batch must be a CanonicalTrialBatch"
+        )
+
+    payload = projection_payload_to_dict(
+        batch.projections
+    )
+
+    outcomes = batch.outcomes
+
+    payload["outcomes"] = {
+        "simulation_count": (
+            outcomes.simulation_count
+        ),
+        "away_win_probability": (
+            outcomes.away_win_probability
+        ),
+        "home_win_probability": (
+            outcomes.home_win_probability
+        ),
+        "tie_probability": (
+            outcomes.tie_probability
+        ),
+        "extra_innings_probability": (
+            outcomes.extra_innings_probability
+        ),
+        "walk_off_probability": (
+            outcomes.walk_off_probability
+        ),
+        "away_run_distribution": {
+            str(point.value): point.probability
+            for point
+            in outcomes.away_run_distribution
+        },
+        "home_run_distribution": {
+            str(point.value): point.probability
+            for point
+            in outcomes.home_run_distribution
+        },
+        "total_run_distribution": {
+            str(point.value): point.probability
+            for point
+            in outcomes.total_run_distribution
+        },
+        "team_total_probabilities": {
+            metric.name: metric.probability
+            for metric
+            in outcomes.team_total_probabilities
+        },
+        "total_probabilities": {
+            metric.name: metric.probability
+            for metric
+            in outcomes.total_probabilities
+        },
+    }
+
+    payload["trial_diagnostics"] = {
+        "game_validation_pass_rate": (
+            batch.diagnostics
+            .game_validation_pass_rate
+        ),
+        (
+            "box_score_reconciliation_"
+            "pass_rate"
+        ): (
+            batch.diagnostics
+            .box_score_reconciliation_pass_rate
+        ),
+        "warnings": list(
+            batch.diagnostics.warnings
+        ),
+    }
+
+    payload["shadow_metadata"] = {
+        "source": "canonical_trial_batch",
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+    return payload

--- a/tests/test_canonical_trial_shadow_adapter.py
+++ b/tests/test_canonical_trial_shadow_adapter.py
@@ -1,0 +1,256 @@
+import json
+
+from mlb_app.simulation import (
+    game_simulation_builder as builder,
+)
+from mlb_app.simulation.box_score import (
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.game import (
+    CanonicalGameOutcomeProjection,
+    CanonicalTrialBatch,
+    CanonicalTrialDiagnostics,
+    DistributionPoint,
+    ProbabilityMetric,
+)
+from mlb_app.simulation.projections import (
+    aggregate_projection_payload,
+)
+from mlb_app.simulation.shadow import (
+    canonical_trial_batch_to_shadow_payload,
+    compare_shadow_payloads,
+)
+
+
+def reduced_box_score():
+    return ReducedBoxScore(
+        away=TeamBoxScore(
+            team_side="away",
+            runs=3,
+            hits=7,
+        ),
+        home=TeamBoxScore(
+            team_side="home",
+            runs=4,
+            hits=8,
+        ),
+        pitcher_attribution_complete=True,
+    )
+
+
+def trial_batch():
+    box_score = reduced_box_score()
+
+    projections = aggregate_projection_payload(
+        box_scores=(box_score,),
+        model_version="canonical_trial_shadow_v1",
+        replay_validation_passes=(True,),
+    )
+
+    outcomes = CanonicalGameOutcomeProjection(
+        simulation_count=1,
+        away_win_probability=0.0,
+        home_win_probability=1.0,
+        tie_probability=0.0,
+        extra_innings_probability=0.0,
+        walk_off_probability=0.0,
+        away_run_distribution=(
+            DistributionPoint(
+                value=3,
+                probability=1.0,
+            ),
+        ),
+        home_run_distribution=(
+            DistributionPoint(
+                value=4,
+                probability=1.0,
+            ),
+        ),
+        total_run_distribution=(
+            DistributionPoint(
+                value=7,
+                probability=1.0,
+            ),
+        ),
+        team_total_probabilities=(
+            ProbabilityMetric(
+                name="away_3_plus",
+                probability=1.0,
+            ),
+            ProbabilityMetric(
+                name="home_3_plus",
+                probability=1.0,
+            ),
+        ),
+        total_probabilities=(
+            ProbabilityMetric(
+                name="over_6.5",
+                probability=1.0,
+            ),
+            ProbabilityMetric(
+                name="under_6.5",
+                probability=0.0,
+            ),
+        ),
+    )
+
+    return CanonicalTrialBatch(
+        games=(object(),),
+        box_scores=(box_score,),
+        reconciliations=(object(),),
+        outcomes=outcomes,
+        projections=projections,
+        diagnostics=CanonicalTrialDiagnostics(
+            game_validation_pass_rate=1.0,
+            box_score_reconciliation_pass_rate=(
+                1.0
+            ),
+        ),
+    )
+
+
+def legacy_result():
+    return {
+        "model_version": "legacy_test_v1",
+        "simulations": 1,
+        "away_expected_runs": 3.0,
+        "home_expected_runs": 4.0,
+        "total_expected_runs": 7.0,
+        "home_win_probability": 1.0,
+        "away_run_distribution": {
+            "3": 1.0,
+        },
+        "home_run_distribution": {
+            "4": 1.0,
+        },
+        "total_run_distribution": {
+            "7": 1.0,
+        },
+        "metadata": {
+            "simulation_count": 1,
+        },
+    }
+
+
+def comparison(diagnostics, name):
+    return next(
+        item
+        for item in diagnostics.comparisons
+        if item.name == name
+    )
+
+
+def test_trial_batch_adapts_to_shadow_payload():
+    payload = (
+        canonical_trial_batch_to_shadow_payload(
+            trial_batch()
+        )
+    )
+
+    assert payload["simulation_count"] == 1
+    assert (
+        payload["outcomes"]
+        ["home_win_probability"]
+        == 1.0
+    )
+    assert (
+        payload["outcomes"]
+        ["away_run_distribution"]
+        == {"3": 1.0}
+    )
+    assert (
+        payload["trial_diagnostics"]
+        ["game_validation_pass_rate"]
+        == 1.0
+    )
+    assert (
+        payload["shadow_metadata"]
+        ["authoritative_source"]
+        == "legacy"
+    )
+
+
+def test_trial_batch_enables_home_win_comparison():
+    payload = (
+        canonical_trial_batch_to_shadow_payload(
+            trial_batch()
+        )
+    )
+
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=payload,
+    )
+
+    home_win = comparison(
+        diagnostics,
+        "home_win_probability",
+    )
+
+    assert home_win.available is True
+    assert home_win.canonical_value == 1.0
+    assert home_win.absolute_difference == 0.0
+    assert diagnostics.status == "complete"
+
+
+def test_trial_batch_shadow_payload_is_json_safe():
+    payload = (
+        canonical_trial_batch_to_shadow_payload(
+            trial_batch()
+        )
+    )
+
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+    )
+
+    assert "canonical_trial_batch" in encoded
+    assert "home_win_probability" in encoded
+
+
+def test_builder_accepts_trial_batch_without_changing_legacy(
+    monkeypatch,
+):
+    observed = {}
+
+    def engine(game_pk, config):
+        observed["game_pk"] = game_pk
+        observed["config"] = config
+        return legacy_result()
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    result = builder.build_game_simulation(
+        123,
+        {
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_trial_batch": (
+                trial_batch()
+            ),
+        },
+    )
+
+    assert observed["game_pk"] == 123
+    assert (
+        "canonical_shadow_trial_batch"
+        not in observed["config"]
+    )
+    assert result["away_expected_runs"] == 3.0
+    assert result["home_expected_runs"] == 4.0
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "complete"
+    )
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]
+        ["authoritative_source"]
+        == "legacy"
+    )


### PR DESCRIPTION
## Summary

Implements the fourth Layer 10J slice: adapting coherent `CanonicalTrialBatch` results into the existing canonical shadow-comparison boundary.

This change serializes trial-batch projections, attaches game-level outcomes and trial diagnostics as additive shadow fields, and allows the production builder to accept a prebuilt canonical trial batch without changing legacy simulation authority.

## Added

- `canonical_trial_batch_to_shadow_payload()`
- Additive serialization of canonical game outcomes
- Away/home/tie probabilities in the shadow payload
- Away, home, and total run distributions
- Team-total and game-total probability maps
- Trial validation and reconciliation diagnostics
- Explicit non-authoritative shadow metadata
- Builder support for `canonical_shadow_trial_batch`
- Backward-compatible precedence for explicit `canonical_shadow_payload`
- Removal of canonical trial-batch config before invoking the legacy engine

## Architecture

```text
CanonicalTrialBatch
        ↓
canonical_trial_batch_to_shadow_payload()
        ├─ canonical projection payload
        ├─ game-level outcomes
        ├─ trial diagnostics
        └─ non-authoritative metadata
        ↓
existing shadow comparator
        ↓
legacy-vs-canonical diagnostics
```

## Authority guarantees

- Legacy simulation output remains authoritative.
- Canonical data is attached only through diagnostics.
- `authoritative_source` remains `legacy`.
- The adapter does not run canonical simulations.
- The shadow path remains fail-open.
- Trial-batch config is not passed into the legacy engine.
- Existing explicit `canonical_shadow_payload` behavior is preserved and takes precedence.

## New shadow fields

```text
outcomes.simulation_count
outcomes.away_win_probability
outcomes.home_win_probability
outcomes.tie_probability
outcomes.extra_innings_probability
outcomes.walk_off_probability
outcomes.away_run_distribution
outcomes.home_run_distribution
outcomes.total_run_distribution
outcomes.team_total_probabilities
outcomes.total_probabilities
trial_diagnostics.game_validation_pass_rate
trial_diagnostics.box_score_reconciliation_pass_rate
trial_diagnostics.warnings
shadow_metadata.source
shadow_metadata.authoritative
shadow_metadata.authoritative_source
```

## Scope

This slice intentionally does not yet:

- construct production canonical trial factories;
- run canonical simulation inside the builder;
- derive production seeds;
- select real pitchers or relievers;
- replace legacy production output;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical trial shadow-adapter tests passed
- Result: `127 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game_simulation_builder.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/trial_adapter.py`
- `tests/test_canonical_trial_shadow_adapter.py`

## Next slice

Add an explicitly injected canonical trial-batch factory hook at the builder boundary so internally generated canonical trials can run in shadow mode while preserving fail-open behavior and legacy authority.