### PR TITLE
Add stolen bases to hitter projections

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -61,6 +61,7 @@ test('projections tab renders requested batter metrics', async () => {
     '3B',
     'HR',
     'BB',
+    'SB',
     'DK Mean',
     'DK Floor',
     'DK Median',

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -113,6 +113,10 @@ function batterRow(row) {
     triples,
     homeRuns,
     walks: metricValue(row, 'walks'),
+    stolenBases: metricValue(
+      row,
+      'stolen_bases',
+    ),
     strikeouts: metricValue(
       row,
       'strikeouts',

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -52,6 +52,7 @@ function payload() {
                 runs: metric(0.8),
                 rbis: metric(1.1),
                 walks: metric(0.5),
+                stolen_bases: metric(0.2),
                 strikeouts: metric(1.2),
               },
             },
@@ -114,6 +115,7 @@ test('derives batter hits from component means', () => {
   assert.equal(batter.name, 'Test Batter')
   assert.equal(batter.plateAppearances, 4.4)
   assert.equal(batter.hits, 1.5)
+  assert.equal(batter.stolenBases, 0.2)
   assert.equal(batter.dfsMean, 10.5)
   assert.equal(batter.dfsFloor, 3)
   assert.equal(batter.dfsMedian, 9)
@@ -145,4 +147,26 @@ test('returns unavailable view without rows', () => {
   assert.equal(view.available, false)
   assert.deepEqual(view.batters, [])
   assert.deepEqual(view.pitchers, [])
+})
+
+test('leaves stolen bases unavailable when simulation omits metric', () => {
+  const source = payload()
+  delete (
+    source
+      .diagnostics
+      .canonical_shadow
+      .player_projections
+      .players[0]
+      .metrics
+      .stolen_bases
+  )
+
+  const view = (
+    buildCanonicalProjectionsViewModel(source)
+  )
+
+  assert.equal(
+    view.batters[0].stolenBases,
+    null,
+  )
 })

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -876,6 +876,7 @@ const BATTER_PROJECTION_COLUMNS = [
   { key: 'triples', label: '3B' },
   { key: 'homeRuns', label: 'HR' },
   { key: 'walks', label: 'BB' },
+  { key: 'stolenBases', label: 'SB' },
   { key: 'strikeouts', label: 'K' },
   { key: 'dfsMean', label: 'DK Mean' },
   { key: 'dfsFloor', label: 'DK Floor' },


### PR DESCRIPTION
## Summary

Adds a forward-compatible stolen-base column to the canonical hitter projections table.

The UI now reads the same-run `stolen_bases` metric when present and displays an unavailable value when the canonical simulation has not yet activated stolen-base modeling. This avoids presenting an unsupported zero while allowing the projection table to populate automatically once steals are produced by the simulation.

## Added

- `SB` column in the hitter projections table
- `stolenBases` field in the canonical projections view model
- same-run `stolen_bases` mean mapping
- unavailable-state behavior when the metric is absent
- focused view-model and UI-contract coverage

## Behavior

```text
stolen_bases metric present
→ render projected mean

stolen_bases metric absent
→ render —
→ do not imply modeled zero
```

## Architecture

- Reads only from the existing same-run canonical player projection payload.
- Does not activate steal events in the simulation.
- Does not synthesize or default stolen bases to zero.
- Will populate automatically when canonical steal modeling is added.

## Validation

- focused projections tests: `9 passed`
- production frontend build passed
- `git diff --check` passed

Existing unrelated Vite warnings remain unchanged.

## Files

- `frontend/src/lib/canonicalProjectionsUiContract.test.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`
- `frontend/src/pages/ModelProjectionsPage.jsx`