### PR TITLE
Surface canonical realism capabilities

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -60,12 +60,14 @@ def _build_game_state_realism_diagnostics() -> dict:
         "walkoff_shortening_enabled": True,
         "extras_walkoff_model_status": "diagnostic_wired",
         "double_play_enabled": True,
+        "multi_out_scoring": True,
         "double_play_rate_source": "existing_simulation_transition_logic",
         "double_play_transition_summary": {
             "status": "diagnostic_only",
             "final_probability_replacement": False,
         },
         "sac_fly_enabled": True,
+        "sacrifice_fly_scoring": True,
         "sac_fly_rate_source": "existing_simulation_transition_logic",
         "sac_fly_transition_summary": {
             "status": "diagnostic_only",

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -323,3 +323,50 @@ def test_invalid_legacy_payload_is_rejected():
         raise AssertionError(
             "invalid legacy payload must fail"
         )
+
+
+def test_executed_shadow_attaches_same_run_player_projections():
+    execution = executed_shadow()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result={
+                "status": "ok",
+                "diagnostics": {},
+            },
+            production_execution=execution,
+        )
+    )
+
+    shadow = result["diagnostics"]["canonical_shadow"]
+    projections = shadow["player_projections"]
+
+    assert projections["schema_version"] == (
+        "canonical_player_projection_rows_v1"
+    )
+    assert projections["run_id"] == (
+        execution.material.canonical_payload["run_id"]
+    )
+    assert projections["simulation_count"] == (
+        execution
+        .material
+        .canonical_payload["simulation_count"]
+    )
+    assert projections["players"]
+
+
+def test_realism_payload_exposes_frontend_capability_aliases():
+    realism = (
+        model_projections
+        ._build_game_state_realism_diagnostics()
+    )
+
+    assert realism["multi_out_scoring"] is True
+    assert (
+        realism["sacrifice_fly_scoring"]
+        is True
+    )
+    assert realism["steals_model_status"] == (
+        "deferred_not_active"
+    )


### PR DESCRIPTION
## Summary

Surfaces implemented canonical game-state realism capabilities in the Model Projections payload and adds regression coverage for same-run canonical player projection attachment.

## Changes

- adds frontend-recognized `multi_out_scoring` capability metadata
- adds frontend-recognized `sacrifice_fly_scoring` capability metadata
- preserves stolen-base status as deferred/not active
- verifies executed production shadow material attaches same-run canonical player projection rows
- verifies run identity and simulation count are preserved through the attachment bridge

## Validation

- focused test suite: `18 passed`
- Python compilation passed
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/model_projections.py`
- `tests/test_model_projection_production_shadow_comparator.py`