### PR TITLE
Show canonical bootstrap readiness blockers

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
@@ -92,3 +92,24 @@ test('raw canonical payload requires canonical shadow data', async () => {
     /view\.hasCanonicalShadow \? \(\s*<details/,
   )
 })
+
+test('not-run state renders bootstrap readiness blockers', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /Activation readiness/,
+  )
+  assert.match(
+    source,
+    /bootstrap\.items\.map/,
+  )
+  assert.match(
+    source,
+    /bootstrap\.readyCount/,
+  )
+  assert.match(
+    source,
+    /Diagnostic only\. Readiness does not permit/,
+  )
+})

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -1,6 +1,25 @@
 export const CANONICAL_DIAGNOSTICS_VIEW_MODEL_VERSION =
   'canonical_diagnostics_view_model_v1'
 
+const BOOTSTRAP_REQUIREMENTS = [
+  ['game_identity', 'Game identity'],
+  ['away_lineup', 'Away lineup'],
+  ['home_lineup', 'Home lineup'],
+  ['away_starter', 'Away starter'],
+  ['home_starter', 'Home starter'],
+  ['away_bullpen', 'Away bullpen plan'],
+  ['home_bullpen', 'Home bullpen plan'],
+  ['probability_provider', 'Probability provider'],
+  [
+    'exact_probability_artifact',
+    'Exact probability artifact',
+  ],
+  [
+    'fallback_probability_catalog',
+    'Fallback probability catalog',
+  ],
+]
+
 const REALISM_FEATURES = [
   {
     key: 'base_out_state',
@@ -238,6 +257,108 @@ function uniqueStrings(values) {
     ),
   ]
 }
