### PR TITLE
Attach canonical production shadow comparison

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -23,6 +23,7 @@ from mlb_app.simulation.shadow import (
     discover_canonical_shadow_exact_artifact,
     discover_canonical_shadow_fallback_catalog,
     discover_canonical_shadow_lineups,
+    attach_canonical_shadow,
     discover_canonical_shadow_probability_provider,
     run_canonical_production_shadow,
 )
@@ -652,6 +653,50 @@ def _canonical_probability_payload(matchup: Dict[str, Any], projection_sim: Opti
     }
 
 
+def _attach_production_shadow_comparison(
+    *,
+    legacy_result: Dict[str, Any],
+    production_execution: Any,
+) -> Dict[str, Any]:
+    """
+    Attach executed canonical material to the existing shadow comparator.
+
+    Blocked or unavailable production executions leave the legacy payload
+    unchanged. Successful comparisons remain diagnostic-only and preserve
+    legacy authority.
+    """
+
+    if not isinstance(legacy_result, dict):
+        raise TypeError(
+            "legacy_result must be a dictionary"
+        )
+
+    material = getattr(
+        production_execution,
+        "material",
+        None,
+    )
+
+    if material is None:
+        return legacy_result
+
+    return attach_canonical_shadow(
+        legacy_result=legacy_result,
+        enabled=True,
+        canonical_payload=(
+            material.canonical_payload
+        ),
+        probability_resolution_diagnostics=(
+            material
+            .probability_resolution_diagnostics
+        ),
+        canonical_shadow_execution_inputs=(
+            material
+            .canonical_shadow_execution_inputs
+        ),
+    )
+
+
 def build_model_projection_payload(session: Session, target_date: str) -> Dict[str, Any]:
     try:
         date_obj = datetime.datetime.strptime(target_date, "%Y-%m-%d").date()
@@ -843,6 +888,15 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             except Exception as shared_exc:
                 shared_simulation = {"status": "error", "error": str(shared_exc), "meta": {"game_pk": matchup.get("game_pk") or matchup.get("gamePk"), "source_route": "/models/projections"}}
