### PR TITLE
Materialize confirmed catcher observations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -25,6 +25,11 @@ from .catcher_assignment_discovery import (
     CanonicalCatcherAssignmentDiscovery,
     discover_confirmed_catcher_assignments,
 )
+from .catcher_observation_composition import (
+    CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION,
+    CanonicalCatcherObservationComposition,
+    compose_confirmed_catcher_observations,
+)
 from .comparator import compare_shadow_payloads
 from .bullpen_discovery import (
     CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION,
@@ -163,6 +168,9 @@ __all__ = [
     "CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION",
     "CanonicalCatcherAssignmentDiscovery",
     "discover_confirmed_catcher_assignments",
+    "CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION",
+    "CanonicalCatcherObservationComposition",
+    "compose_confirmed_catcher_observations",
     "SHADOW_SCHEMA_VERSION",
     "CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION",
     "CanonicalShadowBaserunningEvidenceDiscovery",

--- a/mlb_app/simulation/shadow/catcher_observation_composition.py
+++ b/mlb_app/simulation/shadow/catcher_observation_composition.py
@@ -1,0 +1,303 @@
+"""Compose complete observed catcher baserunning evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .catcher_assignment_discovery import (
+    CanonicalCatcherAssignmentDiscovery,
+)
+from .catcher_baserunning_evidence import (
+    CanonicalCatcherBaserunningObservation,
+)
+from .catcher_context_composition import (
+    compose_catcher_baserunning_contexts,
+)
+from .catcher_pop_time_evidence import (
+    CanonicalCatcherPopTimeObservation,
+)
+from .statcast_baserunning_source import (
+    CanonicalStatcastCatcherBaserunningCounts,
+    materialize_statcast_catcher_observations,
+)
+
+
+CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION = (
+    "canonical_catcher_observation_composition_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalCatcherObservationComposition:
+    """Fail-open result of composing matchup catcher evidence."""
+
+    observations: Tuple[
+        CanonicalCatcherBaserunningObservation,
+        ...,
+    ] = ()
+    assignment_count: int = 0
+    count_record_count: int = 0
+    pop_time_count: int = 0
+    context_count: int = 0
+    status: str = "unavailable"
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    composition_version: str = (
+        CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported catcher observation "
+                "composition status"
+            )
+
+        for name, value in (
+            ("assignment_count", self.assignment_count),
+            ("count_record_count", self.count_record_count),
+            ("pop_time_count", self.pop_time_count),
+            ("context_count", self.context_count),
+        ):
+            if not isinstance(value, int):
+                raise TypeError(
+                    f"{name} must be an integer"
+                )
+            if value < 0:
+                raise ValueError(
+                    f"{name} must be nonnegative"
+                )
+
+        for value in self.observations:
+            if not isinstance(
+                value,
+                CanonicalCatcherBaserunningObservation,
+            ):
+                raise TypeError(
+                    "observations must contain "
+                    "CanonicalCatcherBaserunningObservation"
+                )
+
+        if self.status == "ready":
+            if len(self.observations) != 2:
+                raise ValueError(
+                    "ready composition requires two "
+                    "catcher observations"
+                )
+
+            sides = {
+                value.team_side
+                for value in self.observations
+            }
+
+            if sides != {"away", "home"}:
+                raise ValueError(
+                    "ready composition requires away "
+                    "and home catcher observations"
+                )
+        elif self.observations:
+            raise ValueError(
+                "non-ready composition cannot expose "
+                "catcher observations"
+            )
+
+        if self.composition_version != (
+            CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION
+        ):
+            raise ValueError(
+                "unsupported catcher observation "
+                "composition version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.status == "ready"
+            and len(self.observations) == 2
+        )
+
+    @property
+    def away_observation(
+        self,
+    ) -> Optional[
+        CanonicalCatcherBaserunningObservation
+    ]:
+        return next(
+            (
+                value
+                for value in self.observations
+                if value.team_side == "away"
+            ),
+            None,
+        )
+
+    @property
+    def home_observation(
+        self,
+    ) -> Optional[
+        CanonicalCatcherBaserunningObservation
+    ]:
+        return next(
+            (
+                value
+                for value in self.observations
+                if value.team_side == "home"
+            ),
+            None,
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.composition_version,
+            "status": self.status,
+            "ready": self.ready,
+            "assignment_count": self.assignment_count,
+            "count_record_count": self.count_record_count,
+            "pop_time_count": self.pop_time_count,
+            "context_count": self.context_count,
+            "observation_count": len(
+                self.observations
+            ),
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "production_activation": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def compose_confirmed_catcher_observations(
+    *,
+    assignment_discovery: (
+        CanonicalCatcherAssignmentDiscovery
+    ),
+    counts: Tuple[
+        CanonicalStatcastCatcherBaserunningCounts,
+        ...,
+    ] = (),
+    pop_times: Tuple[
+        CanonicalCatcherPopTimeObservation,
+        ...,
+    ] = (),
+) -> CanonicalCatcherObservationComposition:
+    """
+    Compose complete catcher observations for both matchup sides.
+
+    Confirmed identity, exact outcome counts, and sourced pop time must
+    all be present for both teams. Partial or invalid evidence fails open
+    and cannot expose observations or activate production behavior.
+    """
+
+    if not isinstance(
+        assignment_discovery,
+        CanonicalCatcherAssignmentDiscovery,
+    ):
+        return CanonicalCatcherObservationComposition(
+            status="error",
+            error_type="TypeError",
+            error_message=(
+                "assignment_discovery must be "
+                "CanonicalCatcherAssignmentDiscovery"
+            ),
+        )
+
+    assignment_count = len(
+        assignment_discovery.assignments
+    )
+    count_record_count = (
+        len(counts)
+        if isinstance(counts, tuple)
+        else 0
+    )
+    pop_time_count = (
+        len(pop_times)
+        if isinstance(pop_times, tuple)
+        else 0
+    )
+
+    if not assignment_discovery.ready:
+        return CanonicalCatcherObservationComposition(
+            assignment_count=assignment_count,
+            count_record_count=count_record_count,
+            pop_time_count=pop_time_count,
+            status="unavailable",
+        )
+
+    try:
+        if not isinstance(counts, tuple):
+            raise TypeError(
+                "counts must be a tuple"
+            )
+
+        if not isinstance(pop_times, tuple):
+            raise TypeError(
+                "pop_times must be a tuple"
+            )
+
+        contexts = compose_catcher_baserunning_contexts(
+            assignments=(
+                assignment_discovery.assignments
+            ),
+            pop_times=pop_times,
+        )
+
+        observations = (
+            materialize_statcast_catcher_observations(
+                counts=counts,
+                contexts=contexts,
+            )
+        )
+
+        observations_by_side = {
+            value.team_side: value
+            for value in observations
+        }
+
+        complete = (
+            len(contexts) == 2
+            and len(observations) == 2
+            and set(observations_by_side)
+            == {"away", "home"}
+        )
+
+        if not complete:
+            return (
+                CanonicalCatcherObservationComposition(
+                    assignment_count=assignment_count,
+                    count_record_count=(
+                        count_record_count
+                    ),
+                    pop_time_count=pop_time_count,
+                    context_count=len(contexts),
+                    status="unavailable",
+                )
+            )
+
+        ordered = (
+            observations_by_side["away"],
+            observations_by_side["home"],
+        )
+
+        return CanonicalCatcherObservationComposition(
+            observations=ordered,
+            assignment_count=assignment_count,
+            count_record_count=count_record_count,
+            pop_time_count=pop_time_count,
+            context_count=len(contexts),
+            status="ready",
+        )
+    except Exception as exc:
+        return CanonicalCatcherObservationComposition(
+            assignment_count=assignment_count,
+            count_record_count=count_record_count,
+            pop_time_count=pop_time_count,
+            status="error",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+        )

--- a/tests/test_canonical_catcher_observation_composition.py
+++ b/tests/test_canonical_catcher_observation_composition.py
@@ -1,0 +1,275 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION,
+    CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION,
+    CanonicalCatcherAssignmentDiscovery,
+    CanonicalCatcherPopTimeObservation,
+    CanonicalCatcherTeamAssignment,
+    CanonicalStatcastCatcherBaserunningCounts,
+    compose_confirmed_catcher_observations,
+)
+
+
+def assignment(
+    catcher_id,
+    team_side,
+):
+    return CanonicalCatcherTeamAssignment(
+        catcher_id=catcher_id,
+        team_side=team_side,
+        assignment_source_version=(
+            CONFIRMED_CATCHER_ASSIGNMENT_SOURCE_VERSION
+        ),
+    )
+
+
+def assignment_discovery(
+    *,
+    status="ready",
+    assignments=None,
+):
+    if assignments is None:
+        assignments = (
+            assignment("away-catcher", "away"),
+            assignment("home-catcher", "home"),
+        )
+
+    return CanonicalCatcherAssignmentDiscovery(
+        assignments=assignments,
+        away_candidate_count=1,
+        home_candidate_count=1,
+        status=status,
+    )
+
+
+def count(
+    catcher_id,
+    *,
+    opportunities=20,
+    stolen_bases_allowed=5,
+    caught_stealing=2,
+):
+    return CanonicalStatcastCatcherBaserunningCounts(
+        catcher_id=catcher_id,
+        eligible_opportunities=opportunities,
+        stolen_bases_allowed=stolen_bases_allowed,
+        caught_stealing=caught_stealing,
+    )
+
+
+def pop_time(
+    catcher_id,
+    seconds,
+):
+    return CanonicalCatcherPopTimeObservation(
+        catcher_id=catcher_id,
+        pop_time_seconds=seconds,
+    )
+
+
+def compose(**overrides):
+    values = {
+        "assignment_discovery": (
+            assignment_discovery()
+        ),
+        "counts": (
+            count("home-catcher"),
+            count(
+                "away-catcher",
+                stolen_bases_allowed=4,
+                caught_stealing=3,
+            ),
+        ),
+        "pop_times": (
+            pop_time("home-catcher", 1.95),
+            pop_time("away-catcher", 1.89),
+        ),
+    }
+    values.update(overrides)
+
+    return compose_confirmed_catcher_observations(
+        **values
+    )
+
+
+def test_composes_complete_confirmed_observations():
+    result = compose()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.assignment_count == 2
+    assert result.count_record_count == 2
+    assert result.pop_time_count == 2
+    assert result.context_count == 2
+
+    assert result.away_observation is not None
+    assert result.home_observation is not None
+
+    assert result.away_observation.catcher_id == (
+        "away-catcher"
+    )
+    assert (
+        result.away_observation.steal_attempts_against
+        == 7
+    )
+    assert result.away_observation.caught_stealing == 3
+    assert result.away_observation.pop_time_score == 0.7
+
+    assert result.home_observation.catcher_id == (
+        "home-catcher"
+    )
+    assert (
+        result.home_observation.steal_attempts_against
+        == 7
+    )
+    assert result.home_observation.caught_stealing == 2
+    assert result.home_observation.pop_time_score == 0.5
+
+
+def test_observations_are_ordered_away_then_home():
+    result = compose()
+
+    assert tuple(
+        value.team_side
+        for value in result.observations
+    ) == ("away", "home")
+
+
+def test_incomplete_assignment_discovery_fails_open():
+    result = compose(
+        assignment_discovery=(
+            CanonicalCatcherAssignmentDiscovery(
+                assignments=(
+                    assignment(
+                        "away-catcher",
+                        "away",
+                    ),
+                ),
+                away_candidate_count=1,
+                home_candidate_count=0,
+                status="partial",
+            )
+        ),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.observations == ()
+    assert result.assignment_count == 1
+
+
+def test_missing_pop_time_fails_open():
+    result = compose(
+        pop_times=(
+            pop_time("away-catcher", 1.89),
+        ),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.observations == ()
+    assert result.context_count == 1
+
+
+def test_missing_count_record_fails_open():
+    result = compose(
+        counts=(
+            count("away-catcher"),
+        ),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.observations == ()
+
+
+def test_unassigned_evidence_does_not_complete_matchup():
+    result = compose(
+        counts=(
+            count("away-catcher"),
+            count("other-catcher"),
+        ),
+        pop_times=(
+            pop_time("away-catcher", 1.89),
+            pop_time("other-catcher", 1.95),
+        ),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.observations == ()
+
+
+def test_invalid_assignment_contract_fails_open():
+    result = compose_confirmed_catcher_observations(
+        assignment_discovery=object(),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.observations == ()
+    assert result.error_type == "TypeError"
+    assert result.error_message == (
+        "assignment_discovery must be "
+        "CanonicalCatcherAssignmentDiscovery"
+    )
+
+
+def test_invalid_count_contract_fails_open():
+    result = compose(
+        counts=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.observations == ()
+    assert result.error_type == "AttributeError"
+
+
+def test_invalid_pop_time_contract_fails_open():
+    result = compose(
+        pop_times=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.observations == ()
+    assert result.error_type == "TypeError"
+    assert result.error_message == (
+        "pop_times must contain "
+        "CanonicalCatcherPopTimeObservation"
+    )
+
+
+def test_non_tuple_evidence_fails_open():
+    result = compose(
+        counts=[],
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.error_type == "TypeError"
+    assert result.error_message == (
+        "counts must be a tuple"
+    )
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = compose().to_diagnostics()
+
+    assert diagnostics["ready"] is True
+    assert diagnostics["observation_count"] == 2
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_composition_is_deterministic():
+    first = compose()
+    second = compose()
+
+    assert first == second
+
+
+def test_composition_version_is_explicit():
+    assert compose().composition_version == (
+        CANONICAL_CATCHER_OBSERVATION_COMPOSITION_VERSION
+    )


### PR DESCRIPTION
## Summary
- compose confirmed catcher assignments with sourced pop-time evidence
- join the resulting catcher contexts to exact Statcast catcher counts
- expose complete away and home catcher observations only when all required evidence is present
- preserve deterministic ordering, diagnostics, and fail-open behavior

## Why
Canonical baserunning catalog discovery requires complete catcher observations for both matchup sides. This slice connects the existing identity, pop-time, and Statcast-count contracts without fabricating partial evidence or activating production behavior.

## Safety
- legacy remains authoritative
- production activation remains false
- incomplete or invalid evidence exposes no observations

## Validation
- `125 passed, 1 warning in 1.05s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment