### PR TITLE
Add canonical player projections tab

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs src/lib/dashboardReportFolders.test.mjs src/lib/dashboardRenameState.test.mjs src/lib/canonicalDiagnosticsViewModel.test.mjs",
+    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs src/lib/dashboardReportFolders.test.mjs src/lib/dashboardRenameState.test.mjs src/lib/canonicalDiagnosticsViewModel.test.mjs src/lib/canonicalProjectionsViewModel.test.mjs src/lib/canonicalProjectionsUiContract.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const pageUrl = new URL(
+  '../pages/ModelProjectionsPage.jsx',
+  import.meta.url,
+)
+
+async function pageSource() {
+  return readFile(pageUrl, 'utf8')
+}
+
+test('projections tab follows simulation and precedes diagnostics', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /\['simulation', 'Simulation'\],\s*\['projections', 'Projections'\],\s*\['diagnostics', 'Diagnostics'\]/,
+  )
+})
+
+test('projections tab consumes canonical projections view model', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /buildCanonicalProjectionsViewModel/,
+  )
+  assert.match(
+    source,
+    /Canonical Player Projections/,
+  )
+  assert.match(
+    source,
+    /<ProjectionsTab game=\{game\}/,
+  )
+})
+
+test('projections tab describes same-run coherence', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /exact same trial\s*batch/i,
+  )
+  assert.match(
+    source,
+    /Non-authoritative shadow/,
+  )
+})
+
+test('projections tab renders requested batter metrics', async () => {
+  const source = await pageSource()
+
+  for (const label of [
+    'PA',
+    'RBI',
+    '1B',
+    '2B',
+    '3B',
+    'HR',
+    'BB',
+    'DK Mean',
+    'DK Floor',
+    'DK Median',
+    'DK Ceiling',
+  ]) {
+    assert.match(source, new RegExp(label))
+  }
+})

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -1,0 +1,266 @@
+function asObject(value) {
+  return value && typeof value === 'object'
+    ? value
+    : {}
+}
+
+function asArray(value) {
+  return Array.isArray(value)
+    ? value
+    : []
+}
+
+function number(value) {
+  const parsed = Number(value)
+
+  return Number.isFinite(parsed)
+    ? parsed
+    : null
+}
+
+function metricSummary(row, name) {
+  const metrics = asObject(row?.metrics)
+  const metric = asObject(metrics[name])
+
+  return metric
+}
+
+function metricValue(row, name, key = 'mean') {
+  return number(
+    metricSummary(row, name)?.[key],
+  )
+}
+
+function sumValues(values) {
+  const available = values.filter(
+    value => value !== null,
+  )
+
+  if (!available.length) return null
+
+  return available.reduce(
+    (total, value) => total + value,
+    0,
+  )
+}
+
+function playerName(row) {
+  return (
+    row?.full_name ||
+    row?.player_name ||
+    row?.player_id ||
+    'Unknown player'
+  )
+}
+
+function teamSide(row) {
+  const value = String(
+    row?.team_side ||
+    row?.side ||
+    '',
+  ).trim()
+
+  return value || '—'
+}
+
+function dfsValue(row, key) {
+  const direct = number(row?.[key])
+
+  if (direct !== null) return direct
+
+  const mapping = {
+    projected_dfs_points: 'mean',
+    dfs_floor: 'p10',
+    dfs_median: 'median',
+    dfs_ceiling: 'p90',
+  }
+
+  return metricValue(
+    row,
+    'dfs_points',
+    mapping[key],
+  )
+}
+
+function batterRow(row) {
+  const singles = metricValue(row, 'singles')
+  const doubles = metricValue(row, 'doubles')
+  const triples = metricValue(row, 'triples')
+  const homeRuns = metricValue(
+    row,
+    'home_runs',
+  )
+
+  return {
+    playerId: row?.player_id ?? null,
+    mlbPlayerId: row?.mlb_player_id ?? null,
+    name: playerName(row),
+    side: teamSide(row),
+    plateAppearances: metricValue(
+      row,
+      'plate_appearances',
+    ),
+    hits: sumValues([
+      singles,
+      doubles,
+      triples,
+      homeRuns,
+    ]),
+    runs: metricValue(row, 'runs'),
+    rbis: metricValue(row, 'rbis'),
+    singles,
+    doubles,
+    triples,
+    homeRuns,
+    walks: metricValue(row, 'walks'),
+    strikeouts: metricValue(
+      row,
+      'strikeouts',
+    ),
+    dfsMean: dfsValue(
+      row,
+      'projected_dfs_points',
+    ),
+    dfsFloor: dfsValue(row, 'dfs_floor'),
+    dfsMedian: dfsValue(row, 'dfs_median'),
+    dfsCeiling: dfsValue(
+      row,
+      'dfs_ceiling',
+    ),
+  }
+}
+
+function pitcherRow(row) {
+  const outs = metricValue(row, 'outs')
+
+  return {
+    playerId: row?.player_id ?? null,
+    mlbPlayerId: row?.mlb_player_id ?? null,
+    name: playerName(row),
+    side: teamSide(row),
+    battersFaced: metricValue(
+      row,
+      'batters_faced',
+    ),
+    inningsPitched: (
+      outs === null
+        ? null
+        : outs / 3
+    ),
+    hitsAllowed: (
+      metricValue(row, 'hits_allowed') ??
+      metricValue(row, 'hits')
+    ),
+    walks: metricValue(row, 'walks'),
+    hitByPitch: (
+      metricValue(row, 'hit_by_pitch') ??
+      metricValue(row, 'hit_batters')
+    ),
+    strikeouts: metricValue(
+      row,
+      'strikeouts',
+    ),
+    runs: (
+      metricValue(row, 'runs_allowed') ??
+      metricValue(row, 'runs')
+    ),
+    earnedRuns: (
+      metricValue(row, 'earned_runs') ??
+      metricValue(row, 'earned_runs_allowed')
+    ),
+    dfsMean: dfsValue(
+      row,
+      'projected_dfs_points',
+    ),
+    dfsFloor: dfsValue(row, 'dfs_floor'),
+    dfsMedian: dfsValue(row, 'dfs_median'),
+    dfsCeiling: dfsValue(
+      row,
+      'dfs_ceiling',
+    ),
+  }
+}
+
+function sortRows(rows) {
+  return [...rows].sort((left, right) => {
+    const sideComparison = String(
+      left.side,
+    ).localeCompare(String(right.side))
+
+    if (sideComparison) return sideComparison
+
+    return String(left.name).localeCompare(
+      String(right.name),
+    )
+  })
+}
+
+export function buildCanonicalProjectionsViewModel(
+  game,
+) {
+  const shadow = asObject(
+    game?.diagnostics?.canonical_shadow,
+  )
+  const projections = asObject(
+    shadow.player_projections,
+  )
+  const players = asArray(projections.players)
+
+  const available = (
+    projections.schema_version ===
+      'canonical_player_projection_rows_v1' &&
+    players.length > 0
+  )
+
+  return {
+    available,
+    status: projections.status || (
+      available ? 'available' : 'unavailable'
+    ),
+    schemaVersion: (
+      projections.schema_version || null
+    ),
+    sourceProjectionSchemaVersion: (
+      projections
+        .source_projection_schema_version ||
+      null
+    ),
+    runId: projections.run_id || null,
+    modelVersion: (
+      projections.model_version || null
+    ),
+    simulationCount: number(
+      projections.simulation_count,
+    ),
+    authoritative: (
+      projections.authoritative === true
+    ),
+    authoritativeSource: (
+      projections.authoritative_source ||
+      shadow.authoritative_source ||
+      'legacy'
+    ),
+    identityEnrichmentApplied: (
+      projections
+        .identity_enrichment_applied === true
+    ),
+    batters: sortRows(
+      players
+        .filter(
+          row => row?.player_type === 'batter',
+        )
+        .map(batterRow),
+    ),
+    pitchers: sortRows(
+      players
+        .filter(
+          row => row?.player_type === 'pitcher',
+        )
+        .map(pitcherRow),
+    ),
+    errorMessage: (
+      projections.error_message || null
+    ),
+    raw: projections,
+  }
+}

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildCanonicalProjectionsViewModel,
+} from './canonicalProjectionsViewModel.mjs'
+
+function metric(mean, overrides = {}) {
+  return {
+    mean,
+    median: mean,
+    p10: mean - 1,
+    p90: mean + 1,
+    ...overrides,
+  }
+}
+
+function payload() {
+  return {
+    diagnostics: {
+      canonical_shadow: {
+        authoritative_source: 'legacy',
+        player_projections: {
+          schema_version: (
+            'canonical_player_projection_rows_v1'
+          ),
+          source_projection_schema_version: (
+            'canonical_projection_payload_v1'
+          ),
+          run_id: 'run-123',
+          model_version: 'canonical-v1',
+          simulation_count: 25,
+          identity_enrichment_applied: false,
+          authoritative: false,
+          authoritative_source: 'legacy',
+          players: [
+            {
+              player_id: 'b-1',
+              full_name: 'Test Batter',
+              team_side: 'away',
+              player_type: 'batter',
+              projected_dfs_points: 10.5,
+              dfs_floor: 3,
+              dfs_median: 9,
+              dfs_ceiling: 20,
+              metrics: {
+                plate_appearances: metric(4.4),
+                singles: metric(0.7),
+                doubles: metric(0.3),
+                triples: metric(0.1),
+                home_runs: metric(0.4),
+                runs: metric(0.8),
+                rbis: metric(1.1),
+                walks: metric(0.5),
+                strikeouts: metric(1.2),
+              },
+            },
+            {
+              player_id: 'p-1',
+              player_type: 'pitcher',
+              team_side: 'home',
+              metrics: {
+                batters_faced: metric(24),
+                outs: metric(18),
+                hits_allowed: metric(5),
+                walks: metric(2),
+                hit_by_pitch: metric(0.3),
+                strikeouts: metric(7),
+                runs_allowed: metric(2.5),
+                earned_runs: metric(2),
+                dfs_points: metric(
+                  18,
+                  {
+                    p10: 8,
+                    median: 17,
+                    p90: 27,
+                  },
+                ),
+              },
+            },
+          ],
+        },
+      },
+    },
+  }
+}
+
+test('builds same-run projection metadata', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel(
+      payload(),
+    )
+  )
+
+  assert.equal(view.available, true)
+  assert.equal(view.runId, 'run-123')
+  assert.equal(view.modelVersion, 'canonical-v1')
+  assert.equal(view.simulationCount, 25)
+  assert.equal(view.authoritative, false)
+  assert.equal(
+    view.authoritativeSource,
+    'legacy',
+  )
+})
+
+test('derives batter hits from component means', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel(
+      payload(),
+    )
+  )
+  const batter = view.batters[0]
+
+  assert.equal(batter.name, 'Test Batter')
+  assert.equal(batter.plateAppearances, 4.4)
+  assert.equal(batter.hits, 1.5)
+  assert.equal(batter.dfsMean, 10.5)
+  assert.equal(batter.dfsFloor, 3)
+  assert.equal(batter.dfsMedian, 9)
+  assert.equal(batter.dfsCeiling, 20)
+})
+
+test('derives pitcher innings from outs', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel(
+      payload(),
+    )
+  )
+  const pitcher = view.pitchers[0]
+
+  assert.equal(pitcher.name, 'p-1')
+  assert.equal(pitcher.inningsPitched, 6)
+  assert.equal(pitcher.battersFaced, 24)
+  assert.equal(pitcher.dfsMean, 18)
+  assert.equal(pitcher.dfsFloor, 8)
+  assert.equal(pitcher.dfsMedian, 17)
+  assert.equal(pitcher.dfsCeiling, 27)
+})
+
+test('returns unavailable view without rows', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({})
+  )
+
+  assert.equal(view.available, false)
+  assert.deepEqual(view.batters, [])
+  assert.deepEqual(view.pitchers, [])
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -3,6 +3,9 @@ import { API_BASE } from '../lib/api'
 import {
   buildCanonicalDiagnosticsViewModel,
 } from '../lib/canonicalDiagnosticsViewModel.mjs'
