### PR TITLE
Fix authenticated Query Studio initial render

### DIFF
--- a/frontend/src/lib/dashboardQueryStudioState.mjs
+++ b/frontend/src/lib/dashboardQueryStudioState.mjs
@@ -21,8 +21,8 @@ export function queryStudioObjects(metadata = {}) {
 }
 
 export function queryStudioRows(result = {}) {
-  if (Array.isArray(result.records)) return result.records
-  return Array.isArray(result.items) ? result.items : []
+  if (Array.isArray(result?.records)) return result.records
+  return Array.isArray(result?.items) ? result.items : []
 }
 
 export function queryStudioColumns(result = {}) {

--- a/frontend/src/lib/dashboardQueryStudioState.test.mjs
+++ b/frontend/src/lib/dashboardQueryStudioState.test.mjs
@@ -32,6 +32,11 @@ test('Query Studio metadata tolerates missing and malformed object fields', () =
   ])
 })
 
+test('Query Studio initial render accepts a null result before execution', () => {
+  assert.deepEqual(queryStudioRows(null), [])
+  assert.deepEqual(queryStudioColumns(null), [])
+})
+
 test('Query Studio result helpers preserve the server plan and row contract', () => {
   const result = {
     component: 'hitters',


### PR DESCRIPTION
## Root cause

Authorized owner accounts mount Query Studio immediately after MyDashboard authentication. Its initial `result` state is `null`, but `queryStudioRows` dereferenced `result.records` before the first execution response existed. That synchronous render exception triggered the MyDashboard recovery boundary.

## Fix

- use null-safe access for Query Studio result rows and items
- add a regression covering the exact pre-execution `null` result state

## Verification

- reproduced the authenticated owner crash with the exact React component stack: `QueryStudioPanel` → `queryStudioRows(null)`
- 10 focused Query Studio and routed-workspace tests passed
- production Vite build passed
- `git diff --check` passed
- existing unrelated LandingV2 duplicate-key and bundle-size warnings remain unchanged

Follow-up to #1182.