### PR TITLE
Add DraftKings salary slate ingestion

### DIFF
--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -38,6 +38,11 @@ __all__ = [
     "canonical_player_projection_rows",
     "CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION",
     "enrich_canonical_player_projection_rows",
+    "DRAFTKINGS_SLATE_SCHEMA_VERSION",
+    "DraftKingsSlate",
+    "DraftKingsSlatePlayer",
+    "draftkings_slate_to_dict",
+    "ingest_draftkings_salary_csv",
 ]
 
 from .player_rows import (
@@ -48,4 +53,12 @@ from .player_rows import (
 from .player_identity import (
     CANONICAL_PLAYER_IDENTITY_ENRICHMENT_VERSION,
     enrich_canonical_player_projection_rows,
+)
+
+from .draftkings_slate import (
+    DRAFTKINGS_SLATE_SCHEMA_VERSION,
+    DraftKingsSlate,
+    DraftKingsSlatePlayer,
+    draftkings_slate_to_dict,
+    ingest_draftkings_salary_csv,
 )

--- a/mlb_app/simulation/projections/draftkings_slate.py
+++ b/mlb_app/simulation/projections/draftkings_slate.py
@@ -1,0 +1,476 @@
+"""Deterministic DraftKings MLB salary-slate ingestion."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import io
+from pathlib import Path
+import re
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+
+
+DRAFTKINGS_SLATE_SCHEMA_VERSION = (
+    "draftkings_mlb_slate_v1"
+)
+
+_REQUIRED_COLUMNS = (
+    "Position",
+    "Name + ID",
+    "Name",
+    "ID",
+    "Roster Position",
+    "Salary",
+    "Game Info",
+    "TeamAbbrev",
+    "AvgPointsPerGame",
+)
+
+
+@dataclass(frozen=True)
+class DraftKingsSlatePlayer:
+    dk_player_id: str
+    player_name: str
+    position: str
+    roster_positions: Tuple[str, ...]
+    salary: int
+    game_info: str
+    away_team: str
+    home_team: str
+    team_abbrev: str
+    average_points_per_game: float
+    status: Optional[str] = None
+    starting: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class DraftKingsSlate:
+    schema_version: str
+    source: str
+    source_filename: Optional[str]
+    slate_id: str
+    player_count: int
+    players: Tuple[DraftKingsSlatePlayer, ...]
+    warnings: Tuple[str, ...]
+
+
+def ingest_draftkings_salary_csv(
+    source: Any,
+    *,
+    source_filename: Optional[str] = None,
+) -> DraftKingsSlate:
+    """
+    Parse one DraftKings MLB salary CSV into a normalized slate.
+
+    The parser accepts a path, text stream, bytes, or raw CSV text.
+    """
+
+    text, inferred_filename = _read_source(source)
+
+    filename = (
+        source_filename
+        or inferred_filename
+    )
+
+    reader = csv.DictReader(
+        io.StringIO(text)
+    )
+
+    headers = tuple(
+        reader.fieldnames or ()
+    )
+
+    missing = [
+        column
+        for column in _REQUIRED_COLUMNS
+        if column not in headers
+    ]
+
+    if missing:
+        raise ValueError(
+            "missing required DraftKings columns: "
+            + ", ".join(missing)
+        )
+
+    players = []
+    seen_ids = set()
+    warnings = []
+
+    for row_number, row in enumerate(
+        reader,
+        start=2,
+    ):
+        player = _normalize_player(
+            row,
+            row_number=row_number,
+        )
+
+        if player.dk_player_id in seen_ids:
+            raise ValueError(
+                "duplicate DraftKings player ID: "
+                f"{player.dk_player_id}"
+            )
+
+        seen_ids.add(player.dk_player_id)
+        players.append(player)
+
+    if not players:
+        raise ValueError(
+            "DraftKings slate contains no players"
+        )
+
+    ordered_players = tuple(
+        sorted(
+            players,
+            key=lambda player: (
+                player.game_info,
+                player.team_abbrev,
+                player.position,
+                player.player_name.casefold(),
+                player.dk_player_id,
+            ),
+        )
+    )
+
+    if any(
+        player.starting is None
+        for player in ordered_players
+    ):
+        warnings.append(
+            "starting_status_partially_unavailable"
+        )
+
+    digest = sha256(
+        text.encode("utf-8")
+    ).hexdigest()
+
+    return DraftKingsSlate(
+        schema_version=(
+            DRAFTKINGS_SLATE_SCHEMA_VERSION
+        ),
+        source="draftkings_salary_csv",
+        source_filename=filename,
+        slate_id=digest,
+        player_count=len(ordered_players),
+        players=ordered_players,
+        warnings=tuple(warnings),
+    )
+
+
+def draftkings_slate_to_dict(
+    slate: DraftKingsSlate,
+) -> Dict[str, Any]:
+    if not isinstance(
+        slate,
+        DraftKingsSlate,
+    ):
+        raise TypeError(
+            "slate must be DraftKingsSlate"
+        )
+
+    payload = asdict(slate)
+    payload["players"] = [
+        {
+            **asdict(player),
+            "roster_positions": list(
+                player.roster_positions
+            ),
+        }
+        for player in slate.players
+    ]
+    payload["warnings"] = list(
+        slate.warnings
+    )
+
+    return payload
+
+
+def _read_source(
+    source: Any,
+) -> Tuple[str, Optional[str]]:
+    if isinstance(source, Path):
+        return (
+            source.read_text(
+                encoding="utf-8-sig"
+            ),
+            source.name,
+        )
+
+    if isinstance(source, bytes):
+        return (
+            source.decode("utf-8-sig"),
+            None,
+        )
+
+    if hasattr(source, "read"):
+        value = source.read()
+
+        if isinstance(value, bytes):
+            value = value.decode(
+                "utf-8-sig"
+            )
+
+        if not isinstance(value, str):
+            raise TypeError(
+                "CSV stream must return str or bytes"
+            )
+
+        name = getattr(
+            source,
+            "name",
+            None,
+        )
+
+        return value, (
+            Path(name).name
+            if isinstance(name, str)
+            else None
+        )
+
+    if isinstance(source, str):
+        candidate = Path(source)
+
+        if (
+            "\n" not in source
+            and "\r" not in source
+            and candidate.exists()
+        ):
+            return (
+                candidate.read_text(
+                    encoding="utf-8-sig"
+                ),
+                candidate.name,
+            )
+
+        return source, None
+
+    raise TypeError(
+        "source must be a path, stream, bytes, or CSV text"
+    )
+
+
+def _normalize_player(
+    row: Mapping[str, Any],
+    *,
+    row_number: int,
+) -> DraftKingsSlatePlayer:
+    dk_player_id = _required_text(
+        row.get("ID"),
+        field_name="ID",
+        row_number=row_number,
+    )
+    player_name = _required_text(
+        row.get("Name"),
+        field_name="Name",
+        row_number=row_number,
+    )
+    position = _required_text(
+        row.get("Position"),
+        field_name="Position",
+        row_number=row_number,
+    )
+    roster_positions = _roster_positions(
+        row.get("Roster Position"),
+        row_number=row_number,
+    )
+    salary = _positive_int(
+        row.get("Salary"),
+        field_name="Salary",
+        row_number=row_number,
+    )
+    game_info = _required_text(
+        row.get("Game Info"),
+        field_name="Game Info",
+        row_number=row_number,
+    )
+    team_abbrev = _required_text(
+        row.get("TeamAbbrev"),
+        field_name="TeamAbbrev",
+        row_number=row_number,
+    ).upper()
+
+    away_team, home_team = _teams_from_game_info(
+        game_info,
+        row_number=row_number,
+    )
+
+    average_points = _float_value(
+        row.get("AvgPointsPerGame"),
+        field_name="AvgPointsPerGame",
+        row_number=row_number,
+    )
+
+    status = _optional_text(
+        row.get("Status")
+    )
+    starting = _starting_value(
+        row.get("Starting")
+    )
+
+    return DraftKingsSlatePlayer(
+        dk_player_id=dk_player_id,
+        player_name=player_name,
+        position=position,
+        roster_positions=roster_positions,
+        salary=salary,
+        game_info=game_info,
+        away_team=away_team,
+        home_team=home_team,
+        team_abbrev=team_abbrev,
+        average_points_per_game=(
+            average_points
+        ),
+        status=status,
+        starting=starting,
+    )
+
+
+def _teams_from_game_info(
+    game_info: str,
+    *,
+    row_number: int,
+) -> Tuple[str, str]:
+    matchup = game_info.split()[0]
+
+    match = re.fullmatch(
+        r"([A-Za-z0-9]+)@([A-Za-z0-9]+)",
+        matchup,
+    )
+
+    if match is None:
+        raise ValueError(
+            "invalid Game Info matchup "
+            f"at row {row_number}: {game_info}"
+        )
+
+    return (
+        match.group(1).upper(),
+        match.group(2).upper(),
+    )
+
+
+def _roster_positions(
+    value: Any,
+    *,
+    row_number: int,
+) -> Tuple[str, ...]:
+    text = _required_text(
+        value,
+        field_name="Roster Position",
+        row_number=row_number,
+    )
+
+    positions = tuple(
+        dict.fromkeys(
+            item.strip()
+            for item in text.split("/")
+            if item.strip()
+        )
+    )
+
+    if not positions:
+        raise ValueError(
+            "Roster Position is empty "
+            f"at row {row_number}"
+        )
+
+    return positions
+
+
+def _required_text(
+    value: Any,
+    *,
+    field_name: str,
+    row_number: int,
+) -> str:
+    text = str(
+        value or ""
+    ).strip()
+
+    if not text:
+        raise ValueError(
+            f"{field_name} is required "
+            f"at row {row_number}"
+        )
+
+    return text
+
+
+def _optional_text(
+    value: Any,
+) -> Optional[str]:
+    text = str(
+        value or ""
+    ).strip()
+
+    return text or None
+
+
+def _positive_int(
+    value: Any,
+    *,
+    field_name: str,
+    row_number: int,
+) -> int:
+    try:
+        normalized = int(
+            str(value).strip()
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{field_name} must be an integer "
+            f"at row {row_number}"
+        ) from exc
+
+    if normalized <= 0:
+        raise ValueError(
+            f"{field_name} must be positive "
+            f"at row {row_number}"
+        )
+
+    return normalized
+
+
+def _float_value(
+    value: Any,
+    *,
+    field_name: str,
+    row_number: int,
+) -> float:
+    try:
+        return float(
+            str(value).strip()
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{field_name} must be numeric "
+            f"at row {row_number}"
+        ) from exc
+
+
+def _starting_value(
+    value: Any,
+) -> Optional[bool]:
+    text = str(
+        value or ""
+    ).strip().casefold()
+
+    if text in {
+        "yes",
+        "y",
+        "true",
+        "1",
+        "confirmed",
+    }:
+        return True
+
+    if text in {
+        "no",
+        "n",
+        "false",
+        "0",
+    }:
+        return False
+
+    return None

--- a/tests/test_draftkings_slate_ingestion.py
+++ b/tests/test_draftkings_slate_ingestion.py
@@ -1,0 +1,165 @@
+import io
+
+import pytest
+
+from mlb_app.simulation.projections import (
+    DRAFTKINGS_SLATE_SCHEMA_VERSION,
+    draftkings_slate_to_dict,
+    ingest_draftkings_salary_csv,
+)
+
+
+HEADER = (
+    "Position,Name + ID,Name,ID,"
+    "Roster Position,Salary,Game Info,"
+    "TeamAbbrev,AvgPointsPerGame,"
+    "Status,Starting\n"
+)
+
+
+def csv_text():
+    return HEADER + (
+        'OF,"Mookie Betts (123)",'
+        "Mookie Betts,123,OF/UTIL,6200,"
+        "LAD@CHC 07/22/2026 08:05PM ET,"
+        "LAD,10.4,,Yes\n"
+        'SP,"Pitcher One (456)",'
+        "Pitcher One,456,P,9400,"
+        "LAD@CHC 07/22/2026 08:05PM ET,"
+        "CHC,18.7,Q,\n"
+    )
+
+
+def test_salary_csv_normalizes_slate():
+    slate = ingest_draftkings_salary_csv(
+        csv_text(),
+        source_filename="DKSalaries.csv",
+    )
+
+    assert slate.schema_version == (
+        DRAFTKINGS_SLATE_SCHEMA_VERSION
+    )
+    assert slate.source == (
+        "draftkings_salary_csv"
+    )
+    assert slate.source_filename == (
+        "DKSalaries.csv"
+    )
+    assert slate.player_count == 2
+    assert len(slate.slate_id) == 64
+
+    batter = next(
+        player
+        for player in slate.players
+        if player.dk_player_id == "123"
+    )
+
+    assert batter.player_name == (
+        "Mookie Betts"
+    )
+    assert batter.position == "OF"
+    assert batter.roster_positions == (
+        "OF",
+        "UTIL",
+    )
+    assert batter.salary == 6200
+    assert batter.away_team == "LAD"
+    assert batter.home_team == "CHC"
+    assert batter.team_abbrev == "LAD"
+    assert batter.starting is True
+
+
+def test_serialization_is_plain_json_shape():
+    serialized = draftkings_slate_to_dict(
+        ingest_draftkings_salary_csv(
+            csv_text()
+        )
+    )
+
+    assert isinstance(
+        serialized["players"],
+        list,
+    )
+    batter = next(
+        player
+        for player in serialized["players"]
+        if player["dk_player_id"] == "123"
+    )
+
+    assert batter["roster_positions"] == [
+        "OF",
+        "UTIL",
+    ]
+
+
+def test_stream_input_is_supported():
+    stream = io.StringIO(
+        csv_text()
+    )
+    stream.name = "tonight.csv"
+
+    slate = ingest_draftkings_salary_csv(
+        stream
+    )
+
+    assert slate.source_filename == (
+        "tonight.csv"
+    )
+
+
+def test_missing_required_column_is_rejected():
+    malformed = (
+        "Name,ID,Salary\n"
+        "Player,1,5000\n"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="missing required DraftKings columns",
+    ):
+        ingest_draftkings_salary_csv(
+            malformed
+        )
+
+
+def test_duplicate_player_id_is_rejected():
+    duplicated = csv_text() + (
+        'OF,"Duplicate (123)",'
+        "Duplicate,123,OF,4000,"
+        "LAD@CHC 07/22/2026 08:05PM ET,"
+        "LAD,5.0,,No\n"
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="duplicate DraftKings player ID",
+    ):
+        ingest_draftkings_salary_csv(
+            duplicated
+        )
+
+
+def test_invalid_game_info_is_rejected():
+    malformed = csv_text().replace(
+        "LAD@CHC",
+        "invalid",
+        1,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="invalid Game Info matchup",
+    ):
+        ingest_draftkings_salary_csv(
+            malformed
+        )
+
+
+def test_empty_slate_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="contains no players",
+    ):
+        ingest_draftkings_salary_csv(
+            HEADER
+        )


### PR DESCRIPTION
## Summary

Adds deterministic DraftKings MLB salary-slate ingestion for the canonical projection pipeline.

This slice introduces a normalized `draftkings_mlb_slate_v1` contract, strict CSV validation, deterministic player ordering, source hashing, and JSON-compatible serialization without yet matching salaries to canonical projections.

## Added

- `DraftKingsSlate` and `DraftKingsSlatePlayer`
- `draftkings_mlb_slate_v1` schema
- CSV ingestion from path, stream, bytes, or raw text
- required-column validation
- salary, DK ID, position, roster eligibility, game, and team normalization
- deterministic ordering
- duplicate DK player-ID rejection
- matchup parsing from `Game Info`
- optional status and starting-state normalization
- SHA-256 slate identifier
- JSON-compatible serialization
- focused ingestion coverage

## Behavior

```text
DraftKings salary CSV
→ normalized MLB slate
→ deterministic player records
→ strict validation
→ projection matching next
```

## Architecture

- Keeps DFS salary ingestion separate from sportsbook odds integrations.
- Performs no projection matching in this slice.
- Performs no external DraftKings API calls.
- Leaves simulation aggregation unchanged.
- Leaves legacy authority unchanged.

## Validation

- Focused DK ingestion/player-row/identity tests: `16 passed`
- Broader projection/trial/production-shadow tests: `29 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/simulation/projections/__init__.py`
- `mlb_app/simulation/projections/draftkings_slate.py`
- `tests/test_draftkings_slate_ingestion.py`