### PR TITLE
Digest observed baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -51,6 +51,7 @@ from .pitcher_baserunning_evidence import (
     adapt_observed_pitcher_baserunning_evidence,
 )
 from .observed_baserunning_evidence import (
+    CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION,
     discover_observed_canonical_baserunning_evidence,
 )
 from .probability_provider_discovery import (
@@ -119,6 +120,7 @@ __all__ = [
     "CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalPitcherBaserunningObservation",
     "adapt_observed_pitcher_baserunning_evidence",
+    "CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION",
     "discover_observed_canonical_baserunning_evidence",
     "CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",

--- a/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
+++ b/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
@@ -37,6 +37,7 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
     available_pitcher_count: int = 0
     status: str = "unavailable"
     error_message: Optional[str] = None
+    observation_digest: Optional[str] = None
     discovery_version: str = (
         CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
     )
@@ -106,6 +107,14 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
                 "non-ready discovery cannot expose a catalog"
             )
 
+        if (
+            self.observation_digest is not None
+            and not self.observation_digest
+        ):
+            raise ValueError(
+                "observation_digest must be nonempty or None"
+            )
+
         if self.discovery_version != (
             CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
         ):
@@ -141,6 +150,9 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
                 self.catalog.digest
                 if self.catalog is not None
                 else None
+            ),
+            "observation_digest": (
+                self.observation_digest
             ),
             "error_message": self.error_message,
             "production_activation": False,

--- a/mlb_app/simulation/shadow/observed_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/observed_baserunning_evidence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+import hashlib
 from typing import Optional, Tuple
 
 from .baserunning_evidence_discovery import (
@@ -20,6 +22,65 @@ from .runner_baserunning_evidence import (
     CanonicalRunnerBaserunningObservation,
     adapt_observed_runner_baserunning_evidence,
 )
+
+
+CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION = (
+    "canonical_observed_baserunning_digest_v1"
+)
+
+
+def _observation_digest(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    runner_observations: Tuple[
+        CanonicalRunnerBaserunningObservation,
+        ...,
+    ],
+    pitcher_observations: Tuple[
+        CanonicalPitcherBaserunningObservation,
+        ...,
+    ],
+    away_catcher_observation: Optional[
+        CanonicalCatcherBaserunningObservation
+    ],
+    home_catcher_observation: Optional[
+        CanonicalCatcherBaserunningObservation
+    ],
+) -> str:
+    parts = [
+        CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION,
+        "required_runners",
+        *required_runner_ids,
+        "required_pitchers",
+        *required_pitcher_ids,
+        "runner_observations",
+        *(
+            observation.digest
+            for observation in runner_observations
+        ),
+        "pitcher_observations",
+        *(
+            observation.digest
+            for observation in pitcher_observations
+        ),
+        "away_catcher",
+        (
+            away_catcher_observation.digest
+            if away_catcher_observation is not None
+            else "missing"
+        ),
+        "home_catcher",
+        (
+            home_catcher_observation.digest
+            if home_catcher_observation is not None
+            else "missing"
+        ),
+    ]
+
+    return hashlib.sha256(
+        "\x1f".join(parts).encode("utf-8")
+    ).hexdigest()
 
 
 def discover_observed_canonical_baserunning_evidence(
@@ -75,6 +136,18 @@ def discover_observed_canonical_baserunning_evidence(
             if home_catcher_observation is not None
             else None
         )
+        observation_digest = _observation_digest(
+            required_runner_ids=required_runner_ids,
+            required_pitcher_ids=required_pitcher_ids,
+            runner_observations=runner_observations,
+            pitcher_observations=pitcher_observations,
+            away_catcher_observation=(
+                away_catcher_observation
+            ),
+            home_catcher_observation=(
+                home_catcher_observation
+            ),
+        )
     except Exception as exc:
         return CanonicalShadowBaserunningEvidenceDiscovery(
             requested_runner_count=len(
@@ -87,11 +160,18 @@ def discover_observed_canonical_baserunning_evidence(
             error_message=str(exc),
         )
 
-    return discover_canonical_shadow_baserunning_evidence(
-        required_runner_ids=required_runner_ids,
-        required_pitcher_ids=required_pitcher_ids,
-        runner_profiles=runner_profiles,
-        pitcher_profiles=pitcher_profiles,
-        away_catcher=away_catcher,
-        home_catcher=home_catcher,
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=required_runner_ids,
+            required_pitcher_ids=required_pitcher_ids,
+            runner_profiles=runner_profiles,
+            pitcher_profiles=pitcher_profiles,
+            away_catcher=away_catcher,
+            home_catcher=home_catcher,
+        )
+    )
+
+    return replace(
+        discovery,
+        observation_digest=observation_digest,
     )

--- a/tests/test_canonical_baserunning_evidence_discovery.py
+++ b/tests/test_canonical_baserunning_evidence_discovery.py
@@ -177,3 +177,19 @@ def test_discovery_version_is_explicit():
     assert discovery.discovery_version == (
         CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
     )
+
+
+
+def test_discovery_diagnostics_default_observation_digest():
+    discovery = (
+        discover_canonical_shadow_baserunning_evidence(
+            required_runner_ids=(),
+            required_pitcher_ids=(),
+        )
+    )
+
+    assert discovery.observation_digest is None
+    assert (
+        discovery.to_diagnostics()["observation_digest"]
+        is None
+    )

--- a/tests/test_canonical_observed_baserunning_evidence.py
+++ b/tests/test_canonical_observed_baserunning_evidence.py
@@ -1,4 +1,5 @@
 from mlb_app.simulation.shadow import (
+    CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION,
     CanonicalCatcherBaserunningObservation,
     CanonicalPitcherBaserunningObservation,
     CanonicalRunnerBaserunningObservation,
@@ -184,3 +185,75 @@ def test_same_observations_produce_same_catalog_digest():
     assert first.catalog is not None
     assert second.catalog is not None
     assert first.catalog.digest == second.catalog.digest
+
+
+
+def test_complete_observations_expose_digest_provenance():
+    result = discover()
+
+    assert result.observation_digest is not None
+    assert len(result.observation_digest) == 64
+    assert (
+        result.to_diagnostics()["observation_digest"]
+        == result.observation_digest
+    )
+
+
+def test_same_observations_produce_same_observation_digest():
+    first = discover()
+    second = discover()
+
+    assert first.observation_digest is not None
+    assert (
+        first.observation_digest
+        == second.observation_digest
+    )
+
+
+def test_changed_observation_changes_observation_digest():
+    first = discover()
+    changed = discover(
+        runner_observations=(
+            CanonicalRunnerBaserunningObservation(
+                runner_id="runner",
+                eligible_opportunities=20,
+                stolen_bases=5,
+                caught_stealing=2,
+                speed_score=0.90,
+                lead_quality=0.80,
+                fatigue_index=0.10,
+            ),
+        ),
+    )
+
+    assert first.observation_digest is not None
+    assert changed.observation_digest is not None
+    assert (
+        first.observation_digest
+        != changed.observation_digest
+    )
+
+
+def test_incomplete_observations_preserve_digest():
+    result = discover(
+        runner_observations=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.observation_digest is not None
+
+
+def test_invalid_observations_do_not_claim_digest():
+    result = discover(
+        runner_observations=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.observation_digest is None
+
+
+def test_observation_digest_version_is_explicit():
+    assert (
+        CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION
+        == "canonical_observed_baserunning_digest_v1"
+    )


### PR DESCRIPTION
## Summary
- add deterministic provenance digests for assembled runner, pitcher, and catcher observations
- include required identity ordering and missing catcher state in the digest input
- expose the observation digest through canonical discovery diagnostics
- preserve provenance for incomplete evidence while withholding it for invalid contracts
- leave production activation and legacy authority unchanged

## Validation
- `79 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment