### PR TITLE
Add canonical shadow trial factory hook

### DIFF
--- a/mlb_app/simulation/game_simulation_builder.py
+++ b/mlb_app/simulation/game_simulation_builder.py
@@ -691,6 +691,7 @@ CANONICAL_SHADOW_CONFIG_KEYS = frozenset(
     {
         "canonical_shadow_enabled",
         "canonical_shadow_payload",
+        "canonical_shadow_trial_batch",
     }
 )
 
@@ -777,14 +778,41 @@ def _canonical_shadow_enabled(
     )
 
 
+def _canonical_shadow_factory_config(
+    config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Return canonical-factory inputs without shadow control artifacts.
+
+    The injected factory receives ordinary simulation inputs such as the
+    requested simulation count or seed, but never receives a prebuilt
+    canonical payload or trial batch.
+    """
+
+    return {
+        key: deepcopy(value)
+        for key, value in dict(config or {}).items()
+        if key not in CANONICAL_SHADOW_CONFIG_KEYS
+    }
+
+
 def _canonical_shadow_payload(
     config: Optional[Dict[str, Any]],
+    *,
+    game_pk: Optional[int] = None,
+    trial_batch_factory=None,
 ):
     """
-    Resolve a prebuilt payload or adapt a canonical trial batch.
+    Resolve or explicitly construct a canonical shadow payload.
 
-    An explicit canonical_shadow_payload takes precedence for backward
-    compatibility. This helper does not run canonical simulation.
+    Precedence is:
+
+    1. explicit canonical_shadow_payload;
+    2. explicit canonical_shadow_trial_batch;
+    3. injected trial_batch_factory.
+
+    The factory hook is dependency injection only. No default production
+    canonical factory is imported or selected here.
     """
 
     config_snapshot = dict(config or {})
@@ -801,7 +829,27 @@ def _canonical_shadow_payload(
     )
 
     if trial_batch is None:
-        return None
+        if trial_batch_factory is None:
+            return None
+
+        if not callable(trial_batch_factory):
+            raise TypeError(
+                "canonical shadow trial-batch factory "
+                "must be callable"
+            )
+
+        if game_pk is None:
+            raise ValueError(
+                "game_pk is required for canonical "
+                "shadow factory execution"
+            )
+
+        trial_batch = trial_batch_factory(
+            game_pk=int(game_pk),
+            config=_canonical_shadow_factory_config(
+                config
+            ),
+        )
 
     from mlb_app.simulation.shadow import (
         canonical_trial_batch_to_shadow_payload,
@@ -816,6 +864,8 @@ def _attach_canonical_shadow_diagnostics(
     payload: Dict[str, Any],
     *,
     config: Optional[Dict[str, Any]],
+    game_pk: Optional[int] = None,
+    trial_batch_factory=None,
 ) -> Dict[str, Any]:
     """
     Attach fail-open canonical shadow diagnostics when explicitly
@@ -834,9 +884,16 @@ def _attach_canonical_shadow_diagnostics(
 
     try:
         enabled = _canonical_shadow_enabled(config)
-        canonical_payload = _canonical_shadow_payload(
-            config
-        )
+
+        if enabled:
+            canonical_payload = _canonical_shadow_payload(
+                config,
+                game_pk=game_pk,
+                trial_batch_factory=(
+                    trial_batch_factory
+                ),
+            )
+
         canonical_available = (
             canonical_payload is not None
         )
@@ -895,6 +952,8 @@ def _attach_canonical_shadow_diagnostics(
 def build_game_simulation(
     game_pk: int,
     config: Optional[Dict[str, Any]] = None,
+    *,
+    canonical_shadow_trial_batch_factory=None,
 ) -> Dict[str, Any]:
     import traceback
 
@@ -979,6 +1038,10 @@ def build_game_simulation(
         return _attach_canonical_shadow_diagnostics(
             position_player_substitution_payload,
             config=config_snapshot,
+            game_pk=int(game_pk),
+            trial_batch_factory=(
+                canonical_shadow_trial_batch_factory
+            ),
         )
     except Exception as exc:
         return {

--- a/tests/test_canonical_trial_shadow_adapter.py
+++ b/tests/test_canonical_trial_shadow_adapter.py
@@ -254,3 +254,228 @@ def test_builder_accepts_trial_batch_without_changing_legacy(
         ["authoritative_source"]
         == "legacy"
     )
+
+
+def test_builder_runs_injected_trial_factory(monkeypatch):
+    observed = {
+        "factory_calls": 0,
+    }
+
+    def engine(game_pk, config):
+        observed["engine_game_pk"] = game_pk
+        observed["engine_config"] = config
+        return legacy_result()
+
+    def factory(*, game_pk, config):
+        observed["factory_calls"] += 1
+        observed["factory_game_pk"] = game_pk
+        observed["factory_config"] = config
+        return trial_batch()
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    result = builder.build_game_simulation(
+        456,
+        {
+            "simulation_count": 1,
+            "seed": 12345,
+            "canonical_shadow_enabled": True,
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    assert observed["factory_calls"] == 1
+    assert observed["factory_game_pk"] == 456
+    assert observed["factory_config"] == {
+        "simulation_count": 1,
+        "seed": 12345,
+    }
+    assert observed["engine_config"] == {
+        "simulation_count": 1,
+        "seed": 12345,
+    }
+    assert result["away_expected_runs"] == 3.0
+    assert result["home_expected_runs"] == 4.0
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "complete"
+    )
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]
+        ["authoritative_source"]
+        == "legacy"
+    )
+
+
+def test_disabled_shadow_does_not_run_injected_factory(
+    monkeypatch,
+):
+    observed = {
+        "factory_calls": 0,
+    }
+
+    def engine(game_pk, config):
+        return legacy_result()
+
+    def factory(*, game_pk, config):
+        observed["factory_calls"] += 1
+        return trial_batch()
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    result = builder.build_game_simulation(
+        456,
+        {
+            "canonical_shadow_enabled": False,
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    assert observed["factory_calls"] == 0
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "disabled"
+    )
+    assert result["away_expected_runs"] == 3.0
+
+
+def test_explicit_payload_precedes_injected_factory(
+    monkeypatch,
+):
+    observed = {
+        "factory_calls": 0,
+    }
+
+    def engine(game_pk, config):
+        return legacy_result()
+
+    def factory(*, game_pk, config):
+        observed["factory_calls"] += 1
+        raise AssertionError(
+            "factory must not run when payload is explicit"
+        )
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    explicit_payload = (
+        canonical_trial_batch_to_shadow_payload(
+            trial_batch()
+        )
+    )
+
+    result = builder.build_game_simulation(
+        456,
+        {
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_payload": explicit_payload,
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    assert observed["factory_calls"] == 0
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "complete"
+    )
+
+
+def test_explicit_trial_batch_precedes_injected_factory(
+    monkeypatch,
+):
+    observed = {
+        "factory_calls": 0,
+    }
+
+    def engine(game_pk, config):
+        observed["engine_config"] = config
+        return legacy_result()
+
+    def factory(*, game_pk, config):
+        observed["factory_calls"] += 1
+        raise AssertionError(
+            "factory must not run when batch is explicit"
+        )
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    result = builder.build_game_simulation(
+        456,
+        {
+            "simulation_count": 1,
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_trial_batch": (
+                trial_batch()
+            ),
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    assert observed["factory_calls"] == 0
+    assert observed["engine_config"] == {
+        "simulation_count": 1,
+    }
+    assert (
+        result["diagnostics"]
+        ["canonical_shadow"]["status"]
+        == "complete"
+    )
+
+
+def test_injected_factory_failure_is_fail_open(
+    monkeypatch,
+):
+    def engine(game_pk, config):
+        return legacy_result()
+
+    def factory(*, game_pk, config):
+        raise RuntimeError(
+            "canonical factory test failure"
+        )
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+    result = builder.build_game_simulation(
+        456,
+        {
+            "canonical_shadow_enabled": True,
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+
+    assert shadow["status"] == "error"
+    assert shadow["authoritative_source"] == "legacy"
+    assert shadow["error_type"] == "RuntimeError"
+    assert (
+        "canonical factory test failure"
+        in shadow["error_message"]
+    )
+    assert result["away_expected_runs"] == 3.0
+    assert result["home_expected_runs"] == 4.0


### PR DESCRIPTION
## Summary

Implements the fifth Layer 10J slice: an explicitly injected canonical trial-batch factory hook at the shared game-simulation builder boundary.

This change allows callers to supply a canonical trial-batch factory that runs only when canonical shadow mode is enabled. The resulting `CanonicalTrialBatch` flows through the existing adapter and comparator while legacy simulation output remains authoritative.

## Added

- `canonical_shadow_trial_batch_factory` dependency-injection hook on `build_game_simulation()`
- Sanitized canonical-factory config derived from ordinary simulation inputs
- Explicit precedence across canonical shadow inputs
- Builder propagation of `game_pk` into the injected factory
- Disabled-shadow suppression of factory execution
- Fail-open handling for factory failures
- Expanded canonical shadow config-key isolation
- Regression tests for execution, precedence, sanitization, disabled behavior, and failure containment

## Architecture

```text
build_game_simulation()
        ↓
legacy engine executes normally
        ↓
canonical shadow enabled?
        ├─ no → factory never runs
        └─ yes
             ↓
    resolve canonical source
        1. explicit payload
        2. explicit trial batch
        3. injected trial-batch factory
             ↓
    CanonicalTrialBatch
             ↓
    existing shadow adapter
             ↓
    existing shadow comparator
             ↓
    diagnostics only
```

## Factory contract

The injected callable receives:

```python
factory(
    game_pk=<int>,
    config=<sanitized ordinary simulation config>,
)
```

The factory must return a `CanonicalTrialBatch`.

Shadow-control artifacts are excluded from the factory config, including:

- `canonical_shadow_enabled`
- `canonical_shadow_payload`
- `canonical_shadow_trial_batch`

## Precedence

```text
explicit canonical_shadow_payload
> explicit canonical_shadow_trial_batch
> injected canonical_shadow_trial_batch_factory
> unavailable canonical shadow
```

Existing explicit payload and explicit trial-batch behavior therefore remains backward compatible.

## Authority and safety guarantees

- Legacy simulation output remains authoritative.
- The injected factory runs only when canonical shadow mode is enabled.
- No default production canonical factory is imported or selected.
- Canonical control objects never reach the legacy engine.
- Factory failures are captured by the existing fail-open shadow boundary.
- Error diagnostics preserve `authoritative_source = legacy`.
- Canonical output is never promoted over legacy production values.

## Scope

This slice intentionally does not yet:

- implement a production canonical trial-batch factory;
- construct real lineups, pitchers, or reliever plans;
- derive canonical random seeds internally;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New injected-factory tests passed
- Result: `132 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game_simulation_builder.py`
- `tests/test_canonical_trial_shadow_adapter.py`

## Next slice

Define a production-facing canonical trial-factory input contract and deterministic seed derivation without yet binding it to real matchup probability generation or changing legacy authority.