### PR TITLE
Clarify canonical shadow trial count warnings

### DIFF
--- a/mlb_app/simulation/shadow/comparator.py
+++ b/mlb_app/simulation/shadow/comparator.py
@@ -169,9 +169,6 @@ def compare_shadow_payloads(
         )
     )
 
-    if legacy_count != canonical_count:
-        warnings.add("simulation_count_mismatch")
-
     unavailable = [
         item.name
         for item in comparisons + ranges

--- a/tests/test_canonical_shadow_integration.py
+++ b/tests/test_canonical_shadow_integration.py
@@ -283,3 +283,44 @@ def test_output_is_json_serializable():
     )
 
     assert "canonical_shadow_v1" in encoded
+
+
+def test_different_shadow_trial_count_is_not_a_warning():
+    legacy = legacy_result()
+    legacy["simulations"] = 3000
+    legacy["metadata"]["simulation_count"] = 3000
+
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy,
+        canonical_payload=canonical_payload(),
+    )
+
+    count = comparison(
+        diagnostics,
+        "simulation_count",
+    )
+
+    assert count.available is True
+    assert count.legacy_value == 3000.0
+    assert count.canonical_value == 2.0
+    assert count.absolute_difference == 2998.0
+    assert (
+        "simulation_count_mismatch"
+        not in diagnostics.warnings
+    )
+
+
+def test_earned_run_warning_remains_preserved():
+    diagnostics = compare_shadow_payloads(
+        legacy_result=legacy_result(),
+        canonical_payload=canonical_payload(),
+    )
+
+    assert (
+        diagnostics.earned_run_status
+        == "not_reconstructed"
+    )
+    assert (
+        "earned_runs_not_fully_reconstructed"
+        in diagnostics.warnings
+    )


### PR DESCRIPTION
## Summary

Removes the false-positive `simulation_count_mismatch` warning from canonical shadow comparison diagnostics.

The legacy engine intentionally runs a larger authoritative simulation batch while the canonical engine currently runs a smaller diagnostic shadow batch. Their counts should remain visible as a comparison metric, but the difference is not an integrity failure and should not appear in the warning list.

The earned-run reconstruction warning remains unchanged and continues to identify the next substantive canonical simulation limitation.

## Behavior

- Legacy and canonical simulation counts remain exposed in diagnostics.
- The simulation-count comparison remains available with both values and the absolute difference.
- Differing trial counts no longer generate `simulation_count_mismatch`.
- Earned-run reconstruction warnings remain preserved.
- Legacy projections remain authoritative.
- Canonical execution remains diagnostic-only and fail-open.

## Validation

- Focused comparator tests passed: `11 passed`
- Combined shadow/production tests passed: `37 passed`
- Python compilation passed
- `git diff --check` passed

Three pre-existing dependency warnings remain unrelated to this change.

## Files

- `mlb_app/simulation/shadow/comparator.py`
- `tests/test_canonical_shadow_integration.py`

## Production impact

Before:

```text
Legacy simulations:    3000
Canonical simulations:   25
Warning: simulation count mismatch
```

After:

```text
Legacy simulations:    3000
Canonical simulations:   25
No mismatch warning
```

The remaining earned-run warning stays visible and accurately represents the next quality gap.