### PR TITLE
Digest canonical baserunning evidence catalogs

### DIFF
--- a/mlb_app/simulation/game/baserunning_evidence_catalog.py
+++ b/mlb_app/simulation/game/baserunning_evidence_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 from typing import Callable, Optional, Tuple
 
 from mlb_app.simulation.events import Base
@@ -197,6 +198,64 @@ class CanonicalBaserunningEvidenceCatalog:
             raise ValueError(
                 "unsupported baserunning evidence catalog version"
             )
+
+    @property
+    def digest(self) -> str:
+        """Return deterministic provenance for the complete catalog."""
+
+        parts = [
+            self.catalog_version,
+        ]
+
+        for profile in sorted(
+            self.runners,
+            key=lambda value: value.runner_id,
+        ):
+            parts.extend(
+                (
+                    "runner",
+                    profile.runner_id,
+                    repr(profile.speed_score),
+                    repr(profile.attempt_rate),
+                    repr(profile.success_rate),
+                    repr(profile.lead_quality),
+                    repr(profile.fatigue_index),
+                    repr(profile.injury_limit_flag),
+                )
+            )
+
+        for profile in sorted(
+            self.pitchers,
+            key=lambda value: value.pitcher_id,
+        ):
+            parts.extend(
+                (
+                    "pitcher",
+                    profile.pitcher_id,
+                    repr(profile.hold_score),
+                    repr(profile.delivery_time_score),
+                    repr(profile.pickoff_attempt_rate),
+                    repr(profile.pickoff_success_rate),
+                )
+            )
+
+        for profile in (
+            self.away_catcher,
+            self.home_catcher,
+        ):
+            parts.extend(
+                (
+                    "catcher",
+                    profile.team_side,
+                    profile.catcher_id,
+                    repr(profile.throwing_score),
+                    repr(profile.pop_time_score),
+                )
+            )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
 
     def runner_profile(
         self,

--- a/tests/test_canonical_baserunning_evidence_catalog.py
+++ b/tests/test_canonical_baserunning_evidence_catalog.py
@@ -210,3 +210,97 @@ def test_catalog_preserves_version():
         catalog().catalog_version
         == CANONICAL_BASERUNNING_EVIDENCE_CATALOG_VERSION
     )
+
+
+def test_catalog_digest_is_explicit():
+    value = catalog()
+
+    assert len(value.digest) == 64
+    assert value.digest == value.digest
+
+
+def test_catalog_digest_is_profile_order_independent():
+    value = catalog()
+
+    reversed_catalog = CanonicalBaserunningEvidenceCatalog(
+        runners=tuple(reversed(value.runners)),
+        pitchers=tuple(reversed(value.pitchers)),
+        away_catcher=value.away_catcher,
+        home_catcher=value.home_catcher,
+    )
+
+    assert reversed_catalog.digest == value.digest
+
+
+def test_runner_evidence_change_changes_catalog_digest():
+    value = catalog()
+    runner = value.runners[0]
+
+    changed = CanonicalBaserunningEvidenceCatalog(
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id=runner.runner_id,
+                speed_score=runner.speed_score,
+                attempt_rate=runner.attempt_rate,
+                success_rate=runner.success_rate,
+                lead_quality=runner.lead_quality,
+                fatigue_index=0.20,
+                injury_limit_flag=(
+                    runner.injury_limit_flag
+                ),
+            ),
+            *value.runners[1:],
+        ),
+        pitchers=value.pitchers,
+        away_catcher=value.away_catcher,
+        home_catcher=value.home_catcher,
+    )
+
+    assert changed.digest != value.digest
+
+
+def test_pitcher_evidence_change_changes_catalog_digest():
+    value = catalog()
+    pitcher = value.pitchers[0]
+
+    changed = CanonicalBaserunningEvidenceCatalog(
+        runners=value.runners,
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id=pitcher.pitcher_id,
+                hold_score=pitcher.hold_score,
+                delivery_time_score=(
+                    pitcher.delivery_time_score
+                ),
+                pickoff_attempt_rate=0.25,
+                pickoff_success_rate=(
+                    pitcher.pickoff_success_rate
+                ),
+            ),
+            *value.pitchers[1:],
+        ),
+        away_catcher=value.away_catcher,
+        home_catcher=value.home_catcher,
+    )
+
+    assert changed.digest != value.digest
+
+
+def test_catcher_evidence_change_changes_catalog_digest():
+    value = catalog()
+
+    changed = CanonicalBaserunningEvidenceCatalog(
+        runners=value.runners,
+        pitchers=value.pitchers,
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id=value.away_catcher.catcher_id,
+            team_side="away",
+            throwing_score=0.10,
+            pop_time_score=(
+                value.away_catcher.pop_time_score
+            ),
+        ),
+        home_catcher=value.home_catcher,
+    )
+
+    assert changed.digest != value.digest


### PR DESCRIPTION
## Summary

- add deterministic SHA-256 provenance for canonical baserunning evidence catalogs
- include every runner, pitcher, and catcher evidence field in the digest
- preserve digest stability across runner and pitcher record ordering
- change the digest when any participant evidence changes
- prepare the catalog for atomic shadow-input assembly without activating baserunning

## Validation

- 81 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment