### PR TITLE
Enrich game workspace player projection identities

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -17,6 +17,9 @@ from .team_offense_prior import build_team_offense_prior
 from .simulation.pa_outcome_model import build_pa_outcome_probabilities
 from .simulation.game_simulator import simulate_game_with_bullpen
 from mlb_app.simulation.game_simulation_builder import build_game_simulation as build_shared_game_simulation
+from mlb_app.simulation.projections import (
+    enrich_canonical_player_projection_rows,
+)
 from mlb_app.simulation.shadow import (
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
@@ -697,6 +700,89 @@ def _attach_production_shadow_comparison(
     )
 
 
+def _enrich_game_workspace_player_projections(
+    *,
+    session: Session,
+    shared_simulation: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Enrich attached same-run canonical player rows.
+
+    This function never reruns simulation, changes projection values, or
+    changes legacy production authority. Missing or malformed shadow
+    projection material fails open and leaves the game payload usable.
+    """
+
+    if not isinstance(shared_simulation, dict):
+        return shared_simulation
+
+    diagnostics = shared_simulation.get(
+        "diagnostics"
+    )
+
+    if not isinstance(diagnostics, dict):
+        return shared_simulation
+
+    shadow = diagnostics.get(
+        "canonical_shadow"
+    )
+
+    if not isinstance(shadow, dict):
+        return shared_simulation
+
+    player_projections = shadow.get(
+        "player_projections"
+    )
+
+    if not isinstance(player_projections, dict):
+        return shared_simulation
+
+    try:
+        shadow["player_projections"] = (
+            enrich_canonical_player_projection_rows(
+                session=session,
+                payload=player_projections,
+            )
+        )
+    except Exception as exc:
+        identity_diagnostics = (
+            player_projections.setdefault(
+                "identity_enrichment",
+                {},
+            )
+        )
+
+        if not isinstance(
+            identity_diagnostics,
+            dict,
+        ):
+            identity_diagnostics = {}
+            player_projections[
+                "identity_enrichment"
+            ] = identity_diagnostics
+
+        identity_diagnostics.update(
+            {
+                "schema_version": (
+                    "canonical_player_identity_enrichment_v1"
+                ),
+                "status": "error",
+                "error_type": (
+                    exc.__class__.__name__
+                ),
+                "error_message": str(exc),
+                "source": (
+                    "dashboard_player_current"
+                ),
+                "authoritative_source": (
+                    "legacy"
+                ),
+            }
+        )
+
+    return shared_simulation
+
+
 def build_model_projection_payload(session: Session, target_date: str) -> Dict[str, Any]:
     try:
         date_obj = datetime.datetime.strptime(target_date, "%Y-%m-%d").date()
@@ -895,6 +981,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     production_execution=(
                         canonical_production_shadow_execution
                     ),
+                )
+            )
+
+            shared_simulation = (
+                _enrich_game_workspace_player_projections(
+                    session=session,
+                    shared_simulation=shared_simulation,
                 )
             )
 

--- a/tests/test_model_projection_player_identity_attachment.py
+++ b/tests/test_model_projection_player_identity_attachment.py
@@ -1,0 +1,227 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+from mlb_app import model_projections
+
+
+class QueryStub:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return list(self.rows)
+
+
+class SessionStub:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def query(self, model):
+        return QueryStub(self.rows)
+
+
+def shared_simulation():
+    return {
+        "status": "ok",
+        "diagnostics": {
+            "canonical_shadow": {
+                "status": "available",
+                "authoritative_source": "legacy",
+                "player_projections": {
+                    "schema_version": (
+                        "canonical_player_projection_rows_v1"
+                    ),
+                    "source_schema_version": (
+                        "canonical_projection_payload_v1"
+                    ),
+                    "run_id": "run-123",
+                    "model_version": "canonical-v1",
+                    "simulation_count": 25,
+                    "players": [
+                        {
+                            "player_id": "101",
+                            "player_type": "batter",
+                            "team_side": "away",
+                            "projected_dfs_points": 10.5,
+                            "metrics": {},
+                        },
+                        {
+                            "player_id": (
+                                "synthetic_pitcher"
+                            ),
+                            "player_type": "pitcher",
+                            "team_side": "home",
+                            "projected_dfs_points": 4.0,
+                            "metrics": {},
+                        },
+                    ],
+                    "identity_enrichment_applied": False,
+                    "authoritative": False,
+                    "authoritative_source": "legacy",
+                },
+            },
+        },
+    }
+
+
+def identity():
+    return SimpleNamespace(
+        mlb_player_id=101,
+        full_name="Resolved Batter",
+        team_id=12,
+        team_name="Away Club",
+        primary_position="3B",
+        player_type="batter",
+        is_active=True,
+    )
+
+
+def test_enriches_attached_player_rows_from_same_run():
+    source = shared_simulation()
+
+    result = (
+        model_projections
+        ._enrich_game_workspace_player_projections(
+            session=SessionStub([identity()]),
+            shared_simulation=source,
+        )
+    )
+
+    projections = result["diagnostics"][
+        "canonical_shadow"
+    ]["player_projections"]
+
+    assert projections["run_id"] == "run-123"
+    assert projections["model_version"] == (
+        "canonical-v1"
+    )
+    assert projections["simulation_count"] == 25
+    assert (
+        projections[
+            "identity_enrichment_applied"
+        ]
+        is True
+    )
+
+    resolved = projections["players"][0]
+
+    assert resolved["mlb_player_id"] == 101
+    assert resolved["full_name"] == (
+        "Resolved Batter"
+    )
+    assert resolved["team_name"] == "Away Club"
+    assert (
+        resolved["projected_dfs_points"]
+        == 10.5
+    )
+
+
+def test_preserves_unresolved_rows():
+    result = (
+        model_projections
+        ._enrich_game_workspace_player_projections(
+            session=SessionStub([identity()]),
+            shared_simulation=shared_simulation(),
+        )
+    )
+
+    unresolved = result["diagnostics"][
+        "canonical_shadow"
+    ]["player_projections"]["players"][1]
+
+    assert unresolved["player_id"] == (
+        "synthetic_pitcher"
+    )
+    assert unresolved["full_name"] is None
+    assert unresolved[
+        "identity_resolution_status"
+    ] == "unresolved"
+    assert (
+        unresolved["projected_dfs_points"]
+        == 4.0
+    )
+
+
+def test_missing_projection_attachment_is_unchanged():
+    source = {
+        "status": "ok",
+        "diagnostics": {
+            "canonical_shadow": {
+                "status": "unavailable",
+            },
+        },
+    }
+    original = deepcopy(source)
+
+    result = (
+        model_projections
+        ._enrich_game_workspace_player_projections(
+            session=SessionStub([]),
+            shared_simulation=source,
+        )
+    )
+
+    assert result == original
+
+
+def test_identity_failure_fails_open(monkeypatch):
+    source = shared_simulation()
+
+    def fail(**kwargs):
+        raise RuntimeError("identity lookup failed")
+
+    monkeypatch.setattr(
+        model_projections,
+        "enrich_canonical_player_projection_rows",
+        fail,
+    )
+
+    result = (
+        model_projections
+        ._enrich_game_workspace_player_projections(
+            session=SessionStub([]),
+            shared_simulation=source,
+        )
+    )
+
+    projections = result["diagnostics"][
+        "canonical_shadow"
+    ]["player_projections"]
+
+    assert len(projections["players"]) == 2
+    assert (
+        projections[
+            "identity_enrichment_applied"
+        ]
+        is False
+    )
+
+    diagnostics = projections[
+        "identity_enrichment"
+    ]
+
+    assert diagnostics["status"] == "error"
+    assert diagnostics["error_type"] == (
+        "RuntimeError"
+    )
+    assert diagnostics["error_message"] == (
+        "identity lookup failed"
+    )
+
+
+def test_non_dictionary_shared_simulation_is_preserved():
+    value = (
+        model_projections
+        ._enrich_game_workspace_player_projections(
+            session=SessionStub([]),
+            shared_simulation=None,
+        )
+    )
+
+    assert value is None


### PR DESCRIPTION
## Summary

Enriches the canonical player projection rows already attached to each model-projection game workspace using the existing `DashboardPlayerCurrent` identity source while the model-projection database session is still open.

The enrichment happens after the exact same canonical trial batch has been attached to `sharedSimulation.diagnostics.canonical_shadow.player_projections`, preserving run identity, simulation metrics, and non-authoritative legacy authority without rerunning canonical simulations.

## Added

- game-workspace identity enrichment for attached canonical player rows
- resolved MLB player IDs, names, team identity, primary position, player type, and active status
- explicit identity-enrichment diagnostics
- unresolved-row preservation
- fail-open behavior for lookup/enrichment errors
- focused tests for resolved, unresolved, missing, failing, and non-dictionary inputs

## Behavior

```text
same canonical trial batch
→ attached canonical player rows
→ dashboard-backed identity lookup
→ resolved player names and teams
→ unchanged run_id / model_version / simulation_count
→ unchanged simulation metrics
→ no rerun
→ fail open
```

## Architecture

- Enrichment occurs inside `build_model_projection_payload(session, target_date)` while the existing SQLAlchemy session is available.
- `attach_canonical_shadow()` remains transport-only and database-independent.
- Missing canonical projection attachments leave the game unchanged.
- Enrichment errors are recorded under the existing player-projection identity diagnostics without breaking the game response.
- Legacy remains authoritative.

## Validation

- focused identity/attachment tests: `14 passed`
- broader production-shadow/wiring tests: `36 passed`
- Python compilation passed
- `git diff --check` passed

Existing SQLAlchemy, pandas/numexpr, and pandas/bottleneck warnings remain unchanged.

## Files

- `mlb_app/model_projections.py`
- `tests/test_model_projection_player_identity_attachment.py`