### PR TITLE
Discover confirmed catcher assignments

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -19,6 +19,12 @@ from .catcher_context_composition import (
     CanonicalCatcherTeamAssignment,
     compose_catcher_baserunning_contexts,
 )
+from .catcher_assignment_discovery import (
+    CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION,
+    CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION,
+    CanonicalCatcherAssignmentDiscovery,
+    discover_confirmed_catcher_assignments,
+)
 from .comparator import compare_shadow_payloads
 from .bullpen_discovery import (
     CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
@@ -153,6 +159,10 @@ __all__ = [
     "CANONICAL_CATCHER_CONTEXT_COMPOSITION_VERSION",
     "CanonicalCatcherTeamAssignment",
     "compose_catcher_baserunning_contexts",
+    "CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION",
+    "CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION",
+    "CanonicalCatcherAssignmentDiscovery",
+    "discover_confirmed_catcher_assignments",
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
     "CanonicalShadowBaserunningEvidenceDiscovery",

--- a/mlb_app/simulation/shadow/catcher_assignment_discovery.py
+++ b/mlb_app/simulation/shadow/catcher_assignment_discovery.py
@@ -1,0 +1,240 @@
+"""Discover exact active catchers from confirmed boxscore lineups."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
+
+from .catcher_context_composition import (
+    CanonicalCatcherTeamAssignment,
+)
+
+
+CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION = (
+    "canonical_catcher_assignment_discovery_v1"
+)
+CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION = (
+    "mlb_stats_confirmed_lineup_catcher_v1"
+)
+
+
+def _normalize_identifier(
+    value: Any,
+) -> Optional[str]:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        return str(int(value))
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        return text or None
+
+
+def _is_explicit_catcher(
+    record: Mapping[str, Any],
+) -> bool:
+    position = str(
+        record.get("position") or ""
+    ).strip().lower()
+    position_code = str(
+        record.get("position_code") or ""
+    ).strip()
+
+    return (
+        position in {"c", "catcher"}
+        or position_code == "2"
+    )
+
+
+def _catcher_identifiers(
+    records: Any,
+) -> Tuple[str, ...]:
+    if not isinstance(records, Sequence) or isinstance(
+        records,
+        (str, bytes),
+    ):
+        return ()
+
+    ordered = []
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+
+        if not _is_explicit_catcher(record):
+            continue
+
+        identifier = _normalize_identifier(
+            record.get("batter_id")
+            or record.get("player_id")
+            or record.get("id")
+            or record.get("person_id")
+        )
+
+        if (
+            identifier is not None
+            and identifier not in ordered
+        ):
+            ordered.append(identifier)
+
+    return tuple(ordered)
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherAssignmentDiscovery:
+    """Exact catcher assignments discovered for one matchup."""
+
+    assignments: Tuple[
+        CanonicalCatcherTeamAssignment,
+        ...,
+    ] = ()
+    away_candidate_count: int = 0
+    home_candidate_count: int = 0
+    status: str = "unavailable"
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    discovery_version: str = (
+        CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.discovery_version != (
+            CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher assignment "
+                "discovery version"
+            )
+
+        for value in self.assignments:
+            if not isinstance(
+                value,
+                CanonicalCatcherTeamAssignment,
+            ):
+                raise TypeError(
+                    "assignments must contain "
+                    "CanonicalCatcherTeamAssignment"
+                )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.status == "ready"
+            and len(self.assignments) == 2
+            and {
+                value.team_side
+                for value in self.assignments
+            }
+            == {"away", "home"}
+        )
+
+
+def discover_confirmed_catcher_assignments(
+    *,
+    game_pk: Any,
+    lineup_fetcher: Optional[
+        Callable[[int], Mapping[str, Any]]
+    ] = None,
+) -> CanonicalCatcherAssignmentDiscovery:
+    """
+    Discover catchers only from explicit confirmed positions.
+
+    Missing, malformed, or ambiguous position evidence fails open.
+    Batting order and roster membership are never used to infer a catcher.
+    """
+
+    identifier = _normalize_identifier(game_pk)
+
+    if identifier is None:
+        return CanonicalCatcherAssignmentDiscovery(
+            status="blocked",
+            error_type="missing_game_pk",
+            error_message=(
+                "game_pk is required for confirmed "
+                "catcher assignment discovery"
+            ),
+        )
+
+    if lineup_fetcher is None:
+        from mlb_app.lineup_profile import (
+            fetch_boxscore_lineup,
+        )
+
+        lineup_fetcher = fetch_boxscore_lineup
+
+    try:
+        payload = lineup_fetcher(int(identifier))
+    except Exception as exc:
+        return CanonicalCatcherAssignmentDiscovery(
+            status="error",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )
+
+    if not isinstance(payload, Mapping):
+        return CanonicalCatcherAssignmentDiscovery(
+            status="blocked",
+            error_type="invalid_payload",
+            error_message=(
+                "lineup fetcher must return a mapping"
+            ),
+        )
+
+    away_ids = _catcher_identifiers(
+        payload.get("away") or []
+    )
+    home_ids = _catcher_identifiers(
+        payload.get("home") or []
+    )
+
+    if len(away_ids) > 1 or len(home_ids) > 1:
+        return CanonicalCatcherAssignmentDiscovery(
+            away_candidate_count=len(away_ids),
+            home_candidate_count=len(home_ids),
+            status="blocked",
+            error_type="ambiguous_catcher_assignment",
+            error_message=(
+                "confirmed lineup must identify exactly "
+                "one catcher per team"
+            ),
+        )
+
+    assignments = []
+
+    if len(away_ids) == 1:
+        assignments.append(
+            CanonicalCatcherTeamAssignment(
+                catcher_id=away_ids[0],
+                team_side="away",
+                assignment_source_version=(
+                    CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION
+                ),
+            )
+        )
+
+    if len(home_ids) == 1:
+        assignments.append(
+            CanonicalCatcherTeamAssignment(
+                catcher_id=home_ids[0],
+                team_side="home",
+                assignment_source_version=(
+                    CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION
+                ),
+            )
+        )
+
+    ready = len(assignments) == 2
+
+    return CanonicalCatcherAssignmentDiscovery(
+        assignments=tuple(assignments),
+        away_candidate_count=len(away_ids),
+        home_candidate_count=len(home_ids),
+        status=(
+            "ready"
+            if ready
+            else "partial"
+            if assignments
+            else "unavailable"
+        ),
+    )

--- a/tests/test_canonical_catcher_assignment_discovery.py
+++ b/tests/test_canonical_catcher_assignment_discovery.py
@@ -1,0 +1,216 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION,
+    CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION,
+    discover_confirmed_catcher_assignments,
+)
+
+
+def lineup():
+    return {
+        "away": [
+            {
+                "batter_id": 101,
+                "position": "SS",
+                "position_code": "6",
+            },
+            {
+                "batter_id": 102,
+                "position": "C",
+                "position_code": "2",
+            },
+        ],
+        "home": [
+            {
+                "batter_id": 201,
+                "position": "Catcher",
+                "position_code": "2",
+            },
+            {
+                "batter_id": 202,
+                "position": "1B",
+                "position_code": "3",
+            },
+        ],
+    }
+
+
+def discover(payload=None):
+    value = lineup() if payload is None else payload
+
+    return discover_confirmed_catcher_assignments(
+        game_pk=824406,
+        lineup_fetcher=lambda game_pk: value,
+    )
+
+
+def test_discovers_exact_confirmed_catchers():
+    result = discover()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.away_candidate_count == 1
+    assert result.home_candidate_count == 1
+
+    assert tuple(
+        (
+            value.catcher_id,
+            value.team_side,
+            value.assignment_source_version,
+        )
+        for value in result.assignments
+    ) == (
+        (
+            "102",
+            "away",
+            CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION,
+        ),
+        (
+            "201",
+            "home",
+            CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION,
+        ),
+    )
+
+
+def test_position_code_is_exact_catcher_evidence():
+    result = discover(
+        {
+            "away": [
+                {
+                    "batter_id": "301",
+                    "position": None,
+                    "position_code": 2,
+                },
+            ],
+            "home": [
+                {
+                    "batter_id": "401",
+                    "position": None,
+                    "position_code": "2",
+                },
+            ],
+        }
+    )
+
+    assert result.ready is True
+    assert tuple(
+        value.catcher_id
+        for value in result.assignments
+    ) == ("301", "401")
+
+
+def test_roster_membership_does_not_infer_catcher():
+    result = discover(
+        {
+            "away": [
+                {
+                    "batter_id": 101,
+                    "position": "SS",
+                },
+            ],
+            "home": [
+                {
+                    "batter_id": 201,
+                    "position": "1B",
+                },
+            ],
+        }
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.assignments == ()
+
+
+def test_missing_one_side_is_partial():
+    result = discover(
+        {
+            "away": [
+                {
+                    "batter_id": 102,
+                    "position": "C",
+                },
+            ],
+            "home": [],
+        }
+    )
+
+    assert result.status == "partial"
+    assert result.ready is False
+    assert len(result.assignments) == 1
+    assert result.assignments[0].team_side == "away"
+
+
+def test_ambiguous_catcher_assignment_fails_open():
+    result = discover(
+        {
+            "away": [
+                {
+                    "batter_id": 101,
+                    "position": "C",
+                },
+                {
+                    "batter_id": 102,
+                    "position": "Catcher",
+                },
+            ],
+            "home": [
+                {
+                    "batter_id": 201,
+                    "position": "C",
+                },
+            ],
+        }
+    )
+
+    assert result.status == "blocked"
+    assert result.ready is False
+    assert result.assignments == ()
+    assert result.error_type == (
+        "ambiguous_catcher_assignment"
+    )
+
+
+def test_fetch_failure_fails_open():
+    def unavailable(game_pk):
+        raise RuntimeError("lineup source unavailable")
+
+    result = discover_confirmed_catcher_assignments(
+        game_pk=824406,
+        lineup_fetcher=unavailable,
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.error_type == "RuntimeError"
+    assert result.error_message == (
+        "lineup source unavailable"
+    )
+
+
+def test_invalid_payload_fails_open():
+    result = discover_confirmed_catcher_assignments(
+        game_pk=824406,
+        lineup_fetcher=lambda game_pk: object(),
+    )
+
+    assert result.status == "blocked"
+    assert result.ready is False
+    assert result.error_type == "invalid_payload"
+
+
+def test_missing_game_pk_is_blocked_without_fetch():
+    result = discover_confirmed_catcher_assignments(
+        game_pk=None,
+        lineup_fetcher=lambda game_pk: lineup(),
+    )
+
+    assert result.status == "blocked"
+    assert result.ready is False
+    assert result.error_type == "missing_game_pk"
+
+
+def test_discovery_version_is_explicit():
+    assert discover().discovery_version == (
+        CANONICAL_CATCHER_ASSIGNMENT_DISCOVERY_VERSION
+    )


### PR DESCRIPTION
## Summary
- discover exact away and home catcher assignments from confirmed MLB boxscore lineup positions
- accept only explicit catcher position evidence and fail open for missing, malformed, or ambiguous assignments
- export versioned discovery contracts for downstream catcher-context composition

## Why
Canonical baserunning needs the active catcher identity before sourced pop-time evidence can be attached safely. This slice adds that identity boundary without inferring from roster membership or activating stolen bases in production.

## Validation
- `112 passed, 1 warning in 1.07s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment