### PR TITLE
Accept production baserunning catalogs

### DIFF
--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Mapping, Optional, Tuple
 
 from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
     CanonicalLineup,
     CanonicalMatchupInput,
     CanonicalPitchingPlan,
@@ -136,6 +137,12 @@ class CanonicalProductionShadowExecution:
             "fallback_catalog_digest": (
                 self.execution_inputs
                 .fallback_catalog_digest
+                if self.execution_inputs is not None
+                else None
+            ),
+            "baserunning_evidence_catalog_digest": (
+                self.execution_inputs
+                .baserunning_evidence_catalog_digest
                 if self.execution_inputs is not None
                 else None
             ),
@@ -331,6 +338,9 @@ def run_canonical_production_shadow(
         CanonicalShadowFallbackCatalogDiscovery
     ),
     bootstrap_ready: bool,
+    baserunning_evidence_catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None,
     simulation_count: int = (
         DEFAULT_PRODUCTION_SHADOW_SIMULATION_COUNT
     ),
@@ -418,6 +428,9 @@ def run_canonical_production_shadow(
                 matchup_input=matchup_input,
                 exact_artifact=exact_artifact,
                 fallback_catalog=fallback_catalog,
+                baserunning_evidence_catalog=(
+                    baserunning_evidence_catalog
+                ),
                 fallback_policy=fallback_policy,
                 batter_dfs_rules=(
                     DRAFTKINGS_CLASSIC_BATTER_RULES

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -6,7 +6,11 @@ from mlb_app.simulation.box_score import (
 )
 from mlb_app.simulation.game import (
     CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
     CanonicalOutcomeProbability,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
     CanonicalProbabilityArtifact,
     CanonicalProbabilityArtifactRecord,
     CanonicalProbabilityFallbackCatalog,
@@ -150,6 +154,58 @@ def fallback_discovery():
         catalog=catalog,
         source_model_count=4,
         status="ready",
+    )
+
+
+def baserunning_catalog():
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=tuple(
+            CanonicalRunnerBaserunningProfile(
+                runner_id=runner_id,
+                speed_score=0.50,
+                attempt_rate=0.0,
+                success_rate=0.75,
+                lead_quality=0.50,
+                fatigue_index=0.0,
+            )
+            for runner_id in (
+                *(
+                    f"a{index}"
+                    for index in range(1, 10)
+                ),
+                *(
+                    f"h{index}"
+                    for index in range(1, 10)
+                ),
+            )
+        ),
+        pitchers=tuple(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id=pitcher_id,
+                hold_score=0.50,
+                delivery_time_score=0.50,
+                pickoff_attempt_rate=0.0,
+                pickoff_success_rate=0.0,
+            )
+            for pitcher_id in (
+                "100",
+                "101",
+                "200",
+                "201",
+            )
+        ),
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="away-catcher",
+            team_side="away",
+            throwing_score=0.50,
+            pop_time_score=0.50,
+        ),
+        home_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="home-catcher",
+            team_side="home",
+            throwing_score=0.50,
+            pop_time_score=0.50,
+        ),
     )
 
 
@@ -457,3 +513,36 @@ def test_production_shadow_exposes_reconstructed_earned_runs():
     )
     assert "earned_runs" in pitcher_metric_names
     assert "dfs_points" in pitcher_metric_names
+
+
+
+def test_production_shadow_accepts_injected_baserunning_catalog():
+    source = baserunning_catalog()
+    result = run(
+        baserunning_evidence_catalog=source,
+    )
+
+    assert result.status == "executed"
+    assert result.execution_inputs is not None
+    assert (
+        result.execution_inputs
+        .baserunning_evidence_catalog
+        is source
+    )
+    assert (
+        result.to_diagnostics()[
+            "baserunning_evidence_catalog_digest"
+        ]
+        == source.digest
+    )
+
+
+def test_invalid_production_baserunning_catalog_fails_open():
+    result = run(
+        baserunning_evidence_catalog=object(),
+    )
+
+    assert result.status == "error"
+    assert result.executed is False
+    assert result.material is None
+    assert result.error_type == "TypeError"


### PR DESCRIPTION
## Summary

- allow the production canonical shadow wrapper to accept an explicitly assembled baserunning evidence catalog
- carry that catalog through the existing atomic input assembly and execution bundle path
- expose the catalog digest in production shadow diagnostics
- retain fail-open behavior when an invalid catalog is supplied
- leave catalog discovery, live production injection, legacy authority, and canonical activation unchanged

## Validation

- 67 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment