### PR TITLE
Activate canonical DraftKings scoring

### DIFF
--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from mlb_app.simulation.box_score import (
+    DRAFTKINGS_CLASSIC_BATTER_RULES,
+    DRAFTKINGS_CLASSIC_PITCHER_RULES,
+)
+
 from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Tuple
 
@@ -414,6 +419,12 @@ def run_canonical_production_shadow(
                 exact_artifact=exact_artifact,
                 fallback_catalog=fallback_catalog,
                 fallback_policy=fallback_policy,
+                batter_dfs_rules=(
+                    DRAFTKINGS_CLASSIC_BATTER_RULES
+                ),
+                pitcher_dfs_rules=(
+                    DRAFTKINGS_CLASSIC_PITCHER_RULES
+                ),
             )
         )
 

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from mlb_app.simulation.box_score import (
+    DRAFTKINGS_CLASSIC_BATTER_RULES,
+    DRAFTKINGS_CLASSIC_PITCHER_RULES,
+)
 from mlb_app.simulation.game import (
     CANONICAL_PA_OUTCOME_ORDER,
     CanonicalOutcomeProbability,
@@ -379,3 +383,47 @@ def test_preferred_replacement_outside_bullpen_is_ignored():
         plan.preferred_replacement_pitcher_ids
         == ()
     )
+
+
+def test_production_shadow_activates_draftkings_scoring_rules():
+    result = run()
+
+    assert result.status == "executed"
+    assert result.material is not None
+    assert result.execution_inputs is not None
+
+    payload = result.material.canonical_payload
+
+    batter_metric_names = {
+        metric["name"]
+        for row in payload["batters"]
+        for metric in row["metrics"]
+    }
+    pitcher_metric_names = {
+        metric["name"]
+        for row in payload["pitchers"]
+        for metric in row["metrics"]
+    }
+
+    assert "dfs_points" in batter_metric_names
+
+    assert (
+        result.execution_inputs.batter_dfs_rules
+        is DRAFTKINGS_CLASSIC_BATTER_RULES
+    )
+    assert (
+        result.execution_inputs.pitcher_dfs_rules
+        is DRAFTKINGS_CLASSIC_PITCHER_RULES
+    )
+
+    if (
+        payload["diagnostics"]["earned_run_status"]
+        == "reconstructed"
+    ):
+        assert "dfs_points" in pitcher_metric_names
+    else:
+        assert "dfs_points" not in pitcher_metric_names
+        assert (
+            "pitcher_dfs_earned_runs_unavailable"
+            in payload["diagnostics"]["warnings"]
+        )


### PR DESCRIPTION
## Summary

Activates DraftKings Classic scoring rules in production canonical shadow execution so same-run player projection payloads include batter DFS metrics and carry explicit pitcher scoring configuration.

## Changes

- injects `DRAFTKINGS_CLASSIC_BATTER_RULES` into canonical production execution inputs
- injects `DRAFTKINGS_CLASSIC_PITCHER_RULES` into canonical production execution inputs
- preserves existing execution-bundle and legacy-authority contracts
- adds regression coverage proving production shadow execution carries active DraftKings scoring rules and emits batter DFS metrics

## Validation

- focused test suite: `37 passed`
- Python compilation passed
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/shadow/production_execution.py`
- `tests/test_canonical_production_shadow_execution.py`

## Follow-up

Pitcher DFS metrics still remain gated when earned-run reconstruction is unavailable for a player across the batch. Ordinary run-producing events also still need explicit RBI attribution in a separate scoring-realism slice.