### PR TITLE
Discover canonical fallback catalog

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -20,6 +20,7 @@ from mlb_app.simulation.game_simulation_builder import build_game_simulation as 
 from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
+    discover_canonical_shadow_fallback_catalog,
     discover_canonical_shadow_lineups,
     discover_canonical_shadow_probability_provider,
 )
@@ -665,11 +666,25 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             )
 
+            canonical_shadow_fallback_catalog_discovery = (
+                discover_canonical_shadow_fallback_catalog(
+                    workspace=workspace,
+                    provider=(
+                        canonical_shadow_probability_provider_discovery
+                        .provider
+                    ),
+                )
+            )
+
             canonical_readiness_workspace = dict(
                 workspace
             )
             canonical_readiness_workspace.update(
                 canonical_shadow_probability_provider_discovery
+                .readiness_workspace_fields()
+            )
+            canonical_readiness_workspace.update(
+                canonical_shadow_fallback_catalog_discovery
                 .readiness_workspace_fields()
             )
 
@@ -701,6 +716,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "canonicalShadowProbabilityProviderDiscovery"
             ] = (
                 canonical_shadow_probability_provider_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalShadowFallbackCatalogDiscovery"
+            ] = (
+                canonical_shadow_fallback_catalog_discovery
                 .to_diagnostics()
             )
 
@@ -766,6 +788,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
 
                 shared_diagnostics[
+                    "canonical_shadow_fallback_catalog_discovery"
+                ] = (
+                    canonical_shadow_fallback_catalog_discovery
+                    .to_diagnostics()
+                )
+
+                shared_diagnostics[
                     "canonical_shadow_bootstrap_readiness"
                 ] = canonical_shadow_bootstrap_readiness
 
