### PR TITLE
Auto-populate empty canonical dashboard reports

### DIFF
--- a/frontend/src/lib/dashboardReportBuilderState.mjs
+++ b/frontend/src/lib/dashboardReportBuilderState.mjs
@@ -48,6 +48,7 @@ export function buildReportRequest({ objectKey, activeLineupsOnly, date, cleaned
       reportType,
       payload: {
         report_type: reportType,
+        as_of_date: date,
         filters: criteria,
         weights,
         page_size: query.page_size,

--- a/frontend/src/lib/dashboardReportBuilderState.test.mjs
+++ b/frontend/src/lib/dashboardReportBuilderState.test.mjs
@@ -17,6 +17,7 @@ test('unfiltered hitters query the complete canonical active-player report', () 
   assert.deepEqual(request.payload.filters, {})
   assert.deepEqual(request.payload.weights, {})
   assert.equal(request.payload.sort_by, 'adjusted_score')
+  assert.equal(request.payload.as_of_date, '2026-07-16')
   assert.equal('date' in request.payload, false)
 })
 

--- a/mlb_app/dashboard_projection_operator.py
+++ b/mlb_app/dashboard_projection_operator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
+import threading
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import requests
@@ -11,6 +13,16 @@ from .dashboard_object_models import DashboardPlayer, DashboardPlayerCurrent, Da
 from .dashboard_player_population import fetch_active_roster, fetch_confirmed_lineup_players, populate_dashboard_players
 from .dashboard_player_projection import backfill_player_projection, refresh_player_projection
 from .lineup_data import MLB_STATS_BASE
+
+
+_AUTO_BOOTSTRAP_LOCK = threading.Lock()
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def canonical_auto_bootstrap_enabled() -> bool:
+    """Allow empty canonical reports to perform one guarded initial population."""
+
+    return os.getenv("DASHBOARD_CANONICAL_AUTO_BOOTSTRAP", "true").strip().lower() not in _FALSE_VALUES
 
 
 def fetch_active_mlb_teams(
@@ -137,6 +149,64 @@ def run_canonical_projection_refresh(
         session.rollback()
         _complete_run(session, run.id, status="failed", completed_at=dt.datetime.utcnow(), error=exc)
         raise
+
+
+
+def ensure_canonical_projection(
+    session: Any,
+    *,
+    target_date: dt.date,
+    refresh: Callable[..., Dict[str, Any]] = run_canonical_projection_refresh,
+    now: Optional[dt.datetime] = None,
+) -> Dict[str, Any]:
+    """Populate an empty canonical projection once, then leave report requests read-only."""
+
+    current_count = session.query(DashboardPlayerCurrent).count()
+    if current_count:
+        return {"status": "already_available", "current_count": current_count}
+    if not canonical_auto_bootstrap_enabled():
+        return {"status": "disabled", "current_count": 0}
+
+    checked_at = now or dt.datetime.utcnow()
+    with _AUTO_BOOTSTRAP_LOCK:
+        session.expire_all()
+        current_count = session.query(DashboardPlayerCurrent).count()
+        if current_count:
+            return {"status": "already_available", "current_count": current_count}
+
+        recent_cutoff = checked_at - dt.timedelta(minutes=15)
+        running = (
+            session.query(DashboardProjectionRun)
+            .filter(
+                DashboardProjectionRun.run_type == "canonical_refresh",
+                DashboardProjectionRun.status == "running",
+                DashboardProjectionRun.started_at >= recent_cutoff,
+            )
+            .order_by(DashboardProjectionRun.started_at.desc(), DashboardProjectionRun.id.desc())
+            .first()
+        )
+        if running is not None:
+            return {"status": "in_progress", "current_count": 0, "run_id": running.id}
+
+        try:
+            result = refresh(session, target_date=target_date)
+        except Exception as exc:
+            # The operator records the full sanitized run evidence. The public
+            # query response only receives a safe error type and keeps its
+            # established empty-result contract.
+            return {
+                "status": "failed",
+                "current_count": session.query(DashboardPlayerCurrent).count(),
+                "error_type": exc.__class__.__name__,
+            }
+
+        current_count = session.query(DashboardPlayerCurrent).count()
+        return {
+            "status": "populated" if current_count else "empty",
+            "current_count": current_count,
+            "run_id": result.get("run_id"),
+            "projection_version": result.get("projection_version"),
+        }
 
 
 def run_projection_backfill(

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -11,6 +11,7 @@ from . import my_dashboard_solver as dashboard_solver
 from .active_lineup_solver import build_active_lineup_solver_payload
 from .dashboard_canonical_status import canonical_dashboard_status
 from .dashboard_player_report_query import query_player_report
+from .dashboard_projection_operator import ensure_canonical_projection
 from .dashboard_related_report_query import query_related_report
 from .dashboard_report_types import list_report_types
 from .database import create_tables, get_engine, get_session
@@ -64,6 +65,7 @@ class MyDashboardHydrateRequest(BaseModel):
 
 class DashboardPlayerReportRequest(BaseModel):
     report_type: str
+    as_of_date: Optional[dt.date] = None
     filters: Optional[Any] = None
     weights: Optional[Dict[str, float]] = None
     page_size: int = DEFAULT_PAGE_SIZE
@@ -149,12 +151,21 @@ def my_dashboard_player_report_query(payload: DashboardPlayerReportRequest) -> D
                     sort_direction=payload.sort_direction,
                     selected_fields=payload.selected_fields, include_metadata=payload.include_metadata,
                 )
-            return query_player_report(
+            bootstrap = None
+            if payload.report_type in {"all_active_hitters", "all_active_pitchers"}:
+                bootstrap = ensure_canonical_projection(
+                    session,
+                    target_date=payload.as_of_date or mlb_business_date(),
+                )
+            result = query_player_report(
                 session, payload.report_type, filters=payload.filters, weights=payload.weights,
                 page_size=payload.page_size, page_number=payload.page_number,
                 sort_by=payload.sort_by, sort_direction=payload.sort_direction,
                 selected_fields=payload.selected_fields, include_metadata=payload.include_metadata,
             )
+            if bootstrap is not None:
+                result["population_bootstrap"] = bootstrap
+            return result
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/tests/test_dashboard_projection_operator.py
+++ b/tests/test_dashboard_projection_operator.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from mlb_app.dashboard_object_models import DashboardPlayerCurrent, DashboardProjectionRun
-from mlb_app.dashboard_projection_operator import run_canonical_projection_refresh
+from mlb_app.dashboard_projection_operator import ensure_canonical_projection, run_canonical_projection_refresh
 from mlb_app.database import Base
 
 
@@ -68,3 +68,65 @@ def test_operator_failure_is_audited_without_erasing_prior_current_projection():
         run_canonical_projection_refresh(session, target_date=today, request_get=incomplete_teams)
     assert session.query(DashboardPlayerCurrent).one().projection_version == version
     assert session.query(DashboardProjectionRun).filter(DashboardProjectionRun.status == "failed").count() == 1
+
+
+
+def test_empty_projection_auto_bootstraps_once_and_reuses_current_rows(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_CANONICAL_AUTO_BOOTSTRAP", "true")
+    session = make_session()
+    calls = []
+
+    def refresh(current_session, *, target_date):
+        calls.append(target_date)
+        now = dt.datetime(2026, 7, 20, 12, 0, 0)
+        current_session.add(DashboardPlayerCurrent(
+            mlb_player_id=101,
+            snapshot_id=1,
+            player_type="hitter",
+            full_name="Bootstrap Hitter",
+            is_active=True,
+            metrics_json={},
+            projection_version="bootstrap-v1",
+            source_freshness_json={"snapshot_date": target_date.isoformat()},
+            provenance_json={},
+            promoted_at=now,
+            updated_at=now,
+        ))
+        current_session.commit()
+        return {"run_id": 7, "projection_version": "bootstrap-v1"}
+
+    target_date = dt.date(2026, 7, 20)
+    first = ensure_canonical_projection(session, target_date=target_date, refresh=refresh)
+    second = ensure_canonical_projection(session, target_date=target_date, refresh=refresh)
+
+    assert first == {
+        "status": "populated",
+        "current_count": 1,
+        "run_id": 7,
+        "projection_version": "bootstrap-v1",
+    }
+    assert second == {"status": "already_available", "current_count": 1}
+    assert calls == [target_date]
+
+
+def test_auto_bootstrap_can_be_disabled_and_redacts_refresh_failure(monkeypatch):
+    session = make_session()
+    target_date = dt.date(2026, 7, 20)
+    monkeypatch.setenv("DASHBOARD_CANONICAL_AUTO_BOOTSTRAP", "false")
+    assert ensure_canonical_projection(session, target_date=target_date) == {
+        "status": "disabled",
+        "current_count": 0,
+    }
+
+    monkeypatch.setenv("DASHBOARD_CANONICAL_AUTO_BOOTSTRAP", "true")
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("sensitive upstream detail")
+
+    result = ensure_canonical_projection(session, target_date=target_date, refresh=fail)
+    assert result == {
+        "status": "failed",
+        "current_count": 0,
+        "error_type": "RuntimeError",
+    }
+    assert "sensitive" not in str(result)

--- a/tests/test_dashboard_report_auto_bootstrap.py
+++ b/tests/test_dashboard_report_auto_bootstrap.py
@@ -1,0 +1,68 @@
+import datetime as dt
+
+from mlb_app import my_dashboard_routes as routes
+
+
+class SessionContext:
+    def __enter__(self):
+        return object()
+
+    def __exit__(self, *_args):
+        return False
+
+
+def test_canonical_report_query_bootstraps_for_requested_mlb_date(monkeypatch):
+    calls = {}
+    monkeypatch.setattr(routes, "session_factory", lambda: lambda: SessionContext())
+
+    def ensure(_session, *, target_date):
+        calls["target_date"] = target_date
+        return {"status": "populated", "current_count": 300}
+
+    def query(_session, report_type, **kwargs):
+        calls["report_type"] = report_type
+        calls["query"] = kwargs
+        return {"report_type": report_type, "records": [], "totalSize": 300}
+
+    monkeypatch.setattr(routes, "ensure_canonical_projection", ensure)
+    monkeypatch.setattr(routes, "query_player_report", query)
+
+    payload = routes.DashboardPlayerReportRequest(
+        report_type="all_active_hitters",
+        as_of_date=dt.date(2026, 7, 20),
+        page_size=50,
+        page_number=1,
+    )
+    result = routes.my_dashboard_player_report_query(payload)
+
+    assert calls["target_date"] == dt.date(2026, 7, 20)
+    assert calls["report_type"] == "all_active_hitters"
+    assert result["totalSize"] == 300
+    assert result["population_bootstrap"] == {
+        "status": "populated",
+        "current_count": 300,
+    }
+
+
+def test_noncanonical_related_report_does_not_auto_bootstrap(monkeypatch):
+    monkeypatch.setattr(routes, "session_factory", lambda: lambda: SessionContext())
+    monkeypatch.setattr(
+        routes,
+        "ensure_canonical_projection",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected bootstrap")),
+    )
+    monkeypatch.setattr(
+        routes,
+        "query_related_report",
+        lambda _session, report_type, **_kwargs: {
+            "report_type": report_type,
+            "records": [],
+            "totalSize": 0,
+        },
+    )
+
+    result = routes.my_dashboard_player_report_query(
+        routes.DashboardPlayerReportRequest(report_type="players_lineup_history")
+    )
+    assert result["report_type"] == "players_lineup_history"
+    assert "population_bootstrap" not in result


### PR DESCRIPTION
## What changed

- makes the first empty canonical hitter or pitcher report request invoke the existing guarded canonical projection refresh;
- sends the selected MLB date to the canonical report endpoint as `as_of_date`;
- rechecks current rows under a process lock and respects a recent persisted running refresh;
- keeps subsequent populated report requests on the existing SQL-only path;
- preserves prior/empty projections when refresh fails and returns only a safe error type in the public response;
- supports `DASHBOARD_CANONICAL_AUTO_BOOTSTRAP=false` as an emergency disable switch;
- attaches non-sensitive bootstrap status to the report response.

## Root cause

The canonical roster/snapshot/current projection implementation and guarded refresh operator were merged, but the production Report Builder could only query `dashboard_player_current`. When that table was empty, it returned `0` indefinitely because the only population entrypoint was the CLI.

## Product impact

After deployment, opening an unfiltered Hitters or Pitchers report for the selected MLB date can populate the complete canonical active-player projection without a separate Railway-shell operation. The successful response then uses the existing `dashboard_player_current_sql_query` contract, stable counts, sorting, pagination, filters, and request-scoped weights.

## Safety

- no new public refresh endpoint;
- no arbitrary table/SQL input;
- only canonical hitter/pitcher reports can trigger the one-time bootstrap;
- verified 30-team/active-roster checks and atomic promotion remain authoritative;
- empty or failed replacements cannot erase a valid current projection;
- refresh details remain in the existing run audit; public output redacts raw errors;
- legacy solvers, saved reports, confirmed 1–9 behavior, and unrelated product routes are unchanged.

## Validation added

- one-time bootstrap and populated-row reuse;
- disable switch and failure redaction;
- route-level selected-date propagation and bootstrap metadata;
- related reports do not trigger bootstrap;
- frontend request contract includes `as_of_date`.

## Production acceptance after merge

1. Open Hitters for `2026-07-20` with no filters.
2. Allow the first request to complete the guarded bootstrap.
3. Verify Hitters and Pitchers both return non-zero `totalSize`.
4. Verify source remains `dashboard_player_current_sql_query`.
5. Verify page 1/page 2 stability and weight-only count preservation.
6. Attach sanitized counts/version/freshness evidence to #1055.

Closes the empty-production recovery portion of #1055 only after live population is observed.