### PR TITLE
Explain unavailable canonical projections

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -70,3 +70,24 @@ test('projections tab renders requested batter metrics', async () => {
     assert.match(source, new RegExp(label))
   }
 })
+
+test('projections tab explains unavailable canonical states', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /view\.unavailable\.title/,
+  )
+  assert.match(
+    source,
+    /view\.unavailable\.message/,
+  )
+  assert.match(
+    source,
+    /view\.unavailable\.blockers/,
+  )
+  assert.match(
+    source,
+    /same\s+canonical simulation run/i,
+  )
+})

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -1,3 +1,7 @@
+import {
+  buildCanonicalDiagnosticsViewModel,
+} from './canonicalDiagnosticsViewModel.mjs'
+
 function asObject(value) {
   return value && typeof value === 'object'
     ? value
@@ -199,6 +203,92 @@ function sortRows(rows) {
   })
 }
 
+function unavailableProjectionState(game) {
+  const diagnostics = (
+    buildCanonicalDiagnosticsViewModel(game)
+  )
+
+  const execution = (
+    diagnostics.productionExecution || {}
+  )
+  const readiness = (
+    diagnostics.bootstrapReadiness || {}
+  )
+
+  const status = String(
+    execution.status ||
+    diagnostics.status?.state ||
+    'not_run'
+  ).toLowerCase()
+
+  if (status === 'error') {
+    return {
+      state: 'error',
+      title: 'Canonical projection run failed',
+      message: (
+        diagnostics.status?.availabilityReason ||
+        execution.errorMessage ||
+        'The canonical simulation failed open before player projections could be attached.'
+      ),
+      blockers: [],
+      errorType: execution.errorType || null,
+      errorMessage: execution.errorMessage || null,
+    }
+  }
+
+  if (
+    readiness.available &&
+    readiness.blockedCount > 0
+  ) {
+    return {
+      state: 'blocked',
+      title: 'Canonical projections blocked',
+      message: (
+        diagnostics.status?.availabilityReason ||
+        'Required canonical simulation inputs are missing.'
+      ),
+      blockers: (
+        readiness.items || []
+      )
+        .filter(item => !item.ready)
+        .map(item => ({
+          key: item.key,
+          label: item.label,
+          detail: item.detail || null,
+        })),
+      errorType: null,
+      errorMessage: null,
+    }
+  }
+
+  if (status === 'executed') {
+    return {
+      state: 'attachment_missing',
+      title: 'Canonical projections were not attached',
+      message: (
+        diagnostics.status?.availabilityReason ||
+        'Canonical trials executed, but same-run player projection rows were not attached to this response.'
+      ),
+      blockers: [],
+      errorType: null,
+      errorMessage: null,
+    }
+  }
+
+  return {
+    state: 'not_run',
+    title: 'Canonical simulation was not available',
+    message: (
+      diagnostics.status?.availabilityReason ||
+      'Canonical player projections require a completed canonical simulation run for this game.'
+    ),
+    blockers: [],
+    errorType: null,
+    errorMessage: null,
+  }
+}
+
+
 export function buildCanonicalProjectionsViewModel(
   game,
 ) {
@@ -216,8 +306,15 @@ export function buildCanonicalProjectionsViewModel(
     players.length > 0
   )
 
+  const unavailable = (
+    available
+      ? null
+      : unavailableProjectionState(game)
+  )
+
   return {
     available,
+    unavailable,
     status: projections.status || (
       available ? 'available' : 'unavailable'
     ),

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -170,3 +170,143 @@ test('leaves stolen bases unavailable when simulation omits metric', () => {
     null,
   )
 })
+
+test('explains blocked canonical projections', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow_bootstrap_readiness: {
+          status: 'blocked',
+          ready: false,
+          requirements: {
+            game_identity: {
+              ready: true,
+            },
+            away_lineup: {
+              ready: false,
+              player_count: 7,
+              required_player_count: 9,
+            },
+            home_lineup: {
+              ready: true,
+              player_count: 9,
+              required_player_count: 9,
+            },
+            away_starter: {
+              ready: true,
+            },
+            home_starter: {
+              ready: true,
+            },
+            away_bullpen: {
+              ready: true,
+              pitcher_count: 7,
+            },
+            home_bullpen: {
+              ready: true,
+              pitcher_count: 7,
+            },
+            probability_provider: {
+              ready: true,
+              source: 'canonical provider',
+            },
+            exact_probability_artifact: {
+              ready: true,
+              source: 'exact artifact',
+            },
+            fallback_probability_catalog: {
+              ready: true,
+              source: 'fallback catalog',
+            },
+          },
+          missing_requirements: [
+            'away_lineup',
+          ],
+        },
+        canonical_shadow_production_execution: {
+          status: 'blocked',
+          executed: false,
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'blocked',
+  )
+  assert.equal(
+    view.unavailable.title,
+    'Canonical projections blocked',
+  )
+  assert.equal(
+    view.unavailable.blockers.length,
+    1,
+  )
+  assert.equal(
+    view.unavailable.blockers[0].label,
+    'Away lineup',
+  )
+  assert.equal(
+    view.unavailable.blockers[0].detail,
+    '7 of 9 players',
+  )
+})
+
+test('explains canonical execution errors', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow_production_execution: {
+          status: 'error',
+          executed: false,
+          error_type: 'RuntimeError',
+          error_message: 'provider failed',
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'error',
+  )
+  assert.equal(
+    view.unavailable.title,
+    'Canonical projection run failed',
+  )
+  assert.equal(
+    view.unavailable.errorType,
+    'RuntimeError',
+  )
+  assert.match(
+    view.unavailable.message,
+    /provider failed/,
+  )
+})
+
+test('explains missing projection attachment after execution', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow_production_execution: {
+          status: 'executed',
+          executed: true,
+          canonical_available: true,
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'attachment_missing',
+  )
+  assert.equal(
+    view.unavailable.title,
+    'Canonical projections were not attached',
+  )
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -909,10 +909,77 @@ function ProjectionsTab({ game }) {
   if (!view.available) {
     return (
       <div style={s.noData}>
-        Canonical player projections are not available for this
-        game. This tab only renders rows produced by the same
-        canonical simulation run shown in Simulation and
-        Diagnostics.
+        <div
+          style={{
+            color: '#e6edf3',
+            fontSize: '16px',
+            fontWeight: 800,
+            marginBottom: '8px',
+          }}
+        >
+          {view.unavailable.title}
+        </div>
+
+        <div>
+          {view.unavailable.message}
+        </div>
+
+        {view.unavailable.blockers.length ? (
+          <div
+            style={{
+              marginTop: '14px',
+              display: 'grid',
+              gap: '8px',
+            }}
+          >
+            {view.unavailable.blockers.map(
+              blocker => (
+                <div
+                  key={blocker.key}
+                  style={{
+                    border: '1px solid #30363d',
+                    borderRadius: '8px',
+                    padding: '9px 11px',
+                    background: '#161b22',
+                  }}
+                >
+                  <div
+                    style={{
+                      color: '#e6edf3',
+                      fontWeight: 750,
+                    }}
+                  >
+                    {blocker.label}
+                  </div>
+
+                  {blocker.detail ? (
+                    <div
+                      style={{
+                        color: '#8b949e',
+                        fontSize: '12px',
+                        marginTop: '3px',
+                      }}
+                    >
+                      {blocker.detail}
+                    </div>
+                  ) : null}
+                </div>
+              )
+            )}
+          </div>
+        ) : null}
+
+        <div
+          style={{
+            color: '#8b949e',
+            fontSize: '12px',
+            marginTop: '12px',
+          }}
+        >
+          This tab only renders rows produced by the same
+          canonical simulation run shown in Simulation and
+          Diagnostics.
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Improves the canonical Projections tab so unavailable rows are explained with the exact same production diagnostics already shown elsewhere in the workspace.

## Behavior

- blocked canonical execution → show missing readiness requirements
- fail-open execution error → show safe error details
- executed but player rows were not attached → identify the attachment handoff problem
- canonical execution not run or not attached → show an explicit unavailable message
- projection rows present → existing batter and pitcher tables remain unchanged

## Architecture

- Reuses `buildCanonicalDiagnosticsViewModel()` instead of duplicating backend interpretation in the page component.
- Adds a structured `unavailable` object to the projections view model.
- Keeps canonical projections non-authoritative and same-run coherent.
- Does not change simulation execution, readiness rules, or production authority.

## Validation

- focused frontend tests: `27 passed`
- production frontend build passed
- `git diff --check` passed

Existing Vite warnings remain unchanged, including duplicate style keys in `LandingV2Page.jsx` and the large chunk-size warning.

## Files

- `frontend/src/lib/canonicalProjectionsUiContract.test.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`
- `frontend/src/pages/ModelProjectionsPage.jsx`