### PR TITLE
Add canonical sampled outcome event resolution

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -33,6 +33,10 @@ from .orchestrator import (
     PlateAppearanceResolver,
     simulate_canonical_game,
 )
+from .outcome_resolution import (
+    EMPTY_BASE_HIT_DESTINATIONS,
+    resolve_canonical_sampled_plate_appearance,
+)
 from .probability import (
     CANONICAL_PA_OUTCOME_ORDER,
     CANONICAL_PA_PROBABILITY_VERSION,
@@ -85,6 +89,7 @@ __all__ = [
     "CANONICAL_PA_SAMPLING_VERSION",
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
+    "EMPTY_BASE_HIT_DESTINATIONS",
     "CanonicalTrialFactoryInput",
     "CanonicalTrialExecutionPlan",
     "CanonicalTrialResolverContext",
@@ -115,6 +120,7 @@ __all__ = [
     "derive_canonical_pa_sampling_seed",
     "run_canonical_trials",
     "run_canonical_trial_execution_plan",
+    "resolve_canonical_sampled_plate_appearance",
     "reduce_canonical_game_box_score",
     "validate_game_box_score_reconciliation",
     "validate_canonical_game",

--- a/mlb_app/simulation/game/outcome_resolution.py
+++ b/mlb_app/simulation/game/outcome_resolution.py
@@ -1,0 +1,212 @@
+"""Resolve sampled canonical PA outcomes into coherent play events."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Tuple
+
+from mlb_app.simulation.events import (
+    Base,
+    DeterministicPlayResolver,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+    build_play_event,
+)
+
+from .probability import (
+    CanonicalPlateAppearanceOutcome,
+    CanonicalSampledPlateAppearance,
+)
+
+
+EMPTY_BASE_HIT_DESTINATIONS = {
+    CanonicalPlateAppearanceOutcome.SINGLE: Base.FIRST,
+    CanonicalPlateAppearanceOutcome.DOUBLE: Base.SECOND,
+    CanonicalPlateAppearanceOutcome.TRIPLE: Base.THIRD,
+}
+
+
+def resolve_canonical_sampled_plate_appearance(
+    sampled: CanonicalSampledPlateAppearance,
+) -> PlayEvent:
+    """
+    Convert one sampled PA category into a canonical play event.
+
+    Supported in this initial boundary:
+
+    - deterministic walks and hit-by-pitches;
+    - deterministic home runs;
+    - batter outs and strikeouts with existing runners holding;
+    - singles, doubles, and triples when the bases are empty.
+
+    State-dependent advancement for non-home-run hits remains outside
+    this slice.
+    """
+
+    if not isinstance(
+        sampled,
+        CanonicalSampledPlateAppearance,
+    ):
+        raise TypeError(
+            "sampled must be a "
+            "CanonicalSampledPlateAppearance"
+        )
+
+    query = sampled.query
+    state = query.state
+    outcome = sampled.outcome
+
+    if state.outs >= 3:
+        raise ValueError(
+            "cannot resolve a plate appearance with three outs"
+        )
+
+    if outcome in {
+        CanonicalPlateAppearanceOutcome.WALK,
+        CanonicalPlateAppearanceOutcome.HIT_BY_PITCH,
+        CanonicalPlateAppearanceOutcome.HOME_RUN,
+    }:
+        event = DeterministicPlayResolver().resolve(
+            state=state,
+            event_type=outcome.value,
+            batter_id=query.batter_id,
+            sequence=query.sequence,
+        )
+
+        return replace(
+            event,
+            pitcher_id=query.pitcher_id,
+        )
+
+    if outcome in {
+        CanonicalPlateAppearanceOutcome.OUT,
+        CanonicalPlateAppearanceOutcome.STRIKEOUT,
+    }:
+        return _resolve_batter_out(sampled)
+
+    if outcome in EMPTY_BASE_HIT_DESTINATIONS:
+        return _resolve_empty_base_hit(sampled)
+
+    raise ValueError(
+        f"unsupported sampled outcome: {outcome}"
+    )
+
+
+def _resolve_batter_out(
+    sampled: CanonicalSampledPlateAppearance,
+) -> PlayEvent:
+    query = sampled.query
+    state = query.state
+    outcome = sampled.outcome
+
+    movements = list(
+        _stationary_runner_movements(state.bases)
+    )
+
+    movements.append(
+        RunnerMovement(
+            runner_id=query.batter_id,
+            start_base=Base.HOME,
+            end_base=None,
+            is_out=True,
+        )
+    )
+
+    reason = (
+        "strikeout"
+        if outcome
+        is CanonicalPlateAppearanceOutcome.STRIKEOUT
+        else "batted_ball_out"
+    )
+
+    event = build_play_event(
+        sequence=query.sequence,
+        event_type=outcome.value,
+        batter_id=query.batter_id,
+        state_before=state,
+        runner_movements=tuple(movements),
+        outs_recorded=(
+            OutRecord(
+                runner_id=query.batter_id,
+                out_number=state.outs + 1,
+                reason=reason,
+            ),
+        ),
+    )
+
+    return replace(
+        event,
+        pitcher_id=query.pitcher_id,
+    )
+
+
+def _resolve_empty_base_hit(
+    sampled: CanonicalSampledPlateAppearance,
+) -> PlayEvent:
+    query = sampled.query
+    state = query.state
+    outcome = sampled.outcome
+
+    if any(
+        runner_id is not None
+        for runner_id in state.bases
+    ):
+        raise ValueError(
+            "non-home-run hit advancement with occupied "
+            "bases is not supported by this resolver"
+        )
+
+    destination = EMPTY_BASE_HIT_DESTINATIONS[
+        outcome
+    ]
+
+    event = build_play_event(
+        sequence=query.sequence,
+        event_type=outcome.value,
+        batter_id=query.batter_id,
+        state_before=state,
+        runner_movements=(
+            RunnerMovement(
+                runner_id=query.batter_id,
+                start_base=Base.HOME,
+                end_base=destination,
+            ),
+        ),
+    )
+
+    return replace(
+        event,
+        pitcher_id=query.pitcher_id,
+    )
+
+
+def _stationary_runner_movements(
+    bases: Tuple[
+        str | None,
+        str | None,
+        str | None,
+    ],
+) -> Tuple[RunnerMovement, ...]:
+    movements = []
+
+    for base, runner_id in zip(
+        (
+            Base.FIRST,
+            Base.SECOND,
+            Base.THIRD,
+        ),
+        bases,
+    ):
+        if runner_id is None:
+            continue
+
+        movements.append(
+            RunnerMovement(
+                runner_id=runner_id,
+                start_base=base,
+                end_base=base,
+            )
+        )
+
+    return tuple(movements)

--- a/tests/test_canonical_sampled_outcome_resolution.py
+++ b/tests/test_canonical_sampled_outcome_resolution.py
@@ -1,0 +1,301 @@
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+)
+from mlb_app.simulation.game import (
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalSampledPlateAppearance,
+    resolve_canonical_sampled_plate_appearance,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            CanonicalProbabilityProviderIdentity(
+                provider_name="resolution-test",
+                provider_version="v1",
+            )
+        ),
+    )
+
+
+def sampled(
+    outcome,
+    *,
+    state=None,
+    sequence=0,
+):
+    state = state or GameState(
+        inning=1,
+        half="top",
+    )
+
+    query = CanonicalPlateAppearanceQuery(
+        matchup_input=matchup(),
+        state=state,
+        batter_id="away_batter_0",
+        pitcher_id="home_starter",
+        sequence=sequence,
+        trial_index=0,
+        trial_seed=12345,
+    )
+
+    return CanonicalSampledPlateAppearance(
+        query=query,
+        outcome=outcome,
+        draw=0.25,
+        sampling_seed=67890,
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome,event_type",
+    [
+        (
+            CanonicalPlateAppearanceOutcome.WALK,
+            "bb",
+        ),
+        (
+            CanonicalPlateAppearanceOutcome.HIT_BY_PITCH,
+            "hbp",
+        ),
+    ],
+)
+def test_forced_awards_reuse_deterministic_resolution(
+    outcome,
+    event_type,
+):
+    state = GameState(
+        inning=1,
+        half="top",
+        bases=(
+            "away_batter_1",
+            "away_batter_2",
+            "away_batter_3",
+        ),
+    )
+
+    event = (
+        resolve_canonical_sampled_plate_appearance(
+            sampled(
+                outcome,
+                state=state,
+            )
+        )
+    )
+
+    assert event.event_type == event_type
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.bases == (
+        "away_batter_0",
+        "away_batter_1",
+        "away_batter_2",
+    )
+    assert event.runs_scored == (
+        "away_batter_3",
+    )
+    assert event.state_after.away_score == 1
+
+
+@pytest.mark.parametrize(
+    "outcome,event_type,reason",
+    [
+        (
+            CanonicalPlateAppearanceOutcome.OUT,
+            "out",
+            "batted_ball_out",
+        ),
+        (
+            CanonicalPlateAppearanceOutcome.STRIKEOUT,
+            "k",
+            "strikeout",
+        ),
+    ],
+)
+def test_batter_out_preserves_existing_runners(
+    outcome,
+    event_type,
+    reason,
+):
+    state = GameState(
+        inning=2,
+        half="top",
+        outs=1,
+        bases=(
+            "away_batter_1",
+            None,
+            "away_batter_3",
+        ),
+    )
+
+    event = (
+        resolve_canonical_sampled_plate_appearance(
+            sampled(
+                outcome,
+                state=state,
+                sequence=7,
+            )
+        )
+    )
+
+    assert event.sequence == 7
+    assert event.event_type == event_type
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.outs == 2
+    assert event.state_after.bases == state.bases
+    assert event.outs_recorded[0].reason == reason
+    assert event.runs_scored == ()
+
+
+@pytest.mark.parametrize(
+    "outcome,destination",
+    [
+        (
+            CanonicalPlateAppearanceOutcome.SINGLE,
+            Base.FIRST,
+        ),
+        (
+            CanonicalPlateAppearanceOutcome.DOUBLE,
+            Base.SECOND,
+        ),
+        (
+            CanonicalPlateAppearanceOutcome.TRIPLE,
+            Base.THIRD,
+        ),
+    ],
+)
+def test_empty_base_hits_place_batter_at_fixed_base(
+    outcome,
+    destination,
+):
+    event = (
+        resolve_canonical_sampled_plate_appearance(
+            sampled(outcome)
+        )
+    )
+
+    assert event.event_type == outcome.value
+    assert event.pitcher_id == "home_starter"
+    assert event.runner_movements[0].end_base is destination
+    assert (
+        event.state_after.runner_on(destination)
+        == "away_batter_0"
+    )
+    assert event.state_after.outs == 0
+    assert event.runs_scored == ()
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        CanonicalPlateAppearanceOutcome.DOUBLE,
+        CanonicalPlateAppearanceOutcome.TRIPLE,
+    ],
+)
+def test_occupied_base_hits_require_future_advancement_layer(
+    outcome,
+):
+    state = GameState(
+        inning=1,
+        half="top",
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="occupied bases is not supported",
+    ):
+        resolve_canonical_sampled_plate_appearance(
+            sampled(
+                outcome,
+                state=state,
+            )
+        )
+
+
+def test_home_run_scores_all_runners_and_batter():
+    state = GameState(
+        inning=3,
+        half="top",
+        bases=(
+            "away_batter_1",
+            "away_batter_2",
+            "away_batter_3",
+        ),
+    )
+
+    event = (
+        resolve_canonical_sampled_plate_appearance(
+            sampled(
+                CanonicalPlateAppearanceOutcome.HOME_RUN,
+                state=state,
+            )
+        )
+    )
+
+    assert event.event_type == "hr"
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.bases == (
+        None,
+        None,
+        None,
+    )
+    assert event.runs_scored == (
+        "away_batter_1",
+        "away_batter_2",
+        "away_batter_3",
+        "away_batter_0",
+    )
+    assert event.state_after.away_score == 4
+
+
+def test_resolution_rejects_non_sample_contract():
+    with pytest.raises(
+        TypeError,
+        match="CanonicalSampledPlateAppearance",
+    ):
+        resolve_canonical_sampled_plate_appearance(
+            object()
+        )


### PR DESCRIPTION
## Summary

Implements the tenth Layer 10J slice: deterministic conversion of sampled canonical plate-appearance outcomes into validated canonical `PlayEvent` records.

The new resolver composes existing event mechanics rather than creating a parallel state-transition system. Walks, hit-by-pitches, and home runs reuse `DeterministicPlayResolver`; outs and strikeouts use explicit stationary-runner and batter-out movements; and singles, doubles, and triples support deterministic empty-base batter placement.

## Added

- `resolve_canonical_sampled_plate_appearance()`
- `EMPTY_BASE_HIT_DESTINATIONS`
- Sampled-outcome validation
- BB/HBP forced-award integration
- Home-run integration
- Batter-out and strikeout event construction
- Empty-base single, double, and triple placement
- Pitcher attribution propagation
- Explicit rejection of occupied-base non-home-run hit advancement
- Tests for forced awards, outs, strikeouts, hits, home runs, and unsupported state handling

## Architecture

```text
CanonicalSampledPlateAppearance
        ↓
resolve_canonical_sampled_plate_appearance()
        ├─ BB/HBP → existing forced-award resolver
        ├─ HR → existing deterministic home-run resolver
        ├─ OUT/K → explicit batter out; runners hold
        └─ 1B/2B/3B → deterministic empty-base placement
        ↓
validated PlayEvent
```

## Contract guarantees

- Every resolved outcome produces a coherent canonical `PlayEvent`.
- Pitcher identity from the plate-appearance query is preserved on the event.
- Existing runners remain stationary on basic outs and strikeouts.
- Forced awards and home runs reuse existing deterministic event logic.
- Empty-base hits place the batter at the correct fixed destination.
- Occupied-base singles, doubles, and triples fail explicitly rather than guessing advancement.
- Event construction continues to require explicit movements for every resulting base, out, and run.

## Scope

This slice intentionally does not yet:

- resolve occupied-base single, double, or triple advancement;
- sample batted-ball context;
- implement state-dependent runner advancement probabilities;
- integrate real production probability artifacts;
- choose pitcher substitutions;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New sampled-outcome event-resolution tests passed
- Result: `171 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/outcome_resolution.py`
- `tests/test_canonical_sampled_outcome_resolution.py`

## Next slice

Integrate deterministic batted-ball context and the existing legal runner-advancement framework for occupied-base singles, doubles, and batted-ball outs without yet introducing production probability artifacts or changing legacy authority.