### PR TITLE
Add canonical baserunning event contract

### DIFF
--- a/mlb_app/simulation/events/__init__.py
+++ b/mlb_app/simulation/events/__init__.py
@@ -38,6 +38,7 @@ from .legal_transitions import (
     validate_runner_movements,
 )
 
+from .baserunning_resolution import build_baserunning_event
 from .event_validation import validate_resolved_play_components
 from .multi_out_resolver import MultiOutPlayResolver
 from .play_resolution import build_play_event
@@ -81,6 +82,7 @@ __all__ = [
     "MultiOutPlayResolver",
     "PlayAttribution",
     "SacrificeType",
+    "build_baserunning_event",
     "build_play_event",
     "counted_scorers",
     "third_out_is_force_or_batter_runner_out",

--- a/mlb_app/simulation/events/baserunning_resolution.py
+++ b/mlb_app/simulation/events/baserunning_resolution.py
@@ -1,0 +1,176 @@
+"""Construct canonical non-plate-appearance baserunning events."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Optional, Tuple
+
+from .contracts import (
+    Base,
+    GameState,
+    OutRecord,
+    PlayEvent,
+    RunnerMovement,
+)
+from .event_validation import validate_resolved_play_components
+
+
+_SUPPORTED_EVENT_TYPES = frozenset(
+    {
+        "stolen_base",
+        "caught_stealing",
+    }
+)
+
+_SUPPORTED_TRANSITIONS = frozenset(
+    {
+        (Base.FIRST, Base.SECOND),
+        (Base.SECOND, Base.THIRD),
+    }
+)
+
+
+def build_baserunning_event(
+    *,
+    sequence: int,
+    event_type: str,
+    batter_id: str,
+    runner_id: str,
+    state_before: GameState,
+    origin_base: Base,
+    target_base: Base,
+    pitcher_id: Optional[str] = None,
+) -> PlayEvent:
+    """Resolve one deterministic steal or caught-stealing event."""
+
+    if state_before.outs >= 3:
+        raise ValueError(
+            "cannot resolve baserunning after three outs"
+        )
+
+    if event_type not in _SUPPORTED_EVENT_TYPES:
+        raise ValueError(
+            f"unsupported baserunning event_type: {event_type}"
+        )
+
+    if (
+        origin_base,
+        target_base,
+    ) not in _SUPPORTED_TRANSITIONS:
+        raise ValueError(
+            "unsupported baserunning base transition"
+        )
+
+    if state_before.runner_on(origin_base) != runner_id:
+        raise ValueError(
+            "runner does not occupy origin base"
+        )
+
+    if state_before.runner_on(target_base) is not None:
+        raise ValueError(
+            "target base must be unoccupied"
+        )
+
+    caught_stealing = event_type == "caught_stealing"
+    movements = _build_movements(
+        state_before=state_before,
+        runner_id=runner_id,
+        origin_base=origin_base,
+        target_base=target_base,
+        caught_stealing=caught_stealing,
+    )
+
+    outs_recorded: Tuple[OutRecord, ...] = ()
+    if caught_stealing:
+        outs_recorded = (
+            OutRecord(
+                runner_id=runner_id,
+                out_number=state_before.outs + 1,
+                reason="caught_stealing",
+            ),
+        )
+
+    bases = [None, None, None]
+    for movement in movements:
+        if movement.is_out:
+            continue
+
+        if movement.end_base is None:
+            raise ValueError(
+                "surviving runner requires an ending base"
+            )
+
+        bases[int(movement.end_base) - 1] = (
+            movement.runner_id
+        )
+
+    state_after = replace(
+        state_before,
+        outs=state_before.outs + len(outs_recorded),
+        bases=tuple(bases),
+    )
+
+    validate_resolved_play_components(
+        state_before=state_before,
+        state_after=state_after,
+        runner_movements=movements,
+        outs_recorded=outs_recorded,
+        runs_scored=(),
+    )
+
+    return PlayEvent(
+        sequence=sequence,
+        event_type=event_type,
+        batter_id=batter_id,
+        pitcher_id=pitcher_id,
+        state_before=state_before,
+        state_after=state_after,
+        runner_movements=movements,
+        outs_recorded=outs_recorded,
+        is_plate_appearance=False,
+    )
+
+
+def _build_movements(
+    *,
+    state_before: GameState,
+    runner_id: str,
+    origin_base: Base,
+    target_base: Base,
+    caught_stealing: bool,
+) -> Tuple[RunnerMovement, ...]:
+    movements = []
+
+    for base in (
+        Base.FIRST,
+        Base.SECOND,
+        Base.THIRD,
+    ):
+        occupant = state_before.runner_on(base)
+        if occupant is None:
+            continue
+
+        if occupant == runner_id:
+            movements.append(
+                RunnerMovement(
+                    runner_id=runner_id,
+                    start_base=origin_base,
+                    end_base=(
+                        None
+                        if caught_stealing
+                        else target_base
+                    ),
+                    is_out=caught_stealing,
+                )
+            )
+            continue
+
+        movements.append(
+            RunnerMovement(
+                runner_id=occupant,
+                start_base=base,
+                end_base=base,
+            )
+        )
+
+    return tuple(movements)

--- a/mlb_app/simulation/events/contracts.py
+++ b/mlb_app/simulation/events/contracts.py
@@ -140,6 +140,7 @@ class PlayEvent:
     runs_scored: Tuple[str, ...] = field(default_factory=tuple)
     attribution: PlayAttribution = field(default_factory=PlayAttribution)
     pitcher_id: Optional[str] = None
+    is_plate_appearance: bool = True
 
     def __post_init__(self) -> None:
         if self.sequence < 0:
@@ -153,19 +154,39 @@ class PlayEvent:
                 "pitcher_id cannot be an empty string"
             )
 
-        if self.state_after.plate_appearance_number != (
-            self.state_before.plate_appearance_number + 1
-        ):
+        if not isinstance(self.is_plate_appearance, bool):
             raise ValueError(
-                "a plate-appearance event must increment "
-                "plate_appearance_number exactly once"
+                "is_plate_appearance must be boolean"
             )
 
-        if self.state_after.batting_order_index != (
-            self.state_before.batting_order_index + 1
-        ) % 9:
+        expected_plate_appearance_number = (
+            self.state_before.plate_appearance_number
+            + int(self.is_plate_appearance)
+        )
+        if (
+            self.state_after.plate_appearance_number
+            != expected_plate_appearance_number
+        ):
             raise ValueError(
-                "a plate-appearance event must advance batting order once"
+                "event plate_appearance_number transition "
+                "does not match is_plate_appearance"
+            )
+
+        expected_batting_order_index = (
+            (
+                self.state_before.batting_order_index + 1
+            )
+            % 9
+            if self.is_plate_appearance
+            else self.state_before.batting_order_index
+        )
+        if (
+            self.state_after.batting_order_index
+            != expected_batting_order_index
+        ):
+            raise ValueError(
+                "event batting order transition does not "
+                "match is_plate_appearance"
             )
 
         score_delta = (

--- a/tests/test_simulation_event_contracts.py
+++ b/tests/test_simulation_event_contracts.py
@@ -7,6 +7,7 @@ from mlb_app.simulation.events import (
     DeterministicPlayResolver,
     GameState,
     PlayLedger,
+    build_baserunning_event,
     replay_events,
 )
 
@@ -232,4 +233,124 @@ def test_resolver_rejects_plate_appearance_after_three_outs():
             event_type="bb",
             batter_id="batter",
             sequence=0,
+        )
+
+
+def test_successful_steal_is_a_non_plate_appearance_event():
+    state = GameState(
+        outs=1,
+        bases=("runner-1", None, "runner-3"),
+        batting_order_index=4,
+        plate_appearance_number=13,
+    )
+
+    event = build_baserunning_event(
+        sequence=0,
+        event_type="stolen_base",
+        batter_id="batter",
+        runner_id="runner-1",
+        state_before=state,
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+        pitcher_id="pitcher",
+    )
+
+    assert event.is_plate_appearance is False
+    assert event.state_after.bases == (
+        None,
+        "runner-1",
+        "runner-3",
+    )
+    assert event.state_after.outs == 1
+    assert event.state_after.batting_order_index == 4
+    assert event.state_after.plate_appearance_number == 13
+    assert event.outs_recorded == ()
+    assert event.runs_scored == ()
+
+
+def test_caught_stealing_records_out_without_advancing_batter():
+    state = GameState(
+        outs=1,
+        bases=("runner-1", "runner-2", None),
+        batting_order_index=7,
+        plate_appearance_number=26,
+    )
+
+    event = build_baserunning_event(
+        sequence=0,
+        event_type="caught_stealing",
+        batter_id="batter",
+        runner_id="runner-2",
+        state_before=state,
+        origin_base=Base.SECOND,
+        target_base=Base.THIRD,
+    )
+
+    assert event.is_plate_appearance is False
+    assert event.state_after.bases == (
+        "runner-1",
+        None,
+        None,
+    )
+    assert event.state_after.outs == 2
+    assert event.state_after.batting_order_index == 7
+    assert event.state_after.plate_appearance_number == 26
+    assert len(event.outs_recorded) == 1
+    assert event.outs_recorded[0].runner_id == "runner-2"
+    assert event.outs_recorded[0].reason == "caught_stealing"
+
+
+def test_baserunning_event_composes_with_next_plate_appearance():
+    resolver = DeterministicPlayResolver()
+    initial_state = GameState(
+        bases=("runner-1", None, None),
+    )
+    ledger = PlayLedger(initial_state=initial_state)
+
+    steal = build_baserunning_event(
+        sequence=0,
+        event_type="stolen_base",
+        batter_id="batter",
+        runner_id="runner-1",
+        state_before=initial_state,
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+    )
+    ledger = ledger.append(steal)
+
+    plate_appearance = resolver.resolve(
+        state=ledger.current_state,
+        event_type="bb",
+        batter_id="batter",
+        sequence=1,
+    )
+    ledger = ledger.append(plate_appearance)
+
+    assert len(ledger.events) == 2
+    assert ledger.events[0].is_plate_appearance is False
+    assert ledger.events[1].is_plate_appearance is True
+    assert ledger.current_state.bases == (
+        "batter",
+        "runner-1",
+        None,
+    )
+    assert ledger.current_state.batting_order_index == 1
+    assert ledger.current_state.plate_appearance_number == 1
+
+
+def test_baserunning_event_rejects_occupied_target_base():
+    with pytest.raises(
+        ValueError,
+        match="target base must be unoccupied",
+    ):
+        build_baserunning_event(
+            sequence=0,
+            event_type="stolen_base",
+            batter_id="batter",
+            runner_id="runner-1",
+            state_before=GameState(
+                bases=("runner-1", "runner-2", None),
+            ),
+            origin_base=Base.FIRST,
+            target_base=Base.SECOND,
         )


### PR DESCRIPTION
## Summary
- allow canonical ledger events that do not advance the plate appearance or batting order
- add deterministic stolen-base and caught-stealing state resolution
- preserve occupied bases, explicit runner movements, and caught-stealing out records
- keep production orchestration and probability authority unchanged

## Validation
- `python -m pytest -q tests/test_simulation_event_contracts.py tests/test_canonical_game_trials.py tests/test_canonical_production_shadow_execution.py` (35 passed)
- `python -m py_compile mlb_app/simulation/events/contracts.py mlb_app/simulation/events/baserunning_resolution.py mlb_app/simulation/events/__init__.py tests/test_simulation_event_contracts.py`
- `git diff --check`

Ruff was unavailable in the local environment.