### PR TITLE
Preserve confirmed offense inputs

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -549,6 +549,42 @@ def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
     return {"away": [away_card, game_total_card], "home": [home_card], "workspace": workspace}
 
 
+def _projection_offense_inputs(
+    *,
+    matchup: Dict[str, Any],
+    side: str,
+    session: Session,
+    team_id: Optional[int],
+    season: int,
+) -> Dict[str, Any]:
+    """
+    Preserve confirmed player-level offense inputs from matchup generation.
+
+    Exact canonical batter-pitcher artifact discovery requires the individual
+    confirmed-lineup rows retained under ``lineup``. Team splits remain the
+    fail-open fallback when confirmed player-level inputs are unavailable.
+    """
+
+    candidate = matchup.get(
+        f"{side}_offense_inputs"
+    )
+
+    if isinstance(candidate, dict):
+        lineup = candidate.get("lineup")
+
+        if (
+            isinstance(lineup, list)
+            and len(lineup) > 0
+        ):
+            return candidate
+
+    return _team_split_inputs(
+        session,
+        team_id,
+        season,
+    )
+
+
 def _side_context(matchup: Dict[str, Any], side: str, session: Session, season: int) -> Dict[str, Any]:
     pitcher_id = matchup.get(f"{side}_pitcher_id")
     arsenal = matchup.get(f"{side}_pitch_arsenal") or {}
@@ -568,7 +604,13 @@ def _side_context(matchup: Dict[str, Any], side: str, session: Session, season: 
         "pitcher_features": matchup.get(f"{side}_pitcher_features") or {},
         "pitch_arsenal": arsenal,
         "pitch_arsenal_source": arsenal_source,
-        "offense_inputs": _team_split_inputs(session, team_id, season),
+        "offense_inputs": _projection_offense_inputs(
+            matchup=matchup,
+            side=side,
+            session=session,
+            team_id=team_id,
+            season=season,
+        ),
         "bullpen_inputs": _bullpen_inputs(session, team_id, team_name),
     }
     ctx["models"] = [

--- a/tests/test_model_projection_confirmed_offense_handoff.py
+++ b/tests/test_model_projection_confirmed_offense_handoff.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from mlb_app import model_projections
+
+
+class DummySession:
+    pass
+
+
+def confirmed_offense_inputs():
+    return {
+        "source": "confirmed_lineup_player_splits",
+        "profile_granularity": "lineup_average",
+        "player_count_used": 9,
+        "real_player_profile_count": 9,
+        "fallback_player_count": 0,
+        "lineup": [
+            {
+                "batter_id": 1000 + index,
+                "has_player_split": True,
+                "has_batter_aggregate": False,
+                "simulation_inputs": {
+                    "k_pct": 0.22,
+                    "bb_pct": 0.09,
+                    "batting_avg": 0.255,
+                    "on_base_pct": 0.330,
+                    "slugging_pct": 0.430,
+                    "iso": 0.175,
+                },
+            }
+            for index in range(1, 10)
+        ],
+    }
+
+
+def test_confirmed_player_level_inputs_are_preserved(
+    monkeypatch,
+):
+    confirmed = confirmed_offense_inputs()
+
+    def unexpected_fallback(*args, **kwargs):
+        raise AssertionError(
+            "team fallback must not replace confirmed inputs"
+        )
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        unexpected_fallback,
+    )
+
+    result = (
+        model_projections
+        ._projection_offense_inputs(
+            matchup={
+                "away_offense_inputs": confirmed,
+            },
+            side="away",
+            session=DummySession(),
+            team_id=1,
+            season=2026,
+        )
+    )
+
+    assert result is confirmed
+    assert len(result["lineup"]) == 9
+    assert result[
+        "profile_granularity"
+    ] == "lineup_average"
+
+
+def test_home_confirmed_inputs_use_home_key(
+    monkeypatch,
+):
+    confirmed = confirmed_offense_inputs()
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        lambda *args, **kwargs: {
+            "source": "unexpected_fallback",
+        },
+    )
+
+    result = (
+        model_projections
+        ._projection_offense_inputs(
+            matchup={
+                "home_offense_inputs": confirmed,
+                "away_offense_inputs": {
+                    "lineup": [{"batter_id": 999}],
+                },
+            },
+            side="home",
+            session=DummySession(),
+            team_id=2,
+            season=2026,
+        )
+    )
+
+    assert result is confirmed
+
+
+def test_missing_confirmed_inputs_use_team_fallback(
+    monkeypatch,
+):
+    fallback = {
+        "source": "team_splits",
+        "lineup_source": (
+            "team_splits_fallback_not_confirmed_lineup"
+        ),
+    }
+
+    calls = []
+
+    def fake_team_split_inputs(
+        session,
+        team_id,
+        season,
+    ):
+        calls.append(
+            (session, team_id, season)
+        )
+        return fallback
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        fake_team_split_inputs,
+    )
+
+    session = DummySession()
+
+    result = (
+        model_projections
+        ._projection_offense_inputs(
+            matchup={},
+            side="away",
+            session=session,
+            team_id=17,
+            season=2026,
+        )
+    )
+
+    assert result is fallback
+    assert calls == [
+        (session, 17, 2026),
+    ]
+
+
+def test_empty_lineup_does_not_claim_confirmed_handoff(
+    monkeypatch,
+):
+    fallback = {
+        "source": "team_splits",
+    }
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        lambda *args, **kwargs: fallback,
+    )
+
+    result = (
+        model_projections
+        ._projection_offense_inputs(
+            matchup={
+                "away_offense_inputs": {
+                    "source": (
+                        "confirmed_lineup_player_splits"
+                    ),
+                    "lineup": [],
+                },
+            },
+            side="away",
+            session=DummySession(),
+            team_id=1,
+            season=2026,
+        )
+    )
+
+    assert result is fallback
+
+
+def test_handoff_retains_exact_artifact_provenance_fields(
+    monkeypatch,
+):
+    confirmed = confirmed_offense_inputs()
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        lambda *args, **kwargs: {
+            "source": "unexpected_fallback",
+        },
+    )
+
+    result = (
+        model_projections
+        ._projection_offense_inputs(
+            matchup={
+                "away_offense_inputs": confirmed,
+            },
+            side="away",
+            session=DummySession(),
+            team_id=1,
+            season=2026,
+        )
+    )
+
+    first = result["lineup"][0]
+
+    assert first["batter_id"] == 1001
+    assert first["has_player_split"] is True
+    assert (
+        first["has_batter_aggregate"]
+        is False
+    )
+    assert first["simulation_inputs"][
+        "batting_avg"
+    ] == 0.255

