### PR TITLE
Handle canonical diagnostics not-run state

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
@@ -66,3 +66,29 @@ test('realism diagnostics live inside diagnostics tab', async () => {
     /Game-State Realism/,
   )
 })
+
+test('not-run state hides empty canonical panels', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /Not run for this payload/,
+  )
+  assert.match(
+    source,
+    /view\.hasCanonicalShadow/,
+  )
+  assert.match(
+    source,
+    /status\.availabilityReason/,
+  )
+})
+
+test('raw canonical payload requires canonical shadow data', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /view\.hasCanonicalShadow \? \(\s*<details/,
+  )
+})

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -554,7 +554,16 @@ export function buildCanonicalDiagnosticsViewModel(
     shadow.status,
     hasCanonicalShadow
       ? 'unknown'
-      : 'unavailable',
+      : 'not_run',
+  )
+
+  const availabilityReason = (
+    hasCanonicalShadow
+      ? null
+      : (
+        'Canonical shadow execution was not attached ' +
+        'to this simulation payload.'
+      )
   )
 
   return {
@@ -586,6 +595,7 @@ export function buildCanonicalDiagnosticsViewModel(
         shadow.schema_version || null,
       errorType: shadow.error_type || null,
       errorMessage: shadow.error_message || null,
+      availabilityReason,
     },
 
     realism: buildRealism(shared, shadow),

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -133,10 +133,14 @@ test('returns a stable empty view model', () => {
     CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION,
   )
   assert.equal(view.hasCanonicalShadow, false)
-  assert.equal(view.status.state, 'unavailable')
+  assert.equal(view.status.state, 'not_run')
   assert.equal(
     view.status.authoritativeSource,
     'legacy',
+  )
+  assert.match(
+    view.status.availabilityReason,
+    /not attached/,
   )
   assert.deepEqual(view.warnings, [])
 })

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -793,10 +793,15 @@ function statusPresentation(state) {
 
   if (
     normalized === 'disabled' ||
-    normalized === 'unavailable'
+    normalized === 'unavailable' ||
+    normalized === 'not_run'
   ) {
     return {
-      label: label(state || 'Unavailable'),
+      label: (
+        normalized === 'not_run'
+          ? 'Not run'
+          : label(state || 'Unavailable')
+      ),
       foreground: '#8b949e',
       background: '#21262d',
       symbol: '○',
@@ -940,53 +945,102 @@ function DiagnosticsTab({ game }) {
         <DiagnosticStatusBadge state={status.state} />
       </div>
 
-      <div style={s.splitGrid}>
-        <GenericPanel
-          title="Canonical Simulation"
-          subtitle={
-            status.modelVersion ||
-            'Canonical shadow simulation'
-          }
-          tag="Shadow"
-          tagTone="diagnostic"
+      {!view.hasCanonicalShadow ? (
+        <div
+          style={{
+            ...s.metricCard,
+            marginBottom: '16px',
+            borderColor: '#30363d',
+          }}
         >
-          <StatRow
-            k="Status"
-            v={status.label || status.state}
-            format="text"
-          />
-          <StatRow
-            k="Canonical Output"
-            v={
-              status.canonicalAvailable
-                ? 'Available'
-                : 'Unavailable'
-            }
-            format="text"
-          />
-          <StatRow
-            k="Authoritative Source"
-            v={status.authoritativeSource}
-            format="text"
-          />
-          <StatRow
-            k="Legacy Simulations"
-            v={status.legacySimulationCount}
-            format="num"
-          />
-          <StatRow
-            k="Canonical Simulations"
-            v={status.canonicalSimulationCount}
-            format="num"
-          />
-          <StatRow
-            k="Schema"
-            v={status.schemaVersion}
-            format="text"
-          />
-        </GenericPanel>
+          <div style={s.metricLabel}>
+            Canonical Simulation
+            <Tag tone="diagnostic">Shadow</Tag>
+          </div>
 
-        <GenericPanel title="Probability Coverage">
+          <h3
+            style={{
+              margin: '0 0 8px',
+              color: '#e6edf3',
+            }}
+          >
+            Not run for this payload
+          </h3>
+
+          <div
+            style={{
+              color: '#8b949e',
+              fontSize: '13px',
+              lineHeight: 1.6,
+            }}
+          >
+            {status.availabilityReason}
+            {' '}
+            The displayed projections remain sourced from the
+            legacy shared simulation.
+          </div>
+
+          <div style={{ marginTop: '12px' }}>
+            <StatRow
+              k="Authoritative Source"
+              v={status.authoritativeSource}
+              format="text"
+            />
+            <StatRow
+              k="Legacy Model"
+              v={status.modelVersion}
+              format="text"
+            />
+          </div>
+        </div>
+      ) : (
+        <div style={s.splitGrid}>
+          <GenericPanel
+            title="Canonical Simulation"
+            subtitle={
+              status.modelVersion ||
+              'Canonical shadow simulation'
+            }
+            tag="Shadow"
+            tagTone="diagnostic"
+          >
+            <StatRow
+              k="Status"
+              v={status.label || status.state}
+              format="text"
+            />
+            <StatRow
+              k="Canonical Output"
+              v={
+                status.canonicalAvailable
+                  ? 'Available'
+                  : 'Unavailable'
+              }
+              format="text"
+            />
+            <StatRow
+              k="Authoritative Source"
+              v={status.authoritativeSource}
+              format="text"
+            />
+            <StatRow
+              k="Legacy Simulations"
+              v={status.legacySimulationCount}
+              format="num"
+            />
+            <StatRow
+              k="Canonical Simulations"
+              v={status.canonicalSimulationCount}
+              format="num"
+            />
+            <StatRow
+              k="Schema"
+              v={status.schemaVersion}
+              format="text"
+            />
+          </GenericPanel>
+
+          <GenericPanel title="Probability Coverage">
           <StatRow
             k="Total Resolutions"
             v={coverage.totalResolutions}
@@ -1029,8 +1083,9 @@ function DiagnosticsTab({ game }) {
               ))}
             </div>
           ) : null}
-        </GenericPanel>
-      </div>
+          </GenericPanel>
+        </div>
+      )}
 
       <h3 style={s.sectionTitle}>
         Game-State Realism
@@ -1045,8 +1100,9 @@ function DiagnosticsTab({ game }) {
         ))}
       </div>
 
-      <div style={s.splitGrid}>
-        <GenericPanel title="Simulation Integrity">
+      {view.hasCanonicalShadow ? (
+        <div style={s.splitGrid}>
+          <GenericPanel title="Simulation Integrity">
           {integrity.metrics.map(metric => (
             <StatRow
               key={metric.key}
@@ -1122,8 +1178,9 @@ function DiagnosticsTab({ game }) {
               format="text"
             />
           ) : null}
-        </GenericPanel>
-      </div>
+          </GenericPanel>
+        </div>
+      ) : null}
 
       {view.warnings.length ? (
         <>
@@ -1137,19 +1194,21 @@ function DiagnosticsTab({ game }) {
         </>
       ) : null}
 
-      <details style={s.details}>
-        <summary style={s.summary}>
-          Advanced: raw canonical payload
-        </summary>
+      {view.hasCanonicalShadow ? (
+        <details style={s.details}>
+          <summary style={s.summary}>
+            Advanced: raw canonical payload
+          </summary>
 
-        <pre style={s.rawPayload}>
-          {JSON.stringify(
-            view.raw.canonicalShadow,
-            null,
-            2,
-          )}
-        </pre>
-      </details>
+          <pre style={s.rawPayload}>
+            {JSON.stringify(
+              view.raw.canonicalShadow,
+              null,
+              2,
+            )}
+          </pre>
+        </details>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Refines the Model Projections Diagnostics tab for payloads where canonical shadow execution was not attached.

Instead of rendering a generic unavailable state plus empty Probability Coverage, Simulation Integrity, Input Provenance, and raw-payload panels, the page now presents a compact, explicit “Not run for this payload” explanation while continuing to show independently available game-state realism diagnostics.

## Added

- Explicit `not_run` canonical diagnostics state
- Availability-reason text in the frontend view model
- Compact not-run explanatory panel
- Legacy-authority and legacy-model context
- Conditional rendering for canonical-only panels
- Conditional raw canonical payload disclosure
- Focused UI contract coverage for not-run behavior

## Behavior

When `diagnostics.canonical_shadow` is absent:

- Status displays `Not run`
- The page explains that canonical shadow execution was not attached
- Legacy shared simulation remains labeled as authoritative
- Game-state realism continues to render
- Empty Probability Coverage is hidden
- Empty Simulation Integrity is hidden
- Empty Input Provenance is hidden
- Empty raw canonical JSON is hidden

When canonical shadow data exists, the full structured diagnostics dashboard remains unchanged.

## Architecture

```text
shared simulation payload
        ↓
buildCanonicalDiagnosticsViewModel()
        ↓
canonical shadow present?
    ├─ yes → full canonical dashboard
    └─ no  → compact not-run state + realism diagnostics
```

## Contract guarantees

- Missing canonical shadow data is distinguished from an execution error.
- Legacy remains the authoritative source.
- Independently available realism diagnostics are preserved.
- Canonical-only panels render only when canonical shadow data exists.
- Source payloads remain unmodified.
- Existing canonical-present behavior is preserved.

## Validation

- Canonical diagnostics view-model tests passed
- Canonical diagnostics UI contract tests passed
- Focused result: `15 passed`
- Vite production build passed
- `git diff --check` passed

Existing unrelated Vite warnings remain in `LandingV2Page.jsx` for duplicate style-object keys and bundle size.

## Files

- `frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs`
- `frontend/src/pages/ModelProjectionsPage.jsx`

## Next slice

After this merges, the next useful product slice is either:

1. enable/inject canonical shadow execution for `/models/projections` so the dashboard receives real coverage, integrity, and provenance data; or
2. continue broader Simulation/Overview presentation polish if canonical execution activation remains intentionally deferred.