### PR TITLE
Add canonical plate appearance resolver factory

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -45,6 +45,11 @@ from .outcome_resolution import (
     EMPTY_BASE_HIT_DESTINATIONS,
     resolve_canonical_sampled_plate_appearance,
 )
+from .pa_resolver_factory import (
+    CANONICAL_PA_RESOLVER_FACTORY_VERSION,
+    CanonicalPlateAppearanceResolverFactory,
+    build_canonical_pa_resolver_factory,
+)
 from .probability import (
     CANONICAL_PA_OUTCOME_ORDER,
     CANONICAL_PA_PROBABILITY_VERSION,
@@ -97,6 +102,7 @@ __all__ = [
     "CANONICAL_OUT_SUBTYPES",
     "CANONICAL_PA_OUTCOME_ORDER",
     "CANONICAL_PA_PROBABILITY_VERSION",
+    "CANONICAL_PA_RESOLVER_FACTORY_VERSION",
     "CANONICAL_PA_SAMPLING_VERSION",
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
@@ -114,6 +120,7 @@ __all__ = [
     "CanonicalOutcomeProbability",
     "CanonicalPlateAppearanceOutcome",
     "CanonicalPlateAppearanceProbabilities",
+    "CanonicalPlateAppearanceResolverFactory",
     "CanonicalPlateAppearanceProbabilityProvider",
     "CanonicalPlateAppearanceQuery",
     "CanonicalSampledPlateAppearance",
@@ -125,6 +132,7 @@ __all__ = [
     "simulate_canonical_game",
     "sample_canonical_plate_appearance",
     "aggregate_game_outcomes",
+    "build_canonical_pa_resolver_factory",
     "build_canonical_trial_factory_input",
     "build_canonical_trial_resolver_context",
     "derive_canonical_base_seed",

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -1,0 +1,211 @@
+"""Deterministic canonical plate-appearance resolver construction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from mlb_app.simulation.events import (
+    GameState,
+    PlayEvent,
+)
+
+from .matchup_input import CanonicalMatchupInput
+from .orchestrator import PlateAppearanceResolver
+from .outcome_resolution import (
+    resolve_canonical_sampled_plate_appearance,
+)
+from .probability import (
+    CanonicalPlateAppearanceProbabilities,
+    CanonicalPlateAppearanceProbabilityProvider,
+    CanonicalPlateAppearanceQuery,
+    sample_canonical_plate_appearance,
+)
+from .trial_factory import (
+    CanonicalTrialResolverContext,
+    CanonicalTrialResolverFactory,
+)
+
+
+CANONICAL_PA_RESOLVER_FACTORY_VERSION = (
+    "canonical_pa_resolver_factory_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalPlateAppearanceResolverFactory:
+    """
+    Build one deterministic canonical PA resolver per trial.
+
+    Pitcher substitutions are intentionally outside this contract.
+    Each half-inning therefore uses the fixed starter from the matchup
+    pitching plan.
+    """
+
+    probability_provider: (
+        CanonicalPlateAppearanceProbabilityProvider
+    )
+    version: str = (
+        CANONICAL_PA_RESOLVER_FACTORY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not callable(self.probability_provider):
+            raise TypeError(
+                "probability_provider must be callable"
+            )
+
+        if self.version != (
+            CANONICAL_PA_RESOLVER_FACTORY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical PA resolver "
+                "factory version"
+            )
+
+    def __call__(
+        self,
+        context: CanonicalTrialResolverContext,
+    ) -> PlateAppearanceResolver:
+        if not isinstance(
+            context,
+            CanonicalTrialResolverContext,
+        ):
+            raise TypeError(
+                "context must be a "
+                "CanonicalTrialResolverContext"
+            )
+
+        matchup_input = context.matchup_input
+
+        if matchup_input is None:
+            raise ValueError(
+                "canonical PA resolver requires "
+                "matchup_input"
+            )
+
+        if not isinstance(
+            matchup_input,
+            CanonicalMatchupInput,
+        ):
+            raise TypeError(
+                "matchup_input must be a "
+                "CanonicalMatchupInput"
+            )
+
+        return _CanonicalPlateAppearanceResolver(
+            context=context,
+            matchup_input=matchup_input,
+            probability_provider=(
+                self.probability_provider
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class _CanonicalPlateAppearanceResolver:
+    """Fresh immutable resolver owned by exactly one trial."""
+
+    context: CanonicalTrialResolverContext
+    matchup_input: CanonicalMatchupInput
+    probability_provider: (
+        CanonicalPlateAppearanceProbabilityProvider
+    )
+
+    def __call__(
+        self,
+        state: GameState,
+        batter_id: str,
+        sequence: int,
+    ) -> PlayEvent:
+        if not isinstance(state, GameState):
+            raise TypeError(
+                "state must be a GameState"
+            )
+
+        pitcher_id = _fixed_pitcher_for_state(
+            matchup_input=self.matchup_input,
+            state=state,
+        )
+
+        query = CanonicalPlateAppearanceQuery(
+            matchup_input=self.matchup_input,
+            state=state,
+            batter_id=batter_id,
+            pitcher_id=pitcher_id,
+            sequence=sequence,
+            trial_index=self.context.trial_index,
+            trial_seed=self.context.trial_seed,
+        )
+
+        probabilities = self.probability_provider(
+            query
+        )
+
+        if not isinstance(
+            probabilities,
+            CanonicalPlateAppearanceProbabilities,
+        ):
+            raise TypeError(
+                "probability provider must return "
+                "CanonicalPlateAppearanceProbabilities"
+            )
+
+        if probabilities.query != query:
+            raise ValueError(
+                "probability provider returned a "
+                "distribution for a different query"
+            )
+
+        sampled = sample_canonical_plate_appearance(
+            probabilities
+        )
+
+        return (
+            resolve_canonical_sampled_plate_appearance(
+                sampled
+            )
+        )
+
+
+def _fixed_pitcher_for_state(
+    *,
+    matchup_input: CanonicalMatchupInput,
+    state: GameState,
+) -> str:
+    """
+    Select the fixed starting pitcher for the fielding side.
+
+    Top half: home starter.
+    Bottom half: away starter.
+    """
+
+    if state.half == "top":
+        return (
+            matchup_input
+            .home_pitching_plan
+            .starter_id
+        )
+
+    if state.half == "bottom":
+        return (
+            matchup_input
+            .away_pitching_plan
+            .starter_id
+        )
+
+    raise ValueError(
+        "state half must be 'top' or 'bottom'"
+    )
+
+
+def build_canonical_pa_resolver_factory(
+    probability_provider: (
+        CanonicalPlateAppearanceProbabilityProvider
+    ),
+) -> CanonicalTrialResolverFactory:
+    """Build the execution-plan-compatible resolver factory."""
+
+    return CanonicalPlateAppearanceResolverFactory(
+        probability_provider=probability_provider,
+    )

--- a/tests/test_canonical_pa_resolver_factory.py
+++ b/tests/test_canonical_pa_resolver_factory.py
@@ -1,0 +1,357 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import GameState
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceProbabilities,
+    CanonicalPlateAppearanceResolverFactory,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalTrialExecutionPlan,
+    build_canonical_pa_resolver_factory,
+    build_canonical_trial_factory_input,
+    build_canonical_trial_resolver_context,
+    run_canonical_trial_execution_plan,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def provider_identity():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="resolver-factory-test",
+        provider_version="v1",
+    )
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=provider_identity(),
+    )
+
+
+def factory_input(simulations=1):
+    return build_canonical_trial_factory_input(
+        game_pk=123,
+        config={
+            "simulation_count": simulations,
+            "seed": 98765,
+            "canonical_model_version": (
+                "pa-resolver-factory-test-v1"
+            ),
+        },
+    )
+
+
+def all_out_provider(observed):
+    def provide(query):
+        observed.append(query)
+
+        return CanonicalPlateAppearanceProbabilities(
+            query=query,
+            probabilities=tuple(
+                CanonicalOutcomeProbability(
+                    outcome=outcome,
+                    probability=(
+                        1.0
+                        if outcome
+                        is CanonicalPlateAppearanceOutcome.STRIKEOUT
+                        else 0.0
+                    ),
+                )
+                for outcome in CANONICAL_PA_OUTCOME_ORDER
+            ),
+            provider=query.matchup_input.probability_provider,
+        )
+
+    return provide
+
+
+def test_factory_requires_matchup_input():
+    resolver_factory = (
+        build_canonical_pa_resolver_factory(
+            all_out_provider([])
+        )
+    )
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="requires matchup_input",
+    ):
+        resolver_factory(context)
+
+
+def test_top_half_uses_home_starter():
+    observed = []
+    matchup_input = matchup()
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            matchup_input=matchup_input,
+        )
+    )
+    resolver = (
+        CanonicalPlateAppearanceResolverFactory(
+            probability_provider=(
+                all_out_provider(observed)
+            )
+        )(context)
+    )
+
+    event = resolver(
+        GameState(
+            inning=1,
+            half="top",
+        ),
+        "away_batter_0",
+        0,
+    )
+
+    assert observed[0].pitcher_id == "home_starter"
+    assert event.pitcher_id == "home_starter"
+    assert event.event_type == "k"
+
+
+def test_bottom_half_uses_away_starter():
+    observed = []
+    matchup_input = matchup()
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            matchup_input=matchup_input,
+        )
+    )
+    resolver = (
+        build_canonical_pa_resolver_factory(
+            all_out_provider(observed)
+        )(context)
+    )
+
+    event = resolver(
+        GameState(
+            inning=1,
+            half="bottom",
+        ),
+        "home_batter_0",
+        0,
+    )
+
+    assert observed[0].pitcher_id == "away_starter"
+    assert event.pitcher_id == "away_starter"
+
+
+def test_resolver_propagates_trial_identity():
+    observed = []
+    matchup_input = matchup()
+    input_value = factory_input(
+        simulations=3
+    )
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=input_value,
+            trial_index=2,
+            matchup_input=matchup_input,
+        )
+    )
+    resolver = (
+        build_canonical_pa_resolver_factory(
+            all_out_provider(observed)
+        )(context)
+    )
+
+    resolver(
+        GameState(
+            inning=1,
+            half="top",
+        ),
+        "away_batter_0",
+        9,
+    )
+
+    assert observed[0].trial_index == 2
+    assert observed[0].trial_seed == (
+        input_value.seed_for_trial(2)
+    )
+    assert observed[0].sequence == 9
+
+
+def test_provider_must_return_matching_query():
+    matchup_input = matchup()
+    input_value = factory_input()
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=input_value,
+            trial_index=0,
+            matchup_input=matchup_input,
+        )
+    )
+
+    different_query = None
+
+    def mismatched_provider(query):
+        nonlocal different_query
+        different_query = replace(
+            query,
+            sequence=query.sequence + 1,
+        )
+
+        return CanonicalPlateAppearanceProbabilities(
+            query=different_query,
+            probabilities=tuple(
+                CanonicalOutcomeProbability(
+                    outcome=outcome,
+                    probability=(
+                        1.0
+                        if outcome
+                        is CanonicalPlateAppearanceOutcome.STRIKEOUT
+                        else 0.0
+                    ),
+                )
+                for outcome in CANONICAL_PA_OUTCOME_ORDER
+            ),
+            provider=query.matchup_input.probability_provider,
+        )
+
+    resolver = (
+        build_canonical_pa_resolver_factory(
+            mismatched_provider
+        )(context)
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="different query",
+    ):
+        resolver(
+            GameState(
+                inning=1,
+                half="top",
+            ),
+            "away_batter_0",
+            0,
+        )
+
+
+def test_execution_plan_runs_full_game_pipeline():
+    observed = []
+    matchup_input = matchup()
+    input_value = factory_input(
+        simulations=2
+    )
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=input_value,
+        away_lineup=matchup_input.away_lineup,
+        home_lineup=matchup_input.home_lineup,
+        resolver_factory=(
+            build_canonical_pa_resolver_factory(
+                all_out_provider(observed)
+            )
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+        matchup_input=matchup_input,
+    )
+
+    batch = run_canonical_trial_execution_plan(
+        plan
+    )
+
+    assert len(batch.games) == 2
+    assert all(
+        game.final_state.away_score == 0
+        and game.final_state.home_score == 0
+        for game in batch.games
+    )
+
+    assert len(observed) == 12
+
+    assert {
+        query.trial_index
+        for query in observed
+    } == {0, 1}
+
+    assert {
+        query.pitcher_id
+        for query in observed
+    } == {
+        "away_starter",
+        "home_starter",
+    }
+
+
+def test_execution_plan_replays_identically():
+    matchup_input = matchup()
+    input_value = factory_input(
+        simulations=2
+    )
+
+    def build_plan():
+        return CanonicalTrialExecutionPlan(
+            factory_input=input_value,
+            away_lineup=matchup_input.away_lineup,
+            home_lineup=matchup_input.home_lineup,
+            resolver_factory=(
+                build_canonical_pa_resolver_factory(
+                    all_out_provider([])
+                )
+            ),
+            game_config=CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+            ),
+            matchup_input=matchup_input,
+        )
+
+    first = run_canonical_trial_execution_plan(
+        build_plan()
+    )
+    second = run_canonical_trial_execution_plan(
+        build_plan()
+    )
+
+    assert first == second


### PR DESCRIPTION
## Summary

Implements the twelfth Layer 10J slice: a deterministic canonical plate-appearance resolver factory that composes fixed matchup identity, an injected provider-neutral probability provider, deterministic categorical sampling, sampled-outcome event resolution, and fixed active-starter identity into the existing full-game execution plan.

The new factory builds one fresh immutable resolver per indexed trial. Each plate appearance creates a canonical query from game state, batter identity, global sequence, trial identity, and the fielding team’s fixed starter; validates the provider response; samples deterministically; and resolves the sampled outcome into a validated canonical `PlayEvent`.

## Added

- `CanonicalPlateAppearanceResolverFactory`
- `CANONICAL_PA_RESOLVER_FACTORY_VERSION`
- `build_canonical_pa_resolver_factory()`
- Fresh resolver construction per trial
- Fixed starter selection by half-inning
- Canonical PA query construction
- Provider-response type and query-identity validation
- Deterministic probability sampling integration
- Sampled-outcome event-resolution integration
- End-to-end execution-plan tests
- Deterministic full-batch replay tests

## Architecture

```text
CanonicalTrialResolverContext
        ↓
fresh CanonicalPlateAppearanceResolverFactory
        ↓
state + batter + global sequence
        ↓
fixed fielding-team starter
        ↓
CanonicalPlateAppearanceQuery
        ↓
injected probability provider
        ↓
CanonicalPlateAppearanceProbabilities
        ↓
deterministic categorical sample
        ↓
resolve_canonical_sampled_plate_appearance()
        ↓
validated PlayEvent
        ↓
simulate_canonical_game()
        ↓
run_canonical_trial_execution_plan()
```

## Contract guarantees

- One fresh immutable resolver is built for each indexed trial.
- Resolver construction requires a fixed `CanonicalMatchupInput`.
- Top halves use the home starter; bottom halves use the away starter.
- Trial index, deterministic trial seed, and global event sequence propagate into every PA query.
- Probability providers must return `CanonicalPlateAppearanceProbabilities` for the exact query supplied.
- Identical execution plans replay to identical canonical trial batches.
- Existing game orchestration, validation, reduction, reconciliation, and aggregation remain reused rather than duplicated.

## Scope

This slice intentionally does not yet:

- load production probability artifacts;
- calculate real batter-versus-pitcher probabilities;
- choose starter exit timing;
- choose bullpen substitutions;
- mutate active-pitcher state;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical PA resolver-factory tests passed
- Result: `183 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/pa_resolver_factory.py`
- `tests/test_canonical_pa_resolver_factory.py`

## Next slice

Define a production-facing canonical probability-artifact adapter contract that maps immutable matchup and plate-appearance queries to complete canonical probability distributions, while still avoiding default activation, bullpen substitutions, and any legacy-authority change.