### PR TITLE
Resolve sampled canonical baserunning

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,5 +1,10 @@
 """Canonical full-game orchestration."""
 
+from .baserunning_outcome_resolution import (
+    CANONICAL_BASERUNNING_RESOLUTION_VERSION,
+    CanonicalBaserunningResolution,
+    resolve_canonical_sampled_baserunning,
+)
 from .baserunning_sampling import (
     CANONICAL_BASERUNNING_SAMPLING_VERSION,
     CanonicalBaserunningOutcome,
@@ -171,7 +176,9 @@ from .validation import (
 )
 
 __all__ = [
+    "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
+    "CanonicalBaserunningResolution",
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",
     "CanonicalBaserunningSamplingQuery",
@@ -288,6 +295,7 @@ __all__ = [
     "run_canonical_trials",
     "run_canonical_trial_execution_plan",
     "resolve_canonical_batted_ball_outcome",
+    "resolve_canonical_sampled_baserunning",
     "resolve_canonical_sampled_plate_appearance",
     "reduce_canonical_game_box_score",
     "validate_game_box_score_reconciliation",

--- a/mlb_app/simulation/game/baserunning_outcome_resolution.py
+++ b/mlb_app/simulation/game/baserunning_outcome_resolution.py
@@ -1,0 +1,133 @@
+"""Resolve sampled baserunning outcomes into canonical events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from mlb_app.simulation.events import (
+    PlayEvent,
+    build_baserunning_event,
+)
+
+from .baserunning_sampling import (
+    CanonicalBaserunningOutcome,
+    CanonicalSampledBaserunning,
+)
+
+
+CANONICAL_BASERUNNING_RESOLUTION_VERSION = (
+    "canonical_baserunning_resolution_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningResolution:
+    """Sampled decision paired with its optional ledger event."""
+
+    sampled: CanonicalSampledBaserunning
+    event: Optional[PlayEvent]
+    resolution_version: str = (
+        CANONICAL_BASERUNNING_RESOLUTION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.sampled,
+            CanonicalSampledBaserunning,
+        ):
+            raise TypeError(
+                "sampled must be CanonicalSampledBaserunning"
+            )
+
+        if (
+            self.sampled.outcome
+            is CanonicalBaserunningOutcome.HOLD
+        ):
+            if self.event is not None:
+                raise ValueError(
+                    "hold outcome cannot produce an event"
+                )
+        else:
+            if self.event is None:
+                raise ValueError(
+                    "attempted steal must produce an event"
+                )
+            self._validate_event()
+
+        if self.resolution_version != (
+            CANONICAL_BASERUNNING_RESOLUTION_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning resolution version"
+            )
+
+    def _validate_event(self) -> None:
+        if self.event is None:
+            raise ValueError(
+                "attempted steal must produce an event"
+            )
+
+        query = self.sampled.probabilities.query
+
+        if self.event.event_type != self.sampled.outcome.value:
+            raise ValueError(
+                "event type must match sampled outcome"
+            )
+        if self.event.sequence != query.sequence:
+            raise ValueError(
+                "event sequence must match sampling query"
+            )
+        if self.event.batter_id != query.batter_id:
+            raise ValueError(
+                "event batter must match sampling query"
+            )
+        if self.event.pitcher_id != query.pitcher_id:
+            raise ValueError(
+                "event pitcher must match sampling query"
+            )
+        if self.event.state_before != query.state:
+            raise ValueError(
+                "event state must match sampling query"
+            )
+        if self.event.is_plate_appearance:
+            raise ValueError(
+                "baserunning event cannot be a plate appearance"
+            )
+
+
+def resolve_canonical_sampled_baserunning(
+    sampled: CanonicalSampledBaserunning,
+) -> CanonicalBaserunningResolution:
+    """Convert one sampled steal decision into a ledger event."""
+
+    if not isinstance(
+        sampled,
+        CanonicalSampledBaserunning,
+    ):
+        raise TypeError(
+            "sampled must be CanonicalSampledBaserunning"
+        )
+
+    if sampled.outcome is CanonicalBaserunningOutcome.HOLD:
+        return CanonicalBaserunningResolution(
+            sampled=sampled,
+            event=None,
+        )
+
+    query = sampled.probabilities.query
+    event = build_baserunning_event(
+        sequence=query.sequence,
+        event_type=sampled.outcome.value,
+        batter_id=query.batter_id,
+        pitcher_id=query.pitcher_id,
+        runner_id=query.runner_id,
+        state_before=query.state,
+        origin_base=query.origin_base,
+        target_base=query.target_base,
+    )
+
+    return CanonicalBaserunningResolution(
+        sampled=sampled,
+        event=event,
+    )

--- a/tests/test_canonical_baserunning_outcome_resolution.py
+++ b/tests/test_canonical_baserunning_outcome_resolution.py
@@ -1,0 +1,152 @@
+import pytest
+
+from mlb_app.simulation.events import Base, GameState
+from mlb_app.simulation.game import (
+    CANONICAL_BASERUNNING_RESOLUTION_VERSION,
+    CanonicalBaserunningOutcome,
+    CanonicalBaserunningProbabilities,
+    CanonicalBaserunningSamplingQuery,
+    resolve_canonical_sampled_baserunning,
+    sample_canonical_baserunning,
+)
+
+
+def sampled(
+    *,
+    attempt_probability,
+    success_probability,
+    state=None,
+):
+    game_state = state or GameState(
+        inning=7,
+        half="bottom",
+        outs=1,
+        bases=("runner", None, "stationary-runner"),
+        away_score=3,
+        home_score=2,
+        batting_order_index=5,
+        plate_appearance_number=24,
+    )
+    probabilities = CanonicalBaserunningProbabilities(
+        query=CanonicalBaserunningSamplingQuery(
+            game_pk=824406,
+            trial_index=3,
+            trial_seed=918273,
+            sequence=17,
+            state=game_state,
+            batter_id="batter",
+            pitcher_id="pitcher",
+            runner_id="runner",
+            origin_base=Base.FIRST,
+            target_base=Base.SECOND,
+        ),
+        attempt_probability=attempt_probability,
+        success_probability=success_probability,
+        probability_provenance=(
+            "stolen_base_pickoff_evaluator_v1"
+        ),
+    )
+    return sample_canonical_baserunning(
+        probabilities
+    )
+
+
+def test_hold_produces_no_canonical_event():
+    resolution = resolve_canonical_sampled_baserunning(
+        sampled(
+            attempt_probability=0.0,
+            success_probability=1.0,
+        )
+    )
+
+    assert (
+        resolution.sampled.outcome
+        is CanonicalBaserunningOutcome.HOLD
+    )
+    assert resolution.event is None
+    assert (
+        resolution.resolution_version
+        == CANONICAL_BASERUNNING_RESOLUTION_VERSION
+    )
+
+
+def test_stolen_base_sample_produces_non_pa_event():
+    resolution = resolve_canonical_sampled_baserunning(
+        sampled(
+            attempt_probability=1.0,
+            success_probability=1.0,
+        )
+    )
+
+    event = resolution.event
+
+    assert event is not None
+    assert event.event_type == "stolen_base"
+    assert event.sequence == 17
+    assert event.batter_id == "batter"
+    assert event.pitcher_id == "pitcher"
+    assert event.is_plate_appearance is False
+    assert event.state_after.bases == (
+        None,
+        "runner",
+        "stationary-runner",
+    )
+    assert event.state_after.outs == 1
+    assert event.state_after.batting_order_index == 5
+    assert event.state_after.plate_appearance_number == 24
+
+
+def test_caught_stealing_sample_produces_explicit_out():
+    resolution = resolve_canonical_sampled_baserunning(
+        sampled(
+            attempt_probability=1.0,
+            success_probability=0.0,
+        )
+    )
+
+    event = resolution.event
+
+    assert event is not None
+    assert event.event_type == "caught_stealing"
+    assert event.state_after.bases == (
+        None,
+        None,
+        "stationary-runner",
+    )
+    assert event.state_after.outs == 2
+    assert len(event.outs_recorded) == 1
+    assert event.outs_recorded[0].runner_id == "runner"
+    assert event.outs_recorded[0].out_number == 2
+    assert event.outs_recorded[0].reason == "caught_stealing"
+
+
+def test_resolution_preserves_sampling_rng_provenance():
+    source = sampled(
+        attempt_probability=1.0,
+        success_probability=1.0,
+    )
+
+    resolution = resolve_canonical_sampled_baserunning(
+        source
+    )
+
+    assert resolution.sampled is source
+    assert resolution.sampled.attempt_seed is not None
+    assert resolution.sampled.attempt_draw is not None
+    assert resolution.sampled.success_seed is not None
+    assert resolution.sampled.success_draw is not None
+    assert (
+        resolution.sampled.probabilities
+        .probability_provenance
+        == "stolen_base_pickoff_evaluator_v1"
+    )
+
+
+def test_resolution_rejects_non_sample_contract():
+    with pytest.raises(
+        TypeError,
+        match="sampled must be CanonicalSampledBaserunning",
+    ):
+        resolve_canonical_sampled_baserunning(
+            object()
+        )


### PR DESCRIPTION
## Summary
- translate sampled stolen-base and caught-stealing outcomes into canonical non-plate-appearance ledger events
- represent a sampled hold as an explicit resolution with no emitted event
- validate event identity against the sampling query while preserving all seed, draw, version, and probability provenance
- leave production game orchestration unchanged

## Validation
- `python -m pytest -q tests/test_canonical_baserunning_outcome_resolution.py tests/test_canonical_baserunning_sampling.py tests/test_simulation_event_contracts.py tests/test_canonical_game_trials.py tests/test_canonical_production_shadow_execution.py` (50 passed)
- `python -m py_compile mlb_app/simulation/game/baserunning_outcome_resolution.py mlb_app/simulation/game/__init__.py tests/test_canonical_baserunning_outcome_resolution.py`
- `git diff --check`

Ruff was unavailable in the local environment.