### PR TITLE
Expose canonical active pitcher identity

### DIFF
--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -178,6 +178,43 @@ class _CanonicalPlateAppearanceResolver:
         ...,
     ] = ()
 
+    def active_pitcher_id(
+        self,
+        state: GameState,
+    ) -> str:
+        """
+        Return the current fielding pitcher without making a hook decision.
+
+        This read-only identity bridge allows non-plate-appearance
+        resolvers to consume the same trial-owned pitching lifecycle.
+        """
+
+        if not isinstance(state, GameState):
+            raise TypeError(
+                "state must be a GameState"
+            )
+
+        if self.pitching_manager is None:
+            return _fixed_pitcher_for_state(
+                matchup_input=self.matchup_input,
+                state=state,
+            )
+
+        if state.half == "top":
+            team_side = "home"
+        elif state.half == "bottom":
+            team_side = "away"
+        else:
+            raise ValueError(
+                "state half must be 'top' or 'bottom'"
+            )
+
+        return (
+            self.pitching_manager
+            .active_lifecycle(team_side)
+            .pitcher_id
+        )
+
     def earned_run_reconstruction_complete(
         self,
     ) -> bool:

--- a/tests/test_canonical_pa_resolver_factory.py
+++ b/tests/test_canonical_pa_resolver_factory.py
@@ -186,6 +186,36 @@ def test_bottom_half_uses_away_starter():
     assert event.pitcher_id == "away_starter"
 
 
+def test_resolver_exposes_fixed_active_pitcher_identity():
+    matchup_input = matchup()
+    context = (
+        build_canonical_trial_resolver_context(
+            factory_input=factory_input(),
+            trial_index=0,
+            matchup_input=matchup_input,
+        )
+    )
+    resolver = (
+        build_canonical_pa_resolver_factory(
+            all_out_provider([])
+        )(context)
+    )
+
+    assert resolver.active_pitcher_id(
+        GameState(
+            inning=1,
+            half="top",
+        )
+    ) == "home_starter"
+
+    assert resolver.active_pitcher_id(
+        GameState(
+            inning=1,
+            half="bottom",
+        )
+    ) == "away_starter"
+
+
 def test_resolver_propagates_trial_identity():
     observed = []
     matchup_input = matchup()
@@ -435,6 +465,12 @@ def test_resolver_factory_can_change_pitchers_with_manager():
         "home_starter",
         "home_reliever",
     )
+    assert resolver.active_pitcher_id(
+        GameState(
+            inning=4,
+            half="top",
+        )
+    ) == "home_reliever"
 
 def test_resolver_registers_extra_inning_automatic_runner():
     queries = []


### PR DESCRIPTION
## Summary

- expose the current fielding pitcher from the trial-owned plate-appearance resolver
- preserve fixed-starter identity when pitching management is unavailable
- return the active reliever after deterministic pitcher substitution
- keep the identity lookup read-only so it does not trigger a hook decision
- provide the identity bridge required by canonical baserunning evidence

## Validation

- 93 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment