### PR TITLE
Add canonical pitcher lifecycle contracts

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -49,6 +49,16 @@ from .pa_resolver_factory import (
     CanonicalPlateAppearanceResolverFactory,
     build_canonical_pa_resolver_factory,
 )
+from .pitcher_lifecycle import (
+    CANONICAL_PITCHER_LIFECYCLE_VERSION,
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    reduce_pitcher_lifecycle,
+    retire_pitcher,
+)
 from .probability import (
     CANONICAL_PA_OUTCOME_ORDER,
     CANONICAL_PA_PROBABILITY_VERSION,
@@ -156,6 +166,14 @@ __all__ = [
     "CanonicalPlateAppearanceQuery",
     "CanonicalSampledPlateAppearance",
     "CanonicalPitchingPlan",
+    "retire_pitcher",
+    "reduce_pitcher_lifecycle",
+    "CanonicalPitchingDecisionContext",
+    "CanonicalPitchingDecisionAction",
+    "CanonicalPitchingDecision",
+    "CanonicalPitcherRole",
+    "CanonicalPitcherLifecycleState",
+    "CANONICAL_PITCHER_LIFECYCLE_VERSION",
     "CanonicalProbabilityArtifact",
     "CanonicalProbabilityArtifactAdapter",
     "CanonicalProbabilityArtifactRecord",

--- a/mlb_app/simulation/game/pitcher_lifecycle.py
+++ b/mlb_app/simulation/game/pitcher_lifecycle.py
@@ -1,0 +1,360 @@
+"""Immutable canonical pitcher lifecycle and decision contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Optional
+
+from mlb_app.simulation.events import PlayEvent
+
+
+CANONICAL_PITCHER_LIFECYCLE_VERSION = (
+    "canonical_pitcher_lifecycle_v1"
+)
+
+
+class CanonicalPitcherRole(str, Enum):
+    """Pitcher role for one simulated appearance."""
+
+    STARTER = "starter"
+    RELIEVER = "reliever"
+
+
+class CanonicalPitchingDecisionAction(str, Enum):
+    """Managerial action before the next plate appearance."""
+
+    HOLD = "hold"
+    REPLACE = "replace"
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherLifecycleState:
+    """
+    Immutable statistics for one pitcher appearance.
+
+    ``runs_scored_during_stint`` is observational only. It does not
+    assign pitcher responsibility or earned runs. Those are handled
+    by the later responsibility-reconstruction layer.
+    """
+
+    team_side: str
+    pitcher_id: str
+    role: CanonicalPitcherRole
+    entered_inning: int
+    entered_half: str
+    batters_faced: int = 0
+    outs_recorded: int = 0
+    hits_allowed: int = 0
+    walks_allowed: int = 0
+    hit_batters: int = 0
+    home_runs_allowed: int = 0
+    strikeouts: int = 0
+    runs_scored_during_stint: int = 0
+    active: bool = True
+    schema_version: str = (
+        CANONICAL_PITCHER_LIFECYCLE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+
+        if not self.pitcher_id:
+            raise ValueError("pitcher_id is required")
+
+        if not isinstance(
+            self.role,
+            CanonicalPitcherRole,
+        ):
+            raise TypeError(
+                "role must be a CanonicalPitcherRole"
+            )
+
+        if self.entered_inning < 1:
+            raise ValueError(
+                "entered_inning must be positive"
+            )
+
+        if self.entered_half not in {"top", "bottom"}:
+            raise ValueError(
+                "entered_half must be 'top' or 'bottom'"
+            )
+
+        counters = (
+            self.batters_faced,
+            self.outs_recorded,
+            self.hits_allowed,
+            self.walks_allowed,
+            self.hit_batters,
+            self.home_runs_allowed,
+            self.strikeouts,
+            self.runs_scored_during_stint,
+        )
+
+        if any(value < 0 for value in counters):
+            raise ValueError(
+                "pitcher lifecycle counters cannot be negative"
+            )
+
+        if self.outs_recorded > (
+            self.batters_faced * 3
+        ):
+            raise ValueError(
+                "outs_recorded is inconsistent with "
+                "batters_faced"
+            )
+
+        if self.schema_version != (
+            CANONICAL_PITCHER_LIFECYCLE_VERSION
+        ):
+            raise ValueError(
+                "unsupported pitcher lifecycle schema"
+            )
+
+    @property
+    def innings_recorded(self) -> float:
+        """Return conventional innings pitched representation."""
+
+        whole, remainder = divmod(
+            self.outs_recorded,
+            3,
+        )
+
+        return float(
+            f"{whole}.{remainder}"
+        )
+
+    @property
+    def lineup_turns_faced(self) -> int:
+        """Number of complete nine-batter lineup turns faced."""
+
+        return self.batters_faced // 9
+
+    @property
+    def current_lineup_pass(self) -> int:
+        """One-indexed pass through the batting order."""
+
+        return (self.batters_faced // 9) + 1
+
+
+@dataclass(frozen=True)
+class CanonicalPitchingDecisionContext:
+    """State supplied to a pitcher hook policy."""
+
+    lifecycle: CanonicalPitcherLifecycleState
+    inning: int
+    half: str
+    outs: int
+    batting_team_score: int
+    fielding_team_score: int
+    runners_on_base: int
+    upcoming_batter_id: str
+    available_reliever_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.lifecycle,
+            CanonicalPitcherLifecycleState,
+        ):
+            raise TypeError(
+                "lifecycle must be a "
+                "CanonicalPitcherLifecycleState"
+            )
+
+        if self.inning < 1:
+            raise ValueError("inning must be positive")
+
+        if self.half not in {"top", "bottom"}:
+            raise ValueError(
+                "half must be 'top' or 'bottom'"
+            )
+
+        if not 0 <= self.outs <= 2:
+            raise ValueError(
+                "outs must be between zero and two"
+            )
+
+        if (
+            self.batting_team_score < 0
+            or self.fielding_team_score < 0
+        ):
+            raise ValueError(
+                "scores cannot be negative"
+            )
+
+        if not 0 <= self.runners_on_base <= 3:
+            raise ValueError(
+                "runners_on_base must be between zero and three"
+            )
+
+        if not self.upcoming_batter_id:
+            raise ValueError(
+                "upcoming_batter_id is required"
+            )
+
+        if any(
+            not pitcher_id
+            for pitcher_id in self.available_reliever_ids
+        ):
+            raise ValueError(
+                "available reliever identifiers are required"
+            )
+
+        if len(self.available_reliever_ids) != len(
+            set(self.available_reliever_ids)
+        ):
+            raise ValueError(
+                "available relievers must be unique"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalPitchingDecision:
+    """Deterministic pitcher decision before one plate appearance."""
+
+    action: CanonicalPitchingDecisionAction
+    current_pitcher_id: str
+    replacement_pitcher_id: Optional[str] = None
+    reason: str = "policy_hold"
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.action,
+            CanonicalPitchingDecisionAction,
+        ):
+            raise TypeError(
+                "action must be a "
+                "CanonicalPitchingDecisionAction"
+            )
+
+        if not self.current_pitcher_id:
+            raise ValueError(
+                "current_pitcher_id is required"
+            )
+
+        if not self.reason:
+            raise ValueError("reason is required")
+
+        if (
+            self.action
+            is CanonicalPitchingDecisionAction.HOLD
+        ):
+            if self.replacement_pitcher_id is not None:
+                raise ValueError(
+                    "hold decision cannot name a replacement"
+                )
+        else:
+            if not self.replacement_pitcher_id:
+                raise ValueError(
+                    "replace decision requires a replacement"
+                )
+
+            if (
+                self.replacement_pitcher_id
+                == self.current_pitcher_id
+            ):
+                raise ValueError(
+                    "replacement pitcher must differ "
+                    "from current pitcher"
+                )
+
+
+def reduce_pitcher_lifecycle(
+    lifecycle: CanonicalPitcherLifecycleState,
+    event: PlayEvent,
+) -> CanonicalPitcherLifecycleState:
+    """Apply one completed plate appearance to pitcher lifecycle."""
+
+    if not isinstance(
+        lifecycle,
+        CanonicalPitcherLifecycleState,
+    ):
+        raise TypeError(
+            "lifecycle must be a "
+            "CanonicalPitcherLifecycleState"
+        )
+
+    if not isinstance(event, PlayEvent):
+        raise TypeError("event must be a PlayEvent")
+
+    if not lifecycle.active:
+        raise ValueError(
+            "cannot apply an event to an inactive pitcher"
+        )
+
+    if event.pitcher_id != lifecycle.pitcher_id:
+        raise ValueError(
+            "event pitcher does not match lifecycle pitcher"
+        )
+
+    event_type = event.event_type
+
+    hit = event_type in {
+        "single",
+        "double",
+        "triple",
+        "hr",
+    }
+
+    return replace(
+        lifecycle,
+        batters_faced=(
+            lifecycle.batters_faced + 1
+        ),
+        outs_recorded=(
+            lifecycle.outs_recorded
+            + len(event.outs_recorded)
+        ),
+        hits_allowed=(
+            lifecycle.hits_allowed
+            + int(hit)
+        ),
+        walks_allowed=(
+            lifecycle.walks_allowed
+            + int(event_type == "bb")
+        ),
+        hit_batters=(
+            lifecycle.hit_batters
+            + int(event_type == "hbp")
+        ),
+        home_runs_allowed=(
+            lifecycle.home_runs_allowed
+            + int(event_type == "hr")
+        ),
+        strikeouts=(
+            lifecycle.strikeouts
+            + int(event_type == "k")
+        ),
+        runs_scored_during_stint=(
+            lifecycle.runs_scored_during_stint
+            + len(event.runs_scored)
+        ),
+    )
+
+
+def retire_pitcher(
+    lifecycle: CanonicalPitcherLifecycleState,
+) -> CanonicalPitcherLifecycleState:
+    """Close one appearance before a replacement enters."""
+
+    if not isinstance(
+        lifecycle,
+        CanonicalPitcherLifecycleState,
+    ):
+        raise TypeError(
+            "lifecycle must be a "
+            "CanonicalPitcherLifecycleState"
+        )
+
+    if not lifecycle.active:
+        raise ValueError(
+            "pitcher lifecycle is already inactive"
+        )
+
+    return replace(
+        lifecycle,
+        active=False,
+    )

--- a/tests/test_canonical_pitcher_lifecycle.py
+++ b/tests/test_canonical_pitcher_lifecycle.py
@@ -1,0 +1,257 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    RunnerMovement,
+    build_play_event,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_PITCHER_LIFECYCLE_VERSION,
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    reduce_pitcher_lifecycle,
+    retire_pitcher,
+)
+
+
+def lifecycle():
+    return CanonicalPitcherLifecycleState(
+        team_side="home",
+        pitcher_id="home_starter",
+        role=CanonicalPitcherRole.STARTER,
+        entered_inning=1,
+        entered_half="top",
+    )
+
+
+def event(
+    event_type,
+    *,
+    pitcher_id="home_starter",
+    outs=0,
+    runs=(),
+):
+    state = GameState(
+        inning=1,
+        half="top",
+        outs=0,
+    )
+
+    movements = []
+
+    for runner_id in runs:
+        movements.append(
+            RunnerMovement(
+                runner_id=runner_id,
+                start_base=Base.THIRD,
+                end_base=Base.HOME,
+                scored=True,
+            )
+        )
+
+    if event_type in {
+        "single",
+        "double",
+        "triple",
+        "hr",
+        "bb",
+        "hbp",
+    }:
+        destination = {
+            "single": Base.FIRST,
+            "double": Base.SECOND,
+            "triple": Base.THIRD,
+            "hr": Base.HOME,
+            "bb": Base.FIRST,
+            "hbp": Base.FIRST,
+        }[event_type]
+
+        movements.append(
+            RunnerMovement(
+                runner_id="batter",
+                start_base=Base.HOME,
+                end_base=destination,
+                scored=(
+                    destination is Base.HOME
+                ),
+            )
+        )
+
+    resolved = build_play_event(
+        sequence=0,
+        event_type=event_type,
+        batter_id="batter",
+        state_before=state,
+        runner_movements=tuple(movements),
+        outs_recorded=(),
+    )
+
+    if outs:
+        resolved = replace(
+            resolved,
+            state_after=replace(
+                resolved.state_after,
+                outs=outs,
+            ),
+        )
+
+    return replace(
+        resolved,
+        pitcher_id=pitcher_id,
+    )
+
+
+def test_lifecycle_starts_with_stable_contract():
+    value = lifecycle()
+
+    assert value.schema_version == (
+        CANONICAL_PITCHER_LIFECYCLE_VERSION
+    )
+    assert value.batters_faced == 0
+    assert value.outs_recorded == 0
+    assert value.innings_recorded == 0.0
+    assert value.current_lineup_pass == 1
+    assert value.active is True
+
+
+@pytest.mark.parametrize(
+    (
+        "event_type",
+        "hits",
+        "walks",
+        "hit_batters",
+        "home_runs",
+        "strikeouts",
+    ),
+    [
+        ("single", 1, 0, 0, 0, 0),
+        ("double", 1, 0, 0, 0, 0),
+        ("triple", 1, 0, 0, 0, 0),
+        ("hr", 1, 0, 0, 1, 0),
+        ("bb", 0, 1, 0, 0, 0),
+        ("hbp", 0, 0, 1, 0, 0),
+        ("k", 0, 0, 0, 0, 1),
+        ("out", 0, 0, 0, 0, 0),
+    ],
+)
+def test_reducer_tracks_terminal_pa_outcomes(
+    event_type,
+    hits,
+    walks,
+    hit_batters,
+    home_runs,
+    strikeouts,
+):
+    updated = reduce_pitcher_lifecycle(
+        lifecycle(),
+        event(event_type),
+    )
+
+    assert updated.batters_faced == 1
+    assert updated.hits_allowed == hits
+    assert updated.walks_allowed == walks
+    assert updated.hit_batters == hit_batters
+    assert updated.home_runs_allowed == home_runs
+    assert updated.strikeouts == strikeouts
+
+
+def test_reducer_tracks_runs_during_stint_without_responsibility():
+    updated = reduce_pitcher_lifecycle(
+        lifecycle(),
+        event(
+            "single",
+            runs=("inherited_runner",),
+        ),
+    )
+
+    assert updated.runs_scored_during_stint == 1
+
+
+def test_reducer_rejects_different_pitcher():
+    with pytest.raises(
+        ValueError,
+        match="does not match",
+    ):
+        reduce_pitcher_lifecycle(
+            lifecycle(),
+            event(
+                "single",
+                pitcher_id="home_reliever",
+            ),
+        )
+
+
+def test_retired_pitcher_cannot_receive_events():
+    retired = retire_pitcher(lifecycle())
+
+    assert retired.active is False
+
+    with pytest.raises(
+        ValueError,
+        match="inactive pitcher",
+    ):
+        reduce_pitcher_lifecycle(
+            retired,
+            event("single"),
+        )
+
+
+def test_hold_decision_rejects_replacement():
+    with pytest.raises(
+        ValueError,
+        match="cannot name a replacement",
+    ):
+        CanonicalPitchingDecision(
+            action=(
+                CanonicalPitchingDecisionAction.HOLD
+            ),
+            current_pitcher_id="home_starter",
+            replacement_pitcher_id="home_reliever",
+        )
+
+
+def test_replace_decision_requires_new_pitcher():
+    decision = CanonicalPitchingDecision(
+        action=(
+            CanonicalPitchingDecisionAction.REPLACE
+        ),
+        current_pitcher_id="home_starter",
+        replacement_pitcher_id="home_reliever",
+        reason="starter_hook",
+    )
+
+    assert decision.replacement_pitcher_id == (
+        "home_reliever"
+    )
+
+
+def test_decision_context_preserves_available_bullpen():
+    context = CanonicalPitchingDecisionContext(
+        lifecycle=lifecycle(),
+        inning=6,
+        half="top",
+        outs=1,
+        batting_team_score=3,
+        fielding_team_score=2,
+        runners_on_base=2,
+        upcoming_batter_id="away_batter_4",
+        available_reliever_ids=(
+            "home_reliever_1",
+            "home_reliever_2",
+        ),
+    )
+
+    assert context.lifecycle.pitcher_id == (
+        "home_starter"
+    )
+    assert context.runners_on_base == 2
+    assert context.available_reliever_ids == (
+        "home_reliever_1",
+        "home_reliever_2",
+    )


### PR DESCRIPTION
## Summary

Adds the first canonical pitcher-lifecycle foundation for bringing the event-driven simulation to life.

This slice introduces immutable pitcher appearance state, managerial decision contracts, per-plate-appearance lifecycle reduction, and explicit pitcher retirement semantics. It deliberately does not change live pitcher selection yet; the current fixed-starter resolver remains authoritative inside canonical shadow execution until the follow-up hook-policy and bullpen-integration slices are added.

## Added

- `CanonicalPitcherLifecycleState`
- `CanonicalPitcherRole`
- `CanonicalPitchingDecisionAction`
- `CanonicalPitchingDecisionContext`
- `CanonicalPitchingDecision`
- `reduce_pitcher_lifecycle`
- `retire_pitcher`
- public game-package exports
- focused lifecycle regression coverage

## Tracked lifecycle state

- pitcher identity and team side
- starter or reliever role
- entry inning and half
- batters faced
- outs recorded
- hits, walks, hit batters, and home runs allowed
- strikeouts
- runs scored during the active stint
- active/inactive appearance state
- lineup pass and innings-recorded helpers

`runs_scored_during_stint` is intentionally observational only. It does not assign inherited-runner responsibility or earned runs; those remain part of the later explicit responsibility and earned-run reconstruction phase.

## Behavior

- One immutable lifecycle state represents one pitcher appearance.
- One completed PA can be reduced into that state only when the event pitcher matches.
- Retired pitchers reject additional events.
- Hold decisions cannot name replacements.
- Replace decisions require a different pitcher.
- Bullpen availability is carried through the decision context.
- Current canonical pitcher selection remains unchanged.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused pitcher-lifecycle tests passed: `15 passed`
- Combined resolver/orchestration/production-shadow tests passed: `45 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/pitcher_lifecycle.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_pitcher_lifecycle.py`

## Next slice

Add a deterministic baseline starter-hook policy using lifecycle state, game context, and bullpen availability. That policy will remain separate from the subsequent resolver/orchestrator integration and inherited-runner responsibility work.