### PR TITLE
Add canonical runner pitcher responsibility

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -72,6 +72,12 @@ from .reliever_hook_policy import (
     CanonicalRelieverHookPolicy,
     build_baseline_reliever_hook_policy,
 )
+from .pitcher_responsibility import (
+    CANONICAL_PITCHER_RESPONSIBILITY_VERSION,
+    CanonicalPitcherResponsibilityLedger,
+    CanonicalRunnerResponsibility,
+    CanonicalScoredRunResponsibility,
+)
 from .pitcher_lifecycle import (
     CANONICAL_PITCHER_LIFECYCLE_VERSION,
     CanonicalPitcherLifecycleState,
@@ -205,6 +211,10 @@ __all__ = [
     "CanonicalPitchingDecision",
     "CanonicalPitcherRole",
     "CanonicalPitcherLifecycleState",
+    "CanonicalScoredRunResponsibility",
+    "CanonicalRunnerResponsibility",
+    "CanonicalPitcherResponsibilityLedger",
+    "CANONICAL_PITCHER_RESPONSIBILITY_VERSION",
     "build_baseline_reliever_hook_policy",
     "CanonicalRelieverHookPolicy",
     "CANONICAL_RELIEVER_HOOK_POLICY_VERSION",

--- a/mlb_app/simulation/game/pitcher_responsibility.py
+++ b/mlb_app/simulation/game/pitcher_responsibility.py
@@ -1,0 +1,225 @@
+"""Canonical pitcher responsibility for baserunners and scored runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from mlb_app.simulation.events import PlayEvent
+
+
+CANONICAL_PITCHER_RESPONSIBILITY_VERSION = (
+    "canonical_pitcher_responsibility_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerResponsibility:
+    """Pitcher responsible for one active baserunner."""
+
+    runner_id: str
+    responsible_pitcher_id: str
+    reached_on_event_sequence: int
+    reached_on_event_type: str
+    schema_version: str = (
+        CANONICAL_PITCHER_RESPONSIBILITY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+
+        if not self.responsible_pitcher_id:
+            raise ValueError(
+                "responsible_pitcher_id is required"
+            )
+
+        if self.reached_on_event_sequence < 0:
+            raise ValueError(
+                "reached_on_event_sequence cannot be negative"
+            )
+
+        if not self.reached_on_event_type:
+            raise ValueError(
+                "reached_on_event_type is required"
+            )
+
+        if self.schema_version != (
+            CANONICAL_PITCHER_RESPONSIBILITY_VERSION
+        ):
+            raise ValueError(
+                "unsupported responsibility schema"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalScoredRunResponsibility:
+    """Responsibility attribution for one runner who scored."""
+
+    runner_id: str
+    responsible_pitcher_id: str
+    pitcher_on_mound_id: str
+    scoring_event_sequence: int
+    scoring_event_type: str
+    schema_version: str = (
+        CANONICAL_PITCHER_RESPONSIBILITY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+
+        if not self.responsible_pitcher_id:
+            raise ValueError(
+                "responsible_pitcher_id is required"
+            )
+
+        if not self.pitcher_on_mound_id:
+            raise ValueError(
+                "pitcher_on_mound_id is required"
+            )
+
+        if self.scoring_event_sequence < 0:
+            raise ValueError(
+                "scoring_event_sequence cannot be negative"
+            )
+
+        if not self.scoring_event_type:
+            raise ValueError(
+                "scoring_event_type is required"
+            )
+
+        if self.schema_version != (
+            CANONICAL_PITCHER_RESPONSIBILITY_VERSION
+        ):
+            raise ValueError(
+                "unsupported responsibility schema"
+            )
+
+
+class CanonicalPitcherResponsibilityLedger:
+    """
+    Mutable runner ledger owned by exactly one canonical trial.
+
+    Responsibility is assigned when a batter becomes a runner and is
+    preserved until that runner scores or is retired.
+    """
+
+    def __init__(self) -> None:
+        self._active: Dict[
+            str,
+            CanonicalRunnerResponsibility,
+        ] = {}
+        self._scored: list[
+            CanonicalScoredRunResponsibility
+        ] = []
+
+    def apply_event(
+        self,
+        event: PlayEvent,
+    ) -> Tuple[
+        CanonicalScoredRunResponsibility,
+        ...,
+    ]:
+        if not isinstance(event, PlayEvent):
+            raise TypeError(
+                "event must be a PlayEvent"
+            )
+
+        if not event.pitcher_id:
+            raise ValueError(
+                "event pitcher_id is required"
+            )
+
+        scored_before = len(self._scored)
+
+        for movement in event.runner_movements:
+            runner_id = movement.runner_id
+
+            if movement.start_base == 0:
+                if runner_id in self._active:
+                    raise ValueError(
+                        "runner already has active "
+                        "pitcher responsibility"
+                    )
+
+                self._active[runner_id] = (
+                    CanonicalRunnerResponsibility(
+                        runner_id=runner_id,
+                        responsible_pitcher_id=(
+                            event.pitcher_id
+                        ),
+                        reached_on_event_sequence=(
+                            event.sequence
+                        ),
+                        reached_on_event_type=(
+                            event.event_type
+                        ),
+                    )
+                )
+
+            if movement.is_out:
+                self._active.pop(
+                    runner_id,
+                    None,
+                )
+                continue
+
+            if movement.scored:
+                responsibility = self._active.pop(
+                    runner_id,
+                    None,
+                )
+
+                if responsibility is None:
+                    raise ValueError(
+                        "scoring runner has no active "
+                        "pitcher responsibility"
+                    )
+
+                self._scored.append(
+                    CanonicalScoredRunResponsibility(
+                        runner_id=runner_id,
+                        responsible_pitcher_id=(
+                            responsibility
+                            .responsible_pitcher_id
+                        ),
+                        pitcher_on_mound_id=(
+                            event.pitcher_id
+                        ),
+                        scoring_event_sequence=(
+                            event.sequence
+                        ),
+                        scoring_event_type=(
+                            event.event_type
+                        ),
+                    )
+                )
+
+        return tuple(
+            self._scored[scored_before:]
+        )
+
+    def responsibility_for_runner(
+        self,
+        runner_id: str,
+    ) -> CanonicalRunnerResponsibility | None:
+        return self._active.get(runner_id)
+
+    def active_responsibilities(
+        self,
+    ) -> Tuple[CanonicalRunnerResponsibility, ...]:
+        return tuple(
+            sorted(
+                self._active.values(),
+                key=lambda value: value.runner_id,
+            )
+        )
+
+    def scored_run_responsibilities(
+        self,
+    ) -> Tuple[
+        CanonicalScoredRunResponsibility,
+        ...,
+    ]:
+        return tuple(self._scored)

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -18,6 +18,11 @@ from .reliever_hook_policy import (
     CanonicalRelieverHookPolicy,
     build_baseline_reliever_hook_policy,
 )
+from .pitcher_responsibility import (
+    CanonicalPitcherResponsibilityLedger,
+    CanonicalRunnerResponsibility,
+    CanonicalScoredRunResponsibility,
+)
 from .pitcher_lifecycle import (
     CanonicalPitcherLifecycleState,
     CanonicalPitcherRole,
@@ -67,6 +72,12 @@ class CanonicalPitchingManager:
         repr=False,
     )
     _used_pitcher_ids: Dict[str, list[str]] = field(
+        init=False,
+        repr=False,
+    )
+    _responsibility_ledger: (
+        CanonicalPitcherResponsibilityLedger
+    ) = field(
         init=False,
         repr=False,
     )
@@ -163,6 +174,10 @@ class CanonicalPitchingManager:
             ],
         }
 
+        self._responsibility_ledger = (
+            CanonicalPitcherResponsibilityLedger()
+        )
+
     def pitcher_for_plate_appearance(
         self,
         *,
@@ -219,8 +234,43 @@ class CanonicalPitchingManager:
             event,
         )
 
+        self._responsibility_ledger.apply_event(
+            event
+        )
+
         self._active[team_side] = updated
         return updated
+
+    def responsibility_for_runner(
+        self,
+        runner_id: str,
+    ) -> CanonicalRunnerResponsibility | None:
+        return (
+            self._responsibility_ledger
+            .responsibility_for_runner(runner_id)
+        )
+
+    def active_runner_responsibilities(
+        self,
+    ) -> Tuple[
+        CanonicalRunnerResponsibility,
+        ...,
+    ]:
+        return (
+            self._responsibility_ledger
+            .active_responsibilities()
+        )
+
+    def scored_run_responsibilities(
+        self,
+    ) -> Tuple[
+        CanonicalScoredRunResponsibility,
+        ...,
+    ]:
+        return (
+            self._responsibility_ledger
+            .scored_run_responsibilities()
+        )
 
     def active_lifecycle(
         self,

--- a/tests/test_canonical_pitcher_responsibility.py
+++ b/tests/test_canonical_pitcher_responsibility.py
@@ -1,0 +1,282 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    OutRecord,
+    RunnerMovement,
+    build_play_event,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_PITCHER_RESPONSIBILITY_VERSION,
+    CanonicalPitcherResponsibilityLedger,
+)
+
+
+def event(
+    *,
+    sequence,
+    pitcher_id,
+    event_type,
+    movements,
+):
+    return replace(
+        build_play_event(
+            sequence=sequence,
+            event_type=event_type,
+            batter_id=f"batter_{sequence}",
+            state_before=GameState(),
+            runner_movements=movements,
+            outs_recorded=(),
+        ),
+        pitcher_id=pitcher_id,
+    )
+
+
+def test_batter_runner_is_assigned_to_event_pitcher():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    ledger.apply_event(
+        event(
+            sequence=0,
+            pitcher_id="starter",
+            event_type="single",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    responsibility = (
+        ledger.responsibility_for_runner(
+            "runner_a"
+        )
+    )
+
+    assert responsibility is not None
+    assert responsibility.responsible_pitcher_id == (
+        "starter"
+    )
+    assert responsibility.schema_version == (
+        CANONICAL_PITCHER_RESPONSIBILITY_VERSION
+    )
+
+
+def test_existing_runner_keeps_original_pitcher():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    ledger.apply_event(
+        event(
+            sequence=0,
+            pitcher_id="starter",
+            event_type="walk",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    ledger.apply_event(
+        event(
+            sequence=1,
+            pitcher_id="reliever",
+            event_type="single",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=1,
+                    end_base=2,
+                ),
+                RunnerMovement(
+                    runner_id="runner_b",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    assert (
+        ledger
+        .responsibility_for_runner("runner_a")
+        .responsible_pitcher_id
+        == "starter"
+    )
+    assert (
+        ledger
+        .responsibility_for_runner("runner_b")
+        .responsible_pitcher_id
+        == "reliever"
+    )
+
+
+def test_scored_run_records_both_pitchers():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    ledger.apply_event(
+        event(
+            sequence=0,
+            pitcher_id="starter",
+            event_type="double",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=0,
+                    end_base=2,
+                ),
+            ),
+        )
+    )
+
+    scored = ledger.apply_event(
+        event(
+            sequence=1,
+            pitcher_id="reliever",
+            event_type="single",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=2,
+                    end_base=Base.HOME,
+                    scored=True,
+                ),
+                RunnerMovement(
+                    runner_id="runner_b",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    assert len(scored) == 1
+    assert scored[0].runner_id == "runner_a"
+    assert scored[0].responsible_pitcher_id == (
+        "starter"
+    )
+    assert scored[0].pitcher_on_mound_id == (
+        "reliever"
+    )
+    assert (
+        ledger.responsibility_for_runner(
+            "runner_a"
+        )
+        is None
+    )
+
+
+def test_retired_runner_is_removed():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    ledger.apply_event(
+        event(
+            sequence=0,
+            pitcher_id="starter",
+            event_type="single",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    retired_event = replace(
+        build_play_event(
+            sequence=1,
+            event_type="fielder_choice",
+            batter_id="batter_1",
+            state_before=GameState(),
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=1,
+                    end_base=None,
+                    is_out=True,
+                ),
+            ),
+            outs_recorded=(
+                OutRecord(
+                    runner_id="runner_a",
+                    out_number=1,
+                    reason="force_out",
+                ),
+            ),
+        ),
+        pitcher_id="starter",
+    )
+
+    ledger.apply_event(retired_event)
+
+    assert (
+        ledger.responsibility_for_runner(
+            "runner_a"
+        )
+        is None
+    )
+
+
+def test_scoring_runner_without_responsibility_fails():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    scoring_event = replace(
+        build_play_event(
+            sequence=0,
+            event_type="single",
+            batter_id="batter_0",
+            state_before=GameState(),
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="unknown_runner",
+                    start_base=2,
+                    end_base=Base.HOME,
+                    scored=True,
+                ),
+            ),
+            outs_recorded=(),
+        ),
+        pitcher_id="reliever",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="no active pitcher responsibility",
+    ):
+        ledger.apply_event(scoring_event)
+
+
+def test_duplicate_batter_runner_assignment_fails():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    first = event(
+        sequence=0,
+        pitcher_id="starter",
+        event_type="walk",
+        movements=(
+            RunnerMovement(
+                runner_id="runner_a",
+                start_base=0,
+                end_base=1,
+            ),
+        ),
+    )
+
+    ledger.apply_event(first)
+
+    with pytest.raises(
+        ValueError,
+        match="already has active",
+    ):
+        ledger.apply_event(first)

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -1,7 +1,9 @@
 from dataclasses import replace
 
 from mlb_app.simulation.events import (
+    Base,
     GameState,
+    RunnerMovement,
     build_play_event,
 )
 from mlb_app.simulation.game import (
@@ -391,3 +393,92 @@ def test_last_available_reliever_is_held():
 
     assert reliever == "home_middle"
     assert held == "home_middle"
+
+
+def test_manager_preserves_inherited_runner_responsibility():
+    value = manager()
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    starter_event = replace(
+        build_play_event(
+            sequence=0,
+            event_type="single",
+            batter_id="away_batter_0",
+            state_before=state,
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+            outs_recorded=(),
+        ),
+        pitcher_id="home_starter",
+    )
+
+    value.record_plate_appearance(
+        starter_event
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=27,
+    )
+
+    reliever_id = (
+        value.pitcher_for_plate_appearance(
+            state=replace(
+                state,
+                bases=("away_batter_0", None, None),
+            ),
+            batter_id="away_batter_1",
+        )
+    )
+
+    scoring_event = replace(
+        build_play_event(
+            sequence=1,
+            event_type="double",
+            batter_id="away_batter_1",
+            state_before=replace(
+                state,
+                bases=("away_batter_0", None, None),
+            ),
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=1,
+                    end_base=Base.HOME,
+                    scored=True,
+                ),
+                RunnerMovement(
+                    runner_id="away_batter_1",
+                    start_base=0,
+                    end_base=2,
+                ),
+            ),
+            outs_recorded=(),
+        ),
+        pitcher_id=reliever_id,
+    )
+
+    value.record_plate_appearance(
+        scoring_event
+    )
+
+    scored = value.scored_run_responsibilities()
+
+    assert len(scored) == 1
+    assert scored[0].runner_id == (
+        "away_batter_0"
+    )
+    assert scored[0].responsible_pitcher_id == (
+        "home_starter"
+    )
+    assert scored[0].pitcher_on_mound_id == (
+        reliever_id
+    )


### PR DESCRIPTION
## Summary

Adds explicit pitcher responsibility tracking for every canonical baserunner and scored run.

This slice establishes the ownership layer required before earned-run reconstruction. When a batter becomes a runner, the pitcher on the event is assigned responsibility. That ownership survives pitching changes, closes when the runner is retired, and is recorded when the runner scores together with the pitcher currently on the mound.

## Added

- `CANONICAL_PITCHER_RESPONSIBILITY_VERSION`
- `CanonicalRunnerResponsibility`
- `CanonicalScoredRunResponsibility`
- `CanonicalPitcherResponsibilityLedger`
- trial-owned responsibility ledger in `CanonicalPitchingManager`
- responsibility assignment for newly created baserunners
- inherited-runner ownership preservation across pitching changes
- responsibility cleanup for retired runners
- scored-run attribution to both responsible pitcher and pitcher on mound
- public game-package exports
- focused ledger and manager integration coverage

## Canonical responsibility flow

```text
batter reaches base
→ current pitcher becomes responsible

pitching change occurs
→ inherited runner keeps original responsible pitcher

runner is retired
→ active responsibility closes

runner scores
→ original responsible pitcher is recorded
→ current pitcher on mound is also recorded
```

## Behavior preserved

- No earned/unearned classification is introduced in this slice.
- Existing pitcher lifecycle and reliever chaining behavior remains unchanged.
- Game state remains immutable; responsibility state is trial-owned.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused responsibility/manager/reliever/resolver/lifecycle tests passed: `50 passed`
- Combined orchestration/trials/production-shadow/comparator tests passed: `44 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning and two unrelated pandas dependency-version warnings remain.

## Files

- `mlb_app/simulation/game/pitcher_responsibility.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_pitcher_responsibility.py`
- `tests/test_canonical_pitching_manager.py`

## Next slice

Classify scored runs as earned or unearned and aggregate reconstructed pitcher run lines on top of explicit responsibility records.