### PR TITLE
Aggregate Statcast runner evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -92,6 +92,8 @@ from .runner_baserunning_evidence import (
 from .statcast_baserunning_source import (
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
     CanonicalStatcastBaserunningOutcome,
+    CanonicalStatcastRunnerBaserunningCounts,
+    aggregate_statcast_runner_baserunning_counts,
     decode_statcast_baserunning_outcomes,
 )
 from .integration import attach_canonical_shadow
@@ -136,6 +138,8 @@ __all__ = [
     "adapt_observed_runner_baserunning_evidence",
     "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
     "CanonicalStatcastBaserunningOutcome",
+    "CanonicalStatcastRunnerBaserunningCounts",
+    "aggregate_statcast_runner_baserunning_counts",
     "decode_statcast_baserunning_outcomes",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",

--- a/mlb_app/simulation/shadow/statcast_baserunning_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_source.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 import math
 import re
-from typing import Any, Mapping, Optional, Tuple
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Tuple,
+)
 
 
 CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION = (
@@ -231,3 +238,228 @@ def decode_statcast_baserunning_outcomes(
         )
 
     return tuple(outcomes)
+
+
+
+@dataclass(frozen=True)
+class CanonicalStatcastRunnerBaserunningCounts:
+    """Exact supported-transition counts for one runner."""
+
+    runner_id: str
+    eligible_opportunities: int
+    stolen_bases: int
+    caught_stealing: int
+    source_version: str = (
+        CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        for name, value in (
+            (
+                "eligible_opportunities",
+                self.eligible_opportunities,
+            ),
+            (
+                "stolen_bases",
+                self.stolen_bases,
+            ),
+            (
+                "caught_stealing",
+                self.caught_stealing,
+            ),
+        ):
+            if not isinstance(value, int):
+                raise TypeError(
+                    f"{name} must be an integer"
+                )
+            if value < 0:
+                raise ValueError(
+                    f"{name} must be nonnegative"
+                )
+
+        if (
+            self.stolen_bases
+            + self.caught_stealing
+            > self.eligible_opportunities
+        ):
+            raise ValueError(
+                "attempts cannot exceed eligible opportunities"
+            )
+
+        if self.source_version != (
+            CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported Statcast baserunning source version"
+            )
+
+
+def _row_key(
+    row: Mapping[str, Any],
+) -> Tuple[int, int, int]:
+    values = tuple(
+        _integer(row.get(name))
+        for name in (
+            "game_pk",
+            "at_bat_number",
+            "pitch_number",
+        )
+    )
+
+    if any(value is None for value in values):
+        raise ValueError(
+            "Statcast row requires game_pk, "
+            "at_bat_number, and pitch_number"
+        )
+
+    return values
+
+
+def _runner_has_outcome(
+    *,
+    runner_id: str,
+    origin_base: str,
+    outcomes: Tuple[
+        CanonicalStatcastBaserunningOutcome,
+        ...,
+    ],
+) -> bool:
+    return any(
+        outcome.runner_id == runner_id
+        and outcome.origin_base == origin_base
+        and outcome.target_base in {
+            "second",
+            "third",
+        }
+        for outcome in outcomes
+    )
+
+
+def aggregate_statcast_runner_baserunning_counts(
+    rows: Iterable[Mapping[str, Any]],
+) -> Tuple[
+    CanonicalStatcastRunnerBaserunningCounts,
+    ...,
+]:
+    """
+    Aggregate exact pitch opportunities and SB/CS outcomes.
+
+    Only first-to-second and second-to-third transitions are included because
+    those are the currently supported canonical steal transitions. Duplicate
+    Statcast pitch rows are ignored using their stable event identity.
+    """
+
+    counts: Dict[str, Dict[str, int]] = {}
+    seen_rows = set()
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "each Statcast row must be a mapping"
+            )
+
+        row_key = _row_key(row)
+
+        if row_key in seen_rows:
+            continue
+
+        seen_rows.add(row_key)
+        outcomes = decode_statcast_baserunning_outcomes(
+            row
+        )
+
+        on_first = _identifier(
+            row.get("on_1b")
+        )
+        on_second = _identifier(
+            row.get("on_2b")
+        )
+        on_third = _identifier(
+            row.get("on_3b")
+        )
+
+        eligible = []
+
+        if on_first is not None:
+            target_available = on_second is None
+            own_outcome = _runner_has_outcome(
+                runner_id=on_first,
+                origin_base="first",
+                outcomes=outcomes,
+            )
+
+            if target_available or own_outcome:
+                eligible.append(on_first)
+
+        if on_second is not None:
+            target_available = on_third is None
+            own_outcome = _runner_has_outcome(
+                runner_id=on_second,
+                origin_base="second",
+                outcomes=outcomes,
+            )
+
+            if target_available or own_outcome:
+                eligible.append(on_second)
+
+        for runner_id in eligible:
+            runner_counts = counts.setdefault(
+                runner_id,
+                {
+                    "eligible_opportunities": 0,
+                    "stolen_bases": 0,
+                    "caught_stealing": 0,
+                },
+            )
+            runner_counts[
+                "eligible_opportunities"
+            ] += 1
+
+        for outcome in outcomes:
+            if outcome.target_base not in {
+                "second",
+                "third",
+            }:
+                continue
+
+            runner_counts = counts.setdefault(
+                outcome.runner_id,
+                {
+                    "eligible_opportunities": 0,
+                    "stolen_bases": 0,
+                    "caught_stealing": 0,
+                },
+            )
+
+            if outcome.runner_id not in eligible:
+                runner_counts[
+                    "eligible_opportunities"
+                ] += 1
+
+            if outcome.event_type == "stolen_base":
+                runner_counts["stolen_bases"] += 1
+            else:
+                runner_counts[
+                    "caught_stealing"
+                ] += 1
+
+    return tuple(
+        CanonicalStatcastRunnerBaserunningCounts(
+            runner_id=runner_id,
+            eligible_opportunities=(
+                values["eligible_opportunities"]
+            ),
+            stolen_bases=values["stolen_bases"],
+            caught_stealing=(
+                values["caught_stealing"]
+            ),
+        )
+        for runner_id, values in sorted(
+            counts.items()
+        )
+    )

--- a/tests/test_canonical_statcast_baserunning_source.py
+++ b/tests/test_canonical_statcast_baserunning_source.py
@@ -2,6 +2,7 @@ import pytest
 
 from mlb_app.simulation.shadow import (
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    aggregate_statcast_runner_baserunning_counts,
     decode_statcast_baserunning_outcomes,
 )
 
@@ -203,3 +204,216 @@ def test_source_version_is_explicit():
     assert outcome.source_version == (
         CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
     )
+
+
+
+def test_aggregates_pitch_opportunities_and_outcomes():
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=650489,
+                des="Called strike.",
+            ),
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=2,
+                on_1b=650489,
+                des=(
+                    "Willi Castro steals (1) "
+                    "2nd base."
+                ),
+            ),
+            row(
+                game_pk=2,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=650489,
+                des=(
+                    "Willi Castro caught stealing "
+                    "2nd."
+                ),
+            ),
+        )
+    )
+
+    assert len(counts) == 1
+    assert counts[0].runner_id == "650489"
+    assert counts[0].eligible_opportunities == 3
+    assert counts[0].stolen_bases == 1
+    assert counts[0].caught_stealing == 1
+
+
+def test_occupied_target_is_not_eligible():
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=111,
+                on_2b=222,
+                on_3b=None,
+                des="Called strike.",
+            ),
+        )
+    )
+
+    assert tuple(
+        (
+            value.runner_id,
+            value.eligible_opportunities,
+        )
+        for value in counts
+    ) == (
+        (
+            "222",
+            1,
+        ),
+    )
+
+
+def test_double_steal_credits_both_runners():
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=111,
+                on_2b=222,
+                on_3b=None,
+                des=(
+                    "Lead Runner steals (1) "
+                    "3rd base. Trail Runner steals "
+                    "(1) 2nd base."
+                ),
+            ),
+        )
+    )
+
+    assert tuple(
+        (
+            value.runner_id,
+            value.eligible_opportunities,
+            value.stolen_bases,
+        )
+        for value in counts
+    ) == (
+        (
+            "111",
+            1,
+            1,
+        ),
+        (
+            "222",
+            1,
+            1,
+        ),
+    )
+
+
+def test_duplicate_pitch_rows_are_ignored():
+    duplicate = row(
+        game_pk=1,
+        at_bat_number=1,
+        pitch_number=1,
+        on_1b=650489,
+        des=(
+            "Willi Castro steals (1) "
+            "2nd base."
+        ),
+    )
+
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            duplicate,
+            dict(duplicate),
+        )
+    )
+
+    assert counts[0].eligible_opportunities == 1
+    assert counts[0].stolen_bases == 1
+
+
+def test_home_attempt_is_not_in_supported_counts():
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=None,
+                on_2b=None,
+                on_3b=333,
+                des=(
+                    "Runner caught stealing home."
+                ),
+            ),
+        )
+    )
+
+    assert counts == ()
+
+
+def test_aggregate_order_is_deterministic():
+    counts = aggregate_statcast_runner_baserunning_counts(
+        (
+            row(
+                game_pk=1,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=222,
+                des="Called strike.",
+            ),
+            row(
+                game_pk=2,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=111,
+                des="Called strike.",
+            ),
+        )
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in counts
+    ) == (
+        "111",
+        "222",
+    )
+
+
+def test_aggregate_requires_stable_pitch_identity():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast row requires game_pk, "
+            "at_bat_number, and pitch_number"
+        ),
+    ):
+        aggregate_statcast_runner_baserunning_counts(
+            (
+                row(
+                    game_pk=None,
+                ),
+            )
+        )
+
+
+def test_aggregate_rejects_non_mapping_rows():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "each Statcast row must be a mapping"
+        ),
+    ):
+        aggregate_statcast_runner_baserunning_counts(
+            (
+                object(),
+            )
+        )


### PR DESCRIPTION
## Summary
- aggregate exact Statcast pitch opportunities and decoded SB/CS outcomes by runner
- limit evidence to currently supported first-to-second and second-to-third transitions
- account for occupied targets and simultaneous double-steal outcomes
- deduplicate source rows using stable game, plate appearance, and pitch identity
- require complete event identity and return deterministic runner ordering
- leave contextual speed/lead enrichment, production activation, and legacy authority unchanged

## Validation
- `84 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment