### PR TITLE
Adapt observed runner evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -70,6 +70,11 @@ from .input_serialization import (
     CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION,
     canonical_shadow_input_provenance_to_dict,
 )
+from .runner_baserunning_evidence import (
+    CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalRunnerBaserunningObservation,
+    adapt_observed_runner_baserunning_evidence,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -99,6 +104,9 @@ __all__ = [
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",
     "CANONICAL_PROBABILITY_DIAGNOSTICS_SHADOW_VERSION",
+    "CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION",
+    "CanonicalRunnerBaserunningObservation",
+    "adapt_observed_runner_baserunning_evidence",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",
     "CanonicalShadowBullpenSideDiscovery",

--- a/mlb_app/simulation/shadow/runner_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/runner_baserunning_evidence.py
@@ -1,0 +1,201 @@
+"""Adapt observed runner opportunities into canonical profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from mlb_app.simulation.game import (
+    CanonicalRunnerBaserunningProfile,
+)
+
+
+CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION = (
+    "canonical_runner_baserunning_evidence_v1"
+)
+
+
+def _validate_count(
+    *,
+    name: str,
+    value: int,
+) -> None:
+    if not isinstance(value, int):
+        raise TypeError(
+            f"{name} must be an integer"
+        )
+    if value < 0:
+        raise ValueError(
+            f"{name} must be nonnegative"
+        )
+
+
+def _validate_rate(
+    *,
+    name: str,
+    value: float,
+) -> None:
+    if not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be numeric"
+        )
+    if not 0.0 <= float(value) <= 1.0:
+        raise ValueError(
+            f"{name} must be between 0 and 1"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerBaserunningObservation:
+    """
+    Immutable observed opportunity evidence for one runner.
+
+    Eligible opportunities must be computed from event-level source data.
+    Plate appearances or times on base are not accepted as substitutes.
+    """
+
+    runner_id: str
+    eligible_opportunities: int
+    stolen_bases: int
+    caught_stealing: int
+    speed_score: float
+    lead_quality: float
+    fatigue_index: float
+    injury_limit_flag: bool = False
+    source_version: str = (
+        CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        for name, value in (
+            (
+                "eligible_opportunities",
+                self.eligible_opportunities,
+            ),
+            ("stolen_bases", self.stolen_bases),
+            (
+                "caught_stealing",
+                self.caught_stealing,
+            ),
+        ):
+            _validate_count(
+                name=name,
+                value=value,
+            )
+
+        attempts = (
+            self.stolen_bases
+            + self.caught_stealing
+        )
+
+        if attempts > self.eligible_opportunities:
+            raise ValueError(
+                "attempts cannot exceed eligible opportunities"
+            )
+
+        for name, value in (
+            ("speed_score", self.speed_score),
+            ("lead_quality", self.lead_quality),
+            ("fatigue_index", self.fatigue_index),
+        ):
+            _validate_rate(
+                name=name,
+                value=value,
+            )
+
+        if not isinstance(
+            self.injury_limit_flag,
+            bool,
+        ):
+            raise TypeError(
+                "injury_limit_flag must be boolean"
+            )
+
+        if not self.source_version:
+            raise ValueError(
+                "source_version is required"
+            )
+
+    @property
+    def attempts(self) -> int:
+        return (
+            self.stolen_bases
+            + self.caught_stealing
+        )
+
+    @property
+    def attempt_rate(self) -> float:
+        if self.eligible_opportunities == 0:
+            return 0.0
+
+        return round(
+            self.attempts
+            / self.eligible_opportunities,
+            6,
+        )
+
+    @property
+    def success_rate(self) -> float:
+        if self.attempts == 0:
+            return 0.0
+
+        return round(
+            self.stolen_bases
+            / self.attempts,
+            6,
+        )
+
+    @property
+    def digest(self) -> str:
+        parts = (
+            self.source_version,
+            self.runner_id,
+            str(self.eligible_opportunities),
+            str(self.stolen_bases),
+            str(self.caught_stealing),
+            repr(float(self.speed_score)),
+            repr(float(self.lead_quality)),
+            repr(float(self.fatigue_index)),
+            repr(self.injury_limit_flag),
+        )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
+
+    def to_profile(
+        self,
+    ) -> CanonicalRunnerBaserunningProfile:
+        return CanonicalRunnerBaserunningProfile(
+            runner_id=self.runner_id,
+            speed_score=float(self.speed_score),
+            attempt_rate=self.attempt_rate,
+            success_rate=self.success_rate,
+            lead_quality=float(self.lead_quality),
+            fatigue_index=float(self.fatigue_index),
+            injury_limit_flag=(
+                self.injury_limit_flag
+            ),
+        )
+
+
+def adapt_observed_runner_baserunning_evidence(
+    observation: CanonicalRunnerBaserunningObservation,
+) -> CanonicalRunnerBaserunningProfile:
+    """Return one deterministic canonical runner profile."""
+
+    if not isinstance(
+        observation,
+        CanonicalRunnerBaserunningObservation,
+    ):
+        raise TypeError(
+            "observation must be a "
+            "CanonicalRunnerBaserunningObservation"
+        )
+
+    return observation.to_profile()

--- a/tests/test_canonical_runner_baserunning_evidence.py
+++ b/tests/test_canonical_runner_baserunning_evidence.py
@@ -1,0 +1,122 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalRunnerBaserunningObservation,
+    adapt_observed_runner_baserunning_evidence,
+)
+
+
+def observation(**overrides):
+    values = {
+        "runner_id": "runner",
+        "eligible_opportunities": 20,
+        "stolen_bases": 7,
+        "caught_stealing": 1,
+        "speed_score": 0.82,
+        "lead_quality": 0.74,
+        "fatigue_index": 0.12,
+    }
+    values.update(overrides)
+
+    return CanonicalRunnerBaserunningObservation(
+        **values
+    )
+
+
+def test_observed_counts_produce_exact_rates():
+    source = observation()
+    profile = (
+        adapt_observed_runner_baserunning_evidence(
+            source
+        )
+    )
+
+    assert source.attempts == 8
+    assert source.attempt_rate == 0.4
+    assert source.success_rate == 0.875
+
+    assert profile.runner_id == "runner"
+    assert profile.attempt_rate == 0.4
+    assert profile.success_rate == 0.875
+    assert profile.speed_score == 0.82
+    assert profile.lead_quality == 0.74
+    assert profile.fatigue_index == 0.12
+
+
+def test_zero_opportunities_produce_zero_rates():
+    source = observation(
+        eligible_opportunities=0,
+        stolen_bases=0,
+        caught_stealing=0,
+    )
+
+    assert source.attempt_rate == 0.0
+    assert source.success_rate == 0.0
+
+
+def test_attempts_cannot_exceed_eligible_opportunities():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "attempts cannot exceed eligible opportunities"
+        ),
+    ):
+        observation(
+            eligible_opportunities=1,
+            stolen_bases=1,
+            caught_stealing=1,
+        )
+
+
+def test_plate_appearance_like_fractional_counts_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match="eligible_opportunities must be an integer",
+    ):
+        observation(
+            eligible_opportunities=20.0,
+        )
+
+
+def test_invalid_rate_evidence_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="speed_score must be between 0 and 1",
+    ):
+        observation(
+            speed_score=1.01,
+        )
+
+
+def test_observation_digest_is_deterministic():
+    first = observation()
+    second = observation()
+
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+
+    changed = observation(
+        stolen_bases=6,
+    )
+
+    assert changed.digest != first.digest
+
+
+def test_non_observation_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "observation must be a "
+            "CanonicalRunnerBaserunningObservation"
+        ),
+    ):
+        adapt_observed_runner_baserunning_evidence(
+            object()
+        )
+
+
+def test_source_version_is_explicit():
+    assert observation().source_version == (
+        CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION
+    )


### PR DESCRIPTION
## Summary

- add an immutable observation contract for event-level runner baserunning evidence
- derive attempt rate from eligible opportunities and SB/CS attempts
- derive success rate from observed stolen bases and caught stealing
- require explicit speed, lead, fatigue, injury, and source-version evidence rather than invented defaults
- add deterministic source digests for provenance
- reject invalid counts, rates, and substituted fractional opportunity inputs
- leave pitcher/catcher materialization, catalog injection, production activation, and legacy authority unchanged

## Validation

- 61 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment