### PR TITLE
Adapt observed pitcher baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -40,6 +40,11 @@ from .production_execution import (
     CanonicalProductionShadowExecution,
     run_canonical_production_shadow,
 )
+from .pitcher_baserunning_evidence import (
+    CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalPitcherBaserunningObservation,
+    adapt_observed_pitcher_baserunning_evidence,
+)
 from .probability_provider_discovery import (
     CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION,
     CanonicalShadowProbabilityProviderDiscovery,
@@ -100,6 +105,9 @@ __all__ = [
     "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
     "DEFAULT_PRODUCTION_SHADOW_SIMULATION_COUNT",
     "MIN_EXACT_BATTER_RECORDS_PER_SIDE",
+    "CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION",
+    "CanonicalPitcherBaserunningObservation",
+    "adapt_observed_pitcher_baserunning_evidence",
     "CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",

--- a/mlb_app/simulation/shadow/pitcher_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/pitcher_baserunning_evidence.py
@@ -1,0 +1,196 @@
+"""Adapt observed pitcher baserunning evidence into profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from mlb_app.simulation.game import (
+    CanonicalPitcherBaserunningProfile,
+)
+
+
+CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION = (
+    "canonical_pitcher_baserunning_evidence_v1"
+)
+
+
+def _validate_count(
+    *,
+    name: str,
+    value: int,
+) -> None:
+    if not isinstance(value, int):
+        raise TypeError(
+            f"{name} must be an integer"
+        )
+    if value < 0:
+        raise ValueError(
+            f"{name} must be nonnegative"
+        )
+
+
+def _validate_rate(
+    *,
+    name: str,
+    value: float,
+) -> None:
+    if not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be numeric"
+        )
+    if not 0.0 <= float(value) <= 1.0:
+        raise ValueError(
+            f"{name} must be between 0 and 1"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherBaserunningObservation:
+    """
+    Immutable event-level hold and pickoff evidence for one pitcher.
+
+    Eligible opportunities must come from source events with a steal-capable
+    runner aboard. Batters faced or innings pitched are not substitutes.
+    """
+
+    pitcher_id: str
+    eligible_pickoff_opportunities: int
+    pickoff_attempts: int
+    successful_pickoffs: int
+    hold_score: float
+    delivery_time_score: float
+    source_version: str = (
+        CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        for name, value in (
+            (
+                "eligible_pickoff_opportunities",
+                self.eligible_pickoff_opportunities,
+            ),
+            (
+                "pickoff_attempts",
+                self.pickoff_attempts,
+            ),
+            (
+                "successful_pickoffs",
+                self.successful_pickoffs,
+            ),
+        ):
+            _validate_count(
+                name=name,
+                value=value,
+            )
+
+        if (
+            self.pickoff_attempts
+            > self.eligible_pickoff_opportunities
+        ):
+            raise ValueError(
+                "pickoff attempts cannot exceed "
+                "eligible opportunities"
+            )
+
+        if (
+            self.successful_pickoffs
+            > self.pickoff_attempts
+        ):
+            raise ValueError(
+                "successful pickoffs cannot exceed attempts"
+            )
+
+        for name, value in (
+            ("hold_score", self.hold_score),
+            (
+                "delivery_time_score",
+                self.delivery_time_score,
+            ),
+        ):
+            _validate_rate(
+                name=name,
+                value=value,
+            )
+
+        if not self.source_version:
+            raise ValueError(
+                "source_version is required"
+            )
+
+    @property
+    def pickoff_attempt_rate(self) -> float:
+        if self.eligible_pickoff_opportunities == 0:
+            return 0.0
+
+        return round(
+            self.pickoff_attempts
+            / self.eligible_pickoff_opportunities,
+            6,
+        )
+
+    @property
+    def pickoff_success_rate(self) -> float:
+        if self.pickoff_attempts == 0:
+            return 0.0
+
+        return round(
+            self.successful_pickoffs
+            / self.pickoff_attempts,
+            6,
+        )
+
+    @property
+    def digest(self) -> str:
+        parts = (
+            self.source_version,
+            self.pitcher_id,
+            str(self.eligible_pickoff_opportunities),
+            str(self.pickoff_attempts),
+            str(self.successful_pickoffs),
+            repr(float(self.hold_score)),
+            repr(float(self.delivery_time_score)),
+        )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
+
+    def to_profile(
+        self,
+    ) -> CanonicalPitcherBaserunningProfile:
+        return CanonicalPitcherBaserunningProfile(
+            pitcher_id=self.pitcher_id,
+            hold_score=float(self.hold_score),
+            delivery_time_score=float(
+                self.delivery_time_score
+            ),
+            pickoff_attempt_rate=(
+                self.pickoff_attempt_rate
+            ),
+            pickoff_success_rate=(
+                self.pickoff_success_rate
+            ),
+        )
+
+
+def adapt_observed_pitcher_baserunning_evidence(
+    observation: CanonicalPitcherBaserunningObservation,
+) -> CanonicalPitcherBaserunningProfile:
+    """Return one deterministic canonical pitcher profile."""
+
+    if not isinstance(
+        observation,
+        CanonicalPitcherBaserunningObservation,
+    ):
+        raise TypeError(
+            "observation must be a "
+            "CanonicalPitcherBaserunningObservation"
+        )
+
+    return observation.to_profile()

--- a/tests/test_canonical_pitcher_baserunning_evidence.py
+++ b/tests/test_canonical_pitcher_baserunning_evidence.py
@@ -1,0 +1,136 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalPitcherBaserunningObservation,
+    adapt_observed_pitcher_baserunning_evidence,
+)
+
+
+def observation(**overrides):
+    values = {
+        "pitcher_id": "pitcher",
+        "eligible_pickoff_opportunities": 40,
+        "pickoff_attempts": 8,
+        "successful_pickoffs": 2,
+        "hold_score": 0.72,
+        "delivery_time_score": 0.38,
+    }
+    values.update(overrides)
+
+    return CanonicalPitcherBaserunningObservation(
+        **values
+    )
+
+
+def test_observed_counts_produce_exact_rates():
+    source = observation()
+    profile = (
+        adapt_observed_pitcher_baserunning_evidence(
+            source
+        )
+    )
+
+    assert source.pickoff_attempt_rate == 0.2
+    assert source.pickoff_success_rate == 0.25
+
+    assert profile.pitcher_id == "pitcher"
+    assert profile.pickoff_attempt_rate == 0.2
+    assert profile.pickoff_success_rate == 0.25
+    assert profile.hold_score == 0.72
+    assert profile.delivery_time_score == 0.38
+
+
+def test_zero_opportunities_produce_zero_rates():
+    source = observation(
+        eligible_pickoff_opportunities=0,
+        pickoff_attempts=0,
+        successful_pickoffs=0,
+    )
+
+    assert source.pickoff_attempt_rate == 0.0
+    assert source.pickoff_success_rate == 0.0
+
+
+def test_attempts_cannot_exceed_eligible_opportunities():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pickoff attempts cannot exceed "
+            "eligible opportunities"
+        ),
+    ):
+        observation(
+            eligible_pickoff_opportunities=1,
+            pickoff_attempts=2,
+            successful_pickoffs=0,
+        )
+
+
+def test_successes_cannot_exceed_attempts():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "successful pickoffs cannot exceed attempts"
+        ),
+    ):
+        observation(
+            pickoff_attempts=1,
+            successful_pickoffs=2,
+        )
+
+
+def test_fractional_opportunity_counts_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "eligible_pickoff_opportunities "
+            "must be an integer"
+        ),
+    ):
+        observation(
+            eligible_pickoff_opportunities=40.0,
+        )
+
+
+def test_invalid_hold_evidence_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="hold_score must be between 0 and 1",
+    ):
+        observation(
+            hold_score=-0.01,
+        )
+
+
+def test_observation_digest_is_deterministic():
+    first = observation()
+    second = observation()
+
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+
+    changed = observation(
+        pickoff_attempts=7,
+    )
+
+    assert changed.digest != first.digest
+
+
+def test_non_observation_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "observation must be a "
+            "CanonicalPitcherBaserunningObservation"
+        ),
+    ):
+        adapt_observed_pitcher_baserunning_evidence(
+            object()
+        )
+
+
+def test_source_version_is_explicit():
+    assert observation().source_version == (
+        CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION
+    )


### PR DESCRIPTION
## Summary

- add an immutable observation contract for event-level pitcher hold and pickoff evidence
- derive pickoff attempt rate from eligible runner-on-base opportunities
- derive pickoff success rate from observed attempts and successful pickoffs
- require explicit hold-score, delivery-time, and source-version evidence rather than neutral defaults
- add deterministic observation digests for provenance
- reject invalid counts, rates, and substituted fractional opportunity inputs
- leave catcher materialization, catalog injection, production activation, and legacy authority unchanged

## Validation

- 70 focused tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment