### PR TITLE
Add canonical diagnostics view model

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs",
+    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs src/lib/canonicalDiagnosticsViewModel.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -1,0 +1,601 @@
+export const CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION =
+  'canonical_diagnostics_view_model_v1'
+
+const REALISM_FEATURES = [
+  {
+    key: 'base_out_state',
+    label: 'Base/out state',
+    aliases: [
+      'base_out_state',
+      'base_out_state_enabled',
+      'base_state',
+    ],
+  },
+  {
+    key: 'runner_advancement',
+    label: 'Runner advancement',
+    aliases: [
+      'runner_advancement',
+      'runner_advancement_enabled',
+    ],
+  },
+  {
+    key: 'extra_innings',
+    label: 'Extra innings',
+    aliases: [
+      'extra_innings',
+      'extra_innings_enabled',
+    ],
+  },
+  {
+    key: 'automatic_runner',
+    label: 'Automatic runner',
+    aliases: [
+      'automatic_runner',
+      'automatic_runner_enabled',
+      'ghost_runner',
+      'ghost_runner_enabled',
+    ],
+  },
+  {
+    key: 'walk_offs',
+    label: 'Walk-off endings',
+    aliases: [
+      'walk_offs',
+      'walk_off_enabled',
+      'walk_off_shortening',
+    ],
+  },
+  {
+    key: 'multi_out_scoring',
+    label: 'Multi-out scoring',
+    aliases: [
+      'multi_out_scoring',
+      'multi_out_scoring_enabled',
+      'double_play_scoring',
+    ],
+  },
+  {
+    key: 'sacrifice_fly_scoring',
+    label: 'Sacrifice-fly scoring',
+    aliases: [
+      'sacrifice_fly_scoring',
+      'sacrifice_fly_scoring_enabled',
+    ],
+  },
+  {
+    key: 'stolen_bases',
+    label: 'Stolen bases',
+    aliases: [
+      'stolen_bases',
+      'stolen_base_model',
+      'steals_model',
+    ],
+  },
+]
+
+function objectValue(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value)
+  )
+    ? value
+    : {}
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function finiteNumber(value) {
+  if (
+    value === null ||
+    value === undefined ||
+    value === ''
+  ) {
+    return null
+  }
+
+  const number = Number(value)
+
+  return Number.isFinite(number)
+    ? number
+    : null
+}
+
+function firstPresent(...values) {
+  return values.find(
+    value =>
+      value !== null &&
+      value !== undefined &&
+      value !== ''
+  )
+}
+
+function humanize(value) {
+  if (
+    value === null ||
+    value === undefined ||
+    value === ''
+  ) {
+    return null
+  }
+
+  return String(value)
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, letter => letter.toUpperCase())
+}
+
+function normalizeFeatureStatus(value) {
+  if (value === true) {
+    return {
+      status: 'enabled',
+      detail: null,
+    }
+  }
+
+  if (value === false) {
+    return {
+      status: 'disabled',
+      detail: null,
+    }
+  }
+
+  if (
+    value === null ||
+    value === undefined ||
+    value === ''
+  ) {
+    return {
+      status: 'unknown',
+      detail: null,
+    }
+  }
+
+  const normalized = String(value)
+    .trim()
+    .toLowerCase()
+
+  if (
+    [
+      'enabled',
+      'active',
+      'implemented',
+      'complete',
+      'supported',
+      'true',
+    ].includes(normalized)
+  ) {
+    return {
+      status: 'enabled',
+      detail: humanize(value),
+    }
+  }
+
+  if (
+    normalized.includes('deferred') ||
+    normalized.includes('not_active') ||
+    normalized.includes('planned')
+  ) {
+    return {
+      status: 'deferred',
+      detail: humanize(value),
+    }
+  }
+
+  if (
+    [
+      'disabled',
+      'inactive',
+      'unsupported',
+      'false',
+    ].includes(normalized)
+  ) {
+    return {
+      status: 'disabled',
+      detail: humanize(value),
+    }
+  }
+
+  return {
+    status: 'unknown',
+    detail: humanize(value),
+  }
+}
+
+function readAlias(source, aliases) {
+  for (const alias of aliases) {
+    if (
+      Object.prototype.hasOwnProperty.call(
+        source,
+        alias,
+      )
+    ) {
+      return source[alias]
+    }
+  }
+
+  return undefined
+}
+
+function uniqueStrings(values) {
+  return [
+    ...new Set(
+      values
+        .flatMap(value =>
+          Array.isArray(value)
+            ? value
+            : [value]
+        )
+        .filter(
+          value =>
+            value !== null &&
+            value !== undefined &&
+            value !== ''
+        )
+        .map(value => String(value))
+    ),
+  ]
+}
+
+function buildRealism(sharedSimulation, shadow) {
+  const diagnostics = objectValue(
+    sharedSimulation.diagnostics
+  )
+
+  const source = {
+    ...objectValue(
+      sharedSimulation.game_state_realism
+    ),
+    ...objectValue(
+      sharedSimulation.game_state_realism_diagnostics
+    ),
+    ...objectValue(
+      diagnostics.game_state_realism
+    ),
+    ...objectValue(
+      diagnostics.game_state_realism_diagnostics
+    ),
+    ...objectValue(
+      shadow.game_state_realism
+    ),
+  }
+
+  return {
+    available: Object.keys(source).length > 0,
+    features: REALISM_FEATURES.map(feature => {
+      const rawValue = readAlias(
+        source,
+        feature.aliases,
+      )
+
+      const normalized =
+        normalizeFeatureStatus(rawValue)
+
+      return {
+        key: feature.key,
+        label: feature.label,
+        status: normalized.status,
+        detail: normalized.detail,
+        rawValue: (
+          rawValue === undefined
+            ? null
+            : rawValue
+        ),
+      }
+    }),
+  }
+}
+
+function buildCoverage(shadow) {
+  const probabilityResolution = objectValue(
+    shadow.probability_resolution
+  )
+  const summary = objectValue(
+    probabilityResolution.summary
+  )
+
+  const totalResolutions = finiteNumber(
+    summary.total_resolutions
+  )
+  const exactResolutions = finiteNumber(
+    summary.exact_resolutions
+  )
+  const fallbackResolutions = finiteNumber(
+    summary.fallback_resolutions
+  )
+
+  const fallbackRate = finiteNumber(
+    summary.fallback_rate
+  )
+
+  const exactRate = (
+    totalResolutions !== null &&
+    totalResolutions > 0 &&
+    exactResolutions !== null
+  )
+    ? exactResolutions / totalResolutions
+    : (
+      fallbackRate !== null
+        ? 1 - fallbackRate
+        : null
+    )
+
+  const tiers = arrayValue(
+    probabilityResolution.tier_usage
+  ).map(item => {
+    const value = objectValue(item)
+
+    return {
+      tier: value.tier || 'unknown',
+      label: humanize(value.tier) || 'Unknown',
+      count: finiteNumber(value.count) || 0,
+    }
+  })
+
+  return {
+    available: (
+      probabilityResolution &&
+      Object.keys(probabilityResolution).length > 0 &&
+      probabilityResolution.status !== 'error'
+    ),
+    status: probabilityResolution.status || null,
+    schemaVersion:
+      probabilityResolution.schema_version || null,
+    diagnosticsVersion:
+      probabilityResolution.diagnostics_version || null,
+    totalResolutions,
+    exactResolutions,
+    fallbackResolutions,
+    exactRate,
+    fallbackRate,
+    tiers,
+  }
+}
+
+function buildIntegrity(shadow) {
+  const coverage = objectValue(shadow.coverage)
+
+  const gameValidationPassRate = finiteNumber(
+    firstPresent(
+      shadow.game_validation_pass_rate,
+      coverage.game_validation_pass_rate,
+    )
+  )
+
+  const reconciliationPassRate = finiteNumber(
+    firstPresent(
+      shadow.box_score_reconciliation_pass_rate,
+      coverage.box_score_reconciliation_pass_rate,
+      coverage.reconciliation_pass_rate,
+    )
+  )
+
+  const replayValidationPassRate = finiteNumber(
+    shadow.replay_validation_pass_rate
+  )
+
+  const pitcherAttributionCompleteRate =
+    finiteNumber(
+      shadow.pitcher_attribution_complete_rate
+    )
+
+  return {
+    available: [
+      gameValidationPassRate,
+      reconciliationPassRate,
+      replayValidationPassRate,
+      pitcherAttributionCompleteRate,
+    ].some(value => value !== null),
+    metrics: [
+      {
+        key: 'game_validation',
+        label: 'Game validation',
+        value: gameValidationPassRate,
+      },
+      {
+        key: 'box_score_reconciliation',
+        label: 'Box-score reconciliation',
+        value: reconciliationPassRate,
+      },
+      {
+        key: 'replay_validation',
+        label: 'Replay validation',
+        value: replayValidationPassRate,
+      },
+      {
+        key: 'pitcher_attribution',
+        label: 'Pitcher attribution',
+        value: pitcherAttributionCompleteRate,
+      },
+    ],
+    earnedRunStatus:
+      shadow.earned_run_status || null,
+  }
+}
+
+function buildProvenance(shadow) {
+  const provenance = objectValue(
+    shadow.input_provenance
+  )
+  const provider = objectValue(
+    provenance.probability_provider
+  )
+  const artifacts = objectValue(
+    provenance.artifacts
+  )
+  const exact = objectValue(artifacts.exact)
+  const fallbackCatalog = objectValue(
+    artifacts.fallback_catalog
+  )
+  const matchup = objectValue(
+    provenance.matchup
+  )
+  const fallbackPolicy = objectValue(
+    provenance.fallback_policy
+  )
+
+  return {
+    available: (
+      Object.keys(provenance).length > 0 &&
+      provenance.status !== 'error'
+    ),
+    status: provenance.status || null,
+    schemaVersion:
+      provenance.schema_version || null,
+    assemblyVersion:
+      provenance.assembly_version || null,
+    assemblyDigest:
+      provenance.assembly_digest || null,
+    gamePk: firstPresent(
+      matchup.game_pk,
+      null,
+    ),
+    provider: {
+      identity: provider.identity || null,
+      name: provider.provider_name || null,
+      version: provider.provider_version || null,
+      artifactId: provider.artifact_id || null,
+    },
+    exactArtifact: {
+      version: firstPresent(
+        exact.artifact_version,
+        exact.schema_version,
+        null,
+      ),
+      digest: exact.digest || null,
+      recordCount: finiteNumber(
+        exact.record_count
+      ),
+    },
+    fallbackCatalog: {
+      version: firstPresent(
+        fallbackCatalog.schema_version,
+        fallbackCatalog.catalog_version,
+        null,
+      ),
+      digest: fallbackCatalog.digest || null,
+      recordCount: finiteNumber(
+        fallbackCatalog.record_count
+      ),
+    },
+    fallbackPolicy: {
+      version:
+        fallbackPolicy.policy_version || null,
+      tiers: arrayValue(
+        fallbackPolicy.tiers
+      ).map(tier => ({
+        key: String(tier),
+        label: humanize(tier),
+      })),
+    },
+    gameConfig: objectValue(
+      provenance.game_config
+    ),
+    dfsRules: objectValue(
+      provenance.dfs_rules
+    ),
+    authoritativeSource:
+      provenance.authoritative_source || null,
+    probabilityRecordsExposed:
+      provenance.probability_records_exposed ??
+      null,
+  }
+}
+
+function buildWarnings(shadow) {
+  const probabilityResolution = objectValue(
+    shadow.probability_resolution
+  )
+  const provenance = objectValue(
+    shadow.input_provenance
+  )
+
+  return uniqueStrings([
+    arrayValue(shadow.warnings),
+    shadow.error_message,
+    (
+      probabilityResolution.status === 'error'
+        ? probabilityResolution.error_message
+        : null
+    ),
+    (
+      provenance.status === 'error'
+        ? provenance.error_message
+        : null
+    ),
+  ])
+}
+
+export function buildCanonicalDiagnosticsViewModel(
+  sharedSimulation,
+) {
+  const shared = objectValue(sharedSimulation)
+  const diagnostics = objectValue(
+    shared.diagnostics
+  )
+  const shadow = objectValue(
+    diagnostics.canonical_shadow
+  )
+  const metadata = {
+    ...objectValue(shared.metadata),
+    ...objectValue(shared.meta),
+  }
+
+  const hasCanonicalShadow =
+    Object.keys(shadow).length > 0
+
+  const canonicalAvailable = Boolean(
+    shadow.canonical_available
+  )
+
+  const state = firstPresent(
+    shadow.status,
+    hasCanonicalShadow
+      ? 'unknown'
+      : 'unavailable',
+  )
+
+  return {
+    viewModelVersion:
+      CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION,
+
+    hasCanonicalShadow,
+
+    status: {
+      state,
+      label: humanize(state),
+      enabled: Boolean(shadow.enabled),
+      canonicalAvailable,
+      authoritativeSource:
+        shadow.authoritative_source || 'legacy',
+      legacySimulationCount: finiteNumber(
+        shadow.legacy_simulation_count
+      ),
+      canonicalSimulationCount: finiteNumber(
+        shadow.canonical_simulation_count
+      ),
+      modelVersion: firstPresent(
+        metadata.canonical_model_version,
+        metadata.model_version,
+        shared.model_version,
+        null,
+      ),
+      schemaVersion:
+        shadow.schema_version || null,
+      errorType: shadow.error_type || null,
+      errorMessage: shadow.error_message || null,
+    },
+
+    realism: buildRealism(shared, shadow),
+    coverage: buildCoverage(shadow),
+    integrity: buildIntegrity(shadow),
+    provenance: buildProvenance(shadow),
+    warnings: buildWarnings(shadow),
+
+    raw: {
+      canonicalShadow: shadow,
+    },
+  }
+}

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION,
+  buildCanonicalDiagnosticsViewModel,
+} from './canonicalDiagnosticsViewModel.mjs'
+
+function sharedSimulation() {
+  return {
+    meta: {
+      model_version: 'shared-simulation-v1',
+    },
+    game_state_realism_diagnostics: {
+      base_out_state: true,
+      runner_advancement_enabled: true,
+      extra_innings: 'enabled',
+      ghost_runner_enabled: true,
+      walk_off_shortening: true,
+      double_play_scoring: true,
+      sacrifice_fly_scoring_enabled: true,
+      steals_model: 'deferred_not_active',
+    },
+    diagnostics: {
+      canonical_shadow: {
+        status: 'complete',
+        enabled: true,
+        canonical_available: true,
+        authoritative_source: 'legacy',
+        schema_version: 'canonical_shadow_v1',
+        legacy_simulation_count: 3000,
+        canonical_simulation_count: 3000,
+        pitcher_attribution_complete_rate: 0.98,
+        replay_validation_pass_rate: 1,
+        coverage: {
+          game_validation_pass_rate: 1,
+          box_score_reconciliation_pass_rate: 1,
+        },
+        warnings: [
+          'legacy_authority_retained',
+        ],
+        probability_resolution: {
+          schema_version:
+            'canonical_probability_diagnostics_shadow_v1',
+          diagnostics_version:
+            'canonical_probability_diagnostics_v1',
+          summary: {
+            total_resolutions: 100,
+            exact_resolutions: 81,
+            fallback_resolutions: 19,
+            fallback_rate: 0.19,
+          },
+          tier_usage: [
+            {
+              tier: 'exact_matchup',
+              count: 81,
+            },
+            {
+              tier: 'batter',
+              count: 10,
+            },
+            {
+              tier: 'pitcher',
+              count: 5,
+            },
+            {
+              tier: 'global',
+              count: 4,
+            },
+          ],
+        },
+        input_provenance: {
+          schema_version:
+            'canonical_shadow_input_provenance_v1',
+          assembly_version:
+            'canonical_shadow_input_assembly_v1',
+          assembly_digest: 'a'.repeat(64),
+          matchup: {
+            game_pk: 123,
+          },
+          probability_provider: {
+            identity: 'provider:v1:artifact-123',
+            provider_name: 'provider',
+            provider_version: 'v1',
+            artifact_id: 'artifact-123',
+          },
+          artifacts: {
+            exact: {
+              artifact_version:
+                'canonical_probability_artifact_v1',
+              digest: 'b'.repeat(64),
+              record_count: 50,
+            },
+            fallback_catalog: {
+              schema_version:
+                'canonical_probability_fallback_v1',
+              digest: 'c'.repeat(64),
+              record_count: 12,
+            },
+          },
+          fallback_policy: {
+            policy_version:
+              'canonical_probability_fallback_v1',
+            tiers: [
+              'exact_matchup',
+              'batter',
+              'pitcher',
+              'global',
+            ],
+          },
+          game_config: {
+            regulation_innings: 9,
+            max_extra_innings: 6,
+            automatic_runner_enabled: true,
+          },
+          dfs_rules: {
+            batter_rules_supplied: false,
+            pitcher_rules_supplied: false,
+          },
+          probability_records_exposed: false,
+          authoritative_source: 'legacy',
+        },
+      },
+    },
+  }
+}
+
+test('returns a stable empty view model', () => {
+  const view = buildCanonicalDiagnosticsViewModel()
+
+  assert.equal(
+    view.viewModelVersion,
+    CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION,
+  )
+  assert.equal(view.hasCanonicalShadow, false)
+  assert.equal(view.status.state, 'unavailable')
+  assert.equal(
+    view.status.authoritativeSource,
+    'legacy',
+  )
+  assert.deepEqual(view.warnings, [])
+})
+
+test('normalizes canonical status', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  assert.equal(view.hasCanonicalShadow, true)
+  assert.equal(view.status.state, 'complete')
+  assert.equal(view.status.enabled, true)
+  assert.equal(
+    view.status.canonicalAvailable,
+    true,
+  )
+  assert.equal(
+    view.status.canonicalSimulationCount,
+    3000,
+  )
+  assert.equal(
+    view.status.authoritativeSource,
+    'legacy',
+  )
+})
+
+test('normalizes probability coverage', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  assert.equal(view.coverage.available, true)
+  assert.equal(
+    view.coverage.totalResolutions,
+    100,
+  )
+  assert.equal(view.coverage.exactRate, 0.81)
+  assert.equal(
+    view.coverage.fallbackRate,
+    0.19,
+  )
+})
+
+test('preserves ordered fallback tiers', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  assert.deepEqual(
+    view.coverage.tiers.map(item => item.tier),
+    [
+      'exact_matchup',
+      'batter',
+      'pitcher',
+      'global',
+    ],
+  )
+})
+
+test('normalizes simulation integrity', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  const values = Object.fromEntries(
+    view.integrity.metrics.map(metric => [
+      metric.key,
+      metric.value,
+    ]),
+  )
+
+  assert.equal(
+    values.game_validation,
+    1,
+  )
+  assert.equal(
+    values.box_score_reconciliation,
+    1,
+  )
+  assert.equal(
+    values.replay_validation,
+    1,
+  )
+  assert.equal(
+    values.pitcher_attribution,
+    0.98,
+  )
+})
+
+test('normalizes atomic input provenance', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  assert.equal(view.provenance.available, true)
+  assert.equal(view.provenance.gamePk, 123)
+  assert.equal(
+    view.provenance.provider.name,
+    'provider',
+  )
+  assert.equal(
+    view.provenance.exactArtifact.recordCount,
+    50,
+  )
+  assert.equal(
+    view.provenance.fallbackCatalog.recordCount,
+    12,
+  )
+  assert.equal(
+    view.provenance.probabilityRecordsExposed,
+    false,
+  )
+})
+
+test('normalizes realism feature aliases and states', () => {
+  const view = buildCanonicalDiagnosticsViewModel(
+    sharedSimulation(),
+  )
+
+  const features = Object.fromEntries(
+    view.realism.features.map(feature => [
+      feature.key,
+      feature.status,
+    ]),
+  )
+
+  assert.equal(
+    features.base_out_state,
+    'enabled',
+  )
+  assert.equal(
+    features.runner_advancement,
+    'enabled',
+  )
+  assert.equal(
+    features.automatic_runner,
+    'enabled',
+  )
+  assert.equal(
+    features.multi_out_scoring,
+    'enabled',
+  )
+  assert.equal(
+    features.stolen_bases,
+    'deferred',
+  )
+})
+
+test('collects and deduplicates warnings', () => {
+  const payload = sharedSimulation()
+
+  payload.diagnostics.canonical_shadow.warnings = [
+    'legacy_authority_retained',
+    'legacy_authority_retained',
+  ]
+
+  payload.diagnostics.canonical_shadow
+    .probability_resolution = {
+      status: 'error',
+      error_message: 'probability diagnostics failed',
+    }
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.deepEqual(view.warnings, [
+    'legacy_authority_retained',
+    'probability diagnostics failed',
+  ])
+})
+
+test('does not mutate the source payload', () => {
+  const payload = sharedSimulation()
+  const snapshot = structuredClone(payload)
+
+  buildCanonicalDiagnosticsViewModel(payload)
+
+  assert.deepEqual(payload, snapshot)
+})


