### PR TITLE
Support occupied-base triple advancement

### DIFF
--- a/mlb_app/simulation/events/advancement_sampler.py
+++ b/mlb_app/simulation/events/advancement_sampler.py
@@ -95,6 +95,12 @@ class BaselineRunnerAdvancementSampler:
                 context=context,
             )
 
+        if outcome == "triple":
+            return self._sample_triple(
+                state=state,
+                batter_id=batter_id,
+            )
+
         if outcome == "out":
             return self._sample_out(
                 state=state,
@@ -249,6 +255,43 @@ class BaselineRunnerAdvancementSampler:
         return RunnerAdvancementResult(
             movements=tuple(movements),
             probabilities_used=tuple(decisions),
+        )
+
+    def _sample_triple(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+    ) -> RunnerAdvancementResult:
+        movements = []
+
+        for start_base, runner_id in (
+            (Base.THIRD, state.third),
+            (Base.SECOND, state.second),
+            (Base.FIRST, state.first),
+        ):
+            if runner_id is None:
+                continue
+
+            movements.append(
+                _movement(
+                    runner_id=runner_id,
+                    start=start_base,
+                    end=Base.HOME,
+                )
+            )
+
+        movements.append(
+            _movement(
+                runner_id=batter_id,
+                start=Base.HOME,
+                end=Base.THIRD,
+                forced=True,
+            )
+        )
+
+        return RunnerAdvancementResult(
+            movements=tuple(movements),
         )
 
     def _sample_out(

--- a/mlb_app/simulation/events/legal_transitions.py
+++ b/mlb_app/simulation/events/legal_transitions.py
@@ -13,6 +13,7 @@ SUPPORTED_ADVANCEMENT_OUTCOMES = frozenset(
     {
         "single",
         "double",
+        "triple",
         "out",
     }
 )
@@ -113,6 +114,14 @@ def enumerate_legal_runner_destinations(
                 destinations=(Base.SECOND,),
             )
         )
+    elif outcome == "triple":
+        legal.append(
+            LegalRunnerDestinations(
+                runner_id=batter_id,
+                start_base=Base.HOME,
+                destinations=(Base.THIRD,),
+            )
+        )
 
     return tuple(legal)
 
@@ -154,7 +163,11 @@ def _third_base_destinations(
     outcome: str,
     context: BattedBallContext,
 ) -> Tuple[Base, ...]:
-    if outcome in {"single", "double"}:
+    if outcome in {
+        "single",
+        "double",
+        "triple",
+    }:
         return (Base.HOME,)
 
     if context.batted_ball_type in {
@@ -175,7 +188,7 @@ def _second_base_destinations(
 ) -> Tuple[Base, ...]:
     if outcome == "single":
         return (Base.THIRD, Base.HOME)
-    if outcome == "double":
+    if outcome in {"double", "triple"}:
         return (Base.HOME,)
 
     if context.batted_ball_type in {
@@ -197,6 +210,8 @@ def _first_base_destinations(
         return (Base.SECOND, Base.THIRD)
     if outcome == "double":
         return (Base.THIRD, Base.HOME)
+    if outcome == "triple":
+        return (Base.HOME,)
 
     # Force plays and fielder's choices are Layer 10E concerns.
     return (Base.FIRST,)

--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -42,7 +42,6 @@ from .orchestrator import (
     simulate_canonical_game,
 )
 from .outcome_resolution import (
-    EMPTY_BASE_HIT_DESTINATIONS,
     resolve_canonical_sampled_plate_appearance,
 )
 from .pa_resolver_factory import (
@@ -139,7 +138,6 @@ __all__ = [
     "DEFAULT_CANONICAL_PROBABILITY_FALLBACK_TIERS",
     "DEFAULT_CANONICAL_MODEL_VERSION",
     "DEFAULT_CANONICAL_SIMULATION_COUNT",
-    "EMPTY_BASE_HIT_DESTINATIONS",
     "CanonicalTrialFactoryInput",
     "CanonicalTrialExecutionPlan",
     "CanonicalTrialResolverContext",

--- a/mlb_app/simulation/game/batted_ball_resolution.py
+++ b/mlb_app/simulation/game/batted_ball_resolution.py
@@ -42,6 +42,7 @@ SUPPORTED_BATTED_BALL_ADVANCEMENT_OUTCOMES = frozenset(
         CanonicalPlateAppearanceOutcome.OUT,
         CanonicalPlateAppearanceOutcome.SINGLE,
         CanonicalPlateAppearanceOutcome.DOUBLE,
+        CanonicalPlateAppearanceOutcome.TRIPLE,
     }
 )
 
@@ -99,7 +100,7 @@ def resolve_canonical_batted_ball_outcome(
     sampled: CanonicalSampledPlateAppearance,
 ) -> CanonicalBattedBallResolution:
     """
-    Resolve a sampled single, double, or batted-ball out.
+    Resolve a sampled single, double, triple, or batted-ball out.
 
     Context and advancement RNGs are independently derived from immutable
     sampled plate-appearance identity. No shared mutable RNG is accepted.

--- a/mlb_app/simulation/game/outcome_resolution.py
+++ b/mlb_app/simulation/game/outcome_resolution.py
@@ -23,13 +23,6 @@ from .probability import (
 )
 
 
-EMPTY_BASE_HIT_DESTINATIONS = {
-    CanonicalPlateAppearanceOutcome.SINGLE: Base.FIRST,
-    CanonicalPlateAppearanceOutcome.DOUBLE: Base.SECOND,
-    CanonicalPlateAppearanceOutcome.TRIPLE: Base.THIRD,
-}
-
-
 def resolve_canonical_sampled_plate_appearance(
     sampled: CanonicalSampledPlateAppearance,
 ) -> PlayEvent:
@@ -41,10 +34,7 @@ def resolve_canonical_sampled_plate_appearance(
     - deterministic walks and hit-by-pitches;
     - deterministic home runs;
     - batter outs and strikeouts with existing runners holding;
-    - singles, doubles, and triples when the bases are empty.
-
-    State-dependent advancement for non-home-run hits remains outside
-    this slice.
+    - state-aware singles, doubles, and triples.
     """
 
     if not isinstance(
@@ -86,6 +76,7 @@ def resolve_canonical_sampled_plate_appearance(
         CanonicalPlateAppearanceOutcome.OUT,
         CanonicalPlateAppearanceOutcome.SINGLE,
         CanonicalPlateAppearanceOutcome.DOUBLE,
+        CanonicalPlateAppearanceOutcome.TRIPLE,
     }:
         return resolve_canonical_batted_ball_outcome(
             sampled
@@ -96,12 +87,6 @@ def resolve_canonical_sampled_plate_appearance(
         is CanonicalPlateAppearanceOutcome.STRIKEOUT
     ):
         return _resolve_batter_out(sampled)
-
-    if (
-        outcome
-        is CanonicalPlateAppearanceOutcome.TRIPLE
-    ):
-        return _resolve_empty_base_hit(sampled)
 
     raise ValueError(
         f"unsupported sampled outcome: {outcome}"
@@ -146,46 +131,6 @@ def _resolve_batter_out(
                 runner_id=query.batter_id,
                 out_number=state.outs + 1,
                 reason=reason,
-            ),
-        ),
-    )
-
-    return replace(
-        event,
-        pitcher_id=query.pitcher_id,
-    )
-
-
-def _resolve_empty_base_hit(
-    sampled: CanonicalSampledPlateAppearance,
-) -> PlayEvent:
-    query = sampled.query
-    state = query.state
-    outcome = sampled.outcome
-
-    if any(
-        runner_id is not None
-        for runner_id in state.bases
-    ):
-        raise ValueError(
-            "non-home-run hit advancement with occupied "
-            "bases is not supported by this resolver"
-        )
-
-    destination = EMPTY_BASE_HIT_DESTINATIONS[
-        outcome
-    ]
-
-    event = build_play_event(
-        sequence=query.sequence,
-        event_type=outcome.value,
-        batter_id=query.batter_id,
-        state_before=state,
-        runner_movements=(
-            RunnerMovement(
-                runner_id=query.batter_id,
-                start_base=Base.HOME,
-                end_base=destination,
             ),
         ),
     )

--- a/tests/test_canonical_batted_ball_advancement.py
+++ b/tests/test_canonical_batted_ball_advancement.py
@@ -93,6 +93,7 @@ def sampled(
     [
         CanonicalPlateAppearanceOutcome.SINGLE,
         CanonicalPlateAppearanceOutcome.DOUBLE,
+        CanonicalPlateAppearanceOutcome.TRIPLE,
     ],
 )
 def test_occupied_base_hits_resolve_with_advancement(
@@ -129,6 +130,73 @@ def test_occupied_base_hits_resolve_with_advancement(
         event.runner_movements
         == resolution.advancement.movements
     )
+
+
+def test_occupied_base_triple_scores_all_runners():
+    state = GameState(
+        inning=4,
+        half="top",
+        bases=(
+            "away_batter_1",
+            "away_batter_2",
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.TRIPLE,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "triple"
+    assert event.state_after.first is None
+    assert event.state_after.second is None
+    assert event.state_after.third == (
+        "away_batter_0"
+    )
+    assert event.state_after.away_score == 3
+    assert event.state_after.home_score == 0
+
+    scored = {
+        movement.runner_id
+        for movement in event.runner_movements
+        if movement.scored
+    }
+
+    assert scored == {
+        "away_batter_1",
+        "away_batter_2",
+        "away_batter_3",
+    }
+
+
+def test_public_sampled_resolver_routes_occupied_triple():
+    state = GameState(
+        inning=6,
+        half="top",
+        bases=(
+            "away_batter_1",
+            None,
+            "away_batter_3",
+        ),
+    )
+
+    event = resolve_canonical_sampled_plate_appearance(
+        sampled(
+            CanonicalPlateAppearanceOutcome.TRIPLE,
+            state=state,
+        )
+    )
+
+    assert event.event_type == "triple"
+    assert event.state_after.third == (
+        "away_batter_0"
+    )
+    assert event.state_after.away_score == 2
 
 
 def test_batted_ball_out_uses_explicit_advancement():

--- a/tests/test_canonical_sampled_outcome_resolution.py
+++ b/tests/test_canonical_sampled_outcome_resolution.py
@@ -217,15 +217,7 @@ def test_empty_base_hits_place_batter_at_fixed_base(
     assert event.runs_scored == ()
 
 
-@pytest.mark.parametrize(
-    "outcome",
-    [
-        CanonicalPlateAppearanceOutcome.TRIPLE,
-    ],
-)
-def test_occupied_base_hits_require_future_advancement_layer(
-    outcome,
-):
+def test_occupied_base_triple_advances_runner():
     state = GameState(
         inning=1,
         half="top",
@@ -236,16 +228,23 @@ def test_occupied_base_hits_require_future_advancement_layer(
         ),
     )
 
-    with pytest.raises(
-        ValueError,
-        match="occupied bases is not supported",
-    ):
-        resolve_canonical_sampled_plate_appearance(
-            sampled(
-                outcome,
-                state=state,
-            )
+    event = resolve_canonical_sampled_plate_appearance(
+        sampled(
+            CanonicalPlateAppearanceOutcome.TRIPLE,
+            state=state,
         )
+    )
+
+    assert event.event_type == "triple"
+    assert event.state_after.first is None
+    assert event.state_after.second is None
+    assert event.state_after.third == (
+        "away_batter_0"
+    )
+    assert event.state_after.away_score == 1
+    assert event.runs_scored == (
+        "away_batter_1",
+    )
 
 
 def test_home_run_scores_all_runners_and_batter():

--- a/tests/test_runner_advancement.py
+++ b/tests/test_runner_advancement.py
@@ -399,7 +399,7 @@ def test_unsupported_outcome_is_rejected():
         sampler.sample(
             state=state(),
             batter_id="batter",
-            primary_outcome="triple",
+            primary_outcome="home_run",
             context=context(),
         )
 


### PR DESCRIPTION
## Summary

Extends canonical batted-ball advancement to support triples with occupied bases.

The production shadow engine previously failed open when a sampled triple occurred with any runner aboard because triples still used the legacy empty-bases-only resolver. Singles and doubles were already routed through the state-aware advancement layer.

This change makes triple advancement deterministic and state-aware:

```text
runner on first  -> scores
runner on second -> scores
runner on third  -> scores
batter           -> third
```

## Added

- `triple` support in legal runner-destination enumeration
- Deterministic triple advancement in `BaselineRunnerAdvancementSampler`
- Triple support in canonical batted-ball resolution
- Public sampled-outcome routing for occupied-base triples
- Removal of obsolete empty-base-only triple resolver and export
- Occupied-base triple regression coverage
- Updated advancement and sampled-outcome expectations

## Behavior

- Existing runners score on a triple.
- The batter ends on third base.
- Active-lineup and pitcher validation remain unchanged.
- Deterministic seed behavior remains unchanged.
- Singles, doubles, outs, walks, HBP, strikeouts, and home runs retain their existing behavior.
- Legacy projections remain authoritative.
- Canonical production execution remains shadow-only and fail-open.

## Validation

- Focused advancement/resolution tests passed: `36 passed`
- Combined orchestration/production-shadow tests passed: `56 passed`
- Python compilation passed
- `git diff --check` passed

Three pre-existing dependency warnings remain unrelated to this change.

## Files

- `mlb_app/simulation/events/advancement_sampler.py`
- `mlb_app/simulation/events/legal_transitions.py`
- `mlb_app/simulation/game/__init__.py`
- `mlb_app/simulation/game/batted_ball_resolution.py`
- `mlb_app/simulation/game/outcome_resolution.py`
- `tests/test_canonical_batted_ball_advancement.py`
- `tests/test_canonical_sampled_outcome_resolution.py`
- `tests/test_runner_advancement.py`

## Production impact

This removes the live fail-open exception:

```text
non-home-run hit advancement with occupied bases is not supported by this resolver
```

for triple outcomes, allowing canonical production shadow trials to continue to the next real execution state while legacy remains authoritative.