### PR TITLE
Materialize Statcast pitcher observations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -126,10 +126,12 @@ from .runner_sprint_speed_evidence import (
 )
 from .statcast_baserunning_source import (
     CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION,
+    CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION,
     CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
     CANONICAL_STATCAST_PICKOFF_SOURCE_VERSION,
     CanonicalCatcherBaserunningContext,
+    CanonicalPitcherBaserunningContext,
     CanonicalRunnerBaserunningContext,
     CanonicalStatcastBaserunningOutcome,
     CanonicalStatcastRunnerBaserunningCounts,
@@ -142,6 +144,7 @@ from .statcast_baserunning_source import (
     aggregate_statcast_catcher_baserunning_counts,
     decode_statcast_baserunning_outcomes,
     materialize_statcast_catcher_observations,
+    materialize_statcast_pitcher_observations,
     materialize_statcast_runner_observations,
 )
 from .integration import attach_canonical_shadow
@@ -210,10 +213,12 @@ __all__ = [
     "decode_baseball_savant_sprint_speed_rows",
     "normalize_runner_sprint_speed",
     "CANONICAL_CATCHER_BASERUNNING_MATERIALIZATION_VERSION",
+    "CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_RUNNER_BASERUNNING_MATERIALIZATION_VERSION",
     "CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION",
     "CANONICAL_STATCAST_PICKOFF_SOURCE_VERSION",
     "CanonicalCatcherBaserunningContext",
+    "CanonicalPitcherBaserunningContext",
     "CanonicalRunnerBaserunningContext",
     "CanonicalStatcastBaserunningOutcome",
     "CanonicalStatcastRunnerBaserunningCounts",
@@ -226,6 +231,7 @@ __all__ = [
     "aggregate_statcast_catcher_baserunning_counts",
     "decode_statcast_baserunning_outcomes",
     "materialize_statcast_catcher_observations",
+    "materialize_statcast_pitcher_observations",
     "materialize_statcast_runner_observations",
     "CanonicalShadowDiagnostics",
     "CanonicalShadowBullpenDiscovery",

--- a/mlb_app/simulation/shadow/statcast_baserunning_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_source.py
@@ -20,6 +20,9 @@ from .catcher_baserunning_evidence import (
 from .runner_baserunning_evidence import (
     CanonicalRunnerBaserunningObservation,
 )
+from .pitcher_baserunning_evidence import (
+    CanonicalPitcherBaserunningObservation,
+)
 
 
 CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION = (
@@ -1305,3 +1308,162 @@ def aggregate_statcast_pitcher_pickoff_counts(
         )
         for pitcher_id, values in counts.items()
     )
+
+
+
+CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION = (
+    "canonical_pitcher_baserunning_materialization_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherBaserunningContext:
+    """Explicit non-count baserunning context for one pitcher."""
+
+    pitcher_id: str
+    hold_score: float
+    delivery_time_score: float
+    context_source_version: str = "unavailable"
+    materialization_version: str = (
+        CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        for name, value in (
+            ("hold_score", self.hold_score),
+            (
+                "delivery_time_score",
+                self.delivery_time_score,
+            ),
+        ):
+            _validate_unit_rate(
+                name=name,
+                value=value,
+            )
+
+        if (
+            not self.context_source_version
+            or self.context_source_version
+            == "unavailable"
+        ):
+            raise ValueError(
+                "context_source_version must identify "
+                "an available source"
+            )
+
+        if self.materialization_version != (
+            CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported pitcher baserunning "
+                "materialization version"
+            )
+
+
+def materialize_statcast_pitcher_observations(
+    *,
+    counts: Tuple[
+        CanonicalStatcastPitcherPickoffCounts,
+        ...,
+    ],
+    contexts: Tuple[
+        CanonicalPitcherBaserunningContext,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalPitcherBaserunningObservation,
+    ...,
+]:
+    """
+    Join exact Statcast pickoff counts to complete pitcher context.
+
+    Missing hold or delivery-time context yields no observation. Neither
+    a neutral score nor another pitcher-level statistic is substituted.
+    """
+
+    for value in counts:
+        if not isinstance(
+            value,
+            CanonicalStatcastPitcherPickoffCounts,
+        ):
+            raise TypeError(
+                "counts must contain "
+                "CanonicalStatcastPitcherPickoffCounts"
+            )
+
+    for value in contexts:
+        if not isinstance(
+            value,
+            CanonicalPitcherBaserunningContext,
+        ):
+            raise TypeError(
+                "contexts must contain "
+                "CanonicalPitcherBaserunningContext"
+            )
+
+    count_ids = [
+        value.pitcher_id
+        for value in counts
+    ]
+    context_ids = [
+        value.pitcher_id
+        for value in contexts
+    ]
+
+    if len(count_ids) != len(set(count_ids)):
+        raise ValueError(
+            "pitcher pickoff count identifiers "
+            "must be unique"
+        )
+
+    if len(context_ids) != len(set(context_ids)):
+        raise ValueError(
+            "pitcher context identifiers must be unique"
+        )
+
+    contexts_by_id = {
+        value.pitcher_id: value
+        for value in contexts
+    }
+
+    observations = []
+
+    for value in counts:
+        context = contexts_by_id.get(
+            value.pitcher_id
+        )
+
+        if context is None:
+            continue
+
+        observations.append(
+            CanonicalPitcherBaserunningObservation(
+                pitcher_id=value.pitcher_id,
+                eligible_pickoff_opportunities=(
+                    value.eligible_opportunities
+                ),
+                pickoff_attempts=(
+                    value.pickoff_attempts
+                ),
+                successful_pickoffs=(
+                    value.successful_pickoffs
+                ),
+                hold_score=float(
+                    context.hold_score
+                ),
+                delivery_time_score=float(
+                    context.delivery_time_score
+                ),
+                source_version=(
+                    f"{value.source_version}+"
+                    f"{context.context_source_version}"
+                ),
+            )
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_pitcher_baserunning_materialization.py
+++ b/tests/test_canonical_pitcher_baserunning_materialization.py
@@ -1,0 +1,216 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION,
+    CANONICAL_STATCAST_PICKOFF_SOURCE_VERSION,
+    CanonicalPitcherBaserunningContext,
+    CanonicalStatcastPitcherPickoffCounts,
+    materialize_statcast_pitcher_observations,
+)
+
+
+def count(
+    pitcher_id="pitcher",
+    *,
+    opportunities=40,
+    attempts=8,
+    successes=2,
+):
+    return CanonicalStatcastPitcherPickoffCounts(
+        pitcher_id=pitcher_id,
+        eligible_opportunities=opportunities,
+        pickoff_attempts=attempts,
+        successful_pickoffs=successes,
+    )
+
+
+def context(
+    pitcher_id="pitcher",
+    *,
+    hold_score=0.72,
+    delivery_time_score=0.38,
+):
+    return CanonicalPitcherBaserunningContext(
+        pitcher_id=pitcher_id,
+        hold_score=hold_score,
+        delivery_time_score=delivery_time_score,
+        context_source_version=(
+            "explicit_pitcher_hold_context_v1"
+        ),
+    )
+
+
+def test_materializes_complete_pitcher_observation():
+    observations = (
+        materialize_statcast_pitcher_observations(
+            counts=(count(),),
+            contexts=(context(),),
+        )
+    )
+
+    assert len(observations) == 1
+
+    value = observations[0]
+
+    assert value.pitcher_id == "pitcher"
+    assert value.eligible_pickoff_opportunities == 40
+    assert value.pickoff_attempts == 8
+    assert value.successful_pickoffs == 2
+    assert value.hold_score == 0.72
+    assert value.delivery_time_score == 0.38
+    assert value.pickoff_attempt_rate == 0.2
+    assert value.pickoff_success_rate == 0.25
+    assert value.source_version == (
+        f"{CANONICAL_STATCAST_PICKOFF_SOURCE_VERSION}+"
+        "explicit_pitcher_hold_context_v1"
+    )
+
+
+def test_missing_context_does_not_fabricate_observation():
+    observations = (
+        materialize_statcast_pitcher_observations(
+            counts=(count(),),
+            contexts=(),
+        )
+    )
+
+    assert observations == ()
+
+
+def test_unmatched_context_is_ignored():
+    observations = (
+        materialize_statcast_pitcher_observations(
+            counts=(count("pitcher-1"),),
+            contexts=(context("pitcher-2"),),
+        )
+    )
+
+    assert observations == ()
+
+
+def test_count_order_is_preserved():
+    observations = (
+        materialize_statcast_pitcher_observations(
+            counts=(
+                count("pitcher-2"),
+                count("pitcher-1"),
+            ),
+            contexts=(
+                context("pitcher-1"),
+                context("pitcher-2"),
+            ),
+        )
+    )
+
+    assert tuple(
+        value.pitcher_id
+        for value in observations
+    ) == ("pitcher-2", "pitcher-1")
+
+
+def test_duplicate_count_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher pickoff count identifiers "
+            "must be unique"
+        ),
+    ):
+        materialize_statcast_pitcher_observations(
+            counts=(
+                count(),
+                count(attempts=7),
+            ),
+            contexts=(context(),),
+        )
+
+
+def test_duplicate_context_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher context identifiers must be unique"
+        ),
+    ):
+        materialize_statcast_pitcher_observations(
+            counts=(count(),),
+            contexts=(
+                context(),
+                context(hold_score=0.60),
+            ),
+        )
+
+
+def test_invalid_count_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "counts must contain "
+            "CanonicalStatcastPitcherPickoffCounts"
+        ),
+    ):
+        materialize_statcast_pitcher_observations(
+            counts=(object(),),
+            contexts=(),
+        )
+
+
+def test_invalid_context_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "contexts must contain "
+            "CanonicalPitcherBaserunningContext"
+        ),
+    ):
+        materialize_statcast_pitcher_observations(
+            counts=(),
+            contexts=(object(),),
+        )
+
+
+def test_context_requires_explicit_source():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "context_source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalPitcherBaserunningContext(
+            pitcher_id="pitcher",
+            hold_score=0.50,
+            delivery_time_score=0.50,
+        )
+
+
+def test_context_rejects_invalid_scores():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "delivery_time_score must be between 0 and 1"
+        ),
+    ):
+        context(
+            delivery_time_score=1.01,
+        )
+
+
+def test_materialization_is_deterministic():
+    first = materialize_statcast_pitcher_observations(
+        counts=(count(),),
+        contexts=(context(),),
+    )
+    second = materialize_statcast_pitcher_observations(
+        counts=(count(),),
+        contexts=(context(),),
+    )
+
+    assert first == second
+    assert first[0].digest == second[0].digest
+
+
+def test_materialization_version_is_explicit():
+    assert context().materialization_version == (
+        CANONICAL_PITCHER_BASERUNNING_MATERIALIZATION_VERSION
+    )


### PR DESCRIPTION
## Summary
- add a versioned explicit pitcher baserunning context contract for hold and delivery-time scores
- materialize canonical pitcher observations by joining exact Statcast pickoff counts to matching context
- preserve count order and deterministic observation digests
- validate contracts before identifier access and reject duplicate identities

## Why
Observed baserunning catalog discovery requires pitcher profiles backed by both exact pickoff counts and complete non-count context. Missing context must omit the observation rather than fabricate neutral behavior.

## Safety
- missing context produces no pitcher observation
- no steal statistic is substituted for pickoff behavior
- legacy remains authoritative and production activation is unchanged

## Validation
- `123 passed, 1 warning in 0.92s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment