### PR TITLE
Discover canonical probability provider

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -21,6 +21,7 @@ from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
     discover_canonical_shadow_lineups,
+    discover_canonical_shadow_probability_provider,
 )
 
 
@@ -658,13 +659,27 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 .readiness_matchup_fields()
             )
 
+            canonical_shadow_probability_provider_discovery = (
+                discover_canonical_shadow_probability_provider(
+                    workspace=workspace,
+                )
+            )
+
+            canonical_readiness_workspace = dict(
+                workspace
+            )
+            canonical_readiness_workspace.update(
+                canonical_shadow_probability_provider_discovery
+                .readiness_workspace_fields()
+            )
+
             canonical_shadow_bootstrap_readiness = (
                 build_canonical_shadow_bootstrap_readiness(
                     game_pk=game_pk,
                     matchup=canonical_readiness_matchup,
                     away_context=away,
                     home_context=home,
-                    workspace=workspace,
+                    workspace=canonical_readiness_workspace,
                 )
             )
 
@@ -679,6 +694,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "canonicalShadowBullpenDiscovery"
             ] = (
                 canonical_shadow_bullpen_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalShadowProbabilityProviderDiscovery"
+            ] = (
+                canonical_shadow_probability_provider_discovery
                 .to_diagnostics()
             )
 
@@ -737,6 +759,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
 
                 shared_diagnostics[
+                    "canonical_shadow_probability_provider_discovery"
+                ] = (
+                    canonical_shadow_probability_provider_discovery
+                    .to_diagnostics()
+                )
+
+                shared_diagnostics[
                     "canonical_shadow_bootstrap_readiness"
                 ] = canonical_shadow_bootstrap_readiness
 
