### PR TITLE
Integrate canonical baserunning orchestration

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -65,6 +65,7 @@ from .matchup_input import (
     CanonicalProbabilityProviderIdentity,
 )
 from .orchestrator import (
+    BaserunningResolver,
     PlateAppearanceResolver,
     simulate_canonical_game,
 )
@@ -179,6 +180,7 @@ __all__ = [
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
     "CanonicalBaserunningResolution",
+    "BaserunningResolver",
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",
     "CanonicalBaserunningSamplingQuery",

--- a/mlb_app/simulation/game/orchestrator.py
+++ b/mlb_app/simulation/game/orchestrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from mlb_app.simulation.events import (
     GameState,
@@ -23,6 +23,10 @@ PlateAppearanceResolver = Callable[
     [GameState, str, int],
     PlayEvent,
 ]
+BaserunningResolver = Callable[
+    [GameState, str, int],
+    Optional[PlayEvent],
+]
 
 
 def simulate_canonical_game(
@@ -31,6 +35,7 @@ def simulate_canonical_game(
     home_lineup: CanonicalLineup,
     resolve_plate_appearance: PlateAppearanceResolver,
     config: CanonicalGameConfig | None = None,
+    resolve_baserunning: BaserunningResolver | None = None,
 ) -> CanonicalGameResult:
     """
     Orchestrate one canonical game using an injected PA resolver.
@@ -54,6 +59,13 @@ def simulate_canonical_game(
     if not callable(resolve_plate_appearance):
         raise TypeError(
             "resolve_plate_appearance must be callable"
+        )
+    if (
+        resolve_baserunning is not None
+        and not callable(resolve_baserunning)
+    ):
+        raise TypeError(
+            "resolve_baserunning must be callable"
         )
 
     halves = []
@@ -89,6 +101,7 @@ def simulate_canonical_game(
             resolve_plate_appearance=(
                 resolve_plate_appearance
             ),
+            resolve_baserunning=resolve_baserunning,
         )
         halves.append(top.record)
 
@@ -126,6 +139,7 @@ def simulate_canonical_game(
             resolve_plate_appearance=(
                 resolve_plate_appearance
             ),
+            resolve_baserunning=resolve_baserunning,
             walk_off_eligible=(
                 inning >= rules.regulation_innings
             ),
@@ -206,6 +220,7 @@ def _simulate_half(
     sequence: int,
     config: CanonicalGameConfig,
     resolve_plate_appearance: PlateAppearanceResolver,
+    resolve_baserunning: BaserunningResolver | None = None,
     walk_off_eligible: bool = False,
 ) -> _HalfSimulation:
     bases = (None, None, None)
@@ -254,6 +269,29 @@ def _simulate_half(
             state.batting_order_index
         )
 
+        if resolve_baserunning is not None:
+            baserunning_event = resolve_baserunning(
+                state,
+                batter_id,
+                current_sequence,
+            )
+
+            if baserunning_event is not None:
+                _validate_resolved_event(
+                    event=baserunning_event,
+                    expected_state=state,
+                    expected_batter_id=batter_id,
+                    expected_sequence=current_sequence,
+                    expected_plate_appearance=False,
+                )
+
+                events.append(baserunning_event)
+                state = baserunning_event.state_after
+                current_sequence += 1
+
+                if state.outs >= 3:
+                    break
+
         event = resolve_plate_appearance(
             state,
             batter_id,
@@ -265,6 +303,7 @@ def _simulate_half(
             expected_state=state,
             expected_batter_id=batter_id,
             expected_sequence=current_sequence,
+            expected_plate_appearance=True,
         )
 
         events.append(event)
@@ -316,6 +355,7 @@ def _validate_resolved_event(
     expected_state: GameState,
     expected_batter_id: str,
     expected_sequence: int,
+    expected_plate_appearance: bool,
 ) -> None:
     if not isinstance(event, PlayEvent):
         raise TypeError(
@@ -334,4 +374,22 @@ def _validate_resolved_event(
         raise ValueError(
             "resolver event state_before does not "
             "match current game state"
+        )
+    if (
+        event.is_plate_appearance
+        is not expected_plate_appearance
+    ):
+        resolver_name = (
+            "plate appearance"
+            if expected_plate_appearance
+            else "baserunning"
+        )
+        expected_kind = (
+            "plate-appearance"
+            if expected_plate_appearance
+            else "non-plate-appearance"
+        )
+        raise ValueError(
+            f"{resolver_name} resolver must return "
+            f"{expected_kind} event"
         )

--- a/tests/test_canonical_game_orchestration.py
+++ b/tests/test_canonical_game_orchestration.py
@@ -4,10 +4,12 @@ import pytest
 
 from mlb_app.simulation.events import (
     Base,
+    DeterministicPlayResolver,
     GameState,
     OutRecord,
     PlayEvent,
     RunnerMovement,
+    build_baserunning_event,
 )
 from mlb_app.simulation.game import (
     CanonicalGameConfig,
@@ -361,5 +363,117 @@ def test_runaway_half_is_safely_bounded():
                 regulation_innings=1,
                 max_extra_innings=0,
                 max_plate_appearances_per_half=5,
+            ),
+        )
+
+
+def test_optional_baserunning_event_precedes_same_batter_pa():
+    def plate_appearance(state, batter_id, sequence):
+        if (
+            state.outs == 0
+            and state.bases == (None, None, None)
+        ):
+            return DeterministicPlayResolver().resolve(
+                state=state,
+                event_type="bb",
+                batter_id=batter_id,
+                sequence=sequence,
+            )
+
+        return out_event(
+            state,
+            batter_id,
+            sequence,
+        )
+
+    def baserunning(state, batter_id, sequence):
+        if (
+            state.first is None
+            or state.second is not None
+        ):
+            return None
+
+        return build_baserunning_event(
+            sequence=sequence,
+            event_type="stolen_base",
+            batter_id=batter_id,
+            runner_id=state.first,
+            state_before=state,
+            origin_base=Base.FIRST,
+            target_base=Base.SECOND,
+        )
+
+    result = simulate_canonical_game(
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolve_plate_appearance=plate_appearance,
+        resolve_baserunning=baserunning,
+        config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    top = result.halves[0]
+
+    assert tuple(
+        event.event_type
+        for event in top.events
+    ) == (
+        "bb",
+        "stolen_base",
+        "out",
+        "out",
+        "out",
+    )
+    assert top.events[1].batter_id == "away_1"
+    assert top.events[2].batter_id == "away_1"
+    assert (
+        top.events[1].state_after
+        == top.events[2].state_before
+    )
+    assert top.events[1].is_plate_appearance is False
+    assert top.events[2].is_plate_appearance is True
+    assert (
+        top.final_state.plate_appearance_number
+        - top.initial_state.plate_appearance_number
+        == 4
+    )
+    assert tuple(
+        event.sequence
+        for event in result.events
+    ) == tuple(range(len(result.events)))
+    assert validate_canonical_game(result).passed is True
+
+
+def test_baserunning_resolver_rejects_plate_appearance_event():
+    def invalid_baserunning(
+        state,
+        batter_id,
+        sequence,
+    ):
+        return out_event(
+            state,
+            batter_id,
+            sequence,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "baserunning resolver must return "
+            "non-plate-appearance event"
+        ),
+    ):
+        simulate_canonical_game(
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            resolve_plate_appearance=out_event,
+            resolve_baserunning=invalid_baserunning,
+            config=CanonicalGameConfig(
+                regulation_innings=1,
+                max_extra_innings=0,
+                automatic_runner_enabled=False,
             ),
         )


### PR DESCRIPTION
## Summary
- add an optional between-plate-appearance baserunning resolver to canonical game orchestration
- append valid non-plate-appearance baserunning events with global sequence continuity
- preserve the current batter and plate-appearance count across baserunning events
- validate that PA and baserunning resolvers return the correct event category
- preserve existing behavior when no baserunning resolver is supplied

## Validation
- `python -m pytest -q tests/test_canonical_game_orchestration.py tests/test_canonical_baserunning_outcome_resolution.py tests/test_canonical_baserunning_sampling.py tests/test_simulation_event_contracts.py tests/test_canonical_game_trials.py tests/test_canonical_production_shadow_execution.py` (61 passed)
- `python -m py_compile mlb_app/simulation/game/orchestrator.py mlb_app/simulation/game/__init__.py tests/test_canonical_game_orchestration.py`
- `git diff --check`

Ruff was unavailable in the local environment.