### PR TITLE
Add canonical shadow bootstrap readiness

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -17,6 +17,9 @@ from .team_offense_prior import build_team_offense_prior
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
 from .simulation.game_simulator import simulate_game_with_bullpen
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+)
 
 
 def _build_game_state_realism_diagnostics() -> dict:
@@ -618,6 +621,25 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             home["models"].extend(simulation_cards.get("home", []))
             workspace = simulation_cards.get("workspace") or {}
 
+            game_pk = (
+                matchup.get("game_pk")
+                or matchup.get("gamePk")
+            )
+
+            canonical_shadow_bootstrap_readiness = (
+                build_canonical_shadow_bootstrap_readiness(
+                    game_pk=game_pk,
+                    matchup=matchup,
+                    away_context=away,
+                    home_context=home,
+                    workspace=workspace,
+                )
+            )
+
+            workspace[
+                "canonicalShadowBootstrapReadiness"
+            ] = canonical_shadow_bootstrap_readiness
+
             try:
                 shared_simulation = build_shared_game_simulation(
                     game_pk=matchup.get("game_pk") or matchup.get("gamePk"),
@@ -632,6 +654,31 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             except Exception as shared_exc:
                 shared_simulation = {"status": "error", "error": str(shared_exc), "meta": {"game_pk": matchup.get("game_pk") or matchup.get("gamePk"), "source_route": "/models/projections"}}
+
+            if isinstance(shared_simulation, dict):
+                shared_diagnostics = (
+                    shared_simulation.setdefault(
+                        "diagnostics",
+                        {},
+                    )
+                )
+
+                if not isinstance(
+                    shared_diagnostics,
+                    dict,
+                ):
+                    shared_diagnostics = {
+                        "legacy_diagnostics": (
+                            shared_diagnostics
+                        )
+                    }
+                    shared_simulation[
+                        "diagnostics"
+                    ] = shared_diagnostics
+
+                shared_diagnostics[
+                    "canonical_shadow_bootstrap_readiness"
+                ] = canonical_shadow_bootstrap_readiness
 
             shared_outputs = shared_simulation.get("derived_outputs", {}) if isinstance(shared_simulation, dict) else {}
             shared_game_sim = shared_outputs.get("game_simulation", {}) or {}
@@ -652,6 +699,9 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             games.append({
                 "game_pk": matchup.get("game_pk"),
                 "game_state_realism": _build_game_state_realism_diagnostics(),
+                "canonical_shadow_bootstrap_readiness": (
+                    canonical_shadow_bootstrap_readiness
+                ),
                 "sharedSimulation": shared_simulation,
                 "game_date": matchup.get("game_date") or target_date,
                 "game_time": matchup.get("game_time"),

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -1,6 +1,10 @@
 """Canonical production-shadow comparison integration."""
 
 from .comparator import compare_shadow_payloads
+from .bootstrap_readiness import (
+    CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION,
+    build_canonical_shadow_bootstrap_readiness,
+)
 from .contracts import (
     SHADOW_SCHEMA_VERSION,
     CanonicalShadowDiagnostics,
@@ -40,6 +44,7 @@ from .probability_serialization import (
 
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
+    "CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
@@ -55,6 +60,7 @@ __all__ = [
     "ShadowCoverage",
     "attach_canonical_shadow",
     "assemble_canonical_shadow_execution_inputs",
+    "build_canonical_shadow_bootstrap_readiness",
     "canonical_shadow_execution_bundle_to_material",
     "canonical_shadow_input_provenance_to_dict",
     "build_canonical_shadow_execution_bundle_factory",

--- a/mlb_app/simulation/shadow/bootstrap_readiness.py
+++ b/mlb_app/simulation/shadow/bootstrap_readiness.py
@@ -1,0 +1,343 @@
+"""Fail-open canonical shadow bootstrap-readiness diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+
+
+CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION = (
+    "canonical_shadow_bootstrap_readiness_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_present(
+    source: Mapping[str, Any],
+    keys: Iterable[str],
+) -> tuple[Any, Optional[str]]:
+    for key in keys:
+        value = source.get(key)
+        if value not in (None, "", [], {}):
+            return value, key
+
+    return None, None
+
+
+def _normalize_identifier(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+
+    if isinstance(value, bool):
+        return None
+
+    return str(value)
+
+
+def _extract_identifier_from_record(
+    record: Any,
+) -> Optional[str]:
+    if isinstance(record, Mapping):
+        for key in (
+            "player_id",
+            "playerId",
+            "id",
+            "mlb_id",
+            "mlbId",
+            "batter_id",
+            "pitcher_id",
+        ):
+            identifier = _normalize_identifier(
+                record.get(key)
+            )
+
+            if identifier is not None:
+                return identifier
+
+        return None
+
+    return _normalize_identifier(record)
+
+
+def _extract_identifiers(
+    value: Any,
+) -> tuple[str, ...]:
+    if isinstance(value, Mapping):
+        nested, _ = _first_present(
+            value,
+            (
+                "players",
+                "lineup",
+                "batting_order",
+                "battingOrder",
+                "pitchers",
+                "bullpen",
+                "relievers",
+                "ids",
+            ),
+        )
+
+        if nested is None:
+            identifier = _extract_identifier_from_record(
+                value
+            )
+            return (
+                (identifier,)
+                if identifier is not None
+                else ()
+            )
+
+        return _extract_identifiers(nested)
+
+    if not isinstance(value, Sequence) or isinstance(
+        value,
+        (str, bytes),
+    ):
+        identifier = _extract_identifier_from_record(
+            value
+        )
+        return (
+            (identifier,)
+            if identifier is not None
+            else ()
+        )
+
+    identifiers = []
+
+    for record in value:
+        identifier = _extract_identifier_from_record(
+            record
+        )
+
+        if (
+            identifier is not None
+            and identifier not in identifiers
+        ):
+            identifiers.append(identifier)
+
+    return tuple(identifiers)
+
+
+def _lineup_requirement(
+    matchup: Mapping[str, Any],
+    *,
+    side: str,
+) -> Dict[str, Any]:
+    raw, source = _first_present(
+        matchup,
+        (
+            f"{side}_lineup",
+            f"{side}Lineup",
+            f"{side}_confirmed_lineup",
+            f"{side}_projected_lineup",
+            f"{side}_batting_order",
+        ),
+    )
+
+    identifiers = _extract_identifiers(raw)
+
+    return {
+        "ready": len(identifiers) == 9,
+        "source": source,
+        "player_count": len(identifiers),
+        "required_player_count": 9,
+    }
+
+
+def _starter_requirement(
+    matchup: Mapping[str, Any],
+    context: Mapping[str, Any],
+    *,
+    side: str,
+) -> Dict[str, Any]:
+    raw, source = _first_present(
+        matchup,
+        (
+            f"{side}_pitcher_id",
+            f"{side}_starter_id",
+            f"{side}PitcherId",
+            f"{side}StarterId",
+        ),
+    )
+
+    if raw in (None, ""):
+        raw, context_source = _first_present(
+            context,
+            (
+                "pitcher_id",
+                "starter_id",
+            ),
+        )
+        source = (
+            f"{side}_context.{context_source}"
+            if context_source
+            else None
+        )
+
+    identifier = _normalize_identifier(raw)
+
+    return {
+        "ready": identifier is not None,
+        "source": source,
+        "pitcher_id_present": identifier is not None,
+    }
+
+
+def _bullpen_requirement(
+    matchup: Mapping[str, Any],
+    context: Mapping[str, Any],
+    *,
+    side: str,
+) -> Dict[str, Any]:
+    raw, source = _first_present(
+        matchup,
+        (
+            f"{side}_bullpen_pitcher_ids",
+            f"{side}_bullpen",
+            f"{side}_relief_pitchers",
+            f"{side}_relievers",
+        ),
+    )
+
+    if raw in (None, "", [], {}):
+        raw, context_source = _first_present(
+            context,
+            (
+                "bullpen_pitcher_ids",
+                "bullpen_pitchers",
+                "relievers",
+            ),
+        )
+        source = (
+            f"{side}_context.{context_source}"
+            if context_source
+            else None
+        )
+
+    identifiers = _extract_identifiers(raw)
+
+    return {
+        "ready": len(identifiers) > 0,
+        "source": source,
+        "pitcher_count": len(identifiers),
+        "minimum_pitcher_count": 1,
+    }
+
+
+def _workspace_requirement(
+    workspace: Mapping[str, Any],
+    *,
+    keys: Sequence[str],
+) -> Dict[str, Any]:
+    raw, source = _first_present(
+        workspace,
+        keys,
+    )
+
+    return {
+        "ready": raw not in (None, "", [], {}),
+        "source": source,
+    }
+
+
+def build_canonical_shadow_bootstrap_readiness(
+    *,
+    game_pk: Any,
+    matchup: Optional[Mapping[str, Any]],
+    away_context: Optional[Mapping[str, Any]],
+    home_context: Optional[Mapping[str, Any]],
+    workspace: Optional[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """
+    Report whether production data can assemble canonical execution inputs.
+
+    This function performs discovery diagnostics only. It does not construct
+    canonical contracts, run simulations, expose probability rows, or change
+    production authority.
+    """
+
+    matchup_data = _mapping(matchup)
+    away_data = _mapping(away_context)
+    home_data = _mapping(home_context)
+    workspace_data = _mapping(workspace)
+
+    requirements = {
+        "game_identity": {
+            "ready": game_pk not in (None, ""),
+            "source": "game_pk",
+        },
+        "away_lineup": _lineup_requirement(
+            matchup_data,
+            side="away",
+        ),
+        "home_lineup": _lineup_requirement(
+            matchup_data,
+            side="home",
+        ),
+        "away_starter": _starter_requirement(
+            matchup_data,
+            away_data,
+            side="away",
+        ),
+        "home_starter": _starter_requirement(
+            matchup_data,
+            home_data,
+            side="home",
+        ),
+        "away_bullpen": _bullpen_requirement(
+            matchup_data,
+            away_data,
+            side="away",
+        ),
+        "home_bullpen": _bullpen_requirement(
+            matchup_data,
+            home_data,
+            side="home",
+        ),
+        "probability_provider": _workspace_requirement(
+            workspace_data,
+            keys=(
+                "canonicalProbabilityProvider",
+                "canonical_probability_provider",
+            ),
+        ),
+        "exact_probability_artifact": _workspace_requirement(
+            workspace_data,
+            keys=(
+                "canonicalExactProbabilityArtifact",
+                "canonical_exact_probability_artifact",
+            ),
+        ),
+        "fallback_probability_catalog": _workspace_requirement(
+            workspace_data,
+            keys=(
+                "canonicalProbabilityFallbackCatalog",
+                "canonical_probability_fallback_catalog",
+            ),
+        ),
+    }
+
+    missing_requirements = [
+        name
+        for name, requirement in requirements.items()
+        if requirement["ready"] is not True
+    ]
+
+    ready = not missing_requirements
+
+    return {
+        "schema_version": (
+            CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION
+        ),
+        "status": "ready" if ready else "blocked",
+        "ready": ready,
+        "game_pk": game_pk,
+        "requirements": requirements,
+        "missing_requirements": missing_requirements,
+        "activation_permitted": False,
+        "activation_status": "diagnostic_only",
+        "probability_records_exposed": False,
+        "authoritative_source": "legacy",
+    }

--- a/tests/test_canonical_shadow_bootstrap_readiness.py
+++ b/tests/test_canonical_shadow_bootstrap_readiness.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION,
+    build_canonical_shadow_bootstrap_readiness,
+)
+
+
+def complete_matchup():
+    return {
+        "game_pk": 123,
+        "away_lineup": [
+            {"player_id": f"away_{index}"}
+            for index in range(9)
+        ],
+        "home_lineup": [
+            {"player_id": f"home_{index}"}
+            for index in range(9)
+        ],
+        "away_pitcher_id": 101,
+        "home_pitcher_id": 201,
+        "away_bullpen_pitcher_ids": [
+            102,
+            103,
+        ],
+        "home_bullpen_pitcher_ids": [
+            202,
+            203,
+        ],
+    }
+
+
+def complete_workspace():
+    return {
+        "canonicalProbabilityProvider": {
+            "provider_name": "test",
+        },
+        "canonicalExactProbabilityArtifact": {
+            "artifact_version": "v1",
+        },
+        "canonicalProbabilityFallbackCatalog": {
+            "catalog_version": "v1",
+        },
+    }
+
+
+def test_complete_inputs_report_ready_without_activation():
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=complete_matchup(),
+        away_context={},
+        home_context={},
+        workspace=complete_workspace(),
+    )
+
+    assert report["schema_version"] == (
+        CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION
+    )
+    assert report["status"] == "ready"
+    assert report["ready"] is True
+    assert report["missing_requirements"] == []
+    assert report["activation_permitted"] is False
+    assert report["authoritative_source"] == "legacy"
+    assert report["probability_records_exposed"] is False
+
+
+def test_current_team_prior_shape_reports_real_blockers():
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=824410,
+        matchup={
+            "game_pk": 824410,
+            "away_pitcher_id": 101,
+            "home_pitcher_id": 201,
+        },
+        away_context={
+            "pitcher_id": 101,
+            "offense_inputs": {
+                "source": "team_splits",
+            },
+        },
+        home_context={
+            "pitcher_id": 201,
+            "offense_inputs": {
+                "source": "team_splits",
+            },
+        },
+        workspace={
+            "awayPAOutcomeModel": {
+                "probabilities": {
+                    "strikeout": 0.2,
+                },
+            },
+            "homePAOutcomeModel": {
+                "probabilities": {
+                    "strikeout": 0.2,
+                },
+            },
+        },
+    )
+
+    assert report["status"] == "blocked"
+    assert report["ready"] is False
+
+    assert report["requirements"][
+        "away_starter"
+    ]["ready"] is True
+
+    assert report["requirements"][
+        "home_starter"
+    ]["ready"] is True
+
+    assert report["requirements"][
+        "away_lineup"
+    ]["player_count"] == 0
+
+    assert report["requirements"][
+        "home_lineup"
+    ]["player_count"] == 0
+
+    assert report["missing_requirements"] == [
+        "away_lineup",
+        "home_lineup",
+        "away_bullpen",
+        "home_bullpen",
+        "probability_provider",
+        "exact_probability_artifact",
+        "fallback_probability_catalog",
+    ]
+
+
+def test_lineup_requires_exactly_nine_unique_ids():
+    matchup = complete_matchup()
+    matchup["away_lineup"] = [
+        {"player_id": "duplicate"}
+        for _ in range(9)
+    ]
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={},
+        home_context={},
+        workspace=complete_workspace(),
+    )
+
+    assert report["requirements"][
+        "away_lineup"
+    ]["ready"] is False
+
+    assert report["requirements"][
+        "away_lineup"
+    ]["player_count"] == 1
+
+
+def test_context_starter_fallback_is_observed():
+    matchup = complete_matchup()
+    matchup.pop("away_pitcher_id")
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={
+            "pitcher_id": 999,
+        },
+        home_context={},
+        workspace=complete_workspace(),
+    )
+
+    away_starter = report[
+        "requirements"
+    ]["away_starter"]
+
+    assert away_starter["ready"] is True
+    assert away_starter["source"] == (
+        "away_context.pitcher_id"
+    )
+
+
+def test_missing_game_identity_is_reported():
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=None,
+        matchup={},
+        away_context={},
+        home_context={},
+        workspace={},
+    )
+
+    assert report["status"] == "blocked"
+    assert report["requirements"][
+        "game_identity"
+    ]["ready"] is False
+
+    assert report["missing_requirements"][0] == (
+        "game_identity"
+    )
+
+
+def test_input_objects_are_not_mutated():
+    matchup = complete_matchup()
+    away_context = {
+        "pitcher_id": 101,
+    }
+    home_context = {
+        "pitcher_id": 201,
+    }
+    workspace = complete_workspace()
+
+    matchup_snapshot = repr(matchup)
+    away_snapshot = repr(away_context)
+    home_snapshot = repr(home_context)
+    workspace_snapshot = repr(workspace)
+
+    build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context=away_context,
+        home_context=home_context,
+        workspace=workspace,
+    )
+
+    assert repr(matchup) == matchup_snapshot
+    assert repr(away_context) == away_snapshot
+    assert repr(home_context) == home_snapshot
+    assert repr(workspace) == workspace_snapshot


### PR DESCRIPTION
## Summary

Implements the next Layer 10J production-facing slice: fail-open canonical shadow bootstrap-readiness diagnostics for `/models/projections`.

The route now evaluates whether each game has enough real production data to assemble canonical shadow execution inputs. It reports exact blockers for lineups, starters, bullpen plans, provider identity, exact probability artifacts, and fallback catalogs without fabricating any player-level data or activating canonical execution.

## Added

- `CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION`
- `build_canonical_shadow_bootstrap_readiness()`
- Game identity readiness
- Away/home lineup readiness with exact nine-player validation
- Starter readiness with matchup and side-context fallback
- Bullpen pitching-plan readiness
- Probability-provider readiness
- Exact probability-artifact readiness
- Fallback probability-catalog readiness
- Ordered missing-requirement reporting
- Explicit diagnostic-only activation status
- Legacy-authority preservation
- Probability-record non-exposure guarantee
- `/models/projections` attachment at game, workspace, and shared-diagnostics levels
- Focused tests for ready, blocked, duplicate-lineup, context-fallback, missing-game, and non-mutation cases

## Architecture

```text
/models/projections game inputs
        ↓
build_canonical_shadow_bootstrap_readiness()
        ↓
ready?
    ├─ no  → exact missing requirements
    └─ yes → eligible for later explicit activation
```

## Contract guarantees

- This slice does not run canonical simulations.
- This slice does not construct canonical contracts.
- This slice does not fabricate lineups, bullpen plans, providers, artifacts, or catalogs.
- Existing team-level offense priors are not treated as lineup-level inputs.
- Exactly nine unique player IDs are required per lineup.
- At least one bullpen pitcher ID is required per side.
- Provider, exact artifact, and fallback catalog must be explicitly present.
- Activation remains prohibited and diagnostic-only.
- Legacy output remains authoritative.
- Probability records are never exposed.
- Input objects are not mutated.

## Current expected blockers

For current team-prior Model Projections payloads, readiness is expected to report blockers such as:

- away lineup
- home lineup
- away bullpen pitching plan
- home bullpen pitching plan
- probability provider identity
- exact probability artifact
- fallback probability catalog

## Validation

- Bootstrap-readiness tests passed: `6 passed`
- Combined canonical input/provenance/readiness tests passed: `30 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/bootstrap_readiness.py`
- `tests/test_canonical_shadow_bootstrap_readiness.py`

## Next slice

Expose the bootstrap-readiness report in the Diagnostics UI so the not-run state explains the exact production blockers, then connect real discovery adapters for those missing inputs one contract at a time before canonical shadow activation.