@@ -765,6 +794,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 ),
                 "canonical_shadow_bullpen_discovery": (
                     canonical_shadow_bullpen_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_shadow_probability_provider_discovery": (
+                    canonical_shadow_probability_provider_discovery
                     .to_diagnostics()
                 ),
                 "canonical_shadow_bootstrap_readiness": (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -29,6 +29,11 @@ from .execution_factory import (
     CanonicalShadowExecutionBundleFactory,
     build_canonical_shadow_execution_bundle_factory,
 )
+from .probability_provider_discovery import (
+    CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION,
+    CanonicalShadowProbabilityProviderDiscovery,
+    discover_canonical_shadow_probability_provider,
+)
 from .lineup_discovery import (
     CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION,
     CanonicalShadowLineupDiscovery,
@@ -61,6 +66,7 @@ __all__ = [
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
     "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
+    "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
     "CanonicalShadowDiagnostics",
@@ -70,6 +76,7 @@ __all__ = [
     "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionInputs",
     "CanonicalShadowLineupDiscovery",
+    "CanonicalShadowProbabilityProviderDiscovery",
     "CanonicalShadowExecutionMaterial",
     "MetricComparison",
     "RangeComparison",
@@ -79,6 +86,7 @@ __all__ = [
     "build_canonical_shadow_bootstrap_readiness",
     "discover_canonical_shadow_bullpens",
     "discover_canonical_shadow_lineups",
+    "discover_canonical_shadow_probability_provider",
     "canonical_shadow_execution_bundle_to_material",
     "canonical_shadow_input_provenance_to_dict",
     "build_canonical_shadow_execution_bundle_factory",

--- a/mlb_app/simulation/shadow/probability_provider_discovery.py
+++ b/mlb_app/simulation/shadow/probability_provider_discovery.py
@@ -1,0 +1,263 @@
+"""Production PA probability-provider discovery for canonical readiness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalProbabilityProviderIdentity,
+)
+
+
+CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION = (
+    "canonical_shadow_probability_provider_discovery_v1"
+)
+
+EXPECTED_PROBABILITY_KEYS = (
+    "k",
+    "bb",
+    "hbp",
+    "single",
+    "double",
+    "triple",
+    "hr",
+    "reached_on_error",
+    "out",
+)
+
+REQUIRED_WORKSPACE_MODELS = (
+    "awayPAOutcomeModel",
+    "homePAOutcomeModel",
+    "awayVsHomeBullpenPAOutcomeModel",
+    "homeVsAwayBullpenPAOutcomeModel",
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _valid_probability_distribution(
+    value: Any,
+) -> bool:
+    probabilities = _mapping(value)
+
+    if tuple(probabilities.keys()) != (
+        EXPECTED_PROBABILITY_KEYS
+    ):
+        return False
+
+    normalized = []
+
+    for key in EXPECTED_PROBABILITY_KEYS:
+        raw = probabilities.get(key)
+
+        if isinstance(raw, bool):
+            return False
+
+        try:
+            probability = float(raw)
+        except (TypeError, ValueError):
+            return False
+
+        if (
+            not math.isfinite(probability)
+            or probability < 0.0
+            or probability > 1.0
+        ):
+            return False
+
+        normalized.append(probability)
+
+    return abs(sum(normalized) - 1.0) <= 0.001
+
+
+@dataclass(frozen=True)
+class CanonicalShadowProbabilityProviderDiscovery:
+    provider: Optional[
+        CanonicalProbabilityProviderIdentity
+    ] = None
+    model_versions: Tuple[str, ...] = ()
+    valid_model_count: int = 0
+    required_model_count: int = len(
+        REQUIRED_WORKSPACE_MODELS
+    )
+    missing_models: Tuple[str, ...] = ()
+    invalid_models: Tuple[str, ...] = ()
+    status: str = "unavailable"
+    discovery_version: str = (
+        CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical probability-provider "
+                "discovery version"
+            )
+
+        if (
+            self.provider is not None
+            and not isinstance(
+                self.provider,
+                CanonicalProbabilityProviderIdentity,
+            )
+        ):
+            raise TypeError(
+                "provider must be a "
+                "CanonicalProbabilityProviderIdentity or None"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.provider is not None
+
+    def readiness_workspace_fields(
+        self,
+    ) -> Dict[str, Any]:
+        if self.provider is None:
+            return {}
+
+        return {
+            "canonicalProbabilityProvider": {
+                "provider_name": (
+                    self.provider.provider_name
+                ),
+                "provider_version": (
+                    self.provider.provider_version
+                ),
+                "artifact_id": (
+                    self.provider.artifact_id
+                ),
+                "identity": self.provider.identity,
+            }
+        }
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        provider = self.provider
+
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "source": (
+                "model_projections_workspace_pa_models"
+            ),
+            "provider": (
+                {
+                    "provider_name": (
+                        provider.provider_name
+                    ),
+                    "provider_version": (
+                        provider.provider_version
+                    ),
+                    "artifact_id": provider.artifact_id,
+                    "identity": provider.identity,
+                }
+                if provider is not None
+                else None
+            ),
+            "model_versions": list(
+                self.model_versions
+            ),
+            "valid_model_count": (
+                self.valid_model_count
+            ),
+            "required_model_count": (
+                self.required_model_count
+            ),
+            "missing_models": list(
+                self.missing_models
+            ),
+            "invalid_models": list(
+                self.invalid_models
+            ),
+            "probability_records_exposed": False,
+            "artifact_discovered": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def discover_canonical_shadow_probability_provider(
+    *,
+    workspace: Optional[Mapping[str, Any]],
+) -> CanonicalShadowProbabilityProviderDiscovery:
+    """
+    Discover a stable provider identity from production PA model outputs.
+
+    Provider discovery proves only that one versioned implementation produced
+    valid team-context PA distributions. It does not construct or imply an
+    exact batter-pitcher probability artifact.
+    """
+
+    workspace_data = _mapping(workspace)
+
+    missing_models = []
+    invalid_models = []
+    versions = []
+    valid_model_count = 0
+
+    for key in REQUIRED_WORKSPACE_MODELS:
+        model = _mapping(
+            workspace_data.get(key)
+        )
+
+        if not model:
+            missing_models.append(key)
+            continue
+
+        version = str(
+            model.get("model_version") or ""
+        ).strip()
+
+        if (
+            not version
+            or not _valid_probability_distribution(
+                model.get("probabilities")
+            )
+        ):
+            invalid_models.append(key)
+            continue
+
+        valid_model_count += 1
+        versions.append(version)
+
+    distinct_versions = tuple(
+        sorted(set(versions))
+    )
+
+    provider = None
+    status = "blocked"
+
+    if (
+        valid_model_count
+        == len(REQUIRED_WORKSPACE_MODELS)
+        and not missing_models
+        and not invalid_models
+        and len(distinct_versions) == 1
+    ):
+        provider = CanonicalProbabilityProviderIdentity(
+            provider_name=(
+                "model_projections_pa_outcome"
+            ),
+            provider_version=distinct_versions[0],
+        )
+        status = "ready"
+    elif valid_model_count > 0:
+        status = "partial"
+    elif missing_models:
+        status = "unavailable"
+
+    return CanonicalShadowProbabilityProviderDiscovery(
+        provider=provider,
+        model_versions=distinct_versions,
+        valid_model_count=valid_model_count,
+        missing_models=tuple(missing_models),
+        invalid_models=tuple(invalid_models),
+        status=status,
+    )

--- a/tests/test_canonical_shadow_probability_provider_discovery.py
+++ b/tests/test_canonical_shadow_probability_provider_discovery.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION,
+    discover_canonical_shadow_probability_provider,
+)
+
+
+def probabilities():
+    return {
+        "k": 0.225,
+        "bb": 0.085,
+        "hbp": 0.011,
+        "single": 0.145,
+        "double": 0.045,
+        "triple": 0.004,
+        "hr": 0.030,
+        "reached_on_error": 0.007,
+        "out": 0.448,
+    }
+
+
+def model(version="pa_outcome_v1"):
+    return {
+        "model_version": version,
+        "probabilities": probabilities(),
+    }
+
+
+def complete_workspace():
+    return {
+        "awayPAOutcomeModel": model(),
+        "homePAOutcomeModel": model(),
+        "awayVsHomeBullpenPAOutcomeModel": model(),
+        "homeVsAwayBullpenPAOutcomeModel": model(),
+    }
+
+
+def test_complete_versioned_models_discover_provider():
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=complete_workspace(),
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.provider is not None
+    assert result.provider.provider_name == (
+        "model_projections_pa_outcome"
+    )
+    assert result.provider.provider_version == (
+        "pa_outcome_v1"
+    )
+    assert result.provider.artifact_id is None
+
+
+def test_readiness_field_contains_serializable_identity():
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=complete_workspace(),
+        )
+    )
+
+    fields = result.readiness_workspace_fields()
+    provider = fields[
+        "canonicalProbabilityProvider"
+    ]
+
+    assert provider["provider_name"] == (
+        "model_projections_pa_outcome"
+    )
+    assert provider["provider_version"] == (
+        "pa_outcome_v1"
+    )
+    assert provider["identity"] == (
+        "model_projections_pa_outcome:pa_outcome_v1"
+    )
+
+
+def test_diagnostics_do_not_claim_artifact_discovery():
+    diagnostics = (
+        discover_canonical_shadow_probability_provider(
+            workspace=complete_workspace(),
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION
+    )
+    assert diagnostics["ready"] is True
+    assert diagnostics["artifact_discovered"] is False
+    assert diagnostics[
+        "probability_records_exposed"
+    ] is False
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["authoritative_source"] == (
+        "legacy"
+    )
+
+
+def test_missing_model_blocks_provider_identity():
+    workspace = complete_workspace()
+    workspace.pop("homePAOutcomeModel")
+
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    assert result.ready is False
+    assert result.status == "partial"
+    assert result.missing_models == (
+        "homePAOutcomeModel",
+    )
+    assert result.readiness_workspace_fields() == {}
+
+
+def test_mismatched_versions_block_provider_identity():
+    workspace = complete_workspace()
+    workspace[
+        "homeVsAwayBullpenPAOutcomeModel"
+    ] = model("pa_outcome_v2")
+
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    assert result.ready is False
+    assert result.status == "partial"
+    assert result.model_versions == (
+        "pa_outcome_v1",
+        "pa_outcome_v2",
+    )
+
+
+def test_missing_outcome_blocks_provider_identity():
+    workspace = complete_workspace()
+    workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"].pop("hbp")
+
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    assert result.ready is False
+    assert result.invalid_models == (
+        "awayPAOutcomeModel",
+    )
+
+
+def test_invalid_probability_total_blocks_provider_identity():
+    workspace = complete_workspace()
+    workspace[
+        "homePAOutcomeModel"
+    ]["probabilities"]["out"] = 0.9
+
+    result = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    assert result.ready is False
+    assert result.invalid_models == (
+        "homePAOutcomeModel",
+    )
+
+
+def test_source_workspace_is_not_mutated():
+    workspace = complete_workspace()
+    snapshot = repr(workspace)
+
+    discover_canonical_shadow_probability_provider(
+        workspace=workspace,
+    )
+
+    assert repr(workspace) == snapshot

--- a/tests/test_model_projection_canonical_provider_readiness.py
+++ b/tests/test_model_projection_canonical_provider_readiness.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_probability_provider,
+)
+
+
+def probabilities():
+    return {
+        "k": 0.225,
+        "bb": 0.085,
+        "hbp": 0.011,
+        "single": 0.145,
+        "double": 0.045,
+        "triple": 0.004,
+        "hr": 0.030,
+        "reached_on_error": 0.007,
+        "out": 0.448,
+    }
+
+
+def workspace_models():
+    model = {
+        "model_version": "pa_outcome_v1",
+        "probabilities": probabilities(),
+    }
+
+    return {
+        "awayPAOutcomeModel": dict(model),
+        "homePAOutcomeModel": dict(model),
+        "awayVsHomeBullpenPAOutcomeModel": dict(model),
+        "homeVsAwayBullpenPAOutcomeModel": dict(model),
+    }
+
+
+def ready_matchup():
+    return {
+        "game_pk": 123,
+        "away_pitcher_id": 100,
+        "home_pitcher_id": 200,
+        "away_lineup": [
+            {"player_id": f"a{index}"}
+            for index in range(9)
+        ],
+        "home_lineup": [
+            {"player_id": f"h{index}"}
+            for index in range(9)
+        ],
+        "away_bullpen_pitcher_ids": [
+            {"pitcher_id": 101},
+        ],
+        "home_bullpen_pitcher_ids": [
+            {"pitcher_id": 201},
+        ],
+    }
+
+
+def test_discovered_provider_advances_readiness_to_eight():
+    workspace = workspace_models()
+
+    discovery = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    readiness_workspace = dict(workspace)
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context={},
+        home_context={},
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "probability_provider"
+    ]["ready"] is True
+
+    assert report["missing_requirements"] == [
+        "exact_probability_artifact",
+        "fallback_probability_catalog",
+    ]
+
+
+def test_invalid_provider_models_keep_requirement_blocked():
+    workspace = workspace_models()
+    workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"] = {}
+
+    discovery = (
+        discover_canonical_shadow_probability_provider(
+            workspace=workspace,
+        )
+    )
+
+    readiness_workspace = dict(workspace)
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context={},
+        home_context={},
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "probability_provider"
+    ]["ready"] is False


### PR DESCRIPTION
## Summary

Implements the next Layer 10J production discovery adapter: canonical probability-provider identity discovery from the existing `/models/projections` PA outcome models.

The adapter validates all four production PA model outputs, requires one consistent nonempty model version, verifies the full nine-outcome probability schema, and confirms each distribution is finite, nonnegative, bounded, and normalized before exposing a stable provider identity to canonical bootstrap readiness.

It deliberately does **not** claim that team-context PA models are exact batter-pitcher artifacts, does not construct probability records, does not activate canonical execution, and does not change legacy authority.

## Added

- `CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION`
- `CanonicalShadowProbabilityProviderDiscovery`
- `discover_canonical_shadow_probability_provider()`
- Validation for all four production PA model outputs
- Exact expected nine-outcome key order validation
- Finite, bounded, normalized probability validation
- Consistent model-version validation
- Stable provider identity:
  - provider name: `model_projections_pa_outcome`
  - provider version: discovered production model version
- Serializable readiness workspace fields
- Sanitized diagnostics without probability rows
- `/models/projections` integration before bootstrap-readiness evaluation
- Game, workspace, and shared-diagnostics discovery attachments
- Focused provider-discovery and readiness integration tests

## Architecture

```text
four production PA models
        ↓
validate schema + probabilities + version
        ↓
one stable provider identity?
    ├─ yes → satisfy provider readiness
    └─ no  → remain blocked
```

## Readiness behavior

Before this slice:

```text
7 of 10 ready
```

After valid provider discovery:

```text
8 of 10 ready
```

Remaining blockers:

- exact probability artifact
- fallback probability catalog

## Contract guarantees

- All four production PA model outputs are required.
- All models must share one nonempty model version.
- All nine expected PA outcomes must be present in canonical source order.
- Every probability must be finite, nonnegative, and no greater than one.
- Each distribution must approximately sum to one.
- Team-context distributions are not represented as exact batter-pitcher rows.
- No probability records are exposed in diagnostics.
- Artifact discovery remains false.
- Canonical execution remains disabled.
- Legacy projections remain authoritative.
- Input workspace data is not mutated.

## Validation

- Probability-provider discovery/readiness tests passed: `10 passed`
- Combined canonical input/readiness tests passed: `59 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/probability_provider_discovery.py`
- `tests/test_canonical_shadow_probability_provider_discovery.py`
- `tests/test_model_projection_canonical_provider_readiness.py`

## Next slice

Build a canonical fallback probability catalog from the existing validated team-context PA distributions, while preserving clear provenance that these are fallback—not exact batter-pitcher—records.