### PR TITLE
Adapt canonical baserunning evidence

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,5 +1,11 @@
 """Canonical full-game orchestration."""
 
+from .baserunning_evidence_adapter import (
+    CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION,
+    CanonicalBaserunningEvaluatorEvidenceAdapter,
+    CanonicalBaserunningStateProvider,
+    build_canonical_baserunning_evidence_provider,
+)
 from .baserunning_outcome_resolution import (
     CANONICAL_BASERUNNING_RESOLUTION_VERSION,
     CanonicalBaserunningResolution,
@@ -185,6 +191,7 @@ from .validation import (
 )
 
 __all__ = [
+    "CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION",
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
     "CANONICAL_BASERUNNING_RESOLVER_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
@@ -193,13 +200,16 @@ __all__ = [
     "CanonicalBaserunningResolverFactory",
     "BaserunningResolver",
     "CanonicalBaserunningEvidence",
+    "CanonicalBaserunningEvaluatorEvidenceAdapter",
     "CanonicalBaserunningEvidenceProvider",
+    "CanonicalBaserunningStateProvider",
     "CanonicalBaserunningEvidenceQuery",
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",
     "CanonicalBaserunningSamplingQuery",
     "CanonicalSampledBaserunning",
     "CanonicalBattedBallResolution",
+    "build_canonical_baserunning_evidence_provider",
     "build_canonical_bullpen_selector",
     "CanonicalBullpenSelector",
     "CanonicalBullpenSelectionContext",

--- a/mlb_app/simulation/game/baserunning_evidence_adapter.py
+++ b/mlb_app/simulation/game/baserunning_evidence_adapter.py
@@ -1,0 +1,181 @@
+"""Adapt diagnostic baserunning evaluations into typed evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from mlb_app.simulation.events import Base
+from mlb_app.simulation.stolen_base_pickoff_evaluator import (
+    evaluate_stolen_base_and_pickoff_state,
+    validate_stolen_base_and_pickoff_evaluation,
+)
+
+from .baserunning_resolver import (
+    CanonicalBaserunningEvidence,
+    CanonicalBaserunningEvidenceProvider,
+    CanonicalBaserunningEvidenceQuery,
+)
+
+
+CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION = (
+    "canonical_baserunning_evidence_adapter_v1"
+)
+
+_BASE_NAMES = {
+    Base.FIRST: "first",
+    Base.SECOND: "second",
+    Base.THIRD: "third",
+}
+
+
+CanonicalBaserunningStateProvider = Callable[
+    [CanonicalBaserunningEvidenceQuery],
+    Optional[Mapping[str, Any]],
+]
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningEvaluatorEvidenceAdapter:
+    """Fail-open adapter around the existing deterministic evaluator."""
+
+    state_provider: CanonicalBaserunningStateProvider
+    adapter_version: str = (
+        CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not callable(self.state_provider):
+            raise TypeError(
+                "state_provider must be callable"
+            )
+        if self.adapter_version != (
+            CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning evidence adapter version"
+            )
+
+    def __call__(
+        self,
+        query: CanonicalBaserunningEvidenceQuery,
+    ) -> Optional[CanonicalBaserunningEvidence]:
+        if not isinstance(
+            query,
+            CanonicalBaserunningEvidenceQuery,
+        ):
+            return None
+
+        try:
+            provided_state = self.state_provider(query)
+
+            if not isinstance(
+                provided_state,
+                Mapping,
+            ):
+                return None
+
+            evaluator_state = dict(provided_state)
+
+            if not _state_matches_query(
+                evaluator_state,
+                query,
+            ):
+                return None
+
+            evaluation = (
+                evaluate_stolen_base_and_pickoff_state(
+                    evaluator_state
+                )
+            )
+            validation = (
+                validate_stolen_base_and_pickoff_evaluation(
+                    evaluation
+                )
+            )
+
+            if validation.get("valid") is not True:
+                return None
+            if (
+                evaluation.get("state_completeness")
+                != "complete"
+            ):
+                return None
+            if evaluation.get("fallback_used") is not False:
+                return None
+            if evaluation.get("steal_eligible") is not True:
+                return None
+
+            pitcher = evaluator_state.get("pitcher")
+            if not isinstance(pitcher, Mapping):
+                return None
+
+            pitcher_id = pitcher.get("pitcher_id")
+            if not pitcher_id:
+                return None
+
+            return CanonicalBaserunningEvidence(
+                pitcher_id=str(pitcher_id),
+                attempt_probability=float(
+                    evaluation["attempt_probability"]
+                ),
+                success_probability=float(
+                    evaluation["success_probability"]
+                ),
+                probability_provenance=(
+                    self.adapter_version
+                ),
+            )
+        except Exception:
+            return None
+
+
+def build_canonical_baserunning_evidence_provider(
+    *,
+    state_provider: CanonicalBaserunningStateProvider,
+) -> CanonicalBaserunningEvidenceProvider:
+    """Build the explicit fail-open evaluator adapter."""
+
+    return CanonicalBaserunningEvaluatorEvidenceAdapter(
+        state_provider=state_provider,
+    )
+
+
+def _state_matches_query(
+    evaluator_state: Mapping[str, Any],
+    query: CanonicalBaserunningEvidenceQuery,
+) -> bool:
+    state = query.state
+
+    if evaluator_state.get("inning") != state.inning:
+        return False
+    if evaluator_state.get("half") != state.half:
+        return False
+    if evaluator_state.get("outs") != state.outs:
+        return False
+    if evaluator_state.get("origin_base") != (
+        _BASE_NAMES[query.origin_base]
+    ):
+        return False
+    if evaluator_state.get("target_base") != (
+        _BASE_NAMES[query.target_base]
+    ):
+        return False
+
+    runner = evaluator_state.get("runner")
+    if not isinstance(runner, Mapping):
+        return False
+    if runner.get("runner_id") != query.runner_id:
+        return False
+
+    base_state = evaluator_state.get("base_state")
+    if not isinstance(base_state, Mapping):
+        return False
+
+    expected_base_state = {
+        "first": state.first is not None,
+        "second": state.second is not None,
+        "third": state.third is not None,
+    }
+
+    return dict(base_state) == expected_base_state

--- a/tests/test_canonical_baserunning_evidence_adapter.py
+++ b/tests/test_canonical_baserunning_evidence_adapter.py
@@ -1,0 +1,189 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.events import Base, GameState
+from mlb_app.simulation.game import (
+    CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION,
+    CanonicalBaserunningEvidenceQuery,
+    build_canonical_baserunning_evidence_provider,
+)
+
+
+def query():
+    return CanonicalBaserunningEvidenceQuery(
+        state=GameState(
+            inning=7,
+            half="top",
+            outs=1,
+            bases=("runner", None, None),
+            away_score=2,
+            home_score=2,
+            batting_order_index=4,
+            plate_appearance_number=25,
+        ),
+        batter_id="batter",
+        runner_id="runner",
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+    )
+
+
+def complete_state():
+    return {
+        "inning": 7,
+        "half": "top",
+        "outs": 1,
+        "base_state": {
+            "first": True,
+            "second": False,
+            "third": False,
+        },
+        "score_margin": 0,
+        "runner": {
+            "runner_id": "runner",
+            "evidence_complete": True,
+            "speed_score": 0.85,
+            "attempt_rate": 0.30,
+            "success_rate": 0.80,
+            "lead_quality": 0.75,
+            "fatigue_index": 0.10,
+            "injury_limit_flag": False,
+        },
+        "origin_base": "first",
+        "target_base": "second",
+        "pitcher": {
+            "pitcher_id": "pitcher",
+            "evidence_complete": True,
+            "hold_score": 0.40,
+            "delivery_time_score": 0.45,
+            "pickoff_attempt_rate": 0.08,
+            "pickoff_success_rate": 0.02,
+        },
+        "catcher": {
+            "catcher_id": "catcher",
+            "evidence_complete": True,
+            "throwing_score": 0.45,
+            "pop_time_score": 0.40,
+        },
+    }
+
+
+def test_complete_evaluation_adapts_to_typed_evidence():
+    source = complete_state()
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    evidence = provider(query())
+
+    assert evidence is not None
+    assert evidence.pitcher_id == "pitcher"
+    assert 0.0 <= evidence.attempt_probability <= 1.0
+    assert 0.0 <= evidence.success_probability <= 1.0
+    assert (
+        evidence.probability_provenance
+        == CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION
+    )
+
+
+def test_adapter_does_not_mutate_provider_state():
+    source = complete_state()
+    snapshot = deepcopy(source)
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    provider(query())
+
+    assert source == snapshot
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("inning", 8),
+        ("half", "bottom"),
+        ("outs", 2),
+        ("origin_base", "second"),
+        ("target_base", "third"),
+    ),
+)
+def test_mismatched_game_state_fails_open(
+    field,
+    value,
+):
+    source = complete_state()
+    source[field] = value
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    assert provider(query()) is None
+
+
+def test_mismatched_runner_identity_fails_open():
+    source = complete_state()
+    source["runner"]["runner_id"] = "other-runner"
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    assert provider(query()) is None
+
+
+def test_mismatched_base_occupancy_fails_open():
+    source = complete_state()
+    source["base_state"]["second"] = True
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    assert provider(query()) is None
+
+
+def test_partial_participant_evidence_fails_open():
+    source = complete_state()
+    source["catcher"]["evidence_complete"] = False
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    assert provider(query()) is None
+
+
+def test_ineligible_evaluation_fails_open():
+    source = complete_state()
+    source["runner"]["injury_limit_flag"] = True
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: source,
+    )
+
+    assert provider(query()) is None
+
+
+def test_missing_state_fails_open():
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: None,
+    )
+
+    assert provider(query()) is None
+
+
+def test_state_provider_exception_fails_open():
+    def state_provider(opportunity):
+        raise RuntimeError("source unavailable")
+
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=state_provider,
+    )
+
+    assert provider(query()) is None
+
+
+def test_non_query_input_fails_open():
+    provider = build_canonical_baserunning_evidence_provider(
+        state_provider=lambda opportunity: complete_state(),
+    )
+
+    assert provider(object()) is None


### PR DESCRIPTION
## Summary
- adapt the existing deterministic stolen-base evaluator into canonical typed evidence
- require exact inning, half, outs, base occupancy, runner, and transition identity matches
- reject partial, fallback, invalid, or ineligible evaluations with no evidence
- preserve pitcher identity and versioned probability provenance
- fail open when the state provider is unavailable or raises an exception
- keep the adapter disconnected from production shadow execution

## Validation
- `python -m pytest -q tests/test_canonical_baserunning_evidence_adapter.py tests/test_canonical_baserunning_resolver.py tests/test_canonical_trial_factory_protocol.py tests/test_canonical_game_orchestration.py tests/test_canonical_baserunning_outcome_resolution.py tests/test_canonical_baserunning_sampling.py tests/test_canonical_production_shadow_execution.py` (73 passed)
- `python -m py_compile mlb_app/simulation/game/baserunning_evidence_adapter.py mlb_app/simulation/game/__init__.py tests/test_canonical_baserunning_evidence_adapter.py`
- `git diff --check`

Ruff was unavailable in the local environment.