### PR TITLE
Integrate canonical earned runs into trial box scores

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -30,6 +30,10 @@ from .contracts import (
     GameCompletionReason,
     HalfInningRecord,
 )
+from .executed_trial import (
+    CanonicalExecutedTrial,
+    overlay_reconstructed_pitcher_run_lines,
+)
 from .factory_input import (
     CANONICAL_TRIAL_FACTORY_INPUT_VERSION,
     CANONICAL_TRIAL_SEED_VERSION,
@@ -169,6 +173,8 @@ __all__ = [
     "CanonicalGameBoxScore",
     "GameBoxScoreReconciliation",
     "CanonicalGameConfig",
+    "overlay_reconstructed_pitcher_run_lines",
+    "CanonicalExecutedTrial",
     "CanonicalGameResult",
     "CanonicalGameOutcomeProjection",
     "CanonicalTrialBatch",

--- a/mlb_app/simulation/game/executed_trial.py
+++ b/mlb_app/simulation/game/executed_trial.py
@@ -1,0 +1,155 @@
+"""Canonical trial result with trial-owned derived pitching state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, Tuple
+
+from mlb_app.simulation.box_score import (
+    PitcherBoxScore,
+    ReducedBoxScore,
+)
+
+from .contracts import CanonicalGameResult
+from .earned_run_reconstruction import (
+    CanonicalPitcherRunLine,
+)
+
+
+@dataclass(frozen=True)
+class CanonicalExecutedTrial:
+    """
+    One completed canonical game plus trial-owned derived state.
+
+    The game remains a pure immutable event result. Pitcher run
+    reconstruction is carried separately because it is produced by
+    the trial-owned pitching manager.
+    """
+
+    game: CanonicalGameResult
+    reconstructed_pitcher_run_lines: Tuple[
+        CanonicalPitcherRunLine,
+        ...,
+    ] = ()
+    earned_run_reconstruction_complete: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.game,
+            CanonicalGameResult,
+        ):
+            raise TypeError(
+                "game must be a CanonicalGameResult"
+            )
+
+        if any(
+            not isinstance(
+                line,
+                CanonicalPitcherRunLine,
+            )
+            for line in self.reconstructed_pitcher_run_lines
+        ):
+            raise TypeError(
+                "reconstructed pitcher lines must use "
+                "CanonicalPitcherRunLine"
+            )
+
+        pitcher_ids = tuple(
+            line.pitcher_id
+            for line in self.reconstructed_pitcher_run_lines
+        )
+
+        if len(pitcher_ids) != len(set(pitcher_ids)):
+            raise ValueError(
+                "reconstructed pitcher identifiers "
+                "must be unique"
+            )
+
+        if not isinstance(
+            self.earned_run_reconstruction_complete,
+            bool,
+        ):
+            raise TypeError(
+                "earned_run_reconstruction_complete "
+                "must be a boolean"
+            )
+
+
+def overlay_reconstructed_pitcher_run_lines(
+    *,
+    box_score: ReducedBoxScore,
+    run_lines: Tuple[
+        CanonicalPitcherRunLine,
+        ...,
+    ],
+) -> ReducedBoxScore:
+    """
+    Replace reducer run attribution with reconstructed responsibility.
+
+    Appearance statistics remain reducer-derived. Every pitcher line is
+    marked reconstructed, including pitchers with zero charged runs.
+    """
+
+    if not isinstance(
+        box_score,
+        ReducedBoxScore,
+    ):
+        raise TypeError(
+            "box_score must be a ReducedBoxScore"
+        )
+
+    if any(
+        not isinstance(line, CanonicalPitcherRunLine)
+        for line in run_lines
+    ):
+        raise TypeError(
+            "run_lines must contain "
+            "CanonicalPitcherRunLine values"
+        )
+
+    reconstructed: Dict[
+        str,
+        CanonicalPitcherRunLine,
+    ] = {
+        line.pitcher_id: line
+        for line in run_lines
+    }
+
+    updated_pitchers = []
+
+    for pitcher in box_score.pitchers:
+        line = reconstructed.pop(
+            pitcher.player_id,
+            None,
+        )
+
+        updated_pitchers.append(
+            replace(
+                pitcher,
+                runs_allowed=(
+                    line.runs_allowed
+                    if line is not None
+                    else 0
+                ),
+                earned_runs=(
+                    line.earned_runs
+                    if line is not None
+                    else 0
+                ),
+                earned_run_status="reconstructed",
+            )
+        )
+
+    if reconstructed:
+        missing_ids = ", ".join(
+            sorted(reconstructed)
+        )
+        raise ValueError(
+            "reconstructed pitcher line has no "
+            f"box-score appearance: {missing_ids}"
+        )
+
+    return replace(
+        box_score,
+        pitchers=tuple(updated_pitchers),
+    )

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -172,6 +172,31 @@ class _CanonicalPlateAppearanceResolver:
     pitching_manager: Optional[
         CanonicalPitchingManager
     ] = None
+    scored_run_count: int = 0
+
+    def earned_run_reconstruction_complete(
+        self,
+    ) -> bool:
+        if self.pitching_manager is None:
+            return False
+
+        reconstructed_count = len(
+            self.pitching_manager
+            .run_classifications()
+        )
+
+        return reconstructed_count == self.scored_run_count
+
+    def reconstructed_pitcher_run_lines(
+        self,
+    ):
+        if self.pitching_manager is None:
+            return ()
+
+        return (
+            self.pitching_manager
+            .reconstructed_pitcher_run_lines()
+        )
 
     def __call__(
         self,
@@ -239,6 +264,13 @@ class _CanonicalPlateAppearanceResolver:
         if self.pitching_manager is not None:
             self.pitching_manager.record_plate_appearance(
                 event
+            )
+
+            object.__setattr__(
+                self,
+                "scored_run_count",
+                self.scored_run_count
+                + len(event.runs_scored),
             )
 
         return event

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -15,6 +15,9 @@ from .contracts import (
     CanonicalGameResult,
     CanonicalLineup,
 )
+from .executed_trial import (
+    CanonicalExecutedTrial,
+)
 from .factory_input import (
     CanonicalTrialFactoryInput,
 )
@@ -263,7 +266,7 @@ def run_canonical_trial_execution_plan(
 
     def trial_factory(
         trial_index: int,
-    ) -> CanonicalGameResult:
+    ) -> CanonicalExecutedTrial:
         context = (
             build_canonical_trial_resolver_context(
                 factory_input=plan.factory_input,
@@ -280,11 +283,39 @@ def run_canonical_trial_execution_plan(
                 "plate-appearance resolver"
             )
 
-        return simulate_canonical_game(
+        game = simulate_canonical_game(
             away_lineup=plan.away_lineup,
             home_lineup=plan.home_lineup,
             resolve_plate_appearance=resolver,
             config=plan.game_config,
+        )
+
+        reconstructed_lines = (
+            resolver.reconstructed_pitcher_run_lines()
+            if hasattr(
+                resolver,
+                "reconstructed_pitcher_run_lines",
+            )
+            else ()
+        )
+
+        reconstruction_complete = (
+            resolver.earned_run_reconstruction_complete()
+            if hasattr(
+                resolver,
+                "earned_run_reconstruction_complete",
+            )
+            else False
+        )
+
+        return CanonicalExecutedTrial(
+            game=game,
+            reconstructed_pitcher_run_lines=(
+                tuple(reconstructed_lines)
+            ),
+            earned_run_reconstruction_complete=(
+                reconstruction_complete
+            ),
         )
 
     return run_canonical_trials(

--- a/mlb_app/simulation/game/trials.py
+++ b/mlb_app/simulation/game/trials.py
@@ -23,6 +23,11 @@ from mlb_app.simulation.projections import (
 from .box_score import (
     GameBoxScoreReconciliation,
     reduce_canonical_game_box_score,
+    validate_game_box_score_reconciliation,
+)
+from .executed_trial import (
+    CanonicalExecutedTrial,
+    overlay_reconstructed_pitcher_run_lines,
 )
 from .contracts import (
     CanonicalGameResult,
@@ -33,7 +38,7 @@ from .validation import validate_canonical_game
 
 CanonicalTrialFactory = Callable[
     [int],
-    CanonicalGameResult,
+    object,
 ]
 
 
@@ -271,12 +276,33 @@ def run_canonical_trials(
     game_validation_values = []
 
     for trial_index in range(simulations):
-        game = trial_factory(trial_index)
+        produced = trial_factory(trial_index)
 
-        if not isinstance(game, CanonicalGameResult):
+        if isinstance(
+            produced,
+            CanonicalExecutedTrial,
+        ):
+            game = produced.game
+            reconstructed_lines = (
+                produced
+                .reconstructed_pitcher_run_lines
+            )
+            reconstruction_complete = (
+                produced
+                .earned_run_reconstruction_complete
+            )
+        elif isinstance(
+            produced,
+            CanonicalGameResult,
+        ):
+            game = produced
+            reconstructed_lines = None
+            reconstruction_complete = False
+        else:
             raise TypeError(
                 "trial_factory must return "
-                "CanonicalGameResult"
+                "CanonicalGameResult or "
+                "CanonicalExecutedTrial"
             )
 
         validation = validate_canonical_game(game)
@@ -294,16 +320,40 @@ def run_canonical_trials(
             game
         )
 
-        if not reduced.reconciliation.passed:
+        box_score = reduced.box_score
+
+        if reconstruction_complete:
+            box_score = (
+                overlay_reconstructed_pitcher_run_lines(
+                    box_score=box_score,
+                    run_lines=reconstructed_lines,
+                )
+            )
+
+            reconciliation = (
+                validate_game_box_score_reconciliation(
+                    result=game,
+                    box_score=box_score,
+                    game_validation_passed=(
+                        validation.passed
+                    ),
+                )
+            )
+        else:
+            reconciliation = (
+                reduced.reconciliation
+            )
+
+        if not reconciliation.passed:
             raise ValueError(
                 "canonical trial failed box-score "
                 f"reconciliation at index {trial_index}"
             )
 
         games.append(game)
-        box_scores.append(reduced.box_score)
+        box_scores.append(box_score)
         reconciliations.append(
-            reduced.reconciliation
+            reconciliation
         )
 
     game_tuple = tuple(games)

--- a/tests/test_canonical_executed_trial.py
+++ b/tests/test_canonical_executed_trial.py
@@ -1,0 +1,244 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.box_score import (
+    PitcherBoxScore,
+    ReducedBoxScore,
+    TeamBoxScore,
+)
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    OutRecord,
+    RunnerMovement,
+    build_play_event,
+)
+from mlb_app.simulation.game import (
+    CanonicalExecutedTrial,
+    CanonicalGameConfig,
+    CanonicalGameResult,
+    CanonicalLineup,
+    CanonicalPitcherRunLine,
+    GameCompletionReason,
+    HalfInningRecord,
+    overlay_reconstructed_pitcher_run_lines,
+)
+
+
+def lineup(side):
+    return CanonicalLineup(
+        team_side=side,
+        player_ids=tuple(
+            f"{side}_{index}"
+            for index in range(9)
+        ),
+    )
+
+
+def completed_game():
+    state = GameState(
+        inning=1,
+        half="top",
+    )
+
+    event = build_play_event(
+        sequence=0,
+        event_type="out",
+        batter_id="away_0",
+        state_before=state,
+        runner_movements=(
+            RunnerMovement(
+                runner_id="away_0",
+                start_base=0,
+                end_base=None,
+                is_out=True,
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id="away_0",
+                out_number=1,
+                reason="batted_out",
+            ),
+        ),
+    )
+
+    second = replace(
+        event,
+        sequence=1,
+        batter_id="away_1",
+        state_before=event.state_after,
+        state_after=replace(
+            event.state_after,
+            outs=2,
+            batting_order_index=2,
+            plate_appearance_number=2,
+        ),
+        runner_movements=(
+            RunnerMovement(
+                runner_id="away_1",
+                start_base=0,
+                end_base=None,
+                is_out=True,
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id="away_1",
+                out_number=2,
+                reason="batted_out",
+            ),
+        ),
+    )
+
+    third = replace(
+        second,
+        sequence=2,
+        batter_id="away_2",
+        state_before=second.state_after,
+        state_after=replace(
+            second.state_after,
+            outs=3,
+            batting_order_index=3,
+            plate_appearance_number=3,
+        ),
+        runner_movements=(
+            RunnerMovement(
+                runner_id="away_2",
+                start_base=0,
+                end_base=None,
+                is_out=True,
+            ),
+        ),
+        outs_recorded=(
+            OutRecord(
+                runner_id="away_2",
+                out_number=3,
+                reason="batted_out",
+            ),
+        ),
+    )
+
+    half = HalfInningRecord(
+        inning=1,
+        half="top",
+        initial_state=state,
+        events=(event, second, third),
+        batting_order_start=0,
+        batting_order_end=3,
+    )
+
+    return CanonicalGameResult(
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+        ),
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        halves=(half,),
+        final_state=third.state_after,
+        completion_reason=(
+            GameCompletionReason.REGULATION
+        ),
+    )
+
+
+def box_score():
+    return ReducedBoxScore(
+        away=TeamBoxScore(
+            team_side="away",
+        ),
+        home=TeamBoxScore(
+            team_side="home",
+        ),
+        pitchers=(
+            PitcherBoxScore(
+                player_id="starter",
+                team_side="home",
+                batters_faced=3,
+                outs_recorded=3,
+                runs_allowed=2,
+            ),
+            PitcherBoxScore(
+                player_id="reliever",
+                team_side="home",
+                batters_faced=1,
+                outs_recorded=0,
+                runs_allowed=1,
+            ),
+        ),
+        pitcher_attribution_complete=True,
+    )
+
+
+def test_executed_trial_retains_game_and_run_lines():
+    game = completed_game()
+    lines = (
+        CanonicalPitcherRunLine(
+            pitcher_id="starter",
+            runs_allowed=1,
+            earned_runs=1,
+            unearned_runs=0,
+        ),
+    )
+
+    value = CanonicalExecutedTrial(
+        game=game,
+        reconstructed_pitcher_run_lines=lines,
+        earned_run_reconstruction_complete=True,
+    )
+
+    assert value.game is game
+    assert value.reconstructed_pitcher_run_lines == (
+        lines
+    )
+
+
+def test_overlay_replaces_run_attribution():
+    updated = overlay_reconstructed_pitcher_run_lines(
+        box_score=box_score(),
+        run_lines=(
+            CanonicalPitcherRunLine(
+                pitcher_id="starter",
+                runs_allowed=3,
+                earned_runs=2,
+                unearned_runs=1,
+            ),
+        ),
+    )
+
+    starter = updated.pitcher("starter")
+    reliever = updated.pitcher("reliever")
+
+    assert starter.runs_allowed == 3
+    assert starter.earned_runs == 2
+    assert starter.earned_run_status == (
+        "reconstructed"
+    )
+
+    assert reliever.runs_allowed == 0
+    assert reliever.earned_runs == 0
+    assert reliever.earned_run_status == (
+        "reconstructed"
+    )
+
+    assert starter.batters_faced == 3
+    assert reliever.batters_faced == 1
+
+
+def test_overlay_rejects_unknown_pitcher():
+    with pytest.raises(
+        ValueError,
+        match="no box-score appearance",
+    ):
+        overlay_reconstructed_pitcher_run_lines(
+            box_score=box_score(),
+            run_lines=(
+                CanonicalPitcherRunLine(
+                    pitcher_id="unknown",
+                    runs_allowed=1,
+                    earned_runs=1,
+                    unearned_runs=0,
+                ),
+            ),
+        )

--- a/tests/test_canonical_game_trials.py
+++ b/tests/test_canonical_game_trials.py
@@ -9,6 +9,8 @@ from mlb_app.simulation.events import (
     RunnerMovement,
 )
 from mlb_app.simulation.game import (
+    CanonicalExecutedTrial,
+    CanonicalPitcherRunLine,
     CanonicalGameConfig,
     CanonicalLineup,
     run_canonical_trials,
@@ -335,3 +337,65 @@ def test_nonpositive_simulation_count_is_rejected():
             simulations=0,
             model_version="canonical_trial_test_v1",
         )
+
+def test_executed_trial_marks_pitcher_runs_reconstructed():
+    observed_indices = []
+
+    game = game_factory(
+        winners=("away",),
+        observed_indices=observed_indices,
+    )(0)
+
+    pitcher_ids = tuple(
+        sorted(
+            {
+                event.pitcher_id
+                for event in game.events
+                if event.pitcher_id is not None
+            }
+        )
+    )
+
+    assert pitcher_ids
+    assert observed_indices == [0]
+
+    responsible_pitcher = next(
+        event.pitcher_id
+        for event in game.events
+        if event.runs_scored
+    )
+
+    executed = CanonicalExecutedTrial(
+        game=game,
+        reconstructed_pitcher_run_lines=(
+            CanonicalPitcherRunLine(
+                pitcher_id=responsible_pitcher,
+                runs_allowed=1,
+                earned_runs=1,
+                unearned_runs=0,
+            ),
+        ),
+        earned_run_reconstruction_complete=True,
+    )
+
+    batch = run_canonical_trials(
+        trial_factory=lambda _: executed,
+        simulations=1,
+        model_version="test-model",
+    )
+
+    assert (
+        batch.projections.diagnostics
+        .earned_run_status
+        == "reconstructed"
+    )
+    assert (
+        "earned_runs_not_fully_reconstructed"
+        not in batch.projections.diagnostics.warnings
+    )
+
+    for line in batch.box_scores[0].pitchers:
+        assert line.earned_run_status == (
+            "reconstructed"
+        )
+        assert line.earned_runs is not None


### PR DESCRIPTION
## Summary

Integrates canonical earned-run reconstruction into trial box scores without mutating the immutable `CanonicalGameResult` contract.

This slice introduces a trial wrapper that carries both the completed game and trial-owned reconstructed pitcher run lines, then overlays those lines onto reduced box scores only when reconstruction is complete.

## Added

- `CanonicalExecutedTrial`
- `overlay_reconstructed_pitcher_run_lines`
- resolver exposure of reconstructed pitcher run lines
- resolver-level scored-run completeness tracking
- trial factory support for returning executed trials
- backward-compatible support for existing factories that still return `CanonicalGameResult`
- trial-runner overlay of responsible-pitcher runs and earned runs
- explicit `earned_run_reconstruction_complete` gating
- public game-package exports
- focused executed-trial and integration coverage

## Compatibility behavior

```text
game-only custom trial
→ unchanged
→ earned runs remain not reconstructed

resolver-backed trial with complete reconstruction
→ overlay reconstructed responsible-pitcher runs
→ mark pitcher lines reconstructed

resolver-backed trial with incomplete reconstruction
→ retain ordinary reduced box score
→ keep production shadow executed
→ retain explicit earned-run warning
```

## Architecture

- `CanonicalGameResult` remains a pure immutable event-derived result.
- Trial-owned pitching-manager state is carried separately by `CanonicalExecutedTrial`.
- Generic box-score reduction remains event-based.
- Responsibility and earned-run reconstruction remain owned by the canonical pitching manager.
- Production shadow remains fail-open and legacy-authoritative.

## Validation

- Focused executed-trial/game-trial/resolver/pitching-manager/earned-run tests: `34 passed`
- Combined orchestration/production-shadow/comparator/integration tests: `44 passed`
- Python compilation passed
- `git diff --check` passed
- Production shadow status remained `executed`
- Incomplete reconstruction retained `earned_run_status="not_reconstructed"` and the existing warning

Pre-existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/simulation/game/executed_trial.py`
- `mlb_app/simulation/game/pa_resolver_factory.py`
- `mlb_app/simulation/game/trial_factory.py`
- `mlb_app/simulation/game/trials.py`
- `mlb_app/simulation/game/__init__.py`
- `tests/test_canonical_executed_trial.py`
- `tests/test_canonical_game_trials.py`

## Next slice

Model automatic-runner pitcher responsibility explicitly so extra-inning trials can participate in complete earned-run reconstruction instead of conservatively remaining `not_reconstructed`.