### PR TITLE
Compose catalog-backed baserunning resolvers

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -1,5 +1,10 @@
 """Canonical full-game orchestration."""
 
+from .baserunning_composition import (
+    CANONICAL_BASERUNNING_COMPOSITION_VERSION,
+    CanonicalCatalogBaserunningResolverFactory,
+    build_canonical_catalog_baserunning_resolver_factory,
+)
 from .baserunning_evidence_catalog import (
     CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION,
     CanonicalActivePitcherProvider,
@@ -202,6 +207,9 @@ from .validation import (
 )
 
 __all__ = [
+    "CANONICAL_BASERUNNING_COMPOSITION_VERSION",
+    "CanonicalCatalogBaserunningResolverFactory",
+    "build_canonical_catalog_baserunning_resolver_factory",
     "CANONICAL_BASERUNNING_EVIDENCE_ADAPTER_VERSION",
     "CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION",
     "CANONICAL_BASERUNNING_RESOLUTION_VERSION",

--- a/mlb_app/simulation/game/baserunning_composition.py
+++ b/mlb_app/simulation/game/baserunning_composition.py
@@ -1,0 +1,125 @@
+"""Compose catalog-backed canonical baserunning resolvers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .baserunning_evidence_adapter import (
+    build_canonical_baserunning_evidence_provider,
+)
+from .baserunning_evidence_catalog import (
+    CanonicalBaserunningEvidenceCatalog,
+    build_canonical_baserunning_state_provider,
+)
+from .baserunning_resolver import (
+    CanonicalBaserunningEvidenceQuery,
+    CanonicalBaserunningResolverAdapterFactory,
+)
+from .orchestrator import (
+    BaserunningResolver,
+    PlateAppearanceResolver,
+)
+from .trial_factory import (
+    CanonicalCoupledBaserunningResolverFactory,
+    CanonicalTrialResolverContext,
+)
+
+
+CANONICAL_BASERUNNING_COMPOSITION_VERSION = (
+    "canonical_baserunning_composition_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalCatalogBaserunningResolverFactory:
+    """
+    Compose one catalog-backed resolver with trial-owned pitcher state.
+
+    Missing active-pitcher access remains fail-open through the catalog
+    state provider and produces no baserunning event.
+    """
+
+    catalog: CanonicalBaserunningEvidenceCatalog
+    composition_version: str = (
+        CANONICAL_BASERUNNING_COMPOSITION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.catalog,
+            CanonicalBaserunningEvidenceCatalog,
+        ):
+            raise TypeError(
+                "catalog must be "
+                "CanonicalBaserunningEvidenceCatalog"
+            )
+
+        if self.composition_version != (
+            CANONICAL_BASERUNNING_COMPOSITION_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning composition version"
+            )
+
+    def __call__(
+        self,
+        context: CanonicalTrialResolverContext,
+        plate_appearance_resolver: PlateAppearanceResolver,
+    ) -> BaserunningResolver:
+        if not isinstance(
+            context,
+            CanonicalTrialResolverContext,
+        ):
+            raise TypeError(
+                "context must be "
+                "CanonicalTrialResolverContext"
+            )
+
+        if not callable(plate_appearance_resolver):
+            raise TypeError(
+                "plate_appearance_resolver must be callable"
+            )
+
+        def active_pitcher_provider(
+            query: CanonicalBaserunningEvidenceQuery,
+        ) -> Optional[str]:
+            identity_provider = getattr(
+                plate_appearance_resolver,
+                "active_pitcher_id",
+                None,
+            )
+
+            if not callable(identity_provider):
+                return None
+
+            return identity_provider(query.state)
+
+        state_provider = (
+            build_canonical_baserunning_state_provider(
+                catalog=self.catalog,
+                active_pitcher_provider=(
+                    active_pitcher_provider
+                ),
+            )
+        )
+        evidence_provider = (
+            build_canonical_baserunning_evidence_provider(
+                state_provider=state_provider,
+            )
+        )
+
+        return CanonicalBaserunningResolverAdapterFactory(
+            evidence_provider=evidence_provider,
+        )(context)
+
+
+def build_canonical_catalog_baserunning_resolver_factory(
+    *,
+    catalog: CanonicalBaserunningEvidenceCatalog,
+) -> CanonicalCoupledBaserunningResolverFactory:
+    """Build an explicit coupled catalog-backed resolver factory."""
+
+    return CanonicalCatalogBaserunningResolverFactory(
+        catalog=catalog,
+    )

--- a/tests/test_canonical_baserunning_composition.py
+++ b/tests/test_canonical_baserunning_composition.py
@@ -1,0 +1,230 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.events import (
+    GameState,
+    OutRecord,
+    PlayEvent,
+)
+from mlb_app.simulation.game import (
+    CANONICAL_BASERUNNING_COMPOSITION_VERSION,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatalogBaserunningResolverFactory,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+    build_canonical_catalog_baserunning_resolver_factory,
+    build_canonical_trial_factory_input,
+    build_canonical_trial_resolver_context,
+)
+
+
+def catalog():
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id="runner",
+                speed_score=0.90,
+                attempt_rate=0.80,
+                success_rate=0.85,
+                lead_quality=0.80,
+                fatigue_index=0.05,
+            ),
+        ),
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id="active-pitcher",
+                hold_score=0.35,
+                delivery_time_score=0.40,
+                pickoff_attempt_rate=0.08,
+                pickoff_success_rate=0.02,
+            ),
+        ),
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="away-catcher",
+            team_side="away",
+            throwing_score=0.45,
+            pop_time_score=0.45,
+        ),
+        home_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="home-catcher",
+            team_side="home",
+            throwing_score=0.45,
+            pop_time_score=0.45,
+        ),
+    )
+
+
+def context():
+    inputs = build_canonical_trial_factory_input(
+        game_pk=123,
+        config={
+            "simulation_count": 1,
+            "seed": 98765,
+            "canonical_model_version": (
+                "baserunning-composition-test-v1"
+            ),
+        },
+    )
+
+    return build_canonical_trial_resolver_context(
+        factory_input=inputs,
+        trial_index=0,
+    )
+
+
+def opportunity_state():
+    return GameState(
+        inning=7,
+        half="top",
+        outs=1,
+        bases=("runner", None, None),
+        away_score=2,
+        home_score=2,
+        batting_order_index=4,
+        plate_appearance_number=25,
+    )
+
+
+class PlateAppearanceResolver:
+    def __init__(self):
+        self.identity_states = []
+
+    def active_pitcher_id(self, state):
+        self.identity_states.append(state)
+        return "active-pitcher"
+
+    def __call__(self, state, batter_id, sequence):
+        next_out = state.outs + 1
+
+        return PlayEvent(
+            sequence=sequence,
+            event_type="out",
+            batter_id=batter_id,
+            pitcher_id="active-pitcher",
+            state_before=state,
+            state_after=replace(
+                state,
+                outs=next_out,
+                batting_order_index=(
+                    state.batting_order_index + 1
+                ) % 9,
+                plate_appearance_number=(
+                    state.plate_appearance_number + 1
+                ),
+            ),
+            outs_recorded=(
+                OutRecord(
+                    runner_id=batter_id,
+                    out_number=next_out,
+                    reason="composition_test_out",
+                ),
+            ),
+        )
+
+
+def test_composition_uses_trial_active_pitcher_identity():
+    plate_appearance_resolver = PlateAppearanceResolver()
+    factory = (
+        build_canonical_catalog_baserunning_resolver_factory(
+            catalog=catalog(),
+        )
+    )
+    resolver = factory(
+        context(),
+        plate_appearance_resolver,
+    )
+    state = opportunity_state()
+
+    event = resolver(
+        state,
+        "batter",
+        10,
+    )
+
+    assert plate_appearance_resolver.identity_states == [
+        state
+    ]
+
+    if event is not None:
+        assert event.pitcher_id == "active-pitcher"
+        assert event.state_before == state
+        assert event.is_plate_appearance is False
+
+
+def test_composed_resolver_replays_identically():
+    factory = CanonicalCatalogBaserunningResolverFactory(
+        catalog=catalog(),
+    )
+
+    first = factory(
+        context(),
+        PlateAppearanceResolver(),
+    )(
+        opportunity_state(),
+        "batter",
+        10,
+    )
+    second = factory(
+        context(),
+        PlateAppearanceResolver(),
+    )(
+        opportunity_state(),
+        "batter",
+        10,
+    )
+
+    assert first == second
+
+
+def test_missing_active_pitcher_interface_fails_open():
+    def plate_appearance_resolver(
+        state,
+        batter_id,
+        sequence,
+    ):
+        raise AssertionError(
+            "plate appearance must not execute"
+        )
+
+    resolver = (
+        build_canonical_catalog_baserunning_resolver_factory(
+            catalog=catalog(),
+        )(
+            context(),
+            plate_appearance_resolver,
+        )
+    )
+
+    assert resolver(
+        opportunity_state(),
+        "batter",
+        10,
+    ) is None
+
+
+def test_composition_rejects_non_callable_pa_resolver():
+    factory = CanonicalCatalogBaserunningResolverFactory(
+        catalog=catalog(),
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "plate_appearance_resolver must be callable"
+        ),
+    ):
+        factory(
+            context(),
+            object(),
+        )
+
+
+def test_composition_preserves_version():
+    assert (
+        CanonicalCatalogBaserunningResolverFactory(
+            catalog=catalog(),
+        ).composition_version
+        == CANONICAL_BASERUNNING_COMPOSITION_VERSION
+    )


### PR DESCRIPTION
## Summary

- compose the immutable baserunning evidence catalog with the existing evaluator adapter
- read active pitcher identity from the exact trial-owned plate-appearance resolver
- build the deterministic baserunning resolver through the coupled trial contract
- fail open when active-pitcher access is unavailable
- preserve seed, draw, and probability provenance through existing sampling contracts
- keep production shadow baserunning inactive

## Validation

- 94 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment