### PR TITLE
Phase 2: add private Control Center settings and audit foundation

### DIFF
--- a/docs/mlbgpt_control_center_phase2.md
+++ b/docs/mlbgpt_control_center_phase2.md
@@ -1,0 +1,72 @@
+# MLBGPT Control Center Phase 2
+
+Issue #1175 extends the owner-only Control Center foundation from #1167. It adds private user-directory metadata, code-validated settings and feature flags, and immutable administrative audit history. It does not add Permission Sets, custom roles, operational execution, federation login, or Workbench execution.
+
+## Additive production schema
+
+The deployed `app_users` table is not altered. Phase 2 adds independent tables that SQLAlchemy can create safely:
+
+- `app_user_directory_profiles` extends an existing user with an immutable public UUID, display metadata, locale/language/timezone, active/locked state, last-login time, and a session-revocation version;
+- `federated_identities` reserves issuer/subject identity mappings with a unique issuer + subject constraint and contains no passwords, tokens, or secrets;
+- `app_access_profiles` persists catalog identity for the code-owned `Owner Administrator` and `Standard User` profiles;
+- `app_global_settings` and `app_user_settings` provide typed configuration storage without changing authorization;
+- `app_feature_flags` stores only the four registered foundation flags and their validated profile targets;
+- `app_admin_audit_events` records immutable safe before/after summaries for successful administrative mutations;
+- `app_login_history` records successful password-backed session issuance without recording credentials or tokens.
+
+The existing `app_user_roles` assignment remains the role source of truth. Profile labels map onto that role/capability registry; they do not create another authorization framework.
+
+## Private APIs
+
+Phase 2 keeps the existing read-only overview, object, app, and user-list routes and adds:
+
+```text
+GET   /admin/me
+GET   /admin/users/{user_id}
+PATCH /admin/users/{user_id}
+GET   /admin/profiles
+GET   /admin/settings
+PATCH /admin/settings
+GET   /admin/feature-flags
+PATCH /admin/feature-flags
+GET   /admin/audit-events
+```
+
+Every route uses a server-owned capability dependency. `admin.users.manage` protects safe directory changes, `admin.settings.manage` protects settings and flag changes, and `admin.audit.read` protects audit history. A modified frontend capability array has no authorization effect.
+
+User updates reject email, password, password hash, role, capability, profile assignment, plan, session, token, secret, arbitrary preferences, and saved-report fields. An authenticated owner cannot deactivate or lock itself. Active/locked changes increment the revocation marker and delete every existing session for the affected account.
+
+## Settings and feature flags
+
+The initial global settings are directory-profile defaults for locale, language, and timezone. The server registry owns their types, allowed values, defaults, and descriptions. Unknown keys and invalid values are rejected.
+
+The initial feature flags are:
+
+- `federation_enabled`
+- `federation_admin_enabled`
+- `workbench_query_enabled`
+- `federation_refresh_enabled`
+
+All four resolve to false without a stored override. Target profiles must be `owner_administrator` or `standard_user`. A flag never grants a capability and none of these flags is connected to public product behavior in this phase.
+
+Plaintext secret values are not accepted. Future sensitive configuration must use an environment-backed or external secret reference and must never be serialized through these APIs.
+
+## Audit boundary
+
+Successful user, setting, and feature-flag changes record actor user/session IDs, action, target, safe before/after summaries, source, and timestamp. Audit records have no update or delete API. The serializer excludes password, session-token, token, secret, and sensitive-reference fields.
+
+## Frontend boundary
+
+The existing private `/admin` page now supports:
+
+- safe user-directory editing and account-state controls;
+- a read-only Owner Administrator / Standard User profile catalog;
+- allowlisted global settings;
+- default-off feature flags with profile targeting;
+- read-only audit history.
+
+Operations and Workbench remain locked. There is still no public Admin navigation entry.
+
+## Next implementation phase
+
+The next ticket should define the constrained MLBGPT Workbench request language and compiler over the existing object/field registry. It must accept structured object, field, filter, grouping, aggregate, weight, sort, pagination, date, and relationship inputs; reject arbitrary SQL and physical table names; use bound parameters; enforce cost and row limits; and preserve saved-report compatibility. Permission Sets and delegated role administration remain a later separately reviewed phase.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs src/lib/dashboardReportFolders.test.mjs src/lib/dashboardRenameState.test.mjs src/lib/canonicalDiagnosticsViewModel.test.mjs src/lib/canonicalProjectionsViewModel.test.mjs src/lib/canonicalProjectionsUiContract.test.mjs",
+    "test": "node --test src/lib/landing/selectBetOfTheDay.test.mjs src/lib/modelTrackerPnl.test.mjs src/lib/dashboardReportUtils.test.mjs src/lib/dashboardQueryState.test.mjs src/lib/dashboardReportBuilderState.test.mjs src/lib/dashboardReportFolders.test.mjs src/lib/dashboardRenameState.test.mjs src/lib/dashboardSession.test.mjs src/lib/adminControlCenterState.test.mjs src/lib/canonicalDiagnosticsViewModel.test.mjs src/lib/canonicalProjectionsViewModel.test.mjs src/lib/canonicalProjectionsUiContract.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/lib/adminControlCenterState.mjs
+++ b/frontend/src/lib/adminControlCenterState.mjs
@@ -1,0 +1,52 @@
+export const EDITABLE_DIRECTORY_FIELDS = Object.freeze([
+  'username',
+  'first_name',
+  'last_name',
+  'display_name',
+  'alias',
+  'title',
+  'company',
+  'locale',
+  'language',
+  'timezone',
+  'is_active',
+  'is_locked',
+])
+
+export function editableUserPayload(values = {}) {
+  return Object.fromEntries(
+    EDITABLE_DIRECTORY_FIELDS
+      .filter(key => Object.prototype.hasOwnProperty.call(values, key))
+      .map(key => [key, values[key]]),
+  )
+}
+
+export function userEditorValues(user = {}) {
+  const directory = user.directory || {}
+  return editableUserPayload({
+    username: user.username || '',
+    first_name: directory.first_name || '',
+    last_name: directory.last_name || '',
+    display_name: directory.display_name || '',
+    alias: directory.alias || '',
+    title: directory.title || '',
+    company: directory.company || '',
+    locale: directory.locale || 'en_US',
+    language: directory.language || 'en',
+    timezone: directory.timezone || 'UTC',
+    is_active: directory.is_active !== false,
+    is_locked: Boolean(directory.is_locked),
+  })
+}
+
+export function settingUpdatePayload(setting, value) {
+  return {
+    updates: [{ namespace: setting.namespace, key: setting.key, value }],
+  }
+}
+
+export function featureFlagUpdatePayload(flag, enabled, targetProfiles = flag.target_profiles || []) {
+  return {
+    updates: [{ key: flag.key, enabled: Boolean(enabled), target_profiles: [...targetProfiles] }],
+  }
+}

--- a/frontend/src/lib/adminControlCenterState.test.mjs
+++ b/frontend/src/lib/adminControlCenterState.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  editableUserPayload,
+  featureFlagUpdatePayload,
+  settingUpdatePayload,
+  userEditorValues,
+} from './adminControlCenterState.mjs'
+
+test('user editor payload excludes authorization and credential fields', () => {
+  assert.deepEqual(editableUserPayload({
+    username: 'analyst',
+    display_name: 'Analyst',
+    role: 'admin',
+    capabilities: ['admin.portal.access'],
+    password_hash: 'nope',
+    plan: 'owner',
+  }), {
+    username: 'analyst',
+    display_name: 'Analyst',
+  })
+})
+
+test('user editor values flatten only safe directory fields', () => {
+  const values = userEditorValues({
+    username: 'owner',
+    role: 'admin',
+    directory: { display_name: 'Owner', is_active: true, is_locked: false },
+  })
+  assert.equal(values.username, 'owner')
+  assert.equal(values.display_name, 'Owner')
+  assert.equal(values.is_active, true)
+  assert.equal('role' in values, false)
+})
+
+test('setting and feature flag payloads use the validated API contracts', () => {
+  assert.deepEqual(
+    settingUpdatePayload({ namespace: 'identity', key: 'default_timezone' }, 'America/Chicago'),
+    { updates: [{ namespace: 'identity', key: 'default_timezone', value: 'America/Chicago' }] },
+  )
+  assert.deepEqual(
+    featureFlagUpdatePayload({ key: 'federation_enabled', target_profiles: [] }, true),
+    { updates: [{ key: 'federation_enabled', enabled: true, target_profiles: [] }] },
+  )
+})

--- a/frontend/src/pages/AdminControlCenterPage.jsx
+++ b/frontend/src/pages/AdminControlCenterPage.jsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { adminAccessState, dashboardApi, logoutDashboardSession } from '../lib/dashboardSession.mjs'
+import {
+  editableUserPayload,
+  featureFlagUpdatePayload,
+  settingUpdatePayload,
+  userEditorValues,
+} from '../lib/adminControlCenterState.mjs'
 
 const FRANKLIN = '"Franklin Gothic Medium", "Franklin Gothic", "Arial Narrow", Arial, sans-serif'
 const CENTURY = '"Century Gothic", CenturyGothic, AppleGothic, Arial, sans-serif'