+
+function buildBootstrapReadiness(
+  sharedSimulation,
+) {
+  const diagnostics = objectValue(
+    sharedSimulation.diagnostics
+  )
+
+  const report = {
+    ...objectValue(
+      diagnostics
+        .canonical_shadow_bootstrap_readiness
+    ),
+    ...objectValue(
+      sharedSimulation
+        .canonical_shadow_bootstrap_readiness
+    ),
+  }
+
+  const requirements = objectValue(
+    report.requirements
+  )
+
+  const items = BOOTSTRAP_REQUIREMENTS.map(
+    ([key, labelText]) => {
+      const requirement = objectValue(
+        requirements[key]
+      )
+
+      const ready = requirement.ready === true
+
+      let detail = null
+
+      if (
+        key.endsWith('_lineup') &&
+        finiteNumber(
+          requirement.player_count
+        ) !== null
+      ) {
+        detail = (
+          `${requirement.player_count} of ` +
+          `${requirement.required_player_count || 9} players`
+        )
+      } else if (
+        key.endsWith('_bullpen') &&
+        finiteNumber(
+          requirement.pitcher_count
+        ) !== null
+      ) {
+        detail = (
+          `${requirement.pitcher_count} pitchers`
+        )
+      } else if (requirement.source) {
+        detail = humanize(requirement.source)
+      }
+
+      return {
+        key,
+        label: labelText,
+        ready,
+        status: ready ? 'ready' : 'blocked',
+        detail,
+        source: requirement.source || null,
+      }
+    }
+  )
+
+  const readyCount = items.filter(
+    item => item.ready
+  ).length
+
+  const missingRequirements = arrayValue(
+    report.missing_requirements
+  ).map(String)
+
+  return {
+    available: Object.keys(report).length > 0,
+    schemaVersion:
+      report.schema_version || null,
+    status: report.status || null,
+    ready: report.ready === true,
+    gamePk: firstPresent(
+      report.game_pk,
+      null,
+    ),
+    readyCount,
+    totalCount: items.length,
+    blockedCount: items.length - readyCount,
+    items,
+    missingRequirements,
+    activationPermitted:
+      report.activation_permitted === true,
+    activationStatus:
+      report.activation_status || null,
+    probabilityRecordsExposed:
+      report.probability_records_exposed ??
+      null,
+    authoritativeSource:
+      report.authoritative_source || 'legacy',
+  }
+}
+
 
 function buildRealism(sharedSimulation, shadow) {
   const diagnostics = objectValue(
@@ -546,6 +667,10 @@ export function buildCanonicalDiagnosticsViewModel(
   const hasCanonicalShadow =
     Object.keys(shadow).length > 0
 
+  const bootstrapReadiness = (
+    buildBootstrapReadiness(shared)
+  )
+
   const canonicalAvailable = Boolean(
     shadow.canonical_available
   )
@@ -561,8 +686,17 @@ export function buildCanonicalDiagnosticsViewModel(
     hasCanonicalShadow
       ? null
       : (
-        'Canonical shadow execution was not attached ' +
-        'to this simulation payload.'
+        bootstrapReadiness.available &&
+        bootstrapReadiness.blockedCount > 0
+          ? (
+            'Canonical shadow execution is blocked by ' +
+            `${bootstrapReadiness.blockedCount} missing ` +
+            'production requirements.'
+          )
+          : (
+            'Canonical shadow execution was not attached ' +
+            'to this simulation payload.'
+          )
       )
   )
 
@@ -598,6 +732,7 @@ export function buildCanonicalDiagnosticsViewModel(
       availabilityReason,
     },
 
+    bootstrapReadiness,
     realism: buildRealism(shared, shadow),
     coverage: buildCoverage(shadow),
     integrity: buildIntegrity(shadow),
@@ -606,6 +741,10 @@ export function buildCanonicalDiagnosticsViewModel(
 
     raw: {
       canonicalShadow: shadow,
+      bootstrapReadiness: objectValue(
+        diagnostics
+          .canonical_shadow_bootstrap_readiness
+      ),
     },
   }
 }

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -22,6 +22,67 @@ function sharedSimulation() {
       steals_model: 'deferred_not_active',
     },
     diagnostics: {
+      canonical_shadow_bootstrap_readiness: {
+        schema_version:
+          'canonical_shadow_bootstrap_readiness_v1',
+        status: 'blocked',
+        ready: false,
+        game_pk: 123,
+        requirements: {
+          game_identity: {
+            ready: true,
+            source: 'game_pk',
+          },
+          away_lineup: {
+            ready: false,
+            player_count: 0,
+            required_player_count: 9,
+          },
+          home_lineup: {
+            ready: false,
+            player_count: 0,
+            required_player_count: 9,
+          },
+          away_starter: {
+            ready: true,
+            source: 'away_pitcher_id',
+          },
+          home_starter: {
+            ready: true,
+            source: 'home_pitcher_id',
+          },
+          away_bullpen: {
+            ready: false,
+            pitcher_count: 0,
+          },
+          home_bullpen: {
+            ready: false,
+            pitcher_count: 0,
+          },
+          probability_provider: {
+            ready: false,
+          },
+          exact_probability_artifact: {
+            ready: false,
+          },
+          fallback_probability_catalog: {
+            ready: false,
+          },
+        },
+        missing_requirements: [
+          'away_lineup',
+          'home_lineup',
+          'away_bullpen',
+          'home_bullpen',
+          'probability_provider',
+          'exact_probability_artifact',
+          'fallback_probability_catalog',
+        ],
+        activation_permitted: false,
+        activation_status: 'diagnostic_only',
+        probability_records_exposed: false,
+        authoritative_source: 'legacy',
+      },
       canonical_shadow: {
         status: 'complete',
         enabled: true,
@@ -143,6 +204,77 @@ test('returns a stable empty view model', () => {
     /not attached/,
   )
   assert.deepEqual(view.warnings, [])
+})
+
+test('normalizes bootstrap readiness blockers', () => {
+  const payload = sharedSimulation()
+  delete payload.diagnostics.canonical_shadow
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.equal(
+    view.bootstrapReadiness.available,
+    true,
+  )
+  assert.equal(
+    view.bootstrapReadiness.status,
+    'blocked',
+  )
+  assert.equal(
+    view.bootstrapReadiness.readyCount,
+    3,
+  )
+  assert.equal(
+    view.bootstrapReadiness.blockedCount,
+    7,
+  )
+  assert.equal(
+    view.bootstrapReadiness.totalCount,
+    10,
+  )
+  assert.equal(
+    view.bootstrapReadiness
+      .activationPermitted,
+    false,
+  )
+  assert.match(
+    view.status.availabilityReason,
+    /7 missing production requirements/,
+  )
+})
+
+test('preserves ordered bootstrap requirements', () => {
+  const payload = sharedSimulation()
+  delete payload.diagnostics.canonical_shadow
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.deepEqual(
+    view.bootstrapReadiness.items.map(
+      item => item.key
+    ),
+    [
+      'game_identity',
+      'away_lineup',
+      'home_lineup',
+      'away_starter',
+      'home_starter',
+      'away_bullpen',
+      'home_bullpen',
+      'probability_provider',
+      'exact_probability_artifact',
+      'fallback_probability_catalog',
+    ],
+  )
+
+  assert.equal(
+    view.bootstrapReadiness.items[1].detail,
+    '0 of 9 players',
+  )
 })
 
 test('normalizes canonical status', () => {

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -912,6 +912,7 @@ function DiagnosticsTab({ game }) {
   })
 
   const status = view.status
+  const bootstrap = view.bootstrapReadiness
   const coverage = view.coverage
   const integrity = view.integrity
   const provenance = view.provenance
@@ -992,6 +993,94 @@ function DiagnosticsTab({ game }) {
               format="text"
             />
           </div>
+
+          {bootstrap.available ? (
+            <div style={{ marginTop: '18px' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: '8px',
+                  marginBottom: '10px',
+                }}
+              >
+                <div style={s.metricLabel}>
+                  Activation readiness
+                </div>
+
+                <span style={s.pill}>
+                  {bootstrap.readyCount} of{' '}
+                  {bootstrap.totalCount} ready
+                </span>
+              </div>
+
+              <div style={s.featureGrid}>
+                {bootstrap.items.map(item => (
+                  <div
+                    key={item.key}
+                    style={s.featureRow}
+                  >
+                    <span
+                      style={{
+                        ...s.featureIcon,
+                        color: (
+                          item.ready
+                            ? '#3fb950'
+                            : '#f85149'
+                        ),
+                        background: (
+                          item.ready
+                            ? 'rgba(46, 160, 67, 0.15)'
+                            : 'rgba(248, 81, 73, 0.15)'
+                        ),
+                      }}
+                    >
+                      {item.ready ? '✓' : '×'}
+                    </span>
+
+                    <div>
+                      <div
+                        style={{
+                          color: '#e6edf3',
+                          fontSize: '13px',
+                          fontWeight: 750,
+                        }}
+                      >
+                        {item.label}
+                      </div>
+
+                      {item.detail ? (
+                        <div
+                          style={{
+                            color: '#8b949e',
+                            fontSize: '11px',
+                            marginTop: '2px',
+                          }}
+                        >
+                          {item.detail}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div
+                style={{
+                  color: '#8b949e',
+                  fontSize: '12px',
+                  lineHeight: 1.5,
+                  marginTop: '10px',
+                }}
+              >
+                Diagnostic only. Readiness does not permit
+                activation or change the authoritative projection
+                source.
+              </div>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div style={s.splitGrid}>


### PR DESCRIPTION
## Summary

Implements the next Layer 10J Diagnostics UI slice: the canonical not-run state now consumes the backend bootstrap-readiness report and explains the exact production blockers preventing canonical shadow activation.

Instead of only saying that canonical execution was not attached, the page now shows ordered readiness requirements for game identity, lineups, starters, bullpen plans, probability provider, exact artifact, and fallback catalog. The UI preserves legacy authority and keeps activation explicitly diagnostic-only.

## Added

- Bootstrap-readiness normalization in `buildCanonicalDiagnosticsViewModel()`
- Stable ordered readiness requirement list
- Ready, blocked, and total requirement counts
- Lineup player-count details
- Bullpen pitcher-count details
- Requirement source details when available
- Blocker-aware canonical availability explanation
- Activation-readiness panel in the canonical not-run state
- Ready and blocked visual indicators
- Explicit diagnostic-only activation disclaimer
- Raw readiness payload retention in the view model
- Focused view-model and UI contract tests

## Architecture

```text
canonical_shadow_bootstrap_readiness
        ↓
buildCanonicalDiagnosticsViewModel()
        ↓
activation readiness
    ├─ game identity
    ├─ away/home lineups
    ├─ away/home starters
    ├─ away/home bullpen plans
    ├─ probability provider
    ├─ exact probability artifact
    └─ fallback probability catalog
```

## Example blocked state

```text
Activation readiness — 3 of 10 ready

✓ Game identity
✕ Away lineup — 0 of 9 players
✕ Home lineup — 0 of 9 players
✓ Away starter
✓ Home starter
✕ Away bullpen plan
✕ Home bullpen plan
✕ Probability provider
✕ Exact probability artifact
✕ Fallback probability catalog
```

## Contract guarantees

- Canonical execution remains disabled.
- Readiness does not grant activation permission.
- Legacy projections remain authoritative.
- Requirement ordering is stable.
- Missing readiness data preserves the existing generic not-run state.
- Existing canonical-present diagnostics remain unchanged.
- Probability records are not exposed.
- Source payloads are not mutated.

## Validation

- Canonical diagnostics view-model tests passed
- Canonical diagnostics UI contract tests passed
- Focused result: `18 passed`
- Vite production build passed
- `git diff --check` passed

Existing unrelated Vite warnings remain in `LandingV2Page.jsx` for duplicate style-object keys and bundle size.

## Files

- `frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs`
- `frontend/src/pages/ModelProjectionsPage.jsx`

## Next slice

Connect the first real production discovery adapter for canonical inputs, beginning with lineup discovery or bullpen pitching-plan discovery, and update readiness from blocked to ready only when validated identifiers are present.