### PR TITLE
Add canonical shadow execution bundle factory

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -14,6 +14,11 @@ from .execution_bundle import (
     CanonicalShadowExecutionMaterial,
     canonical_shadow_execution_bundle_to_material,
 )
+from .execution_factory import (
+    CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION,
+    CanonicalShadowExecutionBundleFactory,
+    build_canonical_shadow_execution_bundle_factory,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -27,15 +32,18 @@ from .probability_serialization import (
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
+    "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowExecutionBundle",
+    "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionMaterial",
     "MetricComparison",
     "RangeComparison",
     "ShadowCoverage",
     "attach_canonical_shadow",
     "canonical_shadow_execution_bundle_to_material",
+    "build_canonical_shadow_execution_bundle_factory",
     "canonical_trial_batch_to_shadow_payload",
     "compare_shadow_payloads",
     "probability_resolution_diagnostics_to_dict",

--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -1,0 +1,259 @@
+"""Injected canonical shadow execution-bundle factory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from mlb_app.simulation.box_score import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+)
+from mlb_app.simulation.game.contracts import (
+    CanonicalGameConfig,
+)
+from mlb_app.simulation.game.factory_input import (
+    CanonicalTrialFactoryInput,
+)
+from mlb_app.simulation.game.matchup_input import (
+    CanonicalMatchupInput,
+)
+from mlb_app.simulation.game.pa_resolver_factory import (
+    build_canonical_pa_resolver_factory,
+)
+from mlb_app.simulation.game.probability_artifact import (
+    CanonicalProbabilityArtifact,
+)
+from mlb_app.simulation.game.probability_diagnostics import (
+    CanonicalProbabilityResolutionDiagnosticsCollector,
+    build_canonical_probability_diagnostics_provider,
+)
+from mlb_app.simulation.game.probability_fallback import (
+    CanonicalProbabilityFallbackAdapter,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+)
+from mlb_app.simulation.game.trial_factory import (
+    CanonicalTrialExecutionPlan,
+    run_canonical_trial_execution_plan,
+)
+
+from .execution_bundle import (
+    CanonicalShadowExecutionBundle,
+)
+
+
+CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION = (
+    "canonical_shadow_execution_bundle_factory_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalShadowExecutionBundleFactory:
+    """
+    Compose one complete canonical shadow execution.
+
+    This factory is dependency-injected only. It does not load artifacts,
+    choose production defaults, mutate legacy output, or activate canonical
+    authority.
+    """
+
+    matchup_input: CanonicalMatchupInput
+    exact_artifact: CanonicalProbabilityArtifact
+    fallback_catalog: CanonicalProbabilityFallbackCatalog
+    fallback_policy: CanonicalProbabilityFallbackPolicy = field(
+        default_factory=CanonicalProbabilityFallbackPolicy
+    )
+    game_config: CanonicalGameConfig = field(
+        default_factory=CanonicalGameConfig
+    )
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None
+    factory_version: str = (
+        CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.matchup_input,
+            CanonicalMatchupInput,
+        ):
+            raise TypeError(
+                "matchup_input must be a CanonicalMatchupInput"
+            )
+
+        if not isinstance(
+            self.exact_artifact,
+            CanonicalProbabilityArtifact,
+        ):
+            raise TypeError(
+                "exact_artifact must be a "
+                "CanonicalProbabilityArtifact"
+            )
+
+        if not isinstance(
+            self.fallback_catalog,
+            CanonicalProbabilityFallbackCatalog,
+        ):
+            raise TypeError(
+                "fallback_catalog must be a "
+                "CanonicalProbabilityFallbackCatalog"
+            )
+
+        if not isinstance(
+            self.fallback_policy,
+            CanonicalProbabilityFallbackPolicy,
+        ):
+            raise TypeError(
+                "fallback_policy must be a "
+                "CanonicalProbabilityFallbackPolicy"
+            )
+
+        if not isinstance(
+            self.game_config,
+            CanonicalGameConfig,
+        ):
+            raise TypeError(
+                "game_config must be a CanonicalGameConfig"
+            )
+
+        provider = (
+            self.matchup_input.probability_provider
+        )
+
+        if self.exact_artifact.provider != provider:
+            raise ValueError(
+                "exact artifact provider must match "
+                "matchup probability-provider identity"
+            )
+
+        if self.fallback_catalog.provider != provider:
+            raise ValueError(
+                "fallback catalog provider must match "
+                "matchup probability-provider identity"
+            )
+
+        if self.factory_version != (
+            CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical shadow execution "
+                "bundle factory version"
+            )
+
+    def __call__(
+        self,
+        *,
+        factory_input: CanonicalTrialFactoryInput,
+    ) -> CanonicalShadowExecutionBundle:
+        if not isinstance(
+            factory_input,
+            CanonicalTrialFactoryInput,
+        ):
+            raise TypeError(
+                "factory_input must be a "
+                "CanonicalTrialFactoryInput"
+            )
+
+        if (
+            factory_input.game_pk
+            != self.matchup_input.game_pk
+        ):
+            raise ValueError(
+                "factory-input game_pk must match "
+                "canonical matchup input"
+            )
+
+        collector = (
+            CanonicalProbabilityResolutionDiagnosticsCollector()
+        )
+
+        fallback_adapter = (
+            CanonicalProbabilityFallbackAdapter(
+                exact_artifact=self.exact_artifact,
+                fallback_catalog=self.fallback_catalog,
+                policy=self.fallback_policy,
+            )
+        )
+
+        probability_provider = (
+            build_canonical_probability_diagnostics_provider(
+                fallback_adapter=fallback_adapter,
+                collector=collector,
+            )
+        )
+
+        resolver_factory = (
+            build_canonical_pa_resolver_factory(
+                probability_provider
+            )
+        )
+
+        plan = CanonicalTrialExecutionPlan(
+            factory_input=factory_input,
+            away_lineup=(
+                self.matchup_input.away_lineup
+            ),
+            home_lineup=(
+                self.matchup_input.home_lineup
+            ),
+            resolver_factory=resolver_factory,
+            game_config=self.game_config,
+            batter_dfs_rules=self.batter_dfs_rules,
+            pitcher_dfs_rules=self.pitcher_dfs_rules,
+            matchup_input=self.matchup_input,
+        )
+
+        trial_batch = (
+            run_canonical_trial_execution_plan(
+                plan
+            )
+        )
+
+        return CanonicalShadowExecutionBundle(
+            trial_batch=trial_batch,
+            probability_resolution_diagnostics=(
+                collector.snapshot()
+            ),
+        )
+
+
+def build_canonical_shadow_execution_bundle_factory(
+    *,
+    matchup_input: CanonicalMatchupInput,
+    exact_artifact: CanonicalProbabilityArtifact,
+    fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    fallback_policy: Optional[
+        CanonicalProbabilityFallbackPolicy
+    ] = None,
+    game_config: Optional[
+        CanonicalGameConfig
+    ] = None,
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None,
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None,
+) -> CanonicalShadowExecutionBundleFactory:
+    """Build an explicit, non-default canonical shadow factory."""
+
+    return CanonicalShadowExecutionBundleFactory(
+        matchup_input=matchup_input,
+        exact_artifact=exact_artifact,
+        fallback_catalog=fallback_catalog,
+        fallback_policy=(
+            fallback_policy
+            or CanonicalProbabilityFallbackPolicy()
+        ),
+        game_config=(
+            game_config
+            or CanonicalGameConfig()
+        ),
+        batter_dfs_rules=batter_dfs_rules,
+        pitcher_dfs_rules=pitcher_dfs_rules,
+    )

--- a/tests/test_canonical_shadow_execution_bundle_factory.py
+++ b/tests/test_canonical_shadow_execution_bundle_factory.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import pytest
+
+import mlb_app.simulation.game_simulation_builder as builder
+from mlb_app.simulation.events import GameState
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalPlateAppearanceQuery,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    build_canonical_trial_factory_input,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION,
+    CanonicalShadowExecutionBundle,
+    CanonicalShadowExecutionBundleFactory,
+    build_canonical_shadow_execution_bundle_factory,
+)
+
+
+def provider_identity(
+    artifact_id="execution-factory-artifact",
+):
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="execution-factory-test",
+        provider_version="v1",
+        artifact_id=artifact_id,
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup(provider=None):
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            provider or provider_identity()
+        ),
+    )
+
+
+def probabilities(
+    selected=CanonicalPlateAppearanceOutcome.STRIKEOUT,
+):
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome is selected
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def exact_artifact(
+    records=(),
+    provider=None,
+):
+    return CanonicalProbabilityArtifact(
+        provider=provider or provider_identity(),
+        records=tuple(records),
+    )
+
+
+def fallback_catalog(provider=None):
+    return CanonicalProbabilityFallbackCatalog(
+        provider=provider or provider_identity(),
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=(
+                    CanonicalProbabilityFallbackTier.GLOBAL
+                ),
+                identity=None,
+                probabilities=probabilities(),
+            ),
+        ),
+    )
+
+
+def fallback_policy():
+    return CanonicalProbabilityFallbackPolicy(
+        tiers=(
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+            CanonicalProbabilityFallbackTier.GLOBAL,
+        )
+    )
+
+
+def factory_input(
+    *,
+    game_pk=123,
+):
+    return build_canonical_trial_factory_input(
+        game_pk=game_pk,
+        config={
+            "simulation_count": 2,
+            "seed": 98765,
+            "canonical_model_version": (
+                "execution-bundle-factory-test-v1"
+            ),
+        },
+    )
+
+
+def execution_factory(
+    *,
+    records=(),
+):
+    return (
+        build_canonical_shadow_execution_bundle_factory(
+            matchup_input=matchup(),
+            exact_artifact=exact_artifact(records),
+            fallback_catalog=fallback_catalog(),
+            fallback_policy=fallback_policy(),
+            game_config=CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+            ),
+        )
+    )
+
+
+def legacy_result():
+    return {
+        "model_version": "legacy-test-v1",
+        "simulations": 2,
+        "away_expected_runs": 0.0,
+        "home_expected_runs": 0.0,
+        "total_expected_runs": 0.0,
+        "home_win_probability": 0.0,
+        "away_run_distribution": {
+            "0": 1.0,
+        },
+        "home_run_distribution": {
+            "0": 1.0,
+        },
+        "total_run_distribution": {
+            "0": 1.0,
+        },
+        "metadata": {
+            "simulation_count": 2,
+        },
+    }
+
+
+def test_factory_version_is_explicit():
+    value = execution_factory()
+
+    assert value.factory_version == (
+        CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION
+    )
+
+
+def test_factory_rejects_provider_mismatch():
+    different = provider_identity(
+        "different-artifact"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="exact artifact provider",
+    ):
+        CanonicalShadowExecutionBundleFactory(
+            matchup_input=matchup(),
+            exact_artifact=exact_artifact(
+                provider=different
+            ),
+            fallback_catalog=fallback_catalog(),
+        )
+
+
+def test_factory_rejects_game_identity_mismatch():
+    value = execution_factory()
+
+    with pytest.raises(
+        ValueError,
+        match="game_pk",
+    ):
+        value(
+            factory_input=factory_input(
+                game_pk=456
+            )
+        )
+
+
+def test_factory_returns_atomic_bundle():
+    bundle = execution_factory()(
+        factory_input=factory_input()
+    )
+
+    assert isinstance(
+        bundle,
+        CanonicalShadowExecutionBundle,
+    )
+    assert len(bundle.trial_batch.games) == 2
+    assert (
+        bundle.probability_resolution_diagnostics
+        .total_resolutions
+        == 12
+    )
+
+
+def test_global_fallback_usage_is_collected():
+    bundle = execution_factory()(
+        factory_input=factory_input()
+    )
+    diagnostics = (
+        bundle.probability_resolution_diagnostics
+    )
+
+    assert diagnostics.exact_resolutions == 0
+    assert diagnostics.fallback_resolutions == 12
+    assert diagnostics.count_for(
+        CanonicalProbabilityFallbackTier.GLOBAL
+    ) == 12
+
+
+def test_exact_rows_take_priority_when_available():
+    records = tuple(
+        CanonicalProbabilityArtifactRecord(
+            batter_id=batter_id,
+            pitcher_id=pitcher_id,
+            probabilities=probabilities(),
+        )
+        for batter_id, pitcher_id in (
+            *(
+                (
+                    f"away_batter_{index}",
+                    "home_starter",
+                )
+                for index in range(3)
+            ),
+            *(
+                (
+                    f"home_batter_{index}",
+                    "away_starter",
+                )
+                for index in range(3)
+            ),
+        )
+    )
+
+    bundle = execution_factory(
+        records=records
+    )(
+        factory_input=factory_input()
+    )
+    diagnostics = (
+        bundle.probability_resolution_diagnostics
+    )
+
+    assert diagnostics.exact_resolutions == 12
+    assert diagnostics.fallback_resolutions == 0
+
+
+def test_each_factory_call_uses_fresh_diagnostics():
+    value = execution_factory()
+    input_value = factory_input()
+
+    first = value(
+        factory_input=input_value
+    )
+    second = value(
+        factory_input=input_value
+    )
+
+    assert first == second
+    assert (
+        first.probability_resolution_diagnostics
+        .total_resolutions
+        == 12
+    )
+    assert (
+        second.probability_resolution_diagnostics
+        .total_resolutions
+        == 12
+    )
+
+
+def test_builder_accepts_first_class_factory():
+    value = execution_factory()
+
+    output = (
+        builder._attach_canonical_shadow_diagnostics(
+            legacy_result(),
+            config={
+                "canonical_shadow_enabled": True,
+                "simulation_count": 2,
+                "seed": 98765,
+                "canonical_model_version": (
+                    "execution-bundle-factory-test-v1"
+                ),
+            },
+            game_pk=123,
+            trial_batch_factory=value,
+        )
+    )
+
+    shadow = output[
+        "diagnostics"
+    ]["canonical_shadow"]
+
+    assert shadow["authoritative_source"] == "legacy"
+    assert shadow["canonical_available"] is True
+    assert (
+        shadow["probability_resolution"]
+        ["summary"]["total_resolutions"]
+        == 12
+    )
+    assert output["away_expected_runs"] == 0.0


### PR DESCRIPTION
## Summary

Implements the eighteenth Layer 10J slice: a first-class injected canonical shadow execution-bundle factory that composes fixed matchup identity, immutable probability artifacts, explicit fallback policy, diagnostics collection, deterministic plate-appearance resolution, indexed trial execution, and atomic shadow transport.

The new factory is dependency-injected only. It creates a fresh diagnostics collector per call, builds the existing fallback adapter and observational provider, constructs the existing canonical PA resolver factory and trial execution plan, delegates execution to `run_canonical_trial_execution_plan()`, and returns a `CanonicalShadowExecutionBundle` containing both the trial batch and immutable probability-resolution diagnostics snapshot.

## Added

- `CanonicalShadowExecutionBundleFactory`
- `CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION`
- `build_canonical_shadow_execution_bundle_factory()`
- Provider-identity validation across matchup, exact artifact, and fallback catalog
- Factory-input game identity validation
- Fresh diagnostics collector per execution
- Composition of existing fallback, diagnostics, resolver, and trial contracts
- Atomic trial batch plus diagnostics output
- Exact-row precedence and global-fallback diagnostics tests
- Deterministic repeated factory execution tests
- Builder integration test using the first-class injected factory

## Architecture

```text
CanonicalShadowExecutionBundleFactory
    ├─ CanonicalMatchupInput
    ├─ CanonicalProbabilityArtifact
    ├─ CanonicalProbabilityFallbackCatalog
    ├─ CanonicalProbabilityFallbackPolicy
    └─ fixed game / DFS rules
        ↓
fresh diagnostics collector
        ↓
CanonicalProbabilityFallbackAdapter
        ↓
CanonicalProbabilityDiagnosticsProvider
        ↓
CanonicalPlateAppearanceResolverFactory
        ↓
CanonicalTrialExecutionPlan
        ↓
run_canonical_trial_execution_plan()
        ↓
CanonicalTrialBatch
        +
immutable diagnostics snapshot
        ↓
CanonicalShadowExecutionBundle
```

## Contract guarantees

- The factory is explicit and dependency-injected; no default production registration is added.
- Matchup, exact artifact, and fallback catalog must share the same provider identity.
- Factory-input `game_pk` must match the fixed matchup input.
- Every call creates a fresh diagnostics collector.
- Existing fallback policy remains authoritative for exact and fallback selection.
- Existing PA resolver and indexed trial execution paths remain reused rather than duplicated.
- Exact rows take priority when available.
- Fallback usage remains fully observable in the returned diagnostics snapshot.
- Repeated identical factory calls produce identical bundles.
- The builder may consume the factory through the existing injected canonical shadow hook.
- Legacy output remains unchanged and authoritative.

## Scope

This slice intentionally does not yet:

- load probability artifacts from production storage;
- discover matchup inputs automatically;
- register a default factory in production wiring;
- persist diagnostics externally;
- expose canonical diagnostics in the frontend;
- alter fallback probability mass;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical shadow execution-bundle factory tests passed
- Result: `232 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/execution_factory.py`
- `tests/test_canonical_shadow_execution_bundle_factory.py`

## Next slice

Define a production-facing canonical shadow input assembly contract that validates and bundles externally supplied matchup identity, exact probability artifacts, fallback catalogs, policy, and game configuration for the first-class execution factory without performing artifact discovery, storage access, or default activation.