### PR TITLE
Couple trial baserunning resolver construction

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -179,6 +179,7 @@ from .probability_fallback import (
 )
 from .trial_factory import (
     CanonicalBaserunningResolverFactory,
+    CanonicalCoupledBaserunningResolverFactory,
     CanonicalTrialExecutionPlan,
     CanonicalTrialResolverContext,
     CanonicalTrialResolverFactory,
@@ -209,6 +210,7 @@ __all__ = [
     "CanonicalBaserunningResolution",
     "CanonicalBaserunningResolverAdapterFactory",
     "CanonicalBaserunningResolverFactory",
+    "CanonicalCoupledBaserunningResolverFactory",
     "BaserunningResolver",
     "CanonicalActivePitcherProvider",
     "CanonicalBaserunningCatalogStateProvider",

--- a/mlb_app/simulation/game/trial_factory.py
+++ b/mlb_app/simulation/game/trial_factory.py
@@ -129,6 +129,13 @@ CanonicalBaserunningResolverFactory = Callable[
     [CanonicalTrialResolverContext],
     BaserunningResolver,
 ]
+CanonicalCoupledBaserunningResolverFactory = Callable[
+    [
+        CanonicalTrialResolverContext,
+        PlateAppearanceResolver,
+    ],
+    BaserunningResolver,
+]
 
 
 @dataclass(frozen=True)
@@ -147,6 +154,9 @@ class CanonicalTrialExecutionPlan:
     resolver_factory: CanonicalTrialResolverFactory
     baserunning_resolver_factory: Optional[
         CanonicalBaserunningResolverFactory
+    ] = None
+    coupled_baserunning_resolver_factory: Optional[
+        CanonicalCoupledBaserunningResolverFactory
     ] = None
     game_config: CanonicalGameConfig = field(
         default_factory=CanonicalGameConfig
@@ -220,6 +230,28 @@ class CanonicalTrialExecutionPlan:
             raise TypeError(
                 "baserunning_resolver_factory "
                 "must be callable"
+            )
+
+        if (
+            self.coupled_baserunning_resolver_factory
+            is not None
+            and not callable(
+                self.coupled_baserunning_resolver_factory
+            )
+        ):
+            raise TypeError(
+                "coupled_baserunning_resolver_factory "
+                "must be callable"
+            )
+
+        if (
+            self.baserunning_resolver_factory is not None
+            and self.coupled_baserunning_resolver_factory
+            is not None
+        ):
+            raise ValueError(
+                "only one baserunning resolver factory "
+                "may be configured"
             )
 
         if self.matchup_input is not None:
@@ -323,6 +355,22 @@ def run_canonical_trial_execution_plan(
 
         baserunning_resolver = None
         if (
+            plan.coupled_baserunning_resolver_factory
+            is not None
+        ):
+            baserunning_resolver = (
+                plan.coupled_baserunning_resolver_factory(
+                    context,
+                    resolver,
+                )
+            )
+
+            if not callable(baserunning_resolver):
+                raise TypeError(
+                    "coupled_baserunning_resolver_factory "
+                    "must return a baserunning resolver"
+                )
+        elif (
             plan.baserunning_resolver_factory
             is not None
         ):

--- a/tests/test_canonical_trial_factory_protocol.py
+++ b/tests/test_canonical_trial_factory_protocol.py
@@ -359,3 +359,114 @@ def test_plan_rejects_non_callable_baserunning_factory():
             resolver_factory=lambda context: out_event,
             baserunning_resolver_factory="invalid",
         )
+
+
+def test_coupled_factory_receives_trial_plate_appearance_resolver():
+    inputs = factory_input(simulations=2)
+    created_resolvers = []
+    coupled_calls = []
+
+    def resolver_factory(context):
+        def resolver(state, batter_id, sequence):
+            return out_event(
+                state,
+                batter_id,
+                sequence,
+            )
+
+        created_resolvers.append(resolver)
+        return resolver
+
+    def coupled_factory(
+        context,
+        plate_appearance_resolver,
+    ):
+        coupled_calls.append(
+            (
+                context.trial_index,
+                plate_appearance_resolver,
+            )
+        )
+
+        return lambda state, batter_id, sequence: None
+
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=inputs,
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=resolver_factory,
+        coupled_baserunning_resolver_factory=(
+            coupled_factory
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    batch = run_canonical_trial_execution_plan(plan)
+
+    assert len(batch.games) == 2
+    assert [
+        trial_index
+        for trial_index, _ in coupled_calls
+    ] == [0, 1]
+    assert [
+        resolver
+        for _, resolver in coupled_calls
+    ] == created_resolvers
+
+
+def test_plan_rejects_both_baserunning_factory_modes():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "only one baserunning resolver factory "
+            "may be configured"
+        ),
+    ):
+        CanonicalTrialExecutionPlan(
+            factory_input=factory_input(),
+            away_lineup=lineup("away"),
+            home_lineup=lineup("home"),
+            resolver_factory=lambda context: out_event,
+            baserunning_resolver_factory=(
+                lambda context: (
+                    lambda state, batter_id, sequence: None
+                )
+            ),
+            coupled_baserunning_resolver_factory=(
+                lambda context, resolver: (
+                    lambda state, batter_id, sequence: None
+                )
+            ),
+        )
+
+
+def test_non_callable_coupled_baserunning_resolver_is_rejected():
+    plan = CanonicalTrialExecutionPlan(
+        factory_input=factory_input(
+            simulations=1
+        ),
+        away_lineup=lineup("away"),
+        home_lineup=lineup("home"),
+        resolver_factory=lambda context: out_event,
+        coupled_baserunning_resolver_factory=(
+            lambda context, resolver: None
+        ),
+        game_config=CanonicalGameConfig(
+            regulation_innings=1,
+            max_extra_innings=0,
+            automatic_runner_enabled=False,
+        ),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "coupled_baserunning_resolver_factory must "
+            "return a baserunning resolver"
+        ),
+    ):
+        run_canonical_trial_execution_plan(plan)


### PR DESCRIPTION
## Summary

- add an optional coupled baserunning resolver factory contract
- provide the exact trial-owned plate-appearance resolver during baserunning resolver construction
- preserve the existing context-only baserunning factory unchanged
- reject simultaneous configuration of both factory modes
- validate coupled resolver outputs before game simulation
- keep production baserunning inactive

## Validation

- 89 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment