### PR TITLE
Attach composed catchers to baserunning discovery

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -77,6 +77,7 @@ from .pitcher_baserunning_evidence import (
 )
 from .observed_baserunning_evidence import (
     CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION,
+    discover_composed_canonical_baserunning_evidence,
     discover_observed_canonical_baserunning_evidence,
 )
 from .probability_provider_discovery import (
@@ -189,6 +190,7 @@ __all__ = [
     "CanonicalPitcherBaserunningObservation",
     "adapt_observed_pitcher_baserunning_evidence",
     "CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION",
+    "discover_composed_canonical_baserunning_evidence",
     "discover_observed_canonical_baserunning_evidence",
     "CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",

--- a/mlb_app/simulation/shadow/observed_baserunning_evidence.py
+++ b/mlb_app/simulation/shadow/observed_baserunning_evidence.py
@@ -14,6 +14,9 @@ from .catcher_baserunning_evidence import (
     CanonicalCatcherBaserunningObservation,
     adapt_observed_catcher_baserunning_evidence,
 )
+from .catcher_observation_composition import (
+    CanonicalCatcherObservationComposition,
+)
 from .pitcher_baserunning_evidence import (
     CanonicalPitcherBaserunningObservation,
     adapt_observed_pitcher_baserunning_evidence,
@@ -174,4 +177,83 @@ def discover_observed_canonical_baserunning_evidence(
     return replace(
         discovery,
         observation_digest=observation_digest,
+    )
+
+
+
+def discover_composed_canonical_baserunning_evidence(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    catcher_composition: (
+        CanonicalCatcherObservationComposition
+    ),
+    runner_observations: Tuple[
+        CanonicalRunnerBaserunningObservation,
+        ...,
+    ] = (),
+    pitcher_observations: Tuple[
+        CanonicalPitcherBaserunningObservation,
+        ...,
+    ] = (),
+) -> CanonicalShadowBaserunningEvidenceDiscovery:
+    """
+    Discover a catalog from one composed two-sided catcher result.
+
+    An unavailable catcher composition leaves catalog discovery unavailable.
+    An invalid or failed composition returns a fail-open error. Production
+    activation and legacy authority remain unchanged.
+    """
+
+    if not isinstance(
+        catcher_composition,
+        CanonicalCatcherObservationComposition,
+    ):
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            requested_runner_count=len(
+                required_runner_ids
+            ),
+            requested_pitcher_count=len(
+                required_pitcher_ids
+            ),
+            status="error",
+            error_message=(
+                "catcher_composition must be "
+                "CanonicalCatcherObservationComposition"
+            ),
+        )
+
+    if catcher_composition.status == "error":
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            requested_runner_count=len(
+                required_runner_ids
+            ),
+            requested_pitcher_count=len(
+                required_pitcher_ids
+            ),
+            status="error",
+            error_message=(
+                catcher_composition.error_message
+                or "catcher observation composition failed"
+            ),
+        )
+
+    away_catcher = (
+        catcher_composition.away_observation
+        if catcher_composition.ready
+        else None
+    )
+    home_catcher = (
+        catcher_composition.home_observation
+        if catcher_composition.ready
+        else None
+    )
+
+    return discover_observed_canonical_baserunning_evidence(
+        required_runner_ids=required_runner_ids,
+        required_pitcher_ids=required_pitcher_ids,
+        runner_observations=runner_observations,
+        pitcher_observations=pitcher_observations,
+        away_catcher_observation=away_catcher,
+        home_catcher_observation=home_catcher,
     )

--- a/tests/test_canonical_composed_baserunning_discovery.py
+++ b/tests/test_canonical_composed_baserunning_discovery.py
@@ -1,0 +1,219 @@
+from mlb_app.simulation.shadow import (
+    CanonicalCatcherBaserunningObservation,
+    CanonicalCatcherObservationComposition,
+    CanonicalPitcherBaserunningObservation,
+    CanonicalRunnerBaserunningObservation,
+    discover_composed_canonical_baserunning_evidence,
+)
+
+
+def runner():
+    return CanonicalRunnerBaserunningObservation(
+        runner_id="runner",
+        eligible_opportunities=20,
+        stolen_bases=6,
+        caught_stealing=2,
+        speed_score=0.90,
+        lead_quality=0.80,
+        fatigue_index=0.10,
+    )
+
+
+def pitcher():
+    return CanonicalPitcherBaserunningObservation(
+        pitcher_id="pitcher",
+        eligible_pickoff_opportunities=25,
+        pickoff_attempts=5,
+        successful_pickoffs=1,
+        hold_score=0.75,
+        delivery_time_score=0.70,
+    )
+
+
+def catcher(
+    catcher_id,
+    team_side,
+):
+    return CanonicalCatcherBaserunningObservation(
+        catcher_id=catcher_id,
+        team_side=team_side,
+        steal_attempts_against=10,
+        caught_stealing=3,
+        pop_time_score=0.85,
+    )
+
+
+def ready_composition():
+    return CanonicalCatcherObservationComposition(
+        observations=(
+            catcher("away-catcher", "away"),
+            catcher("home-catcher", "home"),
+        ),
+        assignment_count=2,
+        count_record_count=2,
+        pop_time_count=2,
+        context_count=2,
+        status="ready",
+    )
+
+
+def discover(
+    *,
+    catcher_composition=None,
+):
+    if catcher_composition is None:
+        catcher_composition = ready_composition()
+
+    return discover_composed_canonical_baserunning_evidence(
+        required_runner_ids=("runner",),
+        required_pitcher_ids=("pitcher",),
+        runner_observations=(runner(),),
+        pitcher_observations=(pitcher(),),
+        catcher_composition=catcher_composition,
+    )
+
+
+def test_ready_composition_builds_catalog():
+    result = discover()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.catalog is not None
+
+    assert result.catalog.away_catcher.catcher_id == (
+        "away-catcher"
+    )
+    assert result.catalog.away_catcher.team_side == "away"
+
+    assert result.catalog.home_catcher.catcher_id == (
+        "home-catcher"
+    )
+    assert result.catalog.home_catcher.team_side == "home"
+
+
+def test_ready_composition_preserves_observation_digest():
+    result = discover()
+
+    assert result.observation_digest is not None
+    assert len(result.observation_digest) == 64
+    assert (
+        result.to_diagnostics()["observation_digest"]
+        == result.observation_digest
+    )
+
+
+def test_unavailable_composition_blocks_catalog():
+    result = discover(
+        catcher_composition=(
+            CanonicalCatcherObservationComposition(
+                assignment_count=1,
+                count_record_count=1,
+                pop_time_count=1,
+                context_count=1,
+                status="unavailable",
+            )
+        ),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.observation_digest is not None
+
+
+def test_error_composition_fails_open():
+    result = discover(
+        catcher_composition=(
+            CanonicalCatcherObservationComposition(
+                status="error",
+                error_type="ValueError",
+                error_message=(
+                    "catcher evidence is incomplete"
+                ),
+            )
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.observation_digest is None
+    assert result.error_message == (
+        "catcher evidence is incomplete"
+    )
+
+
+def test_error_without_message_uses_explicit_fallback():
+    result = discover(
+        catcher_composition=(
+            CanonicalCatcherObservationComposition(
+                status="error",
+                error_type="RuntimeError",
+            )
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "catcher observation composition failed"
+    )
+
+
+def test_invalid_composition_contract_fails_open():
+    result = (
+        discover_composed_canonical_baserunning_evidence(
+            required_runner_ids=("runner",),
+            required_pitcher_ids=("pitcher",),
+            runner_observations=(runner(),),
+            pitcher_observations=(pitcher(),),
+            catcher_composition=object(),
+        )
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.requested_runner_count == 1
+    assert result.requested_pitcher_count == 1
+    assert result.error_message == (
+        "catcher_composition must be "
+        "CanonicalCatcherObservationComposition"
+    )
+
+
+def test_missing_runner_evidence_remains_unavailable():
+    result = (
+        discover_composed_canonical_baserunning_evidence(
+            required_runner_ids=("runner",),
+            required_pitcher_ids=("pitcher",),
+            runner_observations=(),
+            pitcher_observations=(pitcher(),),
+            catcher_composition=ready_composition(),
+        )
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_runner_count == 0
+
+
+def test_same_composition_produces_same_catalog():
+    first = discover()
+    second = discover()
+
+    assert first.catalog is not None
+    assert second.catalog is not None
+    assert first.catalog.digest == second.catalog.digest
+    assert (
+        first.observation_digest
+        == second.observation_digest
+    )
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = discover().to_diagnostics()
+
+    assert diagnostics["ready"] is True
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"


### PR DESCRIPTION
## Summary
- accept a complete two-sided catcher observation composition in observed baserunning discovery
- map composed away and home observations into the existing catalog-discovery contract
- keep incomplete compositions unavailable and propagate composition failures through fail-open discovery errors
- preserve deterministic catalog and observation digests

## Why
The catcher evidence pipeline now produces complete matchup observations. Catalog discovery needs a direct, typed integration point so callers do not manually wire away and home catcher observations.

## Safety
- legacy remains authoritative
- production activation remains false
- incomplete or invalid catcher compositions cannot expose a catalog

## Validation
- `80 passed, 1 warning in 1.17s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment