### PR TITLE
Add canonical reliever workload chaining

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -67,6 +67,11 @@ from .pitcher_hook_policy import (
     CanonicalStarterHookPolicy,
     build_baseline_starter_hook_policy,
 )
+from .reliever_hook_policy import (
+    CANONICAL_RELIEVER_HOOK_POLICY_VERSION,
+    CanonicalRelieverHookPolicy,
+    build_baseline_reliever_hook_policy,
+)
 from .pitcher_lifecycle import (
     CANONICAL_PITCHER_LIFECYCLE_VERSION,
     CanonicalPitcherLifecycleState,
@@ -200,6 +205,9 @@ __all__ = [
     "CanonicalPitchingDecision",
     "CanonicalPitcherRole",
     "CanonicalPitcherLifecycleState",
+    "build_baseline_reliever_hook_policy",
+    "CanonicalRelieverHookPolicy",
+    "CANONICAL_RELIEVER_HOOK_POLICY_VERSION",
     "build_baseline_starter_hook_policy",
     "CanonicalStarterHookPolicy",
     "CANONICAL_STARTER_HOOK_POLICY_VERSION",

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -20,6 +20,10 @@ from .pitcher_hook_policy import (
     build_baseline_starter_hook_policy,
 )
 from .pitching_manager import CanonicalPitchingManager
+from .reliever_hook_policy import (
+    CanonicalRelieverHookPolicy,
+    build_baseline_reliever_hook_policy,
+)
 from .matchup_input import CanonicalMatchupInput
 from .orchestrator import PlateAppearanceResolver
 from .outcome_resolution import (
@@ -63,6 +67,9 @@ class CanonicalPlateAppearanceResolverFactory:
     ] = None
     bullpen_selector: Optional[
         CanonicalBullpenSelector
+    ] = None
+    reliever_hook_policy: Optional[
+        CanonicalRelieverHookPolicy
     ] = None
     away_bullpen: Optional[
         Tuple[CanonicalBullpenPitcher, ...]
@@ -133,6 +140,10 @@ class CanonicalPlateAppearanceResolverFactory:
                 bullpen_selector=(
                     self.bullpen_selector
                     or build_canonical_bullpen_selector()
+                ),
+                reliever_hook_policy=(
+                    self.reliever_hook_policy
+                    or build_baseline_reliever_hook_policy()
                 ),
                 away_bullpen=self.away_bullpen,
                 home_bullpen=self.home_bullpen,

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -14,6 +14,10 @@ from .bullpen_selector import (
 )
 from .matchup_input import CanonicalMatchupInput
 from .pitcher_hook_policy import CanonicalStarterHookPolicy
+from .reliever_hook_policy import (
+    CanonicalRelieverHookPolicy,
+    build_baseline_reliever_hook_policy,
+)
 from .pitcher_lifecycle import (
     CanonicalPitcherLifecycleState,
     CanonicalPitcherRole,
@@ -43,6 +47,13 @@ class CanonicalPitchingManager:
     bullpen_selector: CanonicalBullpenSelector
     away_bullpen: Tuple[CanonicalBullpenPitcher, ...]
     home_bullpen: Tuple[CanonicalBullpenPitcher, ...]
+    reliever_hook_policy: CanonicalRelieverHookPolicy = (
+        field(
+            default_factory=(
+                build_baseline_reliever_hook_policy
+            )
+        )
+    )
     version: str = CANONICAL_PITCHING_MANAGER_VERSION
     _active: Dict[str, CanonicalPitcherLifecycleState] = field(
         init=False,
@@ -86,6 +97,15 @@ class CanonicalPitchingManager:
             raise TypeError(
                 "bullpen_selector must be a "
                 "CanonicalBullpenSelector"
+            )
+
+        if not isinstance(
+            self.reliever_hook_policy,
+            CanonicalRelieverHookPolicy,
+        ):
+            raise TypeError(
+                "reliever_hook_policy must be a "
+                "CanonicalRelieverHookPolicy"
             )
 
         if self.version != (
@@ -154,29 +174,32 @@ class CanonicalPitchingManager:
         team_side = self._fielding_team_side(state)
         lifecycle = self._active[team_side]
 
-        if (
-            lifecycle.role
-            is CanonicalPitcherRole.STARTER
-        ):
-            decision_context = self._decision_context(
-                state=state,
-                batter_id=batter_id,
-                lifecycle=lifecycle,
-            )
+        decision_context = self._decision_context(
+            state=state,
+            batter_id=batter_id,
+            lifecycle=lifecycle,
+        )
 
+        if lifecycle.role is (
+            CanonicalPitcherRole.STARTER
+        ):
             decision = self.starter_hook_policy.decide(
                 decision_context
             )
+        else:
+            decision = self.reliever_hook_policy.decide(
+                decision_context
+            )
 
-            if decision.action is (
-                CanonicalPitchingDecisionAction.REPLACE
-            ):
-                lifecycle = self._replace_pitcher(
-                    team_side=team_side,
-                    state=state,
-                    decision_context=decision_context,
-                    decision=decision,
-                )
+        if decision.action is (
+            CanonicalPitchingDecisionAction.REPLACE
+        ):
+            lifecycle = self._replace_pitcher(
+                team_side=team_side,
+                state=state,
+                decision_context=decision_context,
+                decision=decision,
+            )
 
         return lifecycle.pitcher_id
 

--- a/mlb_app/simulation/game/reliever_hook_policy.py
+++ b/mlb_app/simulation/game/reliever_hook_policy.py
@@ -1,0 +1,190 @@
+"""Deterministic canonical reliever workload policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .pitcher_lifecycle import (
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+)
+
+
+CANONICAL_RELIEVER_HOOK_POLICY_VERSION = (
+    "canonical_reliever_hook_policy_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalRelieverHookPolicy:
+    """
+    Baseline deterministic reliever-removal policy.
+
+    This policy decides whether an active reliever should remain in the
+    game. Replacement identity remains owned by the bullpen selector.
+    """
+
+    minimum_batters_faced: int = 3
+    target_batters_faced: int = 6
+    maximum_batters_faced: int = 9
+    maximum_runs_during_stint: int = 3
+    maximum_walks_allowed: int = 2
+    maximum_home_runs_allowed: int = 2
+    schema_version: str = (
+        CANONICAL_RELIEVER_HOOK_POLICY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        thresholds = (
+            self.minimum_batters_faced,
+            self.target_batters_faced,
+            self.maximum_batters_faced,
+            self.maximum_runs_during_stint,
+            self.maximum_walks_allowed,
+            self.maximum_home_runs_allowed,
+        )
+
+        if any(value < 0 for value in thresholds):
+            raise ValueError(
+                "reliever hook thresholds cannot be negative"
+            )
+
+        if self.minimum_batters_faced < 3:
+            raise ValueError(
+                "minimum_batters_faced must be at least three"
+            )
+
+        if not (
+            self.minimum_batters_faced
+            <= self.target_batters_faced
+            <= self.maximum_batters_faced
+        ):
+            raise ValueError(
+                "reliever batter thresholds must be ordered"
+            )
+
+        if self.schema_version != (
+            CANONICAL_RELIEVER_HOOK_POLICY_VERSION
+        ):
+            raise ValueError(
+                "unsupported reliever hook policy schema"
+            )
+
+    def decide(
+        self,
+        context: CanonicalPitchingDecisionContext,
+    ) -> CanonicalPitchingDecision:
+        lifecycle = context.lifecycle
+
+        if lifecycle.role is not (
+            CanonicalPitcherRole.RELIEVER
+        ):
+            return self._hold(
+                lifecycle.pitcher_id,
+                "non_reliever_not_evaluated",
+            )
+
+        if not lifecycle.active:
+            raise ValueError(
+                "reliever hook policy requires "
+                "an active pitcher"
+            )
+
+        if not context.available_reliever_ids:
+            return self._hold(
+                lifecycle.pitcher_id,
+                "no_available_reliever",
+            )
+
+        if (
+            lifecycle.batters_faced
+            < self.minimum_batters_faced
+        ):
+            return self._hold(
+                lifecycle.pitcher_id,
+                "minimum_batters_not_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.maximum_batters_faced
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "maximum_batters_reached",
+            )
+
+        if (
+            lifecycle.runs_scored_during_stint
+            >= self.maximum_runs_during_stint
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "runs_threshold_reached",
+            )
+
+        if (
+            lifecycle.walks_allowed
+            >= self.maximum_walks_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "walks_threshold_reached",
+            )
+
+        if (
+            lifecycle.home_runs_allowed
+            >= self.maximum_home_runs_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "home_run_threshold_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.target_batters_faced
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "target_workload_reached",
+            )
+
+        return self._hold(
+            lifecycle.pitcher_id,
+            "reliever_within_limits",
+        )
+
+    @staticmethod
+    def _hold(
+        pitcher_id: str,
+        reason: str,
+    ) -> CanonicalPitchingDecision:
+        return CanonicalPitchingDecision(
+            action=CanonicalPitchingDecisionAction.HOLD,
+            current_pitcher_id=pitcher_id,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _replace(
+        pitcher_id: str,
+        reason: str,
+    ) -> CanonicalPitchingDecision:
+        return CanonicalPitchingDecision(
+            action=(
+                CanonicalPitchingDecisionAction.REPLACE
+            ),
+            current_pitcher_id=pitcher_id,
+            replacement_pitcher_id=(
+                "pending_bullpen_selection"
+            ),
+            reason=reason,
+        )
+
+
+def build_baseline_reliever_hook_policy(
+) -> CanonicalRelieverHookPolicy:
+    return CanonicalRelieverHookPolicy()

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -11,6 +11,7 @@ from mlb_app.simulation.game import (
     CanonicalMatchupInput,
     CanonicalPitcherRole,
     CanonicalPitchingManager,
+    CanonicalRelieverHookPolicy,
     CanonicalPitchingPlan,
     CanonicalProbabilityProviderIdentity,
     CanonicalStarterHookPolicy,
@@ -257,3 +258,136 @@ def test_reliever_is_not_reprocessed_by_starter_policy():
 
     assert first == "home_long"
     assert second == "home_long"
+
+
+def test_manager_chains_relievers_after_workload():
+    value = CanonicalPitchingManager(
+        matchup_input=matchup(),
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        reliever_hook_policy=CanonicalRelieverHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=bullpen("home"),
+    )
+
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    starter = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_0",
+    )
+
+    first_reliever = starter
+
+    for index in range(3):
+        value.record_plate_appearance(
+            event(
+                state=state,
+                pitcher_id=first_reliever,
+                batter_id=f"away_batter_{index}",
+            )
+        )
+
+    second_reliever = (
+        value.pitcher_for_plate_appearance(
+            state=state,
+            batter_id="away_batter_3",
+        )
+    )
+
+    assert first_reliever == "home_long"
+    assert second_reliever == "home_middle"
+    assert value.used_pitcher_ids("home") == (
+        "home_starter",
+        "home_long",
+        "home_middle",
+    )
+
+    completed = value.completed_lifecycles(
+        "home"
+    )
+
+    assert tuple(
+        lifecycle.pitcher_id
+        for lifecycle in completed
+    ) == (
+        "home_starter",
+        "home_long",
+    )
+
+
+def test_last_available_reliever_is_held():
+    value = CanonicalPitchingManager(
+        matchup_input=matchup(),
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        reliever_hook_policy=CanonicalRelieverHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=bullpen("home"),
+    )
+
+    state = GameState(
+        inning=6,
+        half="top",
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    starter = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_0",
+    )
+
+    reliever = starter
+
+    value._used_pitcher_ids["home"].append(
+        "home_long"
+    )
+
+    for index in range(3):
+        value.record_plate_appearance(
+            event(
+                state=state,
+                pitcher_id=reliever,
+                batter_id=f"away_batter_{index}",
+            )
+        )
+
+    held = value.pitcher_for_plate_appearance(
+        state=state,
+        batter_id="away_batter_3",
+    )
+
+    assert reliever == "home_middle"
+    assert held == "home_middle"

--- a/tests/test_canonical_reliever_hook_policy.py
+++ b/tests/test_canonical_reliever_hook_policy.py
@@ -1,0 +1,239 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_RELIEVER_HOOK_POLICY_VERSION,
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+    CanonicalRelieverHookPolicy,
+    build_baseline_reliever_hook_policy,
+)
+
+
+def lifecycle(**changes):
+    value = CanonicalPitcherLifecycleState(
+        team_side="home",
+        pitcher_id="home_reliever",
+        role=CanonicalPitcherRole.RELIEVER,
+        entered_inning=6,
+        entered_half="top",
+    )
+
+    return replace(value, **changes)
+
+
+def context(
+    *,
+    pitcher=None,
+    relievers=("next_reliever",),
+):
+    return CanonicalPitchingDecisionContext(
+        lifecycle=pitcher or lifecycle(),
+        inning=7,
+        half="top",
+        outs=1,
+        batting_team_score=3,
+        fielding_team_score=4,
+        runners_on_base=1,
+        upcoming_batter_id="away_batter_0",
+        available_reliever_ids=relievers,
+    )
+
+
+def test_default_policy_has_stable_version():
+    policy = build_baseline_reliever_hook_policy()
+
+    assert policy.schema_version == (
+        CANONICAL_RELIEVER_HOOK_POLICY_VERSION
+    )
+
+
+def test_thresholds_must_be_ordered():
+    with pytest.raises(
+        ValueError,
+        match="must be ordered",
+    ):
+        CanonicalRelieverHookPolicy(
+            minimum_batters_faced=6,
+            target_batters_faced=3,
+        )
+
+
+def test_minimum_batters_must_be_at_least_three():
+    with pytest.raises(
+        ValueError,
+        match="at least three",
+    ):
+        CanonicalRelieverHookPolicy(
+            minimum_batters_faced=2,
+            target_batters_faced=3,
+            maximum_batters_faced=6,
+        )
+
+
+def test_holds_before_minimum_batters():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=2,
+                    runs_scored_during_stint=5,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "minimum_batters_not_reached"
+    )
+
+
+def test_holds_when_no_reliever_remains():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=9,
+                ),
+                relievers=(),
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "no_available_reliever"
+    )
+
+
+def test_replaces_at_maximum_batters():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=9,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "maximum_batters_reached"
+    )
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {
+                "batters_faced": 3,
+                "runs_scored_during_stint": 3,
+            },
+            "runs_threshold_reached",
+        ),
+        (
+            {
+                "batters_faced": 3,
+                "walks_allowed": 2,
+            },
+            "walks_threshold_reached",
+        ),
+        (
+            {
+                "batters_faced": 3,
+                "home_runs_allowed": 2,
+            },
+            "home_run_threshold_reached",
+        ),
+    ],
+)
+def test_replaces_at_performance_thresholds(
+    changes,
+    reason,
+):
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(**changes)
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == reason
+
+
+def test_replaces_at_target_workload():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=6,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "target_workload_reached"
+    )
+
+
+def test_starter_is_not_evaluated():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    role=CanonicalPitcherRole.STARTER,
+                    batters_faced=20,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "non_reliever_not_evaluated"
+    )
+
+
+def test_inactive_reliever_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="active pitcher",
+    ):
+        (
+            build_baseline_reliever_hook_policy()
+            .decide(
+                context(
+                    pitcher=lifecycle(
+                        active=False,
+                    )
+                )
+            )
+        )


### PR DESCRIPTION
## Summary

Adds deterministic reliever workload evaluation and bullpen chaining to the canonical trial-owned pitching manager.

This slice extends live pitcher lifecycle behavior beyond starters. Active relievers are now evaluated before each plate appearance, may be replaced after configured workload or performance thresholds, and are chained to the next unused eligible bullpen arm. The universal three-batter minimum is enforced for both starters and relievers.

## Added

- `CanonicalRelieverHookPolicy`
- `CANONICAL_RELIEVER_HOOK_POLICY_VERSION`
- `build_baseline_reliever_hook_policy`
- reliever-policy wiring through the resolver factory
- active reliever evaluation in `CanonicalPitchingManager`
- deterministic reliever-to-reliever chaining
- final-arm hold behavior when no unused reliever remains
- public game-package exports
- focused reliever-policy and pitching-manager regression coverage

## Universal three-batter minimum

Both starter and reliever policies now reject configurations below three batters faced.

```text
starter minimum: 3 batters
reliever minimum: 3 batters
```

A pitcher may remain longer because of workload thresholds or bullpen exhaustion, but the canonical hook flow cannot remove an active pitcher before three batters faced.

## Reliever behavior

- Hold before three batters faced.
- Hold when no unused reliever remains.
- Replace at the maximum batter threshold.
- Replace after configured run, walk, or home-run thresholds.
- Replace after the target workload.
- Exclude already used pitchers from future selection.
- Continue selecting from the remaining bullpen deterministically.
- Preserve the final available pitcher when the bullpen is exhausted.

## Canonical flow

```text
starter
→ starter hook
→ first reliever
→ reliever workload hook
→ next unused reliever
→ hold final available arm when bullpen is exhausted
```

## Behavior preserved

- Starter-hook policy semantics remain unchanged.
- Existing resolver behavior remains unchanged when bullpen inputs are omitted.
- Game state remains immutable; pitcher lifecycle state remains trial-owned.
- Inherited-runner responsibility and earned-run reconstruction remain unchanged.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused reliever/manager/resolver/bullpen/hook/lifecycle tests passed: `68 passed`
- Combined orchestration/trials/production-shadow/comparator tests passed: `57 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning and two unrelated pandas dependency-version warnings remain.

## Files

- `mlb_app/simulation/game/reliever_hook_policy.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `mlb_app/simulation/game/pa_resolver_factory.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_reliever_hook_policy.py`
- `tests/test_canonical_pitching_manager.py`

## Next slice

Add explicit inherited-runner responsibility and earned-run reconstruction on top of completed pitcher lifecycle history.