### PR TITLE
Expose canonical production execution status

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -360,6 +360,61 @@ function buildBootstrapReadiness(
 }
 
 
+function buildProductionExecution(
+  sharedSimulation,
+) {
+  const diagnostics = objectValue(
+    sharedSimulation.diagnostics
+  )
+
+  const execution = {
+    ...objectValue(
+      diagnostics
+        .canonical_shadow_production_execution
+    ),
+    ...objectValue(
+      sharedSimulation
+        .canonical_shadow_production_execution
+    ),
+  }
+
+  const status = execution.status || null
+  const errorType = execution.error_type || null
+  const errorMessage = execution.error_message || null
+
+  return {
+    available: Object.keys(execution).length > 0,
+    schemaVersion:
+      execution.schema_version || null,
+    status,
+    executed: execution.executed === true,
+    canonicalAvailable:
+      execution.canonical_available === true,
+    simulationCount: finiteNumber(
+      execution.simulation_count
+    ),
+    providerIdentity:
+      execution.provider_identity || null,
+    exactArtifactDigest:
+      execution.exact_artifact_digest || null,
+    fallbackCatalogDigest:
+      execution.fallback_catalog_digest || null,
+    inputAssemblyDigest:
+      execution.input_assembly_digest || null,
+    canonicalModelVersion:
+      execution.canonical_model_version || null,
+    errorType,
+    errorMessage,
+    activationPermitted:
+      execution.activation_permitted === true,
+    productionAuthorityChanged:
+      execution.production_authority_changed === true,
+    authoritativeSource:
+      execution.authoritative_source || 'legacy',
+  }
+}
+
+
 function buildRealism(sharedSimulation, shadow) {
   const diagnostics = objectValue(
     sharedSimulation.diagnostics
@@ -671,34 +726,77 @@ export function buildCanonicalDiagnosticsViewModel(
     buildBootstrapReadiness(shared)
   )
 
+  const productionExecution = (
+    buildProductionExecution(shared)
+  )
+
   const canonicalAvailable = Boolean(
     shadow.canonical_available
   )
 
   const state = firstPresent(
     shadow.status,
+    (
+      productionExecution.available &&
+      productionExecution.status !== 'not_run'
+        ? productionExecution.status
+        : null
+    ),
     hasCanonicalShadow
       ? 'unknown'
       : 'not_run',
   )
 
-  const availabilityReason = (
-    hasCanonicalShadow
-      ? null
-      : (
-        bootstrapReadiness.available &&
-        bootstrapReadiness.blockedCount > 0
-          ? (
-            'Canonical shadow execution is blocked by ' +
-            `${bootstrapReadiness.blockedCount} missing ` +
-            'production requirements.'
-          )
-          : (
-            'Canonical shadow execution was not attached ' +
-            'to this simulation payload.'
-          )
+  let availabilityReason = null
+
+  if (!hasCanonicalShadow) {
+    if (
+      productionExecution.status === 'error'
+    ) {
+      const errorPrefix = (
+        productionExecution.errorType
+          ? `${productionExecution.errorType}: `
+          : ''
       )
-  )
+
+      availabilityReason = (
+        'Canonical shadow execution failed open. ' +
+        errorPrefix +
+        (
+          productionExecution.errorMessage ||
+          'No error message was supplied.'
+        )
+      )
+    } else if (
+      productionExecution.status === 'executed'
+    ) {
+      availabilityReason = (
+        'Canonical trials executed, but comparison ' +
+        'diagnostics were not attached to this payload.'
+      )
+    } else if (
+      bootstrapReadiness.available &&
+      bootstrapReadiness.blockedCount > 0
+    ) {
+      availabilityReason = (
+        'Canonical shadow execution is blocked by ' +
+        `${bootstrapReadiness.blockedCount} missing ` +
+        'production requirements.'
+      )
+    } else if (
+      productionExecution.status === 'blocked'
+    ) {
+      availabilityReason = (
+        'Canonical shadow execution remained blocked ' +
+        'despite complete bootstrap readiness.'
+      )
+    } else {
+      availabilityReason = (
+        'Canonical shadow execution was not attached ' +
+        'to this simulation payload.'
+      )
+    }
+  }
 
   return {
     viewModelVersion:
@@ -720,6 +818,8 @@ export function buildCanonicalDiagnosticsViewModel(
         shadow.canonical_simulation_count
       ),
       modelVersion: firstPresent(
+        productionExecution
+          .canonicalModelVersion,
         metadata.canonical_model_version,
         metadata.model_version,
         shared.model_version,
@@ -733,17 +833,29 @@ export function buildCanonicalDiagnosticsViewModel(
     },
 
     bootstrapReadiness,
+    productionExecution,
     realism: buildRealism(shared, shadow),
     coverage: buildCoverage(shadow),
     integrity: buildIntegrity(shadow),
     provenance: buildProvenance(shadow),
-    warnings: buildWarnings(shadow),
+    warnings: uniqueStrings([
+      buildWarnings(shadow),
+      (
+        productionExecution.status === 'error'
+          ? productionExecution.errorMessage
+          : null
+      ),
+    ]),
 
     raw: {
       canonicalShadow: shadow,
       bootstrapReadiness: objectValue(
         diagnostics
           .canonical_shadow_bootstrap_readiness
+      ),
+      productionExecution: objectValue(
+        diagnostics
+          .canonical_shadow_production_execution
       ),
     },
   }

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -453,3 +453,153 @@ test('does not mutate the source payload', () => {
 
   assert.deepEqual(payload, snapshot)
 })
+
+test('surfaces fail-open production execution errors', () => {
+  const payload = sharedSimulation()
+
+  delete payload.diagnostics.canonical_shadow
+
+  payload.diagnostics
+    .canonical_shadow_bootstrap_readiness.status =
+      'ready'
+
+  payload.diagnostics
+    .canonical_shadow_bootstrap_readiness.ready =
+      true
+
+  payload.diagnostics
+    .canonical_shadow_bootstrap_readiness
+    .missing_requirements = []
+
+  for (
+    const requirement of Object.values(
+      payload.diagnostics
+        .canonical_shadow_bootstrap_readiness
+        .requirements
+    )
+  ) {
+    requirement.ready = true
+  }
+
+  payload.diagnostics
+    .canonical_shadow_production_execution = {
+      schema_version:
+        'canonical_production_shadow_execution_v1',
+      status: 'error',
+      executed: false,
+      simulation_count: 0,
+      canonical_available: false,
+      provider_identity:
+        'model_projections_pa_outcome:pa_outcome_v1',
+      error_type: 'ValueError',
+      error_message:
+        'example production execution failure',
+      activation_permitted: false,
+      production_authority_changed: false,
+      authoritative_source: 'legacy',
+    }
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.equal(view.status.state, 'error')
+  assert.equal(
+    view.productionExecution.available,
+    true,
+  )
+  assert.equal(
+    view.productionExecution.status,
+    'error',
+  )
+  assert.equal(
+    view.productionExecution.errorType,
+    'ValueError',
+  )
+  assert.equal(
+    view.productionExecution.errorMessage,
+    'example production execution failure',
+  )
+  assert.match(
+    view.status.availabilityReason,
+    /ValueError: example production execution failure/,
+  )
+  assert.deepEqual(
+    view.warnings,
+    ['example production execution failure'],
+  )
+  assert.equal(
+    view.status.authoritativeSource,
+    'legacy',
+  )
+})
+
+test('distinguishes executed-but-unattached material', () => {
+  const payload = sharedSimulation()
+
+  delete payload.diagnostics.canonical_shadow
+
+  payload.diagnostics
+    .canonical_shadow_production_execution = {
+      schema_version:
+        'canonical_production_shadow_execution_v1',
+      status: 'executed',
+      executed: true,
+      simulation_count: 25,
+      canonical_available: true,
+      canonical_model_version:
+        'canonical-event-model-v1',
+      activation_permitted: false,
+      production_authority_changed: false,
+      authoritative_source: 'legacy',
+    }
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.equal(view.status.state, 'executed')
+  assert.equal(
+    view.productionExecution.executed,
+    true,
+  )
+  assert.equal(
+    view.productionExecution.simulationCount,
+    25,
+  )
+  assert.equal(
+    view.status.modelVersion,
+    'canonical-event-model-v1',
+  )
+  assert.match(
+    view.status.availabilityReason,
+    /executed, but comparison diagnostics were not attached/,
+  )
+})
+
+test('preserves blocked readiness presentation', () => {
+  const payload = sharedSimulation()
+
+  delete payload.diagnostics.canonical_shadow
+
+  payload.diagnostics
+    .canonical_shadow_production_execution = {
+      schema_version:
+        'canonical_production_shadow_execution_v1',
+      status: 'blocked',
+      executed: false,
+      simulation_count: 0,
+      canonical_available: false,
+      authoritative_source: 'legacy',
+    }
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  assert.equal(view.status.state, 'blocked')
+  assert.match(
+    view.status.availabilityReason,
+    /7 missing production requirements/,
+  )
+})


### PR DESCRIPTION
## Summary

Exposes canonical production execution diagnostics in the Model Projections canonical dashboard view model.

The backend already emits `canonical_shadow_production_execution` diagnostics even when canonical execution fails open or completes without comparator attachment. The frontend previously ignored that object and collapsed every no-comparison state into the generic `not_run` presentation.

This change preserves the existing successful comparator view while distinguishing blocked inputs, fail-open execution errors, and executed-but-unattached material.

## Added

- `buildProductionExecution()` normalization in `canonicalDiagnosticsViewModel.mjs`
- Production execution status, simulation count, provider identity, model version, artifact/catalog digests, input assembly digest, and authority fields
- Fail-open error type and message visibility
- `executed` state when trials ran but comparison diagnostics were not attached
- Existing blocked-readiness presentation preservation
- Production execution warnings in the view-model warning set
- Raw production-execution diagnostics exposure for debugging
- Focused view-model tests for error, executed-but-unattached, and blocked states

## State behavior

```text
blocked inputs
    -> blocked readiness message

execution error
    -> exact fail-open exception displayed

executed without comparator attachment
    -> executed status with explicit attachment warning

comparison attached
    -> existing canonical shadow comparison dashboard
```

## Authority guarantees

- Legacy projections remain authoritative.
- Production activation remains disabled.
- The frontend does not infer successful comparison from 10/10 readiness alone.
- Backend execution truth remains the source of status.

## Validation

- Canonical diagnostics view-model tests passed: `14 passed`
- `git diff --check` passed

## Files

- `frontend/src/lib/canonicalDiagnosticsViewModel.mjs`
- `frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs`

## Next slice

Use the newly surfaced live fail-open exception from a 10/10-ready game to correct the production canonical execution path, then verify the dashboard transitions from `error` to a real legacy-versus-canonical comparison.