### PR TITLE
Activate canonical pitcher earned runs

### DIFF
--- a/mlb_app/simulation/game/pitcher_responsibility.py
+++ b/mlb_app/simulation/game/pitcher_responsibility.py
@@ -245,6 +245,14 @@ class CanonicalPitcherResponsibilityLedger:
             self._scored[scored_before:]
         )
 
+    def retire_runner(
+        self,
+        runner_id: str,
+    ) -> None:
+        """Remove responsibility when a runner leaves the bases."""
+
+        self._active.pop(runner_id, None)
+
     def responsibility_for_runner(
         self,
         runner_id: str,

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -308,6 +308,24 @@ class CanonicalPitchingManager:
                     event=event,
                 )
 
+        for responsibility in scored:
+            if (
+                responsibility.runner_id not in before
+                and responsibility.runner_id not in after
+            ):
+                transient_reach = CanonicalRunnerResponsibility(
+                    runner_id=responsibility.runner_id,
+                    responsible_pitcher_id=(
+                        responsibility.responsible_pitcher_id
+                    ),
+                    reached_on_event_sequence=event.sequence,
+                    reached_on_event_type=event.event_type,
+                )
+                self._earned_run_reconstructor.record_runner_reach(
+                    responsibility=transient_reach,
+                    event=event,
+                )
+
         for movement in event.runner_movements:
             if movement.is_out:
                 self._earned_run_reconstructor.retire_runner(
@@ -319,6 +337,20 @@ class CanonicalPitchingManager:
                 self._earned_run_reconstructor
                 .classify_scored_run(responsibility)
             )
+
+        if event.state_after.outs == 3:
+            stranded = (
+                self._responsibility_ledger
+                .active_responsibilities()
+            )
+
+            for responsibility in stranded:
+                self._responsibility_ledger.retire_runner(
+                    responsibility.runner_id
+                )
+                self._earned_run_reconstructor.retire_runner(
+                    responsibility.runner_id
+                )
 
         self._active[team_side] = updated
         return updated

--- a/mlb_app/simulation/projections/aggregator.py
+++ b/mlb_app/simulation/projections/aggregator.py
@@ -335,17 +335,24 @@ def _aggregate_pitchers(
             for metric in PITCHER_METRICS
         }
 
+        earned_runs_available = (
+            _player_earned_runs_available(
+                runs=runs,
+                team_side=team_side,
+                player_id=player_id,
+            )
+        )
+
         include_dfs = (
             dfs_rules is not None
             and (
                 dfs_rules.earned_run == 0.0
-                or _player_earned_runs_available(
-                    runs=runs,
-                    team_side=team_side,
-                    player_id=player_id,
-                )
+                or earned_runs_available
             )
         )
+
+        if earned_runs_available:
+            metric_values["earned_runs"] = []
 
         if include_dfs:
             metric_values["dfs_points"] = []
@@ -361,6 +368,15 @@ def _aggregate_pitchers(
                 metric_values[metric].append(
                     float(
                         getattr(line, metric)
+                        if line is not None
+                        else 0
+                    )
+                )
+
+            if earned_runs_available:
+                metric_values["earned_runs"].append(
+                    float(
+                        line.earned_runs
                         if line is not None
                         else 0
                     )

--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -18,8 +18,12 @@ from mlb_app.simulation.game.factory_input import (
 from mlb_app.simulation.game.matchup_input import (
     CanonicalMatchupInput,
 )
+from mlb_app.simulation.game.bullpen_selector import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+)
 from mlb_app.simulation.game.pa_resolver_factory import (
-    build_canonical_pa_resolver_factory,
+    CanonicalPlateAppearanceResolverFactory,
 )
 from mlb_app.simulation.game.probability_artifact import (
     CanonicalProbabilityArtifact,
@@ -46,6 +50,21 @@ from .execution_bundle import (
 CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION = (
     "canonical_shadow_execution_bundle_factory_v1"
 )
+
+
+def _baseline_bullpen(
+    pitcher_ids: tuple[str, ...],
+) -> tuple[CanonicalBullpenPitcher, ...]:
+    """Adapt an identity-only pitching plan into stable bullpen inputs."""
+
+    return tuple(
+        CanonicalBullpenPitcher(
+            pitcher_id=pitcher_id,
+            role=CanonicalBullpenRole.MIDDLE_RELIEF,
+            appearance_priority=index,
+        )
+        for index, pitcher_id in enumerate(pitcher_ids)
+    )
 
 
 @dataclass(frozen=True)
@@ -188,8 +207,18 @@ class CanonicalShadowExecutionBundleFactory:
         )
 
         resolver_factory = (
-            build_canonical_pa_resolver_factory(
-                probability_provider
+            CanonicalPlateAppearanceResolverFactory(
+                probability_provider=probability_provider,
+                away_bullpen=_baseline_bullpen(
+                    self.matchup_input
+                    .away_pitching_plan
+                    .bullpen_pitcher_ids
+                ),
+                home_bullpen=_baseline_bullpen(
+                    self.matchup_input
+                    .home_pitching_plan
+                    .bullpen_pitcher_ids
+                ),
             )
         )
 

--- a/tests/test_canonical_pitcher_responsibility.py
+++ b/tests/test_canonical_pitcher_responsibility.py
@@ -280,3 +280,53 @@ def test_duplicate_batter_runner_assignment_fails():
         match="already has active",
     ):
         ledger.apply_event(first)
+
+
+
+def test_retired_stranded_runner_can_reach_again():
+    ledger = CanonicalPitcherResponsibilityLedger()
+
+    reach = event(
+        sequence=0,
+        pitcher_id="starter",
+        event_type="single",
+        movements=(
+            RunnerMovement(
+                runner_id="runner_a",
+                start_base=0,
+                end_base=1,
+            ),
+        ),
+    )
+
+    ledger.apply_event(reach)
+    ledger.retire_runner("runner_a")
+
+    assert (
+        ledger.responsibility_for_runner("runner_a")
+        is None
+    )
+
+    ledger.apply_event(
+        event(
+            sequence=6,
+            pitcher_id="reliever",
+            event_type="single",
+            movements=(
+                RunnerMovement(
+                    runner_id="runner_a",
+                    start_base=0,
+                    end_base=1,
+                ),
+            ),
+        )
+    )
+
+    responsibility = (
+        ledger.responsibility_for_runner("runner_a")
+    )
+
+    assert responsibility is not None
+    assert responsibility.responsible_pitcher_id == (
+        "reliever"
+    )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -702,3 +702,45 @@ def test_manager_falls_back_when_preferred_pitcher_unavailable():
     )
 
     assert pitcher == "home_long"
+
+
+
+def test_manager_reconstructs_same_play_home_run_batter():
+    value = manager()
+    state = GameState(
+        inning=1,
+        half="top",
+    )
+
+    home_run = replace(
+        build_play_event(
+            sequence=0,
+            event_type="hr",
+            batter_id="away_batter_0",
+            state_before=state,
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=Base.HOME,
+                    end_base=Base.HOME,
+                    scored=True,
+                ),
+            ),
+        ),
+        pitcher_id="home_starter",
+    )
+
+    value.record_plate_appearance(home_run)
+
+    classifications = value.run_classifications()
+    lines = value.reconstructed_pitcher_run_lines()
+
+    assert len(classifications) == 1
+    assert classifications[0].runner_id == (
+        "away_batter_0"
+    )
+    assert classifications[0].earned is True
+    assert len(lines) == 1
+    assert lines[0].pitcher_id == "home_starter"
+    assert lines[0].runs_allowed == 1
+    assert lines[0].earned_runs == 1

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -427,3 +427,33 @@ def test_production_shadow_activates_draftkings_scoring_rules():
             "pitcher_dfs_earned_runs_unavailable"
             in payload["diagnostics"]["warnings"]
         )
+
+
+
+def test_production_shadow_exposes_reconstructed_earned_runs():
+    result = run()
+
+    assert result.status == "executed"
+    assert result.material is not None
+
+    payload = result.material.canonical_payload
+    diagnostics = payload["diagnostics"]
+    pitcher_metric_names = {
+        metric["name"]
+        for row in payload["pitchers"]
+        for metric in row["metrics"]
+    }
+
+    assert diagnostics["earned_run_status"] == (
+        "reconstructed"
+    )
+    assert (
+        "earned_runs_not_fully_reconstructed"
+        not in diagnostics["warnings"]
+    )
+    assert (
+        "pitcher_dfs_earned_runs_unavailable"
+        not in diagnostics["warnings"]
+    )
+    assert "earned_runs" in pitcher_metric_names
+    assert "dfs_points" in pitcher_metric_names


### PR DESCRIPTION
## Summary

Activates the existing trial-owned pitching manager in canonical shadow execution so pitcher responsibility and earned runs are reconstructed from the same immutable event stream as the game simulation.

## Changes

- adapts identity-only canonical bullpen plans into deterministic baseline bullpen inputs
- activates starter and reliever lifecycle management in shadow trials
- preserves pitcher responsibility for inherited runners
- clears stranded-runner responsibility after the third out
- records same-play reach provenance for home-run batters
- emits `earned_runs` only when reconstruction is available
- unlocks pitcher DraftKings metrics when earned-run reconstruction is complete

## Production safety

- canonical execution remains non-authoritative shadow output
- legacy production authority is unchanged
- existing fail-open behavior is preserved
- unreconstructed pitcher rows continue to omit earned runs and earned-run-dependent DFS metrics

## Validation

- focused simulation suite: `71 passed`
- Python compilation passed
- `git diff --check` passed

Ruff was unavailable in the local environment. One existing SQLAlchemy deprecation warning remains unchanged.

## Files

- `mlb_app/simulation/game/pitcher_responsibility.py`
- `mlb_app/simulation/game/pitching_manager.py`
- `mlb_app/simulation/projections/aggregator.py`
- `mlb_app/simulation/shadow/execution_factory.py`
- `tests/test_canonical_pitcher_responsibility.py`
- `tests/test_canonical_pitching_manager.py`
- `tests/test_canonical_production_shadow_execution.py`