### PR TITLE
Match canonical projections to DraftKings

### DIFF
--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -43,6 +43,8 @@ __all__ = [
     "DraftKingsSlatePlayer",
     "draftkings_slate_to_dict",
     "ingest_draftkings_salary_csv",
+    "DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION",
+    "match_canonical_projections_to_draftkings",
 ]
 
 from .player_rows import (
@@ -61,4 +63,9 @@ from .draftkings_slate import (
     DraftKingsSlatePlayer,
     draftkings_slate_to_dict,
     ingest_draftkings_salary_csv,
+)
+
+from .draftkings_matching import (
+    DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION,
+    match_canonical_projections_to_draftkings,
 )

--- a/mlb_app/simulation/projections/draftkings_matching.py
+++ b/mlb_app/simulation/projections/draftkings_matching.py
@@ -1,0 +1,530 @@
+"""Conservative matching of canonical projections to DraftKings slates."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+import unicodedata
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from .draftkings_slate import (
+    DraftKingsSlate,
+    DraftKingsSlatePlayer,
+)
+
+
+DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION = (
+    "draftkings_projection_match_v1"
+)
+
+
+_TEAM_ALIASES = {
+    "AZ": "ARI",
+    "CWS": "CHW",
+    "KC": "KCR",
+    "SD": "SDP",
+    "SF": "SFG",
+    "TB": "TBR",
+    "WSH": "WSN",
+}
+
+
+def match_canonical_projections_to_draftkings(
+    *,
+    projection_payload: Mapping[str, Any],
+    slate: DraftKingsSlate,
+) -> Dict[str, Any]:
+    """
+    Match identity-enriched canonical rows to one DraftKings slate.
+
+    Matching is exact after deterministic name normalization and requires
+    compatible player type plus compatible team when a team abbreviation
+    can be resolved from the canonical row.
+    """
+
+    if not isinstance(projection_payload, Mapping):
+        raise TypeError(
+            "projection_payload must be a mapping"
+        )
+
+    if not isinstance(slate, DraftKingsSlate):
+        raise TypeError(
+            "slate must be DraftKingsSlate"
+        )
+
+    canonical_players = projection_payload.get(
+        "players"
+    )
+
+    if not isinstance(
+        canonical_players,
+        (list, tuple),
+    ):
+        raise TypeError(
+            "projection players must be a list or tuple"
+        )
+
+    canonical_rows = tuple(
+        _validated_projection_row(row)
+        for row in canonical_players
+    )
+
+    indexes = _canonical_indexes(
+        canonical_rows
+    )
+
+    output_rows = []
+    matched_projection_keys = set()
+    matched_count = 0
+    ambiguous_count = 0
+    unmatched_count = 0
+
+    for dk_player in slate.players:
+        candidates = _match_candidates(
+            dk_player=dk_player,
+            indexes=indexes,
+        )
+
+        if len(candidates) == 1:
+            projection = candidates[0]
+            matched_count += 1
+            matched_projection_keys.add(
+                _projection_key(projection)
+            )
+            output_rows.append(
+                _matched_row(
+                    dk_player=dk_player,
+                    projection=projection,
+                )
+            )
+        elif len(candidates) > 1:
+            ambiguous_count += 1
+            output_rows.append(
+                _unmatched_row(
+                    dk_player=dk_player,
+                    status="ambiguous",
+                    candidate_count=len(candidates),
+                )
+            )
+        else:
+            unmatched_count += 1
+            output_rows.append(
+                _unmatched_row(
+                    dk_player=dk_player,
+                    status="unmatched",
+                    candidate_count=0,
+                )
+            )
+
+    unmatched_canonical = [
+        {
+            "player_id": row.get("player_id"),
+            "mlb_player_id": row.get(
+                "mlb_player_id"
+            ),
+            "full_name": row.get("full_name"),
+            "player_type": row.get(
+                "player_type"
+            ),
+            "team_name": row.get("team_name"),
+        }
+        for row in canonical_rows
+        if _projection_key(row)
+        not in matched_projection_keys
+    ]
+
+    return {
+        "schema_version": (
+            DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION
+        ),
+        "source_projection_schema_version": (
+            projection_payload.get(
+                "schema_version"
+            )
+        ),
+        "slate_schema_version": (
+            slate.schema_version
+        ),
+        "slate_id": slate.slate_id,
+        "simulation_count": (
+            projection_payload.get(
+                "simulation_count"
+            )
+        ),
+        "players": output_rows,
+        "diagnostics": {
+            "draftkings_player_count": (
+                slate.player_count
+            ),
+            "canonical_player_count": len(
+                canonical_rows
+            ),
+            "matched_player_count": matched_count,
+            "ambiguous_player_count": (
+                ambiguous_count
+            ),
+            "unmatched_draftkings_player_count": (
+                unmatched_count
+            ),
+            "unmatched_canonical_player_count": (
+                len(unmatched_canonical)
+            ),
+            "unmatched_canonical_players": (
+                unmatched_canonical
+            ),
+            "match_policy": (
+                "exact_normalized_name_team_type"
+            ),
+            "fuzzy_matching_used": False,
+        },
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+
+def _validated_projection_row(
+    row: Any,
+) -> Mapping[str, Any]:
+    if not isinstance(row, Mapping):
+        raise TypeError(
+            "projection player entries must be mappings"
+        )
+
+    return row
+
+
+def _canonical_indexes(
+    rows: Sequence[Mapping[str, Any]],
+) -> Dict[
+    Tuple[str, str],
+    Tuple[Mapping[str, Any], ...],
+]:
+    grouped: Dict[
+        Tuple[str, str],
+        list,
+    ] = {}
+
+    for row in rows:
+        name = _normalize_name(
+            row.get("full_name")
+        )
+        player_type = _canonical_type(
+            row.get("player_type")
+        )
+
+        if not name or player_type is None:
+            continue
+
+        grouped.setdefault(
+            (name, player_type),
+            [],
+        ).append(row)
+
+    return {
+        key: tuple(values)
+        for key, values in grouped.items()
+    }
+
+
+def _match_candidates(
+    *,
+    dk_player: DraftKingsSlatePlayer,
+    indexes: Mapping[
+        Tuple[str, str],
+        Tuple[Mapping[str, Any], ...],
+    ],
+) -> Tuple[Mapping[str, Any], ...]:
+    name = _normalize_name(
+        dk_player.player_name
+    )
+    player_type = _dk_player_type(
+        dk_player
+    )
+
+    candidates = indexes.get(
+        (name, player_type),
+        (),
+    )
+
+    compatible = tuple(
+        row
+        for row in candidates
+        if _team_compatible(
+            canonical_row=row,
+            dk_team=dk_player.team_abbrev,
+        )
+    )
+
+    return compatible
+
+
+def _matched_row(
+    *,
+    dk_player: DraftKingsSlatePlayer,
+    projection: Mapping[str, Any],
+) -> Dict[str, Any]:
+    projected = _optional_float(
+        projection.get(
+            "projected_dfs_points"
+        )
+    )
+    floor = _optional_float(
+        projection.get("dfs_floor")
+    )
+    median = _optional_float(
+        projection.get("dfs_median")
+    )
+    ceiling = _optional_float(
+        projection.get("dfs_ceiling")
+    )
+
+    return {
+        "dk_player_id": dk_player.dk_player_id,
+        "mlb_player_id": projection.get(
+            "mlb_player_id"
+        ),
+        "player_id": projection.get(
+            "player_id"
+        ),
+        "full_name": projection.get(
+            "full_name"
+        ),
+        "team_name": projection.get(
+            "team_name"
+        ),
+        "team_abbrev": dk_player.team_abbrev,
+        "position": dk_player.position,
+        "roster_positions": list(
+            dk_player.roster_positions
+        ),
+        "salary": dk_player.salary,
+        "game_info": dk_player.game_info,
+        "average_points_per_game": (
+            dk_player.average_points_per_game
+        ),
+        "status": dk_player.status,
+        "starting": dk_player.starting,
+        "player_type": projection.get(
+            "player_type"
+        ),
+        "projected_dfs_points": projected,
+        "dfs_floor": floor,
+        "dfs_median": median,
+        "dfs_ceiling": ceiling,
+        "value_per_1000": _value_metric(
+            projected,
+            dk_player.salary,
+        ),
+        "floor_value_per_1000": _value_metric(
+            floor,
+            dk_player.salary,
+        ),
+        "median_value_per_1000": _value_metric(
+            median,
+            dk_player.salary,
+        ),
+        "ceiling_value_per_1000": _value_metric(
+            ceiling,
+            dk_player.salary,
+        ),
+        "metrics": deepcopy(
+            projection.get("metrics") or {}
+        ),
+        "match_method": (
+            "exact_normalized_name_team_type"
+        ),
+        "match_status": "matched",
+        "match_candidate_count": 1,
+    }
+
+
+def _unmatched_row(
+    *,
+    dk_player: DraftKingsSlatePlayer,
+    status: str,
+    candidate_count: int,
+) -> Dict[str, Any]:
+    return {
+        "dk_player_id": dk_player.dk_player_id,
+        "mlb_player_id": None,
+        "player_id": None,
+        "full_name": dk_player.player_name,
+        "team_name": None,
+        "team_abbrev": dk_player.team_abbrev,
+        "position": dk_player.position,
+        "roster_positions": list(
+            dk_player.roster_positions
+        ),
+        "salary": dk_player.salary,
+        "game_info": dk_player.game_info,
+        "average_points_per_game": (
+            dk_player.average_points_per_game
+        ),
+        "status": dk_player.status,
+        "starting": dk_player.starting,
+        "player_type": _dk_player_type(
+            dk_player
+        ),
+        "projected_dfs_points": None,
+        "dfs_floor": None,
+        "dfs_median": None,
+        "dfs_ceiling": None,
+        "value_per_1000": None,
+        "floor_value_per_1000": None,
+        "median_value_per_1000": None,
+        "ceiling_value_per_1000": None,
+        "metrics": {},
+        "match_method": None,
+        "match_status": status,
+        "match_candidate_count": (
+            candidate_count
+        ),
+    }
+
+
+def _projection_key(
+    row: Mapping[str, Any],
+) -> Tuple[Any, Any, Any]:
+    return (
+        row.get("player_id"),
+        row.get("mlb_player_id"),
+        row.get("player_type"),
+    )
+
+
+def _canonical_type(
+    value: Any,
+) -> Optional[str]:
+    text = str(
+        value or ""
+    ).strip().casefold()
+
+    if text in {"pitcher", "p"}:
+        return "pitcher"
+
+    if text in {
+        "batter",
+        "hitter",
+        "position_player",
+    }:
+        return "batter"
+
+    return None
+
+
+def _dk_player_type(
+    player: DraftKingsSlatePlayer,
+) -> str:
+    if (
+        player.position.strip().upper() == "SP"
+        or "P" in {
+            value.strip().upper()
+            for value in player.roster_positions
+        }
+    ):
+        return "pitcher"
+
+    return "batter"
+
+
+def _team_compatible(
+    *,
+    canonical_row: Mapping[str, Any],
+    dk_team: str,
+) -> bool:
+    canonical_team = (
+        canonical_row.get("team_abbrev")
+        or canonical_row.get(
+            "team_abbreviation"
+        )
+    )
+
+    if canonical_team:
+        return (
+            _normalize_team(canonical_team)
+            == _normalize_team(dk_team)
+        )
+
+    team_name = canonical_row.get("team_name")
+
+    if not team_name:
+        return True
+
+    normalized_name = _normalize_team(
+        team_name
+    )
+
+    normalized_dk = _normalize_team(
+        dk_team
+    )
+
+    return (
+        normalized_name == normalized_dk
+        or normalized_dk in normalized_name
+    )
+
+
+def _normalize_name(
+    value: Any,
+) -> str:
+    text = unicodedata.normalize(
+        "NFKD",
+        str(value or ""),
+    )
+    text = "".join(
+        character
+        for character in text
+        if not unicodedata.combining(
+            character
+        )
+    )
+    text = text.casefold()
+    text = re.sub(
+        r"[^a-z0-9]+",
+        " ",
+        text,
+    )
+
+    return " ".join(
+        text.split()
+    )
+
+
+def _normalize_team(
+    value: Any,
+) -> str:
+    text = re.sub(
+        r"[^A-Za-z0-9]+",
+        "",
+        str(value or ""),
+    ).upper()
+
+    return _TEAM_ALIASES.get(
+        text,
+        text,
+    )
+
+
+def _optional_float(
+    value: Any,
+) -> Optional[float]:
+    if value is None:
+        return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _value_metric(
+    points: Optional[float],
+    salary: int,
+) -> Optional[float]:
+    if points is None:
+        return None
+
+    return round(
+        points / (salary / 1000.0),
+        6,
+    )

--- a/tests/test_draftkings_projection_matching.py
+++ b/tests/test_draftkings_projection_matching.py
@@ -1,0 +1,213 @@
+from mlb_app.simulation.projections import (
+    DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION,
+    ingest_draftkings_salary_csv,
+    match_canonical_projections_to_draftkings,
+)
+
+
+HEADER = (
+    "Position,Name + ID,Name,ID,"
+    "Roster Position,Salary,Game Info,"
+    "TeamAbbrev,AvgPointsPerGame,"
+    "Status,Starting\n"
+)
+
+
+def slate():
+    return ingest_draftkings_salary_csv(
+        HEADER
+        + 'OF,"José Ramírez (1)",'
+        "José Ramírez,1,3B/UTIL,6000,"
+        "CLE@DET 07/22/2026 07:10PM ET,"
+        "CLE,10.0,,Yes\n"
+        + 'SP,"Pitcher One (2)",'
+        "Pitcher One,2,P,9000,"
+        "CLE@DET 07/22/2026 07:10PM ET,"
+        "DET,18.0,,Yes\n"
+        + 'OF,"Missing Player (3)",'
+        "Missing Player,3,OF/UTIL,4000,"
+        "CLE@DET 07/22/2026 07:10PM ET,"
+        "CLE,5.0,,No\n"
+    )
+
+
+def projections():
+    return {
+        "schema_version": (
+            "canonical_player_projection_rows_v1"
+        ),
+        "simulation_count": 1000,
+        "players": [
+            {
+                "player_id": "100",
+                "mlb_player_id": 100,
+                "full_name": "Jose Ramirez",
+                "player_type": "batter",
+                "team_name": "CLE",
+                "projected_dfs_points": 12.0,
+                "dfs_floor": 4.0,
+                "dfs_median": 10.0,
+                "dfs_ceiling": 24.0,
+                "metrics": {"runs": {"mean": 0.8}},
+            },
+            {
+                "player_id": "200",
+                "mlb_player_id": 200,
+                "full_name": "Pitcher One",
+                "player_type": "pitcher",
+                "team_name": "DET",
+                "projected_dfs_points": 21.0,
+                "dfs_floor": 8.0,
+                "dfs_median": 19.0,
+                "dfs_ceiling": 34.0,
+                "metrics": {
+                    "strikeouts": {"mean": 7.0}
+                },
+            },
+            {
+                "player_id": "300",
+                "mlb_player_id": 300,
+                "full_name": "Off Slate",
+                "player_type": "batter",
+                "team_name": "CHC",
+                "projected_dfs_points": 9.0,
+                "dfs_floor": 2.0,
+                "dfs_median": 7.0,
+                "dfs_ceiling": 18.0,
+                "metrics": {},
+            },
+        ],
+        "identity_enrichment_applied": True,
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+
+def test_exact_normalized_name_team_type_matching():
+    value = match_canonical_projections_to_draftkings(
+        projection_payload=projections(),
+        slate=slate(),
+    )
+
+    assert value["schema_version"] == (
+        DRAFTKINGS_PROJECTION_MATCH_SCHEMA_VERSION
+    )
+
+    jose = next(
+        row
+        for row in value["players"]
+        if row["dk_player_id"] == "1"
+    )
+
+    assert jose["match_status"] == "matched"
+    assert jose["mlb_player_id"] == 100
+    assert jose["position"] == "OF"
+    assert jose["roster_positions"] == [
+        "3B",
+        "UTIL",
+    ]
+    assert jose["salary"] == 6000
+    assert jose["projected_dfs_points"] == 12.0
+    assert jose["value_per_1000"] == 2.0
+    assert jose["floor_value_per_1000"] == (
+        0.666667
+    )
+    assert jose["median_value_per_1000"] == (
+        1.666667
+    )
+    assert jose["ceiling_value_per_1000"] == 4.0
+
+
+def test_pitcher_type_must_be_compatible():
+    value = match_canonical_projections_to_draftkings(
+        projection_payload=projections(),
+        slate=slate(),
+    )
+
+    pitcher = next(
+        row
+        for row in value["players"]
+        if row["dk_player_id"] == "2"
+    )
+
+    assert pitcher["match_status"] == "matched"
+    assert pitcher["player_type"] == "pitcher"
+    assert pitcher["mlb_player_id"] == 200
+
+
+def test_unmatched_draftkings_rows_are_preserved():
+    value = match_canonical_projections_to_draftkings(
+        projection_payload=projections(),
+        slate=slate(),
+    )
+
+    missing = next(
+        row
+        for row in value["players"]
+        if row["dk_player_id"] == "3"
+    )
+
+    assert missing["match_status"] == "unmatched"
+    assert missing["salary"] == 4000
+    assert missing["projected_dfs_points"] is None
+    assert missing["value_per_1000"] is None
+
+
+def test_diagnostics_report_unmatched_canonical_rows():
+    value = match_canonical_projections_to_draftkings(
+        projection_payload=projections(),
+        slate=slate(),
+    )
+
+    diagnostics = value["diagnostics"]
+
+    assert diagnostics["matched_player_count"] == 2
+    assert (
+        diagnostics[
+            "unmatched_draftkings_player_count"
+        ]
+        == 1
+    )
+    assert (
+        diagnostics[
+            "unmatched_canonical_player_count"
+        ]
+        == 1
+    )
+    assert diagnostics["fuzzy_matching_used"] is False
+    assert diagnostics[
+        "unmatched_canonical_players"
+    ][0]["full_name"] == "Off Slate"
+
+
+def test_ambiguous_matches_are_not_selected():
+    duplicate = projections()
+    duplicate["players"].append(
+        {
+            "player_id": "101",
+            "mlb_player_id": 101,
+            "full_name": "José Ramírez",
+            "player_type": "batter",
+            "team_name": "CLE",
+            "projected_dfs_points": 11.0,
+            "dfs_floor": 3.0,
+            "dfs_median": 9.0,
+            "dfs_ceiling": 20.0,
+            "metrics": {},
+        }
+    )
+
+    value = match_canonical_projections_to_draftkings(
+        projection_payload=duplicate,
+        slate=slate(),
+    )
+
+    jose = next(
+        row
+        for row in value["players"]
+        if row["dk_player_id"] == "1"
+    )
+
+    assert jose["match_status"] == "ambiguous"
+    assert jose["match_candidate_count"] == 2
+    assert jose["projected_dfs_points"] is None


### PR DESCRIPTION
## Summary

Matches identity-enriched canonical player projections to normalized DraftKings MLB salary slates.

This slice adds conservative exact matching after deterministic name normalization, team/type compatibility checks, salary and roster-position attachment, salary-based value metrics, and explicit ambiguous/unmatched diagnostics without using fuzzy matching.

## Added

- `draftkings_projection_match_v1` schema
- exact normalized-name matching
- team compatibility checks with common MLB abbreviation aliases
- pitcher/batter type compatibility enforcement
- ambiguity rejection
- preservation of unmatched DraftKings rows
- diagnostics for unmatched canonical projections
- salary, game, position, and roster-eligibility attachment
- mean/floor/median/ceiling value-per-$1,000 metrics
- focused projection-matching coverage

## Behavior

```text
identity-enriched canonical projections
+
normalized DraftKings slate
→ exact normalized name/team/type matching
→ salary and roster-position attachment
→ mean/floor/median/ceiling value metrics
→ ambiguous and unmatched diagnostics
```

## Architecture

- No fuzzy matching in this slice.
- No silent resolution of ambiguous players.
- Unmatched DraftKings players remain in the output.
- Off-slate canonical projections are reported in diagnostics.
- Simulation values are not changed.
- Legacy production authority remains unchanged.
- Canonical output remains diagnostic-only.

## Validation

- Focused projection-matching/slate/identity/player-row tests: `21 passed`
- Broader scoring/projection/trial/production-shadow tests: `33 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/simulation/projections/__init__.py`
- `mlb_app/simulation/projections/draftkings_matching.py`
- `tests/test_draftkings_projection_matching.py`