### PR TITLE
Integrate canonical batted ball advancement

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -6,6 +6,14 @@ from .box_score import (
     reduce_canonical_game_box_score,
     validate_game_box_score_reconciliation,
 )
+from .batted_ball_resolution import (
+    CANONICAL_BATTED_BALL_RESOLUTION_VERSION,
+    CANONICAL_OUT_SUBTYPES,
+    SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES,
+    CanonicalBattedBallResolution,
+    derive_canonical_batted_ball_seed,
+    resolve_canonical_batted_ball_outcome,
+)
 from .contracts import (
     CanonicalGameConfig,
     CanonicalGameResult,
@@ -73,6 +81,7 @@ from .validation import (
 )
 
 __all__ = [
+    "CanonicalBattedBallResolution",
     "CanonicalGameBoxScore",
     "GameBoxScoreReconciliation",
     "CanonicalGameConfig",
@@ -84,6 +93,8 @@ __all__ = [
     "CANONICAL_TRIAL_FACTORY_INPUT_VERSION",
     "CANONICAL_TRIAL_SEED_VERSION",
     "CANONICAL_MATCHUP_INPUT_VERSION",
+    "CANONICAL_BATTED_BALL_RESOLUTION_VERSION",
+    "CANONICAL_OUT_SUBTYPES",
     "CANONICAL_PA_OUTCOME_ORDER",
     "CANONICAL_PA_PROBABILITY_VERSION",
     "CANONICAL_PA_SAMPLING_VERSION",
@@ -96,6 +107,7 @@ __all__ = [
     "CanonicalTrialResolverFactory",
     "DistributionPoint",
     "ProbabilityMetric",
+    "SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES",
     "CanonicalGameValidation",
     "CanonicalLineup",
     "CanonicalMatchupInput",
@@ -117,9 +129,11 @@ __all__ = [
     "build_canonical_trial_resolver_context",
     "derive_canonical_base_seed",
     "derive_canonical_trial_seed",
+    "derive_canonical_batted_ball_seed",
     "derive_canonical_pa_sampling_seed",
     "run_canonical_trials",
     "run_canonical_trial_execution_plan",
+    "resolve_canonical_batted_ball_outcome",
     "resolve_canonical_sampled_plate_appearance",
     "reduce_canonical_game_box_score",
     "validate_game_box_score_reconciliation",

--- a/mlb_app/simulation/game/batted_ball_resolution.py
+++ b/mlb_app/simulation/game/batted_ball_resolution.py
@@ -1,0 +1,267 @@
+"""Deterministic canonical batted-ball and runner advancement resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import hashlib
+import random
+from typing import Optional, Tuple
+
+from mlb_app.simulation.events import (
+    Base,
+    BaselineBattedBallContextProvider,
+    BaselineRunnerAdvancementSampler,
+    BattedBallContext,
+    OutRecord,
+    PlayEvent,
+    RunnerAdvancementResult,
+    RunnerMovement,
+    build_play_event,
+)
+
+from .factory_input import MAX_CANONICAL_SEED
+from .probability import (
+    CanonicalPlateAppearanceOutcome,
+    CanonicalSampledPlateAppearance,
+)
+
+
+CANONICAL_BATTED_BALL_RESOLUTION_VERSION = (
+    "canonical_batted_ball_resolution_v1"
+)
+
+CANONICAL_OUT_SUBTYPES: Tuple[str, ...] = (
+    "groundout",
+    "flyout",
+    "lineout_popout",
+    "other_out",
+)
+
+SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES = frozenset(
+    {
+        CanonicalPlateAppearanceOutcome.OUT,
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        CanonicalPlateAppearanceOutcome.DOUBLE,
+    }
+)
+
+
+@dataclass(frozen=True)
+class CanonicalBattedBallResolution:
+    """Resolved event plus deterministic batted-ball provenance."""
+
+    sampled: CanonicalSampledPlateAppearance
+    event: PlayEvent
+    context: BattedBallContext
+    advancement: RunnerAdvancementResult
+    context_seed: int
+    advancement_seed: int
+    outcome_subtype: Optional[str] = None
+    resolution_version: str = (
+        CANONICAL_BATTED_BALL_RESOLUTION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.event.state_before != self.sampled.query.state:
+            raise ValueError(
+                "resolved event must begin from sampled query state"
+            )
+
+        if self.event.batter_id != self.sampled.query.batter_id:
+            raise ValueError(
+                "resolved event batter must match sampled query"
+            )
+
+        if self.event.pitcher_id != self.sampled.query.pitcher_id:
+            raise ValueError(
+                "resolved event pitcher must match sampled query"
+            )
+
+        if self.context_seed < 0:
+            raise ValueError(
+                "context_seed cannot be negative"
+            )
+
+        if self.advancement_seed < 0:
+            raise ValueError(
+                "advancement_seed cannot be negative"
+            )
+
+        if self.resolution_version != (
+            CANONICAL_BATTED_BALL_RESOLUTION_VERSION
+        ):
+            raise ValueError(
+                "unsupported batted-ball resolution version"
+            )
+
+
+def resolve_canonical_batted_ball_outcome(
+    sampled: CanonicalSampledPlateAppearance,
+) -> CanonicalBattedBallResolution:
+    """
+    Resolve a sampled single, double, or batted-ball out.
+
+    Context and advancement RNGs are independently derived from immutable
+    sampled plate-appearance identity. No shared mutable RNG is accepted.
+    """
+
+    if not isinstance(
+        sampled,
+        CanonicalSampledPlateAppearance,
+    ):
+        raise TypeError(
+            "sampled must be a "
+            "CanonicalSampledPlateAppearance"
+        )
+
+    if (
+        sampled.outcome
+        not in SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES
+    ):
+        raise ValueError(
+            "sampled outcome is not supported by the "
+            "batted-ball advancement resolver"
+        )
+
+    query = sampled.query
+    outcome = sampled.outcome
+    context_seed = derive_canonical_batted_ball_seed(
+        sampled=sampled,
+        purpose="context",
+    )
+    advancement_seed = derive_canonical_batted_ball_seed(
+        sampled=sampled,
+        purpose="advancement",
+    )
+
+    outcome_subtype = (
+        _sample_outcome_subtype(context_seed)
+        if outcome is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
+
+    context = BaselineBattedBallContextProvider(
+        rng=random.Random(context_seed),
+    ).sample(
+        primary_outcome=outcome.value,
+        outcome_subtype=outcome_subtype,
+    )
+
+    if context is None:
+        raise RuntimeError(
+            "batted-ball outcome produced no context"
+        )
+
+    advancement = BaselineRunnerAdvancementSampler(
+        rng=random.Random(advancement_seed),
+    ).sample(
+        state=query.state,
+        batter_id=query.batter_id,
+        primary_outcome=outcome.value,
+        context=context,
+    )
+
+    if outcome is CanonicalPlateAppearanceOutcome.OUT:
+        movements = advancement.movements + (
+            RunnerMovement(
+                runner_id=query.batter_id,
+                start_base=Base.HOME,
+                end_base=None,
+                is_out=True,
+            ),
+        )
+        outs_recorded = (
+            OutRecord(
+                runner_id=query.batter_id,
+                out_number=query.state.outs + 1,
+                reason=outcome_subtype,
+            ),
+        )
+    else:
+        movements = advancement.movements
+        outs_recorded = ()
+
+    event = build_play_event(
+        sequence=query.sequence,
+        event_type=outcome.value,
+        batter_id=query.batter_id,
+        state_before=query.state,
+        runner_movements=movements,
+        outs_recorded=outs_recorded,
+    )
+
+    event = replace(
+        event,
+        pitcher_id=query.pitcher_id,
+    )
+
+    return CanonicalBattedBallResolution(
+        sampled=sampled,
+        event=event,
+        context=context,
+        advancement=advancement,
+        context_seed=context_seed,
+        advancement_seed=advancement_seed,
+        outcome_subtype=outcome_subtype,
+    )
+
+
+def derive_canonical_batted_ball_seed(
+    *,
+    sampled: CanonicalSampledPlateAppearance,
+    purpose: str,
+) -> int:
+    """Derive deterministic independent RNG identity for one stage."""
+
+    if not isinstance(
+        sampled,
+        CanonicalSampledPlateAppearance,
+    ):
+        raise TypeError(
+            "sampled must be a "
+            "CanonicalSampledPlateAppearance"
+        )
+
+    if not purpose:
+        raise ValueError(
+            "purpose is required"
+        )
+
+    query = sampled.query
+
+    payload = "\x1f".join(
+        (
+            CANONICAL_BATTED_BALL_RESOLUTION_VERSION,
+            purpose,
+            str(query.matchup_input.game_pk),
+            str(query.trial_index),
+            str(query.trial_seed),
+            str(query.sequence),
+            str(sampled.sampling_seed),
+            sampled.outcome.value,
+            query.batter_id,
+            query.pitcher_id,
+        )
+    ).encode("utf-8")
+
+    digest = hashlib.sha256(payload).digest()
+
+    return int.from_bytes(
+        digest[:8],
+        byteorder="big",
+        signed=False,
+    ) & MAX_CANONICAL_SEED
+
+
+def _sample_outcome_subtype(
+    context_seed: int,
+) -> str:
+    rng = random.Random(
+        context_seed ^ 0x5A5A5A5A
+    )
+
+    return CANONICAL_OUT_SUBTYPES[
+        rng.randrange(
+            len(CANONICAL_OUT_SUBTYPES)
+        )
+    ]

--- a/mlb_app/simulation/game/outcome_resolution.py
+++ b/mlb_app/simulation/game/outcome_resolution.py
@@ -14,6 +14,9 @@ from mlb_app.simulation.events import (
     build_play_event,
 )
 
+from .batted_ball_resolution import (
+    resolve_canonical_batted_ball_outcome,
+)
 from .probability import (
     CanonicalPlateAppearanceOutcome,
     CanonicalSampledPlateAppearance,
@@ -81,11 +84,23 @@ def resolve_canonical_sampled_plate_appearance(
 
     if outcome in {
         CanonicalPlateAppearanceOutcome.OUT,
-        CanonicalPlateAppearanceOutcome.STRIKEOUT,
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        CanonicalPlateAppearanceOutcome.DOUBLE,
     }:
+        return resolve_canonical_batted_ball_outcome(
+            sampled
+        ).event
+
+    if (
+        outcome
+        is CanonicalPlateAppearanceOutcome.STRIKEOUT
+    ):
         return _resolve_batter_out(sampled)
 
-    if outcome in EMPTY_BASE_HIT_DESTINATIONS:
+    if (
+        outcome
+        is CanonicalPlateAppearanceOutcome.TRIPLE
+    ):
         return _resolve_empty_base_hit(sampled)
 
     raise ValueError(

--- a/tests/test_canonical_batted_ball_advancement.py
+++ b/tests/test_canonical_batted_ball_advancement.py
@@ -1,0 +1,264 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    BattedBallContext,
+    GameState,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_OUT_SUBTYPES,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalSampledPlateAppearance,
+    derive_canonical_batted_ball_seed,
+    resolve_canonical_batted_ball_outcome,
+    resolve_canonical_sampled_plate_appearance,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            CanonicalProbabilityProviderIdentity(
+                provider_name="advancement-test",
+                provider_version="v1",
+            )
+        ),
+    )
+
+
+def sampled(
+    outcome,
+    *,
+    state=None,
+    sequence=0,
+):
+    state = state or GameState(
+        inning=1,
+        half="top",
+    )
+
+    return CanonicalSampledPlateAppearance(
+        query=CanonicalPlateAppearanceQuery(
+            matchup_input=matchup(),
+            state=state,
+            batter_id="away_batter_0",
+            pitcher_id="home_starter",
+            sequence=sequence,
+            trial_index=2,
+            trial_seed=12345,
+        ),
+        outcome=outcome,
+        draw=0.25,
+        sampling_seed=67890,
+    )
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        CanonicalPlateAppearanceOutcome.DOUBLE,
+    ],
+)
+def test_occupied_base_hits_resolve_with_advancement(
+    outcome,
+):
+    state = GameState(
+        inning=4,
+        half="top",
+        bases=(
+            "away_batter_1",
+            "away_batter_2",
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            outcome,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert isinstance(
+        resolution.context,
+        BattedBallContext,
+    )
+    assert event.event_type == outcome.value
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.plate_appearance_number == 1
+    assert event.state_after.batting_order_index == 1
+    assert (
+        event.runner_movements
+        == resolution.advancement.movements
+    )
+
+
+def test_batted_ball_out_uses_explicit_advancement():
+    state = GameState(
+        inning=5,
+        half="top",
+        outs=0,
+        bases=(
+            "away_batter_1",
+            "away_batter_2",
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert resolution.outcome_subtype in (
+        CANONICAL_OUT_SUBTYPES
+    )
+    assert event.state_after.outs == 1
+    assert event.outs_recorded[0].runner_id == (
+        "away_batter_0"
+    )
+    assert event.outs_recorded[0].reason == (
+        resolution.outcome_subtype
+    )
+    assert event.runner_movements[-1].is_out
+
+
+def test_identical_sample_reproduces_full_resolution():
+    value = sampled(
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        state=GameState(
+            inning=3,
+            half="top",
+            bases=(
+                "away_batter_1",
+                "away_batter_2",
+                None,
+            ),
+        ),
+    )
+
+    first = resolve_canonical_batted_ball_outcome(
+        value
+    )
+    second = resolve_canonical_batted_ball_outcome(
+        value
+    )
+
+    assert first == second
+
+
+def test_context_and_advancement_use_separate_seeds():
+    value = sampled(
+        CanonicalPlateAppearanceOutcome.DOUBLE
+    )
+
+    context_seed = derive_canonical_batted_ball_seed(
+        sampled=value,
+        purpose="context",
+    )
+    advancement_seed = (
+        derive_canonical_batted_ball_seed(
+            sampled=value,
+            purpose="advancement",
+        )
+    )
+
+    assert context_seed != advancement_seed
+
+
+def test_sequence_changes_batted_ball_seed():
+    first = sampled(
+        CanonicalPlateAppearanceOutcome.SINGLE,
+        sequence=1,
+    )
+    second = replace(
+        first,
+        query=replace(
+            first.query,
+            sequence=2,
+        ),
+    )
+
+    assert derive_canonical_batted_ball_seed(
+        sampled=first,
+        purpose="context",
+    ) != derive_canonical_batted_ball_seed(
+        sampled=second,
+        purpose="context",
+    )
+
+
+def test_public_sampled_resolver_routes_occupied_single():
+    state = GameState(
+        inning=2,
+        half="top",
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    event = resolve_canonical_sampled_plate_appearance(
+        sampled(
+            CanonicalPlateAppearanceOutcome.SINGLE,
+            state=state,
+        )
+    )
+
+    assert event.event_type == "single"
+    assert event.state_after.first == "away_batter_0"
+
+
+def test_strikeout_does_not_use_batted_ball_resolution():
+    with pytest.raises(
+        ValueError,
+        match="not supported",
+    ):
+        resolve_canonical_batted_ball_outcome(
+            sampled(
+                CanonicalPlateAppearanceOutcome.STRIKEOUT
+            )
+        )

--- a/tests/test_canonical_sampled_outcome_resolution.py
+++ b/tests/test_canonical_sampled_outcome_resolution.py
@@ -138,11 +138,6 @@ def test_forced_awards_reuse_deterministic_resolution(
     "outcome,event_type,reason",
     [
         (
-            CanonicalPlateAppearanceOutcome.OUT,
-            "out",
-            "batted_ball_out",
-        ),
-        (
             CanonicalPlateAppearanceOutcome.STRIKEOUT,
             "k",
             "strikeout",
@@ -225,8 +220,6 @@ def test_empty_base_hits_place_batter_at_fixed_base(
 @pytest.mark.parametrize(
     "outcome",
     [
-        CanonicalPlateAppearanceOutcome.SINGLE,
-        CanonicalPlateAppearanceOutcome.DOUBLE,
         CanonicalPlateAppearanceOutcome.TRIPLE,
     ],
 )


### PR DESCRIPTION
## Summary

Implements the eleventh Layer 10J slice: deterministic integration of canonical batted-ball context and the existing runner-advancement framework for sampled outs, singles, and doubles.

The new resolution boundary derives independent deterministic seeds for batted-ball context and runner advancement, reuses `BaselineBattedBallContextProvider` and `BaselineRunnerAdvancementSampler`, and emits validated canonical `PlayEvent` records with explicit runner movements and provenance.

## Added

- `CanonicalBattedBallResolution`
- `CANONICAL_BATTED_BALL_RESOLUTION_VERSION`
- `CANONICAL_OUT_SUBTYPES`
- `SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES`
- `derive_canonical_batted_ball_seed()`
- `resolve_canonical_batted_ball_outcome()`
- Deterministic batted-ball subtype selection for outs
- Independent context and advancement RNG identities
- Occupied-base single and double advancement
- Batted-ball out advancement with explicit batter out
- Public sampled-outcome routing into the batted-ball resolver
- Tests for deterministic replay, seed isolation, occupied-base hits, batted-ball outs, and unsupported outcomes

## Architecture

```text
CanonicalSampledPlateAppearance
        ↓
independent context seed
        ↓
BaselineBattedBallContextProvider
        ↓
independent advancement seed
        ↓
BaselineRunnerAdvancementSampler
        ↓
explicit runner movements
        ↓
build_play_event()
        ↓
CanonicalBattedBallResolution
    ├─ validated PlayEvent
    ├─ batted-ball context
    ├─ advancement result
    ├─ context seed
    ├─ advancement seed
    └─ out subtype
```

## Contract guarantees

- Identical sampled plate-appearance identity reproduces the same full resolution.
- Batted-ball context and runner advancement use independently derived seeds.
- Singles and doubles with occupied bases reuse the existing legal advancement framework.
- Batted-ball outs preserve explicit runner advancement plus an explicit batter out.
- Pitcher identity is preserved on the final event.
- Every resulting base, run, and out remains explained by canonical movement records.
- Unsupported non-batted-ball outcomes fail explicitly.

## Scope

This slice intentionally does not yet:

- resolve occupied-base triples;
- integrate production probability artifacts;
- implement real batter-versus-pitcher probability generation;
- choose pitcher substitutions;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical batted-ball advancement tests passed
- Result: `176 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/batted_ball_resolution.py`
- `mlb_app/simulation/game/outcome_resolution.py`
- `tests/test_canonical_batted_ball_advancement.py`
- `tests/test_canonical_sampled_outcome_resolution.py`

## Next slice

Define a deterministic canonical plate-appearance resolver factory that composes matchup input, a provider-neutral probability provider, categorical sampling, sampled-outcome resolution, and fixed active-pitcher identity into the existing full-game execution plan without yet integrating production probability artifacts or changing legacy authority.