### PR TITLE
Decode Statcast baserunning outcomes

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -89,6 +89,11 @@ from .runner_baserunning_evidence import (
     CanonicalRunnerBaserunningObservation,
     adapt_observed_runner_baserunning_evidence,
 )
+from .statcast_baserunning_source import (
+    CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalStatcastBaserunningOutcome,
+    decode_statcast_baserunning_outcomes,
+)
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
 from .serialization import (
@@ -129,6 +134,9 @@ __all__ = [
     "CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalRunnerBaserunningObservation",
     "adapt_observed_runner_baserunning_evidence",
+    "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
+    "CanonicalStatcastBaserunningOutcome",
+    "decode_statcast_baserunning_outcomes",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",
     "CanonicalShadowBullpenSideDiscovery",

--- a/mlb_app/simulation/shadow/statcast_baserunning_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_source.py
@@ -1,0 +1,233 @@
+"""Decode event-level baserunning outcomes from Statcast rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Any, Mapping, Optional, Tuple
+
+
+CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION = (
+    "canonical_statcast_baserunning_source_v1"
+)
+
+_OUTCOME_PATTERN = re.compile(
+    r"(?P<stolen>steals\s+"
+    r"(?:\(\d+\)\s+)?"
+    r"(?P<stolen_target>2nd|3rd|home)\s+base)"
+    r"|"
+    r"(?P<caught>caught\s+stealing\s+"
+    r"(?P<caught_target>2nd|3rd|home))",
+    re.IGNORECASE,
+)
+
+_TARGET_CONTEXT = {
+    "2nd": (
+        "first",
+        "second",
+        "on_1b",
+    ),
+    "3rd": (
+        "second",
+        "third",
+        "on_2b",
+    ),
+    "home": (
+        "third",
+        "home",
+        "on_3b",
+    ),
+}
+
+
+def _identifier(value: Any) -> Optional[str]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    if isinstance(value, float):
+        if math.isnan(value):
+            return None
+        if value.is_integer():
+            return str(int(value))
+
+    text = str(value).strip()
+
+    if text.lower() in {
+        "",
+        "<na>",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    try:
+        numeric = float(text)
+    except ValueError:
+        return text
+
+    if math.isnan(numeric):
+        return None
+
+    if numeric.is_integer():
+        return str(int(numeric))
+
+    return text
+
+
+def _integer(value: Any) -> Optional[int]:
+    identifier = _identifier(value)
+
+    if identifier is None:
+        return None
+
+    try:
+        numeric = float(identifier)
+    except ValueError:
+        return None
+
+    if not numeric.is_integer():
+        return None
+
+    return int(numeric)
+
+
+@dataclass(frozen=True)
+class CanonicalStatcastBaserunningOutcome:
+    """One runner outcome decoded from a Statcast description."""
+
+    runner_id: str
+    event_type: str
+    origin_base: str
+    target_base: str
+    game_pk: Optional[int] = None
+    at_bat_number: Optional[int] = None
+    pitch_number: Optional[int] = None
+    pitcher_id: Optional[str] = None
+    catcher_id: Optional[str] = None
+    source_version: str = (
+        CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        if self.event_type not in {
+            "stolen_base",
+            "caught_stealing",
+        }:
+            raise ValueError(
+                "unsupported baserunning event_type"
+            )
+
+        if (
+            self.origin_base,
+            self.target_base,
+        ) not in {
+            ("first", "second"),
+            ("second", "third"),
+            ("third", "home"),
+        }:
+            raise ValueError(
+                "unsupported baserunning transition"
+            )
+
+        if self.source_version != (
+            CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported Statcast baserunning source version"
+            )
+
+
+def decode_statcast_baserunning_outcomes(
+    row: Mapping[str, Any],
+) -> Tuple[CanonicalStatcastBaserunningOutcome, ...]:
+    """
+    Decode all stolen-base and caught-stealing outcomes in one row.
+
+    Runner identity comes from the matching pre-play Statcast occupancy field,
+    allowing double steals to produce separate immutable outcomes without
+    resolving player names from free text.
+    """
+
+    if not isinstance(row, Mapping):
+        raise TypeError(
+            "row must be a mapping"
+        )
+
+    description = row.get("des")
+
+    if description in (None, ""):
+        return ()
+
+    text = str(description)
+    outcomes = []
+    seen = set()
+
+    for match in _OUTCOME_PATTERN.finditer(text):
+        target_token = (
+            match.group("stolen_target")
+            or match.group("caught_target")
+        )
+
+        if target_token is None:
+            continue
+
+        target_key = target_token.lower()
+        origin_base, target_base, runner_field = (
+            _TARGET_CONTEXT[target_key]
+        )
+        runner_id = _identifier(
+            row.get(runner_field)
+        )
+
+        if runner_id is None:
+            continue
+
+        event_type = (
+            "stolen_base"
+            if match.group("stolen") is not None
+            else "caught_stealing"
+        )
+
+        identity = (
+            runner_id,
+            event_type,
+            origin_base,
+            target_base,
+        )
+
+        if identity in seen:
+            continue
+
+        seen.add(identity)
+        outcomes.append(
+            CanonicalStatcastBaserunningOutcome(
+                runner_id=runner_id,
+                event_type=event_type,
+                origin_base=origin_base,
+                target_base=target_base,
+                game_pk=_integer(
+                    row.get("game_pk")
+                ),
+                at_bat_number=_integer(
+                    row.get("at_bat_number")
+                ),
+                pitch_number=_integer(
+                    row.get("pitch_number")
+                ),
+                pitcher_id=_identifier(
+                    row.get("pitcher")
+                ),
+                catcher_id=_identifier(
+                    row.get("fielder_2")
+                ),
+            )
+        )
+
+    return tuple(outcomes)

--- a/tests/test_canonical_statcast_baserunning_source.py
+++ b/tests/test_canonical_statcast_baserunning_source.py
@@ -1,0 +1,205 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    decode_statcast_baserunning_outcomes,
+)
+
+
+def row(**overrides):
+    value = {
+        "game_pk": 778462,
+        "at_bat_number": 17,
+        "pitch_number": 5,
+        "pitcher": 686613,
+        "fielder_2": 605170,
+        "on_1b": 650489,
+        "on_2b": None,
+        "on_3b": None,
+        "des": (
+            "Ryan Jeffers strikes out swinging. "
+            "Willi Castro steals (1) 2nd base."
+        ),
+    }
+    value.update(overrides)
+    return value
+
+
+def test_decodes_stolen_base_with_exact_identities():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row()
+    )
+
+    assert len(outcomes) == 1
+
+    outcome = outcomes[0]
+
+    assert outcome.runner_id == "650489"
+    assert outcome.event_type == "stolen_base"
+    assert outcome.origin_base == "first"
+    assert outcome.target_base == "second"
+    assert outcome.game_pk == 778462
+    assert outcome.at_bat_number == 17
+    assert outcome.pitch_number == 5
+    assert outcome.pitcher_id == "686613"
+    assert outcome.catcher_id == "605170"
+
+
+def test_decodes_caught_stealing_from_first():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b=663898,
+            des=(
+                "Cam Smith strikes out swinging and "
+                "Brendan Rodgers caught stealing 2nd, "
+                "catcher Ryan Jeffers."
+            ),
+        )
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].runner_id == "663898"
+    assert (
+        outcomes[0].event_type
+        == "caught_stealing"
+    )
+    assert outcomes[0].origin_base == "first"
+    assert outcomes[0].target_base == "second"
+
+
+def test_decodes_steal_of_third_from_second():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b=None,
+            on_2b=592885,
+            des=(
+                "William Contreras walks. "
+                "Christian Yelich steals (2) "
+                "3rd base."
+            ),
+        )
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].runner_id == "592885"
+    assert outcomes[0].origin_base == "second"
+    assert outcomes[0].target_base == "third"
+
+
+def test_decodes_double_steal_as_two_outcomes():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b=687363,
+            on_2b=691023,
+            des=(
+                "Masyn Winn strikes out swinging. "
+                "Jordan Walker steals (1) 3rd base. "
+                "Victor Scott II steals (4) 2nd base."
+            ),
+        )
+    )
+
+    assert tuple(
+        (
+            outcome.runner_id,
+            outcome.origin_base,
+            outcome.target_base,
+        )
+        for outcome in outcomes
+    ) == (
+        (
+            "691023",
+            "second",
+            "third",
+        ),
+        (
+            "687363",
+            "first",
+            "second",
+        ),
+    )
+
+
+def test_decodes_home_attempt_from_third():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b=None,
+            on_3b=123456,
+            des=(
+                "Runner caught stealing home, "
+                "catcher to pitcher."
+            ),
+        )
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].runner_id == "123456"
+    assert (
+        outcomes[0].event_type
+        == "caught_stealing"
+    )
+    assert outcomes[0].origin_base == "third"
+    assert outcomes[0].target_base == "home"
+
+
+def test_missing_matching_runner_is_not_fabricated():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b=None,
+        )
+    )
+
+    assert outcomes == ()
+
+
+def test_non_baserunning_description_returns_empty():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            des="Batter strikes out swinging.",
+        )
+    )
+
+    assert outcomes == ()
+
+
+def test_duplicate_text_is_deduplicated():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            des=(
+                "Runner steals (1) 2nd base. "
+                "Runner steals (1) 2nd base."
+            ),
+        )
+    )
+
+    assert len(outcomes) == 1
+
+
+def test_pandas_missing_value_text_is_not_identity():
+    outcomes = decode_statcast_baserunning_outcomes(
+        row(
+            on_1b="<NA>",
+        )
+    )
+
+    assert outcomes == ()
+
+
+def test_non_mapping_input_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="row must be a mapping",
+    ):
+        decode_statcast_baserunning_outcomes(
+            object()
+        )
+
+
+def test_source_version_is_explicit():
+    outcome = decode_statcast_baserunning_outcomes(
+        row()
+    )[0]
+
+    assert outcome.source_version == (
+        CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+    )


### PR DESCRIPTION
## Summary
- decode stolen-base and caught-stealing outcomes from Statcast descriptions
- resolve runner identity from exact pre-play base occupancy rather than player-name text
- retain game, plate appearance, pitch, pitcher, and catcher identity provenance
- support steals of second, third, home, and multiple outcomes on double steals
- deduplicate repeated descriptions and refuse to fabricate missing runner identities
- leave aggregation, catalog injection, production activation, and legacy authority unchanged

## Validation
- `76 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment