### PR TITLE
Add canonical player projection rows

### DIFF
--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -34,4 +34,11 @@ __all__ = [
     "projection_payload_to_dict",
     "summarize_values",
     "validate_projection_payload",
+    "CANONICAL_PLAYER_PROJECTION_ROWS_VERSION",
+    "canonical_player_projection_rows",
 ]
+
+from .player_rows import (
+    CANONICAL_PLAYER_PROJECTION_ROWS_VERSION,
+    canonical_player_projection_rows,
+)

--- a/mlb_app/simulation/projections/player_rows.py
+++ b/mlb_app/simulation/projections/player_rows.py
@@ -1,0 +1,280 @@
+"""Frontend-neutral player-row adaptation for canonical projections."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+
+CANONICAL_PLAYER_PROJECTION_ROWS_VERSION = (
+    "canonical_player_projection_rows_v1"
+)
+
+
+def canonical_player_projection_rows(
+    payload: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """
+    Flatten canonical batter and pitcher projections into display rows.
+
+    This adapter is transport-only. It does not enrich identity, change
+    simulation values, or alter canonical/legacy production authority.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            "payload must be a mapping"
+        )
+
+    simulation_count = _positive_int(
+        payload.get("simulation_count"),
+        field_name="simulation_count",
+    )
+
+    rows = tuple(
+        _player_row(
+            projection=projection,
+            player_type="batter",
+            simulation_count=simulation_count,
+        )
+        for projection in _projection_group(
+            payload,
+            "batters",
+        )
+    ) + tuple(
+        _player_row(
+            projection=projection,
+            player_type="pitcher",
+            simulation_count=simulation_count,
+        )
+        for projection in _projection_group(
+            payload,
+            "pitchers",
+        )
+    )
+
+    ordered_rows = tuple(
+        sorted(
+            rows,
+            key=lambda row: (
+                row["team_side"],
+                row["player_type"],
+                row["player_id"],
+            ),
+        )
+    )
+
+    diagnostics = payload.get("diagnostics")
+    if not isinstance(diagnostics, Mapping):
+        diagnostics = {}
+
+    return {
+        "schema_version": (
+            CANONICAL_PLAYER_PROJECTION_ROWS_VERSION
+        ),
+        "source_schema_version": payload.get(
+            "schema_version"
+        ),
+        "run_id": payload.get("run_id"),
+        "model_version": payload.get(
+            "model_version"
+        ),
+        "simulation_count": simulation_count,
+        "players": [
+            dict(row)
+            for row in ordered_rows
+        ],
+        "diagnostics": {
+            "warnings": list(
+                diagnostics.get("warnings") or []
+            ),
+            "pitcher_attribution_complete_rate": (
+                diagnostics.get(
+                    "pitcher_attribution_complete_rate"
+                )
+            ),
+            "replay_validation_pass_rate": (
+                diagnostics.get(
+                    "replay_validation_pass_rate"
+                )
+            ),
+        },
+        "identity_enrichment_applied": False,
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+
+def _projection_group(
+    payload: Mapping[str, Any],
+    key: str,
+) -> Tuple[Mapping[str, Any], ...]:
+    value = payload.get(key)
+
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(
+            f"{key} must be a list or tuple"
+        )
+
+    rows = []
+
+    for projection in value:
+        if not isinstance(projection, Mapping):
+            raise TypeError(
+                f"{key} entries must be mappings"
+            )
+        rows.append(projection)
+
+    return tuple(rows)
+
+
+def _player_row(
+    *,
+    projection: Mapping[str, Any],
+    player_type: str,
+    simulation_count: int,
+) -> Dict[str, Any]:
+    player_id = str(
+        projection.get("player_id") or ""
+    ).strip()
+    team_side = str(
+        projection.get("team_side") or ""
+    ).strip()
+
+    if not player_id:
+        raise ValueError(
+            "player_id is required"
+        )
+
+    if team_side not in {"away", "home"}:
+        raise ValueError(
+            "team_side must be 'away' or 'home'"
+        )
+
+    metrics = _metric_map(
+        projection.get("metrics"),
+        simulation_count=simulation_count,
+    )
+
+    dfs = metrics.get("dfs_points")
+
+    return {
+        "player_id": player_id,
+        "player_type": player_type,
+        "team_side": team_side,
+        "projected_dfs_points": (
+            dfs["mean"]
+            if dfs is not None
+            else None
+        ),
+        "dfs_floor": (
+            dfs["p10"]
+            if dfs is not None
+            else None
+        ),
+        "dfs_median": (
+            dfs["median"]
+            if dfs is not None
+            else None
+        ),
+        "dfs_ceiling": (
+            dfs["p90"]
+            if dfs is not None
+            else None
+        ),
+        "metrics": metrics,
+        "simulation_count": simulation_count,
+    }
+
+
+def _metric_map(
+    value: Any,
+    *,
+    simulation_count: int,
+) -> Dict[str, Dict[str, float]]:
+    if not isinstance(value, (list, tuple)):
+        raise TypeError(
+            "metrics must be a list or tuple"
+        )
+
+    result: Dict[str, Dict[str, float]] = {}
+
+    for metric in value:
+        if not isinstance(metric, Mapping):
+            raise TypeError(
+                "metric entries must be mappings"
+            )
+
+        name = str(
+            metric.get("name") or ""
+        ).strip()
+
+        if not name:
+            raise ValueError(
+                "metric name is required"
+            )
+
+        if name in result:
+            raise ValueError(
+                "metric names must be unique per player"
+            )
+
+        summary = metric.get("summary")
+
+        if not isinstance(summary, Mapping):
+            raise TypeError(
+                "metric summary must be a mapping"
+            )
+
+        count = _positive_int(
+            summary.get("count"),
+            field_name=f"{name}.count",
+        )
+
+        if count != simulation_count:
+            raise ValueError(
+                "metric count must match simulation_count"
+            )
+
+        result[name] = {
+            key: float(summary[key])
+            for key in (
+                "mean",
+                "median",
+                "p10",
+                "p25",
+                "p75",
+                "p90",
+                "minimum",
+                "maximum",
+            )
+        }
+
+    return {
+        key: result[key]
+        for key in sorted(result)
+    }
+
+
+def _positive_int(
+    value: Any,
+    *,
+    field_name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise TypeError(
+            f"{field_name} must be an integer"
+        )
+
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"{field_name} must be an integer"
+        ) from exc
+
+    if normalized <= 0:
+        raise ValueError(
+            f"{field_name} must be positive"
+        )
+
+    return normalized

--- a/tests/test_canonical_player_projection_rows.py
+++ b/tests/test_canonical_player_projection_rows.py
@@ -1,0 +1,188 @@
+import pytest
+
+from mlb_app.simulation.projections import (
+    CANONICAL_PLAYER_PROJECTION_ROWS_VERSION,
+    canonical_player_projection_rows,
+)
+
+
+def summary(
+    *,
+    mean,
+    median=None,
+    p10=0.0,
+    p25=0.0,
+    p75=0.0,
+    p90=0.0,
+    minimum=0.0,
+    maximum=0.0,
+    count=2,
+):
+    return {
+        "count": count,
+        "mean": mean,
+        "median": mean if median is None else median,
+        "p10": p10,
+        "p25": p25,
+        "p75": p75,
+        "p90": p90,
+        "minimum": minimum,
+        "maximum": maximum,
+    }
+
+
+def metric(name, value):
+    return {
+        "name": name,
+        "summary": value,
+    }
+
+
+def payload():
+    return {
+        "schema_version": (
+            "canonical_projection_payload_v1"
+        ),
+        "run_id": "run-123",
+        "model_version": "canonical-event-model-v1",
+        "simulation_count": 2,
+        "batters": [
+            {
+                "player_id": "away_batter",
+                "team_side": "away",
+                "metrics": [
+                    metric(
+                        "runs",
+                        summary(mean=0.5),
+                    ),
+                    metric(
+                        "dfs_points",
+                        summary(
+                            mean=9.5,
+                            median=8.0,
+                            p10=2.0,
+                            p90=18.0,
+                        ),
+                    ),
+                ],
+            },
+        ],
+        "pitchers": [
+            {
+                "player_id": "home_pitcher",
+                "team_side": "home",
+                "metrics": [
+                    metric(
+                        "strikeouts",
+                        summary(mean=6.0),
+                    ),
+                ],
+            },
+        ],
+        "diagnostics": {
+            "warnings": [],
+            "pitcher_attribution_complete_rate": 1.0,
+            "replay_validation_pass_rate": 1.0,
+        },
+    }
+
+
+def test_rows_flatten_existing_canonical_payload():
+    value = canonical_player_projection_rows(
+        payload()
+    )
+
+    assert value["schema_version"] == (
+        CANONICAL_PLAYER_PROJECTION_ROWS_VERSION
+    )
+    assert value["simulation_count"] == 2
+    assert len(value["players"]) == 2
+
+    batter = value["players"][0]
+
+    assert batter["player_id"] == "away_batter"
+    assert batter["player_type"] == "batter"
+    assert batter["projected_dfs_points"] == 9.5
+    assert batter["dfs_floor"] == 2.0
+    assert batter["dfs_median"] == 8.0
+    assert batter["dfs_ceiling"] == 18.0
+    assert batter["metrics"]["runs"]["mean"] == 0.5
+
+
+def test_pitcher_without_dfs_metric_remains_displayable():
+    value = canonical_player_projection_rows(
+        payload()
+    )
+
+    pitcher = value["players"][1]
+
+    assert pitcher["player_id"] == "home_pitcher"
+    assert pitcher["player_type"] == "pitcher"
+    assert pitcher["projected_dfs_points"] is None
+    assert (
+        pitcher["metrics"]["strikeouts"]["mean"]
+        == 6.0
+    )
+
+
+def test_rows_are_deterministically_ordered():
+    value = payload()
+    value["batters"].append(
+        {
+            "player_id": "home_batter",
+            "team_side": "home",
+            "metrics": [
+                metric(
+                    "runs",
+                    summary(mean=0.25),
+                ),
+            ],
+        }
+    )
+
+    rows = canonical_player_projection_rows(
+        value
+    )["players"]
+
+    assert [
+        (
+            row["team_side"],
+            row["player_type"],
+            row["player_id"],
+        )
+        for row in rows
+    ] == [
+        ("away", "batter", "away_batter"),
+        ("home", "batter", "home_batter"),
+        ("home", "pitcher", "home_pitcher"),
+    ]
+
+
+def test_metric_count_must_match_simulation_count():
+    value = payload()
+    value["batters"][0]["metrics"][0][
+        "summary"
+    ]["count"] = 1
+
+    with pytest.raises(
+        ValueError,
+        match="metric count must match",
+    ):
+        canonical_player_projection_rows(
+            value
+        )
+
+
+def test_invalid_team_side_is_rejected():
+    value = payload()
+    value["batters"][0]["team_side"] = (
+        "neutral"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="team_side",
+    ):
+        canonical_player_projection_rows(
+            value
+        )


### PR DESCRIPTION
## Summary

Adds a frontend-neutral player-row adapter for the existing canonical projection payload.

This slice preserves the canonical simulation distribution contract and flattens batter and pitcher projections into deterministic display rows suitable for API or UI consumption, without performing identity enrichment or changing production authority.

## Added

- `canonical_player_projection_rows`
- explicit `canonical_player_projection_rows_v1` schema
- deterministic player ordering by team side, player type, and player ID
- flattened DFS mean, p10 floor, median, and p90 ceiling fields
- complete per-player metric summary maps
- simulation-count validation for every metric
- transport diagnostics and explicit non-authoritative metadata
- focused adapter coverage

## Behavior

```text
canonical projection distributions
→ deterministic player rows
→ DFS mean / floor / median / ceiling
→ complete metric map
→ identity enrichment later
→ API/UI exposure after that
```

## Architecture

- Reuses the existing `canonical_projection_payload_v1` contract.
- Does not duplicate aggregation or scoring logic.
- Does not call external identity services or the dashboard database.
- Keeps identity enrichment as a separate downstream boundary.
- Legacy projections remain authoritative.
- Canonical output remains diagnostic-only.

## Validation

- Focused player-row/projection tests: `16 passed`
- Broader trials/shadow/execution tests: `37 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/simulation/projections/__init__.py`
- `mlb_app/simulation/projections/player_rows.py`
- `tests/test_canonical_player_projection_rows.py`