### PR TITLE
Materialize Statcast catcher observations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -99,8 +99,10 @@ from .runner_sprint_speed_evidence import (
     normalize_runner_sprint_speed,
 )
 from .statcast_baserunning_source import (
+    CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalCatcherBaserunningContext,
     CanonicalRunnerBaserunningContext,
     CanonicalStatcastBaserunningOutcome,
     CanonicalStatcastRunnerBaserunningCounts,
@@ -110,6 +112,7 @@ from .statcast_baserunning_source import (
     aggregate_statcast_pitcher_baserunning_counts,
     aggregate_statcast_catcher_baserunning_counts,
     decode_statcast_baserunning_outcomes,
+    materialize_statcast_catcher_observations,
     materialize_statcast_runner_observations,
 )
 from .integration import attach_canonical_shadow
@@ -159,8 +162,10 @@ __all__ = [
     "CanonicalRunnerSprintSpeedObservation",
     "decode_baseball_savant_sprint_speed_rows",
     "normalize_runner_sprint_speed",
+    "CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
+    "CanonicalCatcherBaserunningContext",
     "CanonicalRunnerBaserunningContext",
     "CanonicalStatcastBaserunningOutcome",
     "CanonicalStatcastRunnerBaserunningCounts",
@@ -170,6 +175,7 @@ __all__ = [
     "aggregate_statcast_pitcher_baserunning_counts",
     "aggregate_statcast_catcher_baserunning_counts",
     "decode_statcast_baserunning_outcomes",
+    "materialize_statcast_catcher_observations",
     "materialize_statcast_runner_observations",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",

--- a/mlb_app/simulation/shadow/statcast_baserunning_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_source.py
@@ -14,6 +14,9 @@ from typing import (
     Tuple,
 )
 
+from .catcher_baserunning_evidence import (
+    CanonicalCatcherBaserunningObservation,
+)
 from .runner_baserunning_evidence import (
     CanonicalRunnerBaserunningObservation,
 )
@@ -24,6 +27,9 @@ CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION = (
 )
 CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION = (
     "canonical_runner_baserunning_materialization_v1"
+)
+CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION = (
+    "canonical_catcher_baserunning_materialization_v1"
 )
 
 _OUTCOME_PATTERN = re.compile(
@@ -955,3 +961,152 @@ def aggregate_statcast_catcher_baserunning_counts(
             counts.items()
         )
     )
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherBaserunningContext:
+    """Explicit non-count context required for one catcher."""
+
+    catcher_id: str
+    team_side: str
+    pop_time_score: float
+    context_source_version: str = "unavailable"
+    materialization_version: str = (
+        CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.catcher_id:
+            raise ValueError(
+                "catcher_id is required"
+            )
+
+        if self.team_side not in {
+            "away",
+            "home",
+        }:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        _validate_unit_rate(
+            name="pop_time_score",
+            value=self.pop_time_score,
+        )
+
+        if (
+            not self.context_source_version
+            or self.context_source_version
+            == "unavailable"
+        ):
+            raise ValueError(
+                "context_source_version must identify "
+                "an available source"
+            )
+
+        if self.materialization_version != (
+            CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher baserunning "
+                "materialization version"
+            )
+
+
+def materialize_statcast_catcher_observations(
+    *,
+    counts: Tuple[
+        CanonicalStatcastCatcherBaserunningCounts,
+        ...,
+    ],
+    contexts: Tuple[
+        CanonicalCatcherBaserunningContext,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalCatcherBaserunningObservation,
+    ...,
+]:
+    """
+    Join exact Statcast catcher outcomes to complete context.
+
+    Missing team-side or pop-time context yields no observation. Neither
+    identity, team assignment, nor pop-time evidence is fabricated.
+    """
+
+    count_ids = [
+        value.catcher_id
+        for value in counts
+    ]
+    context_ids = [
+        value.catcher_id
+        for value in contexts
+    ]
+
+    if len(count_ids) != len(set(count_ids)):
+        raise ValueError(
+            "catcher count identifiers must be unique"
+        )
+
+    if len(context_ids) != len(set(context_ids)):
+        raise ValueError(
+            "catcher context identifiers must be unique"
+        )
+
+    for value in counts:
+        if not isinstance(
+            value,
+            CanonicalStatcastCatcherBaserunningCounts,
+        ):
+            raise TypeError(
+                "counts must contain "
+                "CanonicalStatcastCatcherBaserunningCounts"
+            )
+
+    for value in contexts:
+        if not isinstance(
+            value,
+            CanonicalCatcherBaserunningContext,
+        ):
+            raise TypeError(
+                "contexts must contain "
+                "CanonicalCatcherBaserunningContext"
+            )
+
+    contexts_by_id = {
+        value.catcher_id: value
+        for value in contexts
+    }
+
+    observations = []
+
+    for value in counts:
+        context = contexts_by_id.get(
+            value.catcher_id
+        )
+
+        if context is None:
+            continue
+
+        observations.append(
+            CanonicalCatcherBaserunningObservation(
+                catcher_id=value.catcher_id,
+                team_side=context.team_side,
+                steal_attempts_against=(
+                    value.stolen_bases_allowed
+                    + value.caught_stealing
+                ),
+                caught_stealing=(
+                    value.caught_stealing
+                ),
+                pop_time_score=float(
+                    context.pop_time_score
+                ),
+                source_version=(
+                    f"{value.source_version}+"
+                    f"{context.context_source_version}"
+                ),
+            )
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_statcast_baserunning_source.py
+++ b/tests/test_canonical_statcast_baserunning_source.py
@@ -1,8 +1,10 @@
 import pytest
 
 from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalCatcherBaserunningContext,
     CanonicalRunnerBaserunningContext,
     CanonicalStatcastRunnerBaserunningCounts,
     CanonicalStatcastPitcherBaserunningCounts,
@@ -11,6 +13,7 @@ from mlb_app.simulation.shadow import (
     aggregate_statcast_pitcher_baserunning_counts,
     aggregate_statcast_catcher_baserunning_counts,
     decode_statcast_baserunning_outcomes,
+    materialize_statcast_catcher_observations,
     materialize_statcast_runner_observations,
 )
 
@@ -852,3 +855,176 @@ def test_defender_counts_reject_impossible_attempts():
             stolen_bases_allowed=1,
             caught_stealing=1,
         )
+
+
+def catcher_counts(
+    catcher_id="800",
+):
+    return CanonicalStatcastCatcherBaserunningCounts(
+        catcher_id=catcher_id,
+        eligible_opportunities=20,
+        stolen_bases_allowed=6,
+        caught_stealing=2,
+    )
+
+
+def catcher_context(
+    catcher_id="800",
+):
+    return CanonicalCatcherBaserunningContext(
+        catcher_id=catcher_id,
+        team_side="home",
+        pop_time_score=0.75,
+        context_source_version=(
+            "baseball_savant_pop_time_v1"
+        ),
+    )
+
+
+def test_materializes_complete_catcher_observation():
+    observations = (
+        materialize_statcast_catcher_observations(
+            counts=(catcher_counts(),),
+            contexts=(catcher_context(),),
+        )
+    )
+
+    assert len(observations) == 1
+
+    observation = observations[0]
+
+    assert observation.catcher_id == "800"
+    assert observation.team_side == "home"
+    assert observation.steal_attempts_against == 8
+    assert observation.caught_stealing == 2
+    assert observation.throwing_score == 0.25
+    assert observation.pop_time_score == 0.75
+    assert observation.source_version == (
+        "canonical_statcast_baserunning_source_v1+"
+        "baseball_savant_pop_time_v1"
+    )
+
+
+def test_missing_catcher_context_is_not_fabricated():
+    assert (
+        materialize_statcast_catcher_observations(
+            counts=(catcher_counts(),),
+            contexts=(),
+        )
+        == ()
+    )
+
+
+def test_context_without_catcher_counts_is_ignored():
+    assert (
+        materialize_statcast_catcher_observations(
+            counts=(),
+            contexts=(catcher_context(),),
+        )
+        == ()
+    )
+
+
+def test_catcher_materialization_preserves_count_order():
+    observations = (
+        materialize_statcast_catcher_observations(
+            counts=(
+                catcher_counts("catcher-2"),
+                catcher_counts("catcher-1"),
+            ),
+            contexts=(
+                catcher_context("catcher-1"),
+                catcher_context("catcher-2"),
+            ),
+        )
+    )
+
+    assert tuple(
+        value.catcher_id
+        for value in observations
+    ) == (
+        "catcher-2",
+        "catcher-1",
+    )
+
+
+def test_duplicate_catcher_count_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher count identifiers must be unique"
+        ),
+    ):
+        materialize_statcast_catcher_observations(
+            counts=(
+                catcher_counts(),
+                catcher_counts(),
+            ),
+            contexts=(catcher_context(),),
+        )
+
+
+def test_duplicate_catcher_context_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher context identifiers must be unique"
+        ),
+    ):
+        materialize_statcast_catcher_observations(
+            counts=(catcher_counts(),),
+            contexts=(
+                catcher_context(),
+                catcher_context(),
+            ),
+        )
+
+
+def test_unavailable_catcher_context_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "context_source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalCatcherBaserunningContext(
+            catcher_id="catcher",
+            team_side="away",
+            pop_time_score=0.50,
+        )
+
+
+def test_invalid_catcher_team_side_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="team_side must be away or home",
+    ):
+        CanonicalCatcherBaserunningContext(
+            catcher_id="catcher",
+            team_side="invalid",
+            pop_time_score=0.50,
+            context_source_version="test-v1",
+        )
+
+
+def test_catcher_pop_time_score_is_validated():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pop_time_score must be between 0 and 1"
+        ),
+    ):
+        CanonicalCatcherBaserunningContext(
+            catcher_id="catcher",
+            team_side="away",
+            pop_time_score=1.01,
+            context_source_version="test-v1",
+        )
+
+
+def test_catcher_materialization_version_is_explicit():
+    assert (
+        catcher_context().materialization_version
+        == CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION
+    )


### PR DESCRIPTION
## Summary

- join exact Statcast catcher SB/CS counts to explicit team-side and pop-time context
- materialize existing canonical catcher observations with exact steal attempts against and caught-stealing attribution
- derive throwing score only from those attributed attempts and outcomes
- omit catchers missing complete context instead of fabricating team assignment or pop time
- reject duplicate identities, invalid team sides, invalid scores, and unavailable source versions
- preserve deterministic count ordering and composed provenance

This remains additive canonical shadow evidence. It does not source pop-time data itself, activate stolen bases, or change legacy production authority.

## Validation

- `122 passed, 1 warning`
- targeted modules compiled with `py_compile`
- `git diff --check` passed
- Ruff was unavailable