@@ -798,6 +827,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 ),
                 "canonical_shadow_probability_provider_discovery": (
                     canonical_shadow_probability_provider_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_shadow_fallback_catalog_discovery": (
+                    canonical_shadow_fallback_catalog_discovery
                     .to_diagnostics()
                 ),
                 "canonical_shadow_bootstrap_readiness": (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -34,6 +34,11 @@ from .probability_provider_discovery import (
     CanonicalShadowProbabilityProviderDiscovery,
     discover_canonical_shadow_probability_provider,
 )
+from .fallback_catalog_discovery import (
+    CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION,
+    CanonicalShadowFallbackCatalogDiscovery,
+    discover_canonical_shadow_fallback_catalog,
+)
 from .lineup_discovery import (
     CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION,
     CanonicalShadowLineupDiscovery,
@@ -65,6 +70,7 @@ __all__ = [
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
+    "CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
@@ -75,6 +81,7 @@ __all__ = [
     "CanonicalShadowExecutionBundle",
     "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionInputs",
+    "CanonicalShadowFallbackCatalogDiscovery",
     "CanonicalShadowLineupDiscovery",
     "CanonicalShadowProbabilityProviderDiscovery",
     "CanonicalShadowExecutionMaterial",
@@ -85,6 +92,7 @@ __all__ = [
     "assemble_canonical_shadow_execution_inputs",
     "build_canonical_shadow_bootstrap_readiness",
     "discover_canonical_shadow_bullpens",
+    "discover_canonical_shadow_fallback_catalog",
     "discover_canonical_shadow_lineups",
     "discover_canonical_shadow_probability_provider",
     "canonical_shadow_execution_bundle_to_material",

--- a/mlb_app/simulation/shadow/fallback_catalog_discovery.py
+++ b/mlb_app/simulation/shadow/fallback_catalog_discovery.py
@@ -1,0 +1,377 @@
+"""Fallback probability-catalog discovery for canonical readiness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalOutcomeProbability,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+)
+
+from .probability_provider_discovery import (
+    REQUIRED_WORKSPACE_MODELS,
+)
+
+
+CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION = (
+    "canonical_shadow_fallback_catalog_discovery_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _canonical_distribution(
+    value: Any,
+) -> Optional[Tuple[CanonicalOutcomeProbability, ...]]:
+    source = _mapping(value)
+
+    required_source_keys = {
+        "k",
+        "bb",
+        "hbp",
+        "single",
+        "double",
+        "triple",
+        "hr",
+        "reached_on_error",
+        "out",
+    }
+
+    if set(source.keys()) != required_source_keys:
+        return None
+
+    parsed: Dict[str, float] = {}
+
+    for key in required_source_keys:
+        raw = source.get(key)
+
+        if isinstance(raw, bool):
+            return None
+
+        try:
+            probability = float(raw)
+        except (TypeError, ValueError):
+            return None
+
+        if (
+            not math.isfinite(probability)
+            or probability < 0.0
+            or probability > 1.0
+        ):
+            return None
+
+        parsed[key] = probability
+
+    if abs(sum(parsed.values()) - 1.0) > 0.001:
+        return None
+
+    canonical_values = {
+        CanonicalPlateAppearanceOutcome.OUT: (
+            parsed["out"]
+            + parsed["reached_on_error"]
+        ),
+        CanonicalPlateAppearanceOutcome.SINGLE: (
+            parsed["single"]
+        ),
+        CanonicalPlateAppearanceOutcome.DOUBLE: (
+            parsed["double"]
+        ),
+        CanonicalPlateAppearanceOutcome.TRIPLE: (
+            parsed["triple"]
+        ),
+        CanonicalPlateAppearanceOutcome.HOME_RUN: (
+            parsed["hr"]
+        ),
+        CanonicalPlateAppearanceOutcome.WALK: (
+            parsed["bb"]
+        ),
+        CanonicalPlateAppearanceOutcome.HIT_BY_PITCH: (
+            parsed["hbp"]
+        ),
+        CanonicalPlateAppearanceOutcome.STRIKEOUT: (
+            parsed["k"]
+        ),
+    }
+
+    total = sum(canonical_values.values())
+
+    if total <= 0.0:
+        return None
+
+    normalized = {
+        outcome: value / total
+        for outcome, value in canonical_values.items()
+    }
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=normalized[outcome],
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def _average_distributions(
+    distributions: Tuple[
+        Tuple[CanonicalOutcomeProbability, ...],
+        ...,
+    ],
+) -> Tuple[CanonicalOutcomeProbability, ...]:
+    count = len(distributions)
+
+    if count == 0:
+        raise ValueError(
+            "at least one distribution is required"
+        )
+
+    totals = {
+        outcome: 0.0
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    }
+
+    for distribution in distributions:
+        for point in distribution:
+            totals[point.outcome] += point.probability
+
+    averaged = {
+        outcome: totals[outcome] / count
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    }
+
+    total = sum(averaged.values())
+
+    normalized = {
+        outcome: averaged[outcome] / total
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    }
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=normalized[outcome],
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalShadowFallbackCatalogDiscovery:
+    catalog: Optional[
+        CanonicalProbabilityFallbackCatalog
+    ] = None
+    source_model_count: int = 0
+    required_model_count: int = len(
+        REQUIRED_WORKSPACE_MODELS
+    )
+    missing_models: Tuple[str, ...] = ()
+    invalid_models: Tuple[str, ...] = ()
+    status: str = "unavailable"
+    discovery_version: str = (
+        CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical fallback-catalog "
+                "discovery version"
+            )
+
+        if (
+            self.catalog is not None
+            and not isinstance(
+                self.catalog,
+                CanonicalProbabilityFallbackCatalog,
+            )
+        ):
+            raise TypeError(
+                "catalog must be a "
+                "CanonicalProbabilityFallbackCatalog or None"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.catalog is not None
+
+    def readiness_workspace_fields(
+        self,
+    ) -> Dict[str, Any]:
+        if self.catalog is None:
+            return {}
+
+        return {
+            "canonicalProbabilityFallbackCatalog": {
+                "schema_version": (
+                    self.catalog.schema_version
+                ),
+                "provider_identity": (
+                    self.catalog.provider.identity
+                ),
+                "digest": self.catalog.digest,
+                "record_count": len(
+                    self.catalog.records
+                ),
+                "tiers": [
+                    record.tier.value
+                    for record in self.catalog.records
+                ],
+            }
+        }
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        catalog = self.catalog
+
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "source": (
+                "averaged_production_team_context_pa_models"
+            ),
+            "source_model_count": (
+                self.source_model_count
+            ),
+            "required_model_count": (
+                self.required_model_count
+            ),
+            "missing_models": list(
+                self.missing_models
+            ),
+            "invalid_models": list(
+                self.invalid_models
+            ),
+            "catalog": (
+                {
+                    "schema_version": (
+                        catalog.schema_version
+                    ),
+                    "provider_identity": (
+                        catalog.provider.identity
+                    ),
+                    "digest": catalog.digest,
+                    "record_count": len(
+                        catalog.records
+                    ),
+                    "tiers": [
+                        record.tier.value
+                        for record in catalog.records
+                    ],
+                }
+                if catalog is not None
+                else None
+            ),
+            "global_record_only": True,
+            "reached_on_error_mapping": (
+                "folded_into_canonical_out"
+            ),
+            "probability_records_exposed": False,
+            "exact_artifact_discovered": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def discover_canonical_shadow_fallback_catalog(
+    *,
+    workspace: Optional[Mapping[str, Any]],
+    provider: Optional[
+        CanonicalProbabilityProviderIdentity
+    ],
+) -> CanonicalShadowFallbackCatalogDiscovery:
+    """
+    Build one provider-bound global fallback from production team-context models.
+
+    Team-context distributions cannot honestly satisfy batter- or pitcher-tier
+    identity records. They are averaged into one global fallback distribution.
+    """
+
+    if provider is None:
+        return CanonicalShadowFallbackCatalogDiscovery(
+            status="blocked",
+        )
+
+    if not isinstance(
+        provider,
+        CanonicalProbabilityProviderIdentity,
+    ):
+        raise TypeError(
+            "provider must be a "
+            "CanonicalProbabilityProviderIdentity or None"
+        )
+
+    workspace_data = _mapping(workspace)
+    missing_models = []
+    invalid_models = []
+    distributions = []
+
+    for key in REQUIRED_WORKSPACE_MODELS:
+        model = _mapping(
+            workspace_data.get(key)
+        )
+
+        if not model:
+            missing_models.append(key)
+            continue
+
+        distribution = _canonical_distribution(
+            model.get("probabilities")
+        )
+
+        if distribution is None:
+            invalid_models.append(key)
+            continue
+
+        distributions.append(distribution)
+
+    if (
+        missing_models
+        or invalid_models
+        or len(distributions)
+        != len(REQUIRED_WORKSPACE_MODELS)
+    ):
+        return CanonicalShadowFallbackCatalogDiscovery(
+            source_model_count=len(distributions),
+            missing_models=tuple(missing_models),
+            invalid_models=tuple(invalid_models),
+            status=(
+                "partial"
+                if distributions
+                else "unavailable"
+            ),
+        )
+
+    global_distribution = _average_distributions(
+        tuple(distributions)
+    )
+
+    catalog = CanonicalProbabilityFallbackCatalog(
+        provider=provider,
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=(
+                    CanonicalProbabilityFallbackTier.GLOBAL
+                ),
+                identity=None,
+                probabilities=global_distribution,
+            ),
+        ),
+    )
+
+    return CanonicalShadowFallbackCatalogDiscovery(
+        catalog=catalog,
+        source_model_count=len(distributions),
+        status="ready",
+    )

--- a/tests/test_canonical_shadow_fallback_catalog_discovery.py
+++ b/tests/test_canonical_shadow_fallback_catalog_discovery.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION,
+    discover_canonical_shadow_fallback_catalog,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def probabilities(out=0.448):
+    return {
+        "k": 0.225,
+        "bb": 0.085,
+        "hbp": 0.011,
+        "single": 0.145,
+        "double": 0.045,
+        "triple": 0.004,
+        "hr": 0.030,
+        "reached_on_error": 0.007,
+        "out": out,
+    }
+
+
+def complete_workspace():
+    return {
+        "awayPAOutcomeModel": {
+            "probabilities": probabilities(),
+        },
+        "homePAOutcomeModel": {
+            "probabilities": probabilities(),
+        },
+        "awayVsHomeBullpenPAOutcomeModel": {
+            "probabilities": probabilities(),
+        },
+        "homeVsAwayBullpenPAOutcomeModel": {
+            "probabilities": probabilities(),
+        },
+    }
+
+
+def test_complete_models_build_global_catalog():
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=complete_workspace(),
+        provider=PROVIDER,
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.catalog is not None
+    assert result.catalog.provider == PROVIDER
+    assert len(result.catalog.records) == 1
+
+    record = result.catalog.records[0]
+
+    assert record.tier is (
+        CanonicalProbabilityFallbackTier.GLOBAL
+    )
+    assert record.identity is None
+
+
+def test_catalog_uses_canonical_outcome_order():
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=complete_workspace(),
+        provider=PROVIDER,
+    )
+
+    record = result.catalog.records[0]
+
+    assert tuple(
+        point.outcome
+        for point in record.probabilities
+    ) == CANONICAL_PA_OUTCOME_ORDER
+
+
+def test_reached_on_error_is_folded_into_out():
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=complete_workspace(),
+        provider=PROVIDER,
+    )
+
+    record = result.catalog.records[0]
+    values = {
+        point.outcome: point.probability
+        for point in record.probabilities
+    }
+
+    assert values[
+        CanonicalPlateAppearanceOutcome.OUT
+    ] == 0.455
+
+
+def test_readiness_fields_are_serializable_summary():
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=complete_workspace(),
+        provider=PROVIDER,
+    )
+
+    fields = result.readiness_workspace_fields()
+    summary = fields[
+        "canonicalProbabilityFallbackCatalog"
+    ]
+
+    assert summary["provider_identity"] == (
+        PROVIDER.identity
+    )
+    assert summary["record_count"] == 1
+    assert summary["tiers"] == ["global"]
+    assert len(summary["digest"]) == 64
+
+
+def test_diagnostics_do_not_expose_probability_rows():
+    diagnostics = (
+        discover_canonical_shadow_fallback_catalog(
+            workspace=complete_workspace(),
+            provider=PROVIDER,
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION
+    )
+    assert diagnostics[
+        "probability_records_exposed"
+    ] is False
+    assert diagnostics[
+        "exact_artifact_discovered"
+    ] is False
+    assert diagnostics["global_record_only"] is True
+    assert diagnostics[
+        "reached_on_error_mapping"
+    ] == "folded_into_canonical_out"
+
+
+def test_missing_provider_blocks_catalog():
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=complete_workspace(),
+        provider=None,
+    )
+
+    assert result.status == "blocked"
+    assert result.ready is False
+    assert result.catalog is None
+
+
+def test_missing_model_keeps_catalog_blocked():
+    workspace = complete_workspace()
+    workspace.pop("homePAOutcomeModel")
+
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=workspace,
+        provider=PROVIDER,
+    )
+
+    assert result.status == "partial"
+    assert result.ready is False
+    assert result.missing_models == (
+        "homePAOutcomeModel",
+    )
+
+
+def test_invalid_distribution_keeps_catalog_blocked():
+    workspace = complete_workspace()
+    workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"]["out"] = 0.9
+
+    result = discover_canonical_shadow_fallback_catalog(
+        workspace=workspace,
+        provider=PROVIDER,
+    )
+
+    assert result.ready is False
+    assert result.invalid_models == (
+        "awayPAOutcomeModel",
+    )
+
+
+def test_source_workspace_is_not_mutated():
+    workspace = complete_workspace()
+    snapshot = repr(workspace)
+
+    discover_canonical_shadow_fallback_catalog(
+        workspace=workspace,
+        provider=PROVIDER,
+    )
+
+    assert repr(workspace) == snapshot

--- a/tests/test_model_projection_canonical_fallback_readiness.py
+++ b/tests/test_model_projection_canonical_fallback_readiness.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from mlb_app.simulation.game import (
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_fallback_catalog,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def probabilities():
+    return {
+        "k": 0.225,
+        "bb": 0.085,
+        "hbp": 0.011,
+        "single": 0.145,
+        "double": 0.045,
+        "triple": 0.004,
+        "hr": 0.030,
+        "reached_on_error": 0.007,
+        "out": 0.448,
+    }
+
+
+def workspace_models():
+    return {
+        key: {
+            "model_version": "pa_outcome_v1",
+            "probabilities": probabilities(),
+        }
+        for key in (
+            "awayPAOutcomeModel",
+            "homePAOutcomeModel",
+            "awayVsHomeBullpenPAOutcomeModel",
+            "homeVsAwayBullpenPAOutcomeModel",
+        )
+    }
+
+
+def ready_matchup():
+    return {
+        "game_pk": 123,
+        "away_pitcher_id": 100,
+        "home_pitcher_id": 200,
+        "away_lineup": [
+            {"player_id": f"a{index}"}
+            for index in range(9)
+        ],
+        "home_lineup": [
+            {"player_id": f"h{index}"}
+            for index in range(9)
+        ],
+        "away_bullpen_pitcher_ids": [
+            {"pitcher_id": 101},
+        ],
+        "home_bullpen_pitcher_ids": [
+            {"pitcher_id": 201},
+        ],
+    }
+
+
+def test_fallback_catalog_advances_readiness_to_nine():
+    workspace = workspace_models()
+
+    discovery = (
+        discover_canonical_shadow_fallback_catalog(
+            workspace=workspace,
+            provider=PROVIDER,
+        )
+    )
+
+    readiness_workspace = dict(workspace)
+    readiness_workspace.update({
+        "canonicalProbabilityProvider": {
+            "identity": PROVIDER.identity,
+        }
+    })
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context={},
+        home_context={},
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "fallback_probability_catalog"
+    ]["ready"] is True
+
+    assert report["missing_requirements"] == [
+        "exact_probability_artifact",
+    ]
+
+
+def test_invalid_catalog_source_keeps_requirement_blocked():
+    workspace = workspace_models()
+    workspace[
+        "homePAOutcomeModel"
+    ]["probabilities"] = {}
+
+    discovery = (
+        discover_canonical_shadow_fallback_catalog(
+            workspace=workspace,
+            provider=PROVIDER,
+        )
+    )
+
+    readiness_workspace = dict(workspace)
+    readiness_workspace.update({
+        "canonicalProbabilityProvider": {
+            "identity": PROVIDER.identity,
+        }
+    })
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context={},
+        home_context={},
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "fallback_probability_catalog"
+    ]["ready"] is False


### PR DESCRIPTION
## Summary

Implements the next Layer 10J production discovery adapter: canonical fallback probability catalog discovery from the existing validated `/models/projections` team-context PA models.

The adapter converts all four production PA distributions into the canonical eight-outcome contract, folds `reached_on_error` into canonical `out`, averages the four distributions, and constructs one provider-bound global fallback record. It deliberately does not create batter-tier, pitcher-tier, or exact matchup records from team-context data.

## Added

- `CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION`
- `CanonicalShadowFallbackCatalogDiscovery`
- `discover_canonical_shadow_fallback_catalog()`
- Validation of all four production team-context PA models
- Conversion into canonical outcome ordering
- Explicit `reached_on_error` to canonical `out` mapping
- Averaging and renormalization across the four validated distributions
- Provider-bound `CanonicalProbabilityFallbackCatalog`
- One global fallback record only
- Serializable readiness workspace summary
- Sanitized diagnostics without probability rows
- `/models/projections` integration before bootstrap-readiness evaluation
- Game, workspace, and shared-diagnostics discovery attachments
- Focused catalog-discovery and readiness integration tests

## Architecture

```text
four validated team-context PA models
        ↓
canonical eight-outcome conversion
        ↓
average + renormalize
        ↓
one provider-bound global fallback record
        ↓
bootstrap readiness
```

## Readiness behavior

Before this slice:

```text
8 of 10 ready
```

After valid fallback-catalog discovery:

```text
9 of 10 ready
```

Remaining blocker:

- exact probability artifact

## Contract guarantees

- All four production PA model outputs are required.
- Invalid or incomplete distributions keep the catalog blocked.
- `reached_on_error` is explicitly folded into canonical `out`.
- The catalog is bound to the discovered probability-provider identity.
- Only one global fallback record is created.
- Team-context distributions are not misrepresented as batter or pitcher identity records.
- No exact batter-pitcher records are created.
- No probability rows are exposed in diagnostics.
- Canonical execution remains disabled.
- Legacy projections remain authoritative.
- Input workspace data is not mutated.

## Validation

- Fallback-catalog discovery/readiness tests passed: `11 passed`
- Combined canonical input/readiness tests passed: `70 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/fallback_catalog_discovery.py`
- `tests/test_canonical_shadow_fallback_catalog_discovery.py`
- `tests/test_model_projection_canonical_fallback_readiness.py`

## Next slice

Implement true player-level exact batter-versus-pitcher probability artifact discovery. That remains the final bootstrap-readiness blocker and must not be satisfied by team-level or fallback distributions.