### PR TITLE
Add canonical matchup input contract

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -23,6 +23,12 @@ from .factory_input import (
     derive_canonical_base_seed,
     derive_canonical_trial_seed,
 )
+from .matchup_input import (
+    CANONICAL_MATCHUP_INPUT_VERSION,
+    CanonicalMatchupInput,
+    CanonicalPitchingPlan,
+    CanonicalProbabilityProviderIdentity,
+)
 from .orchestrator import (
     PlateAppearanceResolver,
     simulate_canonical_game,
@@ -60,6 +66,7 @@ __all__ = [
     "CanonicalTrialFactory",
     "CANONICAL_TRIAL_FACTORY_INPUT_VERSION",
     "CANONICAL_TRIAL_SEED_VERSION",
+    "CANONICAL_MATCHUP_INPUT_VERSION",
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
     "CanonicalTrialFactoryInput",
@@ -70,6 +77,9 @@ __all__ = [
     "ProbabilityMetric",
     "CanonicalGameValidation",
     "CanonicalLineup",
+    "CanonicalMatchupInput",
+    "CanonicalPitchingPlan",
+    "CanonicalProbabilityProviderIdentity",
     "GameCompletionReason",
     "HalfInningRecord",
     "PlateAppearanceResolver",

--- a/mlb_app/simulation/game/matchup_input.py
+++ b/mlb_app/simulation/game/matchup_input.py
@@ -1,0 +1,236 @@
+"""Production-facing canonical matchup-input contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from .contracts import CanonicalLineup
+
+
+CANONICAL_MATCHUP_INPUT_VERSION = (
+    "canonical_matchup_input_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalPitchingPlan:
+    """
+    Fixed pitcher identity available to canonical trial resolvers.
+
+    This contract records the planned pitcher pool only. It does not
+    decide when a starter exits or which reliever enters.
+    """
+
+    team_side: str
+    starter_id: str
+    bullpen_pitcher_ids: Tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.team_side not in {
+            "away",
+            "home",
+        }:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+
+        if not self.starter_id:
+            raise ValueError(
+                "starter_id is required"
+            )
+
+        if any(
+            not pitcher_id
+            for pitcher_id in self.bullpen_pitcher_ids
+        ):
+            raise ValueError(
+                "bullpen pitcher identifiers are required"
+            )
+
+        if len(self.bullpen_pitcher_ids) != len(
+            set(self.bullpen_pitcher_ids)
+        ):
+            raise ValueError(
+                "bullpen pitcher identifiers must be unique"
+            )
+
+        if self.starter_id in self.bullpen_pitcher_ids:
+            raise ValueError(
+                "starter cannot also appear in bullpen"
+            )
+
+    @property
+    def available_pitcher_ids(
+        self,
+    ) -> Tuple[str, ...]:
+        return (
+            self.starter_id,
+            *self.bullpen_pitcher_ids,
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityProviderIdentity:
+    """
+    Provenance for the injected probability provider.
+
+    The provider implementation remains external to canonical game
+    orchestration. These fields identify what supplied probabilities.
+    """
+
+    provider_name: str
+    provider_version: str
+    artifact_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.provider_name:
+            raise ValueError(
+                "provider_name is required"
+            )
+
+        if not self.provider_version:
+            raise ValueError(
+                "provider_version is required"
+            )
+
+        if (
+            self.artifact_id is not None
+            and not self.artifact_id
+        ):
+            raise ValueError(
+                "artifact_id cannot be empty"
+            )
+
+    @property
+    def identity(self) -> str:
+        value = (
+            f"{self.provider_name}:"
+            f"{self.provider_version}"
+        )
+
+        if self.artifact_id is not None:
+            value += f":{self.artifact_id}"
+
+        return value
+
+
+@dataclass(frozen=True)
+class CanonicalMatchupInput:
+    """
+    Fixed matchup identity shared by every trial in one batch.
+
+    The contract records participants and provider provenance without
+    constructing plate-appearance probabilities or substitution logic.
+    """
+
+    game_pk: int
+    away_lineup: CanonicalLineup
+    home_lineup: CanonicalLineup
+    away_pitching_plan: CanonicalPitchingPlan
+    home_pitching_plan: CanonicalPitchingPlan
+    probability_provider: (
+        CanonicalProbabilityProviderIdentity
+    )
+    schema_version: str = (
+        CANONICAL_MATCHUP_INPUT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if isinstance(self.game_pk, bool):
+            raise TypeError(
+                "game_pk must be an integer"
+            )
+
+        if self.game_pk <= 0:
+            raise ValueError(
+                "game_pk must be positive"
+            )
+
+        if not isinstance(
+            self.away_lineup,
+            CanonicalLineup,
+        ):
+            raise TypeError(
+                "away_lineup must be a CanonicalLineup"
+            )
+
+        if not isinstance(
+            self.home_lineup,
+            CanonicalLineup,
+        ):
+            raise TypeError(
+                "home_lineup must be a CanonicalLineup"
+            )
+
+        if self.away_lineup.team_side != "away":
+            raise ValueError(
+                "away_lineup must use away team side"
+            )
+
+        if self.home_lineup.team_side != "home":
+            raise ValueError(
+                "home_lineup must use home team side"
+            )
+
+        if not isinstance(
+            self.away_pitching_plan,
+            CanonicalPitchingPlan,
+        ):
+            raise TypeError(
+                "away_pitching_plan must be a "
+                "CanonicalPitchingPlan"
+            )
+
+        if not isinstance(
+            self.home_pitching_plan,
+            CanonicalPitchingPlan,
+        ):
+            raise TypeError(
+                "home_pitching_plan must be a "
+                "CanonicalPitchingPlan"
+            )
+
+        if (
+            self.away_pitching_plan.team_side
+            != "away"
+        ):
+            raise ValueError(
+                "away pitching plan must use away side"
+            )
+
+        if (
+            self.home_pitching_plan.team_side
+            != "home"
+        ):
+            raise ValueError(
+                "home pitching plan must use home side"
+            )
+
+        if not isinstance(
+            self.probability_provider,
+            CanonicalProbabilityProviderIdentity,
+        ):
+            raise TypeError(
+                "probability_provider must be a "
+                "CanonicalProbabilityProviderIdentity"
+            )
+
+        if self.schema_version != (
+            CANONICAL_MATCHUP_INPUT_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical matchup schema"
+            )
+
+        away_players = set(
+            self.away_lineup.player_ids
+        )
+        home_players = set(
+            self.home_lineup.player_ids
+        )
+
+        if away_players & home_players:
+            raise ValueError(
+                "away and home lineups cannot share players"
+            )

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -18,6 +18,9 @@ from .contracts import (
 from .factory_input import (
     CanonicalTrialFactoryInput,
 )
+from .matchup_input import (
+    CanonicalMatchupInput,
+)
 from .orchestrator import (
     PlateAppearanceResolver,
     simulate_canonical_game,
@@ -40,6 +43,9 @@ class CanonicalTrialResolverContext:
     factory_input: CanonicalTrialFactoryInput
     trial_index: int
     trial_seed: int
+    matchup_input: Optional[
+        CanonicalMatchupInput
+    ] = None
 
     def __post_init__(self) -> None:
         if not isinstance(
@@ -77,6 +83,25 @@ class CanonicalTrialResolverContext:
                 "factory-input seed"
             )
 
+        if self.matchup_input is not None:
+            if not isinstance(
+                self.matchup_input,
+                CanonicalMatchupInput,
+            ):
+                raise TypeError(
+                    "matchup_input must be a "
+                    "CanonicalMatchupInput"
+                )
+
+            if (
+                self.matchup_input.game_pk
+                != self.factory_input.game_pk
+            ):
+                raise ValueError(
+                    "matchup game_pk must match "
+                    "factory input"
+                )
+
 
 CanonicalTrialResolverFactory = Callable[
     [CanonicalTrialResolverContext],
@@ -106,6 +131,9 @@ class CanonicalTrialExecutionPlan:
     ] = None
     pitcher_dfs_rules: Optional[
         PitcherDfsScoringRules
+    ] = None
+    matchup_input: Optional[
+        CanonicalMatchupInput
     ] = None
 
     def __post_init__(self) -> None:
@@ -158,11 +186,49 @@ class CanonicalTrialExecutionPlan:
                 "resolver_factory must be callable"
             )
 
+        if self.matchup_input is not None:
+            if not isinstance(
+                self.matchup_input,
+                CanonicalMatchupInput,
+            ):
+                raise TypeError(
+                    "matchup_input must be a "
+                    "CanonicalMatchupInput"
+                )
+
+            if (
+                self.matchup_input.game_pk
+                != self.factory_input.game_pk
+            ):
+                raise ValueError(
+                    "matchup game_pk must match "
+                    "factory input"
+                )
+
+            if (
+                self.matchup_input.away_lineup
+                != self.away_lineup
+            ):
+                raise ValueError(
+                    "matchup away lineup must match plan"
+                )
+
+            if (
+                self.matchup_input.home_lineup
+                != self.home_lineup
+            ):
+                raise ValueError(
+                    "matchup home lineup must match plan"
+                )
+
 
 def build_canonical_trial_resolver_context(
     *,
     factory_input: CanonicalTrialFactoryInput,
     trial_index: int,
+    matchup_input: Optional[
+        CanonicalMatchupInput
+    ] = None,
 ) -> CanonicalTrialResolverContext:
     """Build the deterministic resolver context for one trial."""
 
@@ -172,6 +238,7 @@ def build_canonical_trial_resolver_context(
         trial_seed=factory_input.seed_for_trial(
             trial_index
         ),
+        matchup_input=matchup_input,
     )
 
 
@@ -201,6 +268,7 @@ def run_canonical_trial_execution_plan(
             build_canonical_trial_resolver_context(
                 factory_input=plan.factory_input,
                 trial_index=trial_index,
+                matchup_input=plan.matchup_input,
             )
         )
 

--- a/tests/test_canonical_matchup_input.py
+++ b/tests/test_canonical_matchup_input.py
@@ -1,0 +1,263 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    OutRecord,
+    PlayEvent,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_MATCHUP_INPUT_VERSION,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalPitchingPlan,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalTrialExecutionPlan,
+    build_canonical_trial_factory_input,
+    run_canonical_trial_execution_plan,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever_1",
+            f"{side}_reliever_2",
+        ),
+    )
+
+
+def matchup(game_pk=123):
+    return CanonicalMatchupInput(
+        game_pk=game_pk,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            CanonicalProbabilityProviderIdentity(
+                provider_name="test-provider",
+                provider_version="v1",
+                artifact_id="artifact-123",
+            )
+        ),
+    )
+
+
+def out_event(state, batter_id, sequence):
+    next_out = state.outs + 1
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type="out",
+        batter_id=batter_id,
+        pitcher_id=(
+            "home_starter"
+            if state.half == "top"
+            else "away_starter"
+        ),
+        state_before=state,
+        state_after=replace(
+            state,
+            outs=next_out,
+            batting_order_index=(
+                state.batting_order_index + 1
+            ) % 9,
+            plate_appearance_number=(
+                state.plate_appearance_number + 1
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id=batter_id,
+                out_number=next_out,
+                reason="matchup_contract_out",
+            ),
+        ),
+    )
+
+
+def test_matchup_contract_records_fixed_identity():
+    value = matchup()
+
+    assert value.schema_version == (
+        CANONICAL_MATCHUP_INPUT_VERSION
+    )
+    assert (
+        value.away_pitching_plan.starter_id
+        == "away_starter"
+    )
+    assert value.home_pitching_plan.available_pitcher_ids == (
+        "home_starter",
+        "home_reliever_1",
+        "home_reliever_2",
+    )
+    assert (
+        value.probability_provider.identity
+        == "test-provider:v1:artifact-123"
+    )
+
+
+def test_starter_cannot_appear_in_bullpen():
+    with pytest.raises(
+        ValueError,
+        match="starter cannot also appear",
+    ):
+        CanonicalPitchingPlan(
+            team_side="away",
+            starter_id="pitcher_1",
+            bullpen_pitcher_ids=(
+                "pitcher_1",
+            ),
+        )
+
+
+def test_matchup_rejects_shared_lineup_players():
+    away = lineup("away")
+
+    with pytest.raises(
+        ValueError,
+        match="cannot share players",
+    ):
+        CanonicalMatchupInput(
+            game_pk=123,
+            away_lineup=away,
+            home_lineup=CanonicalLineup(
+                team_side="home",
+                player_ids=away.player_ids,
+            ),
+            away_pitching_plan=(
+                pitching_plan("away")
+            ),
+            home_pitching_plan=(
+                pitching_plan("home")
+            ),
+            probability_provider=(
+                CanonicalProbabilityProviderIdentity(
+                    provider_name="provider",
+                    provider_version="v1",
+                )
+            ),
+        )
+
+
+def test_matchup_is_available_to_each_resolver():
+    matchup_input = matchup()
+    factory_input = (
+        build_canonical_trial_factory_input(
+            game_pk=123,
+            config={
+                "simulation_count": 2,
+                "seed": 999,
+                "canonical_model_version": (
+                    "matchup-contract-test-v1"
+                ),
+            },
+        )
+    )
+    observed = []
+
+    def resolver_factory(context):
+        observed.append(
+            (
+                context.trial_index,
+                context.matchup_input,
+            )
+        )
+
+        return out_event
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=factory_input,
+        away_lineup=matchup_input.away_lineup,
+        home_lineup=matchup_input.home_lineup,
+        resolver_factory=resolver_factory,
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+        matchup_input=matchup_input,
+    )
+
+    batch = run_canonical_trial_execution_plan(
+        plan
+    )
+
+    assert len(batch.games) == 2
+    assert observed == [
+        (0, matchup_input),
+        (1, matchup_input),
+    ]
+
+
+def test_execution_plan_rejects_mismatched_game():
+    matchup_input = matchup(game_pk=124)
+    factory_input = (
+        build_canonical_trial_factory_input(
+            game_pk=123,
+            config={
+                "simulation_count": 1,
+            },
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="matchup game_pk must match",
+    ):
+        CanonicalTrialExecutionPlan(
+            factory_input=factory_input,
+            away_lineup=matchup_input.away_lineup,
+            home_lineup=matchup_input.home_lineup,
+            resolver_factory=lambda context: out_event,
+            matchup_input=matchup_input,
+        )
+
+
+def test_execution_plan_rejects_mismatched_lineup():
+    matchup_input = matchup()
+    factory_input = (
+        build_canonical_trial_factory_input(
+            game_pk=123,
+            config={
+                "simulation_count": 1,
+            },
+        )
+    )
+
+    different_away = CanonicalLineup(
+        team_side="away",
+        player_ids=tuple(
+            f"different_away_{index}"
+            for index in range(9)
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="matchup away lineup must match",
+    ):
+        CanonicalTrialExecutionPlan(
+            factory_input=factory_input,
+            away_lineup=different_away,
+            home_lineup=matchup_input.home_lineup,
+            resolver_factory=lambda context: out_event,
+            matchup_input=matchup_input,
+        )


### PR DESCRIPTION
## Summary

Implements the eighth Layer 10J slice: a production-facing canonical matchup-input contract for fixed lineups, starting pitchers, bullpen availability, and probability-provider provenance.

The new contract is attached to each indexed resolver context while remaining fixed across the trial batch. It records matchup identity and provider provenance without implementing plate-appearance probabilities or pitcher-substitution logic.

## Added

- `CanonicalPitchingPlan`
- `CanonicalProbabilityProviderIdentity`
- `CanonicalMatchupInput`
- Versioned canonical matchup schema
- Fixed away/home lineup validation
- Fixed starter and ordered bullpen availability
- Probability-provider provenance identity
- Matchup propagation into `CanonicalTrialResolverContext`
- Execution-plan validation for game and lineup consistency
- Tests for identity, validation, context propagation, and mismatch handling

## Architecture

```text
CanonicalMatchupInput
    ├─ game identity
    ├─ away/home lineups
    ├─ away/home starting pitchers
    ├─ ordered bullpen pools
    └─ probability-provider provenance
            ↓
CanonicalTrialExecutionPlan
            ↓
CanonicalTrialResolverContext
    ├─ deterministic factory input
    ├─ trial index
    ├─ deterministic trial seed
    └─ fixed matchup input
            ↓
injected resolver factory
```

## Contract guarantees

- Matchup `game_pk` must match the factory input.
- Matchup lineups must match the execution plan.
- Away and home lineups cannot share players.
- Starting pitchers cannot also appear in their bullpen pool.
- Bullpen pitcher identifiers must be ordered and unique.
- Probability-provider provenance is explicit and versioned.
- Matchup identity remains fixed across every trial in the batch.

## Scope

This slice intentionally does not yet:

- generate real batter-versus-pitcher probabilities;
- choose starter exit timing;
- choose reliever entry timing;
- mutate pitcher state during simulation;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical matchup-input tests passed
- Result: `152 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/matchup_input.py`
- `mlb_app/simulation/game/trial_factory.py`
- `tests/test_canonical_matchup_input.py`

## Next slice

Define a provider-neutral canonical plate-appearance probability contract and deterministic categorical sampling boundary that consumes matchup identity and trial seed without yet integrating real production probability artifacts or changing legacy authority.