### PR TITLE
Activate canonical batted-ball out transitions

### DIFF
--- a/mlb_app/simulation/game/batted_ball_resolution.py
+++ b/mlb_app/simulation/game/batted_ball_resolution.py
@@ -12,6 +12,7 @@ from mlb_app.simulation.events import (
     BaselineBattedBallContextProvider,
     BaselineRunnerAdvancementSampler,
     BattedBallContext,
+    MultiOutPlayResolver,
     OutRecord,
     PlayEvent,
     RunnerAdvancementResult,
@@ -162,34 +163,51 @@ def resolve_canonical_batted_ball_outcome(
         context=context,
     )
 
-    if outcome is CanonicalPlateAppearanceOutcome.OUT:
-        movements = advancement.movements + (
-            RunnerMovement(
-                runner_id=query.batter_id,
-                start_base=Base.HOME,
-                end_base=None,
-                is_out=True,
-            ),
+    special_out_event_type = (
+        _select_special_out_event_type(
+            state=query.state,
+            outcome_subtype=outcome_subtype,
         )
-        outs_recorded = (
-            OutRecord(
-                runner_id=query.batter_id,
-                out_number=query.state.outs + 1,
-                reason=outcome_subtype,
-            ),
+        if outcome is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
+
+    if special_out_event_type is not None:
+        event = MultiOutPlayResolver().resolve(
+            state=query.state,
+            event_type=special_out_event_type,
+            batter_id=query.batter_id,
+            sequence=query.sequence,
         )
     else:
-        movements = advancement.movements
-        outs_recorded = ()
+        if outcome is CanonicalPlateAppearanceOutcome.OUT:
+            movements = advancement.movements + (
+                RunnerMovement(
+                    runner_id=query.batter_id,
+                    start_base=Base.HOME,
+                    end_base=None,
+                    is_out=True,
+                ),
+            )
+            outs_recorded = (
+                OutRecord(
+                    runner_id=query.batter_id,
+                    out_number=query.state.outs + 1,
+                    reason=outcome_subtype,
+                ),
+            )
+        else:
+            movements = advancement.movements
+            outs_recorded = ()
 
-    event = build_play_event(
-        sequence=query.sequence,
-        event_type=outcome.value,
-        batter_id=query.batter_id,
-        state_before=query.state,
-        runner_movements=movements,
-        outs_recorded=outs_recorded,
-    )
+        event = build_play_event(
+            sequence=query.sequence,
+            event_type=outcome.value,
+            batter_id=query.batter_id,
+            state_before=query.state,
+            runner_movements=movements,
+            outs_recorded=outs_recorded,
+        )
 
     event = replace(
         event,
@@ -205,6 +223,36 @@ def resolve_canonical_batted_ball_outcome(
         advancement_seed=advancement_seed,
         outcome_subtype=outcome_subtype,
     )
+
+
+def _select_special_out_event_type(
+    *,
+    state,
+    outcome_subtype: Optional[str],
+) -> Optional[str]:
+    """Select an explicit canonical scoring-rule out transition."""
+
+    if (
+        outcome_subtype == "groundout"
+        and state.first is not None
+        and state.outs < 2
+    ):
+        return "ground_ball_double_play"
+
+    if (
+        outcome_subtype == "flyout"
+        and state.third is not None
+        and state.outs < 2
+    ):
+        return "sacrifice_fly"
+
+    if outcome_subtype in {
+        "flyout",
+        "lineout_popout",
+    }:
+        return "caught_fly"
+
+    return None
 
 
 def derive_canonical_batted_ball_seed(

--- a/tests/test_canonical_batted_ball_advancement.py
+++ b/tests/test_canonical_batted_ball_advancement.py
@@ -330,3 +330,174 @@ def test_strikeout_does_not_use_batted_ball_resolution():
                 CanonicalPlateAppearanceOutcome.STRIKEOUT
             )
         )
+
+
+def test_groundout_with_runner_on_first_becomes_double_play(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "groundout",
+    )
+
+    state = GameState(
+        inning=5,
+        half="top",
+        outs=0,
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == (
+        "ground_ball_double_play"
+    )
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.outs == 2
+    assert event.state_after.bases == (
+        None,
+        None,
+        None,
+    )
+    assert len(event.outs_recorded) == 2
+
+
+def test_groundout_with_two_outs_remains_ordinary_out(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "groundout",
+    )
+
+    state = GameState(
+        inning=5,
+        half="top",
+        outs=2,
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "out"
+    assert event.state_after.outs == 3
+    assert len(event.outs_recorded) == 1
+
+
+def test_flyout_with_runner_on_third_becomes_sacrifice_fly(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    state = GameState(
+        inning=7,
+        half="top",
+        outs=1,
+        bases=(
+            None,
+            None,
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "sacrifice_fly"
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.outs == 2
+    assert event.state_after.away_score == 1
+    assert event.runs_scored == (
+        "away_batter_3",
+    )
+    assert event.attribution.rbi_count == 1
+
+
+def test_flyout_without_runner_on_third_becomes_caught_fly(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    state = GameState(
+        inning=7,
+        half="top",
+        outs=0,
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "caught_fly"
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.outs == 1
+    assert event.state_after.first == (
+        "away_batter_1"
+    )
+
+
+def test_lineout_popout_becomes_caught_fly(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "lineout_popout",
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+        )
+    )
+
+    assert resolution.event.event_type == "caught_fly"
+    assert resolution.event.state_after.outs == 1


### PR DESCRIPTION
## Summary

Activates explicit canonical scoring-rule transitions for selected batted-ball outs in the production canonical PA resolution path.

## Behavior

- eligible groundouts with a runner on first and fewer than two outs → `ground_ball_double_play`
- eligible flyouts with a runner on third and fewer than two outs → `sacrifice_fly`
- ordinary flyouts and lineout/popout outcomes → `caught_fly`
- all remaining outs → existing ordinary-out transition

## Architecture

- Reuses the existing `MultiOutPlayResolver` as the sole authority for outs, runner movement, scoring cancellation, RBI attribution, and sacrifice attribution.
- Keeps batted-ball context sampling and deterministic seed derivation unchanged.
- Preserves active pitcher attribution on the resolved event.
- Leaves fielder’s-choice activation deferred until a defensible selector is introduced.

## Validation

- focused test suite: `46 passed`
- Python compilation passed
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/game/batted_ball_resolution.py`
- `tests/test_canonical_batted_ball_advancement.py`