+
+            shared_simulation = (
+                _attach_production_shadow_comparison(
+                    legacy_result=shared_simulation,
+                    production_execution=(
+                        canonical_production_shadow_execution
+                    ),
+                )
+            )
 
             if isinstance(shared_simulation, dict):
                 shared_diagnostics = (

--- a/tests/test_model_projection_production_shadow_authority.py
+++ b/tests/test_model_projection_production_shadow_authority.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from mlb_app.simulation.shadow import (
+    attach_canonical_shadow,
+)
+
+
+def test_comparator_never_changes_legacy_authority():
+    legacy = {
+        "away_win_probability": 0.45,
+        "home_win_probability": 0.55,
+    }
+
+    canonical = {
+        "away_win_probability": 0.60,
+        "home_win_probability": 0.40,
+    }
+
+    result = attach_canonical_shadow(
+        legacy_result=legacy,
+        enabled=True,
+        canonical_payload=canonical,
+    )
+
+    assert result[
+        "away_win_probability"
+    ] == 0.45
+
+    assert result[
+        "home_win_probability"
+    ] == 0.55
+
+    assert result["diagnostics"][
+        "canonical_shadow"
+    ]["authoritative_source"] == "legacy"

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mlb_app import model_projections
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalOutcomeProbability,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow import (
+    CanonicalShadowBullpenDiscovery,
+    CanonicalShadowBullpenSideDiscovery,
+    CanonicalShadowExactArtifactDiscovery,
+    CanonicalShadowFallbackCatalogDiscovery,
+    CanonicalShadowLineupDiscovery,
+    CanonicalShadowProbabilityProviderDiscovery,
+    run_canonical_production_shadow,
+)
+
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def probability_points():
+    values = {
+        "out": 0.43,
+        "single": 0.15,
+        "double": 0.05,
+        "triple": 0.005,
+        "hr": 0.03,
+        "bb": 0.085,
+        "hbp": 0.01,
+        "k": 0.24,
+    }
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=values[outcome.value],
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def lineups():
+    return CanonicalShadowLineupDiscovery(
+        away_player_ids=tuple(
+            f"a{index}"
+            for index in range(1, 10)
+        ),
+        home_player_ids=tuple(
+            f"h{index}"
+            for index in range(1, 10)
+        ),
+        away_source_count=9,
+        home_source_count=9,
+        status="ready",
+    )
+
+
+def bullpens():
+    return CanonicalShadowBullpenDiscovery(
+        away=CanonicalShadowBullpenSideDiscovery(
+            team_id="1",
+            starter_id="100",
+            bullpen_pitcher_ids=("101",),
+            source_record_count=2,
+            status="ready",
+        ),
+        home=CanonicalShadowBullpenSideDiscovery(
+            team_id="2",
+            starter_id="200",
+            bullpen_pitcher_ids=("201",),
+            source_record_count=2,
+            status="ready",
+        ),
+    )
+
+
+def provider_discovery():
+    return CanonicalShadowProbabilityProviderDiscovery(
+        provider=PROVIDER,
+        model_versions=("pa_outcome_v1",),
+        valid_model_count=4,
+        status="ready",
+    )
+
+
+def exact_discovery():
+    records = tuple(
+        CanonicalProbabilityArtifactRecord(
+            batter_id=batter_id,
+            pitcher_id=pitcher_id,
+            probabilities=probability_points(),
+        )
+        for batter_id, pitcher_id in (
+            *(
+                (f"a{index}", "200")
+                for index in range(1, 10)
+            ),
+            *(
+                (f"h{index}", "100")
+                for index in range(1, 10)
+            ),
+        )
+    )
+
+    return CanonicalShadowExactArtifactDiscovery(
+        artifact=CanonicalProbabilityArtifact(
+            provider=PROVIDER,
+            records=records,
+        ),
+        away_record_count=9,
+        home_record_count=9,
+        away_real_profile_count=9,
+        home_real_profile_count=9,
+        status="ready",
+    )
+
+
+def fallback_discovery():
+    return CanonicalShadowFallbackCatalogDiscovery(
+        catalog=CanonicalProbabilityFallbackCatalog(
+            provider=PROVIDER,
+            records=(
+                CanonicalProbabilityFallbackRecord(
+                    tier=(
+                        CanonicalProbabilityFallbackTier
+                        .GLOBAL
+                    ),
+                    identity=None,
+                    probabilities=probability_points(),
+                ),
+            ),
+        ),
+        source_model_count=4,
+        status="ready",
+    )
+
+
+def executed_shadow():
+    return run_canonical_production_shadow(
+        game_pk=123,
+        lineups=lineups(),
+        bullpens=bullpens(),
+        provider_discovery=provider_discovery(),
+        exact_artifact_discovery=exact_discovery(),
+        fallback_catalog_discovery=(
+            fallback_discovery()
+        ),
+        bootstrap_ready=True,
+        simulation_count=2,
+    )
+
+
+def legacy_payload():
+    return {
+        "model_version": "shared-simulation-v1",
+        "simulation_count": 3000,
+        "away_win_probability": 0.48,
+        "home_win_probability": 0.52,
+        "away_expected_runs": 4.1,
+        "home_expected_runs": 4.4,
+        "expected_total_runs": 8.5,
+        "diagnostics": {
+            "existing": True,
+        },
+    }
+
+
+def test_executed_material_reaches_comparator():
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=executed_shadow(),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+
+    assert shadow["enabled"] is True
+    assert shadow["canonical_available"] is True
+    assert shadow["authoritative_source"] == (
+        "legacy"
+    )
+    assert shadow["status"] in {
+        "compared",
+        "partial",
+    }
+
+
+def test_comparator_attaches_probability_diagnostics():
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=executed_shadow(),
+        )
+    )
+
+    probability = result["diagnostics"][
+        "canonical_shadow"
+    ]["probability_resolution"]
+
+    assert probability[
+        "schema_version"
+    ] == (
+        "canonical_probability_diagnostics_shadow_v1"
+    )
+    assert probability["summary"][
+        "total_resolutions"
+    ] > 0
+    assert probability[
+        "tier_usage"
+    ]
+
+
+def test_comparator_attaches_atomic_input_provenance():
+    execution = executed_shadow()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=execution,
+        )
+    )
+
+    provenance = result["diagnostics"][
+        "canonical_shadow"
+    ]["input_provenance"]
+
+    assert provenance[
+        "schema_version"
+    ] == "canonical_shadow_input_provenance_v1"
+    assert provenance[
+        "probability_provider"
+    ]["identity"] == PROVIDER.identity
+    assert provenance["assembly_digest"] == (
+        execution.execution_inputs
+        .assembly_digest
+    )
+    assert provenance[
+        "authoritative_source"
+    ] == "legacy"
+
+
+def test_legacy_values_remain_authoritative():
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(),
+        )
+    )
+
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]
+
+    assert result[
+        "expected_total_runs"
+    ] == legacy["expected_total_runs"]
+
+    assert result is not legacy
+
+
+@dataclass(frozen=True)
+class BlockedExecution:
+    material: object = None
+    status: str = "blocked"
+
+
+def test_blocked_execution_leaves_payload_unchanged():
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=BlockedExecution(),
+        )
+    )
+
+    assert result is legacy
+    assert "canonical_shadow" not in (
+        result["diagnostics"]
+    )
+
+
+def test_invalid_legacy_payload_is_rejected():
+    try:
+        (
+            model_projections
+            ._attach_production_shadow_comparison(
+                legacy_result=[],
+                production_execution=executed_shadow(),
+            )
+        )
+    except TypeError as exc:
+        assert str(exc) == (
+            "legacy_result must be a dictionary"
+        )
+    else:
+        raise AssertionError(
+            "invalid legacy payload must fail"
+        )


### PR DESCRIPTION
## Summary

Attaches successfully executed canonical production shadow material to the existing legacy-versus-canonical comparator path in `/models/projections`.

When canonical production execution succeeds, the shared legacy simulation payload now receives canonical shadow diagnostics containing projection comparisons, probability-resolution diagnostics, and atomic input provenance. Blocked or unavailable canonical executions leave the legacy payload unchanged.

Legacy projections remain authoritative throughout.

## Added

- `_attach_production_shadow_comparison()` integration helper
- Executed canonical material routing into `attach_canonical_shadow()`
- Legacy-versus-canonical comparison attachment
- Probability-resolution diagnostics attachment
- Exact/fallback tier-usage observability
- Atomic canonical input-provenance attachment
- Blocked-execution no-op behavior
- Explicit legacy-authority regression coverage
- Serializer-contract-aligned comparator tests

## Architecture

```text
10/10 production inputs
        ↓
25 canonical shadow trials
        ↓
canonical execution material
        ↓
legacy-versus-canonical comparator
        ↓
projection deltas
+ probability tier usage
+ atomic input provenance
        ↓
legacy remains authoritative
```

## Behavior

- Comparator attachment occurs only when canonical execution material exists.
- Blocked or unavailable execution leaves the legacy payload unchanged.
- Existing legacy projection values are never replaced.
- Canonical comparison remains diagnostic-only.
- Probability diagnostics use the existing versioned shadow serialization contract.
- Input provenance uses the existing versioned provenance serialization contract.
- Failures remain fail-open through the existing comparator boundary.

## Validation

- Production comparator/authority tests passed: `7 passed`
- Combined shadow/execution tests passed: `75 passed`
- Python compilation passed
- `git diff --check` passed

Three pre-existing dependency warnings remain unrelated to this change.

## Files

- `mlb_app/model_projections.py`
- `tests/test_model_projection_production_shadow_comparator.py`
- `tests/test_model_projection_production_shadow_authority.py`

## Next slice

Expose the newly attached production comparison diagnostics in the Model Projections canonical dashboard when execution reaches 10/10 readiness, including concise legacy-versus-canonical deltas, exact-versus-fallback tier usage, and input provenance summaries while preserving the existing blocked/not-run presentation for incomplete lineups.