### PR TITLE
Preserve canonical population when lineups fail

### DIFF
--- a/mlb_app/dashboard_projection_operator.py
+++ b/mlb_app/dashboard_projection_operator.py
@@ -118,12 +118,26 @@ def run_canonical_projection_refresh(
                 team_name=team["team_name"],
                 request_get=request_get,
             ))
-        lineup = fetch_confirmed_lineup_players(
-            session,
-            target_date,
-            matchup_builder=matchup_builder,
-            lineup_fetcher=lineup_fetcher,
-        )
+        try:
+            lineup = fetch_confirmed_lineup_players(
+                session,
+                target_date,
+                matchup_builder=matchup_builder,
+                lineup_fetcher=lineup_fetcher,
+            )
+        except Exception as exc:
+            # Confirmed lineups enrich the canonical population but never
+            # define it. Verified rosters, tracked appearances, and usable
+            # aggregates remain sufficient for a complete baseline refresh.
+            lineup = {
+                "players": [],
+                "unresolved_identities": [],
+                "errors": [{
+                    "reason": "confirmed_lineup_source_failed",
+                    "error_type": exc.__class__.__name__,
+                }],
+                "source": "mlb_boxscore_confirmed_lineup",
+            }
         population = populate_dashboard_players(
             session,
             as_of=target_date,

--- a/tests/test_dashboard_projection_operator.py
+++ b/tests/test_dashboard_projection_operator.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 
 from mlb_app.dashboard_object_models import DashboardPlayerCurrent, DashboardProjectionRun
 from mlb_app.dashboard_projection_operator import ensure_canonical_projection, run_canonical_projection_refresh
-from mlb_app.database import Base
+from mlb_app.database import Base, BatterAggregate
 
 
 class Response:
@@ -130,3 +130,52 @@ def test_auto_bootstrap_can_be_disabled_and_redacts_refresh_failure(monkeypatch)
         "error_type": "RuntimeError",
     }
     assert "sensitive" not in str(result)
+
+
+
+def test_confirmed_lineup_failure_does_not_block_roster_aggregate_baseline():
+    session = make_session()
+    target_date = dt.date(2026, 7, 20)
+    session.add(BatterAggregate(
+        batter_id=201,
+        window="season",
+        end_date=target_date,
+        avg_exit_velocity=91.0,
+        avg_launch_angle=14.0,
+        hard_hit_pct=0.44,
+        barrel_pct=0.11,
+        k_pct=0.19,
+        bb_pct=0.09,
+        batting_avg=0.275,
+    ))
+    session.commit()
+
+    def roster_request_get(url, **kwargs):
+        if url.endswith("/teams"):
+            return Response({"teams": [
+                {"id": index, "name": f"Team {index}"}
+                for index in range(1, 31)
+            ]})
+        if url.endswith("/teams/1/roster"):
+            return Response({"roster": [{
+                "person": {"id": 201, "fullName": "Roster Hitter"},
+                "position": {"abbreviation": "OF", "type": "Outfielder"},
+            }]})
+        return Response({"roster": []})
+
+    result = run_canonical_projection_refresh(
+        session,
+        target_date=target_date,
+        request_get=roster_request_get,
+        matchup_builder=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("matchup source unavailable")
+        ),
+    )
+
+    assert result["status"] == "success"
+    assert result["lineup_player_count"] == 0
+    assert result["lineup_error_count"] == 1
+    assert result["population"]["active_hitter_count"] == 1
+    current = session.query(DashboardPlayerCurrent).one()
+    assert current.full_name == "Roster Hitter"
+    assert current.exit_velocity == 91.0


### PR DESCRIPTION
## Root cause

The report-triggered bootstrap from #1123 is active in production, but the request still returned zero after spending roughly 30 seconds in population. The refresh operator treated confirmed-lineup/matchup collection as mandatory. Any exception from that optional enrichment aborted roster population and projection promotion.

That contradicts #1055: today's report population must not depend exclusively on confirmed lineups or a completed matchup/model run.

## Change

- keeps verified 30-team and active-roster collection mandatory;
- catches a top-level confirmed-lineup/matchup source failure;
- continues population from verified rosters, recent tracked appearances, and usable aggregates;
- records a safe lineup error reason/type in run results;
- keeps incomplete team/roster failures fatal;
- preserves the atomic current-projection promotion and prior-projection failure guards.

## Validation added

The new test supplies 30 verified teams, one active roster hitter with a current batter aggregate, and a matchup builder that raises. The refresh must still:

- finish successfully;
- report the lineup failure;
- activate the roster/aggregate hitter;
- promote one canonical current row with real aggregate metrics.

## Scope

Backend-only emergency recovery. No solver formula, public route, saved-report, navigation, or frontend changes.

## Production acceptance after merge

Open the unfiltered Hitters or Pitchers report for `2026-07-20`. The empty projection bootstrap should now complete from roster/tracked/aggregate sources even if today's lineup enrichment is unavailable. Verify non-zero hitter and pitcher totals before closing #1055.