### PR TITLE
Assemble observed baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -50,6 +50,9 @@ from .pitcher_baserunning_evidence import (
     CanonicalPitcherBaserunningObservation,
     adapt_observed_pitcher_baserunning_evidence,
 )
+from .observed_baserunning_evidence import (
+    discover_observed_canonical_baserunning_evidence,
+)
 from .probability_provider_discovery import (
     CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION,
     CanonicalShadowProbabilityProviderDiscovery,
@@ -116,6 +119,7 @@ __all__ = [
     "CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalPitcherBaserunningObservation",
     "adapt_observed_pitcher_baserunning_evidence",
+    "discover_observed_canonical_baserunning_evidence",
     "CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",

--- a/mlb_app/simulation/shadow/observed_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/observed_baserunning_evidence.py
@@ -1,0 +1,97 @@
+"""Assemble observed baserunning evidence for discovery."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from .baserunning_evidence_discovery import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+    discover_canonical_shadow_baserunning_evidence,
+)
+from .catcher_baserunning_evidence import (
+    CanonicalCatcherBaserunningObservation,
+    adapt_observed_catcher_baserunning_evidence,
+)
+from .pitcher_baserunning_evidence import (
+    CanonicalPitcherBaserunningObservation,
+    adapt_observed_pitcher_baserunning_evidence,
+)
+from .runner_baserunning_evidence import (
+    CanonicalRunnerBaserunningObservation,
+    adapt_observed_runner_baserunning_evidence,
+)
+
+
+def discover_observed_canonical_baserunning_evidence(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    runner_observations: Tuple[
+        CanonicalRunnerBaserunningObservation,
+        ...,
+    ] = (),
+    pitcher_observations: Tuple[
+        CanonicalPitcherBaserunningObservation,
+        ...,
+    ] = (),
+    away_catcher_observation: Optional[
+        CanonicalCatcherBaserunningObservation
+    ] = None,
+    home_catcher_observation: Optional[
+        CanonicalCatcherBaserunningObservation
+    ] = None,
+) -> CanonicalShadowBaserunningEvidenceDiscovery:
+    """
+    Adapt observations and discover one complete evidence catalog.
+
+    Invalid observation contracts fail open through the canonical discovery
+    result and never change legacy production authority.
+    """
+
+    try:
+        runner_profiles = tuple(
+            adapt_observed_runner_baserunning_evidence(
+                observation
+            )
+            for observation in runner_observations
+        )
+        pitcher_profiles = tuple(
+            adapt_observed_pitcher_baserunning_evidence(
+                observation
+            )
+            for observation in pitcher_observations
+        )
+        away_catcher = (
+            adapt_observed_catcher_baserunning_evidence(
+                away_catcher_observation
+            )
+            if away_catcher_observation is not None
+            else None
+        )
+        home_catcher = (
+            adapt_observed_catcher_baserunning_evidence(
+                home_catcher_observation
+            )
+            if home_catcher_observation is not None
+            else None
+        )
+    except Exception as exc:
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            requested_runner_count=len(
+                required_runner_ids
+            ),
+            requested_pitcher_count=len(
+                required_pitcher_ids
+            ),
+            status="error",
+            error_message=str(exc),
+        )
+
+    return discover_canonical_shadow_baserunning_evidence(
+        required_runner_ids=required_runner_ids,
+        required_pitcher_ids=required_pitcher_ids,
+        runner_profiles=runner_profiles,
+        pitcher_profiles=pitcher_profiles,
+        away_catcher=away_catcher,
+        home_catcher=home_catcher,
+    )

--- a/tests/test_canonical_observed_baserunning_evidence.py
+++ b/tests/test_canonical_observed_baserunning_evidence.py
@@ -1,0 +1,186 @@
+from mlb_app.simulation.shadow import (
+    CanonicalCatcherBaserunningObservation,
+    CanonicalPitcherBaserunningObservation,
+    CanonicalRunnerBaserunningObservation,
+    discover_observed_canonical_baserunning_evidence,
+)
+
+
+def runner(
+    runner_id="runner",
+):
+    return CanonicalRunnerBaserunningObservation(
+        runner_id=runner_id,
+        eligible_opportunities=20,
+        stolen_bases=6,
+        caught_stealing=2,
+        speed_score=0.90,
+        lead_quality=0.80,
+        fatigue_index=0.10,
+    )
+
+
+def pitcher(
+    pitcher_id="pitcher",
+):
+    return CanonicalPitcherBaserunningObservation(
+        pitcher_id=pitcher_id,
+        eligible_pickoff_opportunities=25,
+        pickoff_attempts=5,
+        successful_pickoffs=1,
+        hold_score=0.75,
+        delivery_time_score=0.70,
+    )
+
+
+def catcher(
+    *,
+    catcher_id,
+    team_side,
+):
+    return CanonicalCatcherBaserunningObservation(
+        catcher_id=catcher_id,
+        team_side=team_side,
+        steal_attempts_against=10,
+        caught_stealing=3,
+        pop_time_score=0.85,
+    )
+
+
+def discover(**overrides):
+    values = {
+        "required_runner_ids": ("runner",),
+        "required_pitcher_ids": ("pitcher",),
+        "runner_observations": (runner(),),
+        "pitcher_observations": (pitcher(),),
+        "away_catcher_observation": catcher(
+            catcher_id="away-catcher",
+            team_side="away",
+        ),
+        "home_catcher_observation": catcher(
+            catcher_id="home-catcher",
+            team_side="home",
+        ),
+    }
+    values.update(overrides)
+
+    return discover_observed_canonical_baserunning_evidence(
+        **values
+    )
+
+
+def test_complete_observations_build_ready_catalog():
+    result = discover()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.catalog is not None
+
+    runner_profile = result.catalog.runners[0]
+    pitcher_profile = result.catalog.pitchers[0]
+
+    assert runner_profile.runner_id == "runner"
+    assert runner_profile.attempt_rate == 0.4
+    assert runner_profile.success_rate == 0.75
+
+    assert pitcher_profile.pitcher_id == "pitcher"
+    assert pitcher_profile.pickoff_attempt_rate == 0.2
+    assert pitcher_profile.pickoff_success_rate == 0.2
+
+    assert result.catalog.away_catcher.catcher_id == (
+        "away-catcher"
+    )
+    assert (
+        result.catalog.away_catcher.throwing_score
+        == 0.3
+    )
+    assert result.catalog.home_catcher.catcher_id == (
+        "home-catcher"
+    )
+
+
+def test_required_identity_order_is_preserved():
+    result = discover(
+        required_runner_ids=(
+            "runner-2",
+            "runner-1",
+        ),
+        runner_observations=(
+            runner("runner-1"),
+            runner("runner-2"),
+        ),
+    )
+
+    assert result.status == "ready"
+    assert result.catalog is not None
+    assert tuple(
+        profile.runner_id
+        for profile in result.catalog.runners
+    ) == (
+        "runner-2",
+        "runner-1",
+    )
+
+
+def test_missing_observation_remains_unavailable():
+    result = discover(
+        runner_observations=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.requested_runner_count == 1
+    assert result.available_runner_count == 0
+    assert result.error_message is None
+
+
+def test_missing_catcher_remains_unavailable():
+    result = discover(
+        away_catcher_observation=None,
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+
+
+def test_invalid_observation_contract_fails_open():
+    result = discover(
+        runner_observations=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.requested_runner_count == 1
+    assert result.requested_pitcher_count == 1
+    assert result.error_message == (
+        "observation must be a "
+        "CanonicalRunnerBaserunningObservation"
+    )
+
+
+def test_invalid_catcher_side_fails_open_during_discovery():
+    result = discover(
+        away_catcher_observation=catcher(
+            catcher_id="home-catcher-as-away",
+            team_side="home",
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.error_message == (
+        "away_catcher must use away team side"
+    )
+
+
+def test_same_observations_produce_same_catalog_digest():
+    first = discover()
+    second = discover()
+
+    assert first.catalog is not None
+    assert second.catalog is not None
+    assert first.catalog.digest == second.catalog.digest


### PR DESCRIPTION
## Summary
- compose runner, pitcher, and catcher observation adapters into canonical baserunning discovery
- preserve required identity ordering when building the catalog
- return unavailable results for incomplete observation sets
- fail open through canonical discovery errors for invalid observation contracts or catcher sides
- preserve deterministic catalog digests and leave production activation and legacy authority unchanged

## Validation
- `72 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment