### PR TITLE
Expose DraftKings projection preview API

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -102,6 +102,9 @@ from .matchup_workspace_builder import (
     build_bullpen_adjusted_game_simulation,
 )
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
+from .draftkings_projection_routes import (
+    router as draftkings_projection_router,
+)
 from .daily_odds_routes import router as daily_odds_router
 from .simulation.inning_simulator import simulate_half_innings
 from .model_projection_routes import router as model_projection_router
@@ -1391,6 +1394,9 @@ def create_app():
         allow_headers=["*"],
     )
 
+    app.include_router(
+        draftkings_projection_router
+    )
     app.include_router(batter_router)
     app.include_router(daily_odds_router)
     app.include_router(model_projection_router)

--- a/mlb_app/draftkings_projection_routes.py
+++ b/mlb_app/draftkings_projection_routes.py
@@ -1,0 +1,71 @@
+"""Read-only DraftKings projection preview routes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from mlb_app.simulation.projections import (
+    ingest_draftkings_salary_csv,
+    match_canonical_projections_to_draftkings,
+)
+
+
+router = APIRouter(
+    prefix="/dfs/draftkings",
+    tags=["draftkings-dfs"],
+)
+
+
+class DraftKingsProjectionPreviewRequest(BaseModel):
+    projection_payload: Dict[str, Any]
+    salary_csv: str = Field(
+        min_length=1,
+    )
+    source_filename: Optional[str] = None
+
+
+@router.post("/projections/preview")
+def preview_draftkings_projections(
+    request: DraftKingsProjectionPreviewRequest,
+) -> Dict[str, Any]:
+    """
+    Return one non-persistent DraftKings projection preview.
+
+    This endpoint does not persist salaries, generate lineups, alter
+    projection authority, or perform fuzzy identity matching.
+    """
+
+    try:
+        slate = ingest_draftkings_salary_csv(
+            request.salary_csv,
+            source_filename=(
+                request.source_filename
+            ),
+        )
+
+        result = (
+            match_canonical_projections_to_draftkings(
+                projection_payload=(
+                    request.projection_payload
+                ),
+                slate=slate,
+            )
+        )
+    except (
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=str(exc),
+        ) from exc
+
+    return {
+        **result,
+        "preview": True,
+        "persistent": False,
+        "lineup_generation_applied": False,
+    }

--- a/tests/test_draftkings_projection_routes.py
+++ b/tests/test_draftkings_projection_routes.py
@@ -1,0 +1,159 @@
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mlb_app.draftkings_projection_routes import (
+    router,
+)
+
+
+HEADER = (
+    "Position,Name + ID,Name,ID,"
+    "Roster Position,Salary,Game Info,"
+    "TeamAbbrev,AvgPointsPerGame,"
+    "Status,Starting\n"
+)
+
+
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def projection_payload():
+    return {
+        "schema_version": (
+            "canonical_player_projection_rows_v1"
+        ),
+        "simulation_count": 100,
+        "players": [
+            {
+                "player_id": "100",
+                "mlb_player_id": 100,
+                "full_name": "Jose Ramirez",
+                "player_type": "batter",
+                "team_name": "CLE",
+                "projected_dfs_points": 12.0,
+                "dfs_floor": 4.0,
+                "dfs_median": 10.0,
+                "dfs_ceiling": 24.0,
+                "metrics": {},
+            }
+        ],
+        "identity_enrichment_applied": True,
+        "authoritative": False,
+        "authoritative_source": "legacy",
+    }
+
+
+def salary_csv():
+    return (
+        HEADER
+        + 'OF,"José Ramírez (1)",'
+        "José Ramírez,1,3B/UTIL,6000,"
+        "CLE@DET 07/22/2026 07:10PM ET,"
+        "CLE,10.0,,Yes\n"
+    )
+
+
+def test_preview_route_returns_matched_rows():
+    response = client().post(
+        "/dfs/draftkings/projections/preview",
+        json={
+            "projection_payload": (
+                projection_payload()
+            ),
+            "salary_csv": salary_csv(),
+            "source_filename": "DKSalaries.csv",
+        },
+    )
+
+    assert response.status_code == 200
+
+    payload = response.json()
+
+    assert payload["schema_version"] == (
+        "draftkings_projection_match_v1"
+    )
+    assert payload["preview"] is True
+    assert payload["persistent"] is False
+    assert (
+        payload["lineup_generation_applied"]
+        is False
+    )
+
+    player = payload["players"][0]
+
+    assert player["match_status"] == "matched"
+    assert player["salary"] == 6000
+    assert player["projected_dfs_points"] == 12.0
+    assert player["value_per_1000"] == 2.0
+
+
+def test_preview_route_preserves_diagnostics():
+    response = client().post(
+        "/dfs/draftkings/projections/preview",
+        json={
+            "projection_payload": (
+                projection_payload()
+            ),
+            "salary_csv": salary_csv(),
+        },
+    )
+
+    diagnostics = response.json()["diagnostics"]
+
+    assert diagnostics["matched_player_count"] == 1
+    assert (
+        diagnostics[
+            "unmatched_draftkings_player_count"
+        ]
+        == 0
+    )
+    assert diagnostics["fuzzy_matching_used"] is False
+
+
+def test_preview_route_rejects_invalid_csv():
+    response = client().post(
+        "/dfs/draftkings/projections/preview",
+        json={
+            "projection_payload": (
+                projection_payload()
+            ),
+            "salary_csv": (
+                "Name,ID\n"
+                "Player,1\n"
+            ),
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        "missing required DraftKings columns"
+        in response.json()["detail"]
+    )
+
+
+def test_preview_route_rejects_invalid_projection_shape():
+    response = client().post(
+        "/dfs/draftkings/projections/preview",
+        json={
+            "projection_payload": {
+                "players": "invalid"
+            },
+            "salary_csv": salary_csv(),
+        },
+    )
+
+    assert response.status_code == 422
+    assert (
+        response.json()["detail"]
+        == (
+            "projection players must be "
+            "a list or tuple"
+        )
+    )


### PR DESCRIPTION
## Summary

Adds a read-only DraftKings projection preview API for the canonical projection product layer.

This slice exposes `POST /dfs/draftkings/projections/preview`, accepting identity-enriched projection JSON plus DraftKings salary CSV text, then returning normalized slate matching, salary/value metrics, and diagnostics without persistence or lineup generation.

## Added

- `POST /dfs/draftkings/projections/preview`
- request contract for projection payload and salary CSV text
- optional source filename metadata
- DraftKings CSV normalization through the existing ingestion contract
- canonical-to-DraftKings matching through the existing conservative matcher
- salary and value-metric preview response
- explicit preview/non-persistent/no-lineup-generation metadata
- validation errors surfaced as HTTP 422 responses
- focused route coverage

## Behavior

```text
projection JSON + salary CSV text
→ normalized DK slate
→ conservative projection matching
→ salary/value preview
→ no persistence
→ no lineup generation
→ canonical remains non-authoritative
```

## Architecture

- Pure read-only preview adapter.
- No database writes.
- No salary-file persistence.
- No lineup construction.
- No fuzzy identity resolution.
- No production-authority change.
- Keeps the endpoint decoupled from unstable internal shadow-diagnostics storage.

## Validation

- Focused API/matching/slate tests: `16 passed`
- Broader projection/scoring/production-shadow tests: `35 passed`
- Python compilation passed
- `git diff --check` passed

Pre-existing SQLAlchemy warning remains unchanged.

## Files

- `mlb_app/app.py`
- `mlb_app/draftkings_projection_routes.py`
- `tests/test_draftkings_projection_routes.py`