### PR TITLE
Version model projection workspace cache

### DIFF
--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -16,6 +16,7 @@ from .shared_artifacts import (
     attach_artifact_metadata,
     artifact_metadata,
     cache_artifact,
+    MODEL_PROJECTION_WORKSPACE_VERSION,
     model_projection_date_key,
     model_projection_probability_key,
     payload_input_hash,
@@ -44,7 +45,7 @@ def _attach_projection_artifact_metadata(payload: Dict[str, Any], target_date: s
         cache_key=_projection_cache_key(target_date),
         source_route="/models/projections",
         source_builder="model_projection_routes._build_uncached_projection_payload",
-        model_version="model_projection_probability_v1",
+        model_version=MODEL_PROJECTION_WORKSPACE_VERSION,
         probability_source="model_projections",
     )
     attach_artifact_metadata(payload, metadata)
@@ -129,6 +130,7 @@ def _apply_projection_probability_contract(payload: Dict[str, Any], target_date:
     notes.append("Canonical matchup probability remains available as a compatibility/fallback diagnostic, not the displayed Model Projections source of truth.")
     payload["source_notes"] = notes
     payload["probability_contract"] = "model_projection_probability_v1"
+    payload["workspace_contract"] = MODEL_PROJECTION_WORKSPACE_VERSION
     payload["probability_source"] = "model_projections"
     return payload
 
@@ -168,7 +170,7 @@ def warm_model_projection_payload(target_date: str) -> Dict[str, Any]:
         artifact_type="model_projection_date",
         source_route="/models/projections",
         source_builder="model_projection_routes.warm_model_projection_payload",
-        model_version="model_projection_probability_v1",
+        model_version=MODEL_PROJECTION_WORKSPACE_VERSION,
         probability_source="model_projections",
     )
     return {
@@ -177,6 +179,7 @@ def warm_model_projection_payload(target_date: str) -> Dict[str, Any]:
         "games_cached": len(stored.get("games") or []) if isinstance(stored, dict) else None,
         "cache_key": _projection_cache_key(target_date),
         "probability_contract": "model_projection_probability_v1",
+        "workspace_contract": MODEL_PROJECTION_WORKSPACE_VERSION,
         "artifact": stored.get("artifact") if isinstance(stored, dict) else None,
     }
 

--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -36,8 +36,17 @@ def matchups_date_key(date: str) -> str:
     return artifact_key("matchups_date", date)
 
 
+MODEL_PROJECTION_WORKSPACE_VERSION = (
+    "model_projection_workspace_v2"
+)
+
+
 def model_projection_date_key(date: str) -> str:
-    return artifact_key("model_projection_date", "probability_contract_v1", date)
+    return artifact_key(
+        "model_projection_date",
+        MODEL_PROJECTION_WORKSPACE_VERSION,
+        date,
+    )
 
 
 def model_projection_probability_key(
@@ -181,6 +190,7 @@ __all__ = [
     "get_or_build_artifact",
     "matchup_overview_key",
     "matchups_date_key",
+    "MODEL_PROJECTION_WORKSPACE_VERSION",
     "model_projection_date_key",
     "model_projection_probability_key",
     "payload_input_hash",

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from mlb_app.model_projection_routes import _apply_projection_probability_contract, _attach_projection_artifact_metadata, _projection_cache_key
 from mlb_app.schedule_calendar import build_schedule_calendar_snapshot, get_or_build_schedule_calendar_snapshot
 from mlb_app.shared_artifacts import (
+    MODEL_PROJECTION_WORKSPACE_VERSION,
     ARTIFACT_SCHEMA_VERSION,
     artifact_key,
     attach_artifact_metadata,
@@ -44,7 +45,14 @@ def test_artifact_keys_are_separated_by_type_and_model_contract() -> None:
     assert len(keys) == 5
     assert schedule_calendar_key(date).startswith(f"artifact:{ARTIFACT_SCHEMA_VERSION}:schedule_calendar")
     assert model_projection_date_key(date).startswith(f"artifact:{ARTIFACT_SCHEMA_VERSION}:model_projection_date")
-    assert "probability_contract_v1" in model_projection_date_key(date)
+    assert (
+        MODEL_PROJECTION_WORKSPACE_VERSION
+        in model_projection_date_key(date)
+    )
+    assert (
+        "probability_contract_v1"
+        not in model_projection_date_key(date)
+    )
 
 
 def test_unknown_artifact_type_raises() -> None:
@@ -150,3 +158,13 @@ def test_projection_probability_artifact_metadata_is_attached_to_game_probabilit
     assert probability["artifact"]["cache_key"] == expected_key
     assert probability["artifact"]["input_hash"] == expected_hash
     assert updated["games"][0]["probability_cache_key"] == expected_key
+
+
+def test_projection_workspace_version_changes_cache_namespace() -> None:
+    date = "2026-07-09"
+
+    key = model_projection_date_key(date)
+
+    assert key.endswith(
+        f"{MODEL_PROJECTION_WORKSPACE_VERSION}:{date}"
+    )


### PR DESCRIPTION
## Summary

Versions the model-projection workspace cache namespace so deployments do not reuse artifacts created before same-run canonical player projections and identity enrichment were attached to the game workspace.

The route now surfaces an explicit `model_projection_workspace_v2` contract and uses it in the model-projection date artifact key and metadata.

## Why

Fresh local builder output contains same-run canonical player rows, identity enrichment, run IDs, and simulation counts for completed canonical executions. Older cached payloads can still omit those fields because the previous cache key was versioned only by the probability contract.

## Behavior

```text
old artifact namespace
artifact:shared_artifact_v1:model_projection_date:probability_contract_v1:DATE
→ no longer reused

new artifact namespace
artifact:shared_artifact_v1:model_projection_date:model_projection_workspace_v2:DATE
→ rebuilt under the current workspace response contract
```

## Added

- `MODEL_PROJECTION_WORKSPACE_VERSION`
- versioned model-projection date artifact keys
- explicit `workspace_contract` field on model-projection payloads and warm responses
- workspace-version metadata on cached artifacts
- regression tests for the new namespace and removal of the old probability-only key contract

## Validation

- artifact/identity/projection tests: `18 passed`
- production-shadow tests: `17 passed`
- Python compilation passed
- `git diff --check` passed

Existing SQLAlchemy and pandas dependency warnings remain unchanged.

## Files

- `mlb_app/model_projection_routes.py`
- `mlb_app/shared_artifacts.py`
- `tests/test_shared_artifacts.py`