### PR TITLE
Add canonical probability artifact adapter

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -63,6 +63,14 @@ from .probability import (
     derive_canonical_pa_sampling_seed,
     sample_canonical_plate_appearance,
 )
+from .probability_artifact import (
+    CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION,
+    CANONICAL_PROBABILITY_ARTIFACT_VERSION,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactAdapter,
+    CanonicalProbabilityArtifactRecord,
+    build_canonical_probability_artifact_provider,
+)
 from .trial_factory import (
     CanonicalTrialExecutionPlan,
     CanonicalTrialResolverContext,
@@ -104,6 +112,8 @@ __all__ = [
     "CANONICAL_PA_PROBABILITY_VERSION",
     "CANONICAL_PA_RESOLVER_FACTORY_VERSION",
     "CANONICAL_PA_SAMPLING_VERSION",
+    "CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION",
+    "CANONICAL_PROBABILITY_ARTIFACT_VERSION",
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
     "EMPTY_BASE_HIT_DESTINATIONS",
@@ -125,6 +135,9 @@ __all__ = [
     "CanonicalPlateAppearanceQuery",
     "CanonicalSampledPlateAppearance",
     "CanonicalPitchingPlan",
+    "CanonicalProbabilityArtifact",
+    "CanonicalProbabilityArtifactAdapter",
+    "CanonicalProbabilityArtifactRecord",
     "CanonicalProbabilityProviderIdentity",
     "GameCompletionReason",
     "HalfInningRecord",
@@ -133,6 +146,7 @@ __all__ = [
     "sample_canonical_plate_appearance",
     "aggregate_game_outcomes",
     "build_canonical_pa_resolver_factory",
+    "build_canonical_probability_artifact_provider",
     "build_canonical_trial_factory_input",
     "build_canonical_trial_resolver_context",
     "derive_canonical_base_seed",

--- a/mlb_app/simulation/game/probability_artifact.py
+++ b/mlb_app/simulation/game/probability_artifact.py
@@ -1,0 +1,260 @@
+"""Canonical probability-artifact contracts and provider adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from typing import Tuple
+
+from .matchup_input import (
+    CanonicalProbabilityProviderIdentity,
+)
+from .probability import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalOutcomeProbability,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceProbabilities,
+    CanonicalPlateAppearanceProbabilityProvider,
+    CanonicalPlateAppearanceQuery,
+)
+
+
+CANONICAL_PROBABILITY_ARTIFACT_VERSION = (
+    "canonical_probability_artifact_v1"
+)
+CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION = (
+    "canonical_probability_artifact_adapter_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityArtifactRecord:
+    """
+    One immutable batter-versus-pitcher probability artifact row.
+
+    This initial production-facing contract performs exact identity
+    lookup only. State-dependent features, fallbacks, and live model
+    inference remain outside this slice.
+    """
+
+    batter_id: str
+    pitcher_id: str
+    probabilities: Tuple[
+        CanonicalOutcomeProbability,
+        ...,
+    ]
+
+    def __post_init__(self) -> None:
+        if not self.batter_id:
+            raise ValueError(
+                "batter_id is required"
+            )
+
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        outcomes = tuple(
+            point.outcome
+            for point in self.probabilities
+        )
+
+        if outcomes != CANONICAL_PA_OUTCOME_ORDER:
+            raise ValueError(
+                "artifact probabilities must contain "
+                "every canonical outcome exactly once "
+                "in canonical order"
+            )
+
+        total = sum(
+            point.probability
+            for point in self.probabilities
+        )
+
+        if abs(total - 1.0) > 0.000000001:
+            raise ValueError(
+                "artifact probabilities must sum to 1"
+            )
+
+    @property
+    def matchup_key(self) -> Tuple[str, str]:
+        return (
+            self.batter_id,
+            self.pitcher_id,
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityArtifact:
+    """
+    Immutable probability artifact with explicit provenance.
+
+    The artifact contains already-produced probabilities. It does not
+    train models, load files, fetch external data, or infer missing rows.
+    """
+
+    provider: CanonicalProbabilityProviderIdentity
+    records: Tuple[
+        CanonicalProbabilityArtifactRecord,
+        ...,
+    ]
+    artifact_version: str = (
+        CANONICAL_PROBABILITY_ARTIFACT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.provider,
+            CanonicalProbabilityProviderIdentity,
+        ):
+            raise TypeError(
+                "provider must be a "
+                "CanonicalProbabilityProviderIdentity"
+            )
+
+        if self.artifact_version != (
+            CANONICAL_PROBABILITY_ARTIFACT_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical probability "
+                "artifact version"
+            )
+
+        keys = tuple(
+            record.matchup_key
+            for record in self.records
+        )
+
+        if len(keys) != len(set(keys)):
+            raise ValueError(
+                "artifact cannot contain duplicate "
+                "batter-pitcher matchup rows"
+            )
+
+    @property
+    def digest(self) -> str:
+        payload_parts = [
+            self.artifact_version,
+            self.provider.identity,
+        ]
+
+        for record in sorted(
+            self.records,
+            key=lambda value: value.matchup_key,
+        ):
+            payload_parts.extend(
+                (
+                    record.batter_id,
+                    record.pitcher_id,
+                )
+            )
+            payload_parts.extend(
+                (
+                    f"{point.outcome.value}:"
+                    f"{point.probability:.17g}"
+                )
+                for point in record.probabilities
+            )
+
+        payload = "\x1f".join(
+            payload_parts
+        ).encode("utf-8")
+
+        return hashlib.sha256(
+            payload
+        ).hexdigest()
+
+    def record_for(
+        self,
+        *,
+        batter_id: str,
+        pitcher_id: str,
+    ) -> CanonicalProbabilityArtifactRecord:
+        key = (
+            batter_id,
+            pitcher_id,
+        )
+
+        for record in self.records:
+            if record.matchup_key == key:
+                return record
+
+        raise KeyError(
+            "canonical probability artifact has no "
+            f"row for batter={batter_id}, "
+            f"pitcher={pitcher_id}"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityArtifactAdapter:
+    """
+    Adapt exact artifact rows to canonical PA probability responses.
+    """
+
+    artifact: CanonicalProbabilityArtifact
+    adapter_version: str = (
+        CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.artifact,
+            CanonicalProbabilityArtifact,
+        ):
+            raise TypeError(
+                "artifact must be a "
+                "CanonicalProbabilityArtifact"
+            )
+
+        if self.adapter_version != (
+            CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical probability "
+                "artifact adapter version"
+            )
+
+    def __call__(
+        self,
+        query: CanonicalPlateAppearanceQuery,
+    ) -> CanonicalPlateAppearanceProbabilities:
+        if not isinstance(
+            query,
+            CanonicalPlateAppearanceQuery,
+        ):
+            raise TypeError(
+                "query must be a "
+                "CanonicalPlateAppearanceQuery"
+            )
+
+        if (
+            query.matchup_input.probability_provider
+            != self.artifact.provider
+        ):
+            raise ValueError(
+                "artifact provider must match "
+                "matchup probability-provider identity"
+            )
+
+        record = self.artifact.record_for(
+            batter_id=query.batter_id,
+            pitcher_id=query.pitcher_id,
+        )
+
+        return CanonicalPlateAppearanceProbabilities(
+            query=query,
+            probabilities=record.probabilities,
+            provider=self.artifact.provider,
+        )
+
+
+def build_canonical_probability_artifact_provider(
+    artifact: CanonicalProbabilityArtifact,
+) -> CanonicalPlateAppearanceProbabilityProvider:
+    """Build a provider-compatible exact artifact adapter."""
+
+    return CanonicalProbabilityArtifactAdapter(
+        artifact=artifact,
+    )

--- a/tests/test_canonical_probability_artifact_adapter.py
+++ b/tests/test_canonical_probability_artifact_adapter.py
@@ -1,0 +1,264 @@
+import pytest
+
+from mlb_app.simulation.events import GameState
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactAdapter,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityProviderIdentity,
+    build_canonical_probability_artifact_provider,
+)
+
+
+def provider_identity(
+    *,
+    artifact_id="artifact-1",
+):
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="artifact-test",
+        provider_version="v1",
+        artifact_id=artifact_id,
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup(
+    *,
+    provider=None,
+):
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            provider or provider_identity()
+        ),
+    )
+
+
+def probabilities(
+    selected=CanonicalPlateAppearanceOutcome.STRIKEOUT,
+):
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome is selected
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def record(
+    *,
+    batter_id="away_batter_0",
+    pitcher_id="home_starter",
+):
+    return CanonicalProbabilityArtifactRecord(
+        batter_id=batter_id,
+        pitcher_id=pitcher_id,
+        probabilities=probabilities(),
+    )
+
+
+def artifact(
+    *,
+    provider=None,
+    records=None,
+):
+    return CanonicalProbabilityArtifact(
+        provider=provider or provider_identity(),
+        records=tuple(
+            records
+            if records is not None
+            else (record(),)
+        ),
+    )
+
+
+def query(
+    *,
+    matchup_input=None,
+    batter_id="away_batter_0",
+    pitcher_id="home_starter",
+):
+    return CanonicalPlateAppearanceQuery(
+        matchup_input=(
+            matchup_input or matchup()
+        ),
+        state=GameState(
+            inning=1,
+            half="top",
+        ),
+        batter_id=batter_id,
+        pitcher_id=pitcher_id,
+        sequence=0,
+        trial_index=0,
+        trial_seed=12345,
+    )
+
+
+def test_adapter_maps_exact_artifact_row():
+    value = artifact()
+    adapter = (
+        build_canonical_probability_artifact_provider(
+            value
+        )
+    )
+    pa_query = query()
+
+    result = adapter(pa_query)
+
+    assert result.query == pa_query
+    assert result.provider == value.provider
+    assert result.probabilities == (
+        value.records[0].probabilities
+    )
+    assert result.probability_for(
+        CanonicalPlateAppearanceOutcome.STRIKEOUT
+    ) == 1.0
+
+
+def test_artifact_digest_is_order_independent():
+    first_record = record()
+    second_record = record(
+        batter_id="away_batter_1",
+    )
+
+    first = artifact(
+        records=(
+            first_record,
+            second_record,
+        )
+    )
+    second = artifact(
+        records=(
+            second_record,
+            first_record,
+        )
+    )
+
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+
+
+def test_artifact_rejects_duplicate_matchup_rows():
+    value = record()
+
+    with pytest.raises(
+        ValueError,
+        match="duplicate",
+    ):
+        artifact(
+            records=(
+                value,
+                value,
+            )
+        )
+
+
+def test_artifact_record_requires_complete_distribution():
+    with pytest.raises(
+        ValueError,
+        match="canonical order",
+    ):
+        CanonicalProbabilityArtifactRecord(
+            batter_id="away_batter_0",
+            pitcher_id="home_starter",
+            probabilities=probabilities()[:-1],
+        )
+
+
+def test_adapter_rejects_provider_identity_mismatch():
+    artifact_value = artifact()
+    mismatched_matchup = matchup(
+        provider=provider_identity(
+            artifact_id="artifact-2",
+        )
+    )
+    adapter = CanonicalProbabilityArtifactAdapter(
+        artifact=artifact_value,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="provider must match",
+    ):
+        adapter(
+            query(
+                matchup_input=mismatched_matchup,
+            )
+        )
+
+
+def test_adapter_fails_closed_for_missing_row():
+    value = artifact()
+    adapter = CanonicalProbabilityArtifactAdapter(
+        artifact=value,
+    )
+
+    with pytest.raises(
+        KeyError,
+        match="has no row",
+    ):
+        adapter(
+            query(
+                batter_id="away_batter_1",
+            )
+        )
+
+
+def test_digest_changes_with_probability_mass():
+    first = artifact()
+
+    changed_record = (
+        CanonicalProbabilityArtifactRecord(
+            batter_id="away_batter_0",
+            pitcher_id="home_starter",
+            probabilities=probabilities(
+                CanonicalPlateAppearanceOutcome.WALK
+            ),
+        )
+    )
+    second = artifact(
+        records=(
+            changed_record,
+        )
+    )
+
+    assert first.digest != second.digest


### PR DESCRIPTION
## Summary

Implements the thirteenth Layer 10J slice: a production-facing canonical probability-artifact contract and fail-closed adapter that maps immutable batter-pitcher probability rows into the existing provider-neutral canonical plate-appearance probability contract.

The artifact preserves explicit provider identity, versioned schema identity, exact matchup keys, complete ordered canonical probability distributions, and a deterministic content digest. The adapter performs exact lookup only and delegates final query/distribution validation to `CanonicalPlateAppearanceProbabilities`.

## Added

- `CanonicalProbabilityArtifactRecord`
- `CanonicalProbabilityArtifact`
- `CanonicalProbabilityArtifactAdapter`
- `CANONICAL_PROBABILITY_ARTIFACT_VERSION`
- `CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION`
- `build_canonical_probability_artifact_provider()`
- Exact batter-pitcher matchup lookup
- Provider-identity validation
- Duplicate-row rejection
- Complete canonical outcome-order validation
- Deterministic order-independent artifact digest
- Explicit missing-row failure
- Tests for mapping, digest stability, provider mismatch, duplicate rows, incomplete distributions, and missing rows

## Architecture

```text
immutable canonical probability artifact
    ├─ provider identity
    ├─ versioned schema
    ├─ exact batter-pitcher rows
    ├─ complete ordered distributions
    └─ deterministic digest
        ↓
CanonicalProbabilityArtifactAdapter
        ↓
exact query lookup
        ↓
CanonicalPlateAppearanceProbabilities
        ↓
existing deterministic resolver pipeline
```

## Contract guarantees

- Artifact inputs are immutable and versioned.
- Every row contains all canonical PA outcomes exactly once in canonical order.
- Every row sums to unit probability mass.
- Duplicate batter-pitcher rows are rejected.
- Artifact digests are deterministic and independent of record ordering.
- Adapter provider identity must exactly match the matchup contract.
- Missing matchup rows fail closed rather than silently using generic fallback probabilities.
- Existing canonical probability validation remains authoritative.

## Scope

This slice intentionally does not yet:

- load artifacts from production storage;
- perform live model inference;
- define league-average or hierarchical fallback policy;
- add state-dependent artifact keys;
- choose pitcher substitutions;
- activate canonical output as production authority;
- expose canonical projections in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical probability-artifact adapter tests passed
- Result: `190 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/probability_artifact.py`
- `tests/test_canonical_probability_artifact_adapter.py`

## Next slice

Define an explicit canonical probability fallback-policy contract that can resolve missing exact batter-pitcher rows through versioned, observable fallback tiers without hiding fallback use or changing legacy production authority.