### PR TITLE
Propagate trial baserunning resolvers

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -155,6 +155,7 @@ from .probability_fallback import (
     build_canonical_probability_fallback_provider,
 )
 from .trial_factory import (
+    CanonicalBaserunningResolverFactory,
     CanonicalTrialExecutionPlan,
     CanonicalTrialResolverContext,
     CanonicalTrialResolverFactory,
@@ -180,6 +181,7 @@ __all__ = [
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
     "CanonicalBaserunningResolution",
+    "CanonicalBaserunningResolverFactory",
     "BaserunningResolver",
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -25,6 +25,7 @@ from .matchup_input import (
     CanonicalMatchupInput,
 )
 from .orchestrator import (
+    BaserunningResolver,
     PlateAppearanceResolver,
     simulate_canonical_game,
 )
@@ -124,6 +125,10 @@ CanonicalTrialResolverFactory = Callable[
     [CanonicalTrialResolverContext],
     PlateAppearanceResolver,
 ]
+CanonicalBaserunningResolverFactory = Callable[
+    [CanonicalTrialResolverContext],
+    BaserunningResolver,
+]
 
 
 @dataclass(frozen=True)
@@ -140,6 +145,9 @@ class CanonicalTrialExecutionPlan:
     away_lineup: CanonicalLineup
     home_lineup: CanonicalLineup
     resolver_factory: CanonicalTrialResolverFactory
+    baserunning_resolver_factory: Optional[
+        CanonicalBaserunningResolverFactory
+    ] = None
     game_config: CanonicalGameConfig = field(
         default_factory=CanonicalGameConfig
     )
@@ -201,6 +209,17 @@ class CanonicalTrialExecutionPlan:
         if not callable(self.resolver_factory):
             raise TypeError(
                 "resolver_factory must be callable"
+            )
+
+        if (
+            self.baserunning_resolver_factory is not None
+            and not callable(
+                self.baserunning_resolver_factory
+            )
+        ):
+            raise TypeError(
+                "baserunning_resolver_factory "
+                "must be callable"
             )
 
         if self.matchup_input is not None:
@@ -302,11 +321,29 @@ def run_canonical_trial_execution_plan(
                 "plate-appearance resolver"
             )
 
+        baserunning_resolver = None
+        if (
+            plan.baserunning_resolver_factory
+            is not None
+        ):
+            baserunning_resolver = (
+                plan.baserunning_resolver_factory(
+                    context
+                )
+            )
+
+            if not callable(baserunning_resolver):
+                raise TypeError(
+                    "baserunning_resolver_factory "
+                    "must return a baserunning resolver"
+                )
+
         game = simulate_canonical_game(
             away_lineup=plan.away_lineup,
             home_lineup=plan.home_lineup,
             resolve_plate_appearance=resolver,
             config=plan.game_config,
+            resolve_baserunning=baserunning_resolver,
         )
 
         reconstructed_lines = (

--- a/tests/test_canonical_trial_factory_protocol.py
+++ b/tests/test_canonical_trial_factory_protocol.py
@@ -251,3 +251,111 @@ def test_resolver_context_rejects_invalid_regulation_innings():
             trial_index=0,
             regulation_innings=0,
         )
+
+
+def test_execution_plan_builds_baserunning_resolver_per_trial():
+    inputs = factory_input(simulations=2)
+    factory_calls = []
+    resolver_calls = []
+
+    def baserunning_resolver_factory(context):
+        factory_calls.append(
+            (
+                context.trial_index,
+                context.trial_seed,
+            )
+        )
+
+        def resolver(state, batter_id, sequence):
+            resolver_calls.append(
+                (
+                    context.trial_index,
+                    state.half,
+                    batter_id,
+                    sequence,
+                )
+            )
+            return None
+
+        return resolver
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=inputs,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=lambda context: out_event,
+        baserunning_resolver_factory=(
+            baserunning_resolver_factory
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    batch = run_canonical_trial_execution_plan(plan)
+
+    assert len(batch.games) == 2
+    assert factory_calls == [
+        (
+            index,
+            inputs.seed_for_trial(index),
+        )
+        for index in range(2)
+    ]
+    assert resolver_calls
+    assert {
+        trial_index
+        for (
+            trial_index,
+            _,
+            _,
+            _,
+        ) in resolver_calls
+    } == {0, 1}
+
+
+def test_non_callable_baserunning_resolver_is_rejected():
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=factory_input(
+            simulations=1
+        ),
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=lambda context: out_event,
+        baserunning_resolver_factory=(
+            lambda context: None
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "baserunning_resolver_factory must "
+            "return a baserunning resolver"
+        ),
+    ):
+        run_canonical_trial_execution_plan(plan)
+
+
+def test_plan_rejects_non_callable_baserunning_factory():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "baserunning_resolver_factory "
+            "must be callable"
+        ),
+    ):
+        CanonicalTrialExecutionPlan(
+            factory_input=factory_input(),
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            resolver_factory=lambda context: out_event,
+            baserunning_resolver_factory="invalid",
+        )


### PR DESCRIPTION
## Summary
- add an optional baserunning resolver factory to canonical trial execution plans
- construct a fresh baserunning resolver from each immutable indexed trial context
- validate factory and resolver callability before trial execution
- propagate the resolver into canonical game orchestration
- preserve existing production behavior when the factory is absent

## Validation
- `python -m pytest -q tests/test_canonical_trial_factory_protocol.py tests/test_canonical_game_orchestration.py tests/test_canonical_baserunning_outcome_resolution.py tests/test_canonical_baserunning_sampling.py tests/test_canonical_game_trials.py tests/test_canonical_production_shadow_execution.py` (58 passed)
- `python -m py_compile mlb_app/simulation/game/trial_factory.py mlb_app/simulation/game/__init__.py tests/test_canonical_trial_factory_protocol.py`
- `git diff --check`

Ruff was unavailable in the local environment.