### PR TITLE
Add canonical shadow input assembly

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -19,6 +19,11 @@ from .execution_factory import (
     CanonicalShadowExecutionBundleFactory,
     build_canonical_shadow_execution_bundle_factory,
 )
+from .input_assembly import (
+    CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION,
+    CanonicalShadowExecutionInputs,
+    assemble_canonical_shadow_execution_inputs,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -33,15 +38,18 @@ __all__ = [
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
+    "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowExecutionBundle",
     "CanonicalShadowExecutionBundleFactory",
+    "CanonicalShadowExecutionInputs",
     "CanonicalShadowExecutionMaterial",
     "MetricComparison",
     "RangeComparison",
     "ShadowCoverage",
     "attach_canonical_shadow",
+    "assemble_canonical_shadow_execution_inputs",
     "canonical_shadow_execution_bundle_to_material",
     "build_canonical_shadow_execution_bundle_factory",
     "canonical_trial_batch_to_shadow_payload",

--- a/mlb_app/simulation/shadow/input_assembly.py
+++ b/mlb_app/simulation/shadow/input_assembly.py
@@ -1,0 +1,276 @@
+"""Production-facing canonical shadow input assembly contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from typing import Optional
+
+from mlb_app.simulation.box_score import (
+    BatterDfsScoringRules,
+    PitcherDfsScoringRules,
+)
+from mlb_app.simulation.game.contracts import (
+    CanonicalGameConfig,
+)
+from mlb_app.simulation.game.matchup_input import (
+    CanonicalMatchupInput,
+)
+from mlb_app.simulation.game.probability_artifact import (
+    CanonicalProbabilityArtifact,
+)
+from mlb_app.simulation.game.probability_fallback import (
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+)
+
+from .execution_factory import (
+    CanonicalShadowExecutionBundleFactory,
+    build_canonical_shadow_execution_bundle_factory,
+)
+
+
+CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION = (
+    "canonical_shadow_input_assembly_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalShadowExecutionInputs:
+    """
+    Immutable externally assembled canonical shadow inputs.
+
+    This contract validates already-supplied inputs. It does not discover
+    matchup data, load artifacts, read storage, select environment defaults,
+    or activate canonical production authority.
+    """
+
+    matchup_input: CanonicalMatchupInput
+    exact_artifact: CanonicalProbabilityArtifact
+    fallback_catalog: CanonicalProbabilityFallbackCatalog
+    fallback_policy: CanonicalProbabilityFallbackPolicy = field(
+        default_factory=CanonicalProbabilityFallbackPolicy
+    )
+    game_config: CanonicalGameConfig = field(
+        default_factory=CanonicalGameConfig
+    )
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None
+    assembly_version: str = (
+        CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.matchup_input,
+            CanonicalMatchupInput,
+        ):
+            raise TypeError(
+                "matchup_input must be a CanonicalMatchupInput"
+            )
+
+        if not isinstance(
+            self.exact_artifact,
+            CanonicalProbabilityArtifact,
+        ):
+            raise TypeError(
+                "exact_artifact must be a "
+                "CanonicalProbabilityArtifact"
+            )
+
+        if not isinstance(
+            self.fallback_catalog,
+            CanonicalProbabilityFallbackCatalog,
+        ):
+            raise TypeError(
+                "fallback_catalog must be a "
+                "CanonicalProbabilityFallbackCatalog"
+            )
+
+        if not isinstance(
+            self.fallback_policy,
+            CanonicalProbabilityFallbackPolicy,
+        ):
+            raise TypeError(
+                "fallback_policy must be a "
+                "CanonicalProbabilityFallbackPolicy"
+            )
+
+        if not isinstance(
+            self.game_config,
+            CanonicalGameConfig,
+        ):
+            raise TypeError(
+                "game_config must be a CanonicalGameConfig"
+            )
+
+        if (
+            self.batter_dfs_rules is not None
+            and not isinstance(
+                self.batter_dfs_rules,
+                BatterDfsScoringRules,
+            )
+        ):
+            raise TypeError(
+                "batter_dfs_rules must be "
+                "BatterDfsScoringRules or None"
+            )
+
+        if (
+            self.pitcher_dfs_rules is not None
+            and not isinstance(
+                self.pitcher_dfs_rules,
+                PitcherDfsScoringRules,
+            )
+        ):
+            raise TypeError(
+                "pitcher_dfs_rules must be "
+                "PitcherDfsScoringRules or None"
+            )
+
+        provider = (
+            self.matchup_input.probability_provider
+        )
+
+        if self.exact_artifact.provider != provider:
+            raise ValueError(
+                "exact artifact provider must match "
+                "matchup probability-provider identity"
+            )
+
+        if self.fallback_catalog.provider != provider:
+            raise ValueError(
+                "fallback catalog provider must match "
+                "matchup probability-provider identity"
+            )
+
+        if self.assembly_version != (
+            CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical shadow input "
+                "assembly version"
+            )
+
+    @property
+    def provider_identity(self) -> str:
+        return (
+            self.matchup_input
+            .probability_provider
+            .identity
+        )
+
+    @property
+    def exact_artifact_digest(self) -> str:
+        return self.exact_artifact.digest
+
+    @property
+    def fallback_catalog_digest(self) -> str:
+        return self.fallback_catalog.digest
+
+    @property
+    def assembly_digest(self) -> str:
+        """
+        Return a deterministic digest of the complete assembled input set.
+
+        This is input provenance only; it is not an authorization token and
+        does not imply that canonical output is production authoritative.
+        """
+
+        away_plan = (
+            self.matchup_input.away_pitching_plan
+        )
+        home_plan = (
+            self.matchup_input.home_pitching_plan
+        )
+
+        parts = (
+            self.assembly_version,
+            str(self.matchup_input.game_pk),
+            self.provider_identity,
+            *self.matchup_input.away_lineup.player_ids,
+            *self.matchup_input.home_lineup.player_ids,
+            away_plan.starter_id,
+            *away_plan.bullpen_pitcher_ids,
+            home_plan.starter_id,
+            *home_plan.bullpen_pitcher_ids,
+            self.exact_artifact_digest,
+            self.fallback_catalog_digest,
+            self.fallback_policy.policy_version,
+            *(
+                tier.value
+                for tier in self.fallback_policy.tiers
+            ),
+            str(self.game_config.regulation_innings),
+            str(self.game_config.max_extra_innings),
+            str(
+                self.game_config
+                .automatic_runner_enabled
+            ),
+            str(
+                self.game_config
+                .max_plate_appearances_per_half
+            ),
+            repr(self.batter_dfs_rules),
+            repr(self.pitcher_dfs_rules),
+        )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
+
+    def build_factory(
+        self,
+    ) -> CanonicalShadowExecutionBundleFactory:
+        """Delegate execution-factory construction to the existing path."""
+
+        return build_canonical_shadow_execution_bundle_factory(
+            matchup_input=self.matchup_input,
+            exact_artifact=self.exact_artifact,
+            fallback_catalog=self.fallback_catalog,
+            fallback_policy=self.fallback_policy,
+            game_config=self.game_config,
+            batter_dfs_rules=self.batter_dfs_rules,
+            pitcher_dfs_rules=self.pitcher_dfs_rules,
+        )
+
+
+def assemble_canonical_shadow_execution_inputs(
+    *,
+    matchup_input: CanonicalMatchupInput,
+    exact_artifact: CanonicalProbabilityArtifact,
+    fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    fallback_policy: Optional[
+        CanonicalProbabilityFallbackPolicy
+    ] = None,
+    game_config: Optional[
+        CanonicalGameConfig
+    ] = None,
+    batter_dfs_rules: Optional[
+        BatterDfsScoringRules
+    ] = None,
+    pitcher_dfs_rules: Optional[
+        PitcherDfsScoringRules
+    ] = None,
+) -> CanonicalShadowExecutionInputs:
+    """Assemble validated external inputs without discovery or activation."""
+
+    return CanonicalShadowExecutionInputs(
+        matchup_input=matchup_input,
+        exact_artifact=exact_artifact,
+        fallback_catalog=fallback_catalog,
+        fallback_policy=(
+            fallback_policy
+            or CanonicalProbabilityFallbackPolicy()
+        ),
+        game_config=(
+            game_config
+            or CanonicalGameConfig()
+        ),
+        batter_dfs_rules=batter_dfs_rules,
+        pitcher_dfs_rules=pitcher_dfs_rules,
+    )

--- a/tests/test_canonical_shadow_input_assembly.py
+++ b/tests/test_canonical_shadow_input_assembly.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    build_canonical_trial_factory_input,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION,
+    CanonicalShadowExecutionBundle,
+    CanonicalShadowExecutionInputs,
+    assemble_canonical_shadow_execution_inputs,
+)
+
+
+def provider_identity(
+    artifact_id="input-assembly-artifact",
+):
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="input-assembly-test",
+        provider_version="v1",
+        artifact_id=artifact_id,
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def matchup(provider=None):
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=(
+            provider or provider_identity()
+        ),
+    )
+
+
+def probabilities(
+    selected=CanonicalPlateAppearanceOutcome.STRIKEOUT,
+):
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome is selected
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def exact_record(
+    batter_id,
+    pitcher_id,
+):
+    return CanonicalProbabilityArtifactRecord(
+        batter_id=batter_id,
+        pitcher_id=pitcher_id,
+        probabilities=probabilities(),
+    )
+
+
+def exact_artifact(
+    *,
+    records=(),
+    provider=None,
+):
+    return CanonicalProbabilityArtifact(
+        provider=provider or provider_identity(),
+        records=tuple(records),
+    )
+
+
+def fallback_record(
+    tier,
+    identity,
+):
+    return CanonicalProbabilityFallbackRecord(
+        tier=tier,
+        identity=identity,
+        probabilities=probabilities(),
+    )
+
+
+def fallback_catalog(
+    *,
+    records=None,
+    provider=None,
+):
+    return CanonicalProbabilityFallbackCatalog(
+        provider=provider or provider_identity(),
+        records=tuple(
+            records
+            if records is not None
+            else (
+                fallback_record(
+                    CanonicalProbabilityFallbackTier.GLOBAL,
+                    None,
+                ),
+            )
+        ),
+    )
+
+
+def fallback_policy():
+    return CanonicalProbabilityFallbackPolicy(
+        tiers=(
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+            CanonicalProbabilityFallbackTier.GLOBAL,
+        )
+    )
+
+
+def assembled(
+    *,
+    exact=None,
+    catalog=None,
+    policy=None,
+    config=None,
+):
+    return assemble_canonical_shadow_execution_inputs(
+        matchup_input=matchup(),
+        exact_artifact=(
+            exact
+            if exact is not None
+            else exact_artifact()
+        ),
+        fallback_catalog=(
+            catalog
+            if catalog is not None
+            else fallback_catalog()
+        ),
+        fallback_policy=(
+            policy
+            if policy is not None
+            else fallback_policy()
+        ),
+        game_config=(
+            config
+            if config is not None
+            else CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+            )
+        ),
+    )
+
+
+def test_assembly_version_and_provenance_are_explicit():
+    value = assembled()
+
+    assert value.assembly_version == (
+        CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION
+    )
+    assert value.provider_identity == (
+        provider_identity().identity
+    )
+    assert len(value.exact_artifact_digest) == 64
+    assert len(value.fallback_catalog_digest) == 64
+    assert len(value.assembly_digest) == 64
+
+
+def test_assembly_rejects_exact_provider_mismatch():
+    with pytest.raises(
+        ValueError,
+        match="exact artifact provider",
+    ):
+        CanonicalShadowExecutionInputs(
+            matchup_input=matchup(),
+            exact_artifact=exact_artifact(
+                provider=provider_identity(
+                    "different-exact"
+                )
+            ),
+            fallback_catalog=fallback_catalog(),
+        )
+
+
+def test_assembly_rejects_fallback_provider_mismatch():
+    with pytest.raises(
+        ValueError,
+        match="fallback catalog provider",
+    ):
+        CanonicalShadowExecutionInputs(
+            matchup_input=matchup(),
+            exact_artifact=exact_artifact(),
+            fallback_catalog=fallback_catalog(
+                provider=provider_identity(
+                    "different-fallback"
+                )
+            ),
+        )
+
+
+def test_assembly_rejects_invalid_component_type():
+    with pytest.raises(
+        TypeError,
+        match="matchup_input",
+    ):
+        CanonicalShadowExecutionInputs(
+            matchup_input="invalid",
+            exact_artifact=exact_artifact(),
+            fallback_catalog=fallback_catalog(),
+        )
+
+
+def test_assembly_digest_is_record_order_independent():
+    exact_records = (
+        exact_record(
+            "away_batter_0",
+            "home_starter",
+        ),
+        exact_record(
+            "away_batter_1",
+            "home_starter",
+        ),
+    )
+    fallback_records = (
+        fallback_record(
+            CanonicalProbabilityFallbackTier.BATTER,
+            "away_batter_0",
+        ),
+        fallback_record(
+            CanonicalProbabilityFallbackTier.GLOBAL,
+            None,
+        ),
+    )
+
+    first = assembled(
+        exact=exact_artifact(
+            records=exact_records
+        ),
+        catalog=fallback_catalog(
+            records=fallback_records
+        ),
+    )
+    second = assembled(
+        exact=exact_artifact(
+            records=tuple(
+                reversed(exact_records)
+            )
+        ),
+        catalog=fallback_catalog(
+            records=tuple(
+                reversed(fallback_records)
+            )
+        ),
+    )
+
+    assert first.assembly_digest == (
+        second.assembly_digest
+    )
+
+
+def test_policy_change_changes_assembly_digest():
+    exact_only = CanonicalProbabilityFallbackPolicy()
+    exact_and_global = fallback_policy()
+
+    first = assembled(
+        policy=exact_only
+    )
+    second = assembled(
+        policy=exact_and_global
+    )
+
+    assert first.assembly_digest != (
+        second.assembly_digest
+    )
+
+
+def test_build_factory_preserves_assembled_inputs():
+    value = assembled()
+    factory = value.build_factory()
+
+    assert factory.matchup_input is (
+        value.matchup_input
+    )
+    assert factory.exact_artifact is (
+        value.exact_artifact
+    )
+    assert factory.fallback_catalog is (
+        value.fallback_catalog
+    )
+    assert factory.fallback_policy is (
+        value.fallback_policy
+    )
+    assert factory.game_config is (
+        value.game_config
+    )
+
+
+def test_assembled_factory_executes_atomic_bundle():
+    value = assembled()
+    factory = value.build_factory()
+
+    bundle = factory(
+        factory_input=(
+            build_canonical_trial_factory_input(
+                game_pk=123,
+                config={
+                    "simulation_count": 2,
+                    "seed": 98765,
+                    "canonical_model_version": (
+                        "input-assembly-test-v1"
+                    ),
+                },
+            )
+        )
+    )
+
+    assert isinstance(
+        bundle,
+        CanonicalShadowExecutionBundle,
+    )
+    assert len(bundle.trial_batch.games) == 2
+    assert (
+        bundle.probability_resolution_diagnostics
+        .total_resolutions
+        == 12
+    )


### PR DESCRIPTION
## Summary

Implements the nineteenth Layer 10J slice: a production-facing canonical shadow input-assembly contract for externally supplied matchup identity, exact probability artifacts, fallback catalogs, fallback policy, game configuration, and optional DFS scoring rules.

The new immutable assembly contract validates component types, reconciles probability-provider identity across matchup and artifacts, exposes artifact and catalog provenance, computes a deterministic digest for the complete assembled input set, and delegates execution-factory construction to the existing canonical shadow execution-bundle factory.

## Added

- `CanonicalShadowExecutionInputs`
- `CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION`
- `assemble_canonical_shadow_execution_inputs()`
- Type validation for matchup, artifacts, fallback policy, game configuration, and optional DFS rules
- Provider-identity reconciliation across matchup, exact artifact, and fallback catalog
- Exact-artifact and fallback-catalog digest exposure
- Deterministic full input-assembly digest
- Record-order-independent assembly provenance
- Existing execution-factory delegation through `build_factory()`
- End-to-end assembled-factory execution test

## Architecture

```text
externally supplied components
    ├─ CanonicalMatchupInput
    ├─ CanonicalProbabilityArtifact
    ├─ CanonicalProbabilityFallbackCatalog
    ├─ CanonicalProbabilityFallbackPolicy
    ├─ CanonicalGameConfig
    └─ optional DFS scoring rules
        ↓
CanonicalShadowExecutionInputs
    ├─ immutable validation
    ├─ provider reconciliation
    ├─ artifact/catalog provenance
    └─ deterministic assembly digest
        ↓
existing CanonicalShadowExecutionBundleFactory
```

## Contract guarantees

- Inputs are immutable and type-validated.
- Matchup, exact artifact, and fallback catalog must share one provider identity.
- Exact-artifact and fallback-catalog digests remain directly observable.
- Assembly digest includes matchup identity, lineups, pitching plans, provider identity, artifact/catalog digests, fallback policy, game configuration, and optional DFS rules.
- Artifact and fallback record ordering does not change the assembly digest.
- Policy or configuration changes alter the assembly digest.
- `build_factory()` delegates to the existing execution-bundle factory and does not duplicate execution logic.
- Assembled inputs may execute through the existing indexed canonical trial path.
- Legacy output and legacy authority remain unchanged.

## Scope

This slice intentionally does not:

- discover matchup inputs automatically;
- load artifacts from storage;
- read environment configuration;
- register a default canonical shadow factory;
- persist diagnostics or provenance externally;
- expose canonical diagnostics in the frontend;
- alter fallback probability mass;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- Layer 10B through prior Layer 10J regression tests passed
- New canonical shadow input-assembly tests passed
- Result: `240 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/input_assembly.py`
- `tests/test_canonical_shadow_input_assembly.py`

## Next slice

Add a JSON-compatible, versioned serialization contract for canonical shadow input-assembly provenance so assembly identity, provider provenance, artifact/catalog digests, fallback policy, and game configuration can be attached to shadow diagnostics without exposing full probability records or changing execution behavior.