### PR TITLE
Populate canonical reports from verified active rosters

### DIFF
--- a/mlb_app/dashboard_player_population.py
+++ b/mlb_app/dashboard_player_population.py
@@ -27,6 +27,7 @@ ACTIVE_REASONS = (
     "recent_confirmed_lineup",
     "recent_tracked_game",
     "active_roster_with_analytics",
+    "verified_active_roster",
 )
 
 
@@ -133,8 +134,9 @@ def evaluate_active_player(candidate: Dict[str, Any], *, as_of: dt.date, window_
         return True, ACTIVE_REASONS[1]
     if game_date and cutoff <= game_date <= as_of:
         return True, ACTIVE_REASONS[2]
-    if candidate.get("on_active_roster") and candidate.get("has_usable_analytics"):
-        return True, ACTIVE_REASONS[3]
+    if candidate.get("on_active_roster"):
+        reason_index = 3 if candidate.get("has_usable_analytics") else 4
+        return True, ACTIVE_REASONS[reason_index]
     return False, "no_recent_verified_activity"
 
 

--- a/tests/test_dashboard_player_population.py
+++ b/tests/test_dashboard_player_population.py
@@ -43,7 +43,7 @@ def test_active_policy_has_four_explicit_eligibility_paths():
     assert evaluate_active_player({"most_recent_lineup_date": AS_OF - dt.timedelta(days=29)}, as_of=AS_OF, window_days=30) == (True, "recent_confirmed_lineup")
     assert evaluate_active_player({"most_recent_game_date": AS_OF}, as_of=AS_OF, window_days=30) == (True, "recent_tracked_game")
     assert evaluate_active_player({"on_active_roster": True, "has_usable_analytics": True}, as_of=AS_OF, window_days=30) == (True, "active_roster_with_analytics")
-    assert evaluate_active_player({"on_active_roster": True, "has_usable_analytics": False}, as_of=AS_OF, window_days=30)[0] is False
+    assert evaluate_active_player({"on_active_roster": True, "has_usable_analytics": False}, as_of=AS_OF, window_days=30) == (True, "verified_active_roster")
 
 
 def test_verified_roster_adapter_preserves_mlb_identity_position_and_team():
@@ -102,6 +102,24 @@ def test_population_deduplicates_by_id_and_combines_roster_lineup_and_analytics(
     assert player.is_active is True
     assert player.active_status_reason == "today_confirmed_or_projected_lineup"
     assert player.source_provenance_json["sources"] == ["mlb_boxscore_confirmed_lineup", "mlb_stats_active_roster"]
+
+
+def test_verified_roster_populates_baseline_without_local_analytics():
+    session = make_session()
+    roster = normalize_source_player(
+        {"person": {"id": 456, "fullName": "Roster Baseline"}, "position": {"abbreviation": "SP", "type": "Pitcher"}},
+        source="mlb_stats_active_roster",
+        team_id=112,
+        team_name="Cubs",
+    )
+    roster["on_active_roster"] = True
+
+    result = populate_dashboard_players(session, as_of=AS_OF, roster_rows=[roster])
+
+    player = session.get(DashboardPlayer, 456)
+    assert result["active_pitcher_count"] == 1
+    assert player.is_active is True
+    assert player.active_status_reason == "verified_active_roster"
 
 
 def test_population_reports_unresolved_and_does_not_persist_it():


### PR DESCRIPTION
## Root cause

The production bootstrap can fetch valid MLB active rosters and still produce zero report rows. Canonical eligibility currently requires every rostered player to already have a local batter/pitcher aggregate. When production analytics and recent Statcast tables are empty or stale, and confirmed lineups are unavailable, all verified roster candidates are marked inactive. Projection promotion then rejects the empty population.

## Fix

- treat verified MLB active-roster membership as a baseline active-player signal;
- preserve the more specific `active_roster_with_analytics` reason when local analytics exist;
- use `verified_active_roster` when metrics are not hydrated yet;
- keep MLB ID/name resolution, mandatory all-team roster collection, deduplication, and empty-promotion guards unchanged;
- add a roster-only pitcher population regression test.

This allows All Active Hitters/Pitchers to contain real MLB players immediately. Analytics fields remain nullable until their existing source tables hydrate.

## Scope

No report routes, formulas, filters, weights, sorting, pagination, frontend behavior, or public authentication behavior change.

Closes no issue. Production acceptance for #1055 still requires deployment and observed nonzero hitter/pitcher reports.