### PR TITLE
Audit DraftKings classic scoring

### DIFF
--- a/mlb_app/simulation/box_score/__init__.py
+++ b/mlb_app/simulation/box_score/__init__.py
@@ -7,6 +7,9 @@ from .contracts import (
     TeamBoxScore,
 )
 from .dfs_scoring import (
+    DRAFTKINGS_CLASSIC_BATTER_RULES,
+    DRAFTKINGS_CLASSIC_PITCHER_RULES,
+    DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES,
     BatterDfsScoringRules,
     PitcherDfsScoringRules,
     score_batter,
@@ -21,6 +24,9 @@ from .validation import (
 __all__ = [
     "BatterBoxScore",
     "BatterDfsScoringRules",
+    "DRAFTKINGS_CLASSIC_BATTER_RULES",
+    "DRAFTKINGS_CLASSIC_PITCHER_RULES",
+    "DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES",
     "BoxScoreValidation",
     "PitcherBoxScore",
     "PitcherDfsScoringRules",

--- a/mlb_app/simulation/box_score/dfs_scoring.py
+++ b/mlb_app/simulation/box_score/dfs_scoring.py
@@ -31,6 +31,39 @@ class PitcherDfsScoringRules:
     earned_run: float = 0.0
 
 
+DRAFTKINGS_CLASSIC_BATTER_RULES = (
+    BatterDfsScoringRules(
+        single=3.0,
+        double=5.0,
+        triple=8.0,
+        home_run=10.0,
+        walk=2.0,
+        hit_by_pitch=2.0,
+        run=2.0,
+        rbi=2.0,
+    )
+)
+
+DRAFTKINGS_CLASSIC_PITCHER_RULES = (
+    PitcherDfsScoringRules(
+        out_recorded=0.75,
+        strikeout=2.0,
+        hit_allowed=-0.6,
+        walk=-0.6,
+        hit_batter=-0.6,
+        earned_run=-2.0,
+    )
+)
+
+DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES = (
+    "batter_stolen_base",
+    "pitcher_win",
+    "pitcher_complete_game",
+    "pitcher_complete_game_shutout",
+    "pitcher_no_hitter",
+)
+
+
 def score_batter(
     line: BatterBoxScore,
     rules: BatterDfsScoringRules,

--- a/mlb_app/simulation/projections/aggregator.py
+++ b/mlb_app/simulation/projections/aggregator.py
@@ -191,11 +191,13 @@ def aggregate_projection_payload(
             "replay_validation_failures_present"
         )
 
-    if pitcher_dfs_rules is not None and (
-        pitcher_dfs_rules.earned_run != 0.0
+    if (
+        pitcher_dfs_rules is not None
+        and pitcher_dfs_rules.earned_run != 0.0
+        and earned_run_status != "reconstructed"
     ):
         warnings.append(
-            "pitcher_dfs_earned_run_weight_unsupported"
+            "pitcher_dfs_earned_runs_unavailable"
         )
 
     run_id = _deterministic_run_id(
@@ -335,7 +337,14 @@ def _aggregate_pitchers(
 
         include_dfs = (
             dfs_rules is not None
-            and dfs_rules.earned_run == 0.0
+            and (
+                dfs_rules.earned_run == 0.0
+                or _player_earned_runs_available(
+                    runs=runs,
+                    team_side=team_side,
+                    player_id=player_id,
+                )
+            )
         )
 
         if include_dfs:
@@ -427,6 +436,32 @@ def _find_pitcher(
         ),
         None,
     )
+
+
+def _player_earned_runs_available(
+    *,
+    runs: Tuple[ReducedBoxScore, ...],
+    team_side: str,
+    player_id: str,
+) -> bool:
+    for run in runs:
+        line = _find_pitcher(
+            run=run,
+            team_side=team_side,
+            player_id=player_id,
+        )
+
+        if line is None:
+            continue
+
+        if (
+            line.earned_run_status
+            != "reconstructed"
+            or line.earned_runs is None
+        ):
+            return False
+
+    return True
 
 
 def _earned_run_status(

--- a/tests/test_canonical_projection_payload.py
+++ b/tests/test_canonical_projection_payload.py
@@ -178,7 +178,7 @@ def test_dfs_distributions_are_configurable():
     assert pitcher_dfs.mean == -3.0
 
 
-def test_earned_run_weight_is_not_projected():
+def test_earned_run_weight_requires_reconstruction():
     payload = aggregate_projection_payload(
         box_scores=(
             run(
@@ -201,8 +201,62 @@ def test_earned_run_weight_is_not_projected():
 
     assert "dfs_points" not in pitcher_metric_names
     assert (
-        "pitcher_dfs_earned_run_weight_unsupported"
+        "pitcher_dfs_earned_runs_unavailable"
         in payload.diagnostics.warnings
+    )
+
+
+def test_reconstructed_earned_runs_are_scored():
+    box_score = run(
+        away_runs=1,
+        home_runs=0,
+        batter_runs=1,
+        pitcher_runs=1,
+    )
+    pitcher = box_score.pitchers[0]
+
+    reconstructed = ReducedBoxScore(
+        away=box_score.away,
+        home=box_score.home,
+        batters=box_score.batters,
+        pitchers=(
+            PitcherBoxScore(
+                player_id=pitcher.player_id,
+                team_side=pitcher.team_side,
+                batters_faced=pitcher.batters_faced,
+                outs_recorded=pitcher.outs_recorded,
+                hits_allowed=pitcher.hits_allowed,
+                home_runs_allowed=(
+                    pitcher.home_runs_allowed
+                ),
+                walks=pitcher.walks,
+                hit_batters=pitcher.hit_batters,
+                strikeouts=pitcher.strikeouts,
+                runs_allowed=pitcher.runs_allowed,
+                earned_runs=1,
+                earned_run_status="reconstructed",
+            ),
+        ),
+        pitcher_attribution_complete=True,
+    )
+
+    payload = aggregate_projection_payload(
+        box_scores=(reconstructed,),
+        model_version="canonical_event_model_v1",
+        pitcher_dfs_rules=PitcherDfsScoringRules(
+            earned_run=-2.0,
+        ),
+    )
+
+    dfs = metric(
+        payload.pitchers[0],
+        "dfs_points",
+    ).summary
+
+    assert dfs.mean == -2.0
+    assert (
+        "pitcher_dfs_earned_runs_unavailable"
+        not in payload.diagnostics.warnings
     )
 
 

--- a/tests/test_draftkings_scoring_rules.py
+++ b/tests/test_draftkings_scoring_rules.py
@@ -1,0 +1,59 @@
+from mlb_app.simulation.box_score import (
+    DRAFTKINGS_CLASSIC_BATTER_RULES,
+    DRAFTKINGS_CLASSIC_PITCHER_RULES,
+    DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES,
+    BatterBoxScore,
+    PitcherBoxScore,
+    score_batter,
+    score_pitcher,
+)
+
+
+def test_draftkings_classic_batter_supported_scoring():
+    line = BatterBoxScore(
+        player_id="batter",
+        team_side="away",
+        singles=1,
+        doubles=1,
+        triples=1,
+        home_runs=1,
+        walks=1,
+        hit_by_pitch=1,
+        runs=1,
+        rbi=1,
+    )
+
+    assert score_batter(
+        line,
+        DRAFTKINGS_CLASSIC_BATTER_RULES,
+    ) == 34.0
+
+
+def test_draftkings_classic_pitcher_supported_scoring():
+    line = PitcherBoxScore(
+        player_id="pitcher",
+        team_side="home",
+        outs_recorded=18,
+        strikeouts=7,
+        hits_allowed=4,
+        walks=2,
+        hit_batters=1,
+        runs_allowed=3,
+        earned_runs=2,
+        earned_run_status="reconstructed",
+    )
+
+    assert score_pitcher(
+        line,
+        DRAFTKINGS_CLASSIC_PITCHER_RULES,
+    ) == 19.3
+
+
+def test_unsupported_categories_are_explicit():
+    assert DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES == (
+        "batter_stolen_base",
+        "pitcher_win",
+        "pitcher_complete_game",
+        "pitcher_complete_game_shutout",
+        "pitcher_no_hitter",
+    )


### PR DESCRIPTION
## Summary

Audits and hardens DraftKings Classic scoring support in the canonical projection pipeline.

This slice adds explicit DraftKings Classic scoring presets for all currently modeled categories, enables reconstructed earned-run scoring for pitcher DFS projections, and declares unsupported scoring categories explicitly instead of fabricating zero-valued support.

## Added

- `DRAFTKINGS_CLASSIC_BATTER_RULES`
- `DRAFTKINGS_CLASSIC_PITCHER_RULES`
- explicit unsupported-category contract
- hitter Classic scoring preset for singles, doubles, triples, home runs, walks, hit-by-pitch, runs, and RBI
- pitcher Classic scoring preset for outs, strikeouts, hits allowed, walks, hit batters, and earned runs
- reconstructed earned-run eligibility checks in projection aggregation
- explicit warning when pitcher earned-run scoring is unavailable
- focused DraftKings scoring coverage

## Behavior

```text
supported DK hitter categories
→ scored with explicit Classic preset

supported DK pitcher categories
→ earned runs included when reconstructed

incomplete earned-run reconstruction
→ pitcher DFS omitted
→ explicit warning

unsupported DK categories
→ named explicitly
→ no fabricated zero-valued simulation support
```

## Unsupported until simulated

- batter stolen base
- pitcher win
- pitcher complete game
- pitcher complete-game shutout
- pitcher no-hitter

## Architecture

- Keeps scoring rules centralized in the box-score scoring boundary.
- Does not add permanently zero stolen-base or pitcher-bonus fields.
- Uses existing earned-run reconstruction rather than duplicating logic.
- Leaves legacy production authority unchanged.
- Canonical output remains diagnostic-only.

## Validation

- Focused DK scoring/box-score/projection tests: `23 passed`
- Broader trials/shadow/production/DK-ingestion tests: `36 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/simulation/box_score/__init__.py`
- `mlb_app/simulation/box_score/dfs_scoring.py`
- `mlb_app/simulation/projections/aggregator.py`
- `tests/test_canonical_projection_payload.py`
- `tests/test_draftkings_scoring_rules.py`