### PR TITLE
Make automatic runner boundary configurable

### DIFF
--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -228,7 +228,7 @@ class _CanonicalPlateAppearanceResolver:
                 and automatic_runner_key
                 not in self.registered_automatic_runner_keys
                 and state.inning
-                > 9
+                > self.context.regulation_innings
             )
 
             if should_register:

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -46,6 +46,7 @@ class CanonicalTrialResolverContext:
     factory_input: CanonicalTrialFactoryInput
     trial_index: int
     trial_seed: int
+    regulation_innings: int = 9
     matchup_input: Optional[
         CanonicalMatchupInput
     ] = None
@@ -72,6 +73,19 @@ class CanonicalTrialResolverContext:
         ):
             raise ValueError(
                 "trial_index is outside the factory input"
+            )
+
+        if isinstance(
+            self.regulation_innings,
+            bool,
+        ):
+            raise TypeError(
+                "regulation_innings must be an integer"
+            )
+
+        if self.regulation_innings < 1:
+            raise ValueError(
+                "regulation_innings must be positive"
             )
 
         expected_seed = (
@@ -229,6 +243,7 @@ def build_canonical_trial_resolver_context(
     *,
     factory_input: CanonicalTrialFactoryInput,
     trial_index: int,
+    regulation_innings: int = 9,
     matchup_input: Optional[
         CanonicalMatchupInput
     ] = None,
@@ -241,6 +256,7 @@ def build_canonical_trial_resolver_context(
         trial_seed=factory_input.seed_for_trial(
             trial_index
         ),
+        regulation_innings=regulation_innings,
         matchup_input=matchup_input,
     )
 
@@ -271,6 +287,9 @@ def run_canonical_trial_execution_plan(
             build_canonical_trial_resolver_context(
                 factory_input=plan.factory_input,
                 trial_index=trial_index,
+                regulation_innings=(
+                    plan.game_config.regulation_innings
+                ),
                 matchup_input=plan.matchup_input,
             )
         )

--- a/tests/test_canonical_pa_resolver_factory.py
+++ b/tests/test_canonical_pa_resolver_factory.py
@@ -485,3 +485,105 @@ def test_resolver_registers_extra_inning_automatic_runner():
     assert responsibility.responsible_pitcher_id == (
         "home_starter"
     )
+
+
+def test_resolver_uses_configurable_automatic_runner_boundary():
+    queries = []
+
+    factory = CanonicalPlateAppearanceResolverFactory(
+        probability_provider=all_out_provider(queries),
+        away_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="away_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+    )
+
+    resolver = factory(
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            regulation_innings=1,
+            matchup_input=matchup(),
+        )
+    )
+
+    state = GameState(
+        inning=2,
+        half="top",
+        bases=(None, "away_batter_8", None),
+    )
+
+    resolver(
+        state,
+        "away_batter_0",
+        0,
+    )
+
+    responsibility = (
+        resolver.pitching_manager
+        .responsibility_for_runner(
+            "away_batter_8"
+        )
+    )
+
+    assert responsibility is not None
+    assert responsibility.reached_on_event_type == (
+        "automatic_runner:2:top"
+    )
+
+
+def test_resolver_does_not_register_runner_at_regulation_boundary():
+    queries = []
+
+    factory = CanonicalPlateAppearanceResolverFactory(
+        probability_provider=all_out_provider(queries),
+        away_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="away_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_reliever",
+                role=CanonicalBullpenRole.LONG_RELIEF,
+            ),
+        ),
+    )
+
+    resolver = factory(
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            regulation_innings=2,
+            matchup_input=matchup(),
+        )
+    )
+
+    state = GameState(
+        inning=2,
+        half="top",
+        bases=(None, "away_batter_8", None),
+    )
+
+    resolver(
+        state,
+        "away_batter_0",
+        0,
+    )
+
+    assert (
+        resolver.pitching_manager
+        .responsibility_for_runner(
+            "away_batter_8"
+        )
+        is None
+    )

--- a/tests/test_canonical_trial_factory_protocol.py
+++ b/tests/test_canonical_trial_factory_protocol.py
@@ -220,3 +220,34 @@ def test_plan_rejects_reversed_lineups():
             home_lineup=lineup("away"),
             resolver_factory=lambda context: out_event,
         )
+
+
+def test_resolver_context_defaults_to_nine_regulation_innings():
+    value = build_canonical_trial_resolver_context(
+        factory_input=factory_input(),
+        trial_index=0,
+    )
+
+    assert value.regulation_innings == 9
+
+
+def test_resolver_context_accepts_custom_regulation_innings():
+    value = build_canonical_trial_resolver_context(
+        factory_input=factory_input(),
+        trial_index=0,
+        regulation_innings=7,
+    )
+
+    assert value.regulation_innings == 7
+
+
+def test_resolver_context_rejects_invalid_regulation_innings():
+    with pytest.raises(
+        ValueError,
+        match="must be positive",
+    ):
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            regulation_innings=0,
+        )


### PR DESCRIPTION
## Summary

Removes the hard-coded nine-inning assumption from canonical automatic-runner registration.

This slice carries `regulation_innings` through `CanonicalTrialResolverContext`, sources it from `CanonicalTrialExecutionPlan.game_config`, and makes resolver automatic-runner detection activate only when the current inning exceeds the configured regulation boundary.

## Added

- `regulation_innings` on `CanonicalTrialResolverContext`
- backward-compatible default of 9 for direct context construction
- validation that regulation innings is a positive integer
- execution-plan propagation from `game_config.regulation_innings`
- configurable automatic-runner detection in the PA resolver
- focused protocol and resolver coverage for custom regulation lengths and boundary behavior

## Behavior

```text
direct resolver-context construction
→ defaults to 9 regulation innings

execution-plan construction
→ passes game_config.regulation_innings

automatic-runner registration
→ activates only when inning > configured regulation boundary
```

## Compatibility

- Existing direct builder calls remain unchanged through the default value.
- Production nine-inning behavior remains unchanged.
- Shortened test configurations now register automatic runners at the correct extra-inning boundary.
- Legacy authority and production shadow behavior remain unchanged.

## Validation

- Focused context/resolver tests: `20 passed`
- Orchestration/trials/shadow diagnostics tests: `46 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/simulation/game/pa_resolver_factory.py`
- `mlb_app/simulation/game/trial_factory.py`
- `tests/test_canonical_pa_resolver_factory.py`
- `tests/test_canonical_trial_factory_protocol.py`