### PR TITLE
Invalidate stale projection workspace payloads

### DIFF
--- a/mlb_app/model_projection_performance_cache.py
+++ b/mlb_app/model_projection_performance_cache.py
@@ -157,7 +157,7 @@ def cached_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
     ttl = env_ttl("MODEL_PROJECTION_SIMULATION_CACHE_TTL_SECONDS")
     cached = get_cache(cache_key, ttl)
     if isinstance(cached, dict):
-        cached.setdefault("cache_hit", True)
+        cached["cache_hit"] = True
         cached.setdefault("cache_key", cache_key)
         return cached
 

--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -37,7 +37,7 @@ def matchups_date_key(date: str) -> str:
 
 
 MODEL_PROJECTION_WORKSPACE_VERSION = (
-    "model_projection_workspace_v2"
+    "model_projection_workspace_v3"
 )
 
 

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -168,3 +168,21 @@ def test_projection_workspace_version_changes_cache_namespace() -> None:
     assert key.endswith(
         f"{MODEL_PROJECTION_WORKSPACE_VERSION}:{date}"
     )
+
+
+def test_model_projection_workspace_v3_invalidates_prior_payload_cache():
+    date = "2026-07-23"
+
+    key = model_projection_date_key(date)
+
+    assert MODEL_PROJECTION_WORKSPACE_VERSION == (
+        "model_projection_workspace_v3"
+    )
+    assert key.endswith(
+        "model_projection_workspace_v3:"
+        + date
+    )
+    assert (
+        "model_projection_workspace_v2"
+        not in key
+    )


### PR DESCRIPTION
## Summary

Invalidates stale Model Projections payloads so deployed and warmed caches rebuild against the current canonical player-projection attachment contract.

## Changes

- bumps `MODEL_PROJECTION_WORKSPACE_VERSION` from v2 to v3
- forces `/models/projections` cache keys and warmed artifacts onto the new workspace namespace
- adds regression coverage proving v3 no longer reuses v2 keys
- corrects cached simulation-card metadata so subsequent reads report `cache_hit = true`

## Why

The canonical attachment bridge already preserves same-run player projections, but unchanged v2 cache keys could continue serving payloads created before that attachment existed. The workspace contract bump ensures those stale payloads are invalidated without changing simulation semantics.

## Validation

- focused test suite: `31 passed`
- Python compilation passed
- `git diff --check` passed

Existing SQLAlchemy and `datetime.utcnow()` deprecation warnings remain unchanged.

## Files

- `mlb_app/model_projection_performance_cache.py`
- `mlb_app/shared_artifacts.py`
- `tests/test_shared_artifacts.py`