### PR TITLE
Score canonical stolen bases

### DIFF
--- a/mlb_app/simulation/box_score/dfs_scoring.py
+++ b/mlb_app/simulation/box_score/dfs_scoring.py
@@ -18,6 +18,7 @@ class BatterDfsScoringRules:
     hit_by_pitch: float = 0.0
     run: float = 0.0
     rbi: float = 0.0
+    stolen_base: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,7 @@ DRAFTKINGS_CLASSIC_BATTER_RULES = (
         hit_by_pitch=2.0,
         run=2.0,
         rbi=2.0,
+        stolen_base=5.0,
     )
 )
 
@@ -56,7 +58,6 @@ DRAFTKINGS_CLASSIC_PITCHER_RULES = (
 )
 
 DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES = (
-    "batter_stolen_base",
     "pitcher_win",
     "pitcher_complete_game",
     "pitcher_complete_game_shutout",
@@ -77,6 +78,7 @@ def score_batter(
         + line.hit_by_pitch * rules.hit_by_pitch
         + line.runs * rules.run
         + line.rbi * rules.rbi
+        + line.stolen_bases * rules.stolen_base
     )
 
 

--- a/tests/test_draftkings_scoring_rules.py
+++ b/tests/test_draftkings_scoring_rules.py
@@ -3,6 +3,7 @@ from mlb_app.simulation.box_score import (
     DRAFTKINGS_CLASSIC_PITCHER_RULES,
     DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES,
     BatterBoxScore,
+    BatterDfsScoringRules,
     PitcherBoxScore,
     score_batter,
     score_pitcher,
@@ -21,12 +22,13 @@ def test_draftkings_classic_batter_supported_scoring():
         hit_by_pitch=1,
         runs=1,
         rbi=1,
+        stolen_bases=1,
     )
 
     assert score_batter(
         line,
         DRAFTKINGS_CLASSIC_BATTER_RULES,
-    ) == 34.0
+    ) == 39.0
 
 
 def test_draftkings_classic_pitcher_supported_scoring():
@@ -51,9 +53,25 @@ def test_draftkings_classic_pitcher_supported_scoring():
 
 def test_unsupported_categories_are_explicit():
     assert DRAFTKINGS_CLASSIC_UNSUPPORTED_CATEGORIES == (
-        "batter_stolen_base",
         "pitcher_win",
         "pitcher_complete_game",
         "pitcher_complete_game_shutout",
         "pitcher_no_hitter",
     )
+
+
+
+def test_stolen_base_scoring_is_configurable():
+    line = BatterBoxScore(
+        player_id="runner",
+        team_side="away",
+        stolen_bases=2,
+        caught_stealing=1,
+    )
+
+    assert score_batter(
+        line,
+        BatterDfsScoringRules(
+            stolen_base=4.5,
+        ),
+    ) == 9.0


### PR DESCRIPTION
## Summary

- add configurable stolen-base weighting to canonical batter DFS scoring rules
- score each reduced stolen base from the immutable event-derived batter line
- configure the DraftKings Classic preset at five points per stolen base
- remove stolen bases from the explicit unsupported-category list
- confirm caught stealing does not affect DraftKings batter scoring
- leave production baserunning activation and legacy authority unchanged

## Validation

- 62 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment