### PR TITLE
Carry baserunning catalog input provenance

### DIFF
--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -9,6 +9,9 @@ from mlb_app.simulation.box_score import (
     BatterDfsScoringRules,
     PitcherDfsScoringRules,
 )
+from mlb_app.simulation.game.baserunning_evidence_catalog import (
+    CanonicalBaserunningEvidenceCatalog,
+)
 from mlb_app.simulation.game.contracts import (
     CanonicalGameConfig,
 )
@@ -80,6 +83,9 @@ class CanonicalShadowExecutionBundleFactory:
     matchup_input: CanonicalMatchupInput
     exact_artifact: CanonicalProbabilityArtifact
     fallback_catalog: CanonicalProbabilityFallbackCatalog
+    baserunning_evidence_catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None
     fallback_policy: CanonicalProbabilityFallbackPolicy = field(
         default_factory=CanonicalProbabilityFallbackPolicy
     )
@@ -121,6 +127,18 @@ class CanonicalShadowExecutionBundleFactory:
             raise TypeError(
                 "fallback_catalog must be a "
                 "CanonicalProbabilityFallbackCatalog"
+            )
+
+        if (
+            self.baserunning_evidence_catalog is not None
+            and not isinstance(
+                self.baserunning_evidence_catalog,
+                CanonicalBaserunningEvidenceCatalog,
+            )
+        ):
+            raise TypeError(
+                "baserunning_evidence_catalog must be "
+                "CanonicalBaserunningEvidenceCatalog or None"
             )
 
         if not isinstance(
@@ -251,6 +269,9 @@ class CanonicalShadowExecutionBundleFactory:
             matchup_input=self.matchup_input,
             exact_artifact=self.exact_artifact,
             fallback_catalog=self.fallback_catalog,
+            baserunning_evidence_catalog=(
+                self.baserunning_evidence_catalog
+            ),
             fallback_policy=self.fallback_policy,
             game_config=self.game_config,
             batter_dfs_rules=self.batter_dfs_rules,
@@ -273,6 +294,9 @@ def build_canonical_shadow_execution_bundle_factory(
     matchup_input: CanonicalMatchupInput,
     exact_artifact: CanonicalProbabilityArtifact,
     fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    baserunning_evidence_catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None,
     fallback_policy: Optional[
         CanonicalProbabilityFallbackPolicy
     ] = None,
@@ -292,6 +316,9 @@ def build_canonical_shadow_execution_bundle_factory(
         matchup_input=matchup_input,
         exact_artifact=exact_artifact,
         fallback_catalog=fallback_catalog,
+        baserunning_evidence_catalog=(
+            baserunning_evidence_catalog
+        ),
         fallback_policy=(
             fallback_policy
             or CanonicalProbabilityFallbackPolicy()

--- a/mlb_app/simulation/shadow/input_assembly.py
+++ b/mlb_app/simulation/shadow/input_assembly.py
@@ -10,6 +10,9 @@ from mlb_app.simulation.box_score import (
     BatterDfsScoringRules,
     PitcherDfsScoringRules,
 )
+from mlb_app.simulation.game.baserunning_evidence_catalog import (
+    CanonicalBaserunningEvidenceCatalog,
+)
 from mlb_app.simulation.game.contracts import (
     CanonicalGameConfig,
 )
@@ -48,6 +51,9 @@ class CanonicalShadowExecutionInputs:
     matchup_input: CanonicalMatchupInput
     exact_artifact: CanonicalProbabilityArtifact
     fallback_catalog: CanonicalProbabilityFallbackCatalog
+    baserunning_evidence_catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None
     fallback_policy: CanonicalProbabilityFallbackPolicy = field(
         default_factory=CanonicalProbabilityFallbackPolicy
     )
@@ -89,6 +95,18 @@ class CanonicalShadowExecutionInputs:
             raise TypeError(
                 "fallback_catalog must be a "
                 "CanonicalProbabilityFallbackCatalog"
+            )
+
+        if (
+            self.baserunning_evidence_catalog is not None
+            and not isinstance(
+                self.baserunning_evidence_catalog,
+                CanonicalBaserunningEvidenceCatalog,
+            )
+        ):
+            raise TypeError(
+                "baserunning_evidence_catalog must be "
+                "CanonicalBaserunningEvidenceCatalog or None"
             )
 
         if not isinstance(
@@ -173,6 +191,15 @@ class CanonicalShadowExecutionInputs:
         return self.fallback_catalog.digest
 
     @property
+    def baserunning_evidence_catalog_digest(
+        self,
+    ) -> Optional[str]:
+        if self.baserunning_evidence_catalog is None:
+            return None
+
+        return self.baserunning_evidence_catalog.digest
+
+    @property
     def assembly_digest(self) -> str:
         """
         Return a deterministic digest of the complete assembled input set.
@@ -200,6 +227,10 @@ class CanonicalShadowExecutionInputs:
             *home_plan.bullpen_pitcher_ids,
             self.exact_artifact_digest,
             self.fallback_catalog_digest,
+            (
+                self.baserunning_evidence_catalog_digest
+                or "baserunning_catalog:none"
+            ),
             self.fallback_policy.policy_version,
             *(
                 tier.value
@@ -232,6 +263,9 @@ class CanonicalShadowExecutionInputs:
             matchup_input=self.matchup_input,
             exact_artifact=self.exact_artifact,
             fallback_catalog=self.fallback_catalog,
+            baserunning_evidence_catalog=(
+                self.baserunning_evidence_catalog
+            ),
             fallback_policy=self.fallback_policy,
             game_config=self.game_config,
             batter_dfs_rules=self.batter_dfs_rules,
@@ -244,6 +278,9 @@ def assemble_canonical_shadow_execution_inputs(
     matchup_input: CanonicalMatchupInput,
     exact_artifact: CanonicalProbabilityArtifact,
     fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    baserunning_evidence_catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None,
     fallback_policy: Optional[
         CanonicalProbabilityFallbackPolicy
     ] = None,
@@ -263,6 +300,9 @@ def assemble_canonical_shadow_execution_inputs(
         matchup_input=matchup_input,
         exact_artifact=exact_artifact,
         fallback_catalog=fallback_catalog,
+        baserunning_evidence_catalog=(
+            baserunning_evidence_catalog
+        ),
         fallback_policy=(
             fallback_policy
             or CanonicalProbabilityFallbackPolicy()

--- a/tests/test_canonical_shadow_input_assembly.py
+++ b/tests/test_canonical_shadow_input_assembly.py
@@ -4,10 +4,13 @@ import pytest
 
 from mlb_app.simulation.game import (
     CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
     CanonicalGameConfig,
     CanonicalLineup,
     CanonicalMatchupInput,
     CanonicalOutcomeProbability,
+    CanonicalPitcherBaserunningProfile,
     CanonicalPitchingPlan,
     CanonicalPlateAppearanceOutcome,
     CanonicalProbabilityArtifact,
@@ -17,6 +20,7 @@ from mlb_app.simulation.game import (
     CanonicalProbabilityFallbackRecord,
     CanonicalProbabilityFallbackTier,
     CanonicalProbabilityProviderIdentity,
+    CanonicalRunnerBaserunningProfile,
     build_canonical_trial_factory_input,
 )
 from mlb_app.simulation.shadow import (
@@ -152,12 +156,52 @@ def fallback_policy():
     )
 
 
+def baserunning_catalog(
+    *,
+    fatigue_index=0.10,
+):
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id="away_batter_0",
+                speed_score=0.85,
+                attempt_rate=0.30,
+                success_rate=0.80,
+                lead_quality=0.75,
+                fatigue_index=fatigue_index,
+            ),
+        ),
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id="home_starter",
+                hold_score=0.40,
+                delivery_time_score=0.45,
+                pickoff_attempt_rate=0.08,
+                pickoff_success_rate=0.02,
+            ),
+        ),
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="away_catcher",
+            team_side="away",
+            throwing_score=0.45,
+            pop_time_score=0.40,
+        ),
+        home_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="home_catcher",
+            team_side="home",
+            throwing_score=0.45,
+            pop_time_score=0.40,
+        ),
+    )
+
+
 def assembled(
     *,
     exact=None,
     catalog=None,
     policy=None,
     config=None,
+    baserunning=None,
 ):
     return assemble_canonical_shadow_execution_inputs(
         matchup_input=matchup(),
@@ -176,6 +220,7 @@ def assembled(
             if policy is not None
             else fallback_policy()
         ),
+        baserunning_evidence_catalog=baserunning,
         game_config=(
             config
             if config is not None
@@ -325,6 +370,9 @@ def test_build_factory_preserves_assembled_inputs():
     assert factory.fallback_policy is (
         value.fallback_policy
     )
+    assert factory.baserunning_evidence_catalog is (
+        value.baserunning_evidence_catalog
+    )
     assert factory.game_config is (
         value.game_config
     )
@@ -359,3 +407,63 @@ def test_assembled_factory_executes_atomic_bundle():
         .total_resolutions
         == 12
     )
+
+
+def test_optional_baserunning_catalog_provenance_is_explicit():
+    source = baserunning_catalog()
+    value = assembled(
+        baserunning=source,
+    )
+
+    assert value.baserunning_evidence_catalog is source
+    assert (
+        value.baserunning_evidence_catalog_digest
+        == source.digest
+    )
+    assert len(
+        value.baserunning_evidence_catalog_digest
+    ) == 64
+    assert (
+        value.build_factory()
+        .baserunning_evidence_catalog
+        is source
+    )
+
+
+def test_missing_baserunning_catalog_has_no_catalog_digest():
+    value = assembled()
+
+    assert value.baserunning_evidence_catalog is None
+    assert value.baserunning_evidence_catalog_digest is None
+
+
+def test_baserunning_catalog_change_changes_assembly_digest():
+    first = assembled(
+        baserunning=baserunning_catalog(
+            fatigue_index=0.10,
+        ),
+    )
+    second = assembled(
+        baserunning=baserunning_catalog(
+            fatigue_index=0.20,
+        ),
+    )
+
+    assert (
+        first.baserunning_evidence_catalog_digest
+        != second.baserunning_evidence_catalog_digest
+    )
+    assert first.assembly_digest != second.assembly_digest
+
+
+def test_assembly_rejects_invalid_baserunning_catalog_type():
+    with pytest.raises(
+        TypeError,
+        match="baserunning_evidence_catalog",
+    ):
+        CanonicalShadowExecutionInputs(
+            matchup_input=matchup(),
+            exact_artifact=exact_artifact(),
+            fallback_catalog=fallback_catalog(),
+            baserunning_evidence_catalog="invalid",
+        )


### PR DESCRIPTION
## Summary

- add an optional canonical baserunning evidence catalog to atomic shadow inputs
- validate the optional catalog type at assembly and execution-factory boundaries
- expose the catalog digest as explicit input provenance
- include catalog presence and content in the complete assembly digest
- preserve the catalog through bundle-factory construction and execution material
- do not activate baserunning events or change legacy authority

## Validation

- 66 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment