### PR TITLE
Adapt observed catcher baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -1,5 +1,10 @@
 """Canonical production-shadow comparison integration."""
 
+from .catcher_baserunning_evidence import (
+    CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalCatcherBaserunningObservation,
+    adapt_observed_catcher_baserunning_evidence,
+)
 from .comparator import compare_shadow_payloads
 from .bullpen_discovery import (
     CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
@@ -91,6 +96,9 @@ from .probability_serialization import (
 )
 
 __all__ = [
+    "CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION",
+    "CanonicalCatcherBaserunningObservation",
+    "adapt_observed_catcher_baserunning_evidence",
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
     "CanonicalShadowBaserunningEvidenceDiscovery",

--- a/mlb_app/simulation/shadow/catcher_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/catcher_baserunning_evidence.py
@@ -1,0 +1,167 @@
+"""Adapt observed catcher baserunning evidence into profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+
+from mlb_app.simulation.game import (
+    CanonicalCatcherBaserunningProfile,
+)
+
+
+CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION = (
+    "canonical_catcher_baserunning_evidence_v1"
+)
+
+
+def _validate_count(
+    *,
+    name: str,
+    value: int,
+) -> None:
+    if not isinstance(value, int):
+        raise TypeError(
+            f"{name} must be an integer"
+        )
+    if value < 0:
+        raise ValueError(
+            f"{name} must be nonnegative"
+        )
+
+
+def _validate_rate(
+    *,
+    name: str,
+    value: float,
+) -> None:
+    if not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be numeric"
+        )
+    if not 0.0 <= float(value) <= 1.0:
+        raise ValueError(
+            f"{name} must be between 0 and 1"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherBaserunningObservation:
+    """
+    Immutable event-level throwing evidence for one catcher.
+
+    Steal attempts against and caught-stealing outcomes must be attributed
+    to this catcher. Team-level totals are not accepted as substitutes.
+    """
+
+    catcher_id: str
+    team_side: str
+    steal_attempts_against: int
+    caught_stealing: int
+    pop_time_score: float
+    source_version: str = (
+        CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.catcher_id:
+            raise ValueError(
+                "catcher_id is required"
+            )
+
+        if self.team_side not in {
+            "away",
+            "home",
+        }:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        for name, value in (
+            (
+                "steal_attempts_against",
+                self.steal_attempts_against,
+            ),
+            (
+                "caught_stealing",
+                self.caught_stealing,
+            ),
+        ):
+            _validate_count(
+                name=name,
+                value=value,
+            )
+
+        if (
+            self.caught_stealing
+            > self.steal_attempts_against
+        ):
+            raise ValueError(
+                "caught stealing cannot exceed "
+                "steal attempts against"
+            )
+
+        _validate_rate(
+            name="pop_time_score",
+            value=self.pop_time_score,
+        )
+
+        if not self.source_version:
+            raise ValueError(
+                "source_version is required"
+            )
+
+    @property
+    def throwing_score(self) -> float:
+        if self.steal_attempts_against == 0:
+            return 0.0
+
+        return round(
+            self.caught_stealing
+            / self.steal_attempts_against,
+            6,
+        )
+
+    @property
+    def digest(self) -> str:
+        parts = (
+            self.source_version,
+            self.catcher_id,
+            self.team_side,
+            str(self.steal_attempts_against),
+            str(self.caught_stealing),
+            repr(float(self.pop_time_score)),
+        )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
+
+    def to_profile(
+        self,
+    ) -> CanonicalCatcherBaserunningProfile:
+        return CanonicalCatcherBaserunningProfile(
+            catcher_id=self.catcher_id,
+            team_side=self.team_side,
+            throwing_score=self.throwing_score,
+            pop_time_score=float(
+                self.pop_time_score
+            ),
+        )
+
+
+def adapt_observed_catcher_baserunning_evidence(
+    observation: CanonicalCatcherBaserunningObservation,
+) -> CanonicalCatcherBaserunningProfile:
+    """Return one deterministic canonical catcher profile."""
+
+    if not isinstance(
+        observation,
+        CanonicalCatcherBaserunningObservation,
+    ):
+        raise TypeError(
+            "observation must be a "
+            "CanonicalCatcherBaserunningObservation"
+        )
+
+    return observation.to_profile()

--- a/tests/test_canonical_catcher_baserunning_evidence.py
+++ b/tests/test_canonical_catcher_baserunning_evidence.py
@@ -1,0 +1,128 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION,
+    CanonicalCatcherBaserunningObservation,
+    adapt_observed_catcher_baserunning_evidence,
+)
+
+
+def observation(**overrides):
+    values = {
+        "catcher_id": "catcher",
+        "team_side": "home",
+        "steal_attempts_against": 20,
+        "caught_stealing": 6,
+        "pop_time_score": 0.68,
+    }
+    values.update(overrides)
+
+    return CanonicalCatcherBaserunningObservation(
+        **values
+    )
+
+
+def test_observed_counts_produce_exact_throwing_score():
+    source = observation()
+    profile = (
+        adapt_observed_catcher_baserunning_evidence(
+            source
+        )
+    )
+
+    assert source.throwing_score == 0.3
+
+    assert profile.catcher_id == "catcher"
+    assert profile.team_side == "home"
+    assert profile.throwing_score == 0.3
+    assert profile.pop_time_score == 0.68
+
+
+def test_zero_attempts_produce_zero_throwing_score():
+    source = observation(
+        steal_attempts_against=0,
+        caught_stealing=0,
+    )
+
+    assert source.throwing_score == 0.0
+
+
+def test_caught_stealing_cannot_exceed_attempts():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "caught stealing cannot exceed "
+            "steal attempts against"
+        ),
+    ):
+        observation(
+            steal_attempts_against=1,
+            caught_stealing=2,
+        )
+
+
+def test_fractional_attempt_counts_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "steal_attempts_against must be an integer"
+        ),
+    ):
+        observation(
+            steal_attempts_against=20.0,
+        )
+
+
+def test_invalid_team_side_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="team_side must be away or home",
+    ):
+        observation(
+            team_side="neutral",
+        )
+
+
+def test_invalid_pop_time_evidence_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pop_time_score must be between 0 and 1"
+        ),
+    ):
+        observation(
+            pop_time_score=1.01,
+        )
+
+
+def test_observation_digest_is_deterministic():
+    first = observation()
+    second = observation()
+
+    assert first.digest == second.digest
+    assert len(first.digest) == 64
+
+    changed = observation(
+        caught_stealing=5,
+    )
+
+    assert changed.digest != first.digest
+
+
+def test_non_observation_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "observation must be a "
+            "CanonicalCatcherBaserunningObservation"
+        ),
+    ):
+        adapt_observed_catcher_baserunning_evidence(
+            object()
+        )
+
+
+def test_source_version_is_explicit():
+    assert observation().source_version == (
+        CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION
+    )


### PR DESCRIPTION
## Summary
- add an immutable catcher baserunning observation contract
- derive throwing score from caught-stealing results against steal attempts
- require explicit catcher identity, team side, pop-time evidence, and source version
- preserve deterministic digest provenance and reject invalid counts, sides, and rates
- leave source discovery, catalog injection, activation, and legacy production authority unchanged

## Validation
- `79 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment