### PR TITLE
Wire canonical pitching plans into production shadow

### DIFF
--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 from mlb_app.simulation.game import (
     CanonicalLineup,
@@ -150,6 +150,76 @@ class CanonicalProductionShadowExecution:
         }
 
 
+def _canonical_pitching_plan_metadata(
+    *,
+    classification: Optional[
+        Mapping[str, Any]
+    ],
+    starter_id: str,
+    bullpen_pitcher_ids: Tuple[str, ...],
+) -> Tuple[str, Tuple[str, ...]]:
+    if not isinstance(classification, Mapping):
+        return "traditional_starter", ()
+
+    plan_type = str(
+        classification.get(
+            "plan_type",
+            "traditional_starter",
+        )
+    ).strip()
+
+    supported_plan_types = {
+        "traditional_starter",
+        "opener_bulk",
+        "tandem",
+        "bullpen_game",
+        "workload_capped_starter",
+        "unknown_fallback",
+    }
+
+    if plan_type not in supported_plan_types:
+        return "traditional_starter", ()
+
+    if classification.get("fallback_used") is True:
+        return "traditional_starter", ()
+
+    bullpen_ids = set(bullpen_pitcher_ids)
+    preferred = []
+    seen = set()
+
+    planned_sequence = classification.get(
+        "planned_sequence"
+    )
+
+    if isinstance(planned_sequence, (list, tuple)):
+        for row in planned_sequence:
+            if not isinstance(row, Mapping):
+                continue
+
+            pitcher_id = str(
+                row.get("pitcher_id") or ""
+            ).strip()
+
+            if (
+                not pitcher_id
+                or pitcher_id == starter_id
+                or pitcher_id not in bullpen_ids
+                or pitcher_id in seen
+            ):
+                continue
+
+            seen.add(pitcher_id)
+            preferred.append(pitcher_id)
+
+    if plan_type not in {
+        "opener_bulk",
+        "tandem",
+    }:
+        preferred = []
+
+    return plan_type, tuple(preferred)
+
+
 def _build_matchup_input(
     *,
     game_pk: int,
@@ -158,6 +228,12 @@ def _build_matchup_input(
     provider_discovery: (
         CanonicalShadowProbabilityProviderDiscovery
     ),
+    away_pitching_plan_classification: Optional[
+        Mapping[str, Any]
+    ] = None,
+    home_pitching_plan_classification: Optional[
+        Mapping[str, Any]
+    ] = None,
 ) -> CanonicalMatchupInput:
     provider = provider_discovery.provider
 
@@ -174,6 +250,35 @@ def _build_matchup_input(
             "both scheduled starters are required"
         )
 
+    away_bullpen_ids = (
+        bullpens.away.bullpen_pitcher_ids
+    )
+    home_bullpen_ids = (
+        bullpens.home.bullpen_pitcher_ids
+    )
+
+    (
+        away_plan_type,
+        away_preferred_replacements,
+    ) = _canonical_pitching_plan_metadata(
+        classification=(
+            away_pitching_plan_classification
+        ),
+        starter_id=away_starter,
+        bullpen_pitcher_ids=away_bullpen_ids,
+    )
+
+    (
+        home_plan_type,
+        home_preferred_replacements,
+    ) = _canonical_pitching_plan_metadata(
+        classification=(
+            home_pitching_plan_classification
+        ),
+        starter_id=home_starter,
+        bullpen_pitcher_ids=home_bullpen_ids,
+    )
+
     return CanonicalMatchupInput(
         game_pk=int(game_pk),
         away_lineup=CanonicalLineup(
@@ -187,15 +292,19 @@ def _build_matchup_input(
         away_pitching_plan=CanonicalPitchingPlan(
             team_side="away",
             starter_id=away_starter,
-            bullpen_pitcher_ids=(
-                bullpens.away.bullpen_pitcher_ids
+            bullpen_pitcher_ids=away_bullpen_ids,
+            plan_type=away_plan_type,
+            preferred_replacement_pitcher_ids=(
+                away_preferred_replacements
             ),
         ),
         home_pitching_plan=CanonicalPitchingPlan(
             team_side="home",
             starter_id=home_starter,
-            bullpen_pitcher_ids=(
-                bullpens.home.bullpen_pitcher_ids
+            bullpen_pitcher_ids=home_bullpen_ids,
+            plan_type=home_plan_type,
+            preferred_replacement_pitcher_ids=(
+                home_preferred_replacements
             ),
         ),
         probability_provider=provider,
@@ -220,6 +329,12 @@ def run_canonical_production_shadow(
     simulation_count: int = (
         DEFAULT_PRODUCTION_SHADOW_SIMULATION_COUNT
     ),
+    away_pitching_plan_classification: Optional[
+        Mapping[str, Any]
+    ] = None,
+    home_pitching_plan_classification: Optional[
+        Mapping[str, Any]
+    ] = None,
 ) -> CanonicalProductionShadowExecution:
     """
     Execute a small canonical batch when every production input is ready.
@@ -274,6 +389,12 @@ def run_canonical_production_shadow(
             lineups=lineups,
             bullpens=bullpens,
             provider_discovery=provider_discovery,
+            away_pitching_plan_classification=(
+                away_pitching_plan_classification
+            ),
+            home_pitching_plan_classification=(
+                home_pitching_plan_classification
+            ),
         )
 
         fallback_policy = (

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -277,3 +277,105 @@ def test_invalid_simulation_count_fails_open():
     assert result.status == "error"
     assert result.executed is False
     assert result.error_type == "ValueError"
+
+
+def opener_bulk_classification(
+    *,
+    starter_id,
+    bulk_id,
+):
+    return {
+        "plan_type": "opener_bulk",
+        "fallback_used": False,
+        "planned_sequence": [
+            {
+                "order": 1,
+                "role": "opener",
+                "pitcher_id": starter_id,
+            },
+            {
+                "order": 2,
+                "role": "bulk_follower",
+                "pitcher_id": bulk_id,
+            },
+        ],
+        "diagnostics": {
+            "production_activation": False,
+        },
+    }
+
+
+def test_production_matchup_activates_opener_bulk_plan():
+    result = run(
+        away_pitching_plan_classification=(
+            opener_bulk_classification(
+                starter_id="100",
+                bulk_id="101",
+            )
+        ),
+    )
+
+    assert result.status == "executed"
+
+    plan = (
+        result.execution_inputs
+        .matchup_input
+        .away_pitching_plan
+    )
+
+    assert plan.plan_type == "opener_bulk"
+    assert (
+        plan.preferred_replacement_pitcher_ids
+        == ("101",)
+    )
+
+
+def test_unknown_classification_falls_back_safely():
+    result = run(
+        away_pitching_plan_classification={
+            "plan_type": "unknown_fallback",
+            "fallback_used": True,
+            "planned_sequence": [],
+        },
+    )
+
+    assert result.status == "executed"
+
+    plan = (
+        result.execution_inputs
+        .matchup_input
+        .away_pitching_plan
+    )
+
+    assert plan.plan_type == (
+        "traditional_starter"
+    )
+    assert (
+        plan.preferred_replacement_pitcher_ids
+        == ()
+    )
+
+
+def test_preferred_replacement_outside_bullpen_is_ignored():
+    result = run(
+        away_pitching_plan_classification=(
+            opener_bulk_classification(
+                starter_id="100",
+                bulk_id="999",
+            )
+        ),
+    )
+
+    assert result.status == "executed"
+
+    plan = (
+        result.execution_inputs
+        .matchup_input
+        .away_pitching_plan
+    )
+
+    assert plan.plan_type == "opener_bulk"
+    assert (
+        plan.preferred_replacement_pitcher_ids
+        == ()
+    )


### PR DESCRIPTION
## Summary

Wires existing classified pitching-plan payloads into canonical production-shadow matchup assembly.

This slice adds optional away/home pitching-plan classification inputs to `run_canonical_production_shadow`, maps verified opener/bulk and tandem sequences into `CanonicalPitchingPlan`, and preserves fail-open traditional-starter behavior for missing, invalid, or fallback classifications.

## Added

- optional away/home pitching-plan classification inputs on production shadow execution
- canonical mapping from classifier `plan_type`
- ordered preferred replacement extraction from `planned_sequence`
- bullpen-membership filtering for preferred replacements
- safe fallback for unknown, malformed, or fallback classifications
- focused production-shadow coverage for opener/bulk activation and fallback behavior

## Behavior

```text
verified opener/bulk classification
→ canonical plan_type = opener_bulk
→ discovered bulk follower becomes preferred replacement

verified tandem classification
→ ordered secondary pitcher can become preferred replacement

unknown or fallback classification
→ traditional-starter behavior

preferred pitcher outside discovered bullpen
→ ignored safely
→ production shadow still executes
```

## Architecture

- Existing classifier remains deterministic and side-effect free.
- Existing canonical manager replacement logic remains unchanged.
- Existing bullpen selector remains the fallback authority.
- Legacy projections remain authoritative.
- Canonical production shadow remains diagnostic-only and fail-open.

## Validation

- Focused production-shadow/pitching tests: `32 passed`
- Broader trials/comparator/input tests: `37 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/simulation/shadow/production_execution.py`
- `tests/test_canonical_production_shadow_execution.py`