### PR TITLE
Activate canonical pitching plan replacements

### DIFF
--- a/mlb_app/simulation/game/matchup_input.py
+++ b/mlb_app/simulation/game/matchup_input.py
@@ -25,6 +25,11 @@ class CanonicalPitchingPlan:
     team_side: str
     starter_id: str
     bullpen_pitcher_ids: Tuple[str, ...]
+    plan_type: str = "traditional_starter"
+    preferred_replacement_pitcher_ids: Tuple[
+        str,
+        ...,
+    ] = ()
 
     def __post_init__(self) -> None:
         if self.team_side not in {
@@ -58,6 +63,56 @@ class CanonicalPitchingPlan:
         if self.starter_id in self.bullpen_pitcher_ids:
             raise ValueError(
                 "starter cannot also appear in bullpen"
+            )
+
+        allowed_plan_types = {
+            "traditional_starter",
+            "opener_bulk",
+            "tandem",
+            "bullpen_game",
+            "workload_capped_starter",
+            "unknown_fallback",
+        }
+
+        if self.plan_type not in allowed_plan_types:
+            raise ValueError(
+                "unsupported canonical pitching plan type"
+            )
+
+        if any(
+            not pitcher_id
+            for pitcher_id
+            in self.preferred_replacement_pitcher_ids
+        ):
+            raise ValueError(
+                "preferred replacement pitcher "
+                "identifiers are required"
+            )
+
+        if len(
+            self.preferred_replacement_pitcher_ids
+        ) != len(
+            set(
+                self.preferred_replacement_pitcher_ids
+            )
+        ):
+            raise ValueError(
+                "preferred replacement pitcher "
+                "identifiers must be unique"
+            )
+
+        bullpen_ids = set(
+            self.bullpen_pitcher_ids
+        )
+
+        if any(
+            pitcher_id not in bullpen_ids
+            for pitcher_id
+            in self.preferred_replacement_pitcher_ids
+        ):
+            raise ValueError(
+                "preferred replacement pitchers "
+                "must belong to bullpen"
             )
 
     @property

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -401,16 +401,33 @@ class CanonicalPitchingManager:
     ) -> CanonicalPitcherLifecycleState:
         bullpen = self._bullpen_for_team(team_side)
 
-        selection = self.bullpen_selector.select(
-            CanonicalBullpenSelectionContext(
-                pitching_decision=decision,
-                game_context=decision_context,
+        preferred_pitcher_id = (
+            self._preferred_replacement_pitcher_id(
+                team_side=team_side,
                 bullpen=bullpen,
-                previously_used_pitcher_ids=tuple(
-                    self._used_pitcher_ids[team_side]
-                ),
             )
         )
+
+        if preferred_pitcher_id is not None:
+            selection = next(
+                pitcher
+                for pitcher in bullpen
+                if pitcher.pitcher_id
+                == preferred_pitcher_id
+            )
+        else:
+            selection = self.bullpen_selector.select(
+                CanonicalBullpenSelectionContext(
+                    pitching_decision=decision,
+                    game_context=decision_context,
+                    bullpen=bullpen,
+                    previously_used_pitcher_ids=tuple(
+                        self._used_pitcher_ids[
+                            team_side
+                        ]
+                    ),
+                )
+            )
 
         retired = retire_pitcher(
             self._active[team_side]
@@ -431,6 +448,39 @@ class CanonicalPitchingManager:
         )
 
         return replacement
+
+    def _preferred_replacement_pitcher_id(
+        self,
+        *,
+        team_side: str,
+        bullpen: Tuple[
+            CanonicalBullpenPitcher,
+            ...,
+        ],
+    ) -> str | None:
+        plan = (
+            self.matchup_input.away_pitching_plan
+            if team_side == "away"
+            else self.matchup_input.home_pitching_plan
+        )
+
+        available_ids = {
+            pitcher.pitcher_id
+            for pitcher in bullpen
+            if pitcher.available
+            and pitcher.pitcher_id
+            not in self._used_pitcher_ids[team_side]
+        }
+
+        return next(
+            (
+                pitcher_id
+                for pitcher_id
+                in plan.preferred_replacement_pitcher_ids
+                if pitcher_id in available_ids
+            ),
+            None,
+        )
 
     def _decision_context(
         self,

--- a/tests/test_canonical_matchup_input.py
+++ b/tests/test_canonical_matchup_input.py
@@ -261,3 +261,39 @@ def test_execution_plan_rejects_mismatched_lineup():
             resolver_factory=lambda context: out_event,
             matchup_input=matchup_input,
         )
+
+def test_pitching_plan_accepts_opener_bulk_sequence():
+    value = CanonicalPitchingPlan(
+        team_side="home",
+        starter_id="opener",
+        bullpen_pitcher_ids=(
+            "bulk",
+            "middle",
+        ),
+        plan_type="opener_bulk",
+        preferred_replacement_pitcher_ids=(
+            "bulk",
+        ),
+    )
+
+    assert value.plan_type == "opener_bulk"
+    assert (
+        value.preferred_replacement_pitcher_ids
+        == ("bulk",)
+    )
+
+
+def test_pitching_plan_rejects_preferred_pitcher_outside_bullpen():
+    with pytest.raises(
+        ValueError,
+        match="must belong to bullpen",
+    ):
+        CanonicalPitchingPlan(
+            team_side="home",
+            starter_id="opener",
+            bullpen_pitcher_ids=("middle",),
+            plan_type="opener_bulk",
+            preferred_replacement_pitcher_ids=(
+                "bulk",
+            ),
+        )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -592,3 +592,113 @@ def test_manager_assigns_automatic_runner_to_active_pitcher():
     assert responsibility.reached_on_event_type == (
         "automatic_runner:10:top"
     )
+
+
+def test_manager_prefers_bulk_follower_after_opener():
+    matchup_input = matchup()
+
+    matchup_input = replace(
+        matchup_input,
+        home_pitching_plan=CanonicalPitchingPlan(
+            team_side="home",
+            starter_id="home_starter",
+            bullpen_pitcher_ids=(
+                "home_long",
+                "home_middle",
+            ),
+            plan_type="opener_bulk",
+            preferred_replacement_pitcher_ids=(
+                "home_middle",
+            ),
+        ),
+    )
+
+    value = CanonicalPitchingManager(
+        matchup_input=matchup_input,
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=bullpen("home"),
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=2,
+            half="top",
+        ),
+        batter_id="away_batter_0",
+    )
+
+    assert pitcher == "home_middle"
+
+
+def test_manager_falls_back_when_preferred_pitcher_unavailable():
+    matchup_input = matchup()
+
+    matchup_input = replace(
+        matchup_input,
+        home_pitching_plan=CanonicalPitchingPlan(
+            team_side="home",
+            starter_id="home_starter",
+            bullpen_pitcher_ids=(
+                "home_long",
+                "home_middle",
+            ),
+            plan_type="opener_bulk",
+            preferred_replacement_pitcher_ids=(
+                "home_middle",
+            ),
+        ),
+    )
+
+    home_options = (
+        CanonicalBullpenPitcher(
+            pitcher_id="home_long",
+            role=CanonicalBullpenRole.LONG_RELIEF,
+        ),
+        CanonicalBullpenPitcher(
+            pitcher_id="home_middle",
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+            available=False,
+        ),
+    )
+
+    value = CanonicalPitchingManager(
+        matchup_input=matchup_input,
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=home_options,
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    pitcher = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=2,
+            half="top",
+        ),
+        batter_id="away_batter_0",
+    )
+
+    assert pitcher == "home_long"


### PR DESCRIPTION
## Summary

Adds canonical pitching-plan metadata and activates ordered preferred replacement behavior for opener/bulk and tandem-style plans.

This slice extends `CanonicalPitchingPlan` with a plan type and ordered preferred replacement pitcher IDs, then makes `CanonicalPitchingManager` consume the first available preferred replacement before falling back to the existing role-based bullpen selector.

## Added

- `plan_type` on `CanonicalPitchingPlan`
- `preferred_replacement_pitcher_ids` on `CanonicalPitchingPlan`
- validation for supported plan types
- validation that preferred replacements are unique bullpen members
- deterministic preferred replacement selection in `CanonicalPitchingManager`
- fallback to the existing bullpen selector when the preferred pitcher is unavailable
- focused matchup-contract and pitching-manager coverage

## Behavior

```text
traditional starter
→ unchanged generic bullpen behavior

opener/bulk
→ opener starts
→ preferred bulk follower enters first when available

tandem
→ ordered preferred follower can enter first

preferred pitcher unavailable
→ existing role-based bullpen selector remains authoritative
```

## Architecture

- Existing generic starter and reliever hook policies remain unchanged.
- Existing bullpen role and leverage logic remains unchanged.
- The canonical matchup contract now has an ordered activation surface for previously classified opener/bulk and tandem plans.
- Production shadow and legacy authority remain unchanged in this slice.

## Validation

- Focused matchup/bullpen/manager tests: `33 passed`
- Resolver/trials/production-shadow tests: `40 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/simulation/game/matchup_input.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `tests/test_canonical_matchup_input.py`
- `tests/test_canonical_pitching_manager.py`

## Follow-up

Wire existing `classify_pitching_plan` output into production shadow matchup assembly so `plan_type` and `preferred_replacement_pitcher_ids` are populated from opener/bulk and tandem evidence rather than defaulting to traditional-starter behavior.