### PR TITLE
Reduce canonical baserunning statistics

### DIFF
--- a/mlb_app/simulation/box_score/contracts.py
+++ b/mlb_app/simulation/box_score/contracts.py
@@ -33,6 +33,8 @@ class BatterBoxScore:
     reached_on_error: int = 0
     sacrifice_flies: int = 0
     sacrifice_bunts: int = 0
+    stolen_bases: int = 0
+    caught_stealing: int = 0
 
     def __post_init__(self) -> None:
         if not self.player_id:

--- a/mlb_app/simulation/box_score/reducer.py
+++ b/mlb_app/simulation/box_score/reducer.py
@@ -67,6 +67,22 @@ def _fielding_side(event: PlayEvent) -> str:
     return "home" if _batting_side(event) == "away" else "away"
 
 
+def _baserunning_runner_id(
+    event: PlayEvent,
+) -> str:
+    for movement in event.runner_movements:
+        if (
+            movement.is_out
+            or movement.start_base
+            != movement.end_base
+        ):
+            return movement.runner_id
+
+    raise ValueError(
+        "baserunning event requires a moving runner"
+    )
+
+
 def reduce_box_score(
     *,
     initial_state,
@@ -104,44 +120,73 @@ def reduce_box_score(
         fielding_side = _fielding_side(event)
         outcome = event.event_type.strip().lower()
 
-        batter_key = (event.batter_id, batting_side)
-        batter = batter_rows.setdefault(
-            batter_key,
-            _empty_batter(
+        hit_field = None
+
+        if event.is_plate_appearance:
+            batter_key = (
                 event.batter_id,
                 batting_side,
-            ),
-        )
+            )
+            batter = batter_rows.setdefault(
+                batter_key,
+                _empty_batter(
+                    event.batter_id,
+                    batting_side,
+                ),
+            )
 
-        batter["plate_appearances"] += 1
+            batter["plate_appearances"] += 1
 
-        if outcome not in NON_AT_BAT_EVENTS:
-            batter["at_bats"] += 1
+            if outcome not in NON_AT_BAT_EVENTS:
+                batter["at_bats"] += 1
 
-        hit_field = HIT_EVENTS.get(outcome)
-        if hit_field is not None:
-            batter[hit_field] += 1
-            teams[batting_side]["hits"] += 1
+            hit_field = HIT_EVENTS.get(outcome)
+            if hit_field is not None:
+                batter[hit_field] += 1
+                teams[batting_side]["hits"] += 1
 
-        if outcome == "bb":
-            batter["walks"] += 1
-        elif outcome == "hbp":
-            batter["hit_by_pitch"] += 1
-        elif outcome in {"k", "strikeout"}:
-            batter["strikeouts"] += 1
-        elif outcome == "reached_on_error":
-            batter["reached_on_error"] += 1
+            if outcome == "bb":
+                batter["walks"] += 1
+            elif outcome == "hbp":
+                batter["hit_by_pitch"] += 1
+            elif outcome in {"k", "strikeout"}:
+                batter["strikeouts"] += 1
+            elif outcome == "reached_on_error":
+                batter["reached_on_error"] += 1
 
-        if (
-            event.attribution.sacrifice_type
-            is SacrificeType.FLY
-        ):
-            batter["sacrifice_flies"] += 1
-        elif (
-            event.attribution.sacrifice_type
-            is SacrificeType.BUNT
-        ):
-            batter["sacrifice_bunts"] += 1
+            if (
+                event.attribution.sacrifice_type
+                is SacrificeType.FLY
+            ):
+                batter["sacrifice_flies"] += 1
+            elif (
+                event.attribution.sacrifice_type
+                is SacrificeType.BUNT
+            ):
+                batter["sacrifice_bunts"] += 1
+        elif outcome in {
+            "stolen_base",
+            "caught_stealing",
+        }:
+            runner_id = _baserunning_runner_id(
+                event
+            )
+            runner_key = (
+                runner_id,
+                batting_side,
+            )
+            runner = batter_rows.setdefault(
+                runner_key,
+                _empty_batter(
+                    runner_id,
+                    batting_side,
+                ),
+            )
+
+            if outcome == "stolen_base":
+                runner["stolen_bases"] += 1
+            else:
+                runner["caught_stealing"] += 1
 
         if event.attribution.rbi_count:
             rbi_player_id = (
@@ -187,7 +232,9 @@ def reduce_box_score(
                 ),
             )
 
-            pitcher["batters_faced"] += 1
+            if event.is_plate_appearance:
+                pitcher["batters_faced"] += 1
+
             pitcher["outs_recorded"] += len(
                 event.outs_recorded
             )

--- a/tests/test_box_score_reducer.py
+++ b/tests/test_box_score_reducer.py
@@ -11,9 +11,11 @@ from mlb_app.simulation.box_score import (
     validate_box_score_reconstruction,
 )
 from mlb_app.simulation.events import (
+    Base,
     DeterministicPlayResolver,
     GameState,
     MultiOutPlayResolver,
+    build_baserunning_event,
 )
 
 
@@ -246,3 +248,82 @@ def test_reducer_is_deterministic():
     )
 
     assert first == second
+
+
+def test_stolen_base_credits_runner_without_plate_appearance():
+    initial = GameState(
+        bases=("runner", None, None),
+        batting_order_index=4,
+        plate_appearance_number=25,
+    )
+    event = build_baserunning_event(
+        sequence=0,
+        event_type="stolen_base",
+        batter_id="current_batter",
+        runner_id="runner",
+        state_before=initial,
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+        pitcher_id="pitcher",
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    runner = box.batter("runner")
+    pitcher = box.pitcher("pitcher")
+
+    assert runner.stolen_bases == 1
+    assert runner.caught_stealing == 0
+    assert runner.plate_appearances == 0
+    assert runner.at_bats == 0
+    assert pitcher.batters_faced == 0
+    assert pitcher.outs_recorded == 0
+
+    with pytest.raises(KeyError):
+        box.batter("current_batter")
+
+
+def test_caught_stealing_credits_runner_and_non_pa_out():
+    initial = GameState(
+        outs=1,
+        bases=("runner", None, None),
+        batting_order_index=4,
+        plate_appearance_number=25,
+    )
+    event = build_baserunning_event(
+        sequence=0,
+        event_type="caught_stealing",
+        batter_id="current_batter",
+        runner_id="runner",
+        state_before=initial,
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+        pitcher_id="pitcher",
+    )
+
+    box = reduce_box_score(
+        initial_state=initial,
+        events=(event,),
+    )
+
+    runner = box.batter("runner")
+    pitcher = box.pitcher("pitcher")
+
+    assert runner.stolen_bases == 0
+    assert runner.caught_stealing == 1
+    assert runner.plate_appearances == 0
+    assert runner.at_bats == 0
+    assert pitcher.batters_faced == 0
+    assert pitcher.outs_recorded == 1
+    assert pitcher.innings_pitched == "0.1"
+
+    validation = validate_box_score_reconstruction(
+        initial_state=initial,
+        events=(event,),
+        box_score=box,
+    )
+
+    assert validation.passed is True


### PR DESCRIPTION
## Summary

- add stolen-base and caught-stealing totals to canonical batter box-score rows
- credit each baserunning result to the moving runner
- prevent non-plate-appearance baserunning events from inflating PA, AB, or BF
- count caught-stealing outs in pitcher outs without adding a batter faced
- preserve deterministic event-ledger reduction and reconstruction validation
- leave legacy production authority and production baserunning activation unchanged

## Validation

- 69 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment