### PR TITLE
Align canonical projection metric mappings

### DIFF
--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -111,7 +111,10 @@ function batterRow(row) {
       homeRuns,
     ]),
     runs: metricValue(row, 'runs'),
-    rbis: metricValue(row, 'rbis'),
+    rbis: (
+      metricValue(row, 'rbi') ??
+      metricValue(row, 'rbis')
+    ),
     singles,
     doubles,
     triples,
@@ -139,7 +142,10 @@ function batterRow(row) {
 }
 
 function pitcherRow(row) {
-  const outs = metricValue(row, 'outs')
+  const outs = (
+    metricValue(row, 'outs_recorded') ??
+    metricValue(row, 'outs')
+  )
 
   return {
     playerId: row?.player_id ?? null,

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -50,7 +50,7 @@ function payload() {
                 triples: metric(0.1),
                 home_runs: metric(0.4),
                 runs: metric(0.8),
-                rbis: metric(1.1),
+                rbi: metric(1.1),
                 walks: metric(0.5),
                 stolen_bases: metric(0.2),
                 strikeouts: metric(1.2),
@@ -62,7 +62,7 @@ function payload() {
               team_side: 'home',
               metrics: {
                 batters_faced: metric(24),
-                outs: metric(18),
+                outs_recorded: metric(18),
                 hits_allowed: metric(5),
                 walks: metric(2),
                 hit_by_pitch: metric(0.3),
@@ -115,6 +115,7 @@ test('derives batter hits from component means', () => {
   assert.equal(batter.name, 'Test Batter')
   assert.equal(batter.plateAppearances, 4.4)
   assert.equal(batter.hits, 1.5)
+  assert.equal(batter.rbis, 1.1)
   assert.equal(batter.stolenBases, 0.2)
   assert.equal(batter.dfsMean, 10.5)
   assert.equal(batter.dfsFloor, 3)
@@ -122,7 +123,7 @@ test('derives batter hits from component means', () => {
   assert.equal(batter.dfsCeiling, 20)
 })
 
-test('derives pitcher innings from outs', () => {
+test('derives pitcher innings from canonical outs recorded', () => {
   const view = (
     buildCanonicalProjectionsViewModel(
       payload(),
@@ -138,6 +139,31 @@ test('derives pitcher innings from outs', () => {
   assert.equal(pitcher.dfsMedian, 17)
   assert.equal(pitcher.dfsCeiling, 27)
 })
+
+
+test('preserves legacy RBI and outs metric aliases', () => {
+  const source = payload()
+  const players = (
+    source
+      .diagnostics
+      .canonical_shadow
+      .player_projections
+      .players
+  )
+  const batterMetrics = players[0].metrics
+  const pitcherMetrics = players[1].metrics
+
+  batterMetrics.rbis = batterMetrics.rbi
+  delete batterMetrics.rbi
+  pitcherMetrics.outs = pitcherMetrics.outs_recorded
+  delete pitcherMetrics.outs_recorded
+
+  const view = buildCanonicalProjectionsViewModel(source)
+
+  assert.equal(view.batters[0].rbis, 1.1)
+  assert.equal(view.pitchers[0].inningsPitched, 6)
+})
+
 
 test('returns unavailable view without rows', () => {
   const view = (


### PR DESCRIPTION
## Summary

Aligns the canonical projections frontend adapter with the metric names emitted by the backend projection payload.

## Changes

- reads batter RBI from canonical `rbi`
- derives pitcher innings from canonical `outs_recorded`
- preserves compatibility with legacy `rbis` and `outs` aliases
- updates fixtures to exercise the production canonical metric contract
- adds regression coverage for both canonical and legacy metric names

## Validation

- frontend focused suites: `33 passed`
- Node syntax checks passed
- production frontend build passed
- `git diff --check` passed

Existing unrelated Vite duplicate-key and chunk-size warnings remain unchanged.

## Files

- `frontend/src/lib/canonicalProjectionsViewModel.mjs`
- `frontend/src/lib/canonicalProjectionsViewModel.test.mjs`