### PR TITLE
Add canonical baserunning evidence catalog

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,5 +1,15 @@
 """Canonical full-game orchestration."""
 
+from .baserunning_evidence_catalog import (
+    CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION,
+    CanonicalActivePitcherProvider,
+    CanonicalBaserunningCatalogStateProvider,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+    build_canonical_baserunning_state_provider,
+)
 from .baserunning_evidence_adapter import (
     CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION,
     CanonicalBaserunningEvaluatorEvidenceAdapter,
@@ -192,6 +202,7 @@ from .validation import (
 
 __all__ = [
     "CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION",
+    "CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION",
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",
     "CANONICAL_BASERUNNING_RESOLVER_VERSION",
     "CANONICAL_BASERUNNING_SAMPLING_VERSION",
@@ -199,7 +210,10 @@ __all__ = [
     "CanonicalBaserunningResolverAdapterFactory",
     "CanonicalBaserunningResolverFactory",
     "BaserunningResolver",
+    "CanonicalActivePitcherProvider",
+    "CanonicalBaserunningCatalogStateProvider",
     "CanonicalBaserunningEvidence",
+    "CanonicalBaserunningEvidenceCatalog",
     "CanonicalBaserunningEvaluatorEvidenceAdapter",
     "CanonicalBaserunningEvidenceProvider",
     "CanonicalBaserunningStateProvider",
@@ -207,9 +221,13 @@ __all__ = [
     "CanonicalBaserunningOutcome",
     "CanonicalBaserunningProbabilities",
     "CanonicalBaserunningSamplingQuery",
+    "CanonicalCatcherBaserunningProfile",
+    "CanonicalPitcherBaserunningProfile",
+    "CanonicalRunnerBaserunningProfile",
     "CanonicalSampledBaserunning",
     "CanonicalBattedBallResolution",
     "build_canonical_baserunning_evidence_provider",
+    "build_canonical_baserunning_state_provider",
     "build_canonical_bullpen_selector",
     "CanonicalBullpenSelector",
     "CanonicalBullpenSelectionContext",

--- a/mlb_app/simulation/game/baserunning_evidence_catalog.py
+++ b/mlb_app/simulation/game/baserunning_evidence_catalog.py
@@ -1,0 +1,375 @@
+"""Versioned immutable baserunning evidence catalog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+from mlb_app.simulation.events import Base
+
+from .baserunning_evidence_adapter import (
+    CanonicalBaserunningStateProvider,
+)
+from .baserunning_resolver import (
+    CanonicalBaserunningEvidenceQuery,
+)
+
+
+CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION = (
+    "canonical_baserunning_evidence_catalog_v1"
+)
+
+_BASE_NAMES = {
+    Base.FIRST: "first",
+    Base.SECOND: "second",
+    Base.THIRD: "third",
+}
+
+
+def _validate_rate(
+    *,
+    name: str,
+    value: float,
+) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(
+            f"{name} must be between 0 and 1"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerBaserunningProfile:
+    """Complete runner evidence consumed by the evaluator."""
+
+    runner_id: str
+    speed_score: float
+    attempt_rate: float
+    success_rate: float
+    lead_quality: float
+    fatigue_index: float
+    injury_limit_flag: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        for name, value in (
+            ("speed_score", self.speed_score),
+            ("attempt_rate", self.attempt_rate),
+            ("success_rate", self.success_rate),
+            ("lead_quality", self.lead_quality),
+            ("fatigue_index", self.fatigue_index),
+        ):
+            _validate_rate(
+                name=name,
+                value=value,
+            )
+
+        if not isinstance(
+            self.injury_limit_flag,
+            bool,
+        ):
+            raise TypeError(
+                "injury_limit_flag must be boolean"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherBaserunningProfile:
+    """Complete pitcher hold and pickoff evidence."""
+
+    pitcher_id: str
+    hold_score: float
+    delivery_time_score: float
+    pickoff_attempt_rate: float
+    pickoff_success_rate: float
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        for name, value in (
+            ("hold_score", self.hold_score),
+            (
+                "delivery_time_score",
+                self.delivery_time_score,
+            ),
+            (
+                "pickoff_attempt_rate",
+                self.pickoff_attempt_rate,
+            ),
+            (
+                "pickoff_success_rate",
+                self.pickoff_success_rate,
+            ),
+        ):
+            _validate_rate(
+                name=name,
+                value=value,
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherBaserunningProfile:
+    """Complete catcher throwing evidence for one team."""
+
+    catcher_id: str
+    team_side: str
+    throwing_score: float
+    pop_time_score: float
+
+    def __post_init__(self) -> None:
+        if not self.catcher_id:
+            raise ValueError(
+                "catcher_id is required"
+            )
+        if self.team_side not in {
+            "away",
+            "home",
+        }:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        _validate_rate(
+            name="throwing_score",
+            value=self.throwing_score,
+        )
+        _validate_rate(
+            name="pop_time_score",
+            value=self.pop_time_score,
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningEvidenceCatalog:
+    """Immutable complete profiles available for one matchup."""
+
+    runners: Tuple[
+        CanonicalRunnerBaserunningProfile,
+        ...,
+    ]
+    pitchers: Tuple[
+        CanonicalPitcherBaserunningProfile,
+        ...,
+    ]
+    away_catcher: CanonicalCatcherBaserunningProfile
+    home_catcher: CanonicalCatcherBaserunningProfile
+    catalog_version: str = (
+        CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.away_catcher.team_side != "away":
+            raise ValueError(
+                "away_catcher must use away team side"
+            )
+        if self.home_catcher.team_side != "home":
+            raise ValueError(
+                "home_catcher must use home team side"
+            )
+
+        runner_ids = tuple(
+            profile.runner_id
+            for profile in self.runners
+        )
+        if len(runner_ids) != len(set(runner_ids)):
+            raise ValueError(
+                "runner profile identifiers must be unique"
+            )
+
+        pitcher_ids = tuple(
+            profile.pitcher_id
+            for profile in self.pitchers
+        )
+        if len(pitcher_ids) != len(set(pitcher_ids)):
+            raise ValueError(
+                "pitcher profile identifiers must be unique"
+            )
+
+        if self.catalog_version != (
+            CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning evidence catalog version"
+            )
+
+    def runner_profile(
+        self,
+        runner_id: str,
+    ) -> Optional[CanonicalRunnerBaserunningProfile]:
+        return next(
+            (
+                profile
+                for profile in self.runners
+                if profile.runner_id == runner_id
+            ),
+            None,
+        )
+
+    def pitcher_profile(
+        self,
+        pitcher_id: str,
+    ) -> Optional[CanonicalPitcherBaserunningProfile]:
+        return next(
+            (
+                profile
+                for profile in self.pitchers
+                if profile.pitcher_id == pitcher_id
+            ),
+            None,
+        )
+
+    def fielding_catcher(
+        self,
+        half: str,
+    ) -> CanonicalCatcherBaserunningProfile:
+        if half == "top":
+            return self.home_catcher
+        if half == "bottom":
+            return self.away_catcher
+        raise ValueError(
+            "half must be top or bottom"
+        )
+
+
+CanonicalActivePitcherProvider = Callable[
+    [CanonicalBaserunningEvidenceQuery],
+    Optional[str],
+]
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCatalogStateProvider:
+    """Assemble evaluator state from immutable matchup profiles."""
+
+    catalog: CanonicalBaserunningEvidenceCatalog
+    active_pitcher_provider: CanonicalActivePitcherProvider
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.catalog,
+            CanonicalBaserunningEvidenceCatalog,
+        ):
+            raise TypeError(
+                "catalog must be "
+                "CanonicalBaserunningEvidenceCatalog"
+            )
+        if not callable(self.active_pitcher_provider):
+            raise TypeError(
+                "active_pitcher_provider must be callable"
+            )
+
+    def __call__(
+        self,
+        query: CanonicalBaserunningEvidenceQuery,
+    ):
+        if not isinstance(
+            query,
+            CanonicalBaserunningEvidenceQuery,
+        ):
+            return None
+
+        runner = self.catalog.runner_profile(
+            query.runner_id
+        )
+        if runner is None:
+            return None
+
+        try:
+            pitcher_id = self.active_pitcher_provider(
+                query
+            )
+        except Exception:
+            return None
+
+        if not pitcher_id:
+            return None
+
+        pitcher = self.catalog.pitcher_profile(
+            str(pitcher_id)
+        )
+        if pitcher is None:
+            return None
+
+        catcher = self.catalog.fielding_catcher(
+            query.state.half
+        )
+        state = query.state
+
+        score_margin = (
+            state.away_score - state.home_score
+            if state.half == "top"
+            else state.home_score - state.away_score
+        )
+
+        return {
+            "inning": state.inning,
+            "half": state.half,
+            "outs": state.outs,
+            "base_state": {
+                "first": state.first is not None,
+                "second": state.second is not None,
+                "third": state.third is not None,
+            },
+            "score_margin": score_margin,
+            "runner": {
+                "runner_id": runner.runner_id,
+                "evidence_complete": True,
+                "speed_score": runner.speed_score,
+                "attempt_rate": runner.attempt_rate,
+                "success_rate": runner.success_rate,
+                "lead_quality": runner.lead_quality,
+                "fatigue_index": runner.fatigue_index,
+                "injury_limit_flag": (
+                    runner.injury_limit_flag
+                ),
+            },
+            "origin_base": _BASE_NAMES[
+                query.origin_base
+            ],
+            "target_base": _BASE_NAMES[
+                query.target_base
+            ],
+            "pitcher": {
+                "pitcher_id": pitcher.pitcher_id,
+                "evidence_complete": True,
+                "hold_score": pitcher.hold_score,
+                "delivery_time_score": (
+                    pitcher.delivery_time_score
+                ),
+                "pickoff_attempt_rate": (
+                    pitcher.pickoff_attempt_rate
+                ),
+                "pickoff_success_rate": (
+                    pitcher.pickoff_success_rate
+                ),
+            },
+            "catcher": {
+                "catcher_id": catcher.catcher_id,
+                "evidence_complete": True,
+                "throwing_score": (
+                    catcher.throwing_score
+                ),
+                "pop_time_score": (
+                    catcher.pop_time_score
+                ),
+            },
+        }
+
+
+def build_canonical_baserunning_state_provider(
+    *,
+    catalog: CanonicalBaserunningEvidenceCatalog,
+    active_pitcher_provider: CanonicalActivePitcherProvider,
+) -> CanonicalBaserunningStateProvider:
+    """Build an explicit fail-open catalog-backed provider."""
+
+    return CanonicalBaserunningCatalogStateProvider(
+        catalog=catalog,
+        active_pitcher_provider=active_pitcher_provider,
+    )

--- a/tests/test_canonical_baserunning_evidence_catalog.py
+++ b/tests/test_canonical_baserunning_evidence_catalog.py
@@ -1,0 +1,212 @@
+import pytest
+
+from mlb_app.simulation.events import Base, GameState
+from mlb_app.simulation.game import (
+    CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalBaserunningEvidenceQuery,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+    build_canonical_baserunning_state_provider,
+)
+
+
+def runner(runner_id="runner"):
+    return CanonicalRunnerBaserunningProfile(
+        runner_id=runner_id,
+        speed_score=0.85,
+        attempt_rate=0.30,
+        success_rate=0.80,
+        lead_quality=0.75,
+        fatigue_index=0.10,
+    )
+
+
+def pitcher(pitcher_id="home-pitcher"):
+    return CanonicalPitcherBaserunningProfile(
+        pitcher_id=pitcher_id,
+        hold_score=0.40,
+        delivery_time_score=0.45,
+        pickoff_attempt_rate=0.08,
+        pickoff_success_rate=0.02,
+    )
+
+
+def catcher(side):
+    return CanonicalCatcherBaserunningProfile(
+        catcher_id=f"{side}-catcher",
+        team_side=side,
+        throwing_score=0.45,
+        pop_time_score=0.40,
+    )
+
+
+def catalog(
+    *,
+    runners=None,
+    pitchers=None,
+):
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=tuple(
+            runners
+            if runners is not None
+            else (runner(),)
+        ),
+        pitchers=tuple(
+            pitchers
+            if pitchers is not None
+            else (
+                pitcher("home-pitcher"),
+                pitcher("away-pitcher"),
+            )
+        ),
+        away_catcher=catcher("away"),
+        home_catcher=catcher("home"),
+    )
+
+
+def opportunity(half="top"):
+    return CanonicalBaserunningEvidenceQuery(
+        state=GameState(
+            inning=7,
+            half=half,
+            outs=1,
+            bases=("runner", None, None),
+            away_score=3,
+            home_score=2,
+            batting_order_index=4,
+            plate_appearance_number=25,
+        ),
+        batter_id="batter",
+        runner_id="runner",
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+    )
+
+
+def test_catalog_assembles_complete_top_half_state():
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(),
+        active_pitcher_provider=(
+            lambda query: "home-pitcher"
+        ),
+    )
+
+    state = provider(opportunity("top"))
+
+    assert state is not None
+    assert state["runner"]["runner_id"] == "runner"
+    assert state["runner"]["evidence_complete"] is True
+    assert (
+        state["pitcher"]["pitcher_id"]
+        == "home-pitcher"
+    )
+    assert (
+        state["catcher"]["catcher_id"]
+        == "home-catcher"
+    )
+    assert state["score_margin"] == 1
+    assert state["origin_base"] == "first"
+    assert state["target_base"] == "second"
+    assert state["base_state"] == {
+        "first": True,
+        "second": False,
+        "third": False,
+    }
+
+
+def test_bottom_half_uses_away_catcher_and_batting_margin():
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(),
+        active_pitcher_provider=(
+            lambda query: "away-pitcher"
+        ),
+    )
+
+    state = provider(opportunity("bottom"))
+
+    assert state is not None
+    assert (
+        state["catcher"]["catcher_id"]
+        == "away-catcher"
+    )
+    assert state["score_margin"] == -1
+
+
+def test_missing_runner_profile_fails_open():
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(runners=()),
+        active_pitcher_provider=(
+            lambda query: "home-pitcher"
+        ),
+    )
+
+    assert provider(opportunity()) is None
+
+
+def test_missing_pitcher_profile_fails_open():
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(pitchers=()),
+        active_pitcher_provider=(
+            lambda query: "home-pitcher"
+        ),
+    )
+
+    assert provider(opportunity()) is None
+
+
+def test_missing_active_pitcher_fails_open():
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(),
+        active_pitcher_provider=lambda query: None,
+    )
+
+    assert provider(opportunity()) is None
+
+
+def test_active_pitcher_provider_exception_fails_open():
+    def active_pitcher_provider(query):
+        raise RuntimeError("pitcher unavailable")
+
+    provider = build_canonical_baserunning_state_provider(
+        catalog=catalog(),
+        active_pitcher_provider=active_pitcher_provider,
+    )
+
+    assert provider(opportunity()) is None
+
+
+def test_catalog_rejects_duplicate_runner_profiles():
+    with pytest.raises(
+        ValueError,
+        match="runner profile identifiers must be unique",
+    ):
+        catalog(
+            runners=(
+                runner(),
+                runner(),
+            )
+        )
+
+
+def test_profile_rejects_invalid_rate():
+    with pytest.raises(
+        ValueError,
+        match="speed_score must be between 0 and 1",
+    ):
+        CanonicalRunnerBaserunningProfile(
+            runner_id="runner",
+            speed_score=1.1,
+            attempt_rate=0.30,
+            success_rate=0.80,
+            lead_quality=0.75,
+            fatigue_index=0.10,
+        )
+
+
+def test_catalog_preserves_version():
+    assert (
+        catalog().catalog_version
+        == CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION
+    )


### PR DESCRIPTION
## Summary

- add versioned immutable runner, pitcher, and catcher baserunning profiles
- select the fielding catcher from the active half-inning
- assemble evaluator state with score margin and occupied-base context
- require an injected active-pitcher provider
- fail open when profiles, pitcher identity, or provider data are unavailable
- keep canonical baserunning disconnected from authoritative production execution

## Validation

- 82 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment