### PR TITLE
Add canonical probability diagnostics shadow serialization

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -13,9 +13,14 @@ from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
     shadow_diagnostics_to_dict,
 )
+from .probability_serialization import (
+    CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION,
+    probability_resolution_diagnostics_to_dict,
+)
 
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
+    "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
     "MetricComparison",
     "RangeComparison",
@@ -23,5 +28,6 @@ __all__ = [
     "attach_canonical_shadow",
     "canonical_trial_batch_to_shadow_payload",
     "compare_shadow_payloads",
+    "probability_resolution_diagnostics_to_dict",
     "shadow_diagnostics_to_dict",
 ]

--- a/mlb_app/simulation/shadow/integration.py
+++ b/mlb_app/simulation/shadow/integration.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from mlb_app.simulation.game.probability_diagnostics import (
+    CanonicalProbabilityResolutionDiagnostics,
+)
 
 from .comparator import compare_shadow_payloads
 from .contracts import CanonicalShadowDiagnostics
 from .serialization import shadow_diagnostics_to_dict
+from .probability_serialization import (
+    probability_resolution_diagnostics_to_dict,
+)
 
 
 def attach_canonical_shadow(
@@ -15,6 +22,9 @@ def attach_canonical_shadow(
     legacy_result: Dict[str, Any],
     enabled: bool = False,
     canonical_payload=None,
+    probability_resolution_diagnostics: Optional[
+        CanonicalProbabilityResolutionDiagnostics
+    ] = None,
 ) -> Dict[str, Any]:
     """Attach shadow diagnostics without mutating legacy data."""
 
@@ -76,8 +86,32 @@ def attach_canonical_shadow(
                 error_message=str(exc),
             )
 
-    diagnostics["canonical_shadow"] = (
-        shadow_diagnostics_to_dict(shadow)
+    shadow_payload = shadow_diagnostics_to_dict(
+        shadow
     )
+
+    if probability_resolution_diagnostics is not None:
+        try:
+            shadow_payload[
+                "probability_resolution"
+            ] = probability_resolution_diagnostics_to_dict(
+                probability_resolution_diagnostics
+            )
+        except Exception as exc:
+            shadow_payload[
+                "probability_resolution"
+            ] = {
+                "schema_version": (
+                    "canonical_probability_"
+                    "diagnostics_shadow_v1"
+                ),
+                "status": "error",
+                "error_type": (
+                    exc.__class__.__name__
+                ),
+                "error_message": str(exc),
+            }
+
+    diagnostics["canonical_shadow"] = shadow_payload
 
     return output

--- a/mlb_app/simulation/shadow/probability_serialization.py
+++ b/mlb_app/simulation/shadow/probability_serialization.py
@@ -1,0 +1,97 @@
+"""JSON-compatible canonical probability-diagnostics serialization."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from mlb_app.simulation.game.probability_diagnostics import (
+    CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION,
+    CanonicalProbabilityResolutionDiagnostics,
+)
+
+
+CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION = (
+    "canonical_probability_diagnostics_shadow_v1"
+)
+
+
+def probability_resolution_diagnostics_to_dict(
+    diagnostics: CanonicalProbabilityResolutionDiagnostics,
+) -> Dict[str, Any]:
+    """Serialize an immutable diagnostics snapshot for shadow output."""
+
+    if not isinstance(
+        diagnostics,
+        CanonicalProbabilityResolutionDiagnostics,
+    ):
+        raise TypeError(
+            "diagnostics must be a "
+            "CanonicalProbabilityResolutionDiagnostics"
+        )
+
+    if diagnostics.diagnostics_version != (
+        CANONICAL_PROBABILITY_DIAGNOSTICS_VERSION
+    ):
+        raise ValueError(
+            "unsupported probability diagnostics version"
+        )
+
+    return {
+        "schema_version": (
+            CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION
+        ),
+        "diagnostics_version": (
+            diagnostics.diagnostics_version
+        ),
+        "summary": {
+            "total_resolutions": (
+                diagnostics.total_resolutions
+            ),
+            "exact_resolutions": (
+                diagnostics.exact_resolutions
+            ),
+            "fallback_resolutions": (
+                diagnostics.fallback_resolutions
+            ),
+            "fallback_rate": (
+                diagnostics.fallback_rate
+            ),
+        },
+        "tier_usage": [
+            {
+                "tier": usage.tier.value,
+                "count": usage.count,
+            }
+            for usage in diagnostics.tier_usage
+        ],
+        "observations": [
+            {
+                "trial_index": observation.trial_index,
+                "sequence": observation.sequence,
+                "inning": observation.inning,
+                "half": observation.half,
+                "batter_id": observation.batter_id,
+                "pitcher_id": observation.pitcher_id,
+                "tier": observation.tier.value,
+                "source_identity": (
+                    observation.source_identity
+                ),
+                "is_fallback": (
+                    observation.is_fallback
+                ),
+                "exact_artifact_digest": (
+                    observation.exact_artifact_digest
+                ),
+                "fallback_catalog_digest": (
+                    observation.fallback_catalog_digest
+                ),
+                "policy_version": (
+                    observation.policy_version
+                ),
+                "diagnostics_version": (
+                    observation.diagnostics_version
+                ),
+            }
+            for observation in diagnostics.observations
+        ],
+    }

--- a/tests/test_canonical_probability_diagnostics_shadow_serialization.py
+++ b/tests/test_canonical_probability_diagnostics_shadow_serialization.py
@@ -1,0 +1,300 @@
+from copy import deepcopy
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityFallbackAdapter,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalProbabilityResolutionDiagnosticsCollector,
+)
+from mlb_app.simulation.events import GameState
+from mlb_app.simulation.shadow import (
+    CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION,
+    attach_canonical_shadow,
+    probability_resolution_diagnostics_to_dict,
+)
+
+
+def provider_identity():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="shadow-serialization-test",
+        provider_version="v1",
+        artifact_id="shadow-diagnostics-artifact",
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=provider_identity(),
+    )
+
+
+def probabilities():
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome
+                is CanonicalPlateAppearanceOutcome.STRIKEOUT
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def fallback_adapter():
+    return CanonicalProbabilityFallbackAdapter(
+        exact_artifact=CanonicalProbabilityArtifact(
+            provider=provider_identity(),
+            records=(),
+        ),
+        fallback_catalog=(
+            CanonicalProbabilityFallbackCatalog(
+                provider=provider_identity(),
+                records=(
+                    CanonicalProbabilityFallbackRecord(
+                        tier=(
+                            CanonicalProbabilityFallbackTier.GLOBAL
+                        ),
+                        identity=None,
+                        probabilities=probabilities(),
+                    ),
+                ),
+            )
+        ),
+        policy=CanonicalProbabilityFallbackPolicy(
+            tiers=(
+                CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+                CanonicalProbabilityFallbackTier.GLOBAL,
+            )
+        ),
+    )
+
+
+def query(
+    *,
+    trial_index=0,
+    sequence=0,
+):
+    return CanonicalPlateAppearanceQuery(
+        matchup_input=matchup(),
+        state=GameState(
+            inning=1,
+            half="top",
+        ),
+        batter_id="away_batter_0",
+        pitcher_id="home_starter",
+        sequence=sequence,
+        trial_index=trial_index,
+        trial_seed=12345,
+    )
+
+
+def diagnostics_snapshot():
+    collector = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+    )
+    collector.record(
+        fallback_adapter().resolve(
+            query()
+        )
+    )
+    return collector.snapshot()
+
+
+def canonical_payload():
+    return {
+        "simulation_count": 10,
+        "mean": 4.5,
+        "floor": 2.0,
+        "ceiling": 8.0,
+    }
+
+
+def legacy_result():
+    return {
+        "simulation_count": 10,
+        "mean": 4.0,
+        "floor": 1.0,
+        "ceiling": 7.0,
+        "diagnostics": {
+            "legacy_marker": True,
+        },
+    }
+
+
+def test_serializes_summary_and_schema_versions():
+    payload = probability_resolution_diagnostics_to_dict(
+        diagnostics_snapshot()
+    )
+
+    assert payload["schema_version"] == (
+        CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION
+    )
+    assert payload["summary"] == {
+        "total_resolutions": 1,
+        "exact_resolutions": 0,
+        "fallback_resolutions": 1,
+        "fallback_rate": 1.0,
+    }
+
+
+def test_serializes_enum_values_as_json_strings():
+    payload = probability_resolution_diagnostics_to_dict(
+        diagnostics_snapshot()
+    )
+
+    assert payload["tier_usage"][-1] == {
+        "tier": "global",
+        "count": 1,
+    }
+    assert payload["observations"][0]["tier"] == "global"
+    assert payload["observations"][0]["is_fallback"] is True
+
+
+def test_empty_snapshot_serializes_deterministically():
+    snapshot = (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+        .snapshot()
+    )
+
+    first = probability_resolution_diagnostics_to_dict(
+        snapshot
+    )
+    second = probability_resolution_diagnostics_to_dict(
+        snapshot
+    )
+
+    assert first == second
+    assert first["observations"] == []
+    assert first["summary"]["fallback_rate"] == 0.0
+
+
+def test_attachment_is_optional_and_default_output_is_unchanged():
+    legacy = legacy_result()
+
+    before = attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=True,
+        canonical_payload=canonical_payload(),
+    )
+    after = attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        probability_resolution_diagnostics=None,
+    )
+
+    assert before == after
+    assert (
+        "probability_resolution"
+        not in after["diagnostics"]["canonical_shadow"]
+    )
+
+
+def test_snapshot_attaches_under_canonical_shadow_namespace():
+    output = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+    )
+
+    attached = output[
+        "diagnostics"
+    ]["canonical_shadow"]["probability_resolution"]
+
+    assert attached["summary"]["total_resolutions"] == 1
+    assert attached["observations"][0]["tier"] == "global"
+
+
+def test_attachment_does_not_mutate_legacy_input():
+    legacy = legacy_result()
+    original = deepcopy(legacy)
+
+    attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+    )
+
+    assert legacy == original
+
+
+def test_legacy_remains_authoritative_with_attachment():
+    output = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+    )
+
+    shadow = output["diagnostics"]["canonical_shadow"]
+
+    assert shadow["authoritative_source"] == "legacy"
+    assert output["mean"] == 4.0
+
+
+def test_invalid_optional_diagnostics_fail_open():
+    output = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        probability_resolution_diagnostics="invalid",
+    )
+
+    attached = output[
+        "diagnostics"
+    ]["canonical_shadow"]["probability_resolution"]
+
+    assert attached["status"] == "error"
+    assert attached["error_type"] == "TypeError"
+    assert output["mean"] == 4.0


### PR DESCRIPTION
## Summary

Implements the sixteenth Layer 10J slice: versioned JSON-compatible serialization for canonical probability-resolution diagnostics and an optional fail-open attachment path under the existing canonical shadow namespace.

The new serializer converts immutable probability-resolution snapshots into deterministic JSON-compatible payloads containing summary counts, per-tier usage, and ordered per-plate-appearance provenance. `attach_canonical_shadow()` now accepts an optional diagnostics snapshot; when omitted, existing output remains unchanged. When supplied, the serialized payload is attached at `diagnostics.canonical_shadow.probability_resolution` without changing legacy authority or canonical comparison behavior.

## Added

- `CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION`
- `probability_resolution_diagnostics_to_dict()`
- Versioned summary serialization
- Per-tier usage serialization
- Ordered observation serialization
- String serialization for fallback-tier enums
- Optional `probability_resolution_diagnostics` argument on `attach_canonical_shadow()`
- Namespaced attachment under canonical shadow diagnostics
- Fail-open serialization error payload
- Tests for deterministic serialization, optional attachment, non-mutation, legacy authority, and invalid-input isolation

## Architecture

```text
CanonicalProbabilityResolutionDiagnostics
        ↓
probability_resolution_diagnostics_to_dict()
        ↓
versioned JSON-compatible payload
        ↓
attach_canonical_shadow(...)
        ↓
diagnostics.canonical_shadow.probability_resolution
```

## Contract guarantees

- Omitting the new optional argument preserves the existing shadow output structure.
- Valid snapshots serialize deterministically.
- Fallback-tier enums are emitted as JSON strings.
- Summary counts and tier usage remain reconciled from the immutable diagnostics snapshot.
- The legacy result is deep-copied and never mutated.
- `authoritative_source` remains `legacy`.
- Probability diagnostics do not change the canonical comparison result.
- Invalid optional diagnostics fail open into a namespaced error payload.
- Legacy metrics and canonical-shadow comparison output remain available when optional serialization fails.

## Scope

This slice intentionally does not yet:

- automatically construct collectors or providers in production wiring;
- persist diagnostics to external storage;
- expose diagnostics in the frontend;
- alter fallback policy or probability mass;
- load production probability artifacts;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New probability-diagnostics shadow-serialization tests passed
- Result: `216 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/integration.py`
- `mlb_app/simulation/shadow/probability_serialization.py`
- `tests/test_canonical_probability_diagnostics_shadow_serialization.py`

## Next slice

Add an explicit canonical shadow execution-bundle contract that carries a canonical trial batch together with its immutable probability-resolution diagnostics snapshot, allowing the builder to attach both atomically while preserving current precedence, fail-open behavior, and legacy authority.