### PR TITLE
Add canonical shadow execution bundle

### DIFF
--- a/mlb_app/simulation/game_simulation_builder.py
+++ b/mlb_app/simulation/game_simulation_builder.py
@@ -691,6 +691,7 @@ CANONICAL_SHADOW_CONFIG_KEYS = frozenset(
     {
         "canonical_shadow_enabled",
         "canonical_shadow_payload",
+        "canonical_shadow_execution_bundle",
         "canonical_shadow_trial_batch",
     }
 )
@@ -843,8 +844,8 @@ def _canonical_shadow_payload(
     2. explicit canonical_shadow_trial_batch;
     3. injected trial_batch_factory.
 
-    The factory hook is dependency injection only. No default production
-    canonical factory is imported or selected here.
+    This function remains the backward-compatible payload-resolution
+    boundary used by existing callers and fail-open tests.
     """
 
     config_snapshot = dict(config or {})
@@ -900,6 +901,21 @@ def _canonical_shadow_payload(
             )
         )
 
+        from mlb_app.simulation.shadow import (
+            CanonicalShadowExecutionBundle,
+            canonical_shadow_execution_bundle_to_material,
+        )
+
+        if isinstance(
+            trial_batch,
+            CanonicalShadowExecutionBundle,
+        ):
+            return (
+                canonical_shadow_execution_bundle_to_material(
+                    trial_batch
+                ).canonical_payload
+            )
+
     from mlb_app.simulation.shadow import (
         canonical_trial_batch_to_shadow_payload,
     )
@@ -908,6 +924,151 @@ def _canonical_shadow_payload(
         trial_batch
     )
 
+
+def _canonical_shadow_material(
+    config: Optional[Dict[str, Any]],
+    *,
+    game_pk: Optional[int] = None,
+    trial_batch_factory=None,
+):
+    """
+    Resolve canonical payload and optional probability diagnostics.
+
+    Precedence is:
+
+    1. explicit canonical_shadow_payload;
+    2. explicit canonical_shadow_execution_bundle;
+    3. explicit canonical_shadow_trial_batch;
+    4. injected trial_batch_factory.
+
+    Existing payload-only resolution continues through
+    ``_canonical_shadow_payload`` so its compatibility and fail-open
+    boundary remain observable.
+    """
+
+    config_snapshot = dict(config or {})
+
+    explicit_payload = config_snapshot.get(
+        "canonical_shadow_payload"
+    )
+
+    if explicit_payload is not None:
+        return (
+            _canonical_shadow_payload(
+                config,
+                game_pk=game_pk,
+                trial_batch_factory=trial_batch_factory,
+            ),
+            None,
+        )
+
+    execution_bundle = config_snapshot.get(
+        "canonical_shadow_execution_bundle"
+    )
+
+    if execution_bundle is not None:
+        from mlb_app.simulation.shadow import (
+            canonical_shadow_execution_bundle_to_material,
+        )
+
+        material = (
+            canonical_shadow_execution_bundle_to_material(
+                execution_bundle
+            )
+        )
+
+        return (
+            material.canonical_payload,
+            material.probability_resolution_diagnostics,
+        )
+
+    explicit_trial_batch = config_snapshot.get(
+        "canonical_shadow_trial_batch"
+    )
+
+    if explicit_trial_batch is not None:
+        return (
+            _canonical_shadow_payload(
+                config,
+                game_pk=game_pk,
+                trial_batch_factory=trial_batch_factory,
+            ),
+            None,
+        )
+
+    if trial_batch_factory is None:
+        return (
+            _canonical_shadow_payload(
+                config,
+                game_pk=game_pk,
+                trial_batch_factory=trial_batch_factory,
+            ),
+            None,
+        )
+
+    if not callable(trial_batch_factory):
+        raise TypeError(
+            "canonical shadow trial-batch factory "
+            "must be callable"
+        )
+
+    if game_pk is None:
+        raise ValueError(
+            "game_pk is required for canonical "
+            "shadow factory execution"
+        )
+
+    factory_config = (
+        _canonical_shadow_factory_config(
+            config
+        )
+    )
+
+    from mlb_app.simulation.game import (
+        build_canonical_trial_factory_input,
+    )
+
+    factory_input = (
+        build_canonical_trial_factory_input(
+            game_pk=int(game_pk),
+            config=factory_config,
+        )
+    )
+
+    factory_result = (
+        _invoke_canonical_trial_batch_factory(
+            trial_batch_factory,
+            factory_input=factory_input,
+        )
+    )
+
+    from mlb_app.simulation.shadow import (
+        CanonicalShadowExecutionBundle,
+        canonical_shadow_execution_bundle_to_material,
+        canonical_trial_batch_to_shadow_payload,
+    )
+
+    if isinstance(
+        factory_result,
+        CanonicalShadowExecutionBundle,
+    ):
+        material = (
+            canonical_shadow_execution_bundle_to_material(
+                factory_result
+            )
+        )
+
+        return (
+            material.canonical_payload,
+            material.probability_resolution_diagnostics,
+        )
+
+    return (
+        canonical_trial_batch_to_shadow_payload(
+            factory_result
+        ),
+        None,
+    )
 
 def _attach_canonical_shadow_diagnostics(
     payload: Dict[str, Any],
@@ -929,13 +1090,17 @@ def _attach_canonical_shadow_diagnostics(
 
     enabled = False
     canonical_payload = None
+    probability_resolution_diagnostics = None
     canonical_available = False
 
     try:
         enabled = _canonical_shadow_enabled(config)
 
         if enabled:
-            canonical_payload = _canonical_shadow_payload(
+            (
+                canonical_payload,
+                probability_resolution_diagnostics,
+            ) = _canonical_shadow_material(
                 config,
                 game_pk=game_pk,
                 trial_batch_factory=(
@@ -955,6 +1120,9 @@ def _attach_canonical_shadow_diagnostics(
             legacy_result=payload,
             enabled=enabled,
             canonical_payload=canonical_payload,
+            probability_resolution_diagnostics=(
+                probability_resolution_diagnostics
+            ),
         )
     except Exception as exc:
         # Never call shadow config/payload helpers again here. One of those
@@ -1033,6 +1201,7 @@ def build_game_simulation(
             "position_player_substitution_state",
             "canonical_shadow_enabled",
             "canonical_shadow_payload",
+            "canonical_shadow_execution_bundle",
             "canonical_shadow_trial_batch",
         }
     }

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -8,6 +8,12 @@ from .contracts import (
     RangeComparison,
     ShadowCoverage,
 )
+from .execution_bundle import (
+    CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION,
+    CanonicalShadowExecutionBundle,
+    CanonicalShadowExecutionMaterial,
+    canonical_shadow_execution_bundle_to_material,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -20,12 +26,16 @@ from .probability_serialization import (
 
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
+    "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
+    "CanonicalShadowExecutionBundle",
+    "CanonicalShadowExecutionMaterial",
     "MetricComparison",
     "RangeComparison",
     "ShadowCoverage",
     "attach_canonical_shadow",
+    "canonical_shadow_execution_bundle_to_material",
     "canonical_trial_batch_to_shadow_payload",
     "compare_shadow_payloads",
     "probability_resolution_diagnostics_to_dict",

--- a/mlb_app/simulation/shadow/execution_bundle.py
+++ b/mlb_app/simulation/shadow/execution_bundle.py
@@ -1,0 +1,119 @@
+"""Atomic canonical shadow execution-bundle contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from mlb_app.simulation.game.probability_diagnostics import (
+    CanonicalProbabilityResolutionDiagnostics,
+)
+from mlb_app.simulation.game.trials import (
+    CanonicalTrialBatch,
+)
+
+from .trial_adapter import (
+    canonical_trial_batch_to_shadow_payload,
+)
+
+
+CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION = (
+    "canonical_shadow_execution_bundle_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalShadowExecutionBundle:
+    """
+    Carry one canonical trial batch and its diagnostics atomically.
+
+    The bundle is transport-only. It does not run simulations, mutate
+    probability resolution, or alter legacy production authority.
+    """
+
+    trial_batch: CanonicalTrialBatch
+    probability_resolution_diagnostics: (
+        CanonicalProbabilityResolutionDiagnostics
+    )
+    bundle_version: str = (
+        CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.trial_batch,
+            CanonicalTrialBatch,
+        ):
+            raise TypeError(
+                "trial_batch must be a CanonicalTrialBatch"
+            )
+
+        if not isinstance(
+            self.probability_resolution_diagnostics,
+            CanonicalProbabilityResolutionDiagnostics,
+        ):
+            raise TypeError(
+                "probability_resolution_diagnostics must be a "
+                "CanonicalProbabilityResolutionDiagnostics"
+            )
+
+        if self.bundle_version != (
+            CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical shadow execution "
+                "bundle version"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalShadowExecutionMaterial:
+    """Resolved atomic material for canonical shadow attachment."""
+
+    canonical_payload: Dict[str, Any]
+    probability_resolution_diagnostics: (
+        CanonicalProbabilityResolutionDiagnostics
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.canonical_payload,
+            dict,
+        ):
+            raise TypeError(
+                "canonical_payload must be a dictionary"
+            )
+
+        if not isinstance(
+            self.probability_resolution_diagnostics,
+            CanonicalProbabilityResolutionDiagnostics,
+        ):
+            raise TypeError(
+                "probability_resolution_diagnostics must be a "
+                "CanonicalProbabilityResolutionDiagnostics"
+            )
+
+
+def canonical_shadow_execution_bundle_to_material(
+    bundle: CanonicalShadowExecutionBundle,
+) -> CanonicalShadowExecutionMaterial:
+    """Adapt one immutable execution bundle for shadow attachment."""
+
+    if not isinstance(
+        bundle,
+        CanonicalShadowExecutionBundle,
+    ):
+        raise TypeError(
+            "bundle must be a CanonicalShadowExecutionBundle"
+        )
+
+    return CanonicalShadowExecutionMaterial(
+        canonical_payload=(
+            canonical_trial_batch_to_shadow_payload(
+                bundle.trial_batch
+            )
+        ),
+        probability_resolution_diagnostics=(
+            bundle.probability_resolution_diagnostics
+        ),
+    )

--- a/tests/test_canonical_shadow_execution_bundle.py
+++ b/tests/test_canonical_shadow_execution_bundle.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+import mlb_app.simulation.game_simulation_builder as builder
+from mlb_app.simulation.box_score import (
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.game import (
+    CanonicalGameOutcomeProjection,
+    CanonicalProbabilityResolutionDiagnosticsCollector,
+    CanonicalTrialBatch,
+    CanonicalTrialDiagnostics,
+    DistributionPoint,
+    ProbabilityMetric,
+)
+from mlb_app.simulation.projections import (
+    aggregate_projection_payload,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION,
+    CanonicalShadowExecutionBundle,
+    canonical_shadow_execution_bundle_to_material,
+)
+
+
+def trial_batch():
+    box_score = ReducedBoxScore(
+        away=TeamBoxScore(
+            team_side="away",
+            runs=3,
+            hits=7,
+        ),
+        home=TeamBoxScore(
+            team_side="home",
+            runs=4,
+            hits=8,
+        ),
+        pitcher_attribution_complete=True,
+    )
+
+    projections = aggregate_projection_payload(
+        box_scores=(box_score,),
+        model_version="execution-bundle-test-v1",
+        replay_validation_passes=(True,),
+    )
+
+    outcomes = CanonicalGameOutcomeProjection(
+        simulation_count=1,
+        away_win_probability=0.0,
+        home_win_probability=1.0,
+        tie_probability=0.0,
+        extra_innings_probability=0.0,
+        walk_off_probability=0.0,
+        away_run_distribution=(
+            DistributionPoint(
+                value=3,
+                probability=1.0,
+            ),
+        ),
+        home_run_distribution=(
+            DistributionPoint(
+                value=4,
+                probability=1.0,
+            ),
+        ),
+        total_run_distribution=(
+            DistributionPoint(
+                value=7,
+                probability=1.0,
+            ),
+        ),
+        team_total_probabilities=(
+            ProbabilityMetric(
+                name="away_3_plus",
+                probability=1.0,
+            ),
+            ProbabilityMetric(
+                name="home_3_plus",
+                probability=1.0,
+            ),
+        ),
+        total_probabilities=(
+            ProbabilityMetric(
+                name="over_6.5",
+                probability=1.0,
+            ),
+            ProbabilityMetric(
+                name="under_6.5",
+                probability=0.0,
+            ),
+        ),
+    )
+
+    return CanonicalTrialBatch(
+        games=(object(),),
+        box_scores=(box_score,),
+        reconciliations=(object(),),
+        outcomes=outcomes,
+        projections=projections,
+        diagnostics=CanonicalTrialDiagnostics(
+            game_validation_pass_rate=1.0,
+            box_score_reconciliation_pass_rate=1.0,
+        ),
+    )
+
+
+def diagnostics_snapshot():
+    return (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+        .snapshot()
+    )
+
+
+def execution_bundle():
+    return CanonicalShadowExecutionBundle(
+        trial_batch=trial_batch(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+    )
+
+
+def legacy_result():
+    return {
+        "model_version": "legacy-test-v1",
+        "simulations": 1,
+        "away_expected_runs": 3.0,
+        "home_expected_runs": 4.0,
+        "total_expected_runs": 7.0,
+        "home_win_probability": 1.0,
+        "away_run_distribution": {"3": 1.0},
+        "home_run_distribution": {"4": 1.0},
+        "total_run_distribution": {"7": 1.0},
+        "metadata": {
+            "simulation_count": 1,
+        },
+    }
+
+
+def install_engine(monkeypatch, observed):
+    def engine(game_pk, config):
+        observed["game_pk"] = game_pk
+        observed["config"] = deepcopy(config)
+        return legacy_result()
+
+    monkeypatch.setattr(
+        builder,
+        "_load_sandbox_engine",
+        lambda: engine,
+    )
+
+
+def test_bundle_validates_component_types():
+    with pytest.raises(
+        TypeError,
+        match="trial_batch",
+    ):
+        CanonicalShadowExecutionBundle(
+            trial_batch="invalid",
+            probability_resolution_diagnostics=(
+                diagnostics_snapshot()
+            ),
+        )
+
+    with pytest.raises(
+        TypeError,
+        match="probability_resolution_diagnostics",
+    ):
+        CanonicalShadowExecutionBundle(
+            trial_batch=trial_batch(),
+            probability_resolution_diagnostics="invalid",
+        )
+
+
+def test_bundle_version_is_explicit():
+    value = execution_bundle()
+
+    assert value.bundle_version == (
+        CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION
+    )
+
+
+def test_bundle_adapts_payload_and_diagnostics_atomically():
+    value = execution_bundle()
+
+    material = (
+        canonical_shadow_execution_bundle_to_material(
+            value
+        )
+    )
+
+    assert material.canonical_payload[
+        "simulation_count"
+    ] == 1
+    assert (
+        material.probability_resolution_diagnostics
+        is value.probability_resolution_diagnostics
+    )
+
+
+def test_explicit_payload_precedes_execution_bundle():
+    explicit_payload = {
+        "simulation_count": 999,
+    }
+
+    payload, diagnostics = (
+        builder._canonical_shadow_material(
+            {
+                "canonical_shadow_payload": (
+                    explicit_payload
+                ),
+                "canonical_shadow_execution_bundle": (
+                    execution_bundle()
+                ),
+            }
+        )
+    )
+
+    assert payload is explicit_payload
+    assert diagnostics is None
+
+
+def test_execution_bundle_precedes_explicit_trial_batch():
+    payload, diagnostics = (
+        builder._canonical_shadow_material(
+            {
+                "canonical_shadow_execution_bundle": (
+                    execution_bundle()
+                ),
+                "canonical_shadow_trial_batch": (
+                    trial_batch()
+                ),
+            }
+        )
+    )
+
+    assert payload["simulation_count"] == 1
+    assert diagnostics == diagnostics_snapshot()
+
+
+def test_builder_attaches_bundle_atomically(monkeypatch):
+    observed = {}
+    install_engine(monkeypatch, observed)
+
+    result = builder.build_game_simulation(
+        123,
+        {
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_execution_bundle": (
+                execution_bundle()
+            ),
+        },
+    )
+
+    shadow = result["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "complete"
+    assert shadow["authoritative_source"] == "legacy"
+    assert shadow[
+        "probability_resolution"
+    ]["summary"]["total_resolutions"] == 0
+
+    assert (
+        "canonical_shadow_execution_bundle"
+        not in observed["config"]
+    )
+
+
+def test_injected_factory_may_return_execution_bundle(
+    monkeypatch,
+):
+    observed = {}
+    install_engine(monkeypatch, observed)
+    factory_calls = []
+
+    def factory(*, factory_input):
+        factory_calls.append(factory_input)
+        return execution_bundle()
+
+    result = builder.build_game_simulation(
+        123,
+        {
+            "canonical_shadow_enabled": True,
+            "simulation_count": 1,
+            "seed": 12345,
+        },
+        canonical_shadow_trial_batch_factory=factory,
+    )
+
+    shadow = result["diagnostics"]["canonical_shadow"]
+
+    assert len(factory_calls) == 1
+    assert shadow["status"] == "complete"
+    assert (
+        shadow["probability_resolution"]
+        ["summary"]["total_resolutions"]
+        == 0
+    )
+
+
+def test_invalid_explicit_bundle_fails_open(monkeypatch):
+    observed = {}
+    install_engine(monkeypatch, observed)
+
+    result = builder.build_game_simulation(
+        123,
+        {
+            "canonical_shadow_enabled": True,
+            "canonical_shadow_execution_bundle": (
+                "invalid"
+            ),
+        },
+    )
+
+    shadow = result["diagnostics"]["canonical_shadow"]
+
+    assert shadow["status"] == "error"
+    assert shadow["error_type"] == "TypeError"
+    assert shadow["authoritative_source"] == "legacy"
+    assert result["away_expected_runs"] == 3.0


### PR DESCRIPTION
## Summary

Implements the seventeenth Layer 10J slice: an immutable canonical shadow execution-bundle contract that carries a canonical trial batch together with its probability-resolution diagnostics snapshot and lets the builder attach both atomically.

The builder now supports explicit execution bundles and injected factories that may return either the existing `CanonicalTrialBatch` or a `CanonicalShadowExecutionBundle`. Existing payload-only and trial-batch paths remain supported, and the historical `_canonical_shadow_payload()` compatibility boundary is preserved for existing callers and fail-open tests.

## Added

- `CanonicalShadowExecutionBundle`
- `CanonicalShadowExecutionMaterial`
- `CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION`
- `canonical_shadow_execution_bundle_to_material()`
- Atomic trial-batch plus diagnostics transport
- Explicit execution-bundle builder input
- Injected factory bundle return support
- Backward-compatible payload-only resolver boundary
- Execution-bundle precedence over explicit trial batches
- Shadow-only key stripping before legacy engine invocation
- Tests for contract validation, precedence, atomic attachment, injected factory support, legacy authority, and fail-open invalid-bundle handling

## Architecture

```text
CanonicalTrialBatch
        +
CanonicalProbabilityResolutionDiagnostics
        ↓
CanonicalShadowExecutionBundle
        ↓
canonical_shadow_execution_bundle_to_material()
        ↓
canonical comparison payload
        +
probability-resolution diagnostics
        ↓
attach_canonical_shadow(...)
```

## Builder precedence

```text
1. explicit canonical_shadow_payload
2. explicit canonical_shadow_execution_bundle
3. explicit canonical_shadow_trial_batch
4. injected canonical shadow factory result
```

Injected factories may return either:

- `CanonicalTrialBatch`
- `CanonicalShadowExecutionBundle`

## Contract guarantees

- Bundle components are immutable and type-validated.
- Trial batch and diagnostics are transported atomically.
- Existing explicit payload behavior remains highest priority.
- Execution bundles take priority over explicit trial batches.
- Existing trial-batch inputs remain supported.
- Existing payload-only callers continue through `_canonical_shadow_payload()`.
- The established outer fail-open seam remains observable and tested.
- Shadow-only configuration keys never reach the legacy simulation engine.
- Invalid explicit bundles fail open into canonical-shadow error diagnostics.
- Legacy metrics remain unchanged and authoritative.

## Scope

This slice intentionally does not yet:

- construct production execution bundles automatically;
- load production probability artifacts;
- persist diagnostics externally;
- expose canonical diagnostics in the frontend;
- alter probability fallback policy or probability mass;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- Targeted compatibility and execution-bundle tests passed
- Layer 10B through prior Layer 10J regression tests passed
- Result: `224 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game_simulation_builder.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/execution_bundle.py`
- `tests/test_canonical_shadow_execution_bundle.py`

## Next slice

Add a first-class canonical execution-bundle factory that composes matchup input, probability artifacts, fallback policy, diagnostics collection, resolver construction, and indexed trial execution into one injected non-default shadow factory without changing legacy authority or enabling canonical production output by default.