### PR TITLE
Add canonical shadow input provenance serialization

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -24,6 +24,10 @@ from .input_assembly import (
     CanonicalShadowExecutionInputs,
     assemble_canonical_shadow_execution_inputs,
 )
+from .input_serialization import (
+    CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION,
+    canonical_shadow_input_provenance_to_dict,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -39,6 +43,7 @@ __all__ = [
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
+    "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowExecutionBundle",
@@ -51,6 +56,7 @@ __all__ = [
     "attach_canonical_shadow",
     "assemble_canonical_shadow_execution_inputs",
     "canonical_shadow_execution_bundle_to_material",
+    "canonical_shadow_input_provenance_to_dict",
     "build_canonical_shadow_execution_bundle_factory",
     "canonical_trial_batch_to_shadow_payload",
     "compare_shadow_payloads",

--- a/mlb_app/simulation/shadow/input_serialization.py
+++ b/mlb_app/simulation/shadow/input_serialization.py
@@ -1,0 +1,131 @@
+"""JSON-compatible canonical shadow input provenance serialization."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .input_assembly import (
+    CanonicalShadowExecutionInputs,
+)
+
+
+CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION = (
+    "canonical_shadow_input_provenance_v1"
+)
+
+
+def canonical_shadow_input_provenance_to_dict(
+    inputs: CanonicalShadowExecutionInputs,
+) -> Dict[str, Any]:
+    """
+    Serialize canonical shadow input provenance without probability rows.
+
+    This payload is diagnostic only. It does not authorize canonical output,
+    change execution inputs, or expose individual probability distributions.
+    """
+
+    if not isinstance(
+        inputs,
+        CanonicalShadowExecutionInputs,
+    ):
+        raise TypeError(
+            "inputs must be CanonicalShadowExecutionInputs"
+        )
+
+    matchup = inputs.matchup_input
+    provider = matchup.probability_provider
+    away_plan = matchup.away_pitching_plan
+    home_plan = matchup.home_pitching_plan
+
+    return {
+        "schema_version": (
+            CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION
+        ),
+        "assembly_version": inputs.assembly_version,
+        "assembly_digest": inputs.assembly_digest,
+        "matchup": {
+            "schema_version": matchup.schema_version,
+            "game_pk": matchup.game_pk,
+            "away_lineup_player_ids": list(
+                matchup.away_lineup.player_ids
+            ),
+            "home_lineup_player_ids": list(
+                matchup.home_lineup.player_ids
+            ),
+            "away_pitching_plan": {
+                "starter_id": away_plan.starter_id,
+                "bullpen_pitcher_ids": list(
+                    away_plan.bullpen_pitcher_ids
+                ),
+            },
+            "home_pitching_plan": {
+                "starter_id": home_plan.starter_id,
+                "bullpen_pitcher_ids": list(
+                    home_plan.bullpen_pitcher_ids
+                ),
+            },
+        },
+        "probability_provider": {
+            "identity": provider.identity,
+            "provider_name": provider.provider_name,
+            "provider_version": provider.provider_version,
+            "artifact_id": provider.artifact_id,
+        },
+        "artifacts": {
+            "exact": {
+                "artifact_version": (
+                    inputs.exact_artifact.artifact_version
+                ),
+                "digest": inputs.exact_artifact_digest,
+                "record_count": len(
+                    inputs.exact_artifact.records
+                ),
+            },
+            "fallback_catalog": {
+                "schema_version": (
+                    inputs.fallback_catalog.schema_version
+                ),
+                "digest": (
+                    inputs.fallback_catalog_digest
+                ),
+                "record_count": len(
+                    inputs.fallback_catalog.records
+                ),
+            },
+        },
+        "fallback_policy": {
+            "policy_version": (
+                inputs.fallback_policy.policy_version
+            ),
+            "tiers": [
+                tier.value
+                for tier in inputs.fallback_policy.tiers
+            ],
+        },
+        "game_config": {
+            "regulation_innings": (
+                inputs.game_config.regulation_innings
+            ),
+            "max_extra_innings": (
+                inputs.game_config.max_extra_innings
+            ),
+            "automatic_runner_enabled": (
+                inputs.game_config
+                .automatic_runner_enabled
+            ),
+            "max_plate_appearances_per_half": (
+                inputs.game_config
+                .max_plate_appearances_per_half
+            ),
+        },
+        "dfs_rules": {
+            "batter_rules_supplied": (
+                inputs.batter_dfs_rules is not None
+            ),
+            "pitcher_rules_supplied": (
+                inputs.pitcher_dfs_rules is not None
+            ),
+        },
+        "probability_records_exposed": False,
+        "authoritative_source": "legacy",
+    }

--- a/mlb_app/simulation/shadow/integration.py
+++ b/mlb_app/simulation/shadow/integration.py
@@ -8,12 +8,19 @@ from typing import Any, Dict, Optional
 from mlb_app.simulation.game.probability_diagnostics import (
     CanonicalProbabilityResolutionDiagnostics,
 )
+from .input_assembly import (
+    CanonicalShadowExecutionInputs,
+)
 
 from .comparator import compare_shadow_payloads
 from .contracts import CanonicalShadowDiagnostics
 from .serialization import shadow_diagnostics_to_dict
 from .probability_serialization import (
     probability_resolution_diagnostics_to_dict,
+)
+from .input_serialization import (
+    CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION,
+    canonical_shadow_input_provenance_to_dict,
 )
 
 
@@ -24,6 +31,9 @@ def attach_canonical_shadow(
     canonical_payload=None,
     probability_resolution_diagnostics: Optional[
         CanonicalProbabilityResolutionDiagnostics
+    ] = None,
+    canonical_shadow_execution_inputs: Optional[
+        CanonicalShadowExecutionInputs
     ] = None,
 ) -> Dict[str, Any]:
     """Attach shadow diagnostics without mutating legacy data."""
@@ -110,6 +120,28 @@ def attach_canonical_shadow(
                     exc.__class__.__name__
                 ),
                 "error_message": str(exc),
+            }
+
+    if canonical_shadow_execution_inputs is not None:
+        try:
+            shadow_payload[
+                "input_provenance"
+            ] = canonical_shadow_input_provenance_to_dict(
+                canonical_shadow_execution_inputs
+            )
+        except Exception as exc:
+            shadow_payload[
+                "input_provenance"
+            ] = {
+                "schema_version": (
+                    CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION
+                ),
+                "status": "error",
+                "error_type": (
+                    exc.__class__.__name__
+                ),
+                "error_message": str(exc),
+                "authoritative_source": "legacy",
             }
 
     diagnostics["canonical_shadow"] = shadow_payload

--- a/tests/test_canonical_shadow_input_provenance_serialization.py
+++ b/tests/test_canonical_shadow_input_provenance_serialization.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION,
+    assemble_canonical_shadow_execution_inputs,
+    attach_canonical_shadow,
+    canonical_shadow_input_provenance_to_dict,
+)
+
+
+def provider_identity():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="input-provenance-test",
+        provider_version="v1",
+        artifact_id="artifact-123",
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever_1",
+            f"{side}_reliever_2",
+        ),
+    )
+
+
+def probabilities():
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome
+                is CanonicalPlateAppearanceOutcome.STRIKEOUT
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def execution_inputs():
+    provider = provider_identity()
+
+    matchup = CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        away_pitching_plan=(
+            pitching_plan("away")
+        ),
+        home_pitching_plan=(
+            pitching_plan("home")
+        ),
+        probability_provider=provider,
+    )
+
+    exact = CanonicalProbabilityArtifact(
+        provider=provider,
+        records=(
+            CanonicalProbabilityArtifactRecord(
+                batter_id="away_batter_0",
+                pitcher_id="home_starter",
+                probabilities=probabilities(),
+            ),
+        ),
+    )
+
+    fallback = CanonicalProbabilityFallbackCatalog(
+        provider=provider,
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=(
+                    CanonicalProbabilityFallbackTier.GLOBAL
+                ),
+                identity=None,
+                probabilities=probabilities(),
+            ),
+        ),
+    )
+
+    policy = CanonicalProbabilityFallbackPolicy(
+        tiers=(
+            CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+            CanonicalProbabilityFallbackTier.GLOBAL,
+        )
+    )
+
+    return assemble_canonical_shadow_execution_inputs(
+        matchup_input=matchup,
+        exact_artifact=exact,
+        fallback_catalog=fallback,
+        fallback_policy=policy,
+        game_config=CanonicalGameConfig(
+            regulation_innings=9,
+            max_extra_innings=3,
+            automatic_runner_enabled=True,
+            max_plate_appearances_per_half=75,
+        ),
+    )
+
+
+def legacy_result():
+    return {
+        "mean": 4.0,
+        "diagnostics": {
+            "source": "legacy",
+        },
+    }
+
+
+def test_serialization_is_versioned_and_json_safe():
+    payload = (
+        canonical_shadow_input_provenance_to_dict(
+            execution_inputs()
+        )
+    )
+
+    assert payload["schema_version"] == (
+        CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION
+    )
+    assert len(payload["assembly_digest"]) == 64
+
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+    )
+
+    assert "input-provenance-test" in encoded
+    assert "exact_matchup" in encoded
+
+
+def test_serialization_exposes_provenance_not_records():
+    payload = (
+        canonical_shadow_input_provenance_to_dict(
+            execution_inputs()
+        )
+    )
+
+    assert payload["artifacts"]["exact"][
+        "record_count"
+    ] == 1
+    assert payload["artifacts"]["fallback_catalog"][
+        "record_count"
+    ] == 1
+    assert (
+        payload["probability_records_exposed"]
+        is False
+    )
+    assert "records" not in payload["artifacts"]["exact"]
+    assert (
+        "records"
+        not in payload["artifacts"]["fallback_catalog"]
+    )
+
+
+def test_serialization_uses_string_policy_tiers():
+    payload = (
+        canonical_shadow_input_provenance_to_dict(
+            execution_inputs()
+        )
+    )
+
+    assert payload["fallback_policy"]["tiers"] == [
+        "exact_matchup",
+        "global",
+    ]
+
+
+def test_serialization_includes_game_configuration():
+    payload = (
+        canonical_shadow_input_provenance_to_dict(
+            execution_inputs()
+        )
+    )
+
+    assert payload["game_config"] == {
+        "regulation_innings": 9,
+        "max_extra_innings": 3,
+        "automatic_runner_enabled": True,
+        "max_plate_appearances_per_half": 75,
+    }
+
+
+def test_omitted_inputs_preserve_existing_output():
+    original = legacy_result()
+
+    output = attach_canonical_shadow(
+        legacy_result=original,
+        enabled=False,
+    )
+
+    assert "input_provenance" not in (
+        output["diagnostics"]["canonical_shadow"]
+    )
+
+
+def test_inputs_attach_under_canonical_shadow():
+    value = execution_inputs()
+
+    output = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=False,
+        canonical_shadow_execution_inputs=value,
+    )
+
+    attached = output[
+        "diagnostics"
+    ]["canonical_shadow"]["input_provenance"]
+
+    assert attached["assembly_digest"] == (
+        value.assembly_digest
+    )
+    assert attached["authoritative_source"] == "legacy"
+
+
+def test_attachment_does_not_mutate_legacy_input():
+    original = legacy_result()
+    snapshot = deepcopy(original)
+
+    attach_canonical_shadow(
+        legacy_result=original,
+        enabled=False,
+        canonical_shadow_execution_inputs=(
+            execution_inputs()
+        ),
+    )
+
+    assert original == snapshot
+
+
+def test_invalid_optional_inputs_fail_open():
+    output = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=False,
+        canonical_shadow_execution_inputs="invalid",
+    )
+
+    attached = output[
+        "diagnostics"
+    ]["canonical_shadow"]["input_provenance"]
+
+    assert attached["status"] == "error"
+    assert attached["error_type"] == "TypeError"
+    assert attached["authoritative_source"] == "legacy"
+    assert output["mean"] == 4.0


### PR DESCRIPTION
## Summary

Implements the twentieth Layer 10J slice: versioned, JSON-compatible serialization for canonical shadow input-assembly provenance with optional fail-open attachment under the existing canonical shadow diagnostics namespace.

The new serializer exposes assembly identity, provider provenance, artifact and fallback-catalog digests and record counts, fallback policy, matchup identity, pitching plans, game configuration, and DFS-rule presence without exposing underlying probability records. `attach_canonical_shadow()` now accepts an optional `CanonicalShadowExecutionInputs` value and attaches the serialized payload at `diagnostics.canonical_shadow.input_provenance`.

## Added

- `CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION`
- `canonical_shadow_input_provenance_to_dict()`
- Versioned JSON-safe input provenance payload
- Assembly version and deterministic assembly digest
- Matchup, lineup, and pitching-plan identity
- Probability-provider identity and artifact ID
- Exact-artifact version, digest, and row count
- Fallback-catalog schema, digest, and row count
- Ordered fallback-policy tier serialization
- Canonical game-configuration serialization
- DFS scoring-rule presence flags
- Explicit `probability_records_exposed: false`
- Optional `canonical_shadow_execution_inputs` attachment argument
- Namespaced fail-open serialization error payload
- Tests for JSON safety, no probability-row exposure, attachment, non-mutation, and invalid-input isolation

## Architecture

```text
CanonicalShadowExecutionInputs
        ↓
canonical_shadow_input_provenance_to_dict()
        ↓
versioned JSON-compatible provenance payload
        ↓
attach_canonical_shadow(...)
        ↓
diagnostics.canonical_shadow.input_provenance
```

## Contract guarantees

- Omitting the new optional argument preserves existing output.
- The serializer exposes provenance and counts, not probability records.
- Exact artifacts use their explicit `artifact_version` contract.
- Fallback-policy enums are emitted as JSON strings.
- Input assembly, artifact, and catalog digests remain observable.
- Serialization does not alter execution inputs or canonical comparison behavior.
- Invalid optional input provenance fails open into a namespaced error payload.
- Legacy data is deep-copied and never mutated.
- `authoritative_source` remains `legacy`.

## Scope

This slice intentionally does not:

- expose probability distributions or full artifact rows;
- discover matchup inputs automatically;
- load artifacts from storage;
- persist provenance externally;
- register a default canonical shadow factory;
- expose diagnostics in the frontend;
- alter fallback policy or probability mass;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- New input-provenance serialization tests passed
- Layer 10B through prior Layer 10J regression tests passed
- Result: `248 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/input_serialization.py`
- `mlb_app/simulation/shadow/integration.py`
- `tests/test_canonical_shadow_input_provenance_serialization.py`

## Next slice

Carry the validated input-assembly provenance through the canonical shadow execution bundle itself so the builder can attach canonical comparison results, probability-resolution diagnostics, and input provenance atomically from one injected execution result without requiring a separate optional attachment argument.