### PR TITLE
Finish canonical roster bootstrap inside report window

### DIFF
--- a/mlb_app/dashboard_projection_operator.py
+++ b/mlb_app/dashboard_projection_operator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import concurrent.futures
 import os
 import threading
 from typing import Any, Callable, Dict, List, Optional, Sequence
@@ -46,6 +47,50 @@ def fetch_active_mlb_teams(
     if len(teams) < 30:
         raise RuntimeError(f"Verified MLB team source returned only {len(teams)} active teams")
     return teams
+
+
+def fetch_verified_active_rosters(
+    teams: Sequence[Dict[str, Any]],
+    season: int,
+    *,
+    request_get: Callable[..., Any] = requests.get,
+    max_workers: int = 10,
+) -> List[Dict[str, Any]]:
+    """Fetch every verified team roster concurrently while preserving all-team validation."""
+
+    roster_by_team: Dict[int, List[Dict[str, Any]]] = {}
+    errors: List[str] = []
+
+    def fetch(team: Dict[str, Any]) -> List[Dict[str, Any]]:
+        return fetch_active_roster(
+            team["team_id"],
+            season,
+            team_name=team["team_name"],
+            request_get=request_get,
+        )
+
+    worker_count = max(1, min(int(max_workers), len(teams)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = {executor.submit(fetch, team): team for team in teams}
+        for future in concurrent.futures.as_completed(futures):
+            team = futures[future]
+            try:
+                roster_by_team[team["team_id"]] = future.result()
+            except Exception as exc:
+                errors.append(exc.__class__.__name__)
+
+    if errors:
+        error_types = ",".join(sorted(set(errors)))
+        raise RuntimeError(
+            f"Verified MLB active-roster source failed for {len(errors)} of {len(teams)} teams "
+            f"(error types: {error_types})"
+        )
+
+    return [
+        player
+        for team in teams
+        for player in roster_by_team.get(team["team_id"], [])
+    ]
 
 
 def _counts(session: Any) -> Dict[str, int]:
@@ -110,14 +155,11 @@ def run_canonical_projection_refresh(
     run = _begin_run(session, "canonical_refresh", target_date, started_at)
     try:
         teams = fetch_active_mlb_teams(target_date.year, request_get=request_get)
-        roster_rows: List[Dict[str, Any]] = []
-        for team in teams:
-            roster_rows.extend(fetch_active_roster(
-                team["team_id"],
-                target_date.year,
-                team_name=team["team_name"],
-                request_get=request_get,
-            ))
+        roster_rows = fetch_verified_active_rosters(
+            teams,
+            target_date.year,
+            request_get=request_get,
+        )
         try:
             lineup = fetch_confirmed_lineup_players(
                 session,
@@ -188,19 +230,42 @@ def ensure_canonical_projection(
         if current_count:
             return {"status": "already_available", "current_count": current_count}
 
-        recent_cutoff = checked_at - dt.timedelta(minutes=15)
-        running = (
+        try:
+            running_timeout_minutes = max(
+                1,
+                int(os.getenv("DASHBOARD_CANONICAL_RUNNING_TIMEOUT_MINUTES", "5")),
+            )
+        except (TypeError, ValueError):
+            running_timeout_minutes = 5
+        recent_cutoff = checked_at - dt.timedelta(minutes=running_timeout_minutes)
+        running_rows = (
             session.query(DashboardProjectionRun)
             .filter(
                 DashboardProjectionRun.run_type == "canonical_refresh",
                 DashboardProjectionRun.status == "running",
-                DashboardProjectionRun.started_at >= recent_cutoff,
             )
             .order_by(DashboardProjectionRun.started_at.desc(), DashboardProjectionRun.id.desc())
-            .first()
+            .all()
         )
-        if running is not None:
-            return {"status": "in_progress", "current_count": 0, "run_id": running.id}
+        recent_running = next(
+            (run for run in running_rows if run.started_at >= recent_cutoff),
+            None,
+        )
+        if recent_running is not None:
+            return {
+                "status": "in_progress",
+                "current_count": 0,
+                "run_id": recent_running.id,
+            }
+        for abandoned in running_rows:
+            abandoned.status = "failed"
+            abandoned.completed_at = checked_at
+            abandoned.error_type = "AbandonedProjectionRun"
+            abandoned.error_message = (
+                "Canonical refresh exceeded the running timeout and was retired."
+            )
+        if running_rows:
+            session.commit()
 
         try:
             result = refresh(session, target_date=target_date)

--- a/tests/test_dashboard_projection_operator.py
+++ b/tests/test_dashboard_projection_operator.py
@@ -5,7 +5,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from mlb_app.dashboard_object_models import DashboardPlayerCurrent, DashboardProjectionRun
-from mlb_app.dashboard_projection_operator import ensure_canonical_projection, run_canonical_projection_refresh
+from mlb_app.dashboard_projection_operator import (
+    ensure_canonical_projection,
+    fetch_verified_active_rosters,
+    run_canonical_projection_refresh,
+)
 from mlb_app.database import Base, BatterAggregate
 
 
@@ -179,3 +183,118 @@ def test_confirmed_lineup_failure_does_not_block_roster_aggregate_baseline():
     current = session.query(DashboardPlayerCurrent).one()
     assert current.full_name == "Roster Hitter"
     assert current.exit_velocity == 91.0
+
+
+
+def test_verified_rosters_are_collected_for_all_teams_and_fail_as_a_set():
+    teams = [{"team_id": index, "team_name": f"Team {index}"} for index in range(1, 31)]
+    calls = []
+
+    def successful_get(url, **kwargs):
+        calls.append(url)
+        return Response({"roster": []})
+
+    assert fetch_verified_active_rosters(
+        teams,
+        2026,
+        request_get=successful_get,
+        max_workers=8,
+    ) == []
+    assert len(calls) == 30
+
+    def one_failure(url, **kwargs):
+        if "/teams/15/roster" in url:
+            raise TimeoutError("upstream timeout")
+        return Response({"roster": []})
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"failed for 1 of 30 teams .*TimeoutError",
+    ):
+        fetch_verified_active_rosters(
+            teams,
+            2026,
+            request_get=one_failure,
+            max_workers=8,
+        )
+
+
+def test_abandoned_running_refresh_is_retired_before_bootstrap(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_CANONICAL_RUNNING_TIMEOUT_MINUTES", "5")
+    session = make_session()
+    checked_at = dt.datetime(2026, 7, 20, 14, 0, 0)
+    abandoned = DashboardProjectionRun(
+        run_type="canonical_refresh",
+        target_date=checked_at.date(),
+        status="running",
+        started_at=checked_at - dt.timedelta(minutes=6),
+        canonical_count=0,
+        active_count=0,
+        current_count=0,
+        snapshot_count=0,
+    )
+    session.add(abandoned)
+    session.commit()
+
+    def refresh(current_session, *, target_date):
+        current_session.add(DashboardPlayerCurrent(
+            mlb_player_id=301,
+            snapshot_id=1,
+            player_type="pitcher",
+            full_name="Recovered Pitcher",
+            is_active=True,
+            metrics_json={},
+            projection_version="recovered-v1",
+            source_freshness_json={"snapshot_date": target_date.isoformat()},
+            provenance_json={},
+            promoted_at=checked_at,
+            updated_at=checked_at,
+        ))
+        current_session.commit()
+        return {"run_id": 9, "projection_version": "recovered-v1"}
+
+    result = ensure_canonical_projection(
+        session,
+        target_date=checked_at.date(),
+        refresh=refresh,
+        now=checked_at,
+    )
+
+    session.refresh(abandoned)
+    assert abandoned.status == "failed"
+    assert abandoned.error_type == "AbandonedProjectionRun"
+    assert result["status"] == "populated"
+    assert result["current_count"] == 1
+
+
+def test_recent_running_refresh_still_prevents_overlap(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_CANONICAL_RUNNING_TIMEOUT_MINUTES", "5")
+    session = make_session()
+    checked_at = dt.datetime(2026, 7, 20, 14, 0, 0)
+    running = DashboardProjectionRun(
+        run_type="canonical_refresh",
+        target_date=checked_at.date(),
+        status="running",
+        started_at=checked_at - dt.timedelta(minutes=1),
+        canonical_count=0,
+        active_count=0,
+        current_count=0,
+        snapshot_count=0,
+    )
+    session.add(running)
+    session.commit()
+
+    result = ensure_canonical_projection(
+        session,
+        target_date=checked_at.date(),
+        refresh=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("overlapping refresh")
+        ),
+        now=checked_at,
+    )
+
+    assert result == {
+        "status": "in_progress",
+        "current_count": 0,
+        "run_id": running.id,
+    }


### PR DESCRIPTION
## Production evidence

After merged #1124, the canonical report still returned zero. An immediate repeat returned in only a few seconds, proving a persisted `running` projection audit was suppressing retries. The original refresh fan-out performs 30 active-roster requests sequentially, making it vulnerable to the frontend/request timeout and leaving an abandoned running row.

## Changes

- fetches the same verified MLB active-roster endpoint concurrently for all 30 verified teams;
- preserves deterministic team/roster output ordering;
- requires every team roster request to succeed;
- reports only aggregate failure count and safe error types;
- keeps the existing 30-team minimum gate;
- makes the running-run timeout configurable with `DASHBOARD_CANONICAL_RUNNING_TIMEOUT_MINUTES` (default 5);
- retires abandoned running audits as failed before attempting recovery;
- continues to suppress a genuinely recent overlapping refresh.

## Why this is safe

This changes orchestration latency, not source authority or eligibility:

- MLB team and roster endpoints remain authoritative;
- all-team completeness is still required;
- canonical MLBAM IDs remain mandatory;
- the active-player policy is unchanged;
- snapshot coverage and atomic promotion guards are unchanged;
- a failed/incomplete replacement cannot erase a valid projection.

## Tests added

- all 30 rosters are requested and combined;
- one team failure rejects the source set explicitly;
- an abandoned running audit is retired and bootstrap proceeds;
- a recent running audit still prevents overlap.

## Production acceptance after merge

1. Open the unfiltered Pitchers report for `2026-07-20`.
2. Confirm the bootstrap finishes within the report request window.
3. Verify non-zero pitcher and hitter totals.
4. Continue pagination/filter/weight acceptance from #1055.