### PR TITLE
Integrate canonical pitcher lifecycle into resolver

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -58,6 +58,10 @@ from .pa_resolver_factory import (
     CanonicalPlateAppearanceResolverFactory,
     build_canonical_pa_resolver_factory,
 )
+from .pitching_manager import (
+    CANONICAL_PITCHING_MANAGER_VERSION,
+    CanonicalPitchingManager,
+)
 from .pitcher_hook_policy import (
     CANONICAL_STARTER_HOOK_POLICY_VERSION,
     CanonicalStarterHookPolicy,
@@ -187,6 +191,8 @@ __all__ = [
     "CanonicalPlateAppearanceQuery",
     "CanonicalSampledPlateAppearance",
     "CanonicalPitchingPlan",
+    "CanonicalPitchingManager",
+    "CANONICAL_PITCHING_MANAGER_VERSION",
     "retire_pitcher",
     "reduce_pitcher_lifecycle",
     "CanonicalPitchingDecisionContext",

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 from mlb_app.simulation.events import (
     GameState,
     PlayEvent,
 )
 
+from .bullpen_selector import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenSelector,
+    build_canonical_bullpen_selector,
+)
+from .pitcher_hook_policy import (
+    CanonicalStarterHookPolicy,
+    build_baseline_starter_hook_policy,
+)
+from .pitching_manager import CanonicalPitchingManager
 from .matchup_input import CanonicalMatchupInput
 from .orchestrator import PlateAppearanceResolver
 from .outcome_resolution import (
@@ -45,6 +55,21 @@ class CanonicalPlateAppearanceResolverFactory:
     probability_provider: (
         CanonicalPlateAppearanceProbabilityProvider
     )
+    pitching_manager: Optional[
+        CanonicalPitchingManager
+    ] = None
+    starter_hook_policy: Optional[
+        CanonicalStarterHookPolicy
+    ] = None
+    bullpen_selector: Optional[
+        CanonicalBullpenSelector
+    ] = None
+    away_bullpen: Optional[
+        Tuple[CanonicalBullpenPitcher, ...]
+    ] = None
+    home_bullpen: Optional[
+        Tuple[CanonicalBullpenPitcher, ...]
+    ] = None
     version: str = (
         CANONICAL_PA_RESOLVER_FACTORY_VERSION
     )
@@ -93,12 +118,33 @@ class CanonicalPlateAppearanceResolverFactory:
                 "CanonicalMatchupInput"
             )
 
+        pitching_manager = None
+
+        if (
+            self.away_bullpen is not None
+            and self.home_bullpen is not None
+        ):
+            pitching_manager = CanonicalPitchingManager(
+                matchup_input=matchup_input,
+                starter_hook_policy=(
+                    self.starter_hook_policy
+                    or build_baseline_starter_hook_policy()
+                ),
+                bullpen_selector=(
+                    self.bullpen_selector
+                    or build_canonical_bullpen_selector()
+                ),
+                away_bullpen=self.away_bullpen,
+                home_bullpen=self.home_bullpen,
+            )
+
         return _CanonicalPlateAppearanceResolver(
             context=context,
             matchup_input=matchup_input,
             probability_provider=(
                 self.probability_provider
             ),
+            pitching_manager=pitching_manager,
         )
 
 
@@ -112,6 +158,10 @@ class _CanonicalPlateAppearanceResolver:
         CanonicalPlateAppearanceProbabilityProvider
     )
 
+    pitching_manager: Optional[
+        CanonicalPitchingManager
+    ] = None
+
     def __call__(
         self,
         state: GameState,
@@ -123,9 +173,17 @@ class _CanonicalPlateAppearanceResolver:
                 "state must be a GameState"
             )
 
-        pitcher_id = _fixed_pitcher_for_state(
-            matchup_input=self.matchup_input,
-            state=state,
+        pitcher_id = (
+            self.pitching_manager
+            .pitcher_for_plate_appearance(
+                state=state,
+                batter_id=batter_id,
+            )
+            if self.pitching_manager is not None
+            else _fixed_pitcher_for_state(
+                matchup_input=self.matchup_input,
+                state=state,
+            )
         )
 
         query = CanonicalPlateAppearanceQuery(
@@ -161,11 +219,18 @@ class _CanonicalPlateAppearanceResolver:
             probabilities
         )
 
-        return (
+        event = (
             resolve_canonical_sampled_plate_appearance(
                 sampled
             )
         )
+
+        if self.pitching_manager is not None:
+            self.pitching_manager.record_plate_appearance(
+                event
+            )
+
+        return event
 
 
 def _fixed_pitcher_for_state(

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -1,0 +1,371 @@
+"""Trial-owned canonical pitching lifecycle management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+from mlb_app.simulation.events import GameState, PlayEvent
+
+from .bullpen_selector import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenSelectionContext,
+    CanonicalBullpenSelector,
+)
+from .matchup_input import CanonicalMatchupInput
+from .pitcher_hook_policy import CanonicalStarterHookPolicy
+from .pitcher_lifecycle import (
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    reduce_pitcher_lifecycle,
+    retire_pitcher,
+)
+
+
+CANONICAL_PITCHING_MANAGER_VERSION = (
+    "canonical_pitching_manager_v1"
+)
+
+
+@dataclass
+class CanonicalPitchingManager:
+    """
+    Mutable state owned by exactly one canonical trial resolver.
+
+    The game state remains immutable. This manager owns only pitcher
+    appearance state and deterministic substitution history.
+    """
+
+    matchup_input: CanonicalMatchupInput
+    starter_hook_policy: CanonicalStarterHookPolicy
+    bullpen_selector: CanonicalBullpenSelector
+    away_bullpen: Tuple[CanonicalBullpenPitcher, ...]
+    home_bullpen: Tuple[CanonicalBullpenPitcher, ...]
+    version: str = CANONICAL_PITCHING_MANAGER_VERSION
+    _active: Dict[str, CanonicalPitcherLifecycleState] = field(
+        init=False,
+        repr=False,
+    )
+    _completed: Dict[
+        str,
+        list[CanonicalPitcherLifecycleState],
+    ] = field(
+        init=False,
+        repr=False,
+    )
+    _used_pitcher_ids: Dict[str, list[str]] = field(
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.matchup_input,
+            CanonicalMatchupInput,
+        ):
+            raise TypeError(
+                "matchup_input must be a "
+                "CanonicalMatchupInput"
+            )
+
+        if not isinstance(
+            self.starter_hook_policy,
+            CanonicalStarterHookPolicy,
+        ):
+            raise TypeError(
+                "starter_hook_policy must be a "
+                "CanonicalStarterHookPolicy"
+            )
+
+        if not isinstance(
+            self.bullpen_selector,
+            CanonicalBullpenSelector,
+        ):
+            raise TypeError(
+                "bullpen_selector must be a "
+                "CanonicalBullpenSelector"
+            )
+
+        if self.version != (
+            CANONICAL_PITCHING_MANAGER_VERSION
+        ):
+            raise ValueError(
+                "unsupported pitching manager version"
+            )
+
+        self._validate_bullpen(
+            team_side="away",
+            bullpen=self.away_bullpen,
+        )
+        self._validate_bullpen(
+            team_side="home",
+            bullpen=self.home_bullpen,
+        )
+
+        self._active = {
+            "away": CanonicalPitcherLifecycleState(
+                team_side="away",
+                pitcher_id=(
+                    self.matchup_input
+                    .away_pitching_plan
+                    .starter_id
+                ),
+                role=CanonicalPitcherRole.STARTER,
+                entered_inning=1,
+                entered_half="bottom",
+            ),
+            "home": CanonicalPitcherLifecycleState(
+                team_side="home",
+                pitcher_id=(
+                    self.matchup_input
+                    .home_pitching_plan
+                    .starter_id
+                ),
+                role=CanonicalPitcherRole.STARTER,
+                entered_inning=1,
+                entered_half="top",
+            ),
+        }
+
+        self._completed = {
+            "away": [],
+            "home": [],
+        }
+
+        self._used_pitcher_ids = {
+            "away": [
+                self._active["away"].pitcher_id,
+            ],
+            "home": [
+                self._active["home"].pitcher_id,
+            ],
+        }
+
+    def pitcher_for_plate_appearance(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+    ) -> str:
+        """Return the active pitcher after any pre-PA decision."""
+
+        team_side = self._fielding_team_side(state)
+        lifecycle = self._active[team_side]
+
+        if (
+            lifecycle.role
+            is CanonicalPitcherRole.STARTER
+        ):
+            decision_context = self._decision_context(
+                state=state,
+                batter_id=batter_id,
+                lifecycle=lifecycle,
+            )
+
+            decision = self.starter_hook_policy.decide(
+                decision_context
+            )
+
+            if decision.action is (
+                CanonicalPitchingDecisionAction.REPLACE
+            ):
+                lifecycle = self._replace_pitcher(
+                    team_side=team_side,
+                    state=state,
+                    decision_context=decision_context,
+                    decision=decision,
+                )
+
+        return lifecycle.pitcher_id
+
+    def record_plate_appearance(
+        self,
+        event: PlayEvent,
+    ) -> CanonicalPitcherLifecycleState:
+        """Reduce one completed PA into the active lifecycle."""
+
+        team_side = self._fielding_team_side(
+            event.state_before
+        )
+        lifecycle = self._active[team_side]
+
+        updated = reduce_pitcher_lifecycle(
+            lifecycle,
+            event,
+        )
+
+        self._active[team_side] = updated
+        return updated
+
+    def active_lifecycle(
+        self,
+        team_side: str,
+    ) -> CanonicalPitcherLifecycleState:
+        self._validate_team_side(team_side)
+        return self._active[team_side]
+
+    def completed_lifecycles(
+        self,
+        team_side: str,
+    ) -> Tuple[CanonicalPitcherLifecycleState, ...]:
+        self._validate_team_side(team_side)
+        return tuple(self._completed[team_side])
+
+    def used_pitcher_ids(
+        self,
+        team_side: str,
+    ) -> Tuple[str, ...]:
+        self._validate_team_side(team_side)
+        return tuple(self._used_pitcher_ids[team_side])
+
+    def _replace_pitcher(
+        self,
+        *,
+        team_side: str,
+        state: GameState,
+        decision_context: CanonicalPitchingDecisionContext,
+        decision,
+    ) -> CanonicalPitcherLifecycleState:
+        bullpen = self._bullpen_for_team(team_side)
+
+        selection = self.bullpen_selector.select(
+            CanonicalBullpenSelectionContext(
+                pitching_decision=decision,
+                game_context=decision_context,
+                bullpen=bullpen,
+                previously_used_pitcher_ids=tuple(
+                    self._used_pitcher_ids[team_side]
+                ),
+            )
+        )
+
+        retired = retire_pitcher(
+            self._active[team_side]
+        )
+        self._completed[team_side].append(retired)
+
+        replacement = CanonicalPitcherLifecycleState(
+            team_side=team_side,
+            pitcher_id=selection.pitcher_id,
+            role=CanonicalPitcherRole.RELIEVER,
+            entered_inning=state.inning,
+            entered_half=state.half,
+        )
+
+        self._active[team_side] = replacement
+        self._used_pitcher_ids[team_side].append(
+            replacement.pitcher_id
+        )
+
+        return replacement
+
+    def _decision_context(
+        self,
+        *,
+        state: GameState,
+        batter_id: str,
+        lifecycle: CanonicalPitcherLifecycleState,
+    ) -> CanonicalPitchingDecisionContext:
+        team_side = lifecycle.team_side
+
+        batting_score = (
+            state.away_score
+            if state.half == "top"
+            else state.home_score
+        )
+        fielding_score = (
+            state.home_score
+            if state.half == "top"
+            else state.away_score
+        )
+
+        available = tuple(
+            pitcher.pitcher_id
+            for pitcher in self._bullpen_for_team(
+                team_side
+            )
+            if pitcher.available
+            and pitcher.pitcher_id
+            not in self._used_pitcher_ids[team_side]
+        )
+
+        return CanonicalPitchingDecisionContext(
+            lifecycle=lifecycle,
+            inning=state.inning,
+            half=state.half,
+            outs=state.outs,
+            batting_team_score=batting_score,
+            fielding_team_score=fielding_score,
+            runners_on_base=sum(
+                runner is not None
+                for runner in state.bases
+            ),
+            upcoming_batter_id=batter_id,
+            available_reliever_ids=available,
+        )
+
+    def _bullpen_for_team(
+        self,
+        team_side: str,
+    ) -> Tuple[CanonicalBullpenPitcher, ...]:
+        return (
+            self.away_bullpen
+            if team_side == "away"
+            else self.home_bullpen
+        )
+
+    @staticmethod
+    def _fielding_team_side(
+        state: GameState,
+    ) -> str:
+        if state.half == "top":
+            return "home"
+
+        if state.half == "bottom":
+            return "away"
+
+        raise ValueError(
+            "state half must be 'top' or 'bottom'"
+        )
+
+    @staticmethod
+    def _validate_team_side(
+        team_side: str,
+    ) -> None:
+        if team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be 'away' or 'home'"
+            )
+
+    def _validate_bullpen(
+        self,
+        *,
+        team_side: str,
+        bullpen: Tuple[CanonicalBullpenPitcher, ...],
+    ) -> None:
+        plan = (
+            self.matchup_input.away_pitching_plan
+            if team_side == "away"
+            else self.matchup_input.home_pitching_plan
+        )
+
+        bullpen_ids = tuple(
+            pitcher.pitcher_id
+            for pitcher in bullpen
+        )
+
+        if len(bullpen_ids) != len(set(bullpen_ids)):
+            raise ValueError(
+                f"{team_side} bullpen identifiers "
+                "must be unique"
+            )
+
+        if set(bullpen_ids) != set(
+            plan.bullpen_pitcher_ids
+        ):
+            raise ValueError(
+                f"{team_side} bullpen must match "
+                "the canonical pitching plan"
+            )

--- a/tests/test_canonical_pa_resolver_factory.py
+++ b/tests/test_canonical_pa_resolver_factory.py
@@ -4,6 +4,10 @@ import pytest
 
 from mlb_app.simulation.events import GameState
 from mlb_app.simulation.game import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+    CanonicalStarterHookPolicy,
+    build_canonical_bullpen_selector,
     CANONICAL_PA_OUTCOME_ORDER,
     CanonicalGameConfig,
     CanonicalLineup,
@@ -355,3 +359,79 @@ def test_execution_plan_replays_identically():
     )
 
     assert first == second
+
+
+def test_resolver_factory_can_change_pitchers_with_manager():
+    queries = []
+
+    provider = all_out_provider(queries)
+
+    factory = CanonicalPlateAppearanceResolverFactory(
+        probability_provider=provider,
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="away_reliever",
+                role=(
+                    CanonicalBullpenRole.LONG_RELIEF
+                ),
+            ),
+        ),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_reliever",
+                role=(
+                    CanonicalBullpenRole.LONG_RELIEF
+                ),
+            ),
+        ),
+    )
+
+    matchup_input = matchup()
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            matchup_input=matchup_input,
+        )
+    )
+
+    resolver = factory(context)
+
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    for index in range(4):
+        state = replace(
+            state,
+            outs=0,
+            batting_order_index=index,
+            plate_appearance_number=index,
+        )
+
+        event = resolver(
+            state,
+            f"away_batter_{index}",
+            index,
+        )
+
+        state = event.state_after
+
+    assert tuple(
+        query.pitcher_id
+        for query in queries
+    ) == (
+        "home_starter",
+        "home_starter",
+        "home_starter",
+        "home_reliever",
+    )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -1,0 +1,259 @@
+from dataclasses import replace
+
+from mlb_app.simulation.events import (
+    GameState,
+    build_play_event,
+)
+from mlb_app.simulation.game import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalPitcherRole,
+    CanonicalPitchingManager,
+    CanonicalPitchingPlan,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalStarterHookPolicy,
+    build_canonical_bullpen_selector,
+)
+
+
+def matchup():
+    return CanonicalMatchupInput(
+        game_pk=123,
+        away_lineup=CanonicalLineup(
+            team_side="away",
+            player_ids=tuple(
+                f"away_batter_{index}"
+                for index in range(9)
+            ),
+        ),
+        home_lineup=CanonicalLineup(
+            team_side="home",
+            player_ids=tuple(
+                f"home_batter_{index}"
+                for index in range(9)
+            ),
+        ),
+        away_pitching_plan=CanonicalPitchingPlan(
+            team_side="away",
+            starter_id="away_starter",
+            bullpen_pitcher_ids=(
+                "away_long",
+                "away_middle",
+            ),
+        ),
+        home_pitching_plan=CanonicalPitchingPlan(
+            team_side="home",
+            starter_id="home_starter",
+            bullpen_pitcher_ids=(
+                "home_long",
+                "home_middle",
+            ),
+        ),
+        probability_provider=(
+            CanonicalProbabilityProviderIdentity(
+                provider_name="test",
+                provider_version="v1",
+            )
+        ),
+    )
+
+
+def bullpen(prefix):
+    return (
+        CanonicalBullpenPitcher(
+            pitcher_id=f"{prefix}_long",
+            role=CanonicalBullpenRole.LONG_RELIEF,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id=f"{prefix}_middle",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+        ),
+    )
+
+
+def manager():
+    return CanonicalPitchingManager(
+        matchup_input=matchup(),
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=bullpen("home"),
+    )
+
+
+def event(
+    *,
+    state,
+    pitcher_id,
+    batter_id,
+):
+    return replace(
+        build_play_event(
+            sequence=state.plate_appearance_number,
+            event_type="out",
+            batter_id=batter_id,
+            state_before=state,
+            runner_movements=(),
+            outs_recorded=(),
+        ),
+        pitcher_id=pitcher_id,
+    )
+
+
+def test_manager_starts_with_both_starters():
+    value = manager()
+
+    assert (
+        value.active_lifecycle("home").pitcher_id
+        == "home_starter"
+    )
+    assert (
+        value.active_lifecycle("away").pitcher_id
+        == "away_starter"
+    )
+
+
+def test_top_half_uses_home_pitcher():
+    value = manager()
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=1,
+            half="top",
+        ),
+        batter_id="away_batter_0",
+    )
+
+    assert pitcher == "home_starter"
+
+
+def test_bottom_half_uses_away_pitcher():
+    value = manager()
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=1,
+            half="bottom",
+        ),
+        batter_id="home_batter_0",
+    )
+
+    assert pitcher == "away_starter"
+
+
+def test_manager_reduces_active_lifecycle():
+    value = manager()
+    state = GameState(
+        inning=1,
+        half="top",
+    )
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_0",
+    )
+
+    updated = value.record_plate_appearance(
+        event(
+            state=state,
+            pitcher_id=pitcher,
+            batter_id="away_batter_0",
+        )
+    )
+
+    assert updated.batters_faced == 1
+
+
+def test_manager_replaces_starter_after_threshold():
+    value = manager()
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    for index in range(3):
+        state = replace(
+            state,
+            batting_order_index=index,
+            plate_appearance_number=index,
+        )
+
+        pitcher = value.pitcher_for_plate_appearance(
+            state=state,
+            batter_id=f"away_batter_{index}",
+        )
+
+        value.record_plate_appearance(
+            event(
+                state=state,
+                pitcher_id=pitcher,
+                batter_id=f"away_batter_{index}",
+            )
+        )
+
+    next_state = replace(
+        state,
+        batting_order_index=3,
+        plate_appearance_number=3,
+    )
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=next_state,
+        batter_id="away_batter_3",
+    )
+
+    assert pitcher == "home_long"
+    assert (
+        value.active_lifecycle("home").role
+        is CanonicalPitcherRole.RELIEVER
+    )
+    assert value.used_pitcher_ids("home") == (
+        "home_starter",
+        "home_long",
+    )
+
+    completed = value.completed_lifecycles(
+        "home"
+    )
+
+    assert len(completed) == 1
+    assert completed[0].pitcher_id == (
+        "home_starter"
+    )
+    assert completed[0].active is False
+
+
+def test_reliever_is_not_reprocessed_by_starter_policy():
+    value = manager()
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    starter = value.active_lifecycle("home")
+
+    value._active["home"] = replace(
+        starter,
+        batters_faced=3,
+    )
+
+    first = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_3",
+    )
+
+    second = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_3",
+    )
+
+    assert first == "home_long"
+    assert second == "home_long"


### PR DESCRIPTION
## Summary

Integrates canonical pitcher lifecycle state, starter-hook decisions, and deterministic bullpen selection into the trial-owned plate-appearance resolver.

This is the first slice where canonical simulations can make live in-game pitching changes. The resolver now owns a per-trial pitching manager, updates active pitcher lifecycle state after each plate appearance, evaluates the starter hook before the next matchup, selects a reliever when replacement is required, and sends the active pitcher identity into the probability query.

## Added

- `CanonicalPitchingManager`
- `CANONICAL_PITCHING_MANAGER_VERSION`
- trial-owned active pitcher state for away and home teams
- completed appearance history
- used-pitcher tracking
- starter lifecycle initialization from `CanonicalPitchingPlan`
- pre-PA starter-hook evaluation
- deterministic bullpen selection
- post-PA lifecycle reduction
- optional resolver-factory integration
- public game-package exports
- focused manager and resolver integration coverage

## Live canonical flow

```text
starter begins game
→ lifecycle updates after every PA
→ hook policy evaluates the next PA
→ bullpen selector chooses the reliever
→ next probability query uses the reliever
```

## Behavior preserved

- Existing resolver behavior remains unchanged when bullpen inputs are omitted.
- The pitching manager is created once per trial resolver.
- Game state remains immutable; pitcher appearance state is owned separately.
- Only starters are evaluated for removal in this slice.
- Reliever chaining is not yet modeled.
- Inherited-runner responsibility and earned-run reconstruction remain unchanged.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused manager/resolver/bullpen/hook/lifecycle tests passed: `54 passed`
- Combined orchestration/trials/production-shadow/comparator tests passed: `43 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning and two unrelated pandas dependency-version warnings remain.

## Files

- `mlb_app/simulation/game/pitching_manager.py`
- `mlb_app/simulation/game/pa_resolver_factory.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_pitching_manager.py`
- `tests/test_canonical_pa_resolver_factory.py`

## Next slice

Add reliever workload and chaining so active relievers can also be replaced deterministically before moving into explicit inherited-runner responsibility and earned-run reconstruction.