### PR TITLE
Fix canonical snapshot DataError on lineup status

### DIFF
--- a/mlb_app/dashboard_object_models.py
+++ b/mlb_app/dashboard_object_models.py
@@ -83,7 +83,7 @@ class DashboardPlayerSnapshot(Base):
     team_name: Optional[str] = Column(String(120), nullable=True)
     opponent_team_id: Optional[int] = Column(Integer, nullable=True)
     game_pk: Optional[int] = Column(Integer, nullable=True)
-    lineup_status: Optional[str] = Column(String(32), nullable=True)
+    lineup_status: Optional[str] = Column(String(80), nullable=True)
     lineup_position: Optional[int] = Column(Integer, nullable=True)
     model_score: Optional[float] = Column(Float, nullable=True)
     confidence: Optional[str] = Column(String(32), nullable=True)

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -385,6 +385,29 @@ def _ensure_statcast_event_columns(engine) -> None:
         print(f"[database] Non-fatal statcast_events schema guard skipped: {exc}")
 
 
+def _ensure_dashboard_snapshot_lineup_status_width(engine) -> None:
+    """Widen the deployed PostgreSQL column for canonical activity reasons."""
+
+    inspector = inspect(engine)
+    table_name = "dashboard_player_snapshots"
+    if table_name not in inspector.get_table_names():
+        return
+    lineup_status = next(
+        (column for column in inspector.get_columns(table_name) if column["name"] == "lineup_status"),
+        None,
+    )
+    if lineup_status is None:
+        return
+    current_length = getattr(lineup_status["type"], "length", None)
+    if current_length is None or current_length >= 80 or engine.dialect.name != "postgresql":
+        return
+    with engine.begin() as conn:
+        conn.execute(text(
+            "ALTER TABLE dashboard_player_snapshots "
+            "ALTER COLUMN lineup_status TYPE VARCHAR(80)"
+        ))
+
+
 def get_engine(database_url: str):
     return create_engine(database_url, echo=False, future=True)
 
@@ -395,6 +418,7 @@ def create_tables(engine) -> None:
     from . import dashboard_object_models  # noqa: F401
 
     Base.metadata.create_all(engine)
+    _ensure_dashboard_snapshot_lineup_status_width(engine)
     _ensure_statcast_event_columns(engine)
 
 

--- a/tests/test_dashboard_object_schema.py
+++ b/tests/test_dashboard_object_schema.py
@@ -18,6 +18,11 @@ def test_object_tables_and_query_indexes_are_sqlite_compatible():
     assert "ix_dashboard_current_active_type" in {row["name"] for row in inspector.get_indexes("dashboard_player_current")}
 
 
+def test_snapshot_lineup_status_accepts_all_canonical_activity_reasons():
+    longest_reason = "today_confirmed_or_projected_lineup"
+    assert DashboardPlayerSnapshot.__table__.c.lineup_status.type.length >= len(longest_reason)
+
+
 def test_canonical_player_id_is_unique():
     engine = create_engine("sqlite:///:memory:", future=True)
     Base.metadata.create_all(engine)


### PR DESCRIPTION
## Root cause

Production now reports `DataError` during the guarded canonical refresh.

The canonical activity reason `today_confirmed_or_projected_lineup` is 35 characters, while `dashboard_player_snapshots.lineup_status` was declared as `VARCHAR(32)`. SQLite does not enforce the declared string length, so existing tests passed. PostgreSQL rejects the snapshot insert and the current projection is never promoted.

## Fix

- widen the ORM column to `VARCHAR(80)`, matching the canonical player's activity-reason capacity;
- automatically widen the existing PostgreSQL column during the established table-initialization guard;
- add a schema regression test proving every current canonical reason fits.

The PostgreSQL widening is metadata-only and preserves all existing rows. No table, snapshot, or current projection is deleted.

## Expected production behavior

After deployment, the next report query initializes the widened column, retires any abandoned refresh older than one minute, rebuilds snapshots, and promotes verified roster players into `dashboard_player_current`.

## Scope

No report formulas, filters, weights, sorting, pagination, identities, roster rules, or frontend contracts change.