### PR TITLE
Prevent authenticated MyDashboard black screen

### DIFF
--- a/frontend/src/components/QueryStudioPanel.jsx
+++ b/frontend/src/components/QueryStudioPanel.jsx
@@ -4,6 +4,7 @@ import { buildReportCsv, safeFilenamePart } from '../lib/dashboardReportUtils.mj
 import {
   QUERY_STUDIO_EXAMPLE,
   queryStudioColumns,
+  queryStudioObjects,
   queryStudioRows,
   queryStudioSavePayload,
 } from '../lib/dashboardQueryStudioState.mjs'
@@ -32,7 +33,7 @@ function download(filename, contents) {
 }
 
 function exampleForObject(object) {
-  const fields = (object?.fields || []).filter(field => field.name !== 'metrics')
+  const fields = (Array.isArray(object?.fields) ? object.fields : []).filter(field => field?.name && field.name !== 'metrics')
   const selected = fields.slice(0, 4).map(field => field.name)
   const sortable = fields.find(field => field.sortable)
   return `SELECT ${selected.join(', ')}\nFROM ${object.api_name}${sortable ? `\nORDER BY ${sortable.name} DESC` : ''}\nLIMIT 50`
@@ -75,11 +76,12 @@ export default function QueryStudioPanel({ folderId, refreshWorkspace, restore, 
 
   const rows = queryStudioRows(result)
   const columns = queryStudioColumns(result)
+  const objects = useMemo(() => queryStudioObjects(metadata), [metadata])
   const fieldLabels = useMemo(() => {
     const map = {}
-    ;(metadata?.objects || []).forEach(object => (object.fields || []).forEach(field => { map[field.name] = field.label || field.name }))
+    objects.forEach(object => object.fields.forEach(field => { map[field.name] = field.label || field.name }))
     return map
-  }, [metadata])
+  }, [objects])
   const pageInfo = result?.page_info || {}
 
   async function request(path, nextPage = 1) {
@@ -145,7 +147,7 @@ export default function QueryStudioPanel({ folderId, refreshWorkspace, restore, 
 
   return <section style={s.panel}>
     <div style={s.row}><div><div style={s.eyebrow}>Owner Query Studio</div><h3 style={s.title}>Prompt the report registry</h3><p style={s.muted}>SELECT-only MLBGPT language. Your statement becomes a validated report plan; authored SQL never reaches the database.</p></div><span style={s.readyBadge}>Protected</span></div>
-    <div style={s.objectStrip}>{(metadata?.objects || []).map(object => <button type="button" key={object.api_name} style={s.objectChip} title={`Use ${object.label}`} onClick={() => { setStatement(exampleForObject(object)); setPreview(null); setResult(null); setPageNumber(1) }}>{object.label}<small>{object.fields.length} fields</small></button>)}</div>
+    <div style={s.objectStrip}>{objects.map(object => <button type="button" key={object.api_name} style={s.objectChip} title={`Use ${object.label || object.api_name}`} onClick={() => { setStatement(exampleForObject(object)); setPreview(null); setResult(null); setPageNumber(1) }}>{object.label || object.api_name}<small>{object.fields.length} fields</small></button>)}</div>
     <label style={s.label}>MLBGPT statement<textarea aria-label="Query Studio statement" spellCheck="false" style={s.editor} value={statement} onChange={event => setStatement(event.target.value)} onKeyDown={event => { if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') { event.preventDefault(); request('/my-dashboard/query-studio/execute', 1) } }} /></label>
     {error ? <div style={s.error}>{error}</div> : null}
     <div style={s.actions}><button style={s.secondary} disabled={running} onClick={() => request('/my-dashboard/query-studio/preview', 1)}>Preview Plan</button><button style={s.primary} disabled={running} onClick={() => request('/my-dashboard/query-studio/execute', 1)}>{running ? 'Validating…' : 'Run Query'}</button></div>

--- a/frontend/src/lib/dashboardQueryStudioState.mjs
+++ b/frontend/src/lib/dashboardQueryStudioState.mjs
@@ -7,6 +7,19 @@ LIMIT 50`
 export function canOpenQueryStudio(profile = {}) {
   return Array.isArray(profile.capabilities) && profile.capabilities.includes('workbench.advanced')
 }
+
+export function queryStudioObjects(metadata = {}) {
+  if (!Array.isArray(metadata?.objects)) return []
+  return metadata.objects
+    .filter(object => object && typeof object === 'object' && object.api_name)
+    .map(object => ({
+      ...object,
+      fields: Array.isArray(object.fields)
+        ? object.fields.filter(field => field && typeof field === 'object' && field.name)
+        : [],
+    }))
+}
+
 export function queryStudioRows(result = {}) {
   if (Array.isArray(result.records)) return result.records
   return Array.isArray(result.items) ? result.items : []

--- a/frontend/src/lib/dashboardQueryStudioState.test.mjs
+++ b/frontend/src/lib/dashboardQueryStudioState.test.mjs
@@ -5,6 +5,7 @@ import {
   canOpenQueryStudio,
   QUERY_STUDIO_EXAMPLE,
   queryStudioColumns,
+  queryStudioObjects,
   queryStudioRows,
   queryStudioSavePayload,
 } from './dashboardQueryStudioState.mjs'
@@ -14,6 +15,23 @@ test('Query Studio visibility requires the server-returned advanced capability',
   assert.equal(canOpenQueryStudio({ capabilities: ['workbench.execute'] }), false)
   assert.equal(canOpenQueryStudio({ role: 'admin' }), false)
 })
+
+test('Query Studio metadata tolerates missing and malformed object fields', () => {
+  assert.deepEqual(queryStudioObjects(), [])
+  assert.deepEqual(queryStudioObjects({ objects: null }), [])
+  assert.deepEqual(queryStudioObjects({
+    objects: [
+      null,
+      { label: 'Missing API name', fields: [] },
+      { api_name: 'hitters', label: 'Hitters' },
+      { api_name: 'pitchers', fields: [null, {}, { name: 'full_name', label: 'Name' }] },
+    ],
+  }), [
+    { api_name: 'hitters', label: 'Hitters', fields: [] },
+    { api_name: 'pitchers', fields: [{ name: 'full_name', label: 'Name' }] },
+  ])
+})
+
 test('Query Studio result helpers preserve the server plan and row contract', () => {
   const result = {
     component: 'hitters',

--- a/frontend/src/lib/dashboardReportFolders.mjs
+++ b/frontend/src/lib/dashboardReportFolders.mjs
@@ -1,6 +1,8 @@
 function dateValue(value) {
   const text = String(value || '').slice(0, 10)
-  return /^\d{4}-\d{2}-\d{2}$/.test(text) ? text : null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) return null
+  const parsed = new Date(`${text}T00:00:00Z`)
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === text ? text : null
 }
 
 function uniqueItems(folders) {

--- a/frontend/src/lib/dashboardReportFolders.test.mjs
+++ b/frontend/src/lib/dashboardReportFolders.test.mjs
@@ -34,3 +34,15 @@ test('uses a renamed physical folder label without changing computed rollup labe
   assert.equal(organized.monthly[0].label, '2026-07')
   assert.deepEqual(organized.weekly[0].folderIds, [1])
 })
+
+test('malformed legacy folder dates cannot crash authenticated workspace rollups', () => {
+  const organized = organizeReportFolders([
+    ...folders,
+    { id: 5, folder_name: 'Legacy Import', folder_date: '2026-99-45', item_count: 0, items: [] },
+  ])
+
+  assert.equal(organized.daily.some(entry => entry.id === 5), false)
+  assert.equal(organized.weekly.every(entry => entry.key), true)
+  assert.equal(organized.monthly.every(entry => entry.key), true)
+  assert.equal(organized.custom.some(entry => entry.id === 5), true)
+})

--- a/frontend/src/pages/MyDashboardReportBuilderPage.jsx
+++ b/frontend/src/pages/MyDashboardReportBuilderPage.jsx
@@ -39,6 +39,41 @@ const C = { bg: 'var(--md-bg)', panel: 'var(--md-panel)', panel2: 'var(--md-pane
 const FRANKLIN = '"Franklin Gothic Medium", "Franklin Gothic", "Arial Narrow", Arial, sans-serif'
 const CENTURY = '"Century Gothic", CenturyGothic, AppleGothic, Arial, sans-serif'
 
+class DashboardWorkspaceErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  componentDidCatch(error, info) {
+    console.error('MyDashboard workspace render failed', error, info)
+  }
+
+  async signOut() {
+    await logoutDashboardSession().catch(() => null)
+    window.location.assign('/my-dashboard')
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+    return <main style={s.crashPage}>
+      <section style={s.crashCard}>
+        <div style={s.eyebrow}>MyDashboard recovery</div>
+        <h1 style={s.crashTitle}>The workspace could not finish loading.</h1>
+        <p style={s.crashCopy}>Your session is still protected. Reload the latest workspace, or sign out to return to the landing page.</p>
+        <div style={s.actions}>
+          <button type="button" style={s.primary} onClick={() => window.location.reload()}>Reload Workspace</button>
+          <button type="button" style={s.secondary} onClick={() => this.signOut()}>Sign Out</button>
+        </div>
+      </section>
+    </main>
+  }
+}
+
 function safeArray(value) { return Array.isArray(value) ? value : [] }
 function titleCase(value) { return String(value || '').replace(/[_.-]+/g, ' ').replace(/\s+/g, ' ').trim().replace(/\b\w/g, c => c.toUpperCase()) }
 function readJson(key, fallback) { try { return JSON.parse(localStorage.getItem(key)) || fallback } catch { return fallback } }
@@ -193,7 +228,7 @@ function ReportWorkspace({ open, close, objectMeta, result, fields, builderField
   return <div style={s.overlay} role="dialog" aria-modal="true"><section style={s.reportSurface}><header style={s.reportHeader}><div><div style={s.eyebrow}>Report Workspace</div><h2 style={s.reportTitle}>{objectMeta.label} Report</h2><div style={s.copySmall}>MLB date {reportDate} · Generated {generatedAt ? new Date(generatedAt).toLocaleString() : 'now'} · Showing {range.start}–{range.end} of {range.total}</div></div><div style={s.actions}><button style={s.secondary} onClick={exportCsv} disabled={!rows.length}>Export current page CSV</button><button style={s.secondary} onClick={onSave} disabled={!rows.length}>Save Report</button><button style={s.primary} onClick={close}>Back to Builder</button></div></header><div style={{ ...s.reportBody, ...(isMobile ? s.reportBodyMobile : {}) }}><aside style={s.columnPanel}><div style={s.panelTitle}>Report Columns</div><div style={s.copySmall}>Hide or reorder columns without changing saved results.</div><div style={s.columnList}>{columns.map((accessor, index) => { const isHidden = hidden.includes(accessor); return <div style={s.columnRow} key={accessor}><label><input type="checkbox" checked={!isHidden} onChange={() => setHidden(current => isHidden ? current.filter(v => v !== accessor) : [...current, accessor])} /> {fieldMap[accessor]?.label || titleCase(accessor)}</label><div><button style={s.iconButton} disabled={index === 0} onClick={() => setColumns(current => { const next = [...current]; [next[index - 1], next[index]] = [next[index], next[index - 1]]; return next })}>↑</button><button style={s.iconButton} disabled={index === columns.length - 1} onClick={() => setColumns(current => { const next = [...current]; [next[index + 1], next[index]] = [next[index], next[index + 1]]; return next })}>↓</button></div></div> })}</div><button style={s.secondaryWide} onClick={() => { setColumns(builderFields); setHidden([]) }}>Reset to Builder Fields</button></aside><main style={s.gridPanel}><div style={s.gridToolbar}><div style={s.pillRow}><Pill>{range.total} matching rows</Pill><Pill tone="green">Sorted by: {fieldMap[query.sort_by]?.label || titleCase(query.sort_by)} {query.sort_direction}</Pill></div><label style={s.pageSize}>Rows per page <select style={s.input} value={query.page_size} onChange={e => requestPageSize(e.target.value)}>{PAGE_SIZE_OPTIONS.map(size => <option key={size} value={size}>{size}</option>)}</select></label></div>{result?.filter_warnings?.length ? <div style={s.warning}>{result.filter_warnings.join(' • ')}</div> : null}{loading ? <StatePanel tone="loading" title="Loading report page">Loading the complete report.</StatePanel> : rows.length && visible.length ? <div style={s.dataGridWrap}><table style={s.table}><thead><tr>{visible.map(accessor => <th key={accessor} style={s.th}><button style={s.sortButton} disabled={fieldMap[accessor]?.sortable === false} onClick={() => requestSort(accessor)}>{fieldMap[accessor]?.label || titleCase(accessor)} {query.sort_by === accessor ? (query.sort_direction === 'desc' ? '↓' : '↑') : '↕'}</button></th>)}</tr></thead><tbody>{rows.map((row, rowIndex) => <tr key={row.entity_id || `${objectMeta.key}-${rowIndex}`}>{visible.map(accessor => <td style={s.td} key={`${rowIndex}-${accessor}`}>{formatCell(getValue(row, accessor))}</td>)}</tr>)}</tbody></table></div> : <StatePanel tone={bootstrapMessage.tone} title={bootstrapMessage.title}>{bootstrapMessage.detail}</StatePanel>}<div style={s.pagination}><button style={s.secondary} disabled={!pageInfo.has_previous || loading} onClick={() => requestPage(pageInfo.previous_page || Math.max(1, query.page_number - 1))}>← Previous</button><span>Page {pageInfo.page_number || 1} of {pageInfo.page_count || 1}</span><button style={s.secondary} disabled={!pageInfo.has_next || loading} onClick={() => requestPage(pageInfo.next_page || query.page_number + 1)}>Next →</button></div></main></div></section></div>
 }
 
-export default function MyDashboardReportBuilderPage() {
+function MyDashboardReportBuilderContent() {
   const persisted = typeof window === 'undefined' ? {} : readJson(BUILDER_KEY, {}); const [width, setWidth] = useState(() => typeof window === 'undefined' ? 1200 : window.innerWidth)
   const [themePreference, setThemePreference] = useState(() => typeof window === 'undefined' ? 'system' : readThemePreference())
   const [systemDark, setSystemDark] = useState(() => typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches)
@@ -264,7 +299,15 @@ export default function MyDashboardReportBuilderPage() {
   return <main style={s.page}><section style={s.hero}><div><div style={s.brandSmall}>MLB<span>GPT</span></div><div style={s.eyebrow}>Private report workspace</div><h1 style={s.title}>Build your report.</h1><p style={s.copy}>Choose an MLB date, report type, fields, and filters. Sorting and pagination apply to every matching result.</p><div style={s.pillRow}><Pill>Signed in: {profile.username}</Pill><Pill tone="green">MLB date: {reportDate}</Pill></div></div><div style={s.actions}>{hasDashboardCapability(profile, 'admin.portal.access') ? <a style={s.adminLink} href="/admin">Control Center</a> : null}<button style={s.secondary} onClick={signOut}>Sign Out</button><label>MLB date<input type="date" style={s.input} value={reportDate} onChange={e => setReportDate(e.target.value || mlbDateIso())} /></label><button style={s.primary} disabled={loading[activeObject]} onClick={() => populateReport(activeObject, defaultQueryState())}>{loading[activeObject] ? 'Populating…' : 'Populate Report'}</button></div></section>{saveMessage ? <div style={saveMessage.startsWith('Failed') || saveMessage.startsWith('No ') || saveMessage.startsWith('This ') || saveMessage.startsWith('Name ') || saveMessage.startsWith('Choose ') || saveMessage.startsWith('Run ') ? s.error : s.success}>{saveMessage}</div> : null}{error ? <StatePanel tone="error" title="Report could not be generated">{error}</StatePanel> : null}<div style={{ ...s.builderShell, ...(isNarrow ? s.builderShellNarrow : {}) }}><aside style={{ ...s.objectManager, ...(isMobile ? { position: 'static' } : {}) }}><div style={s.panelTitle}>Report Types</div>{OBJECTS.map(object => <button key={object.key} style={activeObject === object.key ? s.objectActive : s.objectButton} onClick={() => selectPrimaryObject(object.key)}><span><strong>{object.label}</strong><small>{object.description}</small></span><b>{results[object.key]?.totalSize ?? safeArray(results[object.key]?.items).length}</b></button>)}</aside><div style={s.mainStack}><section style={s.card}><div style={s.cardHeader}><div><div style={s.panelTitle}>{activeMeta.label}</div><div style={s.copySmall}>{activeMeta.description}</div></div><label><input type="checkbox" checked={activeLineupsOnly} disabled={!ACTIVE_LINEUP_OBJECTS.has(activeObject)} onChange={e => setActiveLineupsOnly(e.target.checked)} /> Confirmed 1–9 only</label></div></section><div style={{ ...s.builderColumns, ...(isNarrow ? s.builderColumnsNarrow : {}) }}><div style={s.stack}><FilterPanel objectKey={activeObject} filters={activeFilters} fields={activeFields} setBasic={setBasic} setMetric={setMetric} setWeight={setWeight} /><FieldLibrary fields={activeFields} selected={selectedFields} setSelected={setSelectedFields} /></div><div style={s.stack}>{hasDashboardCapability(profile, 'workbench.advanced') ? <QueryStudioPanel folderId={folderId} refreshWorkspace={loadWorkspace} restore={queryStudioRestore} onMessage={setSaveMessage} /> : null}<section style={s.card}><div style={s.panelTitle}>Report Preview</div><div style={s.previewStats}><Pill>{selectedFields.length} columns</Pill><Pill tone="green">{Object.keys(cleanFilters(activeFilters)).length} active filter groups</Pill></div><button style={s.populateWide} disabled={loading[activeObject]} onClick={() => populateReport(activeObject, defaultQueryState())}>{loading[activeObject] ? 'Populating Report…' : 'Populate Report'}</button>{activeResult ? <button style={s.secondaryWide} onClick={() => { setReportObject(activeObject); setReportResult(activeResult); setReportColumns([...selectedFields]); setReportQuery(normalizeQueryState(activeResult.query || defaultQueryState())); setGeneratedForDate(reportDate); setGeneratedAt(new Date().toISOString()); setReportOpen(true) }}>Open Last Report</button> : <StatePanel title="No report generated yet">Choose fields and filters, then populate the report.</StatePanel>}</section></div></div><SavedReportsShelfV2 workspace={workspace} loading={workspaceLoading} error={workspaceError} openSaved={openSaved} refresh={loadWorkspace} renameSaved={renameSaved} open={savedShelfOpen} setOpen={setSavedShelfOpen} view={savedShelfView} setView={setSavedShelfView} selectedEntryKey={selectedShelfEntryKey} setSelectedEntryKey={setSelectedShelfEntryKey} selectedFolderId={selectedFolderId} setSelectedFolderId={setSelectedFolderId} newFolderName={newFolderName} setNewFolderName={setNewFolderName} createFolder={createReportFolder} creatingFolder={creatingFolder} /></div></div><ReportWorkspace open={reportOpen} close={() => setReportOpen(false)} objectMeta={reportMeta} result={reportResult} fields={reportFields} builderFields={selectedFields} initialColumns={reportColumns} generatedAt={generatedAt} reportDate={generatedForDate} query={reportQuery} setQuery={setReportQuery} reload={next => populateReport(reportObject, next, false)} loading={loading[reportObject]} onSave={saveReport} isMobile={isMobile} /></main>
 }
 
+export default function MyDashboardReportBuilderPage() {
+  return <DashboardWorkspaceErrorBoundary><MyDashboardReportBuilderContent /></DashboardWorkspaceErrorBoundary>
+}
+
 const s = {
+  crashPage: { minHeight: '100vh', display: 'grid', placeItems: 'center', padding: 24, color: '#edf2fb', background: '#07111f', boxSizing: 'border-box', fontFamily: CENTURY },
+  crashCard: { width: 'min(100%,620px)', padding: 'clamp(24px,5vw,48px)', background: '#111d2d', border: '1px solid #33445a', borderRadius: 24, boxShadow: '0 24px 70px rgba(0,0,0,.38)' },
+  crashTitle: { margin: '8px 0 12px', fontFamily: FRANKLIN, fontSize: 'clamp(28px,5vw,44px)', fontWeight: 500, lineHeight: 1.05 },
+  crashCopy: { margin: '0 0 22px', color: '#b9c5d6', fontSize: 14, lineHeight: 1.6 },
   page: { minHeight: '100vh', padding: 'clamp(12px,2.5vw,28px)', color: C.text, colorScheme: 'var(--md-color-scheme)', background: 'var(--md-page-bg)', boxSizing: 'border-box', fontFamily: CENTURY, fontSize: 13, lineHeight: 1.42, transition: 'color .2s ease,background .2s ease' },
   loadingPage: { minHeight: '100vh', display: 'grid', placeItems: 'center', color: C.text, colorScheme: 'var(--md-color-scheme)', background: 'var(--md-page-bg)', fontFamily: CENTURY },
   authPage: { position: 'relative', minHeight: '100vh', display: 'grid', alignItems: 'center', gap: 'clamp(24px,5vw,84px)', padding: 'clamp(22px,5vw,74px)', overflow: 'hidden', color: C.text, colorScheme: 'var(--md-color-scheme)', background: 'var(--md-auth-bg)', boxSizing: 'border-box', fontFamily: CENTURY, transition: 'color .2s ease,background .2s ease' },


### PR DESCRIPTION
## What changed

- adds a route-level MyDashboard error boundary so authenticated render failures show recovery actions instead of a black screen
- validates legacy saved-folder dates before Daily/Weekly/Monthly rollups
- normalizes Query Studio object metadata before rendering owner-only controls
- adds regressions for malformed legacy folder dates and incomplete Query Studio metadata

## Why

The signed-out landing rendered correctly, but authenticated accounts enter additional saved-workspace and owner Query Studio paths. Malformed legacy folder dates or incomplete object metadata could throw during those renders, and the route had no error boundary, leaving only the dark page background.

## Verification

- 13 focused MyDashboard tests passed
- production Vite build passed
- `git diff --check` passed
- full frontend suite: 100/101 passed
- the lone `topModelProjectionRows showcases projection values first` failure reproduces unchanged on current `main` and is outside this diff
- existing unrelated LandingV2 duplicate-key and bundle-size build warnings remain unchanged

Follow-up hotfix to merged PRs #1179 and #1180.