### PR TITLE
Expose projection attachment diagnostics

### DIFF
--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -203,10 +203,76 @@ function sortRows(rows) {
   })
 }
 
-function unavailableProjectionState(game) {
+function unavailableProjectionState(
+  game,
+  projections,
+) {
   const diagnostics = (
     buildCanonicalDiagnosticsViewModel(game)
   )
+
+  const projectionStatus = String(
+    projections?.status || ''
+  ).toLowerCase()
+  const projectionSchema = (
+    projections?.schema_version || null
+  )
+  const projectionPlayers = asArray(
+    projections?.players,
+  )
+
+  if (projectionStatus === 'error') {
+    return {
+      state: 'attachment_error',
+      title: 'Canonical projection attachment failed',
+      message: (
+        projections?.error_message ||
+        'Canonical player projection rows could not be adapted from the completed simulation payload.'
+      ),
+      blockers: [],
+      errorType: projections?.error_type || null,
+      errorMessage: (
+        projections?.error_message || null
+      ),
+      receivedSchema: projectionSchema,
+    }
+  }
+
+  if (
+    projectionSchema ===
+      'canonical_player_projection_rows_v1' &&
+    projectionPlayers.length === 0
+  ) {
+    return {
+      state: 'empty_rows',
+      title: 'Canonical projection rows were empty',
+      message: (
+        'The canonical projection attachment was present, but it contained no batter or pitcher rows.'
+      ),
+      blockers: [],
+      errorType: null,
+      errorMessage: null,
+      receivedSchema: projectionSchema,
+    }
+  }
+
+  if (
+    projectionSchema &&
+    projectionSchema !==
+      'canonical_player_projection_rows_v1'
+  ) {
+    return {
+      state: 'schema_mismatch',
+      title: 'Canonical projection schema was not recognized',
+      message: (
+        `Expected canonical_player_projection_rows_v1 but received ${projectionSchema}.`
+      ),
+      blockers: [],
+      errorType: null,
+      errorMessage: null,
+      receivedSchema: projectionSchema,
+    }
+  }
 
   const execution = (
     diagnostics.productionExecution || {}
@@ -309,7 +375,10 @@ export function buildCanonicalProjectionsViewModel(
   const unavailable = (
     available
       ? null
-      : unavailableProjectionState(game)
+      : unavailableProjectionState(
+          game,
+          projections,
+        )
   )
 
   return {

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -310,3 +310,114 @@ test('explains missing projection attachment after execution', () => {
     'Canonical projections were not attached',
   )
 })
+
+
+test('explains projection attachment adapter errors', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow: {
+          player_projections: {
+            schema_version: (
+              'canonical_player_projection_rows_v1'
+            ),
+            status: 'error',
+            error_type: 'ValueError',
+            error_message: (
+              'metric count must match simulation_count'
+            ),
+            players: [],
+          },
+        },
+        canonical_shadow_production_execution: {
+          status: 'executed',
+          executed: true,
+          canonical_available: true,
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'attachment_error',
+  )
+  assert.equal(
+    view.unavailable.errorType,
+    'ValueError',
+  )
+  assert.match(
+    view.unavailable.message,
+    /metric count must match simulation_count/,
+  )
+})
+
+
+test('explains empty canonical projection rows', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow: {
+          player_projections: {
+            schema_version: (
+              'canonical_player_projection_rows_v1'
+            ),
+            status: 'available',
+            players: [],
+          },
+        },
+        canonical_shadow_production_execution: {
+          status: 'executed',
+          executed: true,
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'empty_rows',
+  )
+  assert.equal(
+    view.unavailable.title,
+    'Canonical projection rows were empty',
+  )
+})
+
+
+test('explains projection schema mismatches', () => {
+  const view = (
+    buildCanonicalProjectionsViewModel({
+      diagnostics: {
+        canonical_shadow: {
+          player_projections: {
+            schema_version: (
+              'canonical_player_projection_rows_v2'
+            ),
+            players: [
+              {
+                player_id: 'b-1',
+              },
+            ],
+          },
+        },
+      },
+    })
+  )
+
+  assert.equal(view.available, false)
+  assert.equal(
+    view.unavailable.state,
+    'schema_mismatch',
+  )
+  assert.equal(
+    view.unavailable.receivedSchema,
+    'canonical_player_projection_rows_v2',
+  )
+  assert.match(
+    view.unavailable.message,
+    /received canonical_player_projection_rows_v2/,
+  )
+})


### PR DESCRIPTION
## Summary

Improves the Model Projections frontend diagnostics so canonical player-projection failures are no longer collapsed into a generic attachment-missing message.

## Changes

- distinguishes backend player-projection adapter errors from absent attachments
- distinguishes valid projection attachments with zero rows
- reports unexpected projection schema versions explicitly
- preserves the existing generic missing-attachment state when the projection object is truly absent
- surfaces backend `error_type` and `error_message` details through the existing unavailable view contract

## Validation

- frontend view-model suite: `11 passed`
- `git diff --check` passed

## Files

- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`