### PR TITLE
Enrich canonical player projection identities

### DIFF
--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -36,9 +36,16 @@ __all__ = [
     "validate_projection_payload",
     "CANONICAL_PLAYER_PROJECTION_ROWS_VERSION",
     "canonical_player_projection_rows",
+    "CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION",
+    "enrich_canonical_player_projection_rows",
 ]
 
 from .player_rows import (
     CANONICAL_PLAYER_PROJECTION_ROWS_VERSION,
     canonical_player_projection_rows,
+)
+
+from .player_identity import (
+    CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION,
+    enrich_canonical_player_projection_rows,
 )

--- a/mlb_app/simulation/projections/player_identity.py
+++ b/mlb_app/simulation/projections/player_identity.py
@@ -1,0 +1,203 @@
+"""Dashboard-backed identity enrichment for canonical player rows."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from mlb_app.dashboard_object_models import (
+    DashboardPlayerCurrent,
+)
+
+
+CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION = (
+    "canonical_player_identity_enrichment_v1"
+)
+
+
+def enrich_canonical_player_projection_rows(
+    *,
+    session: Any,
+    payload: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """
+    Enrich canonical player rows from DashboardPlayerCurrent.
+
+    Unresolved rows remain present. This function does not mutate the
+    supplied payload or alter simulation values or production authority.
+    """
+
+    if session is None:
+        raise TypeError(
+            "session is required"
+        )
+
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            "payload must be a mapping"
+        )
+
+    players = payload.get("players")
+
+    if not isinstance(players, (list, tuple)):
+        raise TypeError(
+            "players must be a list or tuple"
+        )
+
+    requested_ids = {
+        player_id
+        for player in players
+        if isinstance(player, Mapping)
+        for player_id in (
+            _positive_player_id(
+                player.get("player_id")
+            ),
+        )
+        if player_id is not None
+    }
+
+    identities = _identity_map(
+        session=session,
+        player_ids=tuple(
+            sorted(requested_ids)
+        ),
+    )
+
+    enriched = []
+    resolved_count = 0
+    inactive_count = 0
+    unresolved_ids = []
+
+    for raw_player in players:
+        if not isinstance(raw_player, Mapping):
+            raise TypeError(
+                "player entries must be mappings"
+            )
+
+        player = deepcopy(dict(raw_player))
+        numeric_id = _positive_player_id(
+            player.get("player_id")
+        )
+        identity = (
+            identities.get(numeric_id)
+            if numeric_id is not None
+            else None
+        )
+
+        if identity is None:
+            player.update(
+                {
+                    "mlb_player_id": numeric_id,
+                    "full_name": None,
+                    "team_id": None,
+                    "team_name": None,
+                    "primary_position": None,
+                    "identity_player_type": None,
+                    "is_active": None,
+                    "identity_resolution_status": (
+                        "unresolved"
+                    ),
+                }
+            )
+            unresolved_ids.append(
+                str(player.get("player_id"))
+            )
+        else:
+            resolved_count += 1
+
+            if not identity.is_active:
+                inactive_count += 1
+
+            player.update(
+                {
+                    "mlb_player_id": (
+                        identity.mlb_player_id
+                    ),
+                    "full_name": identity.full_name,
+                    "team_id": identity.team_id,
+                    "team_name": identity.team_name,
+                    "primary_position": (
+                        identity.primary_position
+                    ),
+                    "identity_player_type": (
+                        identity.player_type
+                    ),
+                    "is_active": bool(
+                        identity.is_active
+                    ),
+                    "identity_resolution_status": (
+                        "resolved"
+                    ),
+                }
+            )
+
+        enriched.append(player)
+
+    result = deepcopy(dict(payload))
+    result["players"] = enriched
+    result["identity_enrichment"] = {
+        "schema_version": (
+            CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION
+        ),
+        "source": "dashboard_player_current",
+        "requested_player_count": len(players),
+        "numeric_player_id_count": len(
+            requested_ids
+        ),
+        "resolved_player_count": resolved_count,
+        "unresolved_player_count": (
+            len(players) - resolved_count
+        ),
+        "inactive_player_count": inactive_count,
+        "unresolved_player_ids": sorted(
+            unresolved_ids
+        ),
+    }
+    result["identity_enrichment_applied"] = True
+
+    return result
+
+
+def _identity_map(
+    *,
+    session: Any,
+    player_ids: Tuple[int, ...],
+) -> Dict[int, DashboardPlayerCurrent]:
+    if not player_ids:
+        return {}
+
+    rows = (
+        session.query(DashboardPlayerCurrent)
+        .filter(
+            DashboardPlayerCurrent.mlb_player_id.in_(
+                player_ids
+            )
+        )
+        .order_by(
+            DashboardPlayerCurrent.mlb_player_id.asc()
+        )
+        .all()
+    )
+
+    return {
+        int(row.mlb_player_id): row
+        for row in rows
+    }
+
+
+def _positive_player_id(
+    value: Any,
+) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return (
+        normalized
+        if normalized > 0
+        else None
+    )

--- a/tests/test_canonical_player_projection_identity.py
+++ b/tests/test_canonical_player_projection_identity.py
@@ -1,0 +1,181 @@
+import datetime as dt
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.dashboard_object_models import (
+    DashboardPlayerCurrent,
+)
+from mlb_app.database import Base
+from mlb_app.simulation.projections import (
+    CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION,
+    enrich_canonical_player_projection_rows,
+)
+
+
+NOW = dt.datetime(2026, 7, 15, 12, 0, 0)
+
+
+def make_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+
+    session = sessionmaker(
+        bind=engine,
+        future=True,
+    )()
+
+    session.add_all(
+        [
+            DashboardPlayerCurrent(
+                mlb_player_id=100,
+                snapshot_id=1,
+                player_type="hitter",
+                full_name="Away Batter",
+                team_id=10,
+                team_name="Away Club",
+                primary_position="RF",
+                is_active=True,
+                metrics_json={},
+                projection_version="projection-v1",
+                source_freshness_json={},
+                provenance_json={},
+                promoted_at=NOW,
+                updated_at=NOW,
+            ),
+            DashboardPlayerCurrent(
+                mlb_player_id=200,
+                snapshot_id=2,
+                player_type="pitcher",
+                full_name="Home Pitcher",
+                team_id=20,
+                team_name="Home Club",
+                primary_position="SP",
+                is_active=False,
+                metrics_json={},
+                projection_version="projection-v1",
+                source_freshness_json={},
+                provenance_json={},
+                promoted_at=NOW,
+                updated_at=NOW,
+            ),
+        ]
+    )
+    session.commit()
+
+    return session
+
+
+def payload():
+    return {
+        "schema_version": (
+            "canonical_player_projection_rows_v1"
+        ),
+        "simulation_count": 25,
+        "players": [
+            {
+                "player_id": "100",
+                "player_type": "batter",
+                "team_side": "away",
+                "projected_dfs_points": 9.5,
+                "metrics": {},
+            },
+            {
+                "player_id": "200",
+                "player_type": "pitcher",
+                "team_side": "home",
+                "projected_dfs_points": 16.0,
+                "metrics": {},
+            },
+            {
+                "player_id": "synthetic_batter",
+                "player_type": "batter",
+                "team_side": "away",
+                "projected_dfs_points": 4.0,
+                "metrics": {},
+            },
+        ],
+        "identity_enrichment_applied": False,
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+
+def test_identity_enrichment_resolves_dashboard_players():
+    value = enrich_canonical_player_projection_rows(
+        session=make_session(),
+        payload=payload(),
+    )
+
+    batter = value["players"][0]
+    pitcher = value["players"][1]
+
+    assert batter["mlb_player_id"] == 100
+    assert batter["full_name"] == "Away Batter"
+    assert batter["team_name"] == "Away Club"
+    assert batter["primary_position"] == "RF"
+    assert batter["is_active"] is True
+
+    assert pitcher["full_name"] == "Home Pitcher"
+    assert pitcher["identity_player_type"] == (
+        "pitcher"
+    )
+    assert pitcher["is_active"] is False
+
+
+def test_unresolved_rows_are_preserved():
+    value = enrich_canonical_player_projection_rows(
+        session=make_session(),
+        payload=payload(),
+    )
+
+    unresolved = value["players"][2]
+
+    assert unresolved["player_id"] == (
+        "synthetic_batter"
+    )
+    assert unresolved["full_name"] is None
+    assert unresolved[
+        "identity_resolution_status"
+    ] == "unresolved"
+    assert unresolved["projected_dfs_points"] == 4.0
+
+
+def test_enrichment_diagnostics_are_explicit():
+    value = enrich_canonical_player_projection_rows(
+        session=make_session(),
+        payload=payload(),
+    )
+
+    diagnostics = value[
+        "identity_enrichment"
+    ]
+
+    assert diagnostics["schema_version"] == (
+        CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION
+    )
+    assert diagnostics["requested_player_count"] == 3
+    assert diagnostics["numeric_player_id_count"] == 2
+    assert diagnostics["resolved_player_count"] == 2
+    assert diagnostics["unresolved_player_count"] == 1
+    assert diagnostics["inactive_player_count"] == 1
+    assert diagnostics["unresolved_player_ids"] == [
+        "synthetic_batter"
+    ]
+
+
+def test_input_payload_is_not_mutated():
+    original = payload()
+
+    enrich_canonical_player_projection_rows(
+        session=make_session(),
+        payload=original,
+    )
+
+    assert original[
+        "identity_enrichment_applied"
+    ] is False
+    assert "full_name" not in original["players"][0]


### PR DESCRIPTION
## Summary

Adds dashboard-backed identity enrichment for canonical player projection rows.

This slice matches numeric canonical player IDs against `DashboardPlayerCurrent`, adds display identity fields, preserves unresolved rows, and reports explicit enrichment diagnostics without changing simulation values or production authority.

## Added

- `enrich_canonical_player_projection_rows`
- explicit `canonical_player_identity_enrichment_v1` schema
- `DashboardPlayerCurrent` lookup by MLB player ID
- name, team, position, identity type, and active-state enrichment
- unresolved-row preservation for synthetic or missing IDs
- explicit resolved, unresolved, inactive, and numeric-ID diagnostics
- non-mutating payload handling
- focused SQLite-backed tests

## Behavior

```text
canonical player projection rows
→ DashboardPlayerCurrent identity lookup
→ names / teams / positions / active state
→ unresolved rows retained
→ explicit resolution diagnostics
→ ready for read-only API exposure
```

## Architecture

- Keeps identity enrichment outside simulation aggregation.
- Uses the existing current dashboard identity object.
- Performs no MLB API calls.
- Does not drop unresolved projection rows.
- Does not mutate the supplied payload.
- Legacy projections remain authoritative.
- Canonical output remains diagnostic-only.

## Validation

- Focused identity/player-row/dashboard tests: `19 passed`
- Broader projection/trial/production-shadow tests: `29 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/simulation/projections/__init__.py`
- `mlb_app/simulation/projections/player_identity.py`
- `tests/test_canonical_player_projection_identity.py`