### PR TITLE
Build canonical baserunning resolver adapter

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -5,6 +5,13 @@ from .baserunning_outcome_resolution import (
     CanonicalBaserunningResolution,
     resolve_canonical_sampled_baserunning,
 )
+from .baserunning_resolver import (
+    CANONICAL_BASERUNNING_RESOLVER_VERSION,
+    CanonicalBaserunningEvidence,
+    CanonicalBaserunningEvidenceProvider,
+    CanonicalBaserunningEvidenceQuery,
+    CanonicalBaserunningResolverAdapterFactory,
+)
 from .baserunning_sampling import (
     CANONICAL_BASERUNNING_SAMPLING_VERSION,
     CanonicalBaserunningOutcome,
@@ -179,10 +186,15 @@ from .validation import (
 
 __all__ = [
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
+    "CANONICAL_BASERUNNING_RESOLVER_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
     "CanonicalBaserunningResolution",
+    "CanonicalBaserunningResolverAdapterFactory",
     "CanonicalBaserunningResolverFactory",
     "BaserunningResolver",
+    "CanonicalBaserunningEvidence",
+    "CanonicalBaserunningEvidenceProvider",
+    "CanonicalBaserunningEvidenceQuery",
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",
     "CanonicalBaserunningSamplingQuery",

--- a/mlb_app/simulation/game/baserunning_resolver.py
+++ b/mlb_app/simulation/game/baserunning_resolver.py
@@ -1,0 +1,260 @@
+"""Fail-open canonical baserunning resolver adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from mlb_app.simulation.events import (
+    Base,
+    GameState,
+    PlayEvent,
+)
+
+from .baserunning_outcome_resolution import (
+    resolve_canonical_sampled_baserunning,
+)
+from .baserunning_sampling import (
+    CanonicalBaserunningProbabilities,
+    CanonicalBaserunningSamplingQuery,
+    sample_canonical_baserunning,
+)
+from .orchestrator import BaserunningResolver
+from .trial_factory import CanonicalTrialResolverContext
+
+
+CANONICAL_BASERUNNING_RESOLVER_VERSION = (
+    "canonical_baserunning_resolver_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningEvidenceQuery:
+    """One legal steal opportunity requiring probability evidence."""
+
+    state: GameState
+    batter_id: str
+    runner_id: str
+    origin_base: Base
+    target_base: Base
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.state, GameState):
+            raise TypeError(
+                "state must be a GameState"
+            )
+        if not self.batter_id:
+            raise ValueError(
+                "batter_id is required"
+            )
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+        if (
+            self.state.runner_on(self.origin_base)
+            != self.runner_id
+        ):
+            raise ValueError(
+                "runner does not occupy origin base"
+            )
+        if (
+            self.state.runner_on(self.target_base)
+            is not None
+        ):
+            raise ValueError(
+                "target base must be unoccupied"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningEvidence:
+    """Complete pitcher-aware probabilities for one opportunity."""
+
+    pitcher_id: str
+    attempt_probability: float
+    success_probability: float
+    probability_provenance: str
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        for name, value in (
+            (
+                "attempt_probability",
+                self.attempt_probability,
+            ),
+            (
+                "success_probability",
+                self.success_probability,
+            ),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"{name} must be between 0 and 1"
+                )
+
+        if not self.probability_provenance:
+            raise ValueError(
+                "probability_provenance is required"
+            )
+
+
+CanonicalBaserunningEvidenceProvider = Callable[
+    [CanonicalBaserunningEvidenceQuery],
+    Optional[CanonicalBaserunningEvidence],
+]
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningResolverAdapterFactory:
+    """Build one deterministic fail-open resolver per trial."""
+
+    evidence_provider: CanonicalBaserunningEvidenceProvider
+    resolver_version: str = (
+        CANONICAL_BASERUNNING_RESOLVER_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not callable(self.evidence_provider):
+            raise TypeError(
+                "evidence_provider must be callable"
+            )
+        if self.resolver_version != (
+            CANONICAL_BASERUNNING_RESOLVER_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning resolver version"
+            )
+
+    def __call__(
+        self,
+        context: CanonicalTrialResolverContext,
+    ) -> BaserunningResolver:
+        if not isinstance(
+            context,
+            CanonicalTrialResolverContext,
+        ):
+            raise TypeError(
+                "context must be "
+                "CanonicalTrialResolverContext"
+            )
+
+        def resolve(
+            state: GameState,
+            batter_id: str,
+            sequence: int,
+        ) -> Optional[PlayEvent]:
+            opportunity = _select_opportunity(
+                state=state,
+                batter_id=batter_id,
+            )
+
+            if opportunity is None:
+                return None
+
+            try:
+                evidence = self.evidence_provider(
+                    opportunity
+                )
+            except Exception:
+                return None
+
+            if not isinstance(
+                evidence,
+                CanonicalBaserunningEvidence,
+            ):
+                return None
+
+            probabilities = (
+                CanonicalBaserunningProbabilities(
+                    query=(
+                        CanonicalBaserunningSamplingQuery(
+                            game_pk=(
+                                context.factory_input.game_pk
+                            ),
+                            trial_index=(
+                                context.trial_index
+                            ),
+                            trial_seed=(
+                                context.trial_seed
+                            ),
+                            sequence=sequence,
+                            state=state,
+                            batter_id=batter_id,
+                            pitcher_id=(
+                                evidence.pitcher_id
+                            ),
+                            runner_id=(
+                                opportunity.runner_id
+                            ),
+                            origin_base=(
+                                opportunity.origin_base
+                            ),
+                            target_base=(
+                                opportunity.target_base
+                            ),
+                        )
+                    ),
+                    attempt_probability=(
+                        evidence.attempt_probability
+                    ),
+                    success_probability=(
+                        evidence.success_probability
+                    ),
+                    probability_provenance=(
+                        evidence.probability_provenance
+                    ),
+                )
+            )
+
+            sampled = sample_canonical_baserunning(
+                probabilities
+            )
+            return (
+                resolve_canonical_sampled_baserunning(
+                    sampled
+                ).event
+            )
+
+        return resolve
+
+
+def _select_opportunity(
+    *,
+    state: GameState,
+    batter_id: str,
+) -> Optional[CanonicalBaserunningEvidenceQuery]:
+    """Select at most one legal lead-runner opportunity."""
+
+    if state.outs >= 3:
+        return None
+
+    if (
+        state.second is not None
+        and state.third is None
+    ):
+        return CanonicalBaserunningEvidenceQuery(
+            state=state,
+            batter_id=batter_id,
+            runner_id=state.second,
+            origin_base=Base.SECOND,
+            target_base=Base.THIRD,
+        )
+
+    if (
+        state.first is not None
+        and state.second is None
+    ):
+        return CanonicalBaserunningEvidenceQuery(
+            state=state,
+            batter_id=batter_id,
+            runner_id=state.first,
+            origin_base=Base.FIRST,
+            target_base=Base.SECOND,
+        )
+
+    return None

--- a/tests/test_canonical_baserunning_resolver.py
+++ b/tests/test_canonical_baserunning_resolver.py
@@ -1,0 +1,233 @@
+from mlb_app.simulation.events import Base, GameState
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidence,
+    CanonicalBaserunningResolverAdapterFactory,
+    build_canonical_trial_factory_input,
+    build_canonical_trial_resolver_context,
+)
+
+
+def context():
+    inputs = build_canonical_trial_factory_input(
+        game_pk=824406,
+        config={
+            "simulation_count": 1,
+            "seed": 123456,
+            "canonical_model_version": (
+                "canonical-baserunning-test-v1"
+            ),
+        },
+    )
+    return build_canonical_trial_resolver_context(
+        factory_input=inputs,
+        trial_index=0,
+    )
+
+
+def state(
+    *,
+    bases=("runner", None, None),
+    outs=1,
+):
+    return GameState(
+        inning=7,
+        half="top",
+        outs=outs,
+        bases=bases,
+        away_score=2,
+        home_score=2,
+        batting_order_index=4,
+        plate_appearance_number=25,
+    )
+
+
+def test_resolver_returns_none_without_eligible_runner():
+    calls = []
+
+    def provider(query):
+        calls.append(query)
+        return CanonicalBaserunningEvidence(
+            pitcher_id="pitcher",
+            attempt_probability=1.0,
+            success_probability=1.0,
+            probability_provenance="test-provider-v1",
+        )
+
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=provider,
+    )(context())
+
+    event = resolver(
+        state(bases=(None, None, None)),
+        "batter",
+        10,
+    )
+
+    assert event is None
+    assert calls == []
+
+
+def test_missing_evidence_fails_open():
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=lambda query: None,
+    )(context())
+
+    assert resolver(
+        state(),
+        "batter",
+        10,
+    ) is None
+
+
+def test_provider_exception_fails_open():
+    def provider(query):
+        raise RuntimeError("evidence unavailable")
+
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=provider,
+    )(context())
+
+    assert resolver(
+        state(),
+        "batter",
+        10,
+    ) is None
+
+
+def test_complete_evidence_emits_stolen_base_event():
+    observed = []
+
+    def provider(query):
+        observed.append(query)
+        return CanonicalBaserunningEvidence(
+            pitcher_id="active-pitcher",
+            attempt_probability=1.0,
+            success_probability=1.0,
+            probability_provenance="test-provider-v1",
+        )
+
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=provider,
+    )(context())
+
+    event = resolver(
+        state(),
+        "batter",
+        10,
+    )
+
+    assert event is not None
+    assert event.event_type == "stolen_base"
+    assert event.sequence == 10
+    assert event.batter_id == "batter"
+    assert event.pitcher_id == "active-pitcher"
+    assert event.is_plate_appearance is False
+    assert event.state_after.bases == (
+        None,
+        "runner",
+        None,
+    )
+    assert observed[0].runner_id == "runner"
+    assert observed[0].origin_base is Base.FIRST
+    assert observed[0].target_base is Base.SECOND
+
+
+def test_failed_attempt_emits_caught_stealing_event():
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=lambda query: (
+            CanonicalBaserunningEvidence(
+                pitcher_id="active-pitcher",
+                attempt_probability=1.0,
+                success_probability=0.0,
+                probability_provenance="test-provider-v1",
+            )
+        ),
+    )(context())
+
+    event = resolver(
+        state(),
+        "batter",
+        10,
+    )
+
+    assert event is not None
+    assert event.event_type == "caught_stealing"
+    assert event.state_after.bases == (
+        None,
+        None,
+        None,
+    )
+    assert event.state_after.outs == 2
+
+
+def test_hold_sample_emits_no_event():
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=lambda query: (
+            CanonicalBaserunningEvidence(
+                pitcher_id="active-pitcher",
+                attempt_probability=0.0,
+                success_probability=1.0,
+                probability_provenance="test-provider-v1",
+            )
+        ),
+    )(context())
+
+    assert resolver(
+        state(),
+        "batter",
+        10,
+    ) is None
+
+
+def test_lead_runner_opportunity_is_selected_first():
+    observed = []
+
+    def provider(query):
+        observed.append(query)
+        return None
+
+    resolver = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=provider,
+    )(context())
+
+    resolver(
+        state(
+            bases=(
+                "runner-first",
+                "runner-second",
+                None,
+            )
+        ),
+        "batter",
+        10,
+    )
+
+    assert observed[0].runner_id == "runner-second"
+    assert observed[0].origin_base is Base.SECOND
+    assert observed[0].target_base is Base.THIRD
+
+
+def test_same_trial_identity_reproduces_event():
+    factory = CanonicalBaserunningResolverAdapterFactory(
+        evidence_provider=lambda query: (
+            CanonicalBaserunningEvidence(
+                pitcher_id="active-pitcher",
+                attempt_probability=1.0,
+                success_probability=1.0,
+                probability_provenance="test-provider-v1",
+            )
+        ),
+    )
+
+    first = factory(context())(
+        state(),
+        "batter",
+        10,
+    )
+    second = factory(context())(
+        state(),
+        "batter",
+        10,
+    )
+
+    assert first == second


### PR DESCRIPTION
## Summary
- add typed baserunning evidence query and pitcher-aware probability evidence contracts
- deterministically select at most one legal lead-runner steal opportunity
- build a fresh resolver for each immutable trial context
- sample and resolve complete evidence into canonical stolen-base or caught-stealing events
- fail open with no event when evidence is missing, malformed, or raises an exception
- keep the adapter unattached to production shadow execution

## Validation
- `python -m pytest -q tests/test_canonical_baserunning_resolver.py tests/test_canonical_trial_factory_protocol.py tests/test_canonical_game_orchestration.py tests/test_canonical_baserunning_outcome_resolution.py tests/test_canonical_baserunning_sampling.py tests/test_canonical_game_trials.py tests/test_canonical_production_shadow_execution.py` (66 passed)
- `python -m py_compile mlb_app/simulation/game/baserunning_resolver.py mlb_app/simulation/game/__init__.py tests/test_canonical_baserunning_resolver.py`
- `git diff --check`

Ruff was unavailable in the local environment.