### PR TITLE
Discover canonical exact probability artifact

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -20,6 +20,7 @@ from mlb_app.simulation.game_simulation_builder import build_game_simulation as 
 from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
+    discover_canonical_shadow_exact_artifact,
     discover_canonical_shadow_fallback_catalog,
     discover_canonical_shadow_lineups,
     discover_canonical_shadow_probability_provider,
@@ -676,6 +677,18 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             )
 
+            canonical_shadow_exact_artifact_discovery = (
+                discover_canonical_shadow_exact_artifact(
+                    away_context=away,
+                    home_context=home,
+                    workspace=workspace,
+                    provider=(
+                        canonical_shadow_probability_provider_discovery
+                        .provider
+                    ),
+                )
+            )
+
             canonical_readiness_workspace = dict(
                 workspace
             )
@@ -685,6 +698,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
             )
             canonical_readiness_workspace.update(
                 canonical_shadow_fallback_catalog_discovery
+                .readiness_workspace_fields()
+            )
+            canonical_readiness_workspace.update(
+                canonical_shadow_exact_artifact_discovery
                 .readiness_workspace_fields()
             )
 
@@ -723,6 +740,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "canonicalShadowFallbackCatalogDiscovery"
             ] = (
                 canonical_shadow_fallback_catalog_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalShadowExactArtifactDiscovery"
+            ] = (
+                canonical_shadow_exact_artifact_discovery
                 .to_diagnostics()
             )
 
@@ -795,6 +819,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
 
                 shared_diagnostics[
+                    "canonical_shadow_exact_artifact_discovery"
+                ] = (
+                    canonical_shadow_exact_artifact_discovery
+                    .to_diagnostics()
+                )
+
+                shared_diagnostics[
                     "canonical_shadow_bootstrap_readiness"
                 ] = canonical_shadow_bootstrap_readiness
 
@@ -831,6 +862,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 ),
                 "canonical_shadow_fallback_catalog_discovery": (
                     canonical_shadow_fallback_catalog_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_shadow_exact_artifact_discovery": (
+                    canonical_shadow_exact_artifact_discovery
                     .to_diagnostics()
                 ),
                 "canonical_shadow_bootstrap_readiness": (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -34,6 +34,12 @@ from .probability_provider_discovery import (
     CanonicalShadowProbabilityProviderDiscovery,
     discover_canonical_shadow_probability_provider,
 )
+from .exact_artifact_discovery import (
+    CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION,
+    MIN_EXACT_BATTER_RECORDS_PER_SIDE,
+    CanonicalShadowExactArtifactDiscovery,
+    discover_canonical_shadow_exact_artifact,
+)
 from .fallback_catalog_discovery import (
     CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION,
     CanonicalShadowFallbackCatalogDiscovery,
@@ -70,8 +76,10 @@ __all__ = [
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION",
     "CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION",
+    "CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_FALLBACK_CATALOG_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
+    "MIN_EXACT_BATTER_RECORDS_PER_SIDE",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
@@ -81,6 +89,7 @@ __all__ = [
     "CanonicalShadowExecutionBundle",
     "CanonicalShadowExecutionBundleFactory",
     "CanonicalShadowExecutionInputs",
+    "CanonicalShadowExactArtifactDiscovery",
     "CanonicalShadowFallbackCatalogDiscovery",
     "CanonicalShadowLineupDiscovery",
     "CanonicalShadowProbabilityProviderDiscovery",
@@ -92,6 +101,7 @@ __all__ = [
     "assemble_canonical_shadow_execution_inputs",
     "build_canonical_shadow_bootstrap_readiness",
     "discover_canonical_shadow_bullpens",
+    "discover_canonical_shadow_exact_artifact",
     "discover_canonical_shadow_fallback_catalog",
     "discover_canonical_shadow_lineups",
     "discover_canonical_shadow_probability_provider",

--- a/mlb_app/simulation/shadow/exact_artifact_discovery.py
+++ b/mlb_app/simulation/shadow/exact_artifact_discovery.py
@@ -1,0 +1,560 @@
+"""Exact starter-matchup probability artifact discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalOutcomeProbability,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+
+
+CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION = (
+    "canonical_shadow_exact_artifact_discovery_v1"
+)
+
+MIN_EXACT_BATTER_RECORDS_PER_SIDE = 7
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes),
+    ):
+        return value
+    return ()
+
+
+def _identifier(value: Any) -> Optional[str]:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _rate(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(parsed) or parsed < 0.0:
+        return None
+
+    if parsed > 1.0:
+        parsed /= 100.0
+
+    return parsed
+
+
+def _number(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if math.isfinite(parsed) else None
+
+
+def _real_batter_profile(
+    row: Mapping[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if not (
+        row.get("has_player_split")
+        or row.get("has_batter_aggregate")
+    ):
+        return None
+
+    inputs = _mapping(
+        row.get("simulation_inputs")
+    )
+
+    profile = {
+        "contact_skill": {
+            "k_rate": _rate(inputs.get("k_pct")),
+            "batting_avg": _rate(
+                inputs.get("batting_avg")
+            ),
+            "contact_rate": None,
+        },
+        "plate_discipline": {
+            "bb_rate": _rate(inputs.get("bb_pct")),
+            "on_base_pct": _rate(
+                inputs.get("on_base_pct")
+            ),
+        },
+        "power": {
+            "iso": _rate(inputs.get("iso")),
+            "barrel_rate": _rate(
+                inputs.get("barrel_pct")
+            ),
+            "hard_hit_rate": _rate(
+                inputs.get("hard_hit_pct")
+            ),
+            "slugging_pct": _rate(
+                inputs.get("slugging_pct")
+            ),
+        },
+        "contact_quality": {
+            "avg_exit_velocity": _number(
+                inputs.get("avg_exit_velocity")
+            ),
+            "avg_launch_angle": _number(
+                inputs.get("avg_launch_angle")
+            ),
+        },
+    }
+
+    usable = any(
+        value is not None
+        for section in profile.values()
+        for value in section.values()
+    )
+
+    return profile if usable else None
+
+
+def _canonical_probabilities(
+    source: Any,
+) -> Optional[Tuple[CanonicalOutcomeProbability, ...]]:
+    probabilities = _mapping(source)
+
+    expected = {
+        "k",
+        "bb",
+        "hbp",
+        "single",
+        "double",
+        "triple",
+        "hr",
+        "reached_on_error",
+        "out",
+    }
+
+    if set(probabilities.keys()) != expected:
+        return None
+
+    parsed: Dict[str, float] = {}
+
+    for key in expected:
+        value = _number(probabilities.get(key))
+
+        if (
+            value is None
+            or value < 0.0
+            or value > 1.0
+        ):
+            return None
+
+        parsed[key] = value
+
+    if abs(sum(parsed.values()) - 1.0) > 0.001:
+        return None
+
+    canonical = {
+        CanonicalPlateAppearanceOutcome.OUT: (
+            parsed["out"]
+            + parsed["reached_on_error"]
+        ),
+        CanonicalPlateAppearanceOutcome.SINGLE: (
+            parsed["single"]
+        ),
+        CanonicalPlateAppearanceOutcome.DOUBLE: (
+            parsed["double"]
+        ),
+        CanonicalPlateAppearanceOutcome.TRIPLE: (
+            parsed["triple"]
+        ),
+        CanonicalPlateAppearanceOutcome.HOME_RUN: (
+            parsed["hr"]
+        ),
+        CanonicalPlateAppearanceOutcome.WALK: (
+            parsed["bb"]
+        ),
+        CanonicalPlateAppearanceOutcome.HIT_BY_PITCH: (
+            parsed["hbp"]
+        ),
+        CanonicalPlateAppearanceOutcome.STRIKEOUT: (
+            parsed["k"]
+        ),
+    }
+
+    total = sum(canonical.values())
+
+    if total <= 0.0:
+        return None
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                canonical[outcome] / total
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def _side_records(
+    *,
+    offense_context: Mapping[str, Any],
+    opposing_starter_id: Any,
+    opposing_pitcher_profile: Mapping[str, Any],
+    environment_profile: Mapping[str, Any],
+) -> Tuple[
+    Tuple[CanonicalProbabilityArtifactRecord, ...],
+    int,
+    int,
+]:
+    starter_id = _identifier(
+        opposing_starter_id
+    )
+
+    if starter_id is None:
+        return (), 0, 0
+
+    offense_inputs = _mapping(
+        offense_context.get("offense_inputs")
+    )
+    lineup = _sequence(
+        offense_inputs.get("lineup")
+    )
+
+    records = []
+    real_profile_count = 0
+    invalid_record_count = 0
+
+    for raw_row in lineup:
+        row = _mapping(raw_row)
+        batter_id = _identifier(
+            row.get("batter_id")
+        )
+        batter_profile = _real_batter_profile(
+            row
+        )
+
+        if (
+            batter_id is None
+            or batter_profile is None
+        ):
+            continue
+
+        real_profile_count += 1
+
+        model = build_pa_outcome_probabilities(
+            batter_profile=batter_profile,
+            pitcher_profile=dict(
+                opposing_pitcher_profile
+            ),
+            environment_profile=dict(
+                environment_profile
+            ),
+        )
+
+        probabilities = _canonical_probabilities(
+            model.get("probabilities")
+        )
+
+        if probabilities is None:
+            invalid_record_count += 1
+            continue
+
+        records.append(
+            CanonicalProbabilityArtifactRecord(
+                batter_id=batter_id,
+                pitcher_id=starter_id,
+                probabilities=probabilities,
+            )
+        )
+
+    return (
+        tuple(records),
+        real_profile_count,
+        invalid_record_count,
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalShadowExactArtifactDiscovery:
+    artifact: Optional[
+        CanonicalProbabilityArtifact
+    ] = None
+    away_record_count: int = 0
+    home_record_count: int = 0
+    away_real_profile_count: int = 0
+    home_real_profile_count: int = 0
+    invalid_record_count: int = 0
+    status: str = "unavailable"
+    blocked_reasons: Tuple[str, ...] = ()
+    discovery_version: str = (
+        CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical exact-artifact "
+                "discovery version"
+            )
+
+        if (
+            self.artifact is not None
+            and not isinstance(
+                self.artifact,
+                CanonicalProbabilityArtifact,
+            )
+        ):
+            raise TypeError(
+                "artifact must be a "
+                "CanonicalProbabilityArtifact or None"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.artifact is not None
+
+    def readiness_workspace_fields(
+        self,
+    ) -> Dict[str, Any]:
+        if self.artifact is None:
+            return {}
+
+        return {
+            "canonicalExactProbabilityArtifact": {
+                "artifact_version": (
+                    self.artifact.artifact_version
+                ),
+                "provider_identity": (
+                    self.artifact.provider.identity
+                ),
+                "digest": self.artifact.digest,
+                "record_count": len(
+                    self.artifact.records
+                ),
+                "away_record_count": (
+                    self.away_record_count
+                ),
+                "home_record_count": (
+                    self.home_record_count
+                ),
+                "coverage": (
+                    "confirmed_batters_vs_probable_starters"
+                ),
+            }
+        }
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        artifact = self.artifact
+
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "source": (
+                "confirmed_player_profiles_vs_probable_starters"
+            ),
+            "minimum_records_per_side": (
+                MIN_EXACT_BATTER_RECORDS_PER_SIDE
+            ),
+            "away_record_count": (
+                self.away_record_count
+            ),
+            "home_record_count": (
+                self.home_record_count
+            ),
+            "away_real_profile_count": (
+                self.away_real_profile_count
+            ),
+            "home_real_profile_count": (
+                self.home_real_profile_count
+            ),
+            "invalid_record_count": (
+                self.invalid_record_count
+            ),
+            "blocked_reasons": list(
+                self.blocked_reasons
+            ),
+            "artifact": (
+                {
+                    "artifact_version": (
+                        artifact.artifact_version
+                    ),
+                    "provider_identity": (
+                        artifact.provider.identity
+                    ),
+                    "digest": artifact.digest,
+                    "record_count": len(
+                        artifact.records
+                    ),
+                    "coverage": (
+                        "confirmed_batters_vs_probable_starters"
+                    ),
+                }
+                if artifact is not None
+                else None
+            ),
+            "bullpen_exact_rows_included": False,
+            "team_fallback_profiles_included": False,
+            "reached_on_error_mapping": (
+                "folded_into_canonical_out"
+            ),
+            "probability_records_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def discover_canonical_shadow_exact_artifact(
+    *,
+    away_context: Optional[Mapping[str, Any]],
+    home_context: Optional[Mapping[str, Any]],
+    workspace: Optional[Mapping[str, Any]],
+    provider: Optional[
+        CanonicalProbabilityProviderIdentity
+    ],
+) -> CanonicalShadowExactArtifactDiscovery:
+    """
+    Build exact confirmed-batter versus probable-starter probability rows.
+
+    Only real batter split/aggregate profiles are eligible. Team fallback
+    profiles and team-average PA distributions cannot become exact records.
+    """
+
+    if provider is None:
+        return CanonicalShadowExactArtifactDiscovery(
+            status="blocked",
+            blocked_reasons=("missing_provider",),
+        )
+
+    if not isinstance(
+        provider,
+        CanonicalProbabilityProviderIdentity,
+    ):
+        raise TypeError(
+            "provider must be a "
+            "CanonicalProbabilityProviderIdentity or None"
+        )
+
+    away_data = _mapping(away_context)
+    home_data = _mapping(home_context)
+    workspace_data = _mapping(workspace)
+
+    away_records, away_real, away_invalid = (
+        _side_records(
+            offense_context=away_data,
+            opposing_starter_id=(
+                home_data.get("pitcher_id")
+            ),
+            opposing_pitcher_profile=_mapping(
+                workspace_data.get(
+                    "homePitcherProfile"
+                )
+            ),
+            environment_profile=_mapping(
+                workspace_data.get(
+                    "environmentProfile"
+                )
+            ),
+        )
+    )
+
+    home_records, home_real, home_invalid = (
+        _side_records(
+            offense_context=home_data,
+            opposing_starter_id=(
+                away_data.get("pitcher_id")
+            ),
+            opposing_pitcher_profile=_mapping(
+                workspace_data.get(
+                    "awayPitcherProfile"
+                )
+            ),
+            environment_profile=_mapping(
+                workspace_data.get(
+                    "environmentProfile"
+                )
+            ),
+        )
+    )
+
+    reasons = []
+
+    if (
+        len(away_records)
+        < MIN_EXACT_BATTER_RECORDS_PER_SIDE
+    ):
+        reasons.append(
+            "insufficient_away_exact_records"
+        )
+
+    if (
+        len(home_records)
+        < MIN_EXACT_BATTER_RECORDS_PER_SIDE
+    ):
+        reasons.append(
+            "insufficient_home_exact_records"
+        )
+
+    if reasons:
+        return CanonicalShadowExactArtifactDiscovery(
+            away_record_count=len(away_records),
+            home_record_count=len(home_records),
+            away_real_profile_count=away_real,
+            home_real_profile_count=home_real,
+            invalid_record_count=(
+                away_invalid + home_invalid
+            ),
+            status=(
+                "partial"
+                if away_records or home_records
+                else "unavailable"
+            ),
+            blocked_reasons=tuple(reasons),
+        )
+
+    artifact = CanonicalProbabilityArtifact(
+        provider=provider,
+        records=(
+            *away_records,
+            *home_records,
+        ),
+    )
+
+    return CanonicalShadowExactArtifactDiscovery(
+        artifact=artifact,
+        away_record_count=len(away_records),
+        home_record_count=len(home_records),
+        away_real_profile_count=away_real,
+        home_real_profile_count=home_real,
+        invalid_record_count=(
+            away_invalid + home_invalid
+        ),
+        status="ready",
+    )

--- a/tests/test_canonical_shadow_exact_artifact_discovery.py
+++ b/tests/test_canonical_shadow_exact_artifact_discovery.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION,
+    MIN_EXACT_BATTER_RECORDS_PER_SIDE,
+    discover_canonical_shadow_exact_artifact,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def batter_row(player_id, real=True):
+    return {
+        "batter_id": player_id,
+        "has_player_split": real,
+        "has_batter_aggregate": False,
+        "simulation_inputs": {
+            "k_pct": 0.22,
+            "bb_pct": 0.09,
+            "batting_avg": 0.255,
+            "on_base_pct": 0.330,
+            "slugging_pct": 0.430,
+            "iso": 0.175,
+            "hard_hit_pct": 0.40,
+            "barrel_pct": 0.08,
+        },
+    }
+
+
+def context(prefix, pitcher_id):
+    return {
+        "pitcher_id": pitcher_id,
+        "offense_inputs": {
+            "lineup": [
+                batter_row(f"{prefix}{index}")
+                for index in range(1, 10)
+            ]
+        },
+    }
+
+
+def workspace():
+    pitcher_profile = {
+        "bat_missing": {
+            "k_rate": 0.24,
+        },
+        "command_control": {
+            "bb_rate": 0.08,
+        },
+        "contact_management": {
+            "barrel_rate_allowed": 0.07,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.245,
+        },
+    }
+
+    return {
+        "awayPitcherProfile": pitcher_profile,
+        "homePitcherProfile": pitcher_profile,
+        "environmentProfile": {
+            "run_environment": {
+                "hr_boost_index": 1.0,
+                "hit_boost_index": 1.0,
+                "run_scoring_index": 1.0,
+            }
+        },
+    }
+
+
+def discovery(**overrides):
+    kwargs = {
+        "away_context": context("1", 100),
+        "home_context": context("2", 200),
+        "workspace": workspace(),
+        "provider": PROVIDER,
+    }
+    kwargs.update(overrides)
+
+    return discover_canonical_shadow_exact_artifact(
+        **kwargs
+    )
+
+
+def test_confirmed_player_profiles_build_exact_artifact():
+    result = discovery()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.artifact is not None
+    assert result.away_record_count == 9
+    assert result.home_record_count == 9
+    assert len(result.artifact.records) == 18
+
+
+def test_rows_use_opposing_probable_starter():
+    result = discovery()
+
+    away_records = [
+        record
+        for record in result.artifact.records
+        if record.batter_id.startswith("1")
+    ]
+    home_records = [
+        record
+        for record in result.artifact.records
+        if record.batter_id.startswith("2")
+    ]
+
+    assert {
+        record.pitcher_id
+        for record in away_records
+    } == {"200"}
+
+    assert {
+        record.pitcher_id
+        for record in home_records
+    } == {"100"}
+
+
+def test_records_use_canonical_outcome_order():
+    record = discovery().artifact.records[0]
+
+    assert tuple(
+        point.outcome
+        for point in record.probabilities
+    ) == CANONICAL_PA_OUTCOME_ORDER
+
+    assert abs(
+        sum(
+            point.probability
+            for point in record.probabilities
+        )
+        - 1.0
+    ) < 0.000000001
+
+
+def test_team_fallback_profiles_are_not_exact_rows():
+    away = context("1", 100)
+    away["offense_inputs"]["lineup"][0] = (
+        batter_row("11", real=False)
+    )
+    away["offense_inputs"]["lineup"][1] = (
+        batter_row("12", real=False)
+    )
+
+    result = discovery(
+        away_context=away,
+    )
+
+    assert result.ready is True
+    assert result.away_record_count == 7
+    assert all(
+        record.batter_id not in {"11", "12"}
+        for record in result.artifact.records
+    )
+
+
+def test_fewer_than_seven_real_rows_blocks_side():
+    away = context("1", 100)
+
+    for index in range(3):
+        away["offense_inputs"]["lineup"][index] = (
+            batter_row(
+                f"1{index + 1}",
+                real=False,
+            )
+        )
+
+    result = discovery(
+        away_context=away,
+    )
+
+    assert result.ready is False
+    assert result.status == "partial"
+    assert result.away_record_count == 6
+    assert result.blocked_reasons == (
+        "insufficient_away_exact_records",
+    )
+
+
+def test_missing_provider_blocks_artifact():
+    result = discovery(provider=None)
+
+    assert result.ready is False
+    assert result.status == "blocked"
+    assert result.blocked_reasons == (
+        "missing_provider",
+    )
+
+
+def test_missing_starter_blocks_affected_side():
+    home = context("2", None)
+
+    result = discovery(
+        home_context=home,
+    )
+
+    assert result.ready is False
+    assert result.away_record_count == 0
+    assert (
+        "insufficient_away_exact_records"
+        in result.blocked_reasons
+    )
+
+
+def test_readiness_summary_does_not_expose_rows():
+    result = discovery()
+    summary = result.readiness_workspace_fields()[
+        "canonicalExactProbabilityArtifact"
+    ]
+
+    assert summary["record_count"] == 18
+    assert summary["away_record_count"] == 9
+    assert summary["home_record_count"] == 9
+    assert len(summary["digest"]) == 64
+    assert "records" not in summary
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = discovery().to_diagnostics()
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION
+    )
+    assert diagnostics[
+        "minimum_records_per_side"
+    ] == MIN_EXACT_BATTER_RECORDS_PER_SIDE
+    assert diagnostics[
+        "team_fallback_profiles_included"
+    ] is False
+    assert diagnostics[
+        "bullpen_exact_rows_included"
+    ] is False
+    assert diagnostics[
+        "probability_records_exposed"
+    ] is False
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["authoritative_source"] == (
+        "legacy"
+    )
+
+
+def test_source_inputs_are_not_mutated():
+    away = context("1", 100)
+    home = context("2", 200)
+    workspace_data = workspace()
+    snapshot = (
+        repr(away),
+        repr(home),
+        repr(workspace_data),
+    )
+
+    discover_canonical_shadow_exact_artifact(
+        away_context=away,
+        home_context=home,
+        workspace=workspace_data,
+        provider=PROVIDER,
+    )
+
+    assert (
+        repr(away),
+        repr(home),
+        repr(workspace_data),
+    ) == snapshot

--- a/tests/test_model_projection_canonical_exact_artifact_readiness.py
+++ b/tests/test_model_projection_canonical_exact_artifact_readiness.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from mlb_app.simulation.game import (
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    build_canonical_shadow_bootstrap_readiness,
+    discover_canonical_shadow_exact_artifact,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def side_context(prefix, pitcher_id):
+    return {
+        "pitcher_id": pitcher_id,
+        "offense_inputs": {
+            "lineup": [
+                {
+                    "batter_id": f"{prefix}{index}",
+                    "has_player_split": True,
+                    "has_batter_aggregate": False,
+                    "simulation_inputs": {
+                        "k_pct": 0.22,
+                        "bb_pct": 0.09,
+                        "batting_avg": 0.255,
+                        "on_base_pct": 0.330,
+                        "slugging_pct": 0.430,
+                        "iso": 0.175,
+                        "hard_hit_pct": 0.40,
+                        "barrel_pct": 0.08,
+                    },
+                }
+                for index in range(1, 10)
+            ]
+        },
+    }
+
+
+def probability_workspace():
+    pitcher_profile = {
+        "bat_missing": {"k_rate": 0.24},
+        "command_control": {"bb_rate": 0.08},
+        "contact_management": {
+            "barrel_rate_allowed": 0.07,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.245,
+        },
+    }
+
+    return {
+        "awayPitcherProfile": pitcher_profile,
+        "homePitcherProfile": pitcher_profile,
+        "environmentProfile": {
+            "run_environment": {
+                "hr_boost_index": 1.0,
+                "hit_boost_index": 1.0,
+                "run_scoring_index": 1.0,
+            }
+        },
+    }
+
+
+def ready_matchup():
+    return {
+        "game_pk": 123,
+        "away_pitcher_id": 100,
+        "home_pitcher_id": 200,
+        "away_lineup": [
+            {"player_id": f"1{index}"}
+            for index in range(1, 10)
+        ],
+        "home_lineup": [
+            {"player_id": f"2{index}"}
+            for index in range(1, 10)
+        ],
+        "away_bullpen_pitcher_ids": [
+            {"pitcher_id": 101},
+        ],
+        "home_bullpen_pitcher_ids": [
+            {"pitcher_id": 201},
+        ],
+    }
+
+
+def base_readiness_workspace():
+    return {
+        "canonicalProbabilityProvider": {
+            "identity": PROVIDER.identity,
+        },
+        "canonicalProbabilityFallbackCatalog": {
+            "digest": "a" * 64,
+        },
+    }
+
+
+def test_exact_artifact_advances_readiness_to_ten():
+    away = side_context("1", 100)
+    home = side_context("2", 200)
+    workspace = probability_workspace()
+
+    discovery = discover_canonical_shadow_exact_artifact(
+        away_context=away,
+        home_context=home,
+        workspace=workspace,
+        provider=PROVIDER,
+    )
+
+    readiness_workspace = (
+        base_readiness_workspace()
+    )
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context=away,
+        home_context=home,
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "exact_probability_artifact"
+    ]["ready"] is True
+    assert report["missing_requirements"] == []
+    assert report["ready"] is True
+    assert report["status"] == "ready"
+
+    # Full input readiness still does not authorize execution.
+    assert report["activation_permitted"] is False
+    assert report["activation_status"] == (
+        "diagnostic_only"
+    )
+    assert report["authoritative_source"] == (
+        "legacy"
+    )
+
+
+def test_incomplete_exact_coverage_keeps_final_blocker():
+    away = side_context("1", 100)
+
+    for index in range(3):
+        away["offense_inputs"]["lineup"][index][
+            "has_player_split"
+        ] = False
+
+    home = side_context("2", 200)
+    workspace = probability_workspace()
+
+    discovery = discover_canonical_shadow_exact_artifact(
+        away_context=away,
+        home_context=home,
+        workspace=workspace,
+        provider=PROVIDER,
+    )
+
+    readiness_workspace = (
+        base_readiness_workspace()
+    )
+    readiness_workspace.update(
+        discovery.readiness_workspace_fields()
+    )
+
+    report = build_canonical_shadow_bootstrap_readiness(
+        game_pk=123,
+        matchup=ready_matchup(),
+        away_context=away,
+        home_context=home,
+        workspace=readiness_workspace,
+    )
+
+    assert report["requirements"][
+        "exact_probability_artifact"
+    ]["ready"] is False
+    assert report["missing_requirements"] == [
+        "exact_probability_artifact",
+    ]


### PR DESCRIPTION
## Summary

Implements the final Layer 10J production bootstrap discovery adapter: canonical exact probability artifact discovery from confirmed player-level batter profiles versus opposing probable starters.

The adapter uses confirmed lineup player identities and real player split or batter-aggregate inputs, combines them with the opposing probable starter profile and environment context, converts the resulting PA distributions into the canonical eight-outcome contract, and builds a provider-bound immutable exact probability artifact.

It deliberately excludes team-fallback batter profiles, does not create exact bullpen rows, does not expose probability records in diagnostics, does not authorize canonical execution, and leaves legacy projections authoritative.

## Added

- `CANONICAL_SHADOW_EXACT_ARTIFACT_DISCOVERY_VERSION`
- `MIN_EXACT_BATTER_RECORDS_PER_SIDE`
- `CanonicalShadowExactArtifactDiscovery`
- `discover_canonical_shadow_exact_artifact()`
- Real confirmed-lineup batter eligibility checks
- Player split or batter-aggregate provenance requirement
- Opposing probable-starter matchup construction
- Existing production PA outcome model integration
- Canonical eight-outcome conversion
- Explicit `reached_on_error` to canonical `out` mapping
- Provider-bound `CanonicalProbabilityArtifact`
- Minimum seven exact batter records per side
- Serializable readiness workspace summary
- Sanitized diagnostics without probability rows
- `/models/projections` integration before bootstrap-readiness evaluation
- Game, workspace, and shared-diagnostics discovery attachments
- Focused artifact-discovery and readiness integration tests

## Architecture

```text
confirmed lineup batter identity
        +
real player split / batter aggregate
        +
opposing probable starter profile
        +
environment context
        ↓
production PA outcome model
        ↓
canonical eight-outcome conversion
        ↓
exact batter-versus-starter artifact row
```

## Readiness behavior

Before this slice:

```text
9 of 10 ready
```

After valid exact-artifact discovery:

```text
10 of 10 ready
```

All bootstrap requirements can now be satisfied:

- game identity
- away lineup
- home lineup
- away starter
- home starter
- away bullpen
- home bullpen
- probability provider
- exact probability artifact
- fallback probability catalog

## Contract guarantees

- Only confirmed batter identities are eligible.
- Only real player split or batter-aggregate profiles become exact rows.
- Team fallback profiles are excluded.
- Each exact row is bound to the opposing probable starter.
- At least seven exact batter records are required per side.
- Exact bullpen rows are not fabricated.
- `reached_on_error` is explicitly folded into canonical `out`.
- The artifact is bound to the discovered probability-provider identity.
- No probability rows are exposed in diagnostics.
- Input contexts and workspace data are not mutated.
- Full bootstrap readiness still does not authorize execution.
- Canonical execution remains diagnostic-only.
- Legacy projections remain authoritative.

## Validation

- Exact-artifact discovery/readiness tests passed: `12 passed`
- Combined canonical input/readiness tests passed: `82 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `mlb_app/simulation/shadow/__init__.py`
- `mlb_app/simulation/shadow/exact_artifact_discovery.py`
- `tests/test_canonical_shadow_exact_artifact_discovery.py`
- `tests/test_model_projection_canonical_exact_artifact_readiness.py`

## Next slice

Assemble the discovered player, provider, exact-artifact, and fallback-catalog contracts into the existing atomic canonical execution bundle and begin real production shadow trials while preserving legacy authority and explicit fail-open behavior.