@@ -13,10 +19,10 @@ const SECTIONS = [
   ['objects', 'Object Manager', 'functional'],
   ['apps', 'Apps', 'functional'],
   ['users', 'Users & Access', 'functional'],
-  ['settings', 'Settings', 'locked'],
+  ['settings', 'Settings', 'functional'],
   ['operations', 'Operations', 'locked'],
   ['workbench', 'Workbench', 'locked'],
-  ['audit', 'Audit Log', 'locked'],
+  ['audit', 'Audit Log', 'functional'],
 ]
 
 const ENDPOINTS = {
@@ -24,6 +30,30 @@ const ENDPOINTS = {
   objects: '/admin/objects',
   apps: '/admin/apps',
   users: '/admin/users',
+  audit: '/admin/audit-events',
+}
+
+async function loadAdminSection(section) {
+  if (section === 'users') {
+    const [users, profiles] = await Promise.all([
+      dashboardApi('/admin/users'),
+      dashboardApi('/admin/profiles'),
+    ])
+    return { ...users, profiles: profiles.profiles || [] }
+  }
+  if (section === 'settings') {
+    const [settings, flags, profiles] = await Promise.all([
+      dashboardApi('/admin/settings'),
+      dashboardApi('/admin/feature-flags'),
+      dashboardApi('/admin/profiles'),
+    ])
+    return {
+      settings: settings.settings || [],
+      feature_flags: flags.feature_flags || [],
+      profiles: profiles.profiles || [],
+    }
+  }
+  return dashboardApi(ENDPOINTS[section])
 }
 
 function titleCase(value) {
@@ -62,8 +92,8 @@ function OverviewPanel({ data }) {
   const hydration = data?.operations?.hydration || {}
   return <div style={s.stack}>
     <section style={s.heroCard}>
-      <div><div style={s.eyebrow}>Owner Console</div><h2 style={s.sectionTitle}>System overview</h2><p style={s.copy}>Read-only visibility into registered MLBGPT objects, application surfaces, users, and operational freshness.</p></div>
-      <div style={s.badgeRow}><Badge tone="green">{data?.administrator?.role || 'admin'}</Badge><Badge>{counts.capabilities || 0} capabilities</Badge><Badge tone="amber">Read only</Badge></div>
+      <div><div style={s.eyebrow}>Owner Console</div><h2 style={s.sectionTitle}>System overview</h2><p style={s.copy}>Private visibility into registered MLBGPT objects, applications, users, configuration, and operational freshness.</p></div>
+      <div style={s.badgeRow}><Badge tone="green">{data?.administrator?.role || 'admin'}</Badge><Badge>{counts.capabilities || 0} capabilities</Badge><Badge tone="amber">Owner only</Badge></div>
     </section>
     <div style={s.metricGrid}>
       <Metric label="Registered objects" value={counts.objects} />
@@ -80,7 +110,7 @@ function OverviewPanel({ data }) {
         <Metric label="Warnings" value={hydration.warning_count} />
       </div>
     </section>
-    <section style={s.card}><div style={s.cardHeader}><div><div style={s.eyebrow}>Roadmap Boundary</div><h3 style={s.cardTitle}>Next-phase areas</h3></div><Badge tone="amber">Locked</Badge></div><div style={s.lockGrid}>{(data?.locked_sections || []).map(section => <div style={s.lockCard} key={section.key}><strong>{section.label}</strong><span>{section.next_phase}</span></div>)}</div></section>
+    <section style={s.card}><div style={s.cardHeader}><div><div style={s.eyebrow}>Roadmap Boundary</div><h3 style={s.cardTitle}>Still locked</h3></div><Badge tone="amber">2 areas</Badge></div><div style={s.lockGrid}>{(data?.locked_sections || []).map(section => <div style={s.lockCard} key={section.key}><strong>{section.label}</strong><span>{section.next_phase}</span></div>)}</div></section>
   </div>
 }
 
@@ -115,13 +145,110 @@ function AppsPanel({ data }) {
   return <div style={s.stack}><section style={s.sectionHeader}><div><div style={s.eyebrow}>Code-owned Registry</div><h2 style={s.sectionTitle}>Applications</h2><p style={s.copy}>User-facing application surfaces and their safe availability classifications.</p></div><Badge>{data?.totalSize || 0} surfaces</Badge></section><div style={s.appGrid}>{(data?.apps || []).map(app => <article style={s.card} key={app.key}><div style={s.cardHeader}><div><small style={s.apiName}>{app.route}</small><h3 style={s.cardTitle}>{app.label}</h3></div><Badge tone={app.visibility === 'admin' ? 'amber' : app.visibility === 'authenticated' ? 'green' : 'blue'}>{titleCase(app.visibility)}</Badge></div><div style={s.detailList}><span><b>Status</b>{titleCase(app.feature_status)}</span><span><b>Health</b>{titleCase(app.health_classification)}</span></div></article>)}</div></div>
 }
 
-function UsersPanel({ data }) {
-  return <div style={s.stack}><section style={s.sectionHeader}><div><div style={s.eyebrow}>Safe Directory</div><h2 style={s.sectionTitle}>Users & Access</h2><p style={s.copy}>Identity, role, plan display value, and resolved capabilities only. Sessions, credentials, preferences, and saved report contents are excluded.</p></div><Badge>{data?.totalSize || 0} users</Badge></section><div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>User</th><th style={s.th}>Role</th><th style={s.th}>Plan</th><th style={s.th}>Capabilities</th><th style={s.th}>Created</th><th style={s.th}>Updated</th></tr></thead><tbody>{(data?.users || []).map(user => <tr key={user.id}><td style={s.td}><strong>{user.username}</strong><small style={s.userEmail}>{user.email}</small></td><td style={s.td}><Badge tone={user.role === 'admin' ? 'amber' : 'blue'}>{titleCase(user.role)}</Badge></td><td style={s.td}>{titleCase(user.plan)}</td><td style={s.td}>{formatValue(user.capabilities)}</td><td style={s.td}>{user.created_at || '—'}</td><td style={s.td}>{user.updated_at || '—'}</td></tr>)}</tbody></table></div></div>
+function UsersPanel({ data, currentUserId, onRefresh }) {
+  const [selected, setSelected] = useState(null)
+  const [editor, setEditor] = useState({})
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState('')
+
+  async function editUser(userId) {
+    setMessage('')
+    try {
+      const payload = await dashboardApi(`/admin/users/${userId}`)
+      setSelected(payload.user)
+      setEditor(userEditorValues(payload.user))
+    } catch (error) {
+      setMessage(error.message || 'User profile could not be loaded.')
+    }
+  }
+
+  async function saveUser(event) {
+    event.preventDefault()
+    setSaving(true)
+    setMessage('')
+    try {
+      const payload = await dashboardApi(`/admin/users/${selected.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(editableUserPayload(editor)),
+      })
+      setSelected(payload.user)
+      setEditor(userEditorValues(payload.user))
+      setMessage(payload.sessions_revoked ? 'Profile saved. Existing sessions were revoked.' : 'Profile saved.')
+      await onRefresh()
+    } catch (error) {
+      setMessage(error.message || 'Profile could not be saved.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return <div style={s.stack}>
+    <section style={s.sectionHeader}><div><div style={s.eyebrow}>Safe Directory</div><h2 style={s.sectionTitle}>Users & Access</h2><p style={s.copy}>Edit directory metadata and account state. Roles and capabilities remain server-owned and cannot be changed here.</p></div><Badge>{data?.totalSize || 0} users</Badge></section>
+    <div style={s.appGrid}>{(data?.profiles || []).map(profile => <article style={s.card} key={profile.key}><div style={s.cardHeader}><div><small style={s.apiName}>{profile.key}</small><h3 style={s.cardTitle}>{profile.label}</h3></div><Badge tone={profile.role === 'admin' ? 'amber' : 'blue'}>{titleCase(profile.role)}</Badge></div><p style={s.copy}>{profile.description}</p><small style={s.muted}>{profile.capabilities.length} server-owned capabilities · Read only</small></article>)}</div>
+    {message ? <div style={message.includes('could not') ? s.error : s.success}>{message}</div> : null}
+    {selected ? <form style={s.card} onSubmit={saveUser}>
+      <div style={s.cardHeader}><div><div style={s.eyebrow}>Directory record</div><h3 style={s.cardTitle}>{selected.email}</h3></div><button type="button" style={s.secondaryButton} onClick={() => setSelected(null)}>Cancel</button></div>
+      <div style={s.formGrid}>{['username', 'first_name', 'last_name', 'display_name', 'alias', 'title', 'company', 'locale', 'language', 'timezone'].map(key => <label style={s.field} key={key}>{titleCase(key)}<input style={s.input} value={editor[key] || ''} onChange={event => setEditor(current => ({ ...current, [key]: event.target.value }))} /></label>)}</div>
+      <div style={s.checkRow}><label><input type="checkbox" checked={editor.is_active !== false} disabled={selected.id === currentUserId} onChange={event => setEditor(current => ({ ...current, is_active: event.target.checked }))} /> Active</label><label><input type="checkbox" checked={Boolean(editor.is_locked)} disabled={selected.id === currentUserId} onChange={event => setEditor(current => ({ ...current, is_locked: event.target.checked }))} /> Locked</label><Badge>{titleCase(selected.profile_key)}</Badge></div>
+      <button style={s.primaryButton} disabled={saving}>{saving ? 'Saving…' : 'Save Profile'}</button>
+    </form> : null}
+    <div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>User</th><th style={s.th}>Role</th><th style={s.th}>Plan</th><th style={s.th}>Capabilities</th><th style={s.th}>Updated</th><th style={s.th}>Action</th></tr></thead><tbody>{(data?.users || []).map(user => <tr key={user.id}><td style={s.td}><strong>{user.username}</strong><small style={s.userEmail}>{user.email}</small></td><td style={s.td}><Badge tone={user.role === 'admin' ? 'amber' : 'blue'}>{titleCase(user.role)}</Badge></td><td style={s.td}>{titleCase(user.plan)}</td><td style={s.td}>{formatValue(user.capabilities)}</td><td style={s.td}>{user.updated_at || '—'}</td><td style={s.td}><button style={s.inlineButton} onClick={() => editUser(user.id)}>Edit</button></td></tr>)}</tbody></table></div>
+  </div>
+}
+
+function SettingsPanel({ data, onRefresh, isMobile }) {
+  const [values, setValues] = useState({})
+  const [flagTargets, setFlagTargets] = useState({})
+  const [message, setMessage] = useState('')
+
+  async function saveSetting(setting) {
+    setMessage('')
+    try {
+      await dashboardApi('/admin/settings', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settingUpdatePayload(setting, values[`${setting.namespace}.${setting.key}`] ?? setting.value)),
+      })
+      setMessage(`${titleCase(setting.key)} saved.`)
+      await onRefresh()
+    } catch (error) { setMessage(error.message || 'Setting could not be saved.') }
+  }
+
+  async function saveFlag(flag, enabled) {
+    setMessage('')
+    try {
+      await dashboardApi('/admin/feature-flags', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(featureFlagUpdatePayload(flag, enabled, flagTargets[flag.key] ?? flag.target_profiles)),
+      })
+      setMessage(`${flag.label} saved.`)
+      await onRefresh()
+    } catch (error) { setMessage(error.message || 'Feature flag could not be saved.') }
+  }
+
+  function toggleTarget(flag, key) {
+    const current = flagTargets[flag.key] ?? flag.target_profiles
+    const next = current.includes(key) ? current.filter(item => item !== key) : [...current, key]
+    setFlagTargets(values => ({ ...values, [flag.key]: next }))
+  }
+
+  return <div style={s.stack}>
+    <section style={s.sectionHeader}><div><div style={s.eyebrow}>Validated Configuration</div><h2 style={s.sectionTitle}>Settings</h2><p style={s.copy}>Only code-registered keys and values are accepted. These controls cannot grant capabilities, store secrets, or bypass server authorization.</p></div><Badge tone="green">Audited</Badge></section>
+    {message ? <div style={message.includes('could not') ? s.error : s.success}>{message}</div> : null}
+    <section style={s.card}><div style={s.eyebrow}>Global defaults</div><div style={s.settingList}>{(data?.settings || []).map(setting => { const id = `${setting.namespace}.${setting.key}`; const allowed = setting.validation?.allowed || []; return <div style={{ ...s.settingRow, ...(isMobile ? s.settingRowMobile : {}) }} key={id}><div><strong>{titleCase(setting.key)}</strong><small style={s.muted}>{setting.description}</small><small style={s.apiName}>{id}</small></div>{allowed.length ? <select style={s.input} value={values[id] ?? setting.value} onChange={event => setValues(current => ({ ...current, [id]: event.target.value }))}>{allowed.map(value => <option key={value}>{value}</option>)}</select> : <input style={s.input} value={values[id] ?? setting.value} onChange={event => setValues(current => ({ ...current, [id]: event.target.value }))} />}<button style={s.inlineButton} onClick={() => saveSetting(setting)}>Save</button></div> })}</div></section>
+    <section style={s.card}><div style={s.eyebrow}>Feature flags</div><p style={s.copy}>All flags default off. They are foundation records only and are not wired into public behavior in this phase.</p><div style={s.settingList}>{(data?.feature_flags || []).map(flag => <div style={{ ...s.settingRow, ...(isMobile ? s.settingRowMobile : {}) }} key={flag.key}><div><strong>{flag.label}</strong><small style={s.muted}>{flag.description}</small><small style={s.apiName}>{flag.key}</small><div style={s.checkRow}>{(data?.profiles || []).map(profile => <label key={profile.key}><input type="checkbox" checked={(flagTargets[flag.key] ?? flag.target_profiles).includes(profile.key)} onChange={() => toggleTarget(flag, profile.key)} /> {profile.label}</label>)}</div></div><Badge tone={flag.enabled ? 'green' : 'amber'}>{flag.enabled ? 'Enabled' : 'Disabled'}</Badge><button style={s.inlineButton} onClick={() => saveFlag(flag, !flag.enabled)}>{flag.enabled ? 'Disable' : 'Enable'}</button></div>)}</div></section>
+  </div>
+}
+
+function AuditPanel({ data }) {
+  return <div style={s.stack}><section style={s.sectionHeader}><div><div style={s.eyebrow}>Immutable History</div><h2 style={s.sectionTitle}>Audit Log</h2><p style={s.copy}>Safe summaries of successful Control Center mutations. Credentials, sessions, secrets, and saved-report content are excluded.</p></div><Badge>{data?.totalSize || 0} events</Badge></section><div style={s.tableWrap}><table style={s.table}><thead><tr><th style={s.th}>Time</th><th style={s.th}>Actor</th><th style={s.th}>Action</th><th style={s.th}>Target</th><th style={s.th}>Before</th><th style={s.th}>After</th></tr></thead><tbody>{(data?.audit_events || []).map(event => <tr key={event.id}><td style={s.td}>{event.created_at}</td><td style={s.td}>{event.actor?.username || event.actor?.id}</td><td style={s.codeCell}>{event.action}</td><td style={s.td}>{event.target_type}: {event.target_identifier}</td><td style={s.td}>{formatValue(event.before)}</td><td style={s.td}>{formatValue(event.after)}</td></tr>)}</tbody></table>{!data?.audit_events?.length ? <div style={s.empty}>No administrative changes have been recorded yet.</div> : null}</div></div>
 }
 
 function LockedPanel({ section, overview }) {
   const contract = (overview?.locked_sections || []).find(item => item.key === section)
-  return <section style={s.lockedPanel}><div style={s.lockIcon}>◇</div><div style={s.eyebrow}>Phase 1 Boundary</div><h2 style={s.sectionTitle}>{contract?.label || titleCase(section)} is locked</h2><p style={s.copy}>{contract?.next_phase || 'This administrative area is intentionally unavailable in the current read-only foundation.'}</p><Badge tone="amber">No mutable controls</Badge></section>
+  return <section style={s.lockedPanel}><div style={s.lockIcon}>◇</div><div style={s.eyebrow}>Phase 2 Boundary</div><h2 style={s.sectionTitle}>{contract?.label || titleCase(section)} is locked</h2><p style={s.copy}>{contract?.next_phase || 'This administrative area is intentionally unavailable in the current foundation.'}</p><Badge tone="amber">Unavailable</Badge></section>
 }
 
 export default function AdminControlCenterPage() {
@@ -172,13 +299,13 @@ export default function AdminControlCenterPage() {
   }, [])
 
   useEffect(() => {
-    if (accessState !== 'ready' || !ENDPOINTS[active] || data[active]) return
+    if (accessState !== 'ready' || (!ENDPOINTS[active] && !['users', 'settings'].includes(active)) || data[active]) return
     let cancelled = false
     async function loadSection() {
       setSectionLoading(true)
       setError('')
       try {
-        const payload = await dashboardApi(ENDPOINTS[active])
+        const payload = await loadAdminSection(active)
         if (!cancelled) setData(current => ({ ...current, [active]: payload }))
       } catch (requestError) {
         if (!cancelled) {
@@ -193,13 +320,20 @@ export default function AdminControlCenterPage() {
     return () => { cancelled = true }
   }, [active, accessState, data])
 
+  async function refreshSection(section) {
+    const payload = await loadAdminSection(section)
+    setData(current => ({ ...current, [section]: payload }))
+  }
+
   const sectionContent = useMemo(() => {
     if (active === 'overview') return <OverviewPanel data={data.overview} />
     if (active === 'objects') return <ObjectPanel data={data.objects} />
     if (active === 'apps') return <AppsPanel data={data.apps} />
-    if (active === 'users') return <UsersPanel data={data.users} />
+    if (active === 'users') return <UsersPanel data={data.users} currentUserId={profile?.id} onRefresh={() => refreshSection('users')} />
+    if (active === 'settings') return <SettingsPanel data={data.settings} onRefresh={() => refreshSection('settings')} isMobile={isMobile} />
+    if (active === 'audit') return <AuditPanel data={data.audit} />
     return <LockedPanel section={active} overview={data.overview} />
-  }, [active, data])
+  }, [active, data, profile, isMobile])
 
   if (accessState === 'loading' && !data.overview) return <StatePage eyebrow="MLBGPT Control Center" title="Verifying administrator access">Checking the active server session.</StatePage>
   if (accessState === 'sign_in_required') return <StatePage eyebrow="Private Administration" title="Sign-in required" action={<a style={s.primaryLink} href="/my-dashboard">Sign in through MyDashboard</a>}>A password-backed MyDashboard session is required before this route can verify administrator access.</StatePage>
@@ -276,4 +410,14 @@ const s = {
   secondaryButton: { padding: '8px 11px', color: C.text, fontFamily: FRANKLIN, fontSize: 11, background: C.panel2, border: `1px solid ${C.border}`, borderRadius: 8 },
   loadingBar: { marginBottom: 10, padding: 8, color: C.blue, background: 'rgba(96,165,250,.1)', borderRadius: 8 },
   error: { marginBottom: 10, padding: 10, color: '#fecaca', background: 'rgba(248,113,113,.12)', border: '1px solid rgba(248,113,113,.3)', borderRadius: 9 },
+  success: { marginBottom: 10, padding: 10, color: '#a7f3d0', background: 'rgba(52,211,153,.12)', border: '1px solid rgba(52,211,153,.3)', borderRadius: 9 },
+  formGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 10, margin: '14px 0' },
+  field: { display: 'grid', gap: 5, color: C.muted, fontSize: 11 },
+  input: { minWidth: 0, boxSizing: 'border-box', padding: '8px 9px', color: C.text, fontFamily: CENTURY, fontSize: 12, background: C.panel2, border: `1px solid ${C.border}`, borderRadius: 8 },
+  checkRow: { display: 'flex', gap: 14, flexWrap: 'wrap', alignItems: 'center', margin: '10px 0' },
+  primaryButton: { padding: '9px 13px', color: C.text, fontFamily: FRANKLIN, fontSize: 12, background: 'rgba(52,211,153,.18)', border: '1px solid rgba(52,211,153,.45)', borderRadius: 8 },
+  inlineButton: { padding: '6px 9px', color: C.text, fontFamily: FRANKLIN, fontSize: 10, background: 'rgba(96,165,250,.14)', border: '1px solid rgba(96,165,250,.35)', borderRadius: 7 },
+  settingList: { display: 'grid', gap: 8, marginTop: 12 },
+  settingRow: { display: 'grid', gridTemplateColumns: 'minmax(220px,1fr) minmax(150px,260px) auto', gap: 10, alignItems: 'center', padding: 11, background: C.panel2, border: `1px solid ${C.border}`, borderRadius: 10 },
+  settingRowMobile: { gridTemplateColumns: 'minmax(0,1fr)', alignItems: 'stretch' },
 }

--- a/mlb_app/admin_access.py
+++ b/mlb_app/admin_access.py
@@ -13,6 +13,7 @@ from fastapi import Cookie, Depends, Header, HTTPException
 from .database import (
     AppSession,
     AppUser,
+    AppUserDirectoryProfile,
     AppUserRole,
     create_tables,
     get_engine,
@@ -37,12 +38,19 @@ ADMIN_CAPABILITIES: Tuple[str, ...] = tuple(sorted({
     *USER_CAPABILITIES,
     "admin.apps.read",
     "admin.audit.read",
+    "admin.federation.manage",
     "admin.objects.read",
     "admin.operations.read",
+    "admin.operations.run",
     "admin.portal.access",
+    "admin.profiles.manage",
+    "admin.profiles.read",
     "admin.settings.read",
+    "admin.settings.manage",
+    "admin.users.manage",
     "admin.users.read",
     "workbench.advanced",
+    "workbench.execute",
 }))
 
 
@@ -219,6 +227,13 @@ def resolve_principal(session, token: Optional[str]) -> Optional[DashboardPrinci
     user = session.query(AppUser).filter(AppUser.id == db_session.user_id).first()
     if not user:
         return None
+    directory = (
+        session.query(AppUserDirectoryProfile)
+        .filter(AppUserDirectoryProfile.user_id == user.id)
+        .first()
+    )
+    if directory and (not directory.is_active or directory.is_locked):
+        raise HTTPException(status_code=403, detail="This account is inactive or locked")
     db_session.last_seen_at = now
     role = resolved_role_for_user(
         session,

--- a/mlb_app/admin_configuration.py
+++ b/mlb_app/admin_configuration.py
@@ -1,0 +1,304 @@
+"""Code-owned Control Center profiles, settings, and feature-flag contracts."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
+from fastapi import HTTPException
+
+from .database import (
+    AppAccessProfile,
+    AppAdminAuditEvent,
+    AppFeatureFlag,
+    AppGlobalSetting,
+    AppUserDirectoryProfile,
+)
+
+PROFILE_OWNER = "owner_administrator"
+PROFILE_STANDARD = "standard_user"
+
+PROFILE_DEFINITIONS: Dict[str, Dict[str, str]] = {
+    PROFILE_OWNER: {
+        "label": "Owner Administrator",
+        "role": "admin",
+        "description": "Private owner profile with server-verified administrative capabilities.",
+    },
+    PROFILE_STANDARD: {
+        "label": "Standard User",
+        "role": "user",
+        "description": "Personal MyDashboard reporting, folders, saved reports, and export.",
+    },
+}
+
+SETTING_DEFINITIONS: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("identity", "default_locale"): {
+        "value_type": "string",
+        "default": "en_US",
+        "description": "Default locale for newly materialized directory profiles.",
+        "validation": {"allowed": ["en_US"]},
+        "environment_variable": None,
+        "sensitive": False,
+    },
+    ("identity", "default_language"): {
+        "value_type": "string",
+        "default": "en",
+        "description": "Default language for newly materialized directory profiles.",
+        "validation": {"allowed": ["en"]},
+        "environment_variable": None,
+        "sensitive": False,
+    },
+    ("identity", "default_timezone"): {
+        "value_type": "string",
+        "default": "UTC",
+        "description": "Default timezone for newly materialized directory profiles.",
+        "validation": {
+            "allowed": [
+                "UTC",
+                "America/Chicago",
+                "America/Denver",
+                "America/Los_Angeles",
+                "America/New_York",
+            ]
+        },
+        "environment_variable": None,
+        "sensitive": False,
+    },
+}
+
+FEATURE_FLAG_DEFINITIONS: Dict[str, Dict[str, str]] = {
+    "federation_enabled": {
+        "label": "Federation",
+        "description": "Foundation gate for federated data services. No public behavior is wired in this phase.",
+    },
+    "federation_admin_enabled": {
+        "label": "Federation administration",
+        "description": "Foundation gate for future owner-only federation controls.",
+    },
+    "workbench_query_enabled": {
+        "label": "Workbench query",
+        "description": "Foundation gate only; the Workbench compiler and execution remain unavailable.",
+    },
+    "federation_refresh_enabled": {
+        "label": "Federation refresh",
+        "description": "Foundation gate only; no refresh or backfill action is exposed.",
+    },
+}
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(tzinfo=None)
+
+
+def profile_key_for_role(role: str) -> str:
+    return PROFILE_OWNER if role == "admin" else PROFILE_STANDARD
+
+
+def ensure_profile_catalog(session) -> None:
+    now = _utcnow()
+    existing = {
+        item.profile_key: item
+        for item in session.query(AppAccessProfile).all()
+    }
+    for key, definition in PROFILE_DEFINITIONS.items():
+        item = existing.get(key)
+        if item is None:
+            session.add(AppAccessProfile(
+                profile_key=key,
+                label=definition["label"],
+                role=definition["role"],
+                description=definition["description"],
+                created_at=now,
+                updated_at=now,
+            ))
+            continue
+        # Labels and role mappings are code-owned and converge only when needed.
+        expected = (
+            definition["label"],
+            definition["role"],
+            definition["description"],
+        )
+        if (item.label, item.role, item.description) != expected:
+            item.label, item.role, item.description = expected
+            item.updated_at = now
+
+
+def serialize_profile_catalog(capabilities_for_role) -> List[Dict[str, Any]]:
+    return [
+        {
+            "key": key,
+            "label": definition["label"],
+            "role": definition["role"],
+            "description": definition["description"],
+            "capabilities": list(capabilities_for_role(definition["role"])),
+            "mutable": False,
+        }
+        for key, definition in PROFILE_DEFINITIONS.items()
+    ]
+
+
+def get_or_create_directory_profile(
+    session,
+    user_id: int,
+    *,
+    actor_user_id: int | None = None,
+) -> AppUserDirectoryProfile:
+    profile = (
+        session.query(AppUserDirectoryProfile)
+        .filter(AppUserDirectoryProfile.user_id == user_id)
+        .first()
+    )
+    if profile is not None:
+        return profile
+    defaults = resolved_setting_values(session)
+    now = _utcnow()
+    profile = AppUserDirectoryProfile(
+        user_id=user_id,
+        locale=defaults[("identity", "default_locale")],
+        language=defaults[("identity", "default_language")],
+        timezone=defaults[("identity", "default_timezone")],
+        created_by_user_id=actor_user_id,
+        updated_by_user_id=actor_user_id,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(profile)
+    session.flush()
+    return profile
+
+
+def validate_setting_value(namespace: str, key: str, value: Any) -> Any:
+    definition = SETTING_DEFINITIONS.get((namespace, key))
+    if definition is None:
+        raise HTTPException(status_code=400, detail=f"Unknown setting: {namespace}.{key}")
+    if definition.get("sensitive"):
+        raise HTTPException(status_code=400, detail="Plaintext sensitive settings are not accepted")
+    expected = definition["value_type"]
+    if expected == "boolean" and type(value) is not bool:
+        raise HTTPException(status_code=400, detail=f"{namespace}.{key} must be a boolean")
+    if expected == "integer" and (type(value) is not int):
+        raise HTTPException(status_code=400, detail=f"{namespace}.{key} must be an integer")
+    if expected == "string" and not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{namespace}.{key} must be a string")
+    allowed = definition.get("validation", {}).get("allowed")
+    if allowed is not None and value not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{namespace}.{key} must be one of: {', '.join(map(str, allowed))}",
+        )
+    return value.strip() if isinstance(value, str) else value
+
+
+def resolved_setting_values(session) -> Dict[Tuple[str, str], Any]:
+    values = {
+        identity: definition["default"]
+        for identity, definition in SETTING_DEFINITIONS.items()
+    }
+    for item in session.query(AppGlobalSetting).all():
+        identity = (item.namespace, item.setting_key)
+        if identity in SETTING_DEFINITIONS and item.sensitive_reference is None:
+            values[identity] = item.value_json
+    return values
+
+
+def serialize_settings(session) -> List[Dict[str, Any]]:
+    rows = {
+        (item.namespace, item.setting_key): item
+        for item in session.query(AppGlobalSetting).all()
+    }
+    values = resolved_setting_values(session)
+    payload = []
+    for identity, definition in SETTING_DEFINITIONS.items():
+        namespace, key = identity
+        row = rows.get(identity)
+        payload.append({
+            "namespace": namespace,
+            "key": key,
+            "value_type": definition["value_type"],
+            "value": values[identity],
+            "default_value": definition["default"],
+            "validation": definition.get("validation", {}),
+            "description": definition["description"],
+            "environment_override": bool(definition.get("environment_variable")),
+            "environment_variable": definition.get("environment_variable"),
+            "sensitive": bool(definition.get("sensitive")),
+            "configured": row is not None,
+            "updated_at": row.updated_at.isoformat() if row and row.updated_at else None,
+        })
+    return payload
+
+
+def validate_target_profiles(values: Iterable[str]) -> List[str]:
+    normalized = sorted({str(value or "").strip() for value in values if str(value or "").strip()})
+    unknown = [value for value in normalized if value not in PROFILE_DEFINITIONS]
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown target profile: {unknown[0]}")
+    return normalized
+
+
+def serialize_feature_flags(session) -> List[Dict[str, Any]]:
+    rows = {item.flag_key: item for item in session.query(AppFeatureFlag).all()}
+    payload = []
+    for key, definition in FEATURE_FLAG_DEFINITIONS.items():
+        row = rows.get(key)
+        payload.append({
+            "key": key,
+            "label": definition["label"],
+            "description": definition["description"],
+            "enabled": bool(row.enabled) if row else False,
+            "target_profiles": validate_target_profiles(row.target_profiles_json or []) if row else [],
+            "default_enabled": False,
+            "configured": row is not None,
+            "authorization_effect": "none",
+            "updated_at": row.updated_at.isoformat() if row and row.updated_at else None,
+        })
+    return payload
+
+
+def safe_audit_value(value: Any) -> Any:
+    """Recursively remove security-bearing fields before persistence or response."""
+
+    forbidden = {
+        "password",
+        "password_hash",
+        "session_token",
+        "token",
+        "secret",
+        "sensitive_reference",
+    }
+    if isinstance(value, Mapping):
+        return {
+            str(key): safe_audit_value(item)
+            for key, item in value.items()
+            if str(key).lower() not in forbidden
+        }
+    if isinstance(value, (list, tuple)):
+        return [safe_audit_value(item) for item in value]
+    return value
+
+
+def record_audit_event(
+    session,
+    *,
+    actor_user_id: int,
+    actor_session_id: int | None,
+    action: str,
+    target_type: str,
+    target_identifier: str,
+    before: Any,
+    after: Any,
+) -> AppAdminAuditEvent:
+    event = AppAdminAuditEvent(
+        actor_user_id=actor_user_id,
+        actor_session_id=actor_session_id,
+        action=action,
+        target_type=target_type,
+        target_identifier=str(target_identifier),
+        before_json=safe_audit_value(before),
+        after_json=safe_audit_value(after),
+        source="control_center_api",
+        created_at=_utcnow(),
+    )
+    session.add(event)
+    session.flush()
+    return event

--- a/mlb_app/admin_routes.py
+++ b/mlb_app/admin_routes.py
@@ -1,31 +1,52 @@
-"""Owner-only, read-only MLBGPT Control Center APIs."""
+"""Private MLBGPT Control Center APIs."""
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+import datetime as dt
+from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 from .admin_access import (
     DashboardPrincipal,
     access_payload_for_user,
+    capabilities_for_role,
     dashboard_session_factory,
     require_capability,
 )
+from .admin_configuration import (
+    FEATURE_FLAG_DEFINITIONS,
+    PROFILE_DEFINITIONS,
+    SETTING_DEFINITIONS,
+    ensure_profile_catalog,
+    get_or_create_directory_profile,
+    profile_key_for_role,
+    record_audit_event,
+    serialize_feature_flags,
+    serialize_profile_catalog,
+    serialize_settings,
+    validate_setting_value,
+    validate_target_profiles,
+)
 from .application_registry import list_application_surfaces
 from .dashboard_report_types import list_report_types
-from .database import AppUser, AppUserPreference
+from .database import (
+    AppAdminAuditEvent,
+    AppFeatureFlag,
+    AppGlobalSetting,
+    AppSession,
+    AppUser,
+    AppUserDirectoryProfile,
+    AppUserPreference,
+    FederatedIdentity,
+)
 from .my_dashboard_observability import latest_hydration_status
 
 router = APIRouter(prefix="/admin", tags=["admin-control-center"])
 
 LOCKED_SECTIONS = [
-    {
-        "key": "settings",
-        "label": "Settings",
-        "status": "locked",
-        "next_phase": "Allowlisted settings and feature controls",
-    },
     {
         "key": "operations",
         "label": "Operations",
@@ -38,17 +59,60 @@ LOCKED_SECTIONS = [
         "status": "locked",
         "next_phase": "Constrained MLBGPT report language and compiler",
     },
-    {
-        "key": "audit",
-        "label": "Audit Log",
-        "status": "locked",
-        "next_phase": "Administrative action history",
-    },
 ]
+
+
+class AdminUserUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    username: Optional[str] = Field(default=None, max_length=80)
+    first_name: Optional[str] = Field(default=None, max_length=80)
+    last_name: Optional[str] = Field(default=None, max_length=80)
+    display_name: Optional[str] = Field(default=None, max_length=160)
+    alias: Optional[str] = Field(default=None, max_length=80)
+    title: Optional[str] = Field(default=None, max_length=120)
+    company: Optional[str] = Field(default=None, max_length=160)
+    locale: Optional[str] = Field(default=None, min_length=2, max_length=32)
+    language: Optional[str] = Field(default=None, min_length=2, max_length=16)
+    timezone: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    is_active: Optional[StrictBool] = None
+    is_locked: Optional[StrictBool] = None
+
+
+class AdminSettingUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    namespace: str = Field(min_length=1, max_length=64)
+    key: str = Field(min_length=1, max_length=128)
+    value: Any
+
+
+class AdminSettingsPatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    updates: List[AdminSettingUpdate] = Field(min_length=1, max_length=25)
+
+
+class AdminFeatureFlagUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(min_length=1, max_length=128)
+    enabled: StrictBool
+    target_profiles: List[str] = Field(default_factory=list, max_length=10)
+
+
+class AdminFeatureFlagsPatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    updates: List[AdminFeatureFlagUpdate] = Field(min_length=1, max_length=25)
 
 
 def _session_factory():
     return dashboard_session_factory()
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(tzinfo=None)
 
 
 def _safe_hydration_summary() -> Dict[str, Any]:
@@ -93,6 +157,8 @@ def _object_manager_descriptors() -> List[Dict[str, Any]]:
 
 
 def _admin_user_payload(session, user: AppUser) -> Dict[str, Any]:
+    """Preserve the Phase 1 minimized list contract."""
+
     prefs = (
         session.query(AppUserPreference)
         .filter(AppUserPreference.user_id == user.id)
@@ -111,6 +177,72 @@ def _admin_user_payload(session, user: AppUser) -> Dict[str, Any]:
     }
 
 
+def _directory_payload(profile: AppUserDirectoryProfile) -> Dict[str, Any]:
+    return {
+        "public_id": profile.public_id,
+        "first_name": profile.first_name,
+        "last_name": profile.last_name,
+        "display_name": profile.display_name,
+        "alias": profile.alias,
+        "title": profile.title,
+        "company": profile.company,
+        "is_active": bool(profile.is_active),
+        "is_locked": bool(profile.is_locked),
+        "locale": profile.locale,
+        "language": profile.language,
+        "timezone": profile.timezone,
+        "session_version": profile.session_version,
+        "last_login_at": profile.last_login_at.isoformat() if profile.last_login_at else None,
+        "created_at": profile.created_at.isoformat() if profile.created_at else None,
+        "updated_at": profile.updated_at.isoformat() if profile.updated_at else None,
+    }
+
+
+def _admin_user_detail(session, user: AppUser, *, actor_user_id: int) -> Dict[str, Any]:
+    directory = get_or_create_directory_profile(
+        session,
+        user.id,
+        actor_user_id=actor_user_id,
+    )
+    access = access_payload_for_user(session, user)
+    identities = (
+        session.query(FederatedIdentity)
+        .filter(FederatedIdentity.user_id == user.id)
+        .all()
+    )
+    return {
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "role": access["role"],
+        "profile_key": profile_key_for_role(access["role"]),
+        "capabilities": list(access["capabilities"]),
+        "directory": _directory_payload(directory),
+        "federation": {
+            "identity_count": len(identities),
+            "providers": sorted({identity.provider for identity in identities}),
+        },
+        "created_at": user.created_at.isoformat() if user.created_at else None,
+        "updated_at": user.updated_at.isoformat() if user.updated_at else None,
+    }
+
+
+def _clean_optional_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _validate_timezone(value: str) -> str:
+    cleaned = value.strip()
+    try:
+        ZoneInfo(cleaned)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Unknown timezone") from exc
+    return cleaned
+
+
 @router.get("/overview")
 def admin_overview(
     principal: DashboardPrincipal = Depends(require_capability("admin.portal.access")),
@@ -126,6 +258,7 @@ def admin_overview(
             "username": principal.username,
             "email": principal.email,
             "role": principal.role,
+            "profile_key": profile_key_for_role(principal.role),
             "capabilities": list(principal.capabilities),
         },
         "counts": {
@@ -137,10 +270,22 @@ def admin_overview(
         },
         "operations": {
             "hydration": _safe_hydration_summary(),
-            "mode": "read_only",
+            "mode": "configuration_foundation",
         },
         "locked_sections": LOCKED_SECTIONS,
     }
+
+
+@router.get("/me")
+def admin_me(
+    principal: DashboardPrincipal = Depends(require_capability("admin.portal.access")),
+) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = session.get(AppUser, principal.user_id)
+        payload = _admin_user_detail(session, user, actor_user_id=principal.user_id)
+        session.commit()
+        return {"user": payload}
 
 
 @router.get("/objects")
@@ -183,7 +328,256 @@ def admin_users(
             .all()
         )
         payload = [_admin_user_payload(session, user) for user in users]
-    return {
-        "users": payload,
-        "totalSize": len(payload),
-    }
+    return {"users": payload, "totalSize": len(payload)}
+
+
+@router.get("/users/{user_id}")
+def admin_user_detail(
+    user_id: int,
+    principal: DashboardPrincipal = Depends(require_capability("admin.users.read")),
+) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        user = session.get(AppUser, user_id)
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        payload = _admin_user_detail(session, user, actor_user_id=principal.user_id)
+        session.commit()
+        return {"user": payload}
+
+
+@router.patch("/users/{user_id}")
+def admin_user_update(
+    user_id: int,
+    request: AdminUserUpdateRequest,
+    principal: DashboardPrincipal = Depends(require_capability("admin.users.manage")),
+) -> Dict[str, Any]:
+    values = request.model_dump(exclude_unset=True)
+    if not values:
+        raise HTTPException(status_code=400, detail="At least one profile field is required")
+    Session = _session_factory()
+    with Session() as session:
+        user = session.get(AppUser, user_id)
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        directory = get_or_create_directory_profile(
+            session,
+            user.id,
+            actor_user_id=principal.user_id,
+        )
+        if user.id == principal.user_id and (
+            values.get("is_active") is False or values.get("is_locked") is True
+        ):
+            raise HTTPException(status_code=400, detail="The active owner cannot deactivate or lock itself")
+        before = _admin_user_detail(session, user, actor_user_id=principal.user_id)
+        now = _utcnow()
+        security_changed = False
+        if "username" in values:
+            username = _clean_optional_text(values.pop("username"))
+            if not username:
+                raise HTTPException(status_code=400, detail="Username is required")
+            user.username = username
+        for field_name in (
+            "first_name", "last_name", "display_name", "alias", "title", "company",
+        ):
+            if field_name in values:
+                setattr(directory, field_name, _clean_optional_text(values[field_name]))
+        for field_name in ("locale", "language"):
+            if field_name in values:
+                cleaned = _clean_optional_text(values[field_name])
+                if not cleaned:
+                    raise HTTPException(status_code=400, detail=f"{field_name} is required")
+                setattr(directory, field_name, cleaned)
+        if "timezone" in values:
+            directory.timezone = _validate_timezone(values["timezone"] or "")
+        for field_name in ("is_active", "is_locked"):
+            if field_name in values and getattr(directory, field_name) != values[field_name]:
+                setattr(directory, field_name, values[field_name])
+                security_changed = True
+        if security_changed:
+            directory.session_version = int(directory.session_version or 0) + 1
+            session.query(AppSession).filter(AppSession.user_id == user.id).delete(
+                synchronize_session=False
+            )
+        user.updated_at = now
+        directory.updated_by_user_id = principal.user_id
+        directory.updated_at = now
+        session.flush()
+        after = _admin_user_detail(session, user, actor_user_id=principal.user_id)
+        record_audit_event(
+            session,
+            actor_user_id=principal.user_id,
+            actor_session_id=principal.session_id,
+            action="admin.user.updated",
+            target_type="app_user",
+            target_identifier=str(user.id),
+            before=before,
+            after=after,
+        )
+        session.commit()
+        return {"ok": True, "user": after, "sessions_revoked": security_changed}
+
+
+@router.get("/profiles")
+def admin_profiles(
+    principal: DashboardPrincipal = Depends(require_capability("admin.profiles.read")),
+) -> Dict[str, Any]:
+    del principal
+    Session = _session_factory()
+    with Session() as session:
+        ensure_profile_catalog(session)
+        session.commit()
+    profiles = serialize_profile_catalog(capabilities_for_role)
+    return {"profiles": profiles, "totalSize": len(profiles), "source": "server_capability_registry"}
+
+
+@router.get("/settings")
+def admin_settings(
+    principal: DashboardPrincipal = Depends(require_capability("admin.settings.read")),
+) -> Dict[str, Any]:
+    del principal
+    Session = _session_factory()
+    with Session() as session:
+        settings = serialize_settings(session)
+    return {"settings": settings, "totalSize": len(settings), "source": "settings_registry"}
+
+
+@router.patch("/settings")
+def admin_settings_update(
+    request: AdminSettingsPatchRequest,
+    principal: DashboardPrincipal = Depends(require_capability("admin.settings.manage")),
+) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        now = _utcnow()
+        for update in request.updates:
+            namespace = update.namespace.strip()
+            key = update.key.strip()
+            value = validate_setting_value(namespace, key, update.value)
+            definition = SETTING_DEFINITIONS[(namespace, key)]
+            row = (
+                session.query(AppGlobalSetting)
+                .filter(
+                    AppGlobalSetting.namespace == namespace,
+                    AppGlobalSetting.setting_key == key,
+                )
+                .first()
+            )
+            before = {"namespace": namespace, "key": key, "value": row.value_json if row else definition["default"]}
+            if row is None:
+                row = AppGlobalSetting(
+                    namespace=namespace,
+                    setting_key=key,
+                    value_type=definition["value_type"],
+                    default_value_json=definition["default"],
+                    validation_json=definition.get("validation", {}),
+                    description=definition["description"],
+                    environment_override=bool(definition.get("environment_variable")),
+                    created_at=now,
+                )
+                session.add(row)
+            row.value_json = value
+            row.updated_by_user_id = principal.user_id
+            row.updated_at = now
+            session.flush()
+            record_audit_event(
+                session,
+                actor_user_id=principal.user_id,
+                actor_session_id=principal.session_id,
+                action="admin.setting.updated",
+                target_type="global_setting",
+                target_identifier=f"{namespace}.{key}",
+                before=before,
+                after={"namespace": namespace, "key": key, "value": value},
+            )
+        session.commit()
+        return {"ok": True, "settings": serialize_settings(session)}
+
+
+@router.get("/feature-flags")
+def admin_feature_flags(
+    principal: DashboardPrincipal = Depends(require_capability("admin.settings.read")),
+) -> Dict[str, Any]:
+    del principal
+    Session = _session_factory()
+    with Session() as session:
+        flags = serialize_feature_flags(session)
+    return {"feature_flags": flags, "totalSize": len(flags), "source": "feature_flag_registry"}
+
+
+@router.patch("/feature-flags")
+def admin_feature_flags_update(
+    request: AdminFeatureFlagsPatchRequest,
+    principal: DashboardPrincipal = Depends(require_capability("admin.settings.manage")),
+) -> Dict[str, Any]:
+    Session = _session_factory()
+    with Session() as session:
+        now = _utcnow()
+        for update in request.updates:
+            key = update.key.strip()
+            if key not in FEATURE_FLAG_DEFINITIONS:
+                raise HTTPException(status_code=400, detail=f"Unknown feature flag: {key}")
+            targets = validate_target_profiles(update.target_profiles)
+            row = (
+                session.query(AppFeatureFlag)
+                .filter(AppFeatureFlag.flag_key == key)
+                .first()
+            )
+            before = {
+                "key": key,
+                "enabled": bool(row.enabled) if row else False,
+                "target_profiles": list(row.target_profiles_json or []) if row else [],
+            }
+            if row is None:
+                row = AppFeatureFlag(flag_key=key, created_at=now)
+                session.add(row)
+            row.enabled = update.enabled
+            row.target_profiles_json = targets
+            row.updated_by_user_id = principal.user_id
+            row.updated_at = now
+            session.flush()
+            record_audit_event(
+                session,
+                actor_user_id=principal.user_id,
+                actor_session_id=principal.session_id,
+                action="admin.feature_flag.updated",
+                target_type="feature_flag",
+                target_identifier=key,
+                before=before,
+                after={"key": key, "enabled": update.enabled, "target_profiles": targets},
+            )
+        session.commit()
+        return {"ok": True, "feature_flags": serialize_feature_flags(session)}
+
+
+@router.get("/audit-events")
+def admin_audit_events(
+    limit: int = Query(default=50, ge=1, le=100),
+    principal: DashboardPrincipal = Depends(require_capability("admin.audit.read")),
+) -> Dict[str, Any]:
+    del principal
+    Session = _session_factory()
+    with Session() as session:
+        events = (
+            session.query(AppAdminAuditEvent)
+            .order_by(AppAdminAuditEvent.created_at.desc(), AppAdminAuditEvent.id.desc())
+            .limit(limit)
+            .all()
+        )
+        actor_ids = {event.actor_user_id for event in events}
+        actors = {
+            user.id: user.username
+            for user in session.query(AppUser).filter(AppUser.id.in_(actor_ids)).all()
+        } if actor_ids else {}
+        payload = [{
+            "id": event.public_id,
+            "actor": {"id": event.actor_user_id, "username": actors.get(event.actor_user_id)},
+            "action": event.action,
+            "target_type": event.target_type,
+            "target_identifier": event.target_identifier,
+            "before": event.before_json,
+            "after": event.after_json,
+            "source": event.source,
+            "created_at": event.created_at.isoformat() if event.created_at else None,
+        } for event in events]
+    return {"audit_events": payload, "totalSize": len(payload), "limit": limit}

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -10,6 +10,7 @@ instantiate a database engine and session maker based on a connection URL.
 from __future__ import annotations
 
 from datetime import date, datetime
+import uuid
 from typing import Optional
 
 from sqlalchemy import (
@@ -22,6 +23,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
     create_engine,
     Index,
     inspect,
@@ -299,6 +301,169 @@ class AppUserPreference(Base):
     plan_type: Optional[str] = Column(String(64), nullable=True)
     created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AppUserDirectoryProfile(Base):
+    """Additive administrative metadata for an existing ``app_users`` row."""
+
+    __tablename__ = "app_user_directory_profiles"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, unique=True, index=True)
+    public_id: str = Column(
+        String(36),
+        nullable=False,
+        unique=True,
+        index=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    first_name: Optional[str] = Column(String(80), nullable=True)
+    last_name: Optional[str] = Column(String(80), nullable=True)
+    display_name: Optional[str] = Column(String(160), nullable=True)
+    alias: Optional[str] = Column(String(80), nullable=True)
+    title: Optional[str] = Column(String(120), nullable=True)
+    company: Optional[str] = Column(String(160), nullable=True)
+    is_active: bool = Column(Boolean, nullable=False, default=True, index=True)
+    is_locked: bool = Column(Boolean, nullable=False, default=False, index=True)
+    locale: str = Column(String(32), nullable=False, default="en_US")
+    language: str = Column(String(16), nullable=False, default="en")
+    timezone: str = Column(String(64), nullable=False, default="UTC")
+    session_version: int = Column(Integer, nullable=False, default=1)
+    last_login_at: Optional[datetime] = Column(DateTime, nullable=True)
+    created_by_user_id: Optional[int] = Column(Integer, nullable=True)
+    updated_by_user_id: Optional[int] = Column(Integer, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class FederatedIdentity(Base):
+    """Provider subject mapping only; credentials and provider tokens never belong here."""
+
+    __tablename__ = "federated_identities"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    public_id: str = Column(
+        String(36),
+        nullable=False,
+        unique=True,
+        index=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    user_id: int = Column(Integer, nullable=False, index=True)
+    provider: str = Column(String(64), nullable=False)
+    issuer: str = Column(String(255), nullable=False)
+    subject: str = Column(String(255), nullable=False)
+    federation_identifier: Optional[str] = Column(String(255), nullable=True, index=True)
+    verified_at: Optional[datetime] = Column(DateTime, nullable=True)
+    last_authenticated_at: Optional[datetime] = Column(DateTime, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("issuer", "subject", name="uq_federated_identity_issuer_subject"),
+    )
+
+
+class AppAccessProfile(Base):
+    """Persisted catalog identity for code-owned role/capability profiles."""
+
+    __tablename__ = "app_access_profiles"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    profile_key: str = Column(String(64), nullable=False, unique=True, index=True)
+    label: str = Column(String(120), nullable=False)
+    role: str = Column(String(32), nullable=False, unique=True, index=True)
+    description: Optional[str] = Column(String(500), nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AppGlobalSetting(Base):
+    __tablename__ = "app_global_settings"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    namespace: str = Column(String(64), nullable=False)
+    setting_key: str = Column(String(128), nullable=False)
+    value_type: str = Column(String(24), nullable=False)
+    value_json = Column(JSON, nullable=True)
+    default_value_json = Column(JSON, nullable=True)
+    validation_json = Column(JSON, nullable=True)
+    description: Optional[str] = Column(String(500), nullable=True)
+    environment_override: bool = Column(Boolean, nullable=False, default=False)
+    sensitive_reference: Optional[str] = Column(String(255), nullable=True)
+    updated_by_user_id: Optional[int] = Column(Integer, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("namespace", "setting_key", name="uq_app_global_setting_key"),
+    )
+
+
+class AppUserSetting(Base):
+    __tablename__ = "app_user_settings"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, index=True)
+    namespace: str = Column(String(64), nullable=False)
+    setting_key: str = Column(String(128), nullable=False)
+    value_type: str = Column(String(24), nullable=False)
+    value_json = Column(JSON, nullable=True)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "namespace",
+            "setting_key",
+            name="uq_app_user_setting_key",
+        ),
+    )
+
+
+class AppFeatureFlag(Base):
+    __tablename__ = "app_feature_flags"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    flag_key: str = Column(String(128), nullable=False, unique=True, index=True)
+    enabled: bool = Column(Boolean, nullable=False, default=False)
+    target_profiles_json = Column(JSON, nullable=True)
+    updated_by_user_id: Optional[int] = Column(Integer, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AppAdminAuditEvent(Base):
+    __tablename__ = "app_admin_audit_events"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    public_id: str = Column(
+        String(36),
+        nullable=False,
+        unique=True,
+        index=True,
+        default=lambda: str(uuid.uuid4()),
+    )
+    actor_user_id: int = Column(Integer, nullable=False, index=True)
+    actor_session_id: Optional[int] = Column(Integer, nullable=True, index=True)
+    action: str = Column(String(128), nullable=False, index=True)
+    target_type: str = Column(String(64), nullable=False, index=True)
+    target_identifier: str = Column(String(255), nullable=False)
+    before_json = Column(JSON, nullable=True)
+    after_json = Column(JSON, nullable=True)
+    source: str = Column(String(64), nullable=False, default="control_center_api")
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+
+class AppLoginHistory(Base):
+    __tablename__ = "app_login_history"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    user_id: int = Column(Integer, nullable=False, index=True)
+    session_id: Optional[int] = Column(Integer, nullable=True, index=True)
+    authentication_method: str = Column(String(64), nullable=False, default="password")
+    successful: bool = Column(Boolean, nullable=False, default=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
 
 
 class AppDashboardFolder(Base):

--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -20,12 +20,15 @@ from .admin_access import (
     resolve_principal,
     resolve_session_token,
 )
+from .admin_configuration import get_or_create_directory_profile
 
 from .database import (
     AppDashboardFolder,
     AppDashboardItem,
     AppSession,
+    AppLoginHistory,
     AppUser,
+    AppUserDirectoryProfile,
     AppUserPreference,
     create_tables,
     get_engine,
@@ -527,6 +530,13 @@ def _verified_login_user(session, email: str, password: Optional[str]) -> AppUse
         raise HTTPException(status_code=401, detail="Password is required")
     if not _verify_password(password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid email or password")
+    directory = (
+        session.query(AppUserDirectoryProfile)
+        .filter(AppUserDirectoryProfile.user_id == user.id)
+        .first()
+    )
+    if directory and (not directory.is_active or directory.is_locked):
+        raise HTTPException(status_code=403, detail="This account is inactive or locked")
     return user
 
 
@@ -577,6 +587,16 @@ def _issue_dashboard_session(
     if verified_login:
         ensure_owner_admin_role(session, user, verified_at=now)
     db_session = _create_session(session, user.id, now=now)
+    directory = get_or_create_directory_profile(session, user.id, actor_user_id=user.id)
+    directory.last_login_at = now
+    directory.updated_at = now
+    session.add(AppLoginHistory(
+        user_id=user.id,
+        session_id=db_session.id,
+        authentication_method="password" if verified_login else "password_registration",
+        successful=True,
+        created_at=now,
+    ))
     access = access_payload_for_user(
         session,
         user,

--- a/tests/test_admin_configuration_foundation.py
+++ b/tests/test_admin_configuration_foundation.py
@@ -1,0 +1,279 @@
+import datetime as dt
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app import admin_access, admin_configuration, admin_routes
+from mlb_app.database import (
+    AppAdminAuditEvent,
+    AppFeatureFlag,
+    AppGlobalSetting,
+    AppSession,
+    AppUser,
+    AppUserDirectoryProfile,
+    AppUserRole,
+    Base,
+)
+
+
+def _now():
+    return dt.datetime.now(dt.timezone.utc).replace(tzinfo=None, microsecond=0)
+
+
+def _principal(user_id=1, *, role="admin", capabilities=None):
+    now = _now()
+    return admin_access.DashboardPrincipal(
+        user_id=user_id,
+        email="owner@example.com" if user_id == 1 else "user@example.com",
+        username="owner" if user_id == 1 else "user",
+        role=role,
+        capabilities=tuple(capabilities or admin_access.capabilities_for_role(role)),
+        session_id=100 + user_id,
+        session_created_at=now,
+        session_expires_at=now + dt.timedelta(hours=6),
+    )
+
+
+@pytest.fixture()
+def admin_store(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path / 'admin-configuration.db'}")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    now = _now()
+    with Session() as session:
+        owner = AppUser(
+            email="owner@example.com",
+            username="owner",
+            password_hash="password-backed",
+            created_at=now,
+            updated_at=now,
+        )
+        user = AppUser(
+            email="user@example.com",
+            username="user",
+            password_hash="password-backed",
+            created_at=now,
+            updated_at=now,
+        )
+        session.add_all([owner, user])
+        session.flush()
+        session.add(AppUserRole(
+            user_id=owner.id,
+            role="admin",
+            assignment_source="test",
+            assigned_at=now - dt.timedelta(minutes=1),
+            verified_at=now - dt.timedelta(minutes=1),
+            updated_at=now,
+        ))
+        session.add_all([
+            AppSession(
+                user_id=owner.id,
+                session_token="owner-token",
+                expires_at=now + dt.timedelta(hours=6),
+                created_at=now,
+                last_seen_at=now,
+            ),
+            AppSession(
+                user_id=user.id,
+                session_token="user-token",
+                expires_at=now + dt.timedelta(hours=6),
+                created_at=now,
+                last_seen_at=now,
+            ),
+        ])
+        session.commit()
+        ids = {"owner": owner.id, "user": user.id}
+    monkeypatch.setattr(admin_access, "dashboard_session_factory", lambda: Session)
+    monkeypatch.setattr(admin_routes, "_session_factory", lambda: Session)
+    return Session, ids
+
+
+def test_required_feature_flags_default_false_without_rows(admin_store):
+    Session, _ = admin_store
+    with Session() as session:
+        flags = admin_configuration.serialize_feature_flags(session)
+    assert {item["key"] for item in flags} == {
+        "federation_enabled",
+        "federation_admin_enabled",
+        "workbench_query_enabled",
+        "federation_refresh_enabled",
+    }
+    assert all(item["enabled"] is False for item in flags)
+    assert all(item["authorization_effect"] == "none" for item in flags)
+
+
+def test_profile_catalog_is_code_owned_and_owner_only_capabilities_extend_user(admin_store):
+    payload = admin_routes.admin_profiles(_principal())
+    assert [item["key"] for item in payload["profiles"]] == [
+        "owner_administrator",
+        "standard_user",
+    ]
+    owner, standard = payload["profiles"]
+    assert owner["mutable"] is False
+    assert "admin.settings.manage" in owner["capabilities"]
+    assert "admin.settings.manage" not in standard["capabilities"]
+    assert set(standard["capabilities"]).issubset(owner["capabilities"])
+
+
+def test_settings_reject_unknown_and_invalid_values_without_audit(admin_store):
+    Session, _ = admin_store
+    with pytest.raises(HTTPException) as unknown:
+        admin_routes.admin_settings_update(
+            admin_routes.AdminSettingsPatchRequest(updates=[{
+                "namespace": "secrets",
+                "key": "api_token",
+                "value": "plaintext",
+            }]),
+            _principal(),
+        )
+    assert unknown.value.status_code == 400
+
+    with pytest.raises(HTTPException) as invalid:
+        admin_routes.admin_settings_update(
+            admin_routes.AdminSettingsPatchRequest(updates=[{
+                "namespace": "identity",
+                "key": "default_timezone",
+                "value": "Mars/Olympus",
+            }]),
+            _principal(),
+        )
+    assert invalid.value.status_code == 400
+    with Session() as session:
+        assert session.query(AppGlobalSetting).count() == 0
+        assert session.query(AppAdminAuditEvent).count() == 0
+
+
+def test_setting_update_is_allowlisted_and_audited_without_secrets(admin_store):
+    Session, _ = admin_store
+    payload = admin_routes.admin_settings_update(
+        admin_routes.AdminSettingsPatchRequest(updates=[{
+            "namespace": "identity",
+            "key": "default_timezone",
+            "value": "America/Chicago",
+        }]),
+        _principal(),
+    )
+    assert payload["ok"] is True
+    assert next(item for item in payload["settings"] if item["key"] == "default_timezone")["value"] == "America/Chicago"
+    assert "secret" not in repr(payload).lower()
+    with Session() as session:
+        event = session.query(AppAdminAuditEvent).one()
+        assert event.action == "admin.setting.updated"
+        assert event.target_identifier == "identity.default_timezone"
+        assert event.after_json["value"] == "America/Chicago"
+
+
+def test_feature_flag_targeting_is_server_validated_and_audited(admin_store):
+    Session, _ = admin_store
+    with pytest.raises(HTTPException) as invalid:
+        admin_routes.admin_feature_flags_update(
+            admin_routes.AdminFeatureFlagsPatchRequest(updates=[{
+                "key": "federation_enabled",
+                "enabled": True,
+                "target_profiles": ["forged_admin"],
+            }]),
+            _principal(),
+        )
+    assert invalid.value.status_code == 400
+
+    payload = admin_routes.admin_feature_flags_update(
+        admin_routes.AdminFeatureFlagsPatchRequest(updates=[{
+            "key": "federation_enabled",
+            "enabled": True,
+            "target_profiles": ["owner_administrator"],
+        }]),
+        _principal(),
+    )
+    flag = next(item for item in payload["feature_flags"] if item["key"] == "federation_enabled")
+    assert flag["enabled"] is True
+    assert flag["target_profiles"] == ["owner_administrator"]
+    assert flag["authorization_effect"] == "none"
+    with Session() as session:
+        assert session.query(AppFeatureFlag).count() == 1
+        assert session.query(AppAdminAuditEvent).count() == 1
+
+
+def test_user_patch_rejects_authorization_and_credential_fields():
+    for forbidden in (
+        {"role": "admin"},
+        {"capabilities": ["admin.portal.access"]},
+        {"plan": "owner"},
+        {"email": "attacker@example.com"},
+        {"password_hash": "nope"},
+        {"session_token": "nope"},
+    ):
+        with pytest.raises(ValidationError):
+            admin_routes.AdminUserUpdateRequest(**forbidden)
+
+
+def test_owner_cannot_lock_or_deactivate_itself(admin_store):
+    _, ids = admin_store
+    for request in (
+        admin_routes.AdminUserUpdateRequest(is_active=False),
+        admin_routes.AdminUserUpdateRequest(is_locked=True),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            admin_routes.admin_user_update(ids["owner"], request, _principal(ids["owner"]))
+        assert exc.value.status_code == 400
+
+
+def test_security_state_change_revokes_target_sessions_and_creates_audit(admin_store):
+    Session, ids = admin_store
+    payload = admin_routes.admin_user_update(
+        ids["user"],
+        admin_routes.AdminUserUpdateRequest(
+            display_name="  Standard Analyst  ",
+            is_active=False,
+        ),
+        _principal(ids["owner"]),
+    )
+    assert payload["sessions_revoked"] is True
+    assert payload["user"]["directory"]["display_name"] == "Standard Analyst"
+    assert payload["user"]["directory"]["is_active"] is False
+    with Session() as session:
+        assert session.query(AppSession).filter_by(user_id=ids["user"]).count() == 0
+        event = session.query(AppAdminAuditEvent).one()
+        assert event.action == "admin.user.updated"
+        assert "password" not in repr(event.before_json).lower()
+        assert "token" not in repr(event.after_json).lower()
+
+
+def test_inactive_and_locked_accounts_cannot_resolve_existing_sessions(admin_store):
+    Session, ids = admin_store
+    with Session() as session:
+        profile = admin_configuration.get_or_create_directory_profile(session, ids["owner"])
+        profile.is_locked = True
+        session.commit()
+    with Session() as session:
+        with pytest.raises(HTTPException) as exc:
+            admin_access.resolve_principal(session, "owner-token")
+    assert exc.value.status_code == 403
+
+
+def test_standard_user_cannot_tamper_with_private_mutation_capabilities(admin_store):
+    principal = _principal(
+        user_id=2,
+        role="user",
+        capabilities=admin_access.USER_CAPABILITIES,
+    )
+    for capability in ("admin.users.manage", "admin.settings.manage", "admin.audit.read"):
+        guard = admin_access.require_capability(capability)
+        with pytest.raises(HTTPException) as exc:
+            guard(principal)
+        assert exc.value.status_code == 403
+
+
+def test_admin_router_exposes_only_expected_mutations():
+    methods_by_path = {
+        route.path: route.methods
+        for route in admin_routes.router.routes
+        if hasattr(route, "methods")
+    }
+    assert methods_by_path["/admin/users/{user_id}"] == {"PATCH"}
+    assert methods_by_path["/admin/settings"] == {"PATCH"}
+    assert methods_by_path["/admin/feature-flags"] == {"PATCH"}
+    assert "/admin/profiles/{profile_id}" not in methods_by_path
+    assert "/admin/audit-events/{event_id}" not in methods_by_path

--- a/tests/test_my_dashboard_auth_and_admin.py
+++ b/tests/test_my_dashboard_auth_and_admin.py
@@ -13,8 +13,10 @@ from mlb_app.dashboard_report_types import list_report_types
 from mlb_app.database import (
     AppDashboardFolder,
     AppDashboardItem,
+    AppLoginHistory,
     AppSession,
     AppUser,
+    AppUserDirectoryProfile,
     AppUserPreference,
     AppUserRole,
     Base,
@@ -285,6 +287,12 @@ def test_owner_role_bootstraps_only_after_verified_login(auth_store, monkeypatch
         active = session.query(AppSession).filter_by(user_id=ids["owner"]).all()
         assert len(active) == 1
         assert active[0].session_token == payload["session_token"]
+        directory = session.query(AppUserDirectoryProfile).filter_by(user_id=ids["owner"]).one()
+        assert directory.last_login_at is not None
+        login = session.query(AppLoginHistory).filter_by(user_id=ids["owner"]).one()
+        assert login.session_id == active[0].id
+        assert login.authentication_method == "password"
+        assert login.successful is True
 
 
 def test_allowlisted_email_cannot_be_registered_into_owner_access(auth_store, monkeypatch):
@@ -623,22 +631,25 @@ def test_admin_overview_uses_dynamic_counts_and_safe_identity(auth_store, monkey
     assert "components" not in payload["operations"]["hydration"]
     assert "internal_token" not in repr(payload)
     assert {item["key"] for item in payload["locked_sections"]} == {
-        "settings",
         "operations",
         "workbench",
-        "audit",
     }
 
 
-def test_admin_router_is_direct_and_read_only():
-    methods_by_path = {
-        route.path: route.methods
-        for route in admin_routes.router.routes
-        if hasattr(route, "methods")
-    }
+def test_admin_router_is_direct_and_limits_mutation_to_phase_two_contract():
+    methods_by_path = {}
+    for route in admin_routes.router.routes:
+        if hasattr(route, "methods"):
+            methods_by_path.setdefault(route.path, set()).update(route.methods)
     assert methods_by_path == {
         "/admin/overview": {"GET"},
+        "/admin/me": {"GET"},
         "/admin/objects": {"GET"},
         "/admin/apps": {"GET"},
         "/admin/users": {"GET"},
+        "/admin/users/{user_id}": {"GET", "PATCH"},
+        "/admin/profiles": {"GET"},
+        "/admin/settings": {"GET", "PATCH"},
+        "/admin/feature-flags": {"GET", "PATCH"},
+        "/admin/audit-events": {"GET"},
     }


### PR DESCRIPTION
Closes #1175
Part of #1156

## Summary

- Extends the owner-only Control Center from #1169 with private user-directory profiles, a federation identity registry foundation, code-owned access profiles, typed global/user settings storage, required feature flags, immutable administrative audit events, and successful-login history.
- Keeps `app_users` and `app_user_roles` intact. Every new production model is an additive table so deployment does not depend on `create_all()` altering an existing table.
- Adds server-owned owner capabilities for safe user metadata, profiles, settings, federation foundation, future operations, and future Workbench execution. Standard-user capabilities remain unchanged.
- Adds protected APIs:
  - `GET /admin/me`
  - `GET/PATCH /admin/users/{user_id}`
  - `GET /admin/profiles`
  - `GET/PATCH /admin/settings`
  - `GET/PATCH /admin/feature-flags`
  - `GET /admin/audit-events`
- Makes Users & Access, Settings, and Audit functional in the existing private Control Center while leaving Operations and Workbench intentionally locked.
- Adds a responsive mobile settings layout and preserves Franklin Gothic for headings/navigation/buttons and Century Gothic for body/labels/inputs/data.

## Security boundaries

- Existing roles and the centralized server capability resolver remain authoritative; this PR does not create a second authorization framework.
- User patch requests use an extra-forbidden allowlist and cannot accept email ownership, password/hash, role, capabilities, profile assignment, plan, session/token, secret, arbitrary preferences, or saved-report content.
- The authenticated owner cannot deactivate or lock itself.
- Active/locked changes increment the account revocation marker and delete all existing sessions for the affected account.
- Existing or new sessions for inactive/locked accounts are denied server-side.
- Settings and feature flags are accepted only through code-owned registries with explicit types and allowed values.
- Unknown settings, invalid values, unknown profile targets, and plaintext sensitive settings are rejected.
- The four required flags default false:
  - `federation_enabled`
  - `federation_admin_enabled`
  - `workbench_query_enabled`
  - `federation_refresh_enabled`
- Flags have no authorization effect and are not connected to public product behavior in this phase.
- Successful user/settings/flag mutations create immutable safe audit summaries. Passwords, hashes, session tokens, provider tokens, secrets, unrestricted preferences, and report contents are not serialized.

## Additive data foundation

- `app_user_directory_profiles`
- `federated_identities`
- `app_access_profiles`
- `app_global_settings`
- `app_user_settings`
- `app_feature_flags`
- `app_admin_audit_events`
- `app_login_history`

The initial profile catalog is code-owned:

- Owner Administrator
- Standard User

No Permission Sets, custom profiles, role delegation, OAuth/OIDC/SAML flow, token storage, operational controls, destructive user actions, or Workbench compiler/execution are included.

## Verification

- Relevant MyDashboard backend suite: **127 passed**
- Focused Control Center/session frontend tests: **9 passed**
- New Phase 2 backend security tests: included in the 127-test suite
- FastAPI application mount smoke test: all **13** admin route/method combinations present
- `AdminControlCenterPage.jsx` bundle compilation: passed
- Production Vite build: passed
- Python compilation: passed
- Salesforce terminology search in changed UI: clean
- `git diff --check`: passed
- Remote GitHub branch tree exactly matches the tested local commit tree

The complete frontend Node command reports **83 passed / 1 failed**. The sole failure is the pre-existing `topModelProjectionRows showcases projection values first` assertion in unchanged `frontend/src/lib/modelTrackerPnl.mjs` / `modelTrackerPnl.test.mjs`; `git diff --quiet origin/main --` confirms both files are untouched. The production build also retains existing warnings for duplicate style keys in unchanged `LandingV2Page.jsx` and the current bundle-size warning.

## Next phase

Define the constrained MLBGPT Workbench request language and parameterized compiler over the existing server-owned object/field registry. It must reject raw SQL and physical table names, enforce capability/cost/row limits, use bound parameters, and preserve saved-report compatibility. Permission Sets and delegated role administration remain a later separately reviewed phase.