### PR TITLE
Add deterministic canonical bullpen selector

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -14,6 +14,15 @@ from .batted_ball_resolution import (
     derive_canonical_batted_ball_seed,
     resolve_canonical_batted_ball_outcome,
 )
+from .bullpen_selector import (
+    CANONICAL_BULLPEN_SELECTOR_VERSION,
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+    CanonicalBullpenSelection,
+    CanonicalBullpenSelectionContext,
+    CanonicalBullpenSelector,
+    build_canonical_bullpen_selector,
+)
 from .contracts import (
     CanonicalGameConfig,
     CanonicalGameResult,
@@ -129,6 +138,13 @@ from .validation import (
 
 __all__ = [
     "CanonicalBattedBallResolution",
+    "build_canonical_bullpen_selector",
+    "CanonicalBullpenSelector",
+    "CanonicalBullpenSelectionContext",
+    "CanonicalBullpenSelection",
+    "CanonicalBullpenRole",
+    "CanonicalBullpenPitcher",
+    "CANONICAL_BULLPEN_SELECTOR_VERSION",
     "CanonicalGameBoxScore",
     "GameBoxScoreReconciliation",
     "CanonicalGameConfig",

--- a/mlb_app/simulation/game/bullpen_selector.py
+++ b/mlb_app/simulation/game/bullpen_selector.py
@@ -1,0 +1,372 @@
+"""Deterministic canonical bullpen selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Tuple
+
+from .pitcher_lifecycle import (
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+)
+
+
+CANONICAL_BULLPEN_SELECTOR_VERSION = (
+    "canonical_bullpen_selector_v1"
+)
+
+
+class CanonicalBullpenRole(str, Enum):
+    """Baseline bullpen role used by deterministic selection."""
+
+    LONG_RELIEF = "long_relief"
+    MIDDLE_RELIEF = "middle_relief"
+    SETUP = "setup"
+    CLOSER = "closer"
+
+
+@dataclass(frozen=True)
+class CanonicalBullpenPitcher:
+    """One bullpen option and its game-usage metadata."""
+
+    pitcher_id: str
+    role: CanonicalBullpenRole
+    available: bool = True
+    appearance_priority: int = 0
+    minimum_inning: int = 1
+    maximum_inning: int = 99
+    maximum_score_margin: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError("pitcher_id is required")
+
+        if not isinstance(self.role, CanonicalBullpenRole):
+            raise TypeError(
+                "role must be a CanonicalBullpenRole"
+            )
+
+        if self.appearance_priority < 0:
+            raise ValueError(
+                "appearance_priority cannot be negative"
+            )
+
+        if self.minimum_inning < 1:
+            raise ValueError(
+                "minimum_inning must be positive"
+            )
+
+        if self.maximum_inning < self.minimum_inning:
+            raise ValueError(
+                "maximum_inning cannot precede minimum_inning"
+            )
+
+        if (
+            self.maximum_score_margin is not None
+            and self.maximum_score_margin < 0
+        ):
+            raise ValueError(
+                "maximum_score_margin cannot be negative"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalBullpenSelectionContext:
+    """Context required to choose one replacement pitcher."""
+
+    pitching_decision: CanonicalPitchingDecision
+    game_context: CanonicalPitchingDecisionContext
+    bullpen: Tuple[CanonicalBullpenPitcher, ...]
+    previously_used_pitcher_ids: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.pitching_decision,
+            CanonicalPitchingDecision,
+        ):
+            raise TypeError(
+                "pitching_decision must be a "
+                "CanonicalPitchingDecision"
+            )
+
+        if not isinstance(
+            self.game_context,
+            CanonicalPitchingDecisionContext,
+        ):
+            raise TypeError(
+                "game_context must be a "
+                "CanonicalPitchingDecisionContext"
+            )
+
+        if self.pitching_decision.action is not (
+            CanonicalPitchingDecisionAction.REPLACE
+        ):
+            raise ValueError(
+                "bullpen selection requires a replace decision"
+            )
+
+        pitcher_ids = tuple(
+            pitcher.pitcher_id
+            for pitcher in self.bullpen
+        )
+
+        if len(pitcher_ids) != len(set(pitcher_ids)):
+            raise ValueError(
+                "bullpen pitcher identifiers must be unique"
+            )
+
+        if len(
+            self.previously_used_pitcher_ids
+        ) != len(set(self.previously_used_pitcher_ids)):
+            raise ValueError(
+                "previously used pitcher identifiers "
+                "must be unique"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalBullpenSelection:
+    """Deterministic replacement-pitcher selection."""
+
+    pitcher_id: str
+    role: CanonicalBullpenRole
+    reason: str
+    candidate_pitcher_ids: Tuple[str, ...]
+    schema_version: str = (
+        CANONICAL_BULLPEN_SELECTOR_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError("pitcher_id is required")
+
+        if not isinstance(self.role, CanonicalBullpenRole):
+            raise TypeError(
+                "role must be a CanonicalBullpenRole"
+            )
+
+        if not self.reason:
+            raise ValueError("reason is required")
+
+        if not self.candidate_pitcher_ids:
+            raise ValueError(
+                "candidate_pitcher_ids cannot be empty"
+            )
+
+        if self.pitcher_id not in self.candidate_pitcher_ids:
+            raise ValueError(
+                "selected pitcher must be a candidate"
+            )
+
+        if self.schema_version != (
+            CANONICAL_BULLPEN_SELECTOR_VERSION
+        ):
+            raise ValueError(
+                "unsupported bullpen selector schema"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalBullpenSelector:
+    """
+    Transparent deterministic bullpen selector.
+
+    Selection is role-aware, leverage-aware, inning-aware, and stable
+    under identical inputs. It does not yet model handedness, fatigue,
+    or recent real-world workload.
+    """
+
+    version: str = CANONICAL_BULLPEN_SELECTOR_VERSION
+
+    def __post_init__(self) -> None:
+        if self.version != (
+            CANONICAL_BULLPEN_SELECTOR_VERSION
+        ):
+            raise ValueError(
+                "unsupported bullpen selector version"
+            )
+
+    def select(
+        self,
+        context: CanonicalBullpenSelectionContext,
+    ) -> CanonicalBullpenSelection:
+        if not isinstance(
+            context,
+            CanonicalBullpenSelectionContext,
+        ):
+            raise TypeError(
+                "context must be a "
+                "CanonicalBullpenSelectionContext"
+            )
+
+        eligible = tuple(
+            pitcher
+            for pitcher in context.bullpen
+            if self._is_eligible(
+                pitcher=pitcher,
+                context=context,
+            )
+        )
+
+        if not eligible:
+            raise ValueError(
+                "no eligible bullpen pitcher is available"
+            )
+
+        target_roles = self._target_roles(
+            context.game_context
+        )
+
+        ranked = tuple(
+            sorted(
+                eligible,
+                key=lambda pitcher: (
+                    self._role_rank(
+                        pitcher.role,
+                        target_roles,
+                    ),
+                    pitcher.appearance_priority,
+                    pitcher.pitcher_id,
+                ),
+            )
+        )
+
+        selected = ranked[0]
+
+        return CanonicalBullpenSelection(
+            pitcher_id=selected.pitcher_id,
+            role=selected.role,
+            reason=self._selection_reason(
+                role=selected.role,
+                context=context.game_context,
+            ),
+            candidate_pitcher_ids=tuple(
+                pitcher.pitcher_id
+                for pitcher in ranked
+            ),
+        )
+
+    @staticmethod
+    def _is_eligible(
+        *,
+        pitcher: CanonicalBullpenPitcher,
+        context: CanonicalBullpenSelectionContext,
+    ) -> bool:
+        game = context.game_context
+
+        if not pitcher.available:
+            return False
+
+        if pitcher.pitcher_id in (
+            context.previously_used_pitcher_ids
+        ):
+            return False
+
+        if pitcher.pitcher_id not in (
+            game.available_reliever_ids
+        ):
+            return False
+
+        if not (
+            pitcher.minimum_inning
+            <= game.inning
+            <= pitcher.maximum_inning
+        ):
+            return False
+
+        if pitcher.maximum_score_margin is not None:
+            margin = abs(
+                game.fielding_team_score
+                - game.batting_team_score
+            )
+
+            if margin > pitcher.maximum_score_margin:
+                return False
+
+        return True
+
+    @staticmethod
+    def _target_roles(
+        context: CanonicalPitchingDecisionContext,
+    ) -> Tuple[CanonicalBullpenRole, ...]:
+        score_margin = abs(
+            context.fielding_team_score
+            - context.batting_team_score
+        )
+
+        high_leverage = (
+            score_margin <= 2
+            and (
+                context.runners_on_base > 0
+                or context.outs <= 1
+            )
+        )
+
+        if (
+            context.inning >= 9
+            and context.fielding_team_score
+            > context.batting_team_score
+            and score_margin <= 3
+        ):
+            return (
+                CanonicalBullpenRole.CLOSER,
+                CanonicalBullpenRole.SETUP,
+                CanonicalBullpenRole.MIDDLE_RELIEF,
+                CanonicalBullpenRole.LONG_RELIEF,
+            )
+
+        if context.inning >= 7 and high_leverage:
+            return (
+                CanonicalBullpenRole.SETUP,
+                CanonicalBullpenRole.CLOSER,
+                CanonicalBullpenRole.MIDDLE_RELIEF,
+                CanonicalBullpenRole.LONG_RELIEF,
+            )
+
+        if context.inning <= 5:
+            return (
+                CanonicalBullpenRole.LONG_RELIEF,
+                CanonicalBullpenRole.MIDDLE_RELIEF,
+                CanonicalBullpenRole.SETUP,
+                CanonicalBullpenRole.CLOSER,
+            )
+
+        return (
+            CanonicalBullpenRole.MIDDLE_RELIEF,
+            CanonicalBullpenRole.LONG_RELIEF,
+            CanonicalBullpenRole.SETUP,
+            CanonicalBullpenRole.CLOSER,
+        )
+
+    @staticmethod
+    def _role_rank(
+        role: CanonicalBullpenRole,
+        target_roles: Tuple[CanonicalBullpenRole, ...],
+    ) -> int:
+        return target_roles.index(role)
+
+    @staticmethod
+    def _selection_reason(
+        *,
+        role: CanonicalBullpenRole,
+        context: CanonicalPitchingDecisionContext,
+    ) -> str:
+        if role is CanonicalBullpenRole.CLOSER:
+            return "save_situation_closer"
+
+        if role is CanonicalBullpenRole.SETUP:
+            return "late_high_leverage_setup"
+
+        if role is CanonicalBullpenRole.LONG_RELIEF:
+            return "early_exit_long_relief"
+
+        return "middle_relief_default"
+
+
+def build_canonical_bullpen_selector(
+) -> CanonicalBullpenSelector:
+    """Return the default deterministic bullpen selector."""
+
+    return CanonicalBullpenSelector()

--- a/tests/test_canonical_bullpen_selector.py
+++ b/tests/test_canonical_bullpen_selector.py
@@ -1,0 +1,361 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_BULLPEN_SELECTOR_VERSION,
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+    CanonicalBullpenSelectionContext,
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    build_canonical_bullpen_selector,
+)
+
+
+def lifecycle():
+    return CanonicalPitcherLifecycleState(
+        team_side="home",
+        pitcher_id="home_starter",
+        role=CanonicalPitcherRole.STARTER,
+        entered_inning=1,
+        entered_half="top",
+        batters_faced=24,
+    )
+
+
+def game_context(
+    *,
+    inning=6,
+    outs=1,
+    batting_score=2,
+    fielding_score=3,
+    runners=0,
+    available=(
+        "long",
+        "middle",
+        "setup",
+        "closer",
+    ),
+):
+    return CanonicalPitchingDecisionContext(
+        lifecycle=lifecycle(),
+        inning=inning,
+        half="top",
+        outs=outs,
+        batting_team_score=batting_score,
+        fielding_team_score=fielding_score,
+        runners_on_base=runners,
+        upcoming_batter_id="away_batter_0",
+        available_reliever_ids=available,
+    )
+
+
+def decision():
+    return CanonicalPitchingDecision(
+        action=CanonicalPitchingDecisionAction.REPLACE,
+        current_pitcher_id="home_starter",
+        replacement_pitcher_id=(
+            "pending_bullpen_selection"
+        ),
+        reason="starter_hook",
+    )
+
+
+def bullpen():
+    return (
+        CanonicalBullpenPitcher(
+            pitcher_id="long",
+            role=CanonicalBullpenRole.LONG_RELIEF,
+            appearance_priority=0,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="middle",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+            appearance_priority=0,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="setup",
+            role=CanonicalBullpenRole.SETUP,
+            appearance_priority=0,
+            minimum_inning=7,
+            maximum_score_margin=3,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="closer",
+            role=CanonicalBullpenRole.CLOSER,
+            appearance_priority=0,
+            minimum_inning=9,
+            maximum_score_margin=3,
+        ),
+    )
+
+
+def context(
+    *,
+    game=None,
+    options=None,
+    used=(),
+):
+    return CanonicalBullpenSelectionContext(
+        pitching_decision=decision(),
+        game_context=game or game_context(),
+        bullpen=options or bullpen(),
+        previously_used_pitcher_ids=used,
+    )
+
+
+def test_selector_has_stable_version():
+    selector = build_canonical_bullpen_selector()
+
+    assert selector.version == (
+        CANONICAL_BULLPEN_SELECTOR_VERSION
+    )
+
+
+def test_early_exit_prefers_long_reliever():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game_context(
+                    inning=4,
+                    batting_score=4,
+                    fielding_score=1,
+                )
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "long"
+    assert selection.role is (
+        CanonicalBullpenRole.LONG_RELIEF
+    )
+    assert selection.reason == (
+        "early_exit_long_relief"
+    )
+
+
+def test_middle_inning_prefers_middle_reliever():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(context())
+    )
+
+    assert selection.pitcher_id == "middle"
+    assert selection.role is (
+        CanonicalBullpenRole.MIDDLE_RELIEF
+    )
+
+
+def test_late_high_leverage_prefers_setup():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game_context(
+                    inning=8,
+                    outs=1,
+                    batting_score=3,
+                    fielding_score=4,
+                    runners=2,
+                )
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "setup"
+    assert selection.role is (
+        CanonicalBullpenRole.SETUP
+    )
+    assert selection.reason == (
+        "late_high_leverage_setup"
+    )
+
+
+def test_save_situation_prefers_closer():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game_context(
+                    inning=9,
+                    outs=0,
+                    batting_score=2,
+                    fielding_score=4,
+                    runners=0,
+                )
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "closer"
+    assert selection.role is (
+        CanonicalBullpenRole.CLOSER
+    )
+    assert selection.reason == (
+        "save_situation_closer"
+    )
+
+
+def test_used_pitcher_is_excluded():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game_context(
+                    inning=4,
+                ),
+                used=("long",),
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "middle"
+    assert "long" not in (
+        selection.candidate_pitcher_ids
+    )
+
+
+def test_unavailable_pitcher_is_excluded():
+    options = tuple(
+        replace(
+            pitcher,
+            available=False,
+        )
+        if pitcher.pitcher_id == "middle"
+        else pitcher
+        for pitcher in bullpen()
+    )
+
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(options=options)
+        )
+    )
+
+    assert selection.pitcher_id == "long"
+
+
+def test_game_available_pool_is_enforced():
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game_context(
+                    available=("setup",),
+                    inning=8,
+                    runners=1,
+                )
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "setup"
+    assert selection.candidate_pitcher_ids == (
+        "setup",
+    )
+
+
+def test_priority_breaks_same_role_tie():
+    options = (
+        CanonicalBullpenPitcher(
+            pitcher_id="middle_b",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+            appearance_priority=2,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="middle_a",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+            appearance_priority=1,
+        ),
+    )
+
+    game = game_context(
+        available=("middle_a", "middle_b"),
+    )
+
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game,
+                options=options,
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "middle_a"
+    assert selection.candidate_pitcher_ids == (
+        "middle_a",
+        "middle_b",
+    )
+
+
+def test_identifier_breaks_exact_tie_deterministically():
+    options = (
+        CanonicalBullpenPitcher(
+            pitcher_id="middle_b",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="middle_a",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+        ),
+    )
+
+    game = game_context(
+        available=("middle_a", "middle_b"),
+    )
+
+    selection = (
+        build_canonical_bullpen_selector()
+        .select(
+            context(
+                game=game,
+                options=options,
+            )
+        )
+    )
+
+    assert selection.pitcher_id == "middle_a"
+
+
+def test_no_eligible_pitcher_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="no eligible bullpen pitcher",
+    ):
+        (
+            build_canonical_bullpen_selector()
+            .select(
+                context(
+                    game=game_context(
+                        available=(),
+                    )
+                )
+            )
+        )
+
+
+def test_hold_decision_cannot_enter_selector():
+    with pytest.raises(
+        ValueError,
+        match="requires a replace decision",
+    ):
+        CanonicalBullpenSelectionContext(
+            pitching_decision=(
+                CanonicalPitchingDecision(
+                    action=(
+                        CanonicalPitchingDecisionAction.HOLD
+                    ),
+                    current_pitcher_id="home_starter",
+                )
+            ),
+            game_context=game_context(),
+            bullpen=bullpen(),
+        )


### PR DESCRIPTION
## Summary

Adds a dedicated deterministic bullpen selector that owns replacement-pitcher identity after the starter-hook policy decides to make a change.

This slice keeps bullpen selection separate from live resolver substitution. It introduces role-aware, inning-aware, leverage-aware, availability-aware, and priority-stable reliever selection while preserving the current fixed-starter canonical production behavior until the follow-up integration slice.

## Added

- `CanonicalBullpenRole`
- `CanonicalBullpenPitcher`
- `CanonicalBullpenSelectionContext`
- `CanonicalBullpenSelection`
- `CanonicalBullpenSelector`
- `CANONICAL_BULLPEN_SELECTOR_VERSION`
- `build_canonical_bullpen_selector`
- public game-package exports
- focused deterministic bullpen-selection coverage

## Selection behavior

- Early starter exits prefer long relief.
- Middle innings prefer middle relief.
- Late high-leverage situations prefer setup relievers.
- Save situations prefer the closer.
- Previously used pitchers are excluded.
- Unavailable pitchers are excluded.
- The game-level available-reliever pool is enforced.
- Inning and score-margin eligibility are enforced.
- Appearance priority breaks same-role ties.
- Pitcher identifier provides a final deterministic tie-break.
- Selection fails explicitly when no eligible pitcher exists.
- Hold decisions cannot enter the selector.

## Separation preserved

```text
starter hook policy
→ decides whether to replace

bullpen selector
→ chooses the actual reliever

resolver integration
→ performs the in-game substitution
```

No live canonical pitcher substitutions occur in this slice. Pitcher responsibility and inherited-run attribution remain unchanged. Legacy projections remain authoritative, and canonical execution remains shadow-only and fail-open.

## Validation

- Focused bullpen/hook/lifecycle tests passed: `40 passed`
- Combined resolver/orchestration/production-shadow tests passed: `70 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning remains unrelated to this change.

## Files

- `mlb_app/simulation/game/bullpen_selector.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_bullpen_selector.py`

## Next slice

Integrate lifecycle reduction, starter-hook decisions, and bullpen selection into the trial-owned plate-appearance resolver so canonical games begin changing pitchers during play.