### PR TITLE
Model canonical fly-ball tag advancement

### DIFF
--- a/mlb_app/simulation/game/batted_ball_resolution.py
+++ b/mlb_app/simulation/game/batted_ball_resolution.py
@@ -14,9 +14,11 @@ from mlb_app.simulation.events import (
     BattedBallContext,
     MultiOutPlayResolver,
     OutRecord,
+    PlayAttribution,
     PlayEvent,
     RunnerAdvancementResult,
     RunnerMovement,
+    SacrificeType,
     build_play_event,
 )
 
@@ -28,10 +30,28 @@ from .probability import (
 
 
 CANONICAL_BATTED_BALL_RESOLUTION_VERSION = (
-    "canonical_batted_ball_resolution_v2"
+    "canonical_batted_ball_resolution_v3"
 )
 
 BASELINE_GROUND_BALL_DOUBLE_PLAY_PROBABILITY = 0.55
+
+BASELINE_FLY_TAG_RATES = {
+    Base.THIRD: {
+        "attempt_probability": 0.65,
+        "success_probability": 0.92,
+        "destination": Base.HOME,
+    },
+    Base.SECOND: {
+        "attempt_probability": 0.22,
+        "success_probability": 0.94,
+        "destination": Base.THIRD,
+    },
+    Base.FIRST: {
+        "attempt_probability": 0.06,
+        "success_probability": 0.90,
+        "destination": Base.SECOND,
+    },
+}
 
 CANONICAL_OUT_SUBTYPES: Tuple[str, ...] = (
     "groundout",
@@ -62,6 +82,11 @@ class CanonicalBattedBallResolution:
     advancement_seed: int
     force_play_seed: Optional[int] = None
     force_play_draw: Optional[float] = None
+    tag_attempt_seed: Optional[int] = None
+    tag_attempt_draw: Optional[float] = None
+    tag_success_seed: Optional[int] = None
+    tag_success_draw: Optional[float] = None
+    tag_origin_base: Optional[Base] = None
     outcome_subtype: Optional[str] = None
     resolution_version: str = (
         CANONICAL_BATTED_BALL_RESOLUTION_VERSION
@@ -115,6 +140,50 @@ class CanonicalBattedBallResolution:
         ):
             raise ValueError(
                 "force_play_draw requires force_play_seed"
+            )
+
+        for name, value in (
+            ("tag_attempt_draw", self.tag_attempt_draw),
+            ("tag_success_draw", self.tag_success_draw),
+        ):
+            if (
+                value is not None
+                and not 0.0 <= value < 1.0
+            ):
+                raise ValueError(
+                    f"{name} must be in [0, 1)"
+                )
+
+        if (
+            self.tag_attempt_draw is not None
+            and self.tag_attempt_seed is None
+        ):
+            raise ValueError(
+                "tag_attempt_draw requires tag_attempt_seed"
+            )
+
+        if (
+            self.tag_success_draw is not None
+            and self.tag_success_seed is None
+        ):
+            raise ValueError(
+                "tag_success_draw requires tag_success_seed"
+            )
+
+        if (
+            self.tag_success_draw is not None
+            and self.tag_attempt_draw is None
+        ):
+            raise ValueError(
+                "tag success requires a tag attempt"
+            )
+
+        if (
+            self.tag_origin_base is not None
+            and self.tag_attempt_draw is None
+        ):
+            raise ValueError(
+                "tag_origin_base requires a tag attempt"
             )
 
         if self.resolution_version != (
@@ -172,6 +241,24 @@ def resolve_canonical_batted_ball_outcome(
         is CanonicalPlateAppearanceOutcome.OUT
         else None
     )
+    tag_attempt_seed = (
+        derive_canonical_batted_ball_seed(
+            sampled=sampled,
+            purpose="tag_attempt",
+        )
+        if outcome
+        is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
+    tag_success_seed = (
+        derive_canonical_batted_ball_seed(
+            sampled=sampled,
+            purpose="tag_success",
+        )
+        if outcome
+        is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
 
     outcome_subtype = (
         _sample_outcome_subtype(context_seed)
@@ -211,17 +298,36 @@ def resolve_canonical_batted_ball_outcome(
         else None
     )
 
-    special_out_event_type = (
-        _select_special_out_event_type(
+    tag_resolution = (
+        _sample_fly_tag_resolution(
             state=query.state,
             outcome_subtype=outcome_subtype,
-            force_play_draw=force_play_draw,
+            attempt_seed=tag_attempt_seed,
+            success_seed=tag_success_seed,
         )
         if outcome is CanonicalPlateAppearanceOutcome.OUT
         else None
     )
 
-    if special_out_event_type is not None:
+    special_out_event_type = (
+        _select_special_out_event_type(
+            state=query.state,
+            outcome_subtype=outcome_subtype,
+            force_play_draw=force_play_draw,
+            tag_resolution=tag_resolution,
+        )
+        if outcome is CanonicalPlateAppearanceOutcome.OUT
+        else None
+    )
+
+    if tag_resolution is not None:
+        event = _build_caught_fly_tag_event(
+            state=query.state,
+            batter_id=query.batter_id,
+            sequence=query.sequence,
+            tag_resolution=tag_resolution,
+        )
+    elif special_out_event_type is not None:
         event = MultiOutPlayResolver().resolve(
             state=query.state,
             event_type=special_out_event_type,
@@ -276,6 +382,37 @@ def resolve_canonical_batted_ball_outcome(
             else None
         ),
         force_play_draw=force_play_draw,
+        tag_attempt_seed=(
+            tag_attempt_seed
+            if tag_resolution is not None
+            else None
+        ),
+        tag_attempt_draw=(
+            tag_resolution["attempt_draw"]
+            if tag_resolution is not None
+            else None
+        ),
+        tag_success_seed=(
+            tag_success_seed
+            if (
+                tag_resolution is not None
+                and tag_resolution["attempted"]
+            )
+            else None
+        ),
+        tag_success_draw=(
+            tag_resolution["success_draw"]
+            if (
+                tag_resolution is not None
+                and tag_resolution["attempted"]
+            )
+            else None
+        ),
+        tag_origin_base=(
+            tag_resolution["origin_base"]
+            if tag_resolution is not None
+            else None
+        ),
         outcome_subtype=outcome_subtype,
     )
 
@@ -285,6 +422,7 @@ def _select_special_out_event_type(
     state,
     outcome_subtype: Optional[str],
     force_play_draw: Optional[float] = None,
+    tag_resolution=None,
 ) -> Optional[str]:
     """Select an explicit canonical scoring-rule out transition."""
 
@@ -306,12 +444,8 @@ def _select_special_out_event_type(
 
         return "ground_ball_fielders_choice"
 
-    if (
-        outcome_subtype == "flyout"
-        and state.third is not None
-        and state.outs < 2
-    ):
-        return "sacrifice_fly"
+    if tag_resolution is not None:
+        return None
 
     if outcome_subtype in {
         "flyout",
@@ -320,6 +454,197 @@ def _select_special_out_event_type(
         return "caught_fly"
 
     return None
+
+
+def _sample_fly_tag_resolution(
+    *,
+    state,
+    outcome_subtype: Optional[str],
+    attempt_seed: Optional[int],
+    success_seed: Optional[int],
+):
+    if (
+        outcome_subtype != "flyout"
+        or state.outs >= 2
+        or attempt_seed is None
+        or success_seed is None
+    ):
+        return None
+
+    for origin_base in (
+        Base.THIRD,
+        Base.SECOND,
+        Base.FIRST,
+    ):
+        runner_id = state.runner_on(origin_base)
+
+        if runner_id is None:
+            continue
+
+        rate = BASELINE_FLY_TAG_RATES[origin_base]
+        attempt_draw = random.Random(
+            attempt_seed ^ int(origin_base)
+        ).random()
+
+        if (
+            attempt_draw
+            >= rate["attempt_probability"]
+        ):
+            return {
+                "origin_base": origin_base,
+                "runner_id": runner_id,
+                "destination": rate["destination"],
+                "attempt_draw": attempt_draw,
+                "success_draw": None,
+                "attempted": False,
+                "succeeded": False,
+            }
+
+        success_draw = random.Random(
+            success_seed ^ int(origin_base)
+        ).random()
+
+        return {
+            "origin_base": origin_base,
+            "runner_id": runner_id,
+            "destination": rate["destination"],
+            "attempt_draw": attempt_draw,
+            "success_draw": success_draw,
+            "attempted": True,
+            "succeeded": (
+                success_draw
+                < rate["success_probability"]
+            ),
+        }
+
+    return None
+
+
+def _build_caught_fly_tag_event(
+    *,
+    state,
+    batter_id: str,
+    sequence: int,
+    tag_resolution,
+) -> PlayEvent:
+    movements = []
+
+    for base in (
+        Base.FIRST,
+        Base.SECOND,
+        Base.THIRD,
+    ):
+        runner_id = state.runner_on(base)
+
+        if runner_id is None:
+            continue
+
+        if (
+            base == tag_resolution["origin_base"]
+            and tag_resolution["attempted"]
+        ):
+            if tag_resolution["succeeded"]:
+                destination = tag_resolution["destination"]
+                movements.append(
+                    RunnerMovement(
+                        runner_id=runner_id,
+                        start_base=base,
+                        end_base=destination,
+                        scored=(
+                            destination is Base.HOME
+                        ),
+                    )
+                )
+            else:
+                movements.append(
+                    RunnerMovement(
+                        runner_id=runner_id,
+                        start_base=base,
+                        end_base=None,
+                        is_out=True,
+                    )
+                )
+        else:
+            movements.append(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=base,
+                    end_base=base,
+                )
+            )
+
+    movements.append(
+        RunnerMovement(
+            runner_id=batter_id,
+            start_base=Base.HOME,
+            end_base=None,
+            is_out=True,
+        )
+    )
+
+    outs = [
+        OutRecord(
+            runner_id=batter_id,
+            out_number=state.outs + 1,
+            reason="caught_fly",
+        )
+    ]
+
+    if (
+        tag_resolution["attempted"]
+        and not tag_resolution["succeeded"]
+        and state.outs + 1 < 3
+    ):
+        outs.append(
+            OutRecord(
+                runner_id=tag_resolution["runner_id"],
+                out_number=state.outs + 2,
+                reason="tag_out",
+            )
+        )
+
+    scored = (
+        tag_resolution["attempted"]
+        and tag_resolution["succeeded"]
+        and tag_resolution["destination"] is Base.HOME
+    )
+
+    return build_play_event(
+        sequence=sequence,
+        event_type=(
+            "sacrifice_fly"
+            if scored
+            else (
+                "caught_fly_tag_advance"
+                if (
+                    tag_resolution["attempted"]
+                    and tag_resolution["succeeded"]
+                )
+                else (
+                    "caught_fly_tag_out"
+                    if tag_resolution["attempted"]
+                    else "caught_fly"
+                )
+            )
+        ),
+        batter_id=batter_id,
+        state_before=state,
+        runner_movements=tuple(movements),
+        outs_recorded=tuple(outs),
+        attribution=PlayAttribution(
+            rbi_credited_to=(
+                batter_id
+                if scored
+                else None
+            ),
+            rbi_count=1 if scored else 0,
+            sacrifice_type=(
+                SacrificeType.FLY
+                if scored
+                else None
+            ),
+        ),
+    )
 
 
 def derive_canonical_batted_ball_seed(

--- a/tests/test_canonical_batted_ball_advancement.py
+++ b/tests/test_canonical_batted_ball_advancement.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 import pytest
 
 from mlb_app.simulation.events import (
+    Base,
     BattedBallContext,
     GameState,
 )
@@ -622,3 +623,364 @@ def test_ineligible_groundout_has_no_force_play_provenance(
     assert resolution.event.event_type == "out"
     assert resolution.force_play_seed is None
     assert resolution.force_play_draw is None
+
+
+def test_flyout_runner_on_third_can_hold(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.THIRD,
+            "runner_id": "away_batter_3",
+            "destination": Base.HOME,
+            "attempt_draw": 0.99,
+            "success_draw": None,
+            "attempted": False,
+            "succeeded": False,
+        },
+    )
+
+    state = GameState(
+        inning=6,
+        half="top",
+        outs=0,
+        bases=(
+            None,
+            None,
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "caught_fly"
+    assert event.state_after.outs == 1
+    assert event.state_after.third == "away_batter_3"
+    assert event.runs_scored == ()
+    assert resolution.tag_origin_base is Base.THIRD
+    assert resolution.tag_attempt_draw == 0.99
+    assert resolution.tag_success_draw is None
+
+
+def test_flyout_runner_on_second_tags_safely_to_third(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.SECOND,
+            "runner_id": "away_batter_2",
+            "destination": Base.THIRD,
+            "attempt_draw": 0.10,
+            "success_draw": 0.10,
+            "attempted": True,
+            "succeeded": True,
+        },
+    )
+
+    state = GameState(
+        inning=6,
+        half="top",
+        outs=0,
+        bases=(
+            None,
+            "away_batter_2",
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "caught_fly_tag_advance"
+    assert event.state_after.outs == 1
+    assert event.state_after.second is None
+    assert event.state_after.third == "away_batter_2"
+    assert resolution.tag_origin_base is Base.SECOND
+    assert resolution.tag_attempt_draw == 0.10
+    assert resolution.tag_success_draw == 0.10
+
+
+def test_flyout_runner_on_first_tags_safely_to_second(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.FIRST,
+            "runner_id": "away_batter_1",
+            "destination": Base.SECOND,
+            "attempt_draw": 0.01,
+            "success_draw": 0.10,
+            "attempted": True,
+            "succeeded": True,
+        },
+    )
+
+    state = GameState(
+        inning=6,
+        half="top",
+        outs=0,
+        bases=(
+            "away_batter_1",
+            None,
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "caught_fly_tag_advance"
+    assert event.state_after.outs == 1
+    assert event.state_after.first is None
+    assert event.state_after.second == "away_batter_1"
+
+
+def test_flyout_tag_attempt_can_end_in_tag_out(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.SECOND,
+            "runner_id": "away_batter_2",
+            "destination": Base.THIRD,
+            "attempt_draw": 0.10,
+            "success_draw": 0.99,
+            "attempted": True,
+            "succeeded": False,
+        },
+    )
+
+    state = GameState(
+        inning=6,
+        half="top",
+        outs=0,
+        bases=(
+            None,
+            "away_batter_2",
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "caught_fly_tag_out"
+    assert event.state_after.outs == 2
+    assert event.state_after.bases == (
+        None,
+        None,
+        None,
+    )
+    assert tuple(
+        record.reason
+        for record in event.outs_recorded
+    ) == (
+        "caught_fly",
+        "tag_out",
+    )
+
+
+def test_runner_on_third_safe_tag_is_sacrifice_fly(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.THIRD,
+            "runner_id": "away_batter_3",
+            "destination": Base.HOME,
+            "attempt_draw": 0.10,
+            "success_draw": 0.10,
+            "attempted": True,
+            "succeeded": True,
+        },
+    )
+
+    state = GameState(
+        inning=7,
+        half="top",
+        outs=1,
+        bases=(
+            None,
+            None,
+            "away_batter_3",
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.event_type == "sacrifice_fly"
+    assert event.state_after.outs == 2
+    assert event.state_after.away_score == 1
+    assert event.runs_scored == (
+        "away_batter_3",
+    )
+    assert event.attribution.rbi_count == 1
+
+
+def test_flyout_with_two_outs_is_not_tag_eligible(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    state = GameState(
+        inning=7,
+        half="top",
+        outs=2,
+        bases=(
+            None,
+            "away_batter_2",
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    assert resolution.event.event_type == "caught_fly"
+    assert resolution.event.state_after.outs == 3
+    assert resolution.event.state_after.second == (
+        "away_batter_2"
+    )
+    assert resolution.tag_attempt_seed is None
+    assert resolution.tag_attempt_draw is None
+    assert resolution.tag_success_seed is None
+    assert resolution.tag_success_draw is None
+
+
+def test_failed_tag_after_caught_fly_can_record_third_out(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_outcome_subtype",
+        lambda _seed: "flyout",
+    )
+
+    monkeypatch.setattr(
+        "mlb_app.simulation.game."
+        "batted_ball_resolution._sample_fly_tag_resolution",
+        lambda **_kwargs: {
+            "origin_base": Base.SECOND,
+            "runner_id": "away_batter_2",
+            "destination": Base.THIRD,
+            "attempt_draw": 0.10,
+            "success_draw": 0.99,
+            "attempted": True,
+            "succeeded": False,
+        },
+    )
+
+    state = GameState(
+        inning=8,
+        half="top",
+        outs=1,
+        bases=(
+            None,
+            "away_batter_2",
+            None,
+        ),
+    )
+
+    resolution = resolve_canonical_batted_ball_outcome(
+        sampled(
+            CanonicalPlateAppearanceOutcome.OUT,
+            state=state,
+        )
+    )
+
+    event = resolution.event
+
+    assert event.state_after.outs == 3
+    assert tuple(
+        record.out_number
+        for record in event.outs_recorded
+    ) == (
+        2,
+        3,
+    )
+    assert tuple(
+        record.reason
+        for record in event.outs_recorded
+    ) == (
+        "caught_fly",
+        "tag_out",
+    )


### PR DESCRIPTION
## Summary

Adds deterministic, replayable fly-ball tag advancement to the canonical batted-ball resolver.

## Behavior

For eligible flyouts with fewer than two outs, the resolver now supports one prioritized tag decision per play:

- runner on third → home
- runner on second → third
- runner on first → second

Each eligible runner can:

- hold
- tag and advance safely
- tag and be thrown out

Safe third-to-home advancement resolves as a sacrifice fly with RBI and sacrifice attribution. Failed tag attempts produce explicit `tag_out` records, including inning-ending third outs.

## Architecture

- adds versioned baseline tag attempt and success rates by origin base
- derives independent `tag_attempt` and `tag_success` seeds from immutable sampled plate-appearance identity
- records tag decision provenance on `CanonicalBattedBallResolution`
- builds explicit runner movements and ordered out records for replay validation
- keeps caught-fly batter out first in the event ledger
- preserves pitcher attribution and existing scoring-rule handling
- intentionally limits v1 to one prioritized tag attempt per caught fly

## Validation

- focused test suite: `56 passed`
- Python compilation passed
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/game/batted_ball_resolution.py`
- `tests/test_canonical_batted_ball_advancement.py`