### PR TITLE
Add automatic runner pitcher responsibility

### DIFF
--- a/mlb_app/simulation/game/earned_run_reconstruction.py
+++ b/mlb_app/simulation/game/earned_run_reconstruction.py
@@ -129,9 +129,40 @@ class CanonicalEarnedRunReconstructor:
 
     def __init__(self) -> None:
         self._reach_events: Dict[str, PlayEvent] = {}
+        self._automatic_runners: Dict[
+            str,
+            CanonicalRunnerResponsibility,
+        ] = {}
         self._classifications: list[
             CanonicalRunClassification
         ] = []
+
+    def record_automatic_runner(
+        self,
+        responsibility: CanonicalRunnerResponsibility,
+    ) -> None:
+        if not isinstance(
+            responsibility,
+            CanonicalRunnerResponsibility,
+        ):
+            raise TypeError(
+                "responsibility must be a "
+                "CanonicalRunnerResponsibility"
+            )
+
+        runner_id = responsibility.runner_id
+
+        if (
+            runner_id in self._reach_events
+            or runner_id in self._automatic_runners
+        ):
+            raise ValueError(
+                "runner reach is already recorded"
+            )
+
+        self._automatic_runners[
+            runner_id
+        ] = responsibility
 
     def record_runner_reach(
         self,
@@ -187,14 +218,27 @@ class CanonicalEarnedRunReconstructor:
             responsibility.runner_id,
             None,
         )
+        automatic_runner = (
+            self._automatic_runners.pop(
+                responsibility.runner_id,
+                None,
+            )
+        )
 
-        if reach_event is None:
+        if (
+            reach_event is None
+            and automatic_runner is None
+        ):
             raise ValueError(
                 "scored runner has no recorded reach event"
             )
 
         reached_on_error = bool(
-            reach_event.attribution.error_fielder_id
+            reach_event is not None
+            and reach_event.attribution.error_fielder_id
+        )
+        is_automatic_runner = (
+            automatic_runner is not None
         )
 
         classification = CanonicalRunClassification(
@@ -205,14 +249,24 @@ class CanonicalEarnedRunReconstructor:
             pitcher_on_mound_id=(
                 responsibility.pitcher_on_mound_id
             ),
-            earned=not reached_on_error,
+            earned=(
+                not reached_on_error
+                and not is_automatic_runner
+            ),
             classification_reason=(
-                "reached_on_fielding_error"
-                if reached_on_error
-                else "no_explicit_error_on_reach"
+                "automatic_runner"
+                if is_automatic_runner
+                else (
+                    "reached_on_fielding_error"
+                    if reached_on_error
+                    else "no_explicit_error_on_reach"
+                )
             ),
             reached_on_event_sequence=(
-                reach_event.sequence
+                automatic_runner
+                .reached_on_event_sequence
+                if automatic_runner is not None
+                else reach_event.sequence
             ),
             scoring_event_sequence=(
                 responsibility.scoring_event_sequence
@@ -226,6 +280,10 @@ class CanonicalEarnedRunReconstructor:
 
     def retire_runner(self, runner_id: str) -> None:
         self._reach_events.pop(
+            runner_id,
+            None,
+        )
+        self._automatic_runners.pop(
             runner_id,
             None,
         )

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -173,6 +173,10 @@ class _CanonicalPlateAppearanceResolver:
         CanonicalPitchingManager
     ] = None
     scored_run_count: int = 0
+    registered_automatic_runner_keys: Tuple[
+        Tuple[int, str, str],
+        ...,
+    ] = ()
 
     def earned_run_reconstruction_complete(
         self,
@@ -208,6 +212,39 @@ class _CanonicalPlateAppearanceResolver:
             raise TypeError(
                 "state must be a GameState"
             )
+
+        if self.pitching_manager is not None:
+            automatic_runner_id = state.bases[1]
+            automatic_runner_key = (
+                state.inning,
+                state.half,
+                automatic_runner_id or "",
+            )
+
+            should_register = (
+                state.outs == 0
+                and state.plate_appearance_number >= 0
+                and automatic_runner_id is not None
+                and automatic_runner_key
+                not in self.registered_automatic_runner_keys
+                and state.inning
+                > 9
+            )
+
+            if should_register:
+                self.pitching_manager.register_automatic_runner(
+                    state=state,
+                    runner_id=automatic_runner_id,
+                )
+
+                object.__setattr__(
+                    self,
+                    "registered_automatic_runner_keys",
+                    (
+                        self.registered_automatic_runner_keys
+                        + (automatic_runner_key,)
+                    ),
+                )
 
         pitcher_id = (
             self.pitching_manager

--- a/mlb_app/simulation/game/pitcher_responsibility.py
+++ b/mlb_app/simulation/game/pitcher_responsibility.py
@@ -114,6 +114,51 @@ class CanonicalPitcherResponsibilityLedger:
             CanonicalScoredRunResponsibility
         ] = []
 
+    def register_automatic_runner(
+        self,
+        *,
+        runner_id: str,
+        responsible_pitcher_id: str,
+        inning: int,
+        half: str,
+    ) -> CanonicalRunnerResponsibility:
+        if not runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        if not responsible_pitcher_id:
+            raise ValueError(
+                "responsible_pitcher_id is required"
+            )
+
+        if inning < 1:
+            raise ValueError(
+                "inning must be positive"
+            )
+
+        if half not in {"top", "bottom"}:
+            raise ValueError(
+                "half must be 'top' or 'bottom'"
+            )
+
+        if runner_id in self._active:
+            return self._active[runner_id]
+
+        responsibility = CanonicalRunnerResponsibility(
+            runner_id=runner_id,
+            responsible_pitcher_id=(
+                responsible_pitcher_id
+            ),
+            reached_on_event_sequence=0,
+            reached_on_event_type=(
+                f"automatic_runner:{inning}:{half}"
+            ),
+        )
+
+        self._active[runner_id] = responsibility
+        return responsibility
+
     def apply_event(
         self,
         event: PlayEvent,

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -233,6 +233,37 @@ class CanonicalPitchingManager:
 
         return lifecycle.pitcher_id
 
+    def register_automatic_runner(
+        self,
+        *,
+        state: GameState,
+        runner_id: str,
+    ) -> CanonicalRunnerResponsibility:
+        team_side = self._fielding_team_side(state)
+        pitcher_id = self._active[
+            team_side
+        ].pitcher_id
+
+        responsibility = (
+            self._responsibility_ledger
+            .register_automatic_runner(
+                runner_id=runner_id,
+                responsible_pitcher_id=pitcher_id,
+                inning=state.inning,
+                half=state.half,
+            )
+        )
+
+        try:
+            self._earned_run_reconstructor.record_automatic_runner(
+                responsibility
+            )
+        except ValueError as exc:
+            if "already recorded" not in str(exc):
+                raise
+
+        return responsibility
+
     def record_plate_appearance(
         self,
         event: PlayEvent,

--- a/tests/test_canonical_earned_run_reconstruction.py
+++ b/tests/test_canonical_earned_run_reconstruction.py
@@ -226,3 +226,33 @@ def test_duplicate_reach_record_is_rejected():
             responsibility=responsibility,
             event=event,
         )
+
+
+def test_automatic_runner_is_classified_unearned():
+    value = CanonicalEarnedRunReconstructor()
+
+    responsibility = CanonicalRunnerResponsibility(
+        runner_id="runner_auto",
+        responsible_pitcher_id="starter",
+        reached_on_event_sequence=0,
+        reached_on_event_type="automatic_runner:10:top",
+    )
+
+    value.record_automatic_runner(
+        responsibility
+    )
+
+    classification = value.classify_scored_run(
+        CanonicalScoredRunResponsibility(
+            runner_id="runner_auto",
+            responsible_pitcher_id="starter",
+            pitcher_on_mound_id="starter",
+            scoring_event_sequence=1,
+            scoring_event_type="single",
+        )
+    )
+
+    assert classification.earned is False
+    assert classification.classification_reason == (
+        "automatic_runner"
+    )

--- a/tests/test_canonical_pa_resolver_factory.py
+++ b/tests/test_canonical_pa_resolver_factory.py
@@ -435,3 +435,53 @@ def test_resolver_factory_can_change_pitchers_with_manager():
         "home_starter",
         "home_reliever",
     )
+
+def test_resolver_registers_extra_inning_automatic_runner():
+    queries = []
+    factory = CanonicalPlateAppearanceResolverFactory(
+        probability_provider=all_out_provider(queries),
+        away_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="away_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+    )
+
+    resolver = factory(
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            matchup_input=matchup(),
+        )
+    )
+
+    state = GameState(
+        inning=10,
+        half="top",
+        bases=(None, "away_batter_8", None),
+    )
+
+    resolver(
+        state,
+        "away_batter_0",
+        0,
+    )
+
+    responsibility = (
+        resolver.pitching_manager
+        .responsibility_for_runner(
+            "away_batter_8"
+        )
+    )
+
+    assert responsibility is not None
+    assert responsibility.responsible_pitcher_id == (
+        "home_starter"
+    )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -570,3 +570,25 @@ def test_manager_reconstructs_inherited_earned_run():
     assert lines[0].runs_allowed == 1
     assert lines[0].earned_runs == 1
     assert lines[0].unearned_runs == 0
+
+
+def test_manager_assigns_automatic_runner_to_active_pitcher():
+    value = manager()
+    state = GameState(
+        inning=10,
+        half="top",
+        bases=(None, "away_batter_8", None),
+    )
+
+    responsibility = value.register_automatic_runner(
+        state=state,
+        runner_id="away_batter_8",
+    )
+
+    assert responsibility.runner_id == "away_batter_8"
+    assert responsibility.responsible_pitcher_id == (
+        "home_starter"
+    )
+    assert responsibility.reached_on_event_type == (
+        "automatic_runner:10:top"
+    )


### PR DESCRIPTION
## Summary

Adds explicit canonical pitcher responsibility and earned-run provenance for extra-inning automatic runners.

This slice lazily registers the automatic runner with the active fielding pitcher before the first plate appearance of an extra-inning half, preserves that responsibility until the runner scores or is retired, and classifies any automatic-runner score as unearned.

## Added

- automatic-runner registration in `CanonicalPitcherResponsibilityLedger`
- automatic-runner provenance tracking in `CanonicalEarnedRunReconstructor`
- pitching-manager API for automatic-runner responsibility
- resolver-level automatic-runner detection and one-time registration
- unearned-run classification reason `automatic_runner`
- focused responsibility, reconstructor, manager, and resolver coverage

## Canonical flow

```text
automatic runner placed on second
→ active fielding pitcher receives responsibility
→ automatic-runner provenance recorded

runner scores
→ run charged to responsible pitcher
→ run classified unearned

runner retired
→ responsibility and reconstruction state cleared
```

## Architecture

- No changes to immutable `CanonicalGameResult`.
- No changes to generic box-score reduction.
- Responsibility remains trial-owned by `CanonicalPitchingManager`.
- Registration is lazy at the first plate appearance because the orchestrator places the runner directly into the half-inning initial state.
- Existing production shadow behavior remains fail-open and legacy-authoritative.

## Validation

- Focused responsibility/reconstructor/manager/resolver tests: `33 passed`
- Orchestration/trials/production-shadow/comparator tests: `30 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/simulation/game/earned_run_reconstruction.py`
- `mlb_app/simulation/game/pa_resolver_factory.py`
- `mlb_app/simulation/game/pitcher_responsibility.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `tests/test_canonical_earned_run_reconstruction.py`
- `tests/test_canonical_pa_resolver_factory.py`
- `tests/test_canonical_pitching_manager.py`

## Known limitation

Automatic-runner detection currently uses `state.inning > 9`, matching the production regulation default. A later refinement can pass configurable `regulation_innings` into resolver context for non-nine-inning configurations.