### PR TITLE
Align projection diagnostics contract

### DIFF
--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -358,8 +358,18 @@ function unavailableProjectionState(
 export function buildCanonicalProjectionsViewModel(
   game,
 ) {
+  const sharedSimulation = asObject(
+    game?.sharedSimulation,
+  )
+  const sharedDiagnostics = asObject(
+    sharedSimulation.diagnostics,
+  )
+  const topLevelDiagnostics = asObject(
+    game?.diagnostics,
+  )
   const shadow = asObject(
-    game?.diagnostics?.canonical_shadow,
+    topLevelDiagnostics.canonical_shadow ||
+    sharedDiagnostics.canonical_shadow,
   )
   const projections = asObject(
     shadow.player_projections,

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -421,3 +421,51 @@ test('explains projection schema mismatches', () => {
     /received canonical_player_projection_rows_v2/,
   )
 })
+
+
+test('reads canonical projections from sharedSimulation diagnostics', () => {
+  const source = payload()
+  const shadow = source.diagnostics.canonical_shadow
+
+  const view = buildCanonicalProjectionsViewModel({
+    sharedSimulation: {
+      diagnostics: {
+        canonical_shadow: shadow,
+      },
+    },
+  })
+
+  assert.equal(view.available, true)
+  assert.equal(view.runId, 'run-123')
+  assert.equal(view.batters.length, 1)
+  assert.equal(view.pitchers.length, 1)
+})
+
+
+test('prefers top-level projection diagnostics when both paths exist', () => {
+  const source = payload()
+  const topLevelShadow = source.diagnostics.canonical_shadow
+
+  const view = buildCanonicalProjectionsViewModel({
+    diagnostics: {
+      canonical_shadow: topLevelShadow,
+    },
+    sharedSimulation: {
+      diagnostics: {
+        canonical_shadow: {
+          player_projections: {
+            schema_version: (
+              'canonical_player_projection_rows_v1'
+            ),
+            run_id: 'shared-run',
+            simulation_count: 25,
+            players: [],
+          },
+        },
+      },
+    },
+  })
+
+  assert.equal(view.available, true)
+  assert.equal(view.runId, 'run-123')
+})


### PR DESCRIPTION
## Summary

Aligns the Canonical Player Projections frontend adapter with the actual `/models/projections` response contract.

## Changes

- reads canonical player projections from `game.sharedSimulation.diagnostics.canonical_shadow`
- preserves compatibility with `game.diagnostics.canonical_shadow`
- prefers the explicit top-level diagnostics path when both are present
- adds regression coverage for both access paths

## Why

The live route stores canonical shadow diagnostics under `sharedSimulation`, while the Projections view model previously read only the top-level `game.diagnostics` path. This caused valid same-run player projection rows to appear missing even though the Diagnostics tab showed a completed canonical run.

## Validation

- frontend projection suites: `18 passed`
- `git diff --check` passed

## Files

- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`