### PR TITLE
Discover complete baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -7,6 +7,11 @@ from .bullpen_discovery import (
     CanonicalShadowBullpenSideDiscovery,
     discover_canonical_shadow_bullpens,
 )
+from .baserunning_evidence_discovery import (
+    CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION,
+    CanonicalShadowBaserunningEvidenceDiscovery,
+    discover_canonical_shadow_baserunning_evidence,
+)
 from .bootstrap_readiness import (
     CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION,
     build_canonical_shadow_bootstrap_readiness,
@@ -77,6 +82,9 @@ from .probability_serialization import (
 
 __all__ = [
     "SHADOW_SCHEMA_VERSION",
+    "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
+    "CanonicalShadowBaserunningEvidenceDiscovery",
+    "discover_canonical_shadow_baserunning_evidence",
     "CANONICAL_SHADOW_BOOTSTRAP_READINESS_VERSION",
     "CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_EXECUTION_BUNDLE_VERSION",

--- a/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
+++ b/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
@@ -1,0 +1,282 @@
+"""Fail-open discovery of complete baserunning evidence catalogs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+
+
+CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION = (
+    "canonical_shadow_baserunning_discovery_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalShadowBaserunningEvidenceDiscovery:
+    """Result of validating one matchup's complete evidence set."""
+
+    catalog: Optional[
+        CanonicalBaserunningEvidenceCatalog
+    ] = None
+    requested_runner_count: int = 0
+    available_runner_count: int = 0
+    requested_pitcher_count: int = 0
+    available_pitcher_count: int = 0
+    status: str = "unavailable"
+    error_message: Optional[str] = None
+    discovery_version: str = (
+        CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning discovery status"
+            )
+
+        for name, value in (
+            (
+                "requested_runner_count",
+                self.requested_runner_count,
+            ),
+            (
+                "available_runner_count",
+                self.available_runner_count,
+            ),
+            (
+                "requested_pitcher_count",
+                self.requested_pitcher_count,
+            ),
+            (
+                "available_pitcher_count",
+                self.available_pitcher_count,
+            ),
+        ):
+            if value < 0:
+                raise ValueError(
+                    f"{name} must be nonnegative"
+                )
+
+        if (
+            self.catalog is not None
+            and not isinstance(
+                self.catalog,
+                CanonicalBaserunningEvidenceCatalog,
+            )
+        ):
+            raise TypeError(
+                "catalog must be "
+                "CanonicalBaserunningEvidenceCatalog or None"
+            )
+
+        if self.status == "ready":
+            if self.catalog is None:
+                raise ValueError(
+                    "ready discovery requires a catalog"
+                )
+            if (
+                self.available_runner_count
+                != self.requested_runner_count
+            ):
+                raise ValueError(
+                    "ready discovery requires complete runner evidence"
+                )
+            if (
+                self.available_pitcher_count
+                != self.requested_pitcher_count
+            ):
+                raise ValueError(
+                    "ready discovery requires complete pitcher evidence"
+                )
+        elif self.catalog is not None:
+            raise ValueError(
+                "non-ready discovery cannot expose a catalog"
+            )
+
+        if self.discovery_version != (
+            CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning discovery version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.status == "ready"
+            and self.catalog is not None
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.discovery_version,
+            "status": self.status,
+            "ready": self.ready,
+            "requested_runner_count": (
+                self.requested_runner_count
+            ),
+            "available_runner_count": (
+                self.available_runner_count
+            ),
+            "requested_pitcher_count": (
+                self.requested_pitcher_count
+            ),
+            "available_pitcher_count": (
+                self.available_pitcher_count
+            ),
+            "catalog_digest": (
+                self.catalog.digest
+                if self.catalog is not None
+                else None
+            ),
+            "error_message": self.error_message,
+            "production_activation": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _normalized_ids(
+    values: Tuple[str, ...],
+    *,
+    name: str,
+) -> Tuple[str, ...]:
+    normalized = tuple(
+        str(value).strip()
+        for value in values
+    )
+
+    if any(not value for value in normalized):
+        raise ValueError(
+            f"{name} identifiers must be nonempty"
+        )
+
+    if len(normalized) != len(set(normalized)):
+        raise ValueError(
+            f"{name} identifiers must be unique"
+        )
+
+    return normalized
+
+
+def discover_canonical_shadow_baserunning_evidence(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    runner_profiles: Tuple[
+        CanonicalRunnerBaserunningProfile,
+        ...,
+    ] = (),
+    pitcher_profiles: Tuple[
+        CanonicalPitcherBaserunningProfile,
+        ...,
+    ] = (),
+    away_catcher: Optional[
+        CanonicalCatcherBaserunningProfile
+    ] = None,
+    home_catcher: Optional[
+        CanonicalCatcherBaserunningProfile
+    ] = None,
+) -> CanonicalShadowBaserunningEvidenceDiscovery:
+    """
+    Build a catalog only when every required identity has evidence.
+
+    Missing or invalid evidence fails open and never activates production
+    behavior or changes legacy authority.
+    """
+
+    requested_runner_count = len(required_runner_ids)
+    requested_pitcher_count = len(required_pitcher_ids)
+
+    try:
+        runner_ids = _normalized_ids(
+            required_runner_ids,
+            name="runner",
+        )
+        pitcher_ids = _normalized_ids(
+            required_pitcher_ids,
+            name="pitcher",
+        )
+
+        supplied_runners = {
+            profile.runner_id: profile
+            for profile in runner_profiles
+        }
+        supplied_pitchers = {
+            profile.pitcher_id: profile
+            for profile in pitcher_profiles
+        }
+
+        available_runners = tuple(
+            supplied_runners[runner_id]
+            for runner_id in runner_ids
+            if runner_id in supplied_runners
+        )
+        available_pitchers = tuple(
+            supplied_pitchers[pitcher_id]
+            for pitcher_id in pitcher_ids
+            if pitcher_id in supplied_pitchers
+        )
+
+        complete = (
+            len(available_runners) == len(runner_ids)
+            and len(available_pitchers) == len(pitcher_ids)
+            and away_catcher is not None
+            and home_catcher is not None
+        )
+
+        if not complete:
+            return (
+                CanonicalShadowBaserunningEvidenceDiscovery(
+                    requested_runner_count=len(runner_ids),
+                    available_runner_count=len(
+                        available_runners
+                    ),
+                    requested_pitcher_count=len(
+                        pitcher_ids
+                    ),
+                    available_pitcher_count=len(
+                        available_pitchers
+                    ),
+                    status="unavailable",
+                )
+            )
+
+        catalog = CanonicalBaserunningEvidenceCatalog(
+            runners=available_runners,
+            pitchers=available_pitchers,
+            away_catcher=away_catcher,
+            home_catcher=home_catcher,
+        )
+
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            catalog=catalog,
+            requested_runner_count=len(runner_ids),
+            available_runner_count=len(
+                available_runners
+            ),
+            requested_pitcher_count=len(pitcher_ids),
+            available_pitcher_count=len(
+                available_pitchers
+            ),
+            status="ready",
+        )
+    except Exception as exc:
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            requested_runner_count=requested_runner_count,
+            requested_pitcher_count=requested_pitcher_count,
+            status="error",
+            error_message=str(exc),
+        )

--- a/tests/test_canonical_baserunning_evidence_discovery.py
+++ b/tests/test_canonical_baserunning_evidence_discovery.py
@@ -1,0 +1,179 @@
+from mlb_app.simulation.game import (
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION,
+    discover_canonical_shadow_baserunning_evidence,
+)
+
+
+def runner(player_id):
+    return CanonicalRunnerBaserunningProfile(
+        runner_id=player_id,
+        speed_score=0.70,
+        attempt_rate=0.20,
+        success_rate=0.80,
+        lead_quality=0.65,
+        fatigue_index=0.10,
+    )
+
+
+def pitcher(player_id):
+    return CanonicalPitcherBaserunningProfile(
+        pitcher_id=player_id,
+        hold_score=0.55,
+        delivery_time_score=0.45,
+        pickoff_attempt_rate=0.08,
+        pickoff_success_rate=0.02,
+    )
+
+
+def catcher(player_id, side):
+    return CanonicalCatcherBaserunningProfile(
+        catcher_id=player_id,
+        team_side=side,
+        throwing_score=0.60,
+        pop_time_score=0.55,
+    )
+
+
+def test_complete_evidence_builds_ready_catalog():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=(
+                "away-runner",
+                "home-runner",
+            ),
+            required_pitcher_ids=(
+                "away-pitcher",
+                "home-pitcher",
+            ),
+            runner_profiles=(
+                runner("home-runner"),
+                runner("away-runner"),
+            ),
+            pitcher_profiles=(
+                pitcher("home-pitcher"),
+                pitcher("away-pitcher"),
+            ),
+            away_catcher=catcher(
+                "away-catcher",
+                "away",
+            ),
+            home_catcher=catcher(
+                "home-catcher",
+                "home",
+            ),
+        )
+    )
+
+    assert discovery.ready is True
+    assert discovery.status == "ready"
+    assert discovery.catalog is not None
+    assert tuple(
+        profile.runner_id
+        for profile in discovery.catalog.runners
+    ) == (
+        "away-runner",
+        "home-runner",
+    )
+    assert len(discovery.catalog.digest) == 64
+
+    diagnostics = discovery.to_diagnostics()
+
+    assert diagnostics["ready"] is True
+    assert diagnostics["catalog_digest"] == (
+        discovery.catalog.digest
+    )
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_missing_evidence_fails_open_without_catalog():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=(
+                "away-runner",
+                "home-runner",
+            ),
+            required_pitcher_ids=(
+                "away-pitcher",
+            ),
+            runner_profiles=(
+                runner("away-runner"),
+            ),
+            pitcher_profiles=(
+                pitcher("away-pitcher"),
+            ),
+        )
+    )
+
+    assert discovery.ready is False
+    assert discovery.status == "unavailable"
+    assert discovery.catalog is None
+    assert discovery.requested_runner_count == 2
+    assert discovery.available_runner_count == 1
+    assert discovery.requested_pitcher_count == 1
+    assert discovery.available_pitcher_count == 1
+
+
+def test_invalid_identity_contract_fails_open():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=(
+                "duplicate",
+                "duplicate",
+            ),
+            required_pitcher_ids=(
+                "pitcher",
+            ),
+        )
+    )
+
+    assert discovery.ready is False
+    assert discovery.status == "error"
+    assert discovery.catalog is None
+    assert discovery.error_message == (
+        "runner identifiers must be unique"
+    )
+
+
+def test_wrong_catcher_side_fails_open():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=("runner",),
+            required_pitcher_ids=("pitcher",),
+            runner_profiles=(runner("runner"),),
+            pitcher_profiles=(pitcher("pitcher"),),
+            away_catcher=catcher(
+                "away-catcher",
+                "home",
+            ),
+            home_catcher=catcher(
+                "home-catcher",
+                "home",
+            ),
+        )
+    )
+
+    assert discovery.ready is False
+    assert discovery.status == "error"
+    assert discovery.catalog is None
+    assert discovery.error_message == (
+        "away_catcher must use away team side"
+    )
+
+
+def test_discovery_version_is_explicit():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=(),
+            required_pitcher_ids=(),
+        )
+    )
+
+    assert discovery.discovery_version == (
+        CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
+    )


### PR DESCRIPTION
## Summary

- add a versioned production-shadow discovery result for canonical baserunning evidence
- build an immutable catalog only when all required runner, pitcher, and catcher profiles are present
- preserve required-identity ordering in the assembled catalog
- expose completeness counts, catalog digest, and fail-open status diagnostics
- return unavailable or error results without a catalog when evidence is incomplete or invalid
- leave live evidence materialization, production injection, canonical authority, and legacy output unchanged

## Validation

- 61 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment