### PR TITLE
Add canonical earned run reconstruction

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -72,6 +72,12 @@ from .reliever_hook_policy import (
     CanonicalRelieverHookPolicy,
     build_baseline_reliever_hook_policy,
 )
+from .earned_run_reconstruction import (
+    CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION,
+    CanonicalEarnedRunReconstructor,
+    CanonicalPitcherRunLine,
+    CanonicalRunClassification,
+)
 from .pitcher_responsibility import (
     CANONICAL_PITCHER_RESPONSIBILITY_VERSION,
     CanonicalPitcherResponsibilityLedger,
@@ -211,6 +217,10 @@ __all__ = [
     "CanonicalPitchingDecision",
     "CanonicalPitcherRole",
     "CanonicalPitcherLifecycleState",
+    "CanonicalRunClassification",
+    "CanonicalPitcherRunLine",
+    "CanonicalEarnedRunReconstructor",
+    "CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION",
     "CanonicalScoredRunResponsibility",
     "CanonicalRunnerResponsibility",
     "CanonicalPitcherResponsibilityLedger",

--- a/mlb_app/simulation/game/earned_run_reconstruction.py
+++ b/mlb_app/simulation/game/earned_run_reconstruction.py
@@ -1,0 +1,270 @@
+"""Conservative canonical earned-run reconstruction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from mlb_app.simulation.events import PlayEvent
+
+from .pitcher_responsibility import (
+    CanonicalRunnerResponsibility,
+    CanonicalScoredRunResponsibility,
+)
+
+
+CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION = (
+    "canonical_earned_run_reconstruction_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalRunClassification:
+    """Earned/unearned classification for one scored runner."""
+
+    runner_id: str
+    responsible_pitcher_id: str
+    pitcher_on_mound_id: str
+    earned: bool
+    classification_reason: str
+    reached_on_event_sequence: int
+    scoring_event_sequence: int
+    schema_version: str = (
+        CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError("runner_id is required")
+
+        if not self.responsible_pitcher_id:
+            raise ValueError(
+                "responsible_pitcher_id is required"
+            )
+
+        if not self.pitcher_on_mound_id:
+            raise ValueError(
+                "pitcher_on_mound_id is required"
+            )
+
+        if not self.classification_reason:
+            raise ValueError(
+                "classification_reason is required"
+            )
+
+        if self.reached_on_event_sequence < 0:
+            raise ValueError(
+                "reached_on_event_sequence cannot be negative"
+            )
+
+        if self.scoring_event_sequence < 0:
+            raise ValueError(
+                "scoring_event_sequence cannot be negative"
+            )
+
+        if self.schema_version != (
+            CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION
+        ):
+            raise ValueError(
+                "unsupported earned-run schema"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherRunLine:
+    """Reconstructed runs charged to one responsible pitcher."""
+
+    pitcher_id: str
+    runs_allowed: int
+    earned_runs: int
+    unearned_runs: int
+    earned_run_status: str = "reconstructed"
+    schema_version: str = (
+        CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError("pitcher_id is required")
+
+        counters = (
+            self.runs_allowed,
+            self.earned_runs,
+            self.unearned_runs,
+        )
+
+        if any(value < 0 for value in counters):
+            raise ValueError(
+                "run counters cannot be negative"
+            )
+
+        if self.runs_allowed != (
+            self.earned_runs + self.unearned_runs
+        ):
+            raise ValueError(
+                "runs_allowed must equal earned plus unearned"
+            )
+
+        if self.earned_run_status != "reconstructed":
+            raise ValueError(
+                "earned_run_status must be reconstructed"
+            )
+
+        if self.schema_version != (
+            CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION
+        ):
+            raise ValueError(
+                "unsupported earned-run schema"
+            )
+
+
+class CanonicalEarnedRunReconstructor:
+    """
+    Conservative earned-run classifier.
+
+    Version one marks a run unearned only when the runner originally
+    reached base on a play carrying explicit fielding-error attribution.
+    It does not yet reconstruct hypothetical innings after errors.
+    """
+
+    def __init__(self) -> None:
+        self._reach_events: Dict[str, PlayEvent] = {}
+        self._classifications: list[
+            CanonicalRunClassification
+        ] = []
+
+    def record_runner_reach(
+        self,
+        *,
+        responsibility: CanonicalRunnerResponsibility,
+        event: PlayEvent,
+    ) -> None:
+        if not isinstance(
+            responsibility,
+            CanonicalRunnerResponsibility,
+        ):
+            raise TypeError(
+                "responsibility must be a "
+                "CanonicalRunnerResponsibility"
+            )
+
+        if not isinstance(event, PlayEvent):
+            raise TypeError(
+                "event must be a PlayEvent"
+            )
+
+        if responsibility.runner_id in self._reach_events:
+            raise ValueError(
+                "runner reach event is already recorded"
+            )
+
+        if responsibility.reached_on_event_sequence != (
+            event.sequence
+        ):
+            raise ValueError(
+                "responsibility reach sequence "
+                "must match event sequence"
+            )
+
+        self._reach_events[
+            responsibility.runner_id
+        ] = event
+
+    def classify_scored_run(
+        self,
+        responsibility: CanonicalScoredRunResponsibility,
+    ) -> CanonicalRunClassification:
+        if not isinstance(
+            responsibility,
+            CanonicalScoredRunResponsibility,
+        ):
+            raise TypeError(
+                "responsibility must be a "
+                "CanonicalScoredRunResponsibility"
+            )
+
+        reach_event = self._reach_events.pop(
+            responsibility.runner_id,
+            None,
+        )
+
+        if reach_event is None:
+            raise ValueError(
+                "scored runner has no recorded reach event"
+            )
+
+        reached_on_error = bool(
+            reach_event.attribution.error_fielder_id
+        )
+
+        classification = CanonicalRunClassification(
+            runner_id=responsibility.runner_id,
+            responsible_pitcher_id=(
+                responsibility.responsible_pitcher_id
+            ),
+            pitcher_on_mound_id=(
+                responsibility.pitcher_on_mound_id
+            ),
+            earned=not reached_on_error,
+            classification_reason=(
+                "reached_on_fielding_error"
+                if reached_on_error
+                else "no_explicit_error_on_reach"
+            ),
+            reached_on_event_sequence=(
+                reach_event.sequence
+            ),
+            scoring_event_sequence=(
+                responsibility.scoring_event_sequence
+            ),
+        )
+
+        self._classifications.append(
+            classification
+        )
+        return classification
+
+    def retire_runner(self, runner_id: str) -> None:
+        self._reach_events.pop(
+            runner_id,
+            None,
+        )
+
+    def classifications(
+        self,
+    ) -> Tuple[CanonicalRunClassification, ...]:
+        return tuple(self._classifications)
+
+    def pitcher_run_lines(
+        self,
+    ) -> Tuple[CanonicalPitcherRunLine, ...]:
+        totals: Dict[str, Dict[str, int]] = {}
+
+        for classification in self._classifications:
+            row = totals.setdefault(
+                classification.responsible_pitcher_id,
+                {
+                    "runs_allowed": 0,
+                    "earned_runs": 0,
+                    "unearned_runs": 0,
+                },
+            )
+
+            row["runs_allowed"] += 1
+
+            if classification.earned:
+                row["earned_runs"] += 1
+            else:
+                row["unearned_runs"] += 1
+
+        return tuple(
+            CanonicalPitcherRunLine(
+                pitcher_id=pitcher_id,
+                runs_allowed=row["runs_allowed"],
+                earned_runs=row["earned_runs"],
+                unearned_runs=row["unearned_runs"],
+            )
+            for pitcher_id, row in sorted(
+                totals.items()
+            )
+        )

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -18,6 +18,11 @@ from .reliever_hook_policy import (
     CanonicalRelieverHookPolicy,
     build_baseline_reliever_hook_policy,
 )
+from .earned_run_reconstruction import (
+    CanonicalEarnedRunReconstructor,
+    CanonicalPitcherRunLine,
+    CanonicalRunClassification,
+)
 from .pitcher_responsibility import (
     CanonicalPitcherResponsibilityLedger,
     CanonicalRunnerResponsibility,
@@ -77,6 +82,12 @@ class CanonicalPitchingManager:
     )
     _responsibility_ledger: (
         CanonicalPitcherResponsibilityLedger
+    ) = field(
+        init=False,
+        repr=False,
+    )
+    _earned_run_reconstructor: (
+        CanonicalEarnedRunReconstructor
     ) = field(
         init=False,
         repr=False,
@@ -178,6 +189,10 @@ class CanonicalPitchingManager:
             CanonicalPitcherResponsibilityLedger()
         )
 
+        self._earned_run_reconstructor = (
+            CanonicalEarnedRunReconstructor()
+        )
+
     def pitcher_for_plate_appearance(
         self,
         *,
@@ -234,9 +249,45 @@ class CanonicalPitchingManager:
             event,
         )
 
-        self._responsibility_ledger.apply_event(
-            event
+        before = {
+            value.runner_id: value
+            for value in (
+                self._responsibility_ledger
+                .active_responsibilities()
+            )
+        }
+
+        scored = (
+            self._responsibility_ledger
+            .apply_event(event)
         )
+
+        after = {
+            value.runner_id: value
+            for value in (
+                self._responsibility_ledger
+                .active_responsibilities()
+            )
+        }
+
+        for runner_id, responsibility in after.items():
+            if runner_id not in before:
+                self._earned_run_reconstructor.record_runner_reach(
+                    responsibility=responsibility,
+                    event=event,
+                )
+
+        for movement in event.runner_movements:
+            if movement.is_out:
+                self._earned_run_reconstructor.retire_runner(
+                    movement.runner_id
+                )
+
+        for responsibility in scored:
+            (
+                self._earned_run_reconstructor
+                .classify_scored_run(responsibility)
+            )
 
         self._active[team_side] = updated
         return updated
@@ -259,6 +310,22 @@ class CanonicalPitchingManager:
         return (
             self._responsibility_ledger
             .active_responsibilities()
+        )
+
+    def run_classifications(
+        self,
+    ) -> Tuple[CanonicalRunClassification, ...]:
+        return (
+            self._earned_run_reconstructor
+            .classifications()
+        )
+
+    def reconstructed_pitcher_run_lines(
+        self,
+    ) -> Tuple[CanonicalPitcherRunLine, ...]:
+        return (
+            self._earned_run_reconstructor
+            .pitcher_run_lines()
         )
 
     def scored_run_responsibilities(

--- a/tests/test_canonical_earned_run_reconstruction.py
+++ b/tests/test_canonical_earned_run_reconstruction.py
@@ -1,0 +1,228 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    GameState,
+    PlayAttribution,
+    RunnerMovement,
+    build_play_event,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION,
+    CanonicalEarnedRunReconstructor,
+    CanonicalRunnerResponsibility,
+    CanonicalScoredRunResponsibility,
+)
+
+
+def reach_event(
+    *,
+    sequence=0,
+    runner_id="runner_a",
+    pitcher_id="starter",
+    error_fielder_id=None,
+):
+    return replace(
+        build_play_event(
+            sequence=sequence,
+            event_type=(
+                "reached_on_error"
+                if error_fielder_id
+                else "single"
+            ),
+            batter_id=runner_id,
+            state_before=GameState(),
+            runner_movements=(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+            attribution=PlayAttribution(
+                error_fielder_id=error_fielder_id,
+                error_type=(
+                    "fielding_error"
+                    if error_fielder_id
+                    else None
+                ),
+            ),
+        ),
+        pitcher_id=pitcher_id,
+    )
+
+
+def runner_responsibility(
+    *,
+    runner_id="runner_a",
+    pitcher_id="starter",
+    sequence=0,
+):
+    return CanonicalRunnerResponsibility(
+        runner_id=runner_id,
+        responsible_pitcher_id=pitcher_id,
+        reached_on_event_sequence=sequence,
+        reached_on_event_type="single",
+    )
+
+
+def scored_responsibility(
+    *,
+    runner_id="runner_a",
+    responsible_pitcher_id="starter",
+    pitcher_on_mound_id="reliever",
+    sequence=1,
+):
+    return CanonicalScoredRunResponsibility(
+        runner_id=runner_id,
+        responsible_pitcher_id=responsible_pitcher_id,
+        pitcher_on_mound_id=pitcher_on_mound_id,
+        scoring_event_sequence=sequence,
+        scoring_event_type="single",
+    )
+
+
+def test_normal_reach_is_classified_earned():
+    value = CanonicalEarnedRunReconstructor()
+
+    value.record_runner_reach(
+        responsibility=runner_responsibility(),
+        event=reach_event(),
+    )
+
+    classification = value.classify_scored_run(
+        scored_responsibility()
+    )
+
+    assert classification.earned is True
+    assert classification.classification_reason == (
+        "no_explicit_error_on_reach"
+    )
+    assert classification.schema_version == (
+        CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION
+    )
+
+
+def test_error_reach_is_classified_unearned():
+    value = CanonicalEarnedRunReconstructor()
+
+    value.record_runner_reach(
+        responsibility=runner_responsibility(),
+        event=reach_event(
+            error_fielder_id="shortstop",
+        ),
+    )
+
+    classification = value.classify_scored_run(
+        scored_responsibility()
+    )
+
+    assert classification.earned is False
+    assert classification.classification_reason == (
+        "reached_on_fielding_error"
+    )
+
+
+def test_inherited_run_is_charged_to_responsible_pitcher():
+    value = CanonicalEarnedRunReconstructor()
+
+    value.record_runner_reach(
+        responsibility=runner_responsibility(
+            pitcher_id="starter",
+        ),
+        event=reach_event(
+            pitcher_id="starter",
+        ),
+    )
+
+    value.classify_scored_run(
+        scored_responsibility(
+            responsible_pitcher_id="starter",
+            pitcher_on_mound_id="reliever",
+        )
+    )
+
+    lines = value.pitcher_run_lines()
+
+    assert len(lines) == 1
+    assert lines[0].pitcher_id == "starter"
+    assert lines[0].runs_allowed == 1
+    assert lines[0].earned_runs == 1
+    assert lines[0].unearned_runs == 0
+    assert lines[0].earned_run_status == (
+        "reconstructed"
+    )
+
+
+def test_pitcher_lines_aggregate_earned_and_unearned():
+    value = CanonicalEarnedRunReconstructor()
+
+    for index, error_fielder_id in enumerate(
+        (None, "third_base")
+    ):
+        runner_id = f"runner_{index}"
+
+        value.record_runner_reach(
+            responsibility=runner_responsibility(
+                runner_id=runner_id,
+                sequence=index,
+            ),
+            event=reach_event(
+                sequence=index,
+                runner_id=runner_id,
+                error_fielder_id=error_fielder_id,
+            ),
+        )
+
+        value.classify_scored_run(
+            scored_responsibility(
+                runner_id=runner_id,
+                sequence=index + 2,
+            )
+        )
+
+    line = value.pitcher_run_lines()[0]
+
+    assert line.runs_allowed == 2
+    assert line.earned_runs == 1
+    assert line.unearned_runs == 1
+
+
+def test_retired_runner_is_removed():
+    value = CanonicalEarnedRunReconstructor()
+
+    value.record_runner_reach(
+        responsibility=runner_responsibility(),
+        event=reach_event(),
+    )
+
+    value.retire_runner("runner_a")
+
+    with pytest.raises(
+        ValueError,
+        match="no recorded reach event",
+    ):
+        value.classify_scored_run(
+            scored_responsibility()
+        )
+
+
+def test_duplicate_reach_record_is_rejected():
+    value = CanonicalEarnedRunReconstructor()
+    responsibility = runner_responsibility()
+    event = reach_event()
+
+    value.record_runner_reach(
+        responsibility=responsibility,
+        event=event,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="already recorded",
+    ):
+        value.record_runner_reach(
+            responsibility=responsibility,
+            event=event,
+        )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -482,3 +482,91 @@ def test_manager_preserves_inherited_runner_responsibility():
     assert scored[0].pitcher_on_mound_id == (
         reliever_id
     )
+
+
+def test_manager_reconstructs_inherited_earned_run():
+    value = manager()
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    reach = replace(
+        build_play_event(
+            sequence=0,
+            event_type="single",
+            batter_id="away_batter_0",
+            state_before=state,
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        ),
+        pitcher_id="home_starter",
+    )
+
+    value.record_plate_appearance(reach)
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=27,
+    )
+
+    reliever_id = (
+        value.pitcher_for_plate_appearance(
+            state=replace(
+                state,
+                bases=("away_batter_0", None, None),
+            ),
+            batter_id="away_batter_1",
+        )
+    )
+
+    score = replace(
+        build_play_event(
+            sequence=1,
+            event_type="double",
+            batter_id="away_batter_1",
+            state_before=replace(
+                state,
+                bases=("away_batter_0", None, None),
+            ),
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=1,
+                    end_base=Base.HOME,
+                    scored=True,
+                ),
+                RunnerMovement(
+                    runner_id="away_batter_1",
+                    start_base=0,
+                    end_base=2,
+                ),
+            ),
+        ),
+        pitcher_id=reliever_id,
+    )
+
+    value.record_plate_appearance(score)
+
+    classifications = value.run_classifications()
+    lines = value.reconstructed_pitcher_run_lines()
+
+    assert len(classifications) == 1
+    assert classifications[0].earned is True
+    assert classifications[0].responsible_pitcher_id == (
+        "home_starter"
+    )
+    assert classifications[0].pitcher_on_mound_id == (
+        reliever_id
+    )
+
+    assert len(lines) == 1
+    assert lines[0].pitcher_id == "home_starter"
+    assert lines[0].runs_allowed == 1
+    assert lines[0].earned_runs == 1
+    assert lines[0].unearned_runs == 0


### PR DESCRIPTION
## Summary

Adds conservative canonical earned-run reconstruction on top of explicit runner pitcher responsibility.

This slice classifies scored runs as earned or unearned, preserves inherited-run ownership, and aggregates reconstructed pitcher run lines by the original responsible pitcher.

## Added

- `CANONICAL_EARNED_RUN_RECONSTRUCTION_VERSION`
- `CanonicalRunClassification`
- `CanonicalPitcherRunLine`
- `CanonicalEarnedRunReconstructor`
- trial-owned earned-run reconstructor in `CanonicalPitchingManager`
- reach-event retention for active baserunners
- earned/unearned classification at scoring time
- inherited-run charging to the original responsible pitcher
- reconstructed pitcher run-line aggregation
- public game-package exports
- focused reconstructor and manager integration coverage

## Conservative classification model

Version one uses only explicit canonical fielding-error attribution:

```text
runner reaches without explicit fielding error
→ run classified earned

runner reaches on explicit fielding error
→ run classified unearned
```

This is intentionally not yet a full official-scorer replay of a hypothetical error-free inning. Errors that occur after a runner reaches base are not replayed through alternate inning state in this slice.

## Responsibility behavior

- A scored inherited runner remains charged to the pitcher who originally allowed that runner.
- The pitcher currently on the mound is retained in the run classification for diagnostics.
- Retired runners are removed from pending reconstruction state.
- Pitcher lines expose total runs, earned runs, unearned runs, and `earned_run_status="reconstructed"`.

## Canonical flow

```text
runner reaches base
→ reach event retained
→ pitcher responsibility preserved

runner scores
→ classify earned or unearned
→ charge original responsible pitcher
→ aggregate reconstructed pitcher run line
```

## Behavior preserved

- Existing pitcher lifecycle, bullpen chaining, and responsibility behavior remains unchanged.
- Game state remains immutable; reconstruction state is trial-owned.
- Legacy projections remain authoritative.
- Canonical execution remains shadow-only and fail-open.

## Validation

- Focused earned-run/responsibility/manager/reliever/resolver/lifecycle tests passed: `57 passed`
- Combined orchestration/trials/production-shadow/comparator tests passed: `51 passed`
- Python compilation passed
- `git diff --check` passed

One pre-existing SQLAlchemy deprecation warning and two unrelated pandas dependency-version warnings remain.

## Files

- `mlb_app/simulation/game/earned_run_reconstruction.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_earned_run_reconstruction.py`
- `tests/test_canonical_pitching_manager.py`

## Next slice

Wire reconstructed pitcher run lines into canonical box-score output and production shadow diagnostics, while keeping the conservative reconstruction limitation explicit.