### PR TITLE
Sample canonical ground-ball force plays

### DIFF
--- a/mlb_app/simulation/game/batted_ball_resolution.py
+++ b/mlb_app/simulation/game/batted_ball_resolution.py
@@ -28,8 +28,10 @@ from .probability import (
 
 
 CANONICAL_BATTED_BALL_RESOLUTION_VERSION = (
-    "canonical_batted_ball_resolution_v1"
+    "canonical_batted_ball_resolution_v2"
 )
+
+BASELINE_GROUND_BALL_DOUBLE_PLAY_PROBABILITY = 0.55
 
 CANONICAL_OUT_SUBTYPES: Tuple[str, ...] = (
     "groundout",
@@ -58,6 +60,8 @@ class CanonicalBattedBallResolution:
     advancement: RunnerAdvancementResult
     context_seed: int
     advancement_seed: int
+    force_play_seed: Optional[int] = None
+    force_play_draw: Optional[float] = None
     outcome_subtype: Optional[str] = None
     resolution_version: str = (
         CANONICAL_BATTED_BALL_RESOLUTION_VERSION
@@ -87,6 +91,30 @@ class CanonicalBattedBallResolution:
         if self.advancement_seed < 0:
             raise ValueError(
                 "advancement_seed cannot be negative"
+            )
+
+        if (
+            self.force_play_seed is not None
+            and self.force_play_seed < 0
+        ):
+            raise ValueError(
+                "force_play_seed cannot be negative"
+            )
+
+        if (
+            self.force_play_draw is not None
+            and not 0.0 <= self.force_play_draw < 1.0
+        ):
+            raise ValueError(
+                "force_play_draw must be in [0, 1)"
+            )
+
+        if (
+            self.force_play_draw is not None
+            and self.force_play_seed is None
+        ):
+            raise ValueError(
+                "force_play_draw requires force_play_seed"
             )
 
         if self.resolution_version != (
@@ -135,6 +163,15 @@ def resolve_canonical_batted_ball_outcome(
         sampled=sampled,
         purpose="advancement",
     )
+    force_play_seed = (
+        derive_canonical_batted_ball_seed(
+            sampled=sampled,
+            purpose="force_play",
+        )
+        if outcome
+        is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
 
     outcome_subtype = (
         _sample_outcome_subtype(context_seed)
@@ -163,10 +200,22 @@ def resolve_canonical_batted_ball_outcome(
         context=context,
     )
 
+    force_play_draw = (
+        random.Random(force_play_seed).random()
+        if (
+            force_play_seed is not None
+            and outcome_subtype == "groundout"
+            and query.state.first is not None
+            and query.state.outs < 2
+        )
+        else None
+    )
+
     special_out_event_type = (
         _select_special_out_event_type(
             state=query.state,
             outcome_subtype=outcome_subtype,
+            force_play_draw=force_play_draw,
         )
         if outcome is CanonicalPlateAppearanceOutcome.OUT
         else None
@@ -221,6 +270,12 @@ def resolve_canonical_batted_ball_outcome(
         advancement=advancement,
         context_seed=context_seed,
         advancement_seed=advancement_seed,
+        force_play_seed=(
+            force_play_seed
+            if force_play_draw is not None
+            else None
+        ),
+        force_play_draw=force_play_draw,
         outcome_subtype=outcome_subtype,
     )
 
@@ -229,6 +284,7 @@ def _select_special_out_event_type(
     *,
     state,
     outcome_subtype: Optional[str],
+    force_play_draw: Optional[float] = None,
 ) -> Optional[str]:
     """Select an explicit canonical scoring-rule out transition."""
 
@@ -237,7 +293,18 @@ def _select_special_out_event_type(
         and state.first is not None
         and state.outs < 2
     ):
-        return "ground_ball_double_play"
+        if force_play_draw is None:
+            raise ValueError(
+                "eligible groundout requires force_play_draw"
+            )
+
+        if (
+            force_play_draw
+            < BASELINE_GROUND_BALL_DOUBLE_PLAY_PROBABILITY
+        ):
+            return "ground_ball_double_play"
+
+        return "ground_ball_fielders_choice"
 
     if (
         outcome_subtype == "flyout"

--- a/tests/test_canonical_batted_ball_advancement.py
+++ b/tests/test_canonical_batted_ball_advancement.py
@@ -227,8 +227,16 @@ def test_batted_ball_out_uses_explicit_advancement():
     assert event.outs_recorded[0].runner_id == (
         "away_batter_0"
     )
+    expected_reason = {
+        "flyout": "caught_fly",
+        "lineout_popout": "caught_fly",
+    }.get(
+        resolution.outcome_subtype,
+        resolution.outcome_subtype,
+    )
+
     assert event.outs_recorded[0].reason == (
-        resolution.outcome_subtype
+        expected_reason
     )
     assert event.runner_movements[-1].is_out
 
@@ -339,6 +347,11 @@ def test_groundout_with_runner_on_first_becomes_double_play(
         "mlb_app.simulation.game."
         "batted_ball_resolution._sample_outcome_subtype",
         lambda _seed: "groundout",
+    )
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution.random.Random.random",
+        lambda _rng: 0.10,
     )
 
     state = GameState(
@@ -501,3 +514,111 @@ def test_lineout_popout_becomes_caught_fly(
 
     assert resolution.event.event_type == "caught_fly"
     assert resolution.event.state_after.outs == 1
+
+
+def test_groundout_force_play_can_be_fielders_choice(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "groundout",
+    )
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution.random.Random.random",
+        lambda _rng: 0.90,
+    )
+
+    state = GameState(
+        inning=5,
+        half="top",
+        outs=0,
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == (
+        "ground_ball_fielders_choice"
+    )
+    assert event.pitcher_id == "home_starter"
+    assert event.state_after.outs == 1
+    assert event.state_after.first == (
+        "away_batter_0"
+    )
+    assert event.state_after.second is None
+    assert resolution.force_play_seed is not None
+    assert resolution.force_play_draw == 0.90
+
+
+def test_force_play_seed_is_independent():
+    value = sampled(
+        CanonicalPlateAppearanceOutcome.OUT,
+        state=GameState(
+            inning=5,
+            half="top",
+            bases=(
+                "away_batter_1",
+                None,
+                None,
+            ),
+        ),
+    )
+
+    context_seed = derive_canonical_batted_ball_seed(
+        sampled=value,
+        purpose="context",
+    )
+    advancement_seed = derive_canonical_batted_ball_seed(
+        sampled=value,
+        purpose="advancement",
+    )
+    force_play_seed = derive_canonical_batted_ball_seed(
+        sampled=value,
+        purpose="force_play",
+    )
+
+    assert force_play_seed != context_seed
+    assert force_play_seed != advancement_seed
+
+
+def test_ineligible_groundout_has_no_force_play_provenance(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "groundout",
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=GameState(
+                inning=5,
+                half="top",
+                outs=2,
+                bases=(
+                    "away_batter_1",
+                    None,
+                    None,
+                ),
+            ),
+        )
+    )
+
+    assert resolution.event.event_type == "out"
+    assert resolution.force_play_seed is None
+    assert resolution.force_play_draw is None


### PR DESCRIPTION
## Summary

Introduces deterministic, replayable selection between canonical ground-ball double plays and fielder’s choices for eligible groundouts.

## Behavior

- eligible groundout with a runner on first and fewer than two outs
  - draw below baseline threshold → `ground_ball_double_play`
  - draw at or above threshold → `ground_ball_fielders_choice`
- ineligible groundouts retain the ordinary-out path

## Architecture

- adds a versioned baseline double-play probability
- derives an independent `force_play` decision seed from immutable sampled PA identity
- records `force_play_seed` and `force_play_draw` on `CanonicalBattedBallResolution`
- keeps `MultiOutPlayResolver` as the authority for runner movement, outs, force status, and scoring behavior
- preserves pitcher attribution and deterministic replayability

## Validation

- focused test suite: `49 passed`
- Python compilation passed
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/game/batted_ball_resolution.py`
- `tests/test_canonical_batted_ball_advancement.py`