### PR TITLE
Source canonical catcher pop time

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -5,6 +5,15 @@ from .catcher_baserunning_evidence import (
     CanonicalCatcherBaserunningObservation,
     adapt_observed_catcher_baserunning_evidence,
 )
+from .catcher_pop_time_evidence import (
+    CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION,
+    CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION,
+    ELITE_POP_TIME_SECONDS,
+    SLOW_POP_TIME_SECONDS,
+    CanonicalCatcherPopTimeObservation,
+    decode_baseball_savant_catcher_pop_time_rows,
+    normalize_catcher_pop_time,
+)
 from .comparator import compare_shadow_payloads
 from .bullpen_discovery import (
     CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
@@ -129,6 +138,13 @@ __all__ = [
     "CANONICAL_CATCHER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalCatcherBaserunningObservation",
     "adapt_observed_catcher_baserunning_evidence",
+    "CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION",
+    "CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION",
+    "ELITE_POP_TIME_SECONDS",
+    "SLOW_POP_TIME_SECONDS",
+    "CanonicalCatcherPopTimeObservation",
+    "decode_baseball_savant_catcher_pop_time_rows",
+    "normalize_catcher_pop_time",
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
     "CanonicalShadowBaserunningEvidenceDiscovery",

--- a/mlb_app/simulation/shadow/catcher_pop_time_evidence.py
+++ b/mlb_app/simulation/shadow/catcher_pop_time_evidence.py
@@ -1,0 +1,199 @@
+"""Adapt Baseball Savant catcher pop time into canonical evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Iterable, Mapping, Optional, Tuple
+
+
+CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION = (
+    "baseball_savant_catcher_pop_time_v1"
+)
+CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION = (
+    "canonical_catcher_pop_time_normalization_v1"
+)
+
+ELITE_POP_TIME_SECONDS = 1.80
+SLOW_POP_TIME_SECONDS = 2.10
+
+
+def _identifier(value: Any) -> Optional[str]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    if isinstance(value, float):
+        if math.isnan(value):
+            return None
+        if value.is_integer():
+            return str(int(value))
+
+    text = str(value).strip()
+
+    if text.lower() in {
+        "",
+        "<na>",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    try:
+        numeric = float(text)
+    except ValueError:
+        return text
+
+    if math.isnan(numeric):
+        return None
+
+    if numeric.is_integer():
+        return str(int(numeric))
+
+    return text
+
+
+def _pop_time(value: Any) -> Optional[float]:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(result) or result <= 0.0:
+        return None
+
+    return result
+
+
+def normalize_catcher_pop_time(
+    pop_time_seconds: float,
+) -> float:
+    """
+    Normalize observed pop time onto the canonical unit interval.
+
+    The versioned policy maps 2.10 seconds to zero and 1.80 seconds
+    to one. Lower pop times are better. Observations outside the
+    interval are clamped while the raw measurement is preserved.
+    """
+
+    pop_time = _pop_time(
+        pop_time_seconds
+    )
+
+    if pop_time is None:
+        raise ValueError(
+            "pop_time_seconds must be positive and finite"
+        )
+
+    normalized = (
+        SLOW_POP_TIME_SECONDS - pop_time
+    ) / (
+        SLOW_POP_TIME_SECONDS
+        - ELITE_POP_TIME_SECONDS
+    )
+
+    return round(
+        min(1.0, max(0.0, normalized)),
+        6,
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherPopTimeObservation:
+    """One sourced Baseball Savant catcher pop-time observation."""
+
+    catcher_id: str
+    pop_time_seconds: float
+    source_version: str = (
+        CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION
+    )
+    normalization_version: str = (
+        CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.catcher_id:
+            raise ValueError(
+                "catcher_id is required"
+            )
+
+        if _pop_time(
+            self.pop_time_seconds
+        ) is None:
+            raise ValueError(
+                "pop_time_seconds must be positive and finite"
+            )
+
+        if self.source_version != (
+            CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher pop-time source version"
+            )
+
+        if self.normalization_version != (
+            CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher pop-time "
+                "normalization version"
+            )
+
+    @property
+    def pop_time_score(self) -> float:
+        return normalize_catcher_pop_time(
+            self.pop_time_seconds
+        )
+
+
+def decode_baseball_savant_catcher_pop_time_rows(
+    rows: Iterable[Mapping[str, Any]],
+) -> Tuple[
+    CanonicalCatcherPopTimeObservation,
+    ...,
+]:
+    """
+    Decode complete Baseball Savant catcher pop-time rows.
+
+    The source contract uses Baseball Savant's `player_id` and
+    `pop_2b_sba` fields. Missing measurements are omitted and duplicate
+    catcher identities are rejected instead of resolved implicitly.
+    """
+
+    observations = {}
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "each catcher pop-time row must be a mapping"
+            )
+
+        catcher_id = _identifier(
+            row.get("player_id")
+        )
+        pop_time = _pop_time(
+            row.get("pop_2b_sba")
+        )
+
+        if catcher_id is None or pop_time is None:
+            continue
+
+        if catcher_id in observations:
+            raise ValueError(
+                "catcher pop-time identifiers must be unique"
+            )
+
+        observations[catcher_id] = (
+            CanonicalCatcherPopTimeObservation(
+                catcher_id=catcher_id,
+                pop_time_seconds=pop_time,
+            )
+        )
+
+    return tuple(
+        observations[catcher_id]
+        for catcher_id in sorted(observations)
+    )

--- a/tests/test_canonical_catcher_pop_time_evidence.py
+++ b/tests/test_canonical_catcher_pop_time_evidence.py
@@ -1,0 +1,164 @@
+import math
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION,
+    CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION,
+    CanonicalCatcherPopTimeObservation,
+    decode_baseball_savant_catcher_pop_time_rows,
+    normalize_catcher_pop_time,
+)
+
+
+def row(**overrides):
+    value = {
+        "player_id": 605170,
+        "pop_2b_sba": 1.89,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_decodes_complete_catcher_pop_time():
+    observations = (
+        decode_baseball_savant_catcher_pop_time_rows(
+            (row(),)
+        )
+    )
+
+    assert len(observations) == 1
+
+    observation = observations[0]
+
+    assert observation.catcher_id == "605170"
+    assert observation.pop_time_seconds == 1.89
+    assert observation.pop_time_score == 0.7
+    assert observation.source_version == (
+        CANONICAL_CATCHER_POP_TIME_SOURCE_VERSION
+    )
+    assert observation.normalization_version == (
+        CANONICAL_CATCHER_POP_TIME_NORMALIZATION_VERSION
+    )
+
+
+def test_normalization_rewards_lower_pop_time():
+    assert normalize_catcher_pop_time(2.10) == 0.0
+    assert normalize_catcher_pop_time(2.00) == 0.333333
+    assert normalize_catcher_pop_time(1.90) == 0.666667
+    assert normalize_catcher_pop_time(1.80) == 1.0
+
+
+def test_normalization_clamps_observed_extremes():
+    assert normalize_catcher_pop_time(2.20) == 0.0
+    assert normalize_catcher_pop_time(1.70) == 1.0
+
+
+def test_missing_identity_is_not_fabricated():
+    assert (
+        decode_baseball_savant_catcher_pop_time_rows(
+            (row(player_id=None),)
+        )
+        == ()
+    )
+
+
+def test_missing_pop_time_is_not_fabricated():
+    assert (
+        decode_baseball_savant_catcher_pop_time_rows(
+            (row(pop_2b_sba=None),)
+        )
+        == ()
+    )
+
+
+def test_invalid_pop_time_is_not_fabricated():
+    assert (
+        decode_baseball_savant_catcher_pop_time_rows(
+            (
+                row(pop_2b_sba="unknown"),
+                row(
+                    player_id=2,
+                    pop_2b_sba=math.nan,
+                ),
+            )
+        )
+        == ()
+    )
+
+
+def test_duplicate_catcher_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher pop-time identifiers must be unique"
+        ),
+    ):
+        decode_baseball_savant_catcher_pop_time_rows(
+            (
+                row(),
+                row(pop_2b_sba=1.91),
+            )
+        )
+
+
+def test_output_order_is_deterministic():
+    observations = (
+        decode_baseball_savant_catcher_pop_time_rows(
+            (
+                row(
+                    player_id=222,
+                    pop_2b_sba=2.01,
+                ),
+                row(
+                    player_id=111,
+                    pop_2b_sba=1.88,
+                ),
+            )
+        )
+    )
+
+    assert tuple(
+        value.catcher_id
+        for value in observations
+    ) == (
+        "111",
+        "222",
+    )
+
+
+def test_non_mapping_row_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "each catcher pop-time row must be a mapping"
+        ),
+    ):
+        decode_baseball_savant_catcher_pop_time_rows(
+            (object(),)
+        )
+
+
+def test_observation_rejects_invalid_pop_time():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pop_time_seconds must be positive and finite"
+        ),
+    ):
+        CanonicalCatcherPopTimeObservation(
+            catcher_id="catcher",
+            pop_time_seconds=0.0,
+        )
+
+
+def test_normalization_rejects_invalid_pop_time():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pop_time_seconds must be positive and finite"
+        ),
+    ):
+        normalize_catcher_pop_time(
+            math.inf
+        )


### PR DESCRIPTION
## Summary

- add an immutable Baseball Savant catcher pop-time evidence contract
- decode exact catcher identities and `pop_2b_sba` measurements from source rows
- preserve raw pop-time seconds while applying an explicit, versioned 1.80–2.10 second normalization policy
- reward faster pop times and clamp observations outside the calibrated interval
- omit incomplete or invalid observations rather than substituting averages
- reject duplicate catcher identities and preserve deterministic output ordering

This is additive canonical shadow infrastructure. It does not attach team-side context, assemble the live catcher catalog, activate stolen bases, or change legacy production authority.

## Validation

- `133 passed, 1 warning`
- targeted modules compiled with `py_compile`
- `git diff --check` passed
- Ruff was unavailable