### PR TITLE
Add canonical probability resolution diagnostics

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -71,6 +71,15 @@ from .probability_artifact import (
     CanonicalProbabilityArtifactRecord,
     build_canonical_probability_artifact_provider,
 )
+from .probability_diagnostics import (
+    CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION,
+    CanonicalProbabilityDiagnosticsProvider,
+    CanonicalProbabilityResolutionDiagnostics,
+    CanonicalProbabilityResolutionDiagnosticsCollector,
+    CanonicalProbabilityResolutionObservation,
+    CanonicalProbabilityTierUsage,
+    build_canonical_probability_diagnostics_provider,
+)
 from .probability_fallback import (
     CANONICAL_PROBABILITY_FALLBACK_VERSION,
     DEFAULT_CANONICAL_PROBABILITY_FALLBACK_TIERS,
@@ -125,6 +134,7 @@ __all__ = [
     "CANONICAL_PA_SAMPLING_VERSION",
     "CANONICAL_PROBABILITY_ARTIFACT_ADAPTER_VERSION",
     "CANONICAL_PROBABILITY_ARTIFACT_VERSION",
+    "CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION",
     "CANONICAL_PROBABILITY_FALLBACK_VERSION",
     "DEFAULT_CANONICAL_PROBABILITY_FALLBACK_TIERS",
     "DEFAULT_CANONICAL_MODEL_VERSION",
@@ -151,6 +161,11 @@ __all__ = [
     "CanonicalProbabilityArtifact",
     "CanonicalProbabilityArtifactAdapter",
     "CanonicalProbabilityArtifactRecord",
+    "CanonicalProbabilityDiagnosticsProvider",
+    "CanonicalProbabilityResolutionDiagnostics",
+    "CanonicalProbabilityResolutionDiagnosticsCollector",
+    "CanonicalProbabilityResolutionObservation",
+    "CanonicalProbabilityTierUsage",
     "CanonicalProbabilityFallbackAdapter",
     "CanonicalProbabilityFallbackCatalog",
     "CanonicalProbabilityFallbackPolicy",
@@ -166,6 +181,7 @@ __all__ = [
     "aggregate_game_outcomes",
     "build_canonical_pa_resolver_factory",
     "build_canonical_probability_artifact_provider",
+    "build_canonical_probability_diagnostics_provider",
     "build_canonical_probability_fallback_provider",
     "build_canonical_trial_factory_input",
     "build_canonical_trial_resolver_context",

--- a/mlb_app/simulation/game/probability_diagnostics.py
+++ b/mlb_app/simulation/game/probability_diagnostics.py
@@ -1,0 +1,372 @@
+"""Canonical probability-resolution diagnostics collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from .probability import (
+    CanonicalPlateAppearanceProbabilities,
+    CanonicalPlateAppearanceProbabilityProvider,
+    CanonicalPlateAppearanceQuery,
+)
+from .probability_fallback import (
+    CanonicalProbabilityFallbackAdapter,
+    CanonicalProbabilityFallbackResolution,
+    CanonicalProbabilityFallbackTier,
+)
+
+
+CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION = (
+    "canonical_probability_diagnostics_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityResolutionObservation:
+    """One observed exact-or-fallback probability resolution."""
+
+    trial_index: int
+    sequence: int
+    inning: int
+    half: str
+    batter_id: str
+    pitcher_id: str
+    tier: CanonicalProbabilityFallbackTier
+    source_identity: str | None
+    exact_artifact_digest: str
+    fallback_catalog_digest: str
+    policy_version: str
+    diagnostics_version: str = (
+        CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.trial_index < 0:
+            raise ValueError(
+                "trial_index cannot be negative"
+            )
+
+        if self.sequence < 0:
+            raise ValueError(
+                "sequence cannot be negative"
+            )
+
+        if self.inning < 1:
+            raise ValueError(
+                "inning must be positive"
+            )
+
+        if self.half not in {
+            "top",
+            "bottom",
+        }:
+            raise ValueError(
+                "half must be 'top' or 'bottom'"
+            )
+
+        if not self.batter_id:
+            raise ValueError(
+                "batter_id is required"
+            )
+
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        if not isinstance(
+            self.tier,
+            CanonicalProbabilityFallbackTier,
+        ):
+            raise TypeError(
+                "tier must be a canonical fallback tier"
+            )
+
+        if self.diagnostics_version != (
+            CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION
+        ):
+            raise ValueError(
+                "unsupported probability diagnostics version"
+            )
+
+        _validate_digest(
+            "exact_artifact_digest",
+            self.exact_artifact_digest,
+        )
+        _validate_digest(
+            "fallback_catalog_digest",
+            self.fallback_catalog_digest,
+        )
+
+    @property
+    def is_fallback(self) -> bool:
+        return self.tier is not (
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityTierUsage:
+    """Aggregated resolution count for one tier."""
+
+    tier: CanonicalProbabilityFallbackTier
+    count: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.tier,
+            CanonicalProbabilityFallbackTier,
+        ):
+            raise TypeError(
+                "tier must be a canonical fallback tier"
+            )
+
+        if isinstance(self.count, bool):
+            raise TypeError(
+                "count must be an integer"
+            )
+
+        if self.count < 0:
+            raise ValueError(
+                "count cannot be negative"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityResolutionDiagnostics:
+    """Immutable deterministic diagnostics snapshot."""
+
+    observations: Tuple[
+        CanonicalProbabilityResolutionObservation,
+        ...,
+    ]
+    tier_usage: Tuple[
+        CanonicalProbabilityTierUsage,
+        ...,
+    ]
+    diagnostics_version: str = (
+        CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.diagnostics_version != (
+            CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION
+        ):
+            raise ValueError(
+                "unsupported probability diagnostics version"
+            )
+
+        expected_tiers = tuple(
+            CanonicalProbabilityFallbackTier
+        )
+        actual_tiers = tuple(
+            usage.tier
+            for usage in self.tier_usage
+        )
+
+        if actual_tiers != expected_tiers:
+            raise ValueError(
+                "tier_usage must contain every canonical "
+                "fallback tier exactly once in canonical order"
+            )
+
+        if sum(
+            usage.count
+            for usage in self.tier_usage
+        ) != len(self.observations):
+            raise ValueError(
+                "tier usage counts must reconcile to observations"
+            )
+
+    @property
+    def total_resolutions(self) -> int:
+        return len(self.observations)
+
+    @property
+    def exact_resolutions(self) -> int:
+        return self.count_for(
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP
+        )
+
+    @property
+    def fallback_resolutions(self) -> int:
+        return (
+            self.total_resolutions
+            - self.exact_resolutions
+        )
+
+    @property
+    def fallback_rate(self) -> float:
+        if self.total_resolutions == 0:
+            return 0.0
+
+        return (
+            self.fallback_resolutions
+            / self.total_resolutions
+        )
+
+    def count_for(
+        self,
+        tier: CanonicalProbabilityFallbackTier,
+    ) -> int:
+        for usage in self.tier_usage:
+            if usage.tier is tier:
+                return usage.count
+
+        raise KeyError(tier)
+
+
+class CanonicalProbabilityResolutionDiagnosticsCollector:
+    """
+    Collect resolution observations without changing provider decisions.
+
+    A collector is intended to be owned by one canonical execution run.
+    """
+
+    def __init__(self) -> None:
+        self._observations: List[
+            CanonicalProbabilityResolutionObservation
+        ] = []
+
+    def record(
+        self,
+        resolution: CanonicalProbabilityFallbackResolution,
+    ) -> None:
+        if not isinstance(
+            resolution,
+            CanonicalProbabilityFallbackResolution,
+        ):
+            raise TypeError(
+                "resolution must be a "
+                "CanonicalProbabilityFallbackResolution"
+            )
+
+        query = resolution.probabilities.query
+
+        self._observations.append(
+            CanonicalProbabilityResolutionObservation(
+                trial_index=query.trial_index,
+                sequence=query.sequence,
+                inning=query.state.inning,
+                half=query.state.half,
+                batter_id=query.batter_id,
+                pitcher_id=query.pitcher_id,
+                tier=resolution.tier,
+                source_identity=resolution.source_identity,
+                exact_artifact_digest=(
+                    resolution.exact_artifact_digest
+                ),
+                fallback_catalog_digest=(
+                    resolution.fallback_catalog_digest
+                ),
+                policy_version=resolution.policy_version,
+            )
+        )
+
+    def snapshot(
+        self,
+    ) -> CanonicalProbabilityResolutionDiagnostics:
+        observations = tuple(
+            sorted(
+                self._observations,
+                key=lambda value: (
+                    value.trial_index,
+                    value.sequence,
+                    value.inning,
+                    value.half,
+                    value.batter_id,
+                    value.pitcher_id,
+                    value.tier.value,
+                    value.source_identity or "",
+                ),
+            )
+        )
+
+        usage = tuple(
+            CanonicalProbabilityTierUsage(
+                tier=tier,
+                count=sum(
+                    observation.tier is tier
+                    for observation in observations
+                ),
+            )
+            for tier in CanonicalProbabilityFallbackTier
+        )
+
+        return CanonicalProbabilityResolutionDiagnostics(
+            observations=observations,
+            tier_usage=usage,
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalProbabilityDiagnosticsProvider:
+    """Observe a fallback adapter without changing its response."""
+
+    fallback_adapter: CanonicalProbabilityFallbackAdapter
+    collector: (
+        CanonicalProbabilityResolutionDiagnosticsCollector
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.fallback_adapter,
+            CanonicalProbabilityFallbackAdapter,
+        ):
+            raise TypeError(
+                "fallback_adapter must be a "
+                "CanonicalProbabilityFallbackAdapter"
+            )
+
+        if not isinstance(
+            self.collector,
+            CanonicalProbabilityResolutionDiagnosticsCollector,
+        ):
+            raise TypeError(
+                "collector must be a probability-resolution "
+                "diagnostics collector"
+            )
+
+    def __call__(
+        self,
+        query: CanonicalPlateAppearanceQuery,
+    ) -> CanonicalPlateAppearanceProbabilities:
+        resolution = self.fallback_adapter.resolve(
+            query
+        )
+        self.collector.record(
+            resolution
+        )
+        return resolution.probabilities
+
+
+def build_canonical_probability_diagnostics_provider(
+    *,
+    fallback_adapter: CanonicalProbabilityFallbackAdapter,
+    collector: (
+        CanonicalProbabilityResolutionDiagnosticsCollector
+    ),
+) -> CanonicalPlateAppearanceProbabilityProvider:
+    """Build an observational canonical probability provider."""
+
+    return CanonicalProbabilityDiagnosticsProvider(
+        fallback_adapter=fallback_adapter,
+        collector=collector,
+    )
+
+
+def _validate_digest(
+    name: str,
+    digest: str,
+) -> None:
+    if (
+        len(digest) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in digest
+        )
+    ):
+        raise ValueError(
+            f"{name} must be a SHA256 digest"
+        )

--- a/tests/test_canonical_probability_resolution_diagnostics.py
+++ b/tests/test_canonical_probability_resolution_diagnostics.py
@@ -1,0 +1,367 @@
+from mlb_app.simulation.events import GameState
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackAdapter,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalProbabilityResolutionDiagnosticsCollector,
+    CanonicalTrialExecutionPlan,
+    build_canonical_pa_resolver_factory,
+    build_canonical_probability_diagnostics_provider,
+    build_canonical_trial_factory_input,
+    run_canonical_trial_execution_plan,
+)
+
+
+def provider_identity():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="diagnostics-test",
+        provider_version="v1",
+        artifact_id="diagnostics-artifact",
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=provider_identity(),
+    )
+
+
+def probabilities(selected):
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome is selected
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def exact_record(
+    batter_id="away_batter_0",
+    pitcher_id="home_starter",
+):
+    return CanonicalProbabilityArtifactRecord(
+        batter_id=batter_id,
+        pitcher_id=pitcher_id,
+        probabilities=probabilities(
+            CanonicalPlateAppearanceOutcome.STRIKEOUT
+        ),
+    )
+
+
+def exact_artifact(records=()):
+    return CanonicalProbabilityArtifact(
+        provider=provider_identity(),
+        records=tuple(records),
+    )
+
+
+def global_catalog():
+    return CanonicalProbabilityFallbackCatalog(
+        provider=provider_identity(),
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=(
+                    CanonicalProbabilityFallbackTier.GLOBAL
+                ),
+                identity=None,
+                probabilities=probabilities(
+                    CanonicalPlateAppearanceOutcome.STRIKEOUT
+                ),
+            ),
+        ),
+    )
+
+
+def fallback_policy():
+    return CanonicalProbabilityFallbackPolicy(
+        tiers=(
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+            CanonicalProbabilityFallbackTier.GLOBAL,
+        )
+    )
+
+
+def adapter(records=()):
+    return CanonicalProbabilityFallbackAdapter(
+        exact_artifact=exact_artifact(records),
+        fallback_catalog=global_catalog(),
+        policy=fallback_policy(),
+    )
+
+
+def query(
+    *,
+    batter_id="away_batter_0",
+    sequence=0,
+):
+    return CanonicalPlateAppearanceQuery(
+        matchup_input=matchup(),
+        state=GameState(
+            inning=1,
+            half="top",
+        ),
+        batter_id=batter_id,
+        pitcher_id="home_starter",
+        sequence=sequence,
+        trial_index=0,
+        trial_seed=12345,
+    )
+
+
+def test_empty_collector_snapshot():
+    diagnostics = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+        .snapshot()
+    )
+
+    assert diagnostics.total_resolutions == 0
+    assert diagnostics.exact_resolutions == 0
+    assert diagnostics.fallback_resolutions == 0
+    assert diagnostics.fallback_rate == 0.0
+
+
+def test_exact_resolution_is_observed():
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    provider = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=adapter(
+                (exact_record(),)
+            ),
+            collector=collector,
+        )
+    )
+
+    provider(query())
+
+    diagnostics = collector.snapshot()
+
+    assert diagnostics.total_resolutions == 1
+    assert diagnostics.exact_resolutions == 1
+    assert diagnostics.fallback_resolutions == 0
+    assert diagnostics.observations[0].tier is (
+        CanonicalProbabilityFallbackTier.EXACT_MATCHUP
+    )
+
+
+def test_global_fallback_is_observed():
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    provider = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=adapter(),
+            collector=collector,
+        )
+    )
+
+    provider(query())
+
+    diagnostics = collector.snapshot()
+
+    assert diagnostics.fallback_resolutions == 1
+    assert diagnostics.fallback_rate == 1.0
+    assert diagnostics.observations[0].tier is (
+        CanonicalProbabilityFallbackTier.GLOBAL
+    )
+
+
+def test_mixed_tier_counts_reconcile():
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    provider = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=adapter(
+                (exact_record(),)
+            ),
+            collector=collector,
+        )
+    )
+
+    provider(query())
+    provider(
+        query(
+            batter_id="away_batter_1",
+            sequence=1,
+        )
+    )
+
+    diagnostics = collector.snapshot()
+
+    assert diagnostics.total_resolutions == 2
+    assert diagnostics.exact_resolutions == 1
+    assert diagnostics.fallback_resolutions == 1
+    assert diagnostics.fallback_rate == 0.5
+
+
+def test_wrapper_returns_underlying_probabilities_unchanged():
+    fallback_adapter = adapter()
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    pa_query = query()
+
+    expected = fallback_adapter.resolve(
+        pa_query
+    ).probabilities
+    actual = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=fallback_adapter,
+            collector=collector,
+        )(pa_query)
+    )
+
+    assert actual == expected
+
+
+def test_observation_preserves_resolution_provenance():
+    fallback_adapter = adapter()
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    provider = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=fallback_adapter,
+            collector=collector,
+        )
+    )
+
+    provider(query())
+
+    observation = collector.snapshot().observations[0]
+
+    assert observation.exact_artifact_digest == (
+        fallback_adapter.exact_artifact.digest
+    )
+    assert observation.fallback_catalog_digest == (
+        fallback_adapter.fallback_catalog.digest
+    )
+    assert observation.policy_version == (
+        fallback_adapter.policy.policy_version
+    )
+
+
+def build_execution_plan(collector):
+    matchup_input = matchup()
+    factory_input = build_canonical_trial_factory_input(
+        game_pk=123,
+        config={
+            "simulation_count": 2,
+            "seed": 98765,
+            "canonical_model_version": (
+                "probability-diagnostics-test-v1"
+            ),
+        },
+    )
+    provider = (
+        build_canonical_probability_diagnostics_provider(
+            fallback_adapter=adapter(),
+            collector=collector,
+        )
+    )
+
+    return CanonicalTrialExecutionPlan(
+        factory_input=factory_input,
+        away_lineup=matchup_input.away_lineup,
+        home_lineup=matchup_input.home_lineup,
+        resolver_factory=(
+            build_canonical_pa_resolver_factory(
+                provider
+            )
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+        matchup_input=matchup_input,
+    )
+
+
+def test_full_trial_batch_aggregates_resolution_usage():
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+
+    batch = run_canonical_trial_execution_plan(
+        build_execution_plan(collector)
+    )
+    diagnostics = collector.snapshot()
+
+    assert len(batch.games) == 2
+    assert diagnostics.total_resolutions == 12
+    assert diagnostics.exact_resolutions == 0
+    assert diagnostics.fallback_resolutions == 12
+    assert diagnostics.count_for(
+        CanonicalProbabilityFallbackTier.GLOBAL
+    ) == 12
+
+
+def test_full_trial_batch_diagnostics_replay_identically():
+    first_collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    second_collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+
+    first_batch = run_canonical_trial_execution_plan(
+        build_execution_plan(first_collector)
+    )
+    second_batch = run_canonical_trial_execution_plan(
+        build_execution_plan(second_collector)
+    )
+
+    assert first_batch == second_batch
+    assert (
+        first_collector.snapshot()
+        == second_collector.snapshot()
+    )


### PR DESCRIPTION
## Summary

Implements the fifteenth Layer 10J slice: a deterministic observational diagnostics layer for canonical probability resolution across full-game trial batches.

The new wrapper delegates exact-or-fallback selection to the existing `CanonicalProbabilityFallbackAdapter`, records the already-selected tier and provenance, and returns the exact same canonical probability distribution unchanged. Diagnostics can then be snapshotted deterministically across all plate appearances and trials.

## Added

- `CanonicalProbabilityResolutionObservation`
- `CanonicalProbabilityTierUsage`
- `CanonicalProbabilityResolutionDiagnostics`
- `CanonicalProbabilityResolutionDiagnosticsCollector`
- `CanonicalProbabilityDiagnosticsProvider`
- `CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION`
- `build_canonical_probability_diagnostics_provider()`
- Per-plate-appearance resolution observations
- Exact and fallback counts
- Per-tier usage aggregation
- Fallback-rate calculation
- Artifact and policy provenance retention
- Deterministic observation ordering
- Full-trial-batch diagnostics aggregation
- Deterministic batch and diagnostics replay tests

## Architecture

```text
CanonicalPlateAppearanceQuery
        ↓
CanonicalProbabilityFallbackAdapter.resolve()
        ↓
CanonicalProbabilityFallbackResolution
    ├─ probabilities
    ├─ selected tier
    ├─ source identity
    ├─ exact artifact digest
    ├─ fallback catalog digest
    └─ policy version
        ↓
CanonicalProbabilityResolutionDiagnosticsCollector.record()
        ↓
return unchanged CanonicalPlateAppearanceProbabilities
        ↓
normal deterministic PA sampling and game simulation
```

## Contract guarantees

- The diagnostics wrapper does not choose or alter fallback tiers.
- The underlying adapter remains authoritative for probability resolution.
- The exact canonical probability response is returned unchanged.
- Every observation preserves trial, sequence, inning, half, batter, pitcher, selected tier, source identity, artifact digests, and policy version.
- Tier counts reconcile exactly to the recorded observation count.
- Snapshot ordering is deterministic across runs.
- Empty diagnostics snapshots are valid and report zero fallback rate.
- Identical execution plans produce identical trial batches and identical diagnostics snapshots.

## Scope

This slice intentionally does not yet:

- serialize diagnostics into the shadow payload;
- add production storage or external telemetry;
- change fallback policy or probability mass;
- load production probability artifacts;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority;
- expose canonical diagnostics in the frontend.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical probability-resolution diagnostics tests passed
- Result: `208 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/probability_diagnostics.py`
- `tests/test_canonical_probability_resolution_diagnostics.py`

## Next slice

Add a versioned canonical diagnostics serialization contract and optionally attach the immutable probability-resolution snapshot to canonical shadow output without changing legacy authority or simulation behavior.