### PR TITLE
Attribute ordinary batter RBI

### DIFF
--- a/mlb_app/simulation/game/outcome_resolution.py
+++ b/mlb_app/simulation/game/outcome_resolution.py
@@ -67,10 +67,18 @@ def resolve_canonical_sampled_plate_appearance(
             sequence=query.sequence,
         )
 
-        return replace(
+        event = replace(
             event,
             pitcher_id=query.pitcher_id,
         )
+
+        if (
+            outcome
+            is CanonicalPlateAppearanceOutcome.HOME_RUN
+        ):
+            return _credit_batter_rbi(event)
+
+        return event
 
     if outcome in {
         CanonicalPlateAppearanceOutcome.OUT,
@@ -78,9 +86,18 @@ def resolve_canonical_sampled_plate_appearance(
         CanonicalPlateAppearanceOutcome.DOUBLE,
         CanonicalPlateAppearanceOutcome.TRIPLE,
     }:
-        return resolve_canonical_batted_ball_outcome(
+        event = resolve_canonical_batted_ball_outcome(
             sampled
         ).event
+
+        if outcome in {
+            CanonicalPlateAppearanceOutcome.SINGLE,
+            CanonicalPlateAppearanceOutcome.DOUBLE,
+            CanonicalPlateAppearanceOutcome.TRIPLE,
+        }:
+            return _credit_batter_rbi(event)
+
+        return event
 
     if (
         outcome
@@ -90,6 +107,26 @@ def resolve_canonical_sampled_plate_appearance(
 
     raise ValueError(
         f"unsupported sampled outcome: {outcome}"
+    )
+
+
+def _credit_batter_rbi(
+    event: PlayEvent,
+) -> PlayEvent:
+    """Credit the batter for runs produced by an ordinary hit."""
+
+    run_count = len(event.runs_scored)
+
+    if run_count == 0:
+        return event
+
+    return replace(
+        event,
+        attribution=replace(
+            event.attribution,
+            rbi_credited_to=event.batter_id,
+            rbi_count=run_count,
+        ),
     )
 
 

--- a/tests/test_canonical_sampled_outcome_resolution.py
+++ b/tests/test_canonical_sampled_outcome_resolution.py
@@ -245,6 +245,10 @@ def test_occupied_base_triple_advances_runner():
     assert event.runs_scored == (
         "away_batter_1",
     )
+    assert event.attribution.rbi_credited_to == (
+        "away_batter_0"
+    )
+    assert event.attribution.rbi_count == 1
 
 
 def test_home_run_scores_all_runners_and_batter():
@@ -281,6 +285,22 @@ def test_home_run_scores_all_runners_and_batter():
         "away_batter_0",
     )
     assert event.state_after.away_score == 4
+    assert event.attribution.rbi_credited_to == (
+        "away_batter_0"
+    )
+    assert event.attribution.rbi_count == 4
+
+
+def test_non_scoring_hit_does_not_credit_rbi():
+    event = resolve_canonical_sampled_plate_appearance(
+        sampled(
+            CanonicalPlateAppearanceOutcome.SINGLE,
+        )
+    )
+
+    assert event.runs_scored == ()
+    assert event.attribution.rbi_credited_to is None
+    assert event.attribution.rbi_count == 0
 
 
 def test_resolution_rejects_non_sample_contract():


### PR DESCRIPTION
## Summary

Credits batters with RBI from canonical run-producing hits while preserving immutable event attribution and existing scoring reduction.

## Changes

- credits the batter for every counted run produced by singles, doubles, triples, and home runs
- preserves zero RBI attribution when a hit produces no run
- keeps walks, hit-by-pitches, outs, and sacrifice handling unchanged
- adds regression coverage for a run-scoring triple, a grand slam, and a non-scoring single

## Validation

- focused test suite: `40 passed`
- Python compilation passed
- Ruff passed when available
- `git diff --check` passed

One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/game/outcome_resolution.py`
- `tests/test_canonical_sampled_outcome_resolution.py`