### PR TITLE
Discover confirmed canonical lineups

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -19,6 +19,7 @@ from .simulation.game_simulator import simulate_game_with_bullpen
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_lineups,
 )
 
 
@@ -626,14 +627,35 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 or matchup.get("gamePk")
             )
 
+            canonical_shadow_lineup_discovery = (
+                discover_canonical_shadow_lineups(
+                    game_pk=game_pk,
+                )
+            )
+
+            canonical_readiness_matchup = dict(
+                matchup
+            )
+            canonical_readiness_matchup.update(
+                canonical_shadow_lineup_discovery
+                .readiness_matchup_fields()
+            )
+
             canonical_shadow_bootstrap_readiness = (
                 build_canonical_shadow_bootstrap_readiness(
                     game_pk=game_pk,
-                    matchup=matchup,
+                    matchup=canonical_readiness_matchup,
                     away_context=away,
                     home_context=home,
                     workspace=workspace,
                 )
+            )
+
+            workspace[
+                "canonicalShadowLineupDiscovery"
+            ] = (
+                canonical_shadow_lineup_discovery
+                .to_diagnostics()
             )
 
             workspace[
@@ -677,6 +699,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     ] = shared_diagnostics
 
                 shared_diagnostics[
+                    "canonical_shadow_lineup_discovery"
+                ] = (
+                    canonical_shadow_lineup_discovery
+                    .to_diagnostics()
+                )
+
+                shared_diagnostics[
                     "canonical_shadow_bootstrap_readiness"
                 ] = canonical_shadow_bootstrap_readiness
 
@@ -699,6 +728,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             games.append({
                 "game_pk": matchup.get("game_pk"),
                 "game_state_realism": _build_game_state_realism_diagnostics(),
+                "canonical_shadow_lineup_discovery": (
+                    canonical_shadow_lineup_discovery
+                    .to_diagnostics()
+                ),
                 "canonical_shadow_bootstrap_readiness": (
                     canonical_shadow_bootstrap_readiness
                 ),

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -23,6 +23,11 @@ from .execution_factory import (
     CanonicalShadowExecutionBundleFactory,
     build_canonical_shadow_execution_bundle_factory,
 )
+from .lineup_discovery import (
+    CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION,
+    CanonicalShadowLineupDiscovery,
+    discover_canonical_shadow_lineups,
+)
 from .input_assembly import (
     CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION,
     CanonicalShadowExecutionInputs,
@@ -48,12 +53,14 @@ __all__ = [
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
+    "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowExecutionBundle",
     "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionInputs",
+    "CanonicalShadowLineupDiscovery",
     "CanonicalShadowExecutionMaterial",
     "MetricComparison",
     "RangeComparison",
@@ -61,6 +68,7 @@ __all__ = [
     "attach_canonical_shadow",
     "assemble_canonical_shadow_execution_inputs",
     "build_canonical_shadow_bootstrap_readiness",
+    "discover_canonical_shadow_lineups",
     "canonical_shadow_execution_bundle_to_material",
     "canonical_shadow_input_provenance_to_dict",
     "build_canonical_shadow_execution_bundle_factory",

--- a/mlb_app/simulation/shadow/lineup_discovery.py
+++ b/mlb_app/simulation/shadow/lineup_discovery.py
@@ -1,0 +1,252 @@
+"""Confirmed-lineup discovery for canonical shadow bootstrap inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+
+CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION = (
+    "canonical_shadow_lineup_discovery_v1"
+)
+
+
+def _normalize_identifier(value: Any) -> Optional[str]:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        return str(int(value))
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        return text or None
+
+
+def _lineup_identifiers(
+    records: Any,
+) -> Tuple[str, ...]:
+    if not isinstance(records, Sequence) or isinstance(
+        records,
+        (str, bytes),
+    ):
+        return ()
+
+    ordered = []
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+
+        identifier = _normalize_identifier(
+            record.get("batter_id")
+            or record.get("player_id")
+            or record.get("id")
+            or record.get("person_id")
+        )
+
+        if (
+            identifier is not None
+            and identifier not in ordered
+        ):
+            ordered.append(identifier)
+
+    return tuple(ordered)
+
+
+@dataclass(frozen=True)
+class CanonicalShadowLineupDiscovery:
+    """
+    Confirmed lineup discovery result.
+
+    Player identifiers are retained internally for canonical input assembly.
+    Public diagnostics intentionally expose counts and status only.
+    """
+
+    away_player_ids: Tuple[str, ...] = ()
+    home_player_ids: Tuple[str, ...] = ()
+    away_source_count: int = 0
+    home_source_count: int = 0
+    status: str = "unavailable"
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    discovery_version: str = (
+        CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical shadow lineup "
+                "discovery version"
+            )
+
+        if len(set(self.away_player_ids)) != len(
+            self.away_player_ids
+        ):
+            raise ValueError(
+                "away_player_ids must be unique"
+            )
+
+        if len(set(self.home_player_ids)) != len(
+            self.home_player_ids
+        ):
+            raise ValueError(
+                "home_player_ids must be unique"
+            )
+
+    @property
+    def away_ready(self) -> bool:
+        return len(self.away_player_ids) == 9
+
+    @property
+    def home_ready(self) -> bool:
+        return len(self.home_player_ids) == 9
+
+    @property
+    def ready(self) -> bool:
+        return self.away_ready and self.home_ready
+
+    def readiness_matchup_fields(
+        self,
+    ) -> Dict[str, Any]:
+        fields: Dict[str, Any] = {}
+
+        if self.away_ready:
+            fields["away_lineup"] = [
+                {"player_id": player_id}
+                for player_id in self.away_player_ids
+            ]
+
+        if self.home_ready:
+            fields["home_lineup"] = [
+                {"player_id": player_id}
+                for player_id in self.home_player_ids
+            ]
+
+        return fields
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "source": "mlb_stats_boxscore",
+            "away": {
+                "ready": self.away_ready,
+                "source_record_count": (
+                    self.away_source_count
+                ),
+                "validated_player_count": len(
+                    self.away_player_ids
+                ),
+                "required_player_count": 9,
+            },
+            "home": {
+                "ready": self.home_ready,
+                "source_record_count": (
+                    self.home_source_count
+                ),
+                "validated_player_count": len(
+                    self.home_player_ids
+                ),
+                "required_player_count": 9,
+            },
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "player_identifiers_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def discover_canonical_shadow_lineups(
+    *,
+    game_pk: Any,
+    lineup_fetcher: Optional[
+        Callable[[int], Mapping[str, Any]]
+    ] = None,
+) -> CanonicalShadowLineupDiscovery:
+    """
+    Discover confirmed lineups without activating canonical execution.
+
+    Missing, incomplete, malformed, or failed boxscore responses return a
+    fail-open diagnostic result. No projected lineup is manufactured.
+    """
+
+    identifier = _normalize_identifier(game_pk)
+
+    if identifier is None:
+        return CanonicalShadowLineupDiscovery(
+            status="blocked",
+            error_type="missing_game_pk",
+            error_message=(
+                "game_pk is required for confirmed "
+                "lineup discovery"
+            ),
+        )
+
+    if lineup_fetcher is None:
+        from mlb_app.lineup_profile import (
+            fetch_boxscore_lineup,
+        )
+
+        lineup_fetcher = fetch_boxscore_lineup
+
+    try:
+        payload = lineup_fetcher(int(identifier))
+    except Exception as exc:
+        return CanonicalShadowLineupDiscovery(
+            status="error",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+
+    if not isinstance(payload, Mapping):
+        return CanonicalShadowLineupDiscovery(
+            status="blocked",
+            error_type="invalid_payload",
+            error_message=(
+                "lineup fetcher must return a mapping"
+            ),
+        )
+
+    away_records = payload.get("away") or []
+    home_records = payload.get("home") or []
+
+    away_ids = _lineup_identifiers(away_records)
+    home_ids = _lineup_identifiers(home_records)
+
+    ready = (
+        len(away_ids) == 9
+        and len(home_ids) == 9
+    )
+
+    any_records = bool(
+        away_records or home_records
+    )
+
+    status = (
+        "ready"
+        if ready
+        else "partial"
+        if any_records
+        else "unavailable"
+    )
+
+    return CanonicalShadowLineupDiscovery(
+        away_player_ids=away_ids,
+        home_player_ids=home_ids,
+        away_source_count=(
+            len(away_records)
+            if isinstance(away_records, Sequence)
+            else 0
+        ),
+        home_source_count=(
+            len(home_records)
+            if isinstance(home_records, Sequence)
+            else 0
+        ),
+        status=status,
+    )

--- a/tests/test_canonical_shadow_lineup_discovery.py
+++ b/tests/test_canonical_shadow_lineup_discovery.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION,
+    discover_canonical_shadow_lineups,
+)
+
+
+def lineup(prefix):
+    return [
+        {
+            "batter_id": 1000 + index,
+            "name": f"{prefix} Player {index}",
+            "lineup_slot": index + 1,
+        }
+        for index in range(9)
+    ]
+
+
+def test_complete_confirmed_lineups_are_ready():
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": lineup("Away"),
+            "home": lineup("Home"),
+        },
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.away_ready is True
+    assert result.home_ready is True
+
+    fields = result.readiness_matchup_fields()
+
+    assert len(fields["away_lineup"]) == 9
+    assert len(fields["home_lineup"]) == 9
+
+
+def test_diagnostics_do_not_expose_player_ids():
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": lineup("Away"),
+            "home": lineup("Home"),
+        },
+    )
+
+    diagnostics = result.to_diagnostics()
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION
+    )
+    assert diagnostics[
+        "player_identifiers_exposed"
+    ] is False
+    assert "away_player_ids" not in diagnostics
+    assert "home_player_ids" not in diagnostics
+    assert diagnostics["away"][
+        "validated_player_count"
+    ] == 9
+
+
+def test_incomplete_side_is_not_forwarded():
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": lineup("Away")[:8],
+            "home": lineup("Home"),
+        },
+    )
+
+    assert result.status == "partial"
+    assert result.ready is False
+    assert result.away_ready is False
+    assert result.home_ready is True
+
+    fields = result.readiness_matchup_fields()
+
+    assert "away_lineup" not in fields
+    assert len(fields["home_lineup"]) == 9
+
+
+def test_duplicate_ids_do_not_satisfy_nine_players():
+    duplicate_lineup = [
+        {
+            "batter_id": 999,
+            "lineup_slot": index + 1,
+        }
+        for index in range(9)
+    ]
+
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": duplicate_lineup,
+            "home": lineup("Home"),
+        },
+    )
+
+    assert result.away_ready is False
+    assert len(result.away_player_ids) == 1
+
+
+def test_unavailable_lineups_fail_open():
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": [],
+            "home": [],
+        },
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.readiness_matchup_fields() == {}
+
+
+def test_fetch_failure_returns_error_diagnostics():
+    def failing_fetcher(game_pk):
+        raise RuntimeError("boxscore unavailable")
+
+    result = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=failing_fetcher,
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.error_type == "RuntimeError"
+    assert result.error_message == (
+        "boxscore unavailable"
+    )
+    assert result.readiness_matchup_fields() == {}
+
+
+def test_missing_game_pk_does_not_call_fetcher():
+    calls = []
+
+    def fetcher(game_pk):
+        calls.append(game_pk)
+        return {}
+
+    result = discover_canonical_shadow_lineups(
+        game_pk=None,
+        lineup_fetcher=fetcher,
+    )
+
+    assert result.status == "blocked"
+    assert result.error_type == "missing_game_pk"
+    assert calls == []

--- a/tests/test_model_projection_canonical_lineup_readiness.py
+++ b/tests/test_model_projection_canonical_lineup_readiness.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_lineups,
+)
+
+
+def lineup(start):
+    return [
+        {
+            "batter_id": start + index,
+            "lineup_slot": index + 1,
+        }
+        for index in range(9)
+    ]
+
+
+def test_discovered_lineups_advance_bootstrap_readiness():
+    discovery = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": lineup(1000),
+            "home": lineup(2000),
+        },
+    )
+
+    matchup = {
+        "game_pk": 123,
+        "away_pitcher_id": 101,
+        "home_pitcher_id": 201,
+    }
+    matchup.update(
+        discovery.readiness_matchup_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={},
+        home_context={},
+        workspace={},
+    )
+
+    assert report["requirements"][
+        "away_lineup"
+    ]["ready"] is True
+    assert report["requirements"][
+        "home_lineup"
+    ]["ready"] is True
+    assert report["requirements"][
+        "away_lineup"
+    ]["player_count"] == 9
+    assert report["requirements"][
+        "home_lineup"
+    ]["player_count"] == 9
+
+    assert report["missing_requirements"] == [
+        "away_bullpen",
+        "home_bullpen",
+        "probability_provider",
+        "exact_probability_artifact",
+        "fallback_probability_catalog",
+    ]
+
+
+def test_incomplete_discovery_does_not_mark_lineup_ready():
+    discovery = discover_canonical_shadow_lineups(
+        game_pk=123,
+        lineup_fetcher=lambda game_pk: {
+            "away": lineup(1000)[:8],
+            "home": [],
+        },
+    )
+
+    matchup = {
+        "game_pk": 123,
+        "away_pitcher_id": 101,
+        "home_pitcher_id": 201,
+    }
+    matchup.update(
+        discovery.readiness_matchup_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={},
+        home_context={},
+        workspace={},
+    )
+
+    assert report["requirements"][
+        "away_lineup"
+    ]["ready"] is False
+    assert report["requirements"][
+        "home_lineup"
+    ]["ready"] is False


### PR DESCRIPTION
## Summary

Implements the first real production discovery adapter for Layer 10J canonical shadow bootstrap readiness: confirmed lineup discovery from the existing MLB boxscore lineup source.

The adapter fetches each game’s confirmed batting order, validates exactly nine unique batter IDs per side, and forwards only fully valid lineups into canonical bootstrap readiness. It does not fabricate projected batting orders, expose player identifiers in diagnostics, activate canonical execution, or change legacy authority.

## Added

- `CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION`
- `CanonicalShadowLineupDiscovery`
- `discover_canonical_shadow_lineups()`
- MLB boxscore lineup discovery through the existing `fetch_boxscore_lineup()` source
- Exactly-nine unique player-ID validation per side
- Internal readiness matchup fields for valid lineups only
- Sanitized discovery diagnostics with counts and statuses
- Fail-open handling for missing game IDs, unavailable lineups, malformed responses, and fetch errors
- `/models/projections` integration before bootstrap-readiness evaluation
- Game, workspace, and shared-diagnostics discovery attachments
- Focused tests for complete, incomplete, duplicate, unavailable, failed, and missing-game cases
- Integration tests proving validated lineups advance bootstrap readiness

## Architecture

```text
MLB Stats boxscore
        ↓
confirmed batting orders
        ↓
discover_canonical_shadow_lineups()
        ↓
exactly 9 unique batter IDs per side?
    ├─ yes → forward lineup IDs to readiness
    └─ no  → remain blocked, no fabricated lineup
```

## Readiness behavior

Before confirmed lineups:

```text
3 of 10 ready
```

After both confirmed lineups validate:

```text
5 of 10 ready
```

The remaining expected blockers continue to include bullpen pitching plans, probability-provider identity, exact probability artifact, and fallback probability catalog.

## Contract guarantees

- Only confirmed MLB boxscore batting-order slots are considered.
- Exactly nine unique batter identifiers are required per side.
- Incomplete or duplicate lineups are not forwarded.
- Player identifiers remain internal and are not exposed in public diagnostics.
- Missing or failed lineup discovery is fail-open.
- Projected names are never converted into canonical player IDs.
- Canonical execution remains disabled.
- Legacy projections remain authoritative.
- Input payloads are not mutated.

## Validation

- Lineup discovery/readiness tests passed: `9 passed`
- Combined canonical input/readiness tests passed: `39 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/lineup_discovery.py`
- `tests/test_canonical_shadow_lineup_discovery.py`
- `tests/test_model_projection_canonical_lineup_readiness.py`

## Next slice

Connect the next real production discovery adapter, most likely bullpen pitching-plan discovery, so readiness can advance from 5 of 10 when confirmed reliever identifiers are available.