### PR TITLE
Add canonical indexed resolver factory protocol

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -27,6 +27,13 @@ from .orchestrator import (
     PlateAppearanceResolver,
     simulate_canonical_game,
 )
+from .trial_factory import (
+    CanonicalTrialExecutionPlan,
+    CanonicalTrialResolverContext,
+    CanonicalTrialResolverFactory,
+    build_canonical_trial_resolver_context,
+    run_canonical_trial_execution_plan,
+)
 from .trials import (
     CanonicalGameOutcomeProjection,
     CanonicalTrialBatch,
@@ -56,6 +63,9 @@ __all__ = [
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
     "CanonicalTrialFactoryInput",
+    "CanonicalTrialExecutionPlan",
+    "CanonicalTrialResolverContext",
+    "CanonicalTrialResolverFactory",
     "DistributionPoint",
     "ProbabilityMetric",
     "CanonicalGameValidation",
@@ -66,9 +76,11 @@ __all__ = [
     "simulate_canonical_game",
     "aggregate_game_outcomes",
     "build_canonical_trial_factory_input",
+    "build_canonical_trial_resolver_context",
     "derive_canonical_base_seed",
     "derive_canonical_trial_seed",
     "run_canonical_trials",
+    "run_canonical_trial_execution_plan",
     "reduce_canonical_game_box_score",
     "validate_game_box_score_reconciliation",
     "validate_canonical_game",

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -1,0 +1,232 @@
+"""Indexed canonical trial and resolver-factory protocols."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from mlb_app.simulation.box_score import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+)
+
+from .contracts import (
+    CanonicalGameConfig,
+    CanonicalGameResult,
+    CanonicalLineup,
+)
+from .factory_input import (
+    CanonicalTrialFactoryInput,
+)
+from .orchestrator import (
+    PlateAppearanceResolver,
+    simulate_canonical_game,
+)
+from .trials import (
+    CanonicalTrialBatch,
+    run_canonical_trials,
+)
+
+
+@dataclass(frozen=True)
+class CanonicalTrialResolverContext:
+    """
+    Immutable identity supplied when constructing one trial resolver.
+
+    Matchup probability generation may later consume this context, but
+    this contract does not select or implement any probability model.
+    """
+
+    factory_input: CanonicalTrialFactoryInput
+    trial_index: int
+    trial_seed: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.factory_input,
+            CanonicalTrialFactoryInput,
+        ):
+            raise TypeError(
+                "factory_input must be a "
+                "CanonicalTrialFactoryInput"
+            )
+
+        if isinstance(self.trial_index, bool):
+            raise TypeError(
+                "trial_index must be an integer"
+            )
+
+        if (
+            self.trial_index < 0
+            or self.trial_index
+            >= self.factory_input.simulation_count
+        ):
+            raise ValueError(
+                "trial_index is outside the factory input"
+            )
+
+        expected_seed = (
+            self.factory_input.seed_for_trial(
+                self.trial_index
+            )
+        )
+
+        if self.trial_seed != expected_seed:
+            raise ValueError(
+                "trial_seed does not match the indexed "
+                "factory-input seed"
+            )
+
+
+CanonicalTrialResolverFactory = Callable[
+    [CanonicalTrialResolverContext],
+    PlateAppearanceResolver,
+]
+
+
+@dataclass(frozen=True)
+class CanonicalTrialExecutionPlan:
+    """
+    Complete non-probabilistic plan for running canonical trials.
+
+    Lineups and game rules are fixed across the batch. The injected
+    resolver factory receives one deterministic indexed context for
+    every trial and must return a fresh plate-appearance resolver.
+    """
+
+    factory_input: CanonicalTrialFactoryInput
+    away_lineup: CanonicalLineup
+    home_lineup: CanonicalLineup
+    resolver_factory: CanonicalTrialResolverFactory
+    game_config: CanonicalGameConfig = field(
+        default_factory=CanonicalGameConfig
+    )
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.factory_input,
+            CanonicalTrialFactoryInput,
+        ):
+            raise TypeError(
+                "factory_input must be a "
+                "CanonicalTrialFactoryInput"
+            )
+
+        if not isinstance(
+            self.away_lineup,
+            CanonicalLineup,
+        ):
+            raise TypeError(
+                "away_lineup must be a CanonicalLineup"
+            )
+
+        if not isinstance(
+            self.home_lineup,
+            CanonicalLineup,
+        ):
+            raise TypeError(
+                "home_lineup must be a CanonicalLineup"
+            )
+
+        if self.away_lineup.team_side != "away":
+            raise ValueError(
+                "away_lineup must use away team side"
+            )
+
+        if self.home_lineup.team_side != "home":
+            raise ValueError(
+                "home_lineup must use home team side"
+            )
+
+        if not isinstance(
+            self.game_config,
+            CanonicalGameConfig,
+        ):
+            raise TypeError(
+                "game_config must be a "
+                "CanonicalGameConfig"
+            )
+
+        if not callable(self.resolver_factory):
+            raise TypeError(
+                "resolver_factory must be callable"
+            )
+
+
+def build_canonical_trial_resolver_context(
+    *,
+    factory_input: CanonicalTrialFactoryInput,
+    trial_index: int,
+) -> CanonicalTrialResolverContext:
+    """Build the deterministic resolver context for one trial."""
+
+    return CanonicalTrialResolverContext(
+        factory_input=factory_input,
+        trial_index=trial_index,
+        trial_seed=factory_input.seed_for_trial(
+            trial_index
+        ),
+    )
+
+
+def run_canonical_trial_execution_plan(
+    plan: CanonicalTrialExecutionPlan,
+) -> CanonicalTrialBatch:
+    """
+    Run one complete indexed canonical trial plan.
+
+    This delegates validation, box-score reduction, reconciliation,
+    outcome aggregation, and projection aggregation to the existing
+    canonical multi-trial runner.
+    """
+
+    if not isinstance(
+        plan,
+        CanonicalTrialExecutionPlan,
+    ):
+        raise TypeError(
+            "plan must be a CanonicalTrialExecutionPlan"
+        )
+
+    def trial_factory(
+        trial_index: int,
+    ) -> CanonicalGameResult:
+        context = (
+            build_canonical_trial_resolver_context(
+                factory_input=plan.factory_input,
+                trial_index=trial_index,
+            )
+        )
+
+        resolver = plan.resolver_factory(context)
+
+        if not callable(resolver):
+            raise TypeError(
+                "resolver_factory must return a "
+                "plate-appearance resolver"
+            )
+
+        return simulate_canonical_game(
+            away_lineup=plan.away_lineup,
+            home_lineup=plan.home_lineup,
+            resolve_plate_appearance=resolver,
+            config=plan.game_config,
+        )
+
+    return run_canonical_trials(
+        trial_factory=trial_factory,
+        simulations=(
+            plan.factory_input.simulation_count
+        ),
+        model_version=(
+            plan.factory_input.model_version
+        ),
+        batter_dfs_rules=plan.batter_dfs_rules,
+        pitcher_dfs_rules=plan.pitcher_dfs_rules,
+    )

--- a/tests/test_canonical_trial_factory_protocol.py
+++ b/tests/test_canonical_trial_factory_protocol.py
@@ -1,0 +1,222 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    OutRecord,
+    PlayEvent,
+)
+from mlb_app.simulation.game import (
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalTrialExecutionPlan,
+    CanonicalTrialResolverContext,
+    build_canonical_trial_factory_input,
+    build_canonical_trial_resolver_context,
+    run_canonical_trial_execution_plan,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def out_event(state, batter_id, sequence):
+    next_out = state.outs + 1
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="out",
+        batter_id=batter_id,
+        state_before=state,
+        state_after=replace(
+            state,
+            outs=next_out,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id=batter_id,
+                out_number=next_out,
+                reason="protocol_test_out",
+            ),
+        ),
+    )
+
+
+def factory_input(simulations=3):
+    return build_canonical_trial_factory_input(
+        game_pk=123,
+        config={
+            "simulation_count": simulations,
+            "seed": 98765,
+            "canonical_model_version": (
+                "canonical-protocol-test-v1"
+            ),
+        },
+    )
+
+
+def test_resolver_context_uses_indexed_seed():
+    inputs = factory_input()
+
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=inputs,
+            trial_index=1,
+        )
+    )
+
+    assert isinstance(
+        context,
+        CanonicalTrialResolverContext,
+    )
+    assert context.trial_index == 1
+    assert context.trial_seed == (
+        inputs.seed_for_trial(1)
+    )
+
+
+def test_mismatched_trial_seed_is_rejected():
+    inputs = factory_input()
+
+    with pytest.raises(
+        ValueError,
+        match="trial_seed does not match",
+    ):
+        CanonicalTrialResolverContext(
+            factory_input=inputs,
+            trial_index=0,
+            trial_seed=inputs.seed_for_trial(0) + 1,
+        )
+
+
+def test_execution_plan_runs_exact_indexed_trials():
+    inputs = factory_input(simulations=3)
+    observed = []
+
+    def resolver_factory(context):
+        observed.append(
+            (
+                context.trial_index,
+                context.trial_seed,
+            )
+        )
+
+        def resolver(state, batter_id, sequence):
+            return out_event(
+                state,
+                batter_id,
+                sequence,
+            )
+
+        return resolver
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=inputs,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=resolver_factory,
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    batch = run_canonical_trial_execution_plan(
+        plan
+    )
+
+    assert len(batch.games) == 3
+    assert batch.outcomes.simulation_count == 3
+    assert batch.projections.simulation_count == 3
+    assert observed == [
+        (
+            index,
+            inputs.seed_for_trial(index),
+        )
+        for index in range(3)
+    ]
+    assert batch.outcomes.tie_probability == 1.0
+    assert (
+        "tied_games_present"
+        in batch.diagnostics.warnings
+    )
+
+
+def test_resolver_factory_runs_once_per_trial():
+    calls = []
+
+    def resolver_factory(context):
+        calls.append(context.trial_index)
+
+        return lambda state, batter_id, sequence: (
+            out_event(
+                state,
+                batter_id,
+                sequence,
+            )
+        )
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=factory_input(
+            simulations=2
+        ),
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=resolver_factory,
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+    )
+
+    run_canonical_trial_execution_plan(plan)
+
+    assert calls == [0, 1]
+
+
+def test_non_callable_resolver_is_rejected():
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=factory_input(
+            simulations=1
+        ),
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=lambda context: None,
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="must return a plate-appearance resolver",
+    ):
+        run_canonical_trial_execution_plan(plan)
+
+
+def test_plan_rejects_reversed_lineups():
+    with pytest.raises(
+        ValueError,
+        match="away_lineup must use away team side",
+    ):
+        CanonicalTrialExecutionPlan(
+            factory_input=factory_input(),
+            away_lineup=lineup("home"),
+            home_lineup=lineup("away"),
+            resolver_factory=lambda context: out_event,
+        )


### PR DESCRIPTION
## Summary

Implements the seventh Layer 10J slice: an indexed canonical resolver-factory protocol that connects the versioned `CanonicalTrialFactoryInput` contract to full-game canonical simulation and existing multi-trial aggregation.

The new execution plan creates one deterministic resolver context per trial, requires a fresh plate-appearance resolver from an injected factory, runs `simulate_canonical_game()`, and delegates validation, box-score reduction, reconciliation, outcome aggregation, and projection aggregation to `run_canonical_trials()`.

## Added

- `CanonicalTrialResolverContext`
- `CanonicalTrialResolverFactory`
- `CanonicalTrialExecutionPlan`
- `build_canonical_trial_resolver_context()`
- `run_canonical_trial_execution_plan()`
- Deterministic trial index and seed propagation
- Fresh resolver construction for every trial
- Execution-plan validation for lineups, game config, and resolver factories
- Tests for indexed identity, seed coherence, exact trial counts, resolver isolation, and invalid resolver handling

## Architecture

```text
CanonicalTrialFactoryInput
        ↓
CanonicalTrialExecutionPlan
        ↓
trial index
        ↓
CanonicalTrialResolverContext
    ├─ factory input
    ├─ trial index
    └─ deterministic trial seed
        ↓
injected resolver factory
        ↓
fresh PlateAppearanceResolver
        ↓
simulate_canonical_game()
        ↓
run_canonical_trials()
        ↓
CanonicalTrialBatch
```

## Contract guarantees

- Resolver context seed must match the indexed seed in `CanonicalTrialFactoryInput`.
- Resolver factories execute exactly once per trial.
- Each trial receives a fresh resolver.
- Lineups and game rules remain fixed across the batch.
- Generic multi-trial validation and aggregation are reused rather than duplicated.
- The protocol does not select or implement matchup probabilities.

## Scope

This slice intentionally does not yet:

- generate real batter-versus-pitcher probabilities;
- construct production lineups;
- select starting pitchers or relievers;
- implement bullpen substitution logic;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New indexed resolver-factory tests passed
- Result: `146 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/trial_factory.py`
- `tests/test_canonical_trial_factory_protocol.py`

## Next slice

Define a production-facing canonical matchup-input contract for fixed lineups, starting pitchers, bullpen plans, and probability-provider identity without yet implementing real probability generation or changing legacy authority.