### PR TITLE
Compose canonical catcher contexts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -14,6 +14,11 @@ from .catcher_pop_time_evidence import (
     decode_baseball_savant_catcher_pop_time_rows,
     normalize_catcher_pop_time,
 )
+from .catcher_context_composition import (
+    CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION,
+    CanonicalCatcherTeamAssignment,
+    compose_catcher_baserunning_contexts,
+)
 from .comparator import compare_shadow_payloads
 from .bullpen_discovery import (
     CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
@@ -145,6 +150,9 @@ __all__ = [
     "CanonicalCatcherPopTimeObservation",
     "decode_baseball_savant_catcher_pop_time_rows",
     "normalize_catcher_pop_time",
+    "CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION",
+    "CanonicalCatcherTeamAssignment",
+    "compose_catcher_baserunning_contexts",
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
     "CanonicalShadowBaserunningEvidenceDiscovery",

--- a/mlb_app/simulation/shadow/catcher_context_composition.py
+++ b/mlb_app/simulation/shadow/catcher_context_composition.py
@@ -1,0 +1,171 @@
+"""Compose exact catcher assignments with sourced pop-time evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from .catcher_pop_time_evidence import (
+    CanonicalCatcherPopTimeObservation,
+)
+from .statcast_baserunning_source import (
+    CanonicalCatcherBaserunningContext,
+)
+
+
+CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION = (
+    "canonical_catcher_context_composition_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherTeamAssignment:
+    """Exact active catcher assignment for one matchup side."""
+
+    catcher_id: str
+    team_side: str
+    assignment_source_version: str = "unavailable"
+    composition_version: str = (
+        CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.catcher_id:
+            raise ValueError(
+                "catcher_id is required"
+            )
+
+        if self.team_side not in {
+            "away",
+            "home",
+        }:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        if (
+            not self.assignment_source_version
+            or self.assignment_source_version
+            == "unavailable"
+        ):
+            raise ValueError(
+                "assignment_source_version must identify "
+                "an available source"
+            )
+
+        if self.composition_version != (
+            CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher context "
+                "composition version"
+            )
+
+
+def compose_catcher_baserunning_contexts(
+    *,
+    assignments: Tuple[
+        CanonicalCatcherTeamAssignment,
+        ...,
+    ],
+    pop_times: Tuple[
+        CanonicalCatcherPopTimeObservation,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalCatcherBaserunningContext,
+    ...,
+]:
+    """
+    Join active catcher assignments to exact pop-time evidence.
+
+    A catcher without pop-time evidence is omitted. Pop-time evidence
+    without an active matchup assignment is ignored. No catcher identity,
+    team side, or measurement is inferred.
+    """
+
+    for value in assignments:
+        if not isinstance(
+            value,
+            CanonicalCatcherTeamAssignment,
+        ):
+            raise TypeError(
+                "assignments must contain "
+                "CanonicalCatcherTeamAssignment"
+            )
+
+    for value in pop_times:
+        if not isinstance(
+            value,
+            CanonicalCatcherPopTimeObservation,
+        ):
+            raise TypeError(
+                "pop_times must contain "
+                "CanonicalCatcherPopTimeObservation"
+            )
+
+    assignment_ids = [
+        value.catcher_id
+        for value in assignments
+    ]
+    assignment_sides = [
+        value.team_side
+        for value in assignments
+    ]
+    pop_time_ids = [
+        value.catcher_id
+        for value in pop_times
+    ]
+
+    if len(assignment_ids) != len(
+        set(assignment_ids)
+    ):
+        raise ValueError(
+            "catcher assignment identifiers must be unique"
+        )
+
+    if len(assignment_sides) != len(
+        set(assignment_sides)
+    ):
+        raise ValueError(
+            "catcher assignment team sides must be unique"
+        )
+
+    if len(pop_time_ids) != len(
+        set(pop_time_ids)
+    ):
+        raise ValueError(
+            "catcher pop-time identifiers must be unique"
+        )
+
+    pop_times_by_id = {
+        value.catcher_id: value
+        for value in pop_times
+    }
+
+    contexts = []
+
+    for assignment in assignments:
+        pop_time = pop_times_by_id.get(
+            assignment.catcher_id
+        )
+
+        if pop_time is None:
+            continue
+
+        contexts.append(
+            CanonicalCatcherBaserunningContext(
+                catcher_id=assignment.catcher_id,
+                team_side=assignment.team_side,
+                pop_time_score=(
+                    pop_time.pop_time_score
+                ),
+                context_source_version=(
+                    f"{assignment.assignment_source_version}+"
+                    f"{pop_time.source_version}+"
+                    f"{pop_time.normalization_version}"
+                ),
+            )
+        )
+
+    return tuple(contexts)

--- a/tests/test_canonical_catcher_context_composition.py
+++ b/tests/test_canonical_catcher_context_composition.py
@@ -1,0 +1,199 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION,
+    CanonicalCatcherPopTimeObservation,
+    CanonicalCatcherTeamAssignment,
+    compose_catcher_baserunning_contexts,
+)
+
+
+def assignment(
+    catcher_id="800",
+    team_side="home",
+):
+    return CanonicalCatcherTeamAssignment(
+        catcher_id=catcher_id,
+        team_side=team_side,
+        assignment_source_version=(
+            "confirmed_lineup_catcher_v1"
+        ),
+    )
+
+
+def pop_time(
+    catcher_id="800",
+    seconds=1.89,
+):
+    return CanonicalCatcherPopTimeObservation(
+        catcher_id=catcher_id,
+        pop_time_seconds=seconds,
+    )
+
+
+def test_composes_complete_catcher_context():
+    contexts = compose_catcher_baserunning_contexts(
+        assignments=(assignment(),),
+        pop_times=(pop_time(),),
+    )
+
+    assert len(contexts) == 1
+
+    context = contexts[0]
+
+    assert context.catcher_id == "800"
+    assert context.team_side == "home"
+    assert context.pop_time_score == 0.7
+    assert context.context_source_version == (
+        "confirmed_lineup_catcher_v1+"
+        "baseball_savant_catcher_pop_time_v1+"
+        "canonical_catcher_pop_time_normalization_v1"
+    )
+
+
+def test_missing_pop_time_does_not_fabricate_context():
+    assert (
+        compose_catcher_baserunning_contexts(
+            assignments=(assignment(),),
+            pop_times=(),
+        )
+        == ()
+    )
+
+
+def test_unassigned_pop_time_is_ignored():
+    assert (
+        compose_catcher_baserunning_contexts(
+            assignments=(),
+            pop_times=(pop_time(),),
+        )
+        == ()
+    )
+
+
+def test_assignment_order_is_preserved():
+    contexts = compose_catcher_baserunning_contexts(
+        assignments=(
+            assignment(
+                catcher_id="catcher-2",
+                team_side="away",
+            ),
+            assignment(
+                catcher_id="catcher-1",
+                team_side="home",
+            ),
+        ),
+        pop_times=(
+            pop_time("catcher-1"),
+            pop_time("catcher-2"),
+        ),
+    )
+
+    assert tuple(
+        value.catcher_id
+        for value in contexts
+    ) == (
+        "catcher-2",
+        "catcher-1",
+    )
+
+
+def test_duplicate_assignment_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher assignment identifiers must be unique"
+        ),
+    ):
+        compose_catcher_baserunning_contexts(
+            assignments=(
+                assignment(),
+                assignment(
+                    team_side="away",
+                ),
+            ),
+            pop_times=(pop_time(),),
+        )
+
+
+def test_duplicate_assignment_side_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher assignment team sides must be unique"
+        ),
+    ):
+        compose_catcher_baserunning_contexts(
+            assignments=(
+                assignment("catcher-1", "home"),
+                assignment("catcher-2", "home"),
+            ),
+            pop_times=(
+                pop_time("catcher-1"),
+                pop_time("catcher-2"),
+            ),
+        )
+
+
+def test_duplicate_pop_time_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "catcher pop-time identifiers must be unique"
+        ),
+    ):
+        compose_catcher_baserunning_contexts(
+            assignments=(assignment(),),
+            pop_times=(
+                pop_time(),
+                pop_time(seconds=1.91),
+            ),
+        )
+
+
+def test_non_assignment_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "assignments must contain "
+            "CanonicalCatcherTeamAssignment"
+        ),
+    ):
+        compose_catcher_baserunning_contexts(
+            assignments=(object(),),
+            pop_times=(),
+        )
+
+
+def test_non_pop_time_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "pop_times must contain "
+            "CanonicalCatcherPopTimeObservation"
+        ),
+    ):
+        compose_catcher_baserunning_contexts(
+            assignments=(),
+            pop_times=(object(),),
+        )
+
+
+def test_unavailable_assignment_source_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "assignment_source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalCatcherTeamAssignment(
+            catcher_id="catcher",
+            team_side="away",
+        )
+
+
+def test_composition_version_is_explicit():
+    assert assignment().composition_version == (
+        CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION
+    )


### PR DESCRIPTION
## Summary

- add an immutable exact catcher-to-team assignment contract
- compose active away/home catcher assignments with sourced Baseball Savant pop-time observations
- produce the complete catcher context consumed by Statcast catcher materialization
- preserve the assignment order and compose assignment, measurement, and normalization provenance
- omit assignments missing pop-time evidence and ignore measurements without active assignments
- reject duplicate catcher identities, duplicate team sides, invalid contracts, and unavailable assignment sources

This completes the fail-open catcher context composition path but does not discover confirmed catcher assignments, build a live evidence catalog, activate stolen bases, or change legacy production authority.

## Validation

- `117 passed, 1 warning`
- targeted modules compiled with `py_compile`
- `git diff --check` passed
- Ruff was unavailable