+import {
+  buildCanonicalProjectionsViewModel,
+} from '../lib/canonicalProjectionsViewModel.mjs'
 
 const API = API_BASE
 
@@ -759,6 +762,253 @@ function SimulationTab({ workspace, game }) {
   )
 }
 
+function projectionNumber(value, digits = 2) {
+  const parsed = Number(value)
+
+  if (!Number.isFinite(parsed)) return '—'
+
+  return parsed.toFixed(digits)
+}
+
+function ProjectionTable({
+  title,
+  columns,
+  rows,
+}) {
+  return (
+    <div style={{ ...s.metricCard, marginTop: '14px' }}>
+      <div style={s.metricLabel}>{title}</div>
+
+      {!rows.length ? (
+        <div style={s.noData}>
+          No {title.toLowerCase()} are available for this run.
+        </div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              minWidth: '1120px',
+              marginTop: '10px',
+            }}
+          >
+            <thead>
+              <tr>
+                {columns.map(column => (
+                  <th
+                    key={column.key}
+                    style={{
+                      color: '#8b949e',
+                      fontSize: '11px',
+                      fontWeight: 700,
+                      letterSpacing: '0.04em',
+                      padding: '9px 8px',
+                      textAlign: column.align || 'right',
+                      borderBottom: '1px solid #30363d',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {column.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+
+            <tbody>
+              {rows.map(row => (
+                <tr
+                  key={
+                    row.mlbPlayerId ||
+                    row.playerId ||
+                    `${row.side}-${row.name}`
+                  }
+                >
+                  {columns.map(column => (
+                    <td
+                      key={column.key}
+                      style={{
+                        color: (
+                          column.key === 'name'
+                            ? '#e6edf3'
+                            : '#c9d1d9'
+                        ),
+                        fontSize: '12px',
+                        padding: '9px 8px',
+                        textAlign: column.align || 'right',
+                        borderBottom: '1px solid #21262d',
+                        whiteSpace: 'nowrap',
+                        fontWeight: (
+                          column.key === 'name' ||
+                          column.key === 'dfsMean'
+                            ? 600
+                            : 400
+                        ),
+                      }}
+                    >
+                      {column.format === 'text'
+                        ? row[column.key]
+                        : projectionNumber(
+                            row[column.key],
+                            column.digits ?? 2,
+                          )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const BATTER_PROJECTION_COLUMNS = [
+  { key: 'name', label: 'Player', format: 'text', align: 'left' },
+  { key: 'side', label: 'Side', format: 'text', align: 'left' },
+  { key: 'plateAppearances', label: 'PA' },
+  { key: 'hits', label: 'H' },
+  { key: 'runs', label: 'R' },
+  { key: 'rbis', label: 'RBI' },
+  { key: 'singles', label: '1B' },
+  { key: 'doubles', label: '2B' },
+  { key: 'triples', label: '3B' },
+  { key: 'homeRuns', label: 'HR' },
+  { key: 'walks', label: 'BB' },
+  { key: 'strikeouts', label: 'K' },
+  { key: 'dfsMean', label: 'DK Mean' },
+  { key: 'dfsFloor', label: 'DK Floor' },
+  { key: 'dfsMedian', label: 'DK Median' },
+  { key: 'dfsCeiling', label: 'DK Ceiling' },
+]
+
+const PITCHER_PROJECTION_COLUMNS = [
+  { key: 'name', label: 'Pitcher', format: 'text', align: 'left' },
+  { key: 'side', label: 'Side', format: 'text', align: 'left' },
+  { key: 'battersFaced', label: 'BF' },
+  { key: 'inningsPitched', label: 'IP' },
+  { key: 'hitsAllowed', label: 'H' },
+  { key: 'walks', label: 'BB' },
+  { key: 'hitByPitch', label: 'HBP' },
+  { key: 'strikeouts', label: 'K' },
+  { key: 'runs', label: 'R' },
+  { key: 'earnedRuns', label: 'ER' },
+  { key: 'dfsMean', label: 'DK Mean' },
+  { key: 'dfsFloor', label: 'DK Floor' },
+  { key: 'dfsMedian', label: 'DK Median' },
+  { key: 'dfsCeiling', label: 'DK Ceiling' },
+]
+
+function ProjectionsTab({ game }) {
+  const view = (
+    buildCanonicalProjectionsViewModel(game)
+  )
+
+  if (!view.available) {
+    return (
+      <div style={s.noData}>
+        Canonical player projections are not available for this
+        game. This tab only renders rows produced by the same
+        canonical simulation run shown in Simulation and
+        Diagnostics.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div style={s.diagnosticHeader}>
+        <div>
+          <h3
+            style={{
+              margin: 0,
+              color: '#e6edf3',
+              fontSize: '21px',
+            }}
+          >
+            Canonical Player Projections
+          </h3>
+
+          <div
+            style={{
+              color: '#8b949e',
+              fontSize: '13px',
+              marginTop: '5px',
+            }}
+          >
+            Player outcomes derived from the exact same trial
+            batch as this game simulation.
+          </div>
+        </div>
+
+        <Tag tone="diagnostic">
+          Non-authoritative shadow
+        </Tag>
+      </div>
+
+      <div style={s.grid}>
+        <GenericPanel title="Run Identity">
+          <StatRow
+            k="Run ID"
+            v={view.runId}
+            format="text"
+          />
+          <StatRow
+            k="Model Version"
+            v={view.modelVersion}
+            format="text"
+          />
+          <StatRow
+            k="Simulation Count"
+            v={view.simulationCount}
+            format="num"
+          />
+        </GenericPanel>
+
+        <GenericPanel title="Projection Contract">
+          <StatRow
+            k="Schema"
+            v={view.schemaVersion}
+            format="text"
+          />
+          <StatRow
+            k="Source Schema"
+            v={view.sourceProjectionSchemaVersion}
+            format="text"
+          />
+          <StatRow
+            k="Authoritative Source"
+            v={view.authoritativeSource}
+            format="text"
+          />
+          <StatRow
+            k="Identity Enrichment"
+            v={
+              view.identityEnrichmentApplied
+                ? 'applied'
+                : 'not applied'
+            }
+            format="text"
+          />
+        </GenericPanel>
+      </div>
+
+      <ProjectionTable
+        title="Batter Projections"
+        columns={BATTER_PROJECTION_COLUMNS}
+        rows={view.batters}
+      />
+
+      <ProjectionTable
+        title="Pitcher Projections"
+        columns={PITCHER_PROJECTION_COLUMNS}
+        rows={view.pitchers}
+      />
+    </div>
+  )
+}
+
 function shortDigest(value) {
   if (!value) return '—'
   const text = String(value)
@@ -1310,6 +1560,7 @@ const TABS = [
   ['matchup', 'Matchup Analysis'],
   ['bullpen', 'Bullpen'],
   ['simulation', 'Simulation'],
+  ['projections', 'Projections'],
   ['diagnostics', 'Diagnostics'],
 ]
 
@@ -1331,6 +1582,7 @@ function GameProjectionCard({ game }) {
     if (activeTab === 'matchup') return <MatchupTab workspace={workspace} />
     if (activeTab === 'bullpen') return <BullpenTab workspace={workspace} game={game} />
     if (activeTab === 'simulation') return <SimulationTab workspace={workspace} game={game} />
+    if (activeTab === 'projections') return <ProjectionsTab game={game} />
     if (activeTab === 'diagnostics') return <DiagnosticsTab game={game} />
     return null
   }


### PR DESCRIPTION
## Summary

Adds a first-class **Projections** tab to the model projections game workspace, positioned between **Simulation** and **Diagnostics** so the page tells a coherent story from inputs to simulation outputs to player-level projections to provenance.

The tab consumes only `game.diagnostics.canonical_shadow.player_projections`, which was attached from the exact same canonical trial batch as the game simulation. It does not fetch projections independently, rerun simulations, or create a second source of truth.

## Added

- `Projections` tab between `Simulation` and `Diagnostics`
- pure `canonicalProjectionsViewModel`
- same-run run ID, model version, and simulation-count banner
- batter projection table with:
  - PA
  - H
  - R
  - RBI
  - 1B
  - 2B
  - 3B
  - HR
  - BB
  - K
  - DraftKings mean/floor/median/ceiling
- pitcher projection table with:
  - BF
  - IP
  - H
  - BB
  - HBP
  - K
  - R
  - ER
  - DraftKings mean/floor/median/ceiling
- hitter hits derived coherently from same-run component means
- pitcher innings derived from same-run mean outs
- unavailable-state messaging when canonical player rows are absent
- focused view-model and UI-contract tests

## Behavior

```text
inputs and matchup context
→ simulation-level outputs
→ same-run player projections
→ diagnostics and provenance
```

## Data contract

```text
game.diagnostics.canonical_shadow.player_projections
→ pure frontend view model
→ Projections tab
```

No additional request, simulation execution, identity source, or projection model is introduced.

## Validation

- focused diagnostics/projections tests: `29 passed`
- relevant frontend suite excluding one unrelated pre-existing model-tracker ordering failure: `60 passed`
- production frontend build passed
- `git diff --check` passed

## Known unrelated repository state

- Full `npm test` currently has one unrelated pre-existing failure in `modelTrackerPnl.test.mjs` concerning projection-row ordering. This branch does not modify that code path.
- Existing Vite build warnings remain for duplicate style keys in `LandingV2Page.jsx` and large bundle size.

## Files

- `frontend/package.json`
- `frontend/src/lib/canonicalProjectionsUiContract.test.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`
- `frontend/src/pages/ModelProjectionsPage.jsx`