### PR TITLE
Source canonical runner sprint speed

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -89,6 +89,15 @@ from .runner_baserunning_evidence import (
     CanonicalRunnerBaserunningObservation,
     adapt_observed_runner_baserunning_evidence,
 )
+from .runner_sprint_speed_evidence import (
+    CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION,
+    CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION,
+    SPRINT_SPEED_ELITE_FT_PER_SECOND,
+    SPRINT_SPEED_FLOOR_FT_PER_SECOND,
+    CanonicalRunnerSprintSpeedObservation,
+    decode_baseball_savant_sprint_speed_rows,
+    normalize_runner_sprint_speed,
+)
 from .statcast_baserunning_source import (
     CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
@@ -139,6 +148,13 @@ __all__ = [
     "CANONICAL_RUNNER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalRunnerBaserunningObservation",
     "adapt_observed_runner_baserunning_evidence",
+    "CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION",
+    "CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION",
+    "SPRINT_SPEED_ELITE_FT_PER_SECOND",
+    "SPRINT_SPEED_FLOOR_FT_PER_SECOND",
+    "CanonicalRunnerSprintSpeedObservation",
+    "decode_baseball_savant_sprint_speed_rows",
+    "normalize_runner_sprint_speed",
     "CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
     "CanonicalRunnerBaserunningContext",

--- a/mlb_app/simulation/shadow/runner_sprint_speed_evidence.py
+++ b/mlb_app/simulation/shadow/runner_sprint_speed_evidence.py
@@ -1,0 +1,203 @@
+"""Adapt Baseball Savant sprint speed into canonical evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Iterable, Mapping, Optional, Tuple
+
+
+CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION = (
+    "baseball_savant_sprint_speed_v1"
+)
+CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION = (
+    "canonical_runner_sprint_speed_normalization_v1"
+)
+
+SPRINT_SPEED_FLOOR_FT_PER_SECOND = 23.0
+SPRINT_SPEED_ELITE_FT_PER_SECOND = 30.0
+
+
+def _identifier(value: Any) -> Optional[str]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    if isinstance(value, float):
+        if math.isnan(value):
+            return None
+        if value.is_integer():
+            return str(int(value))
+
+    text = str(value).strip()
+
+    if text.lower() in {
+        "",
+        "<na>",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    try:
+        numeric = float(text)
+    except ValueError:
+        return text
+
+    if math.isnan(numeric):
+        return None
+
+    if numeric.is_integer():
+        return str(int(numeric))
+
+    return text
+
+
+def _sprint_speed(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(result) or result <= 0.0:
+        return None
+
+    return result
+
+
+def normalize_runner_sprint_speed(
+    sprint_speed_ft_per_second: float,
+) -> float:
+    """
+    Normalize observed sprint speed onto the canonical unit interval.
+
+    The versioned policy maps 23 ft/s to zero and the Baseball Savant
+    elite-speed threshold of 30 ft/s to one, clamping observations
+    outside that interval while preserving the raw measurement.
+    """
+
+    speed = _sprint_speed(
+        sprint_speed_ft_per_second
+    )
+
+    if speed is None:
+        raise ValueError(
+            "sprint_speed_ft_per_second must be positive "
+            "and finite"
+        )
+
+    normalized = (
+        speed - SPRINT_SPEED_FLOOR_FT_PER_SECOND
+    ) / (
+        SPRINT_SPEED_ELITE_FT_PER_SECOND
+        - SPRINT_SPEED_FLOOR_FT_PER_SECOND
+    )
+
+    return round(
+        min(1.0, max(0.0, normalized)),
+        6,
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerSprintSpeedObservation:
+    """One sourced Baseball Savant runner-speed observation."""
+
+    runner_id: str
+    sprint_speed_ft_per_second: float
+    source_version: str = (
+        CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION
+    )
+    normalization_version: str = (
+        CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.runner_id:
+            raise ValueError(
+                "runner_id is required"
+            )
+
+        if _sprint_speed(
+            self.sprint_speed_ft_per_second
+        ) is None:
+            raise ValueError(
+                "sprint_speed_ft_per_second must be "
+                "positive and finite"
+            )
+
+        if self.source_version != (
+            CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported runner sprint-speed source "
+                "version"
+            )
+
+        if self.normalization_version != (
+            CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported runner sprint-speed "
+                "normalization version"
+            )
+
+    @property
+    def speed_score(self) -> float:
+        return normalize_runner_sprint_speed(
+            self.sprint_speed_ft_per_second
+        )
+
+
+def decode_baseball_savant_sprint_speed_rows(
+    rows: Iterable[Mapping[str, Any]],
+) -> Tuple[
+    CanonicalRunnerSprintSpeedObservation,
+    ...,
+]:
+    """
+    Decode complete Baseball Savant sprint-speed rows.
+
+    Rows missing an exact player identity or sprint-speed measurement
+    are omitted. Duplicate runner identities are rejected instead of
+    selecting an observation implicitly.
+    """
+
+    observations = {}
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "each sprint-speed row must be a mapping"
+            )
+
+        runner_id = _identifier(
+            row.get("player_id")
+        )
+        speed = _sprint_speed(
+            row.get("sprint_speed")
+        )
+
+        if runner_id is None or speed is None:
+            continue
+
+        if runner_id in observations:
+            raise ValueError(
+                "runner sprint-speed identifiers must "
+                "be unique"
+            )
+
+        observations[runner_id] = (
+            CanonicalRunnerSprintSpeedObservation(
+                runner_id=runner_id,
+                sprint_speed_ft_per_second=speed,
+            )
+        )
+
+    return tuple(
+        observations[runner_id]
+        for runner_id in sorted(observations)
+    )

--- a/tests/test_canonical_runner_sprint_speed_evidence.py
+++ b/tests/test_canonical_runner_sprint_speed_evidence.py
@@ -1,0 +1,165 @@
+import math
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION,
+    CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION,
+    CanonicalRunnerSprintSpeedObservation,
+    decode_baseball_savant_sprint_speed_rows,
+    normalize_runner_sprint_speed,
+)
+
+
+def row(**overrides):
+    value = {
+        "player_id": 650489,
+        "sprint_speed": 28.6,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_decodes_complete_sprint_speed_observation():
+    observations = (
+        decode_baseball_savant_sprint_speed_rows(
+            (row(),)
+        )
+    )
+
+    assert len(observations) == 1
+
+    observation = observations[0]
+
+    assert observation.runner_id == "650489"
+    assert (
+        observation.sprint_speed_ft_per_second
+        == 28.6
+    )
+    assert observation.speed_score == 0.8
+    assert observation.source_version == (
+        CANONICAL_RUNNER_SPRINT_SPEED_SOURCE_VERSION
+    )
+    assert observation.normalization_version == (
+        CANONICAL_RUNNER_SPRINT_SPEED_NORMALIZATION_VERSION
+    )
+
+
+def test_normalization_clamps_observed_extremes():
+    assert normalize_runner_sprint_speed(22.0) == 0.0
+    assert normalize_runner_sprint_speed(23.0) == 0.0
+    assert normalize_runner_sprint_speed(30.0) == 1.0
+    assert normalize_runner_sprint_speed(31.0) == 1.0
+
+
+def test_missing_identity_is_not_fabricated():
+    assert (
+        decode_baseball_savant_sprint_speed_rows(
+            (row(player_id=None),)
+        )
+        == ()
+    )
+
+
+def test_missing_speed_is_not_fabricated():
+    assert (
+        decode_baseball_savant_sprint_speed_rows(
+            (row(sprint_speed=None),)
+        )
+        == ()
+    )
+
+
+def test_invalid_speed_is_not_fabricated():
+    assert (
+        decode_baseball_savant_sprint_speed_rows(
+            (
+                row(sprint_speed="unknown"),
+                row(
+                    player_id=2,
+                    sprint_speed=math.nan,
+                ),
+            )
+        )
+        == ()
+    )
+
+
+def test_duplicate_runner_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "runner sprint-speed identifiers must "
+            "be unique"
+        ),
+    ):
+        decode_baseball_savant_sprint_speed_rows(
+            (
+                row(),
+                row(sprint_speed=28.7),
+            )
+        )
+
+
+def test_output_order_is_deterministic():
+    observations = (
+        decode_baseball_savant_sprint_speed_rows(
+            (
+                row(
+                    player_id=222,
+                    sprint_speed=27.0,
+                ),
+                row(
+                    player_id=111,
+                    sprint_speed=29.0,
+                ),
+            )
+        )
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in observations
+    ) == (
+        "111",
+        "222",
+    )
+
+
+def test_non_mapping_row_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "each sprint-speed row must be a mapping"
+        ),
+    ):
+        decode_baseball_savant_sprint_speed_rows(
+            (object(),)
+        )
+
+
+def test_observation_rejects_invalid_speed():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "sprint_speed_ft_per_second must be "
+            "positive and finite"
+        ),
+    ):
+        CanonicalRunnerSprintSpeedObservation(
+            runner_id="runner",
+            sprint_speed_ft_per_second=0.0,
+        )
+
+
+def test_normalization_rejects_invalid_speed():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "sprint_speed_ft_per_second must be positive "
+            "and finite"
+        ),
+    ):
+        normalize_runner_sprint_speed(
+            math.inf
+        )


### PR DESCRIPTION
## Summary

- add an immutable Baseball Savant sprint-speed evidence contract
- decode exact player identities and observed sprint-speed measurements from source rows
- apply an explicit, versioned 23–30 ft/s normalization policy while preserving raw measurements
- omit incomplete or invalid observations rather than fabricating speed values
- reject duplicate runner identities and preserve deterministic output ordering

This is additive canonical shadow infrastructure. It does not assemble complete runner context, activate stolen bases, or change legacy production authority.

## Validation

- `103 passed, 1 warning`
- targeted modules compiled with `py_compile`
- `git diff --check` passed
- Ruff was unavailable