### PR TITLE
Materialize Statcast runner observations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -90,11 +90,14 @@ from .runner_baserunning_evidence import (
     adapt_observed_runner_baserunning_evidence,
 )
 from .statcast_baserunning_source import (
+    CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalRunnerBaserunningContext,
     CanonicalStatcastBaserunningOutcome,
     CanonicalStatcastRunnerBaserunningCounts,
     aggregate_statcast_runner_baserunning_counts,
     decode_statcast_baserunning_outcomes,
+    materialize_statcast_runner_observations,
 )
 from .integration import attach_canonical_shadow
 from .trial_adapter import canonical_trial_batch_to_shadow_payload
@@ -136,11 +139,14 @@ __all__ = [
     "CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalRunnerBaserunningObservation",
     "adapt_observed_runner_baserunning_evidence",
+    "CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
+    "CanonicalRunnerBaserunningContext",
     "CanonicalStatcastBaserunningOutcome",
     "CanonicalStatcastRunnerBaserunningCounts",
     "aggregate_statcast_runner_baserunning_counts",
     "decode_statcast_baserunning_outcomes",
+    "materialize_statcast_runner_observations",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",
     "CanonicalShadowBullpenSideDiscovery",

--- a/mlb_app/simulation/shadow/statcast_baserunning_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_source.py
@@ -14,9 +14,16 @@ from typing import (
     Tuple,
 )
 
+from .runner_baserunning_evidence import (
+    CanonicalRunnerBaserunningObservation,
+)
+
 
 CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION = (
     "canonical_statcast_baserunning_source_v1"
+)
+CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION = (
+    "canonical_runner_baserunning_materialization_v1"
 )
 
 _OUTCOME_PATTERN = re.compile(
@@ -463,3 +470,195 @@ def aggregate_statcast_runner_baserunning_counts(
             counts.items()
         )
     )
+
+
+
+def _validate_unit_rate(
+    *,
+    name: str,
+    value: float,
+) -> None:
+    if not isinstance(value, (int, float)):
+        raise TypeError(
+            f"{name} must be numeric"
+        )
+
+    if not 0.0 <= float(value) <= 1.0:
+        raise ValueError(
+            f"{name} must be between 0 and 1"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerBaserunningContext:
+    """Explicit non-count context required for one runner."""
+
+    runner_id: str
+    speed_score: float
+    lead_quality: float
+    fatigue_index: float
+    injury_limit_flag: bool = False
+    context_source_version: str = (
+        "unavailable"
+    )
+    materialization_version: str = (
+        CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        for name, value in (
+            (
+                "speed_score",
+                self.speed_score,
+            ),
+            (
+                "lead_quality",
+                self.lead_quality,
+            ),
+            (
+                "fatigue_index",
+                self.fatigue_index,
+            ),
+        ):
+            _validate_unit_rate(
+                name=name,
+                value=value,
+            )
+
+        if not isinstance(
+            self.injury_limit_flag,
+            bool,
+        ):
+            raise TypeError(
+                "injury_limit_flag must be boolean"
+            )
+
+        if (
+            not self.context_source_version
+            or self.context_source_version
+            == "unavailable"
+        ):
+            raise ValueError(
+                "context_source_version must identify "
+                "an available source"
+            )
+
+        if self.materialization_version != (
+            CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported runner baserunning "
+                "materialization version"
+            )
+
+
+def materialize_statcast_runner_observations(
+    *,
+    counts: Tuple[
+        CanonicalStatcastRunnerBaserunningCounts,
+        ...,
+    ],
+    contexts: Tuple[
+        CanonicalRunnerBaserunningContext,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalRunnerBaserunningObservation,
+    ...,
+]:
+    """
+    Join exact Statcast counts to complete runner context.
+
+    Missing context yields no observation for that runner. No speed, lead,
+    fatigue, or injury values are fabricated.
+    """
+
+    count_ids = [
+        value.runner_id
+        for value in counts
+    ]
+    context_ids = [
+        value.runner_id
+        for value in contexts
+    ]
+
+    if len(count_ids) != len(set(count_ids)):
+        raise ValueError(
+            "runner count identifiers must be unique"
+        )
+
+    if len(context_ids) != len(set(context_ids)):
+        raise ValueError(
+            "runner context identifiers must be unique"
+        )
+
+    for value in counts:
+        if not isinstance(
+            value,
+            CanonicalStatcastRunnerBaserunningCounts,
+        ):
+            raise TypeError(
+                "counts must contain "
+                "CanonicalStatcastRunnerBaserunningCounts"
+            )
+
+    for value in contexts:
+        if not isinstance(
+            value,
+            CanonicalRunnerBaserunningContext,
+        ):
+            raise TypeError(
+                "contexts must contain "
+                "CanonicalRunnerBaserunningContext"
+            )
+
+    contexts_by_id = {
+        value.runner_id: value
+        for value in contexts
+    }
+
+    observations = []
+
+    for value in counts:
+        context = contexts_by_id.get(
+            value.runner_id
+        )
+
+        if context is None:
+            continue
+
+        observations.append(
+            CanonicalRunnerBaserunningObservation(
+                runner_id=value.runner_id,
+                eligible_opportunities=(
+                    value.eligible_opportunities
+                ),
+                stolen_bases=value.stolen_bases,
+                caught_stealing=(
+                    value.caught_stealing
+                ),
+                speed_score=float(
+                    context.speed_score
+                ),
+                lead_quality=float(
+                    context.lead_quality
+                ),
+                fatigue_index=float(
+                    context.fatigue_index
+                ),
+                injury_limit_flag=(
+                    context.injury_limit_flag
+                ),
+                source_version=(
+                    f"{value.source_version}+"
+                    f"{context.context_source_version}"
+                ),
+            )
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_statcast_baserunning_source.py
+++ b/tests/test_canonical_statcast_baserunning_source.py
@@ -1,9 +1,13 @@
 import pytest
 
 from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalRunnerBaserunningContext,
+    CanonicalStatcastRunnerBaserunningCounts,
     aggregate_statcast_runner_baserunning_counts,
     decode_statcast_baserunning_outcomes,
+    materialize_statcast_runner_observations,
 )
 
 
@@ -417,3 +421,172 @@ def test_aggregate_rejects_non_mapping_rows():
                 object(),
             )
         )
+
+
+
+def runner_counts(
+    runner_id="650489",
+):
+    return CanonicalStatcastRunnerBaserunningCounts(
+        runner_id=runner_id,
+        eligible_opportunities=20,
+        stolen_bases=6,
+        caught_stealing=2,
+    )
+
+
+def runner_context(
+    runner_id="650489",
+):
+    return CanonicalRunnerBaserunningContext(
+        runner_id=runner_id,
+        speed_score=0.90,
+        lead_quality=0.80,
+        fatigue_index=0.10,
+        injury_limit_flag=False,
+        context_source_version=(
+            "sprint_speed_and_availability_v1"
+        ),
+    )
+
+
+def test_materializes_complete_runner_observation():
+    observations = (
+        materialize_statcast_runner_observations(
+            counts=(runner_counts(),),
+            contexts=(runner_context(),),
+        )
+    )
+
+    assert len(observations) == 1
+
+    observation = observations[0]
+
+    assert observation.runner_id == "650489"
+    assert observation.eligible_opportunities == 20
+    assert observation.stolen_bases == 6
+    assert observation.caught_stealing == 2
+    assert observation.speed_score == 0.90
+    assert observation.lead_quality == 0.80
+    assert observation.fatigue_index == 0.10
+    assert observation.injury_limit_flag is False
+    assert observation.source_version == (
+        "canonical_statcast_baserunning_source_v1+"
+        "sprint_speed_and_availability_v1"
+    )
+
+
+def test_missing_context_does_not_fabricate_observation():
+    observations = (
+        materialize_statcast_runner_observations(
+            counts=(runner_counts(),),
+            contexts=(),
+        )
+    )
+
+    assert observations == ()
+
+
+def test_context_without_counts_is_ignored():
+    observations = (
+        materialize_statcast_runner_observations(
+            counts=(),
+            contexts=(runner_context(),),
+        )
+    )
+
+    assert observations == ()
+
+
+def test_materialization_preserves_count_order():
+    observations = (
+        materialize_statcast_runner_observations(
+            counts=(
+                runner_counts("runner-2"),
+                runner_counts("runner-1"),
+            ),
+            contexts=(
+                runner_context("runner-1"),
+                runner_context("runner-2"),
+            ),
+        )
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in observations
+    ) == (
+        "runner-2",
+        "runner-1",
+    )
+
+
+def test_duplicate_count_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "runner count identifiers must be unique"
+        ),
+    ):
+        materialize_statcast_runner_observations(
+            counts=(
+                runner_counts(),
+                runner_counts(),
+            ),
+            contexts=(runner_context(),),
+        )
+
+
+def test_duplicate_context_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "runner context identifiers must be unique"
+        ),
+    ):
+        materialize_statcast_runner_observations(
+            counts=(runner_counts(),),
+            contexts=(
+                runner_context(),
+                runner_context(),
+            ),
+        )
+
+
+def test_unavailable_context_source_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "context_source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalRunnerBaserunningContext(
+            runner_id="runner",
+            speed_score=0.50,
+            lead_quality=0.50,
+            fatigue_index=0.50,
+        )
+
+
+def test_context_rate_outside_unit_interval_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "speed_score must be between 0 and 1"
+        ),
+    ):
+        runner_context().__class__(
+            runner_id="runner",
+            speed_score=1.01,
+            lead_quality=0.50,
+            fatigue_index=0.10,
+            context_source_version="test-v1",
+        )
+
+
+def test_materialization_version_is_explicit():
+    assert (
+        runner_context().materialization_version
+        == CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION
+    )


### PR DESCRIPTION
## Summary

- join exact aggregated Statcast baserunning counts to explicit runner context
- require sourced speed, lead quality, fatigue, and injury-limit context before materializing observations
- omit incomplete runner observations instead of fabricating defaults
- reject duplicate runner identities, invalid rates, and unavailable source versions
- preserve deterministic ordering and composed input provenance

This remains additive canonical shadow infrastructure. It does not activate production baserunning or change legacy production authority.

## Validation

- `93 passed, 1 warning`
- targeted modules compiled with `py_compile`
- `git diff --check` passed
- Ruff was unavailable