### PR TITLE
Add baseline canonical starter hook policy

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -49,6 +49,11 @@ from .pa_resolver_factory import (
     CanonicalPlateAppearanceResolverFactory,
     build_canonical_pa_resolver_factory,
 )
+from .pitcher_hook_policy import (
+    CANONICAL_STARTER_HOOK_POLICY_VERSION,
+    CanonicalStarterHookPolicy,
+    build_baseline_starter_hook_policy,
+)
 from .pitcher_lifecycle import (
     CANONICAL_PITCHER_LIFECYCLE_VERSION,
     CanonicalPitcherLifecycleState,
@@ -173,6 +178,9 @@ __all__ = [
     "CanonicalPitchingDecision",
     "CanonicalPitcherRole",
     "CanonicalPitcherLifecycleState",
+    "build_baseline_starter_hook_policy",
+    "CanonicalStarterHookPolicy",
+    "CANONICAL_STARTER_HOOK_POLICY_VERSION",
     "CANONICAL_PITCHER_LIFECYCLE_VERSION",
     "CanonicalProbabilityArtifact",
     "CanonicalProbabilityArtifactAdapter",

--- a/mlb_app/simulation/game/pitcher_hook_policy.py
+++ b/mlb_app/simulation/game/pitcher_hook_policy.py
@@ -1,0 +1,233 @@
+"""Deterministic baseline canonical starter-hook policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pitcher_lifecycle import (
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+)
+
+
+CANONICAL_STARTER_HOOK_POLICY_VERSION = (
+    "canonical_starter_hook_policy_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalStarterHookPolicy:
+    """
+    Baseline deterministic starter-removal policy.
+
+    This policy is intentionally transparent and parameter-driven.
+    It does not choose which reliever enters. A later bullpen selector
+    consumes the replace decision and available reliever pool.
+    """
+
+    minimum_batters_faced: int = 18
+    target_batters_faced: int = 24
+    maximum_batters_faced: int = 27
+    maximum_runs_during_stint: int = 5
+    maximum_walks_allowed: int = 4
+    maximum_home_runs_allowed: int = 3
+    late_inning_threshold: int = 7
+    schema_version: str = (
+        CANONICAL_STARTER_HOOK_POLICY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        thresholds = (
+            self.minimum_batters_faced,
+            self.target_batters_faced,
+            self.maximum_batters_faced,
+            self.maximum_runs_during_stint,
+            self.maximum_walks_allowed,
+            self.maximum_home_runs_allowed,
+            self.late_inning_threshold,
+        )
+
+        if any(value < 0 for value in thresholds):
+            raise ValueError(
+                "starter hook thresholds cannot be negative"
+            )
+
+        if self.minimum_batters_faced < 3:
+            raise ValueError(
+                "minimum_batters_faced must be at least three"
+            )
+
+        if not (
+            self.minimum_batters_faced
+            <= self.target_batters_faced
+            <= self.maximum_batters_faced
+        ):
+            raise ValueError(
+                "starter batter thresholds must be ordered"
+            )
+
+        if self.late_inning_threshold < 1:
+            raise ValueError(
+                "late_inning_threshold must be positive"
+            )
+
+        if self.schema_version != (
+            CANONICAL_STARTER_HOOK_POLICY_VERSION
+        ):
+            raise ValueError(
+                "unsupported starter hook policy schema"
+            )
+
+    def decide(
+        self,
+        context: CanonicalPitchingDecisionContext,
+    ) -> CanonicalPitchingDecision:
+        """Return a deterministic hold-or-replace decision."""
+
+        lifecycle = context.lifecycle
+
+        if lifecycle.role is not CanonicalPitcherRole.STARTER:
+            return self._hold(
+                lifecycle.pitcher_id,
+                "non_starter_not_evaluated",
+            )
+
+        if not lifecycle.active:
+            raise ValueError(
+                "starter hook policy requires an active pitcher"
+            )
+
+        if not context.available_reliever_ids:
+            return self._hold(
+                lifecycle.pitcher_id,
+                "no_available_reliever",
+            )
+
+        if (
+            lifecycle.batters_faced
+            < self.minimum_batters_faced
+        ):
+            return self._hold(
+                lifecycle.pitcher_id,
+                "minimum_batters_not_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.maximum_batters_faced
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "maximum_batters_reached",
+            )
+
+        if (
+            lifecycle.runs_scored_during_stint
+            >= self.maximum_runs_during_stint
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "runs_threshold_reached",
+            )
+
+        if (
+            lifecycle.walks_allowed
+            >= self.maximum_walks_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "walks_threshold_reached",
+            )
+
+        if (
+            lifecycle.home_runs_allowed
+            >= self.maximum_home_runs_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "home_run_threshold_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.target_batters_faced
+            and context.inning
+            >= self.late_inning_threshold
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "late_game_target_reached",
+            )
+
+        if (
+            lifecycle.current_lineup_pass >= 3
+            and lifecycle.batters_faced
+            >= self.target_batters_faced
+            and self._is_high_leverage(context)
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "third_time_high_leverage",
+            )
+
+        return self._hold(
+            lifecycle.pitcher_id,
+            "starter_within_limits",
+        )
+
+    @staticmethod
+    def _is_high_leverage(
+        context: CanonicalPitchingDecisionContext,
+    ) -> bool:
+        score_margin = abs(
+            context.fielding_team_score
+            - context.batting_team_score
+        )
+
+        return (
+            score_margin <= 2
+            and (
+                context.runners_on_base >= 1
+                or context.outs <= 1
+            )
+        )
+
+    @staticmethod
+    def _hold(
+        pitcher_id: str,
+        reason: str,
+    ) -> CanonicalPitchingDecision:
+        return CanonicalPitchingDecision(
+            action=CanonicalPitchingDecisionAction.HOLD,
+            current_pitcher_id=pitcher_id,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _replace(
+        pitcher_id: str,
+        reason: str,
+    ) -> CanonicalPitchingDecision:
+        """
+        Signal replacement without selecting a bullpen pitcher.
+
+        The first available reliever is carried only as a temporary
+        contract-compatible placeholder until the dedicated bullpen
+        selector slice owns replacement identity.
+        """
+
+        return CanonicalPitchingDecision(
+            action=CanonicalPitchingDecisionAction.REPLACE,
+            current_pitcher_id=pitcher_id,
+            replacement_pitcher_id="pending_bullpen_selection",
+            reason=reason,
+        )
+
+
+def build_baseline_starter_hook_policy(
+) -> CanonicalStarterHookPolicy:
+    """Return the default deterministic starter-hook policy."""
+
+    return CanonicalStarterHookPolicy()

--- a/tests/test_canonical_pitcher_hook_policy.py
+++ b/tests/test_canonical_pitcher_hook_policy.py
@@ -1,0 +1,283 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_STARTER_HOOK_POLICY_VERSION,
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    CanonicalStarterHookPolicy,
+    build_baseline_starter_hook_policy,
+)
+
+
+def lifecycle(**changes):
+    value = CanonicalPitcherLifecycleState(
+        team_side="home",
+        pitcher_id="home_starter",
+        role=CanonicalPitcherRole.STARTER,
+        entered_inning=1,
+        entered_half="top",
+    )
+
+    return replace(value, **changes)
+
+
+def context(
+    *,
+    pitcher=None,
+    inning=5,
+    outs=0,
+    batting_score=2,
+    fielding_score=2,
+    runners=0,
+    relievers=("reliever_1", "reliever_2"),
+):
+    return CanonicalPitchingDecisionContext(
+        lifecycle=pitcher or lifecycle(),
+        inning=inning,
+        half="top",
+        outs=outs,
+        batting_team_score=batting_score,
+        fielding_team_score=fielding_score,
+        runners_on_base=runners,
+        upcoming_batter_id="away_batter_0",
+        available_reliever_ids=relievers,
+    )
+
+
+def test_default_policy_has_stable_version():
+    policy = build_baseline_starter_hook_policy()
+
+    assert policy.schema_version == (
+        CANONICAL_STARTER_HOOK_POLICY_VERSION
+    )
+
+
+def test_policy_thresholds_must_be_ordered():
+    with pytest.raises(
+        ValueError,
+        match="must be ordered",
+    ):
+        CanonicalStarterHookPolicy(
+            minimum_batters_faced=24,
+            target_batters_faced=18,
+        )
+
+
+def test_holds_before_minimum_batters():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=17,
+                    runs_scored_during_stint=8,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "minimum_batters_not_reached"
+    )
+
+
+def test_holds_when_no_reliever_is_available():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=27,
+                ),
+                relievers=(),
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "no_available_reliever"
+    )
+
+
+def test_replaces_at_maximum_batters():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=27,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "maximum_batters_reached"
+    )
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {
+                "batters_faced": 18,
+                "runs_scored_during_stint": 5,
+            },
+            "runs_threshold_reached",
+        ),
+        (
+            {
+                "batters_faced": 18,
+                "walks_allowed": 4,
+            },
+            "walks_threshold_reached",
+        ),
+        (
+            {
+                "batters_faced": 18,
+                "home_runs_allowed": 3,
+            },
+            "home_run_threshold_reached",
+        ),
+    ],
+)
+def test_replaces_at_performance_thresholds(
+    changes,
+    reason,
+):
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(**changes)
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == reason
+
+
+def test_replaces_after_target_in_late_game():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=24,
+                ),
+                inning=7,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "late_game_target_reached"
+    )
+
+
+def test_replaces_third_time_through_in_high_leverage():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=24,
+                ),
+                inning=6,
+                outs=1,
+                batting_score=3,
+                fielding_score=4,
+                runners=1,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "third_time_high_leverage"
+    )
+
+
+def test_holds_third_time_through_in_low_leverage():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=24,
+                ),
+                inning=6,
+                outs=2,
+                batting_score=1,
+                fielding_score=7,
+                runners=0,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "starter_within_limits"
+    )
+
+
+def test_non_starter_is_not_evaluated():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    role=CanonicalPitcherRole.RELIEVER,
+                    batters_faced=30,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "non_starter_not_evaluated"
+    )
+
+
+def test_inactive_starter_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="active pitcher",
+    ):
+        (
+            build_baseline_starter_hook_policy()
+            .decide(
+                context(
+                    pitcher=lifecycle(
+                        active=False,
+                    )
+                )
+            )
+        )


### PR DESCRIPTION
## Summary

Adds a deterministic baseline starter-hook policy on top of the canonical pitcher-lifecycle contracts.

This slice decides whether an active starter should remain in the game or be replaced based on transparent lifecycle and game-context thresholds. It intentionally does not select a real bullpen arm or alter live canonical pitcher selection yet; those responsibilities remain for the dedicated bullpen-selector and resolver-integration slices.

## Added

- `CanonicalStarterHookPolicy`
- `CANONICAL_STARTER_HOOK_POLICY_VERSION`
- `build_baseline_starter_hook_policy`
- public game-package exports
- focused starter-hook regression coverage

## Decision inputs

- minimum, target, and maximum batters faced
- runs scored during the active stint
- walks allowed
- home runs allowed
- inning
- score margin
- runners on base
- outs
- lineup pass
- bullpen availability

## Baseline behavior

- Hold before the minimum batter threshold.
- Hold when no reliever is available.
- Replace at the maximum batter threshold.
- Replace after configured run, walk, or home-run thresholds.
- Replace after the target workload in late innings.
- Replace on the third lineup pass in high-leverage context.
- Hold in low-leverage conditions while still within limits.
- Do not evaluate relievers with the starter policy.
- Reject inactive starter lifecycle state.

The temporary `pending_bullpen_selection` replacement identity is contract-compatible scaffolding only. The next slice will add a dedicated deterministic bullpen selector before any live substitution integration.

## Behavior preserved

- Current canonical resolver still uses fixed starters.
- No production pitcher substitutions occur in this slice.
- Pitcher responsibility and inherited-run attribution remain unchanged.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused lifecycle/hook-policy tests passed: `28 passed`
- Combined resolver/orchestration/production-shadow tests passed: `58 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/pitcher_hook_policy.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_pitcher_hook_policy.py`

## Next slice

Add a deterministic bullpen selector that owns replacement identity and consumes pitcher role, availability, inning, leverage, and remaining bullpen depth. Resolver integration will follow after the selector contract is stable.