### PR TITLE
Carry canonical input provenance atomically

### DIFF
--- a/mlb_app/simulation/game_simulation_builder.py
+++ b/mlb_app/simulation/game_simulation_builder.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 
+from dataclasses import dataclass
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
@@ -925,6 +926,24 @@ def _canonical_shadow_payload(
     )
 
 
+@dataclass(frozen=True)
+class _CanonicalShadowResolvedMaterial:
+    """
+    Resolved canonical shadow material.
+
+    Iteration intentionally yields only payload and probability diagnostics
+    so existing two-value unpacking remains backward compatible.
+    """
+
+    canonical_payload: Any
+    probability_resolution_diagnostics: Any = None
+    canonical_shadow_execution_inputs: Any = None
+
+    def __iter__(self):
+        yield self.canonical_payload
+        yield self.probability_resolution_diagnostics
+
+
 def _canonical_shadow_material(
     config: Optional[Dict[str, Any]],
     *,
@@ -932,7 +951,7 @@ def _canonical_shadow_material(
     trial_batch_factory=None,
 ):
     """
-    Resolve canonical payload and optional probability diagnostics.
+    Resolve canonical payload, diagnostics, and optional input provenance.
 
     Precedence is:
 
@@ -953,13 +972,16 @@ def _canonical_shadow_material(
     )
 
     if explicit_payload is not None:
-        return (
-            _canonical_shadow_payload(
-                config,
-                game_pk=game_pk,
-                trial_batch_factory=trial_batch_factory,
+        return _CanonicalShadowResolvedMaterial(
+            canonical_payload=(
+                _canonical_shadow_payload(
+                    config,
+                    game_pk=game_pk,
+                    trial_batch_factory=(
+                        trial_batch_factory
+                    ),
+                )
             ),
-            None,
         )
 
     execution_bundle = config_snapshot.get(
@@ -977,9 +999,16 @@ def _canonical_shadow_material(
             )
         )
 
-        return (
-            material.canonical_payload,
-            material.probability_resolution_diagnostics,
+        return _CanonicalShadowResolvedMaterial(
+            canonical_payload=(
+                material.canonical_payload
+            ),
+            probability_resolution_diagnostics=(
+                material.probability_resolution_diagnostics
+            ),
+            canonical_shadow_execution_inputs=(
+                material.canonical_shadow_execution_inputs
+            ),
         )
 
     explicit_trial_batch = config_snapshot.get(
@@ -987,23 +1016,29 @@ def _canonical_shadow_material(
     )
 
     if explicit_trial_batch is not None:
-        return (
-            _canonical_shadow_payload(
-                config,
-                game_pk=game_pk,
-                trial_batch_factory=trial_batch_factory,
+        return _CanonicalShadowResolvedMaterial(
+            canonical_payload=(
+                _canonical_shadow_payload(
+                    config,
+                    game_pk=game_pk,
+                    trial_batch_factory=(
+                        trial_batch_factory
+                    ),
+                )
             ),
-            None,
         )
 
     if trial_batch_factory is None:
-        return (
-            _canonical_shadow_payload(
-                config,
-                game_pk=game_pk,
-                trial_batch_factory=trial_batch_factory,
+        return _CanonicalShadowResolvedMaterial(
+            canonical_payload=(
+                _canonical_shadow_payload(
+                    config,
+                    game_pk=game_pk,
+                    trial_batch_factory=(
+                        trial_batch_factory
+                    ),
+                )
             ),
-            None,
         )
 
     if not callable(trial_batch_factory):
@@ -1058,16 +1093,24 @@ def _canonical_shadow_material(
             )
         )
 
-        return (
-            material.canonical_payload,
-            material.probability_resolution_diagnostics,
+        return _CanonicalShadowResolvedMaterial(
+            canonical_payload=(
+                material.canonical_payload
+            ),
+            probability_resolution_diagnostics=(
+                material.probability_resolution_diagnostics
+            ),
+            canonical_shadow_execution_inputs=(
+                material.canonical_shadow_execution_inputs
+            ),
         )
 
-    return (
-        canonical_trial_batch_to_shadow_payload(
-            factory_result
+    return _CanonicalShadowResolvedMaterial(
+        canonical_payload=(
+            canonical_trial_batch_to_shadow_payload(
+                factory_result
+            )
         ),
-        None,
     )
 
 def _attach_canonical_shadow_diagnostics(
@@ -1091,21 +1134,31 @@ def _attach_canonical_shadow_diagnostics(
     enabled = False
     canonical_payload = None
     probability_resolution_diagnostics = None
+    canonical_shadow_execution_inputs = None
     canonical_available = False
 
     try:
         enabled = _canonical_shadow_enabled(config)
 
         if enabled:
+            resolved_material = (
+                _canonical_shadow_material(
+                    config,
+                    game_pk=game_pk,
+                    trial_batch_factory=(
+                        trial_batch_factory
+                    ),
+                )
+            )
+
             (
                 canonical_payload,
                 probability_resolution_diagnostics,
-            ) = _canonical_shadow_material(
-                config,
-                game_pk=game_pk,
-                trial_batch_factory=(
-                    trial_batch_factory
-                ),
+            ) = resolved_material
+
+            canonical_shadow_execution_inputs = (
+                resolved_material
+                .canonical_shadow_execution_inputs
             )
 
         canonical_available = (
@@ -1122,6 +1175,9 @@ def _attach_canonical_shadow_diagnostics(
             canonical_payload=canonical_payload,
             probability_resolution_diagnostics=(
                 probability_resolution_diagnostics
+            ),
+            canonical_shadow_execution_inputs=(
+                canonical_shadow_execution_inputs
             ),
         )
     except Exception as exc:

--- a/mlb_app/simulation/shadow/execution_bundle.py
+++ b/mlb_app/simulation/shadow/execution_bundle.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 from mlb_app.simulation.game.probability_diagnostics import (
     CanonicalProbabilityResolutionDiagnostics,
@@ -15,6 +15,11 @@ from mlb_app.simulation.game.trials import (
 from .trial_adapter import (
     canonical_trial_batch_to_shadow_payload,
 )
+
+if TYPE_CHECKING:
+    from .input_assembly import (
+        CanonicalShadowExecutionInputs,
+    )
 
 
 CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION = (
@@ -35,6 +40,9 @@ class CanonicalShadowExecutionBundle:
     probability_resolution_diagnostics: (
         CanonicalProbabilityResolutionDiagnostics
     )
+    canonical_shadow_execution_inputs: Optional[
+        "CanonicalShadowExecutionInputs"
+    ] = None
     bundle_version: str = (
         CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION
     )
@@ -57,6 +65,24 @@ class CanonicalShadowExecutionBundle:
                 "CanonicalProbabilityResolutionDiagnostics"
             )
 
+        if (
+            self.canonical_shadow_execution_inputs
+            is not None
+        ):
+            from .input_assembly import (
+                CanonicalShadowExecutionInputs,
+            )
+
+            if not isinstance(
+                self.canonical_shadow_execution_inputs,
+                CanonicalShadowExecutionInputs,
+            ):
+                raise TypeError(
+                    "canonical_shadow_execution_inputs "
+                    "must be CanonicalShadowExecutionInputs "
+                    "or None"
+                )
+
         if self.bundle_version != (
             CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION
         ):
@@ -74,6 +100,9 @@ class CanonicalShadowExecutionMaterial:
     probability_resolution_diagnostics: (
         CanonicalProbabilityResolutionDiagnostics
     )
+    canonical_shadow_execution_inputs: Optional[
+        "CanonicalShadowExecutionInputs"
+    ] = None
 
     def __post_init__(self) -> None:
         if not isinstance(
@@ -92,6 +121,24 @@ class CanonicalShadowExecutionMaterial:
                 "probability_resolution_diagnostics must be a "
                 "CanonicalProbabilityResolutionDiagnostics"
             )
+
+        if (
+            self.canonical_shadow_execution_inputs
+            is not None
+        ):
+            from .input_assembly import (
+                CanonicalShadowExecutionInputs,
+            )
+
+            if not isinstance(
+                self.canonical_shadow_execution_inputs,
+                CanonicalShadowExecutionInputs,
+            ):
+                raise TypeError(
+                    "canonical_shadow_execution_inputs "
+                    "must be CanonicalShadowExecutionInputs "
+                    "or None"
+                )
 
 
 def canonical_shadow_execution_bundle_to_material(
@@ -115,5 +162,8 @@ def canonical_shadow_execution_bundle_to_material(
         ),
         probability_resolution_diagnostics=(
             bundle.probability_resolution_diagnostics
+        ),
+        canonical_shadow_execution_inputs=(
+            bundle.canonical_shadow_execution_inputs
         ),
     )

--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -214,10 +214,27 @@ class CanonicalShadowExecutionBundleFactory:
             )
         )
 
+        from .input_assembly import (
+            CanonicalShadowExecutionInputs,
+        )
+
+        execution_inputs = CanonicalShadowExecutionInputs(
+            matchup_input=self.matchup_input,
+            exact_artifact=self.exact_artifact,
+            fallback_catalog=self.fallback_catalog,
+            fallback_policy=self.fallback_policy,
+            game_config=self.game_config,
+            batter_dfs_rules=self.batter_dfs_rules,
+            pitcher_dfs_rules=self.pitcher_dfs_rules,
+        )
+
         return CanonicalShadowExecutionBundle(
             trial_batch=trial_batch,
             probability_resolution_diagnostics=(
                 collector.snapshot()
+            ),
+            canonical_shadow_execution_inputs=(
+                execution_inputs
             ),
         )
 

--- a/tests/test_canonical_shadow_atomic_input_provenance.py
+++ b/tests/test_canonical_shadow_atomic_input_provenance.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import pytest
+
+import mlb_app.simulation.game_simulation_builder as builder
+from mlb_app.simulation.box_score import (
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalGameOutcomeProjection,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackPolicy,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalTrialBatch,
+    CanonicalTrialDiagnostics,
+    DistributionPoint,
+    ProbabilityMetric,
+    build_canonical_trial_factory_input,
+)
+from mlb_app.simulation.projections import (
+    aggregate_projection_payload,
+)
+from mlb_app.simulation.shadow import (
+    CanonicalShadowExecutionBundle,
+    assemble_canonical_shadow_execution_inputs,
+    canonical_shadow_execution_bundle_to_material,
+)
+
+
+def provider_identity():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="atomic-provenance-test",
+        provider_version="v1",
+        artifact_id="artifact-123",
+    )
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_batter_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def pitching_plan(side):
+    return CanonicalPitchingPlan(
+        team_side=side,
+        starter_id=f"{side}_starter",
+        bullpen_pitcher_ids=(
+            f"{side}_reliever",
+        ),
+    )
+
+
+def probabilities():
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                1.0
+                if outcome
+                is CanonicalPlateAppearanceOutcome.STRIKEOUT
+                else 0.0
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def execution_inputs():
+    provider = provider_identity()
+
+    return assemble_canonical_shadow_execution_inputs(
+        matchup_input=CanonicalMatchupInput(
+            game_pk=123,
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            away_pitching_plan=(
+                pitching_plan("away")
+            ),
+            home_pitching_plan=(
+                pitching_plan("home")
+            ),
+            probability_provider=provider,
+        ),
+        exact_artifact=CanonicalProbabilityArtifact(
+            provider=provider,
+            records=(),
+        ),
+        fallback_catalog=(
+            CanonicalProbabilityFallbackCatalog(
+                provider=provider,
+                records=(
+                    CanonicalProbabilityFallbackRecord(
+                        tier=(
+                            CanonicalProbabilityFallbackTier.GLOBAL
+                        ),
+                        identity=None,
+                        probabilities=probabilities(),
+                    ),
+                ),
+            )
+        ),
+        fallback_policy=(
+            CanonicalProbabilityFallbackPolicy(
+                tiers=(
+                    CanonicalProbabilityFallbackTier.EXACT_MATCHUP,
+                    CanonicalProbabilityFallbackTier.GLOBAL,
+                )
+            )
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+        ),
+    )
+
+
+def trial_batch():
+    box_score = ReducedBoxScore(
+        away=TeamBoxScore(
+            team_side="away",
+            runs=0,
+            hits=0,
+        ),
+        home=TeamBoxScore(
+            team_side="home",
+            runs=0,
+            hits=0,
+        ),
+        pitcher_attribution_complete=True,
+    )
+
+    projections = aggregate_projection_payload(
+        box_scores=(box_score,),
+        model_version="atomic-provenance-test-v1",
+        replay_validation_passes=(True,),
+    )
+
+    outcomes = CanonicalGameOutcomeProjection(
+        simulation_count=1,
+        away_win_probability=0.0,
+        home_win_probability=0.0,
+        tie_probability=1.0,
+        extra_innings_probability=0.0,
+        walk_off_probability=0.0,
+        away_run_distribution=(
+            DistributionPoint(
+                value=0,
+                probability=1.0,
+            ),
+        ),
+        home_run_distribution=(
+            DistributionPoint(
+                value=0,
+                probability=1.0,
+            ),
+        ),
+        total_run_distribution=(
+            DistributionPoint(
+                value=0,
+                probability=1.0,
+            ),
+        ),
+        team_total_probabilities=(
+            ProbabilityMetric(
+                name="away_3_plus",
+                probability=0.0,
+            ),
+            ProbabilityMetric(
+                name="home_3_plus",
+                probability=0.0,
+            ),
+        ),
+        total_probabilities=(
+            ProbabilityMetric(
+                name="over_6.5",
+                probability=0.0,
+            ),
+            ProbabilityMetric(
+                name="under_6.5",
+                probability=1.0,
+            ),
+        ),
+    )
+
+    return CanonicalTrialBatch(
+        games=(object(),),
+        box_scores=(box_score,),
+        reconciliations=(object(),),
+        outcomes=outcomes,
+        projections=projections,
+        diagnostics=CanonicalTrialDiagnostics(
+            game_validation_pass_rate=1.0,
+            box_score_reconciliation_pass_rate=1.0,
+        ),
+    )
+
+
+def diagnostics_snapshot():
+    from mlb_app.simulation.game import (
+        CanonicalProbabilityResolutionDiagnosticsCollector,
+    )
+
+    return (
+        CanonicalProbabilityResolutionDiagnosticsCollector()
+        .snapshot()
+    )
+
+
+def legacy_result():
+    return {
+        "model_version": "legacy-test-v1",
+        "simulations": 1,
+        "away_expected_runs": 0.0,
+        "home_expected_runs": 0.0,
+        "total_expected_runs": 0.0,
+        "home_win_probability": 0.0,
+        "away_run_distribution": {"0": 1.0},
+        "home_run_distribution": {"0": 1.0},
+        "total_run_distribution": {"0": 1.0},
+        "metadata": {
+            "simulation_count": 1,
+        },
+    }
+
+
+def test_existing_bundle_without_inputs_remains_valid():
+    bundle = CanonicalShadowExecutionBundle(
+        trial_batch=trial_batch(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+    )
+
+    assert (
+        bundle.canonical_shadow_execution_inputs
+        is None
+    )
+
+
+def test_bundle_rejects_invalid_optional_inputs():
+    with pytest.raises(
+        TypeError,
+        match="canonical_shadow_execution_inputs",
+    ):
+        CanonicalShadowExecutionBundle(
+            trial_batch=trial_batch(),
+            probability_resolution_diagnostics=(
+                diagnostics_snapshot()
+            ),
+            canonical_shadow_execution_inputs="invalid",
+        )
+
+
+def test_bundle_material_carries_same_inputs():
+    inputs = execution_inputs()
+    bundle = CanonicalShadowExecutionBundle(
+        trial_batch=trial_batch(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+        canonical_shadow_execution_inputs=inputs,
+    )
+
+    material = (
+        canonical_shadow_execution_bundle_to_material(
+            bundle
+        )
+    )
+
+    assert (
+        material.canonical_shadow_execution_inputs
+        is inputs
+    )
+
+
+def test_first_class_factory_includes_inputs():
+    inputs = execution_inputs()
+    factory = inputs.build_factory()
+
+    bundle = factory(
+        factory_input=(
+            build_canonical_trial_factory_input(
+                game_pk=123,
+                config={
+                    "simulation_count": 1,
+                    "seed": 12345,
+                    "canonical_model_version": (
+                        "atomic-provenance-test-v1"
+                    ),
+                },
+            )
+        )
+    )
+
+    assert (
+        bundle.canonical_shadow_execution_inputs
+        is not None
+    )
+    assert (
+        bundle.canonical_shadow_execution_inputs
+        .assembly_digest
+        == inputs.assembly_digest
+    )
+
+
+def test_builder_material_preserves_two_value_unpacking():
+    inputs = execution_inputs()
+    factory = inputs.build_factory()
+
+    resolved = builder._canonical_shadow_material(
+        {
+            "simulation_count": 1,
+            "seed": 12345,
+            "canonical_model_version": (
+                "atomic-provenance-test-v1"
+            ),
+        },
+        game_pk=123,
+        trial_batch_factory=factory,
+    )
+
+    payload, diagnostics = resolved
+
+    assert payload["simulation_count"] == 1
+    assert diagnostics.total_resolutions == 6
+    assert (
+        resolved.canonical_shadow_execution_inputs
+        is not None
+    )
+
+
+def test_builder_attaches_all_atomic_outputs():
+    inputs = execution_inputs()
+    factory = inputs.build_factory()
+
+    output = (
+        builder._attach_canonical_shadow_diagnostics(
+            legacy_result(),
+            config={
+                "canonical_shadow_enabled": True,
+                "simulation_count": 1,
+                "seed": 12345,
+                "canonical_model_version": (
+                    "atomic-provenance-test-v1"
+                ),
+            },
+            game_pk=123,
+            trial_batch_factory=factory,
+        )
+    )
+
+    shadow = output[
+        "diagnostics"
+    ]["canonical_shadow"]
+
+    assert shadow["canonical_available"] is True
+    assert (
+        shadow["probability_resolution"]
+        ["summary"]["total_resolutions"]
+        == 6
+    )
+    assert (
+        shadow["input_provenance"]
+        ["assembly_digest"]
+        == inputs.assembly_digest
+    )
+    assert shadow["authoritative_source"] == "legacy"
+
+
+def test_explicit_bundle_attaches_input_provenance():
+    inputs = execution_inputs()
+    bundle = CanonicalShadowExecutionBundle(
+        trial_batch=trial_batch(),
+        probability_resolution_diagnostics=(
+            diagnostics_snapshot()
+        ),
+        canonical_shadow_execution_inputs=inputs,
+    )
+
+    output = (
+        builder._attach_canonical_shadow_diagnostics(
+            legacy_result(),
+            config={
+                "canonical_shadow_enabled": True,
+                "canonical_shadow_execution_bundle": (
+                    bundle
+                ),
+            },
+            game_pk=123,
+        )
+    )
+
+    assert (
+        output["diagnostics"]["canonical_shadow"]
+        ["input_provenance"]["assembly_digest"]
+        == inputs.assembly_digest
+    )
+
+
+def test_plain_trial_batch_path_omits_provenance():
+    output = (
+        builder._attach_canonical_shadow_diagnostics(
+            legacy_result(),
+            config={
+                "canonical_shadow_enabled": True,
+                "canonical_shadow_trial_batch": (
+                    trial_batch()
+                ),
+            },
+            game_pk=123,
+        )
+    )
+
+    shadow = output[
+        "diagnostics"
+    ]["canonical_shadow"]
+
+    assert "input_provenance" not in shadow
+    assert shadow["authoritative_source"] == "legacy"


### PR DESCRIPTION
## Summary

Implements the twenty-first Layer 10J slice: canonical input provenance now travels atomically inside the canonical shadow execution bundle alongside the canonical trial batch and probability-resolution diagnostics.

The execution bundle and its material adapter now carry an optional validated `CanonicalShadowExecutionInputs` value. The first-class execution factory always includes the exact assembled inputs used for that run. The builder resolves all three outputs from one execution result and attaches canonical comparison metrics, probability-resolution diagnostics, and input provenance together under the existing fail-open canonical shadow namespace.

## Added

- Optional `canonical_shadow_execution_inputs` on `CanonicalShadowExecutionBundle`
- Optional provenance on `CanonicalShadowExecutionMaterial`
- Type validation for bundled execution inputs
- Material-adapter propagation of bundled provenance
- First-class execution-factory provenance output
- `_CanonicalShadowResolvedMaterial` builder contract
- Backward-compatible two-value unpacking for payload and probability diagnostics
- Atomic builder attachment of input provenance
- Tests for old bundle compatibility, invalid provenance rejection, material propagation, first-class factory inclusion, explicit bundle attachment, plain trial-batch behavior, and builder compatibility

## Architecture

```text
CanonicalShadowExecutionBundle
    ├─ CanonicalTrialBatch
    ├─ CanonicalProbabilityResolutionDiagnostics
    └─ CanonicalShadowExecutionInputs
        ↓
canonical_shadow_execution_bundle_to_material()
        ↓
_CanonicalShadowResolvedMaterial
        ↓
attach_canonical_shadow(...)
        ↓
diagnostics.canonical_shadow
    ├─ comparison metrics
    ├─ probability_resolution
    └─ input_provenance
```

## Contract guarantees

- Existing bundles without input provenance remain valid.
- Bundled provenance must be a validated `CanonicalShadowExecutionInputs` instance.
- The first-class execution factory includes the exact inputs used for its run.
- Explicit execution bundles preserve and attach their own provenance.
- Plain canonical trial-batch paths remain supported and omit provenance.
- Existing callers may continue using `payload, diagnostics = resolved_material`.
- New callers can access `resolved_material.canonical_shadow_execution_inputs`.
- Canonical comparison, probability diagnostics, and provenance are attached from one atomic execution result.
- Legacy metrics remain unchanged and authoritative.
- Existing fail-open behavior remains intact.

## Scope

This slice intentionally does not:

- create the frontend canonical view model;
- redesign the Diagnostics tab;
- remove legacy diagnostic model cards;
- load artifacts or matchup inputs from production storage;
- register a default canonical factory;
- alter fallback policy or probability mass;
- mutate active-pitcher state;
- choose bullpen substitutions;
- activate canonical output as production authority.

## Validation

- Python compilation passed
- Atomic-provenance tests passed
- Targeted canonical shadow regression tests passed
- Layer 10B through prior Layer 10J regression tests passed
- Result: `256 passed`
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game_simulation_builder.py`
- `mlb_app/simulation/shadow/execution_bundle.py`
- `mlb_app/simulation/shadow/execution_factory.py`
- `tests/test_canonical_shadow_atomic_input_provenance.py`

## Next slice

Add a frontend-facing canonical diagnostics view-model adapter that normalizes the atomic shadow payload into stable status, realism, probability-coverage, simulation-integrity, provenance, and warning sections before replacing the raw diagnostics display.