### PR TITLE
Discover active canonical bullpens

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -19,6 +19,7 @@ from .simulation.game_simulator import simulate_game_with_bullpen
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
 from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_bullpens,
     discover_canonical_shadow_lineups,
 )
 
@@ -633,11 +634,27 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             )
 
+            canonical_shadow_bullpen_discovery = (
+                discover_canonical_shadow_bullpens(
+                    away_team_id=away.get("team_id"),
+                    away_team_name=away.get("team_name"),
+                    away_starter_id=away.get("pitcher_id"),
+                    home_team_id=home.get("team_id"),
+                    home_team_name=home.get("team_name"),
+                    home_starter_id=home.get("pitcher_id"),
+                    season=date_obj.year,
+                )
+            )
+
             canonical_readiness_matchup = dict(
                 matchup
             )
             canonical_readiness_matchup.update(
                 canonical_shadow_lineup_discovery
+                .readiness_matchup_fields()
+            )
+            canonical_readiness_matchup.update(
+                canonical_shadow_bullpen_discovery
                 .readiness_matchup_fields()
             )
 
@@ -655,6 +672,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "canonicalShadowLineupDiscovery"
             ] = (
                 canonical_shadow_lineup_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalShadowBullpenDiscovery"
+            ] = (
+                canonical_shadow_bullpen_discovery
                 .to_diagnostics()
             )
 
@@ -706,6 +730,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
 
                 shared_diagnostics[
+                    "canonical_shadow_bullpen_discovery"
+                ] = (
+                    canonical_shadow_bullpen_discovery
+                    .to_diagnostics()
+                )
+
+                shared_diagnostics[
                     "canonical_shadow_bootstrap_readiness"
                 ] = canonical_shadow_bootstrap_readiness
 
@@ -730,6 +761,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "game_state_realism": _build_game_state_realism_diagnostics(),
                 "canonical_shadow_lineup_discovery": (
                     canonical_shadow_lineup_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_shadow_bullpen_discovery": (
+                    canonical_shadow_bullpen_discovery
                     .to_diagnostics()
                 ),
                 "canonical_shadow_bootstrap_readiness": (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -1,6 +1,12 @@
 """Canonical production-shadow comparison integration."""
 
 from .comparator import compare_shadow_payloads
+from .bullpen_discovery import (
+    CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
+    CanonicalShadowBullpenDiscovery,
+    CanonicalShadowBullpenSideDiscovery,
+    discover_canonical_shadow_bullpens,
+)
 from .bootstrap_readiness import (
     CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION,
     build_canonical_shadow_bootstrap_readiness,
@@ -50,6 +56,7 @@ from .probability_serialization import (
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION",
+    "CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
@@ -57,6 +64,8 @@ __all__ = [
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
+    "CanonicalShadowBullpenDiscovery",
+    "CanonicalShadowBullpenSideDiscovery",
     "CanonicalShadowExecutionBundle",
     "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionInputs",
@@ -68,6 +77,7 @@ __all__ = [
     "attach_canonical_shadow",
     "assemble_canonical_shadow_execution_inputs",
     "build_canonical_shadow_bootstrap_readiness",
+    "discover_canonical_shadow_bullpens",
     "discover_canonical_shadow_lineups",
     "canonical_shadow_execution_bundle_to_material",
     "canonical_shadow_input_provenance_to_dict",

--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -1,0 +1,312 @@
+"""Active-roster bullpen discovery for canonical shadow bootstrap inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+
+CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION = (
+    "canonical_shadow_bullpen_discovery_v1"
+)
+
+
+def _normalize_identifier(value: Any) -> Optional[str]:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+        return str(parsed) if parsed > 0 else None
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        return text or None
+
+
+def _pitcher_identifiers(
+    records: Any,
+    *,
+    starter_id: Any,
+) -> Tuple[str, ...]:
+    if not isinstance(records, Sequence) or isinstance(
+        records,
+        (str, bytes),
+    ):
+        return ()
+
+    normalized_starter = _normalize_identifier(
+        starter_id
+    )
+    ordered = []
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+
+        player_type = str(
+            record.get("player_type") or ""
+        ).strip().lower()
+
+        if player_type != "pitcher":
+            continue
+
+        identifier = _normalize_identifier(
+            record.get("mlb_player_id")
+            or record.get("player_id")
+            or record.get("pitcher_id")
+            or record.get("id")
+        )
+
+        if (
+            identifier is None
+            or identifier == normalized_starter
+            or identifier in ordered
+        ):
+            continue
+
+        ordered.append(identifier)
+
+    return tuple(ordered)
+
+
+@dataclass(frozen=True)
+class CanonicalShadowBullpenSideDiscovery:
+    team_id: Optional[str] = None
+    starter_id: Optional[str] = None
+    bullpen_pitcher_ids: Tuple[str, ...] = ()
+    source_record_count: int = 0
+    status: str = "unavailable"
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+
+    @property
+    def ready(self) -> bool:
+        return len(self.bullpen_pitcher_ids) > 0
+
+    def readiness_fields(
+        self,
+        *,
+        side: str,
+    ) -> Dict[str, Any]:
+        if not self.ready:
+            return {}
+
+        return {
+            f"{side}_bullpen_pitcher_ids": [
+                {"pitcher_id": pitcher_id}
+                for pitcher_id in self.bullpen_pitcher_ids
+            ]
+        }
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "ready": self.ready,
+            "source": "mlb_stats_active_roster",
+            "team_id_present": self.team_id is not None,
+            "starter_id_present": (
+                self.starter_id is not None
+            ),
+            "source_record_count": (
+                self.source_record_count
+            ),
+            "validated_pitcher_count": len(
+                self.bullpen_pitcher_ids
+            ),
+            "minimum_pitcher_count": 1,
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "pitcher_identifiers_exposed": False,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalShadowBullpenDiscovery:
+    away: CanonicalShadowBullpenSideDiscovery
+    home: CanonicalShadowBullpenSideDiscovery
+    discovery_version: str = (
+        CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical shadow bullpen "
+                "discovery version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.away.ready and self.home.ready
+
+    @property
+    def status(self) -> str:
+        if self.ready:
+            return "ready"
+
+        if (
+            self.away.status == "error"
+            or self.home.status == "error"
+        ):
+            return "error"
+
+        if self.away.ready or self.home.ready:
+            return "partial"
+
+        return "unavailable"
+
+    def readiness_matchup_fields(
+        self,
+    ) -> Dict[str, Any]:
+        fields = {}
+        fields.update(
+            self.away.readiness_fields(side="away")
+        )
+        fields.update(
+            self.home.readiness_fields(side="home")
+        )
+        return fields
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "source": "mlb_stats_active_roster",
+            "away": self.away.to_diagnostics(),
+            "home": self.home.to_diagnostics(),
+            "pitcher_identifiers_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _discover_side(
+    *,
+    team_id: Any,
+    team_name: Any,
+    starter_id: Any,
+    season: int,
+    roster_fetcher: Callable[..., Sequence[Mapping[str, Any]]],
+) -> CanonicalShadowBullpenSideDiscovery:
+    normalized_team = _normalize_identifier(
+        team_id
+    )
+    normalized_starter = _normalize_identifier(
+        starter_id
+    )
+
+    if normalized_team is None:
+        return CanonicalShadowBullpenSideDiscovery(
+            starter_id=normalized_starter,
+            status="blocked",
+            error_type="missing_team_id",
+            error_message=(
+                "team_id is required for active-roster "
+                "bullpen discovery"
+            ),
+        )
+
+    if normalized_starter is None:
+        return CanonicalShadowBullpenSideDiscovery(
+            team_id=normalized_team,
+            status="blocked",
+            error_type="missing_starter_id",
+            error_message=(
+                "starter_id is required to exclude the "
+                "scheduled starter"
+            ),
+        )
+
+    try:
+        records = roster_fetcher(
+            int(normalized_team),
+            int(season),
+            team_name=team_name,
+        )
+    except Exception as exc:
+        return CanonicalShadowBullpenSideDiscovery(
+            team_id=normalized_team,
+            starter_id=normalized_starter,
+            status="error",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+
+    if not isinstance(records, Sequence) or isinstance(
+        records,
+        (str, bytes),
+    ):
+        return CanonicalShadowBullpenSideDiscovery(
+            team_id=normalized_team,
+            starter_id=normalized_starter,
+            status="blocked",
+            error_type="invalid_payload",
+            error_message=(
+                "active-roster fetcher must return a sequence"
+            ),
+        )
+
+    pitcher_ids = _pitcher_identifiers(
+        records,
+        starter_id=normalized_starter,
+    )
+
+    return CanonicalShadowBullpenSideDiscovery(
+        team_id=normalized_team,
+        starter_id=normalized_starter,
+        bullpen_pitcher_ids=pitcher_ids,
+        source_record_count=len(records),
+        status=(
+            "ready"
+            if pitcher_ids
+            else "unavailable"
+        ),
+    )
+
+
+def discover_canonical_shadow_bullpens(
+    *,
+    away_team_id: Any,
+    away_team_name: Any,
+    away_starter_id: Any,
+    home_team_id: Any,
+    home_team_name: Any,
+    home_starter_id: Any,
+    season: int,
+    roster_fetcher: Optional[
+        Callable[..., Sequence[Mapping[str, Any]]]
+    ] = None,
+) -> CanonicalShadowBullpenDiscovery:
+    """
+    Discover active-roster bullpen IDs without activating canonical execution.
+
+    Active-roster pitchers are treated as a bootstrap pitching-plan candidate,
+    not a claim about game availability, leverage role, or expected usage.
+    """
+
+    if roster_fetcher is None:
+        from mlb_app.dashboard_player_population import (
+            fetch_active_roster,
+        )
+
+        roster_fetcher = fetch_active_roster
+
+    return CanonicalShadowBullpenDiscovery(
+        away=_discover_side(
+            team_id=away_team_id,
+            team_name=away_team_name,
+            starter_id=away_starter_id,
+            season=season,
+            roster_fetcher=roster_fetcher,
+        ),
+        home=_discover_side(
+            team_id=home_team_id,
+            team_name=home_team_name,
+            starter_id=home_starter_id,
+            season=season,
+            roster_fetcher=roster_fetcher,
+        ),
+    )

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
+    discover_canonical_shadow_bullpens,
+)
+
+
+def active_roster(team_id, season, team_name=None):
+    starter = 100 if team_id == 10 else 200
+
+    return [
+        {
+            "mlb_player_id": starter,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 1,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 2,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 3,
+            "player_type": "hitter",
+        },
+    ]
+
+
+def discovery(**overrides):
+    kwargs = {
+        "away_team_id": 10,
+        "away_team_name": "Away",
+        "away_starter_id": 100,
+        "home_team_id": 20,
+        "home_team_name": "Home",
+        "home_starter_id": 200,
+        "season": 2026,
+        "roster_fetcher": active_roster,
+    }
+    kwargs.update(overrides)
+
+    return discover_canonical_shadow_bullpens(
+        **kwargs
+    )
+
+
+def test_active_roster_pitchers_build_bullpen_candidates():
+    result = discovery()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+        "102",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "201",
+        "202",
+    )
+
+
+def test_scheduled_starters_are_excluded():
+    result = discovery()
+
+    assert "100" not in (
+        result.away.bullpen_pitcher_ids
+    )
+    assert "200" not in (
+        result.home.bullpen_pitcher_ids
+    )
+
+
+def test_readiness_fields_are_side_specific():
+    fields = discovery().readiness_matchup_fields()
+
+    assert len(
+        fields["away_bullpen_pitcher_ids"]
+    ) == 2
+    assert len(
+        fields["home_bullpen_pitcher_ids"]
+    ) == 2
+
+
+def test_diagnostics_do_not_expose_pitcher_ids():
+    diagnostics = discovery().to_diagnostics()
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION
+    )
+    assert diagnostics[
+        "pitcher_identifiers_exposed"
+    ] is False
+    assert diagnostics["away"][
+        "validated_pitcher_count"
+    ] == 2
+    assert "bullpen_pitcher_ids" not in (
+        diagnostics["away"]
+    )
+
+
+def test_duplicate_and_non_pitcher_records_are_filtered():
+    def roster(team_id, season, team_name=None):
+        return [
+            {
+                "mlb_player_id": 100,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": 101,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": 101,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": 102,
+                "player_type": "hitter",
+            },
+        ]
+
+    result = discovery(
+        home_starter_id=100,
+        roster_fetcher=roster,
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "101",
+    )
+
+
+def test_missing_team_id_blocks_only_that_side():
+    result = discovery(
+        away_team_id=None,
+    )
+
+    assert result.status == "partial"
+    assert result.away.ready is False
+    assert result.away.error_type == (
+        "missing_team_id"
+    )
+    assert result.home.ready is True
+
+
+def test_missing_starter_id_does_not_treat_roster_as_bullpen():
+    result = discovery(
+        away_starter_id=None,
+    )
+
+    assert result.away.ready is False
+    assert result.away.error_type == (
+        "missing_starter_id"
+    )
+    assert (
+        "away_bullpen_pitcher_ids"
+        not in result.readiness_matchup_fields()
+    )
+
+
+def test_roster_failure_fails_open():
+    def failing_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        raise RuntimeError("roster unavailable")
+
+    result = discovery(
+        roster_fetcher=failing_roster,
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.away.error_type == (
+        "RuntimeError"
+    )
+    assert result.readiness_matchup_fields() == {}

--- a/tests/test_model_projection_canonical_bullpen_readiness.py
+++ b/tests/test_model_projection_canonical_bullpen_readiness.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_bullpens,
+)
+
+
+def roster(team_id, season, team_name=None):
+    starter = 100 if team_id == 10 else 200
+
+    return [
+        {
+            "mlb_player_id": starter,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 1,
+            "player_type": "pitcher",
+        },
+    ]
+
+
+def base_matchup():
+    return {
+        "game_pk": 123,
+        "away_pitcher_id": 100,
+        "home_pitcher_id": 200,
+        "away_lineup": [
+            {"player_id": f"a{index}"}
+            for index in range(9)
+        ],
+        "home_lineup": [
+            {"player_id": f"h{index}"}
+            for index in range(9)
+        ],
+    }
+
+
+def test_discovered_bullpens_advance_readiness():
+    discovery = discover_canonical_shadow_bullpens(
+        away_team_id=10,
+        away_team_name="Away",
+        away_starter_id=100,
+        home_team_id=20,
+        home_team_name="Home",
+        home_starter_id=200,
+        season=2026,
+        roster_fetcher=roster,
+    )
+
+    matchup = base_matchup()
+    matchup.update(
+        discovery.readiness_matchup_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={},
+        home_context={},
+        workspace={},
+    )
+
+    assert report["requirements"][
+        "away_bullpen"
+    ]["ready"] is True
+    assert report["requirements"][
+        "home_bullpen"
+    ]["ready"] is True
+
+    assert report["missing_requirements"] == [
+        "probability_provider",
+        "exact_probability_artifact",
+        "fallback_probability_catalog",
+    ]
+
+
+def test_failed_roster_discovery_keeps_bullpens_blocked():
+    def failing_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        raise RuntimeError("unavailable")
+
+    discovery = discover_canonical_shadow_bullpens(
+        away_team_id=10,
+        away_team_name="Away",
+        away_starter_id=100,
+        home_team_id=20,
+        home_team_name="Home",
+        home_starter_id=200,
+        season=2026,
+        roster_fetcher=failing_roster,
+    )
+
+    matchup = base_matchup()
+    matchup.update(
+        discovery.readiness_matchup_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=matchup,
+        away_context={},
+        home_context={},
+        workspace={},
+    )
+
+    assert report["requirements"][
+        "away_bullpen"
+    ]["ready"] is False
+    assert report["requirements"][
+        "home_bullpen"
+    ]["ready"] is False


### PR DESCRIPTION
## Summary

Implements the next Layer 10J production discovery adapter: active-roster bullpen discovery for canonical shadow bootstrap readiness.

The adapter loads each team’s verified MLB active roster, retains only canonical pitcher identities, excludes the scheduled starter, and forwards side-specific bullpen pitcher IDs into readiness only when at least one unique candidate is available. It does not treat team-level bullpen priors as player-level pitching plans, expose pitcher IDs in public diagnostics, activate canonical execution, or change legacy authority.

## Added

- `CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION`
- `CanonicalShadowBullpenSideDiscovery`
- `CanonicalShadowBullpenDiscovery`
- `discover_canonical_shadow_bullpens()`
- Verified active-roster discovery through the existing MLB roster source
- Pitcher-only filtering
- Scheduled-starter exclusion
- Duplicate identity removal
- Side-specific readiness matchup fields
- Sanitized diagnostics with counts and statuses only
- Fail-open handling for missing team IDs, missing starter IDs, malformed payloads, and roster-fetch errors
- `/models/projections` integration before bootstrap-readiness evaluation
- Game, workspace, and shared-diagnostics discovery attachments
- Focused unit and readiness integration tests

## Architecture

```text
MLB active roster
        ↓
canonical pitcher identities
        ↓
remove scheduled starter
        ↓
active bullpen candidates
        ↓
bootstrap readiness
```

## Readiness behavior

With confirmed lineups only:

```text
5 of 10 ready
```

With confirmed lineups and both active-roster bullpen candidates:

```text
7 of 10 ready
```

The remaining expected blockers are:

- probability provider
- exact probability artifact
- fallback probability catalog

## Contract guarantees

- Team-level bullpen aggregate priors do not satisfy pitching-plan readiness.
- Only explicit MLB player IDs are accepted.
- Only roster rows classified as pitchers are retained.
- The scheduled starter is always excluded.
- At least one unique bullpen pitcher ID is required per side.
- Missing starter identity blocks that side rather than treating the entire roster as bullpen.
- Public diagnostics expose counts and status, never pitcher IDs.
- Discovery remains fail-open.
- Canonical execution remains disabled.
- Legacy projections remain authoritative.

## Validation

- Bullpen discovery/readiness tests passed: `10 passed`
- Combined canonical input/readiness tests passed: `49 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/bullpen_discovery.py`
- `tests/test_canonical_shadow_bullpen_discovery.py`
- `tests/test_model_projection_canonical_bullpen_readiness.py`

## Next slice

Connect the production probability-provider identity and canonical artifact discovery boundary so readiness can advance from 7 of 10 toward full eligibility without manufacturing probability records.