--- a/tests/test_model_projection_exact_artifact_handoff.py
+++ b/tests/test_model_projection_exact_artifact_handoff.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from mlb_app import model_projections
+from mlb_app.simulation.game import (
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    discover_canonical_shadow_exact_artifact,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+class DummySession:
+    pass
+
+
+def confirmed_context_inputs(prefix):
+    return {
+        "source": "confirmed_lineup_player_splits",
+        "lineup": [
+            {
+                "batter_id": int(
+                    f"{prefix}{index}"
+                ),
+                "has_player_split": True,
+                "has_batter_aggregate": False,
+                "simulation_inputs": {
+                    "k_pct": 0.22,
+                    "bb_pct": 0.09,
+                    "batting_avg": 0.255,
+                    "on_base_pct": 0.330,
+                    "slugging_pct": 0.430,
+                    "iso": 0.175,
+                    "hard_hit_pct": 0.40,
+                    "barrel_pct": 0.08,
+                },
+            }
+            for index in range(1, 10)
+        ],
+    }
+
+
+def pitcher_profile():
+    return {
+        "bat_missing": {
+            "k_rate": 0.24,
+        },
+        "command_control": {
+            "bb_rate": 0.08,
+        },
+        "contact_management": {
+            "barrel_rate_allowed": 0.07,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.245,
+        },
+    }
+
+
+def test_preserved_context_can_build_exact_artifact(
+    monkeypatch,
+):
+    away_inputs = confirmed_context_inputs(1)
+    home_inputs = confirmed_context_inputs(2)
+
+    monkeypatch.setattr(
+        model_projections,
+        "_team_split_inputs",
+        lambda *args, **kwargs: {
+            "source": "team_splits",
+        },
+    )
+
+    away = {
+        "pitcher_id": 100,
+        "offense_inputs": (
+            model_projections
+            ._projection_offense_inputs(
+                matchup={
+                    "away_offense_inputs": (
+                        away_inputs
+                    ),
+                },
+                side="away",
+                session=DummySession(),
+                team_id=1,
+                season=2026,
+            )
+        ),
+    }
+
+    home = {
+        "pitcher_id": 200,
+        "offense_inputs": (
+            model_projections
+            ._projection_offense_inputs(
+                matchup={
+                    "home_offense_inputs": (
+                        home_inputs
+                    ),
+                },
+                side="home",
+                session=DummySession(),
+                team_id=2,
+                season=2026,
+            )
+        ),
+    }
+
+    result = (
+        discover_canonical_shadow_exact_artifact(
+            away_context=away,
+            home_context=home,
+            workspace={
+                "awayPitcherProfile": (
+                    pitcher_profile()
+                ),
+                "homePitcherProfile": (
+                    pitcher_profile()
+                ),
+                "environmentProfile": {
+                    "run_environment": {
+                        "hr_boost_index": 1.0,
+                        "hit_boost_index": 1.0,
+                        "run_scoring_index": 1.0,
+                    },
+                },
+            },
+            provider=PROVIDER,
+        )
+    )
+
+    assert result.ready is True
+    assert result.away_record_count == 9
+    assert result.home_record_count == 9
+    assert len(result.artifact.records) == 18


### PR DESCRIPTION
## Summary

Fixes the production context handoff that was discarding confirmed player-level offense inputs before canonical exact-artifact discovery.

`model_projections._side_context()` now preserves the existing `away_offense_inputs` and `home_offense_inputs` emitted by matchup generation when they contain confirmed lineup rows. Team-split offense inputs remain the fail-open fallback when player-level lineup data is unavailable.

This allows confirmed batter IDs, player-split/batter-aggregate provenance flags, and individual simulation inputs to reach exact batter-versus-starter artifact discovery and, when all other requirements are ready, canonical production shadow execution.

## Added

- `_projection_offense_inputs()` production handoff helper
- Confirmed player-level lineup preservation
- Side-specific away/home context key handling
- Team-split fallback for missing or empty confirmed lineups
- Exact-artifact provenance-field retention tests
- End-to-end confirmed-context to exact-artifact discovery test

## Architecture

```text
matchup generator confirmed offense inputs
        ↓
preserve player-level lineup rows
        ↓
projection side contexts
        ↓
exact batter-versus-starter artifact discovery
        ↓
10/10 readiness when confirmed lineups exist
```

## Behavior

- Confirmed lineup inputs with player rows are retained unchanged.
- Batter IDs remain available for exact artifact keys.
- `has_player_split` and `has_batter_aggregate` provenance flags are retained.
- Individual `simulation_inputs` remain available.
- Empty or missing lineup inputs fall back to team splits.
- No projected or manufactured lineup is created.
- Games without published confirmed lineups remain honestly blocked.
- Legacy projections remain authoritative.

## Validation

- Confirmed-offense handoff tests passed: `6 passed`
- Combined readiness/execution tests passed: `74 passed`
- Python compilation passed
- `git diff --check` passed

Three pre-existing dependency warnings remain unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `tests/test_model_projection_confirmed_offense_handoff.py`
- `tests/test_model_projection_exact_artifact_handoff.py`

## Next slice

Attach successfully executed canonical production material to the existing canonical-shadow comparator path so diagnostics include legacy-versus-canonical deltas, probability-resolution tier usage, and atomic input provenance while legacy remains authoritative.