### PR DESCRIPTION
## Summary

Implements the twenty-second Layer 10J slice: a frontend-facing canonical diagnostics view-model adapter that converts the atomic canonical shadow payload into a stable presentation contract for the upcoming Diagnostics UI redesign.

The adapter normalizes canonical status, game-state realism, probability coverage, simulation integrity, atomic input provenance, warnings, and the raw canonical shadow payload without mutating the source response. It is intentionally UI-agnostic so React components no longer need to navigate deeply nested backend contracts directly.

## Added

- `CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION`
- `buildCanonicalDiagnosticsViewModel()`
- Stable canonical status normalization
- Canonical availability and authority-state normalization
- Game-state realism feature aliases and states
- Probability-resolution coverage summaries
- Ordered fallback-tier normalization
- Simulation-integrity metrics
- Atomic input-provenance normalization
- Warning aggregation and deduplication
- Stable empty/unavailable state
- Source-payload non-mutation guarantee
- Focused Node test coverage
- Frontend test-script registration

## Architecture

```text
atomic canonical shadow payload
        ↓
buildCanonicalDiagnosticsViewModel()
        ↓
status
realism
probability coverage
simulation integrity
input provenance
warnings
raw advanced payload
```

## Contract guarantees

- Missing canonical data returns a stable unavailable view model.
- Legacy remains the default authoritative source.
- Exact and fallback resolution coverage are normalized consistently.
- Fallback tiers preserve backend ordering.
- Realism fields tolerate current aliases and deferred states.
- Input provenance remains presentation-safe and does not expose probability records.
- Source payloads are never mutated.
- The adapter is independent of React rendering.

## Scope

This slice intentionally does not:

- change the visible Diagnostics tab;
- remove legacy diagnostic model cards;
- render canonical status or provenance panels;
- alter backend simulation output;
- activate canonical output as production authority;
- change model-tracker ranking or deduplication behavior.

## Validation

- Focused canonical diagnostics view-model tests passed: `9 passed`
- Vite production build passed
- `git diff --check` passed
- Full frontend test suite currently has one unrelated upstream baseline failure in `modelTrackerPnl.test.mjs`; this branch does not modify either the implementation or that test

Existing unrelated Vite warnings remain in `LandingV2Page.jsx` for duplicate style-object keys and bundle size.

## Files

- `frontend/package.json`
- `frontend/src/lib/canonicalDiagnosticsViewModel.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs`

## Next slice

Wire this adapter into `ModelProjectionsPage`, remove the legacy diagnostic model cards, and replace the raw-first Diagnostics tab with a compact canonical dashboard for status, realism, probability coverage, simulation integrity, provenance, warnings, and an advanced raw-payload disclosure.