### PR TITLE
Source pitcher delivery-time evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -75,6 +75,15 @@ from .pitcher_baserunning_evidence import (
     CanonicalPitcherBaserunningObservation,
     adapt_observed_pitcher_baserunning_evidence,
 )
+from .pitcher_delivery_time_evidence import (
+    CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION,
+    CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION,
+    FAST_DELIVERY_TIME_SECONDS,
+    SLOW_DELIVERY_TIME_SECONDS,
+    CanonicalPitcherDeliveryTimeObservation,
+    decode_pitcher_delivery_time_rows,
+    normalize_pitcher_delivery_time,
+)
 from .observed_baserunning_evidence import (
     CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION,
     discover_composed_canonical_baserunning_evidence,
@@ -195,6 +204,13 @@ __all__ = [
     "CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalPitcherBaserunningObservation",
     "adapt_observed_pitcher_baserunning_evidence",
+    "CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION",
+    "CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION",
+    "FAST_DELIVERY_TIME_SECONDS",
+    "SLOW_DELIVERY_TIME_SECONDS",
+    "CanonicalPitcherDeliveryTimeObservation",
+    "decode_pitcher_delivery_time_rows",
+    "normalize_pitcher_delivery_time",
     "CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION",
     "discover_composed_canonical_baserunning_evidence",
     "discover_observed_canonical_baserunning_evidence",

--- a/mlb_app/simulation/shadow/pitcher_delivery_time_evidence.py
+++ b/mlb_app/simulation/shadow/pitcher_delivery_time_evidence.py
@@ -1,0 +1,178 @@
+"""Adapt explicit pitcher delivery-time measurements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Mapping, Tuple
+
+
+CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION = (
+    "observed_pitcher_delivery_time_v1"
+)
+CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION = (
+    "canonical_pitcher_delivery_time_normalization_v1"
+)
+
+FAST_DELIVERY_TIME_SECONDS = 1.20
+SLOW_DELIVERY_TIME_SECONDS = 1.60
+
+
+def normalize_pitcher_delivery_time(
+    seconds_to_plate: float,
+) -> float:
+    """
+    Normalize measured seconds to plate onto a unit score.
+
+    Faster delivery receives a higher score. Values outside the explicit
+    versioned bounds are clamped. Missing or invalid measurements are not
+    converted to neutral values.
+    """
+
+    if not isinstance(
+        seconds_to_plate,
+        (int, float),
+    ):
+        raise TypeError(
+            "seconds_to_plate must be numeric"
+        )
+
+    value = float(seconds_to_plate)
+
+    if not math.isfinite(value) or value <= 0.0:
+        raise ValueError(
+            "seconds_to_plate must be positive and finite"
+        )
+
+    span = (
+        SLOW_DELIVERY_TIME_SECONDS
+        - FAST_DELIVERY_TIME_SECONDS
+    )
+    score = (
+        SLOW_DELIVERY_TIME_SECONDS
+        - value
+    ) / span
+
+    return round(
+        min(max(score, 0.0), 1.0),
+        6,
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherDeliveryTimeObservation:
+    """One explicit measured pitcher delivery time."""
+
+    pitcher_id: str
+    seconds_to_plate: float
+    source_version: str = (
+        CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION
+    )
+    normalization_version: str = (
+        CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.pitcher_id:
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        normalize_pitcher_delivery_time(
+            self.seconds_to_plate
+        )
+
+        if (
+            not self.source_version
+            or self.source_version == "unavailable"
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+        if self.normalization_version != (
+            CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported pitcher delivery-time "
+                "normalization version"
+            )
+
+    @property
+    def delivery_time_score(self) -> float:
+        return normalize_pitcher_delivery_time(
+            self.seconds_to_plate
+        )
+
+
+def decode_pitcher_delivery_time_rows(
+    rows: Tuple[
+        Mapping[str, Any],
+        ...,
+    ],
+) -> Tuple[
+    CanonicalPitcherDeliveryTimeObservation,
+    ...,
+]:
+    """
+    Decode explicit source-agnostic pitcher timing rows.
+
+    Required fields are pitcher_id and seconds_to_plate. The optional
+    source_version must identify the actual upstream measurement source.
+    Duplicate pitcher identities are rejected rather than averaged.
+    """
+
+    if not isinstance(rows, tuple):
+        raise TypeError(
+            "rows must be a tuple"
+        )
+
+    observations = []
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "rows must contain mappings"
+            )
+
+        pitcher_id = row.get("pitcher_id")
+        seconds_to_plate = row.get(
+            "seconds_to_plate"
+        )
+
+        if pitcher_id in (None, ""):
+            raise ValueError(
+                "pitcher_id is required"
+            )
+
+        if seconds_to_plate is None:
+            raise ValueError(
+                "seconds_to_plate is required"
+            )
+
+        observations.append(
+            CanonicalPitcherDeliveryTimeObservation(
+                pitcher_id=str(pitcher_id),
+                seconds_to_plate=float(
+                    seconds_to_plate
+                ),
+                source_version=str(
+                    row.get("source_version")
+                    or CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION
+                ),
+            )
+        )
+
+    identifiers = [
+        value.pitcher_id
+        for value in observations
+    ]
+
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError(
+            "pitcher delivery-time identifiers "
+            "must be unique"
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_pitcher_delivery_time_evidence.py
+++ b/tests/test_canonical_pitcher_delivery_time_evidence.py
@@ -1,0 +1,196 @@
+import math
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION,
+    CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION,
+    FAST_DELIVERY_TIME_SECONDS,
+    SLOW_DELIVERY_TIME_SECONDS,
+    CanonicalPitcherDeliveryTimeObservation,
+    decode_pitcher_delivery_time_rows,
+    normalize_pitcher_delivery_time,
+)
+
+
+def observation(
+    *,
+    pitcher_id="pitcher",
+    seconds=1.30,
+):
+    return CanonicalPitcherDeliveryTimeObservation(
+        pitcher_id=pitcher_id,
+        seconds_to_plate=seconds,
+    )
+
+
+def test_normalizes_explicit_seconds_to_plate():
+    assert normalize_pitcher_delivery_time(
+        FAST_DELIVERY_TIME_SECONDS
+    ) == 1.0
+    assert normalize_pitcher_delivery_time(
+        SLOW_DELIVERY_TIME_SECONDS
+    ) == 0.0
+    assert normalize_pitcher_delivery_time(
+        1.30
+    ) == 0.75
+    assert normalize_pitcher_delivery_time(
+        1.40
+    ) == 0.5
+
+
+def test_normalization_clamps_outside_bounds():
+    assert normalize_pitcher_delivery_time(
+        1.00
+    ) == 1.0
+    assert normalize_pitcher_delivery_time(
+        1.80
+    ) == 0.0
+
+
+def test_observation_exposes_raw_and_normalized_values():
+    value = observation()
+
+    assert value.pitcher_id == "pitcher"
+    assert value.seconds_to_plate == 1.30
+    assert value.delivery_time_score == 0.75
+    assert value.source_version == (
+        CANONICAL_PITCHER_DELIVERY_TIME_SOURCE_VERSION
+    )
+    assert value.normalization_version == (
+        CANONICAL_PITCHER_DELIVERY_TIME_NORMALIZATION_VERSION
+    )
+
+
+def test_decodes_explicit_measurement_rows():
+    values = decode_pitcher_delivery_time_rows(
+        (
+            {
+                "pitcher_id": 100,
+                "seconds_to_plate": 1.28,
+                "source_version": (
+                    "measured_delivery_time_feed_v1"
+                ),
+            },
+            {
+                "pitcher_id": "200",
+                "seconds_to_plate": "1.44",
+                "source_version": (
+                    "measured_delivery_time_feed_v1"
+                ),
+            },
+        )
+    )
+
+    assert tuple(
+        value.pitcher_id
+        for value in values
+    ) == ("100", "200")
+    assert values[0].seconds_to_plate == 1.28
+    assert values[0].source_version == (
+        "measured_delivery_time_feed_v1"
+    )
+
+
+def test_duplicate_pitcher_measurements_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher delivery-time identifiers "
+            "must be unique"
+        ),
+    ):
+        decode_pitcher_delivery_time_rows(
+            (
+                {
+                    "pitcher_id": "pitcher",
+                    "seconds_to_plate": 1.30,
+                },
+                {
+                    "pitcher_id": "pitcher",
+                    "seconds_to_plate": 1.35,
+                },
+            )
+        )
+
+
+def test_missing_measurement_is_not_fabricated():
+    with pytest.raises(
+        ValueError,
+        match="seconds_to_plate is required",
+    ):
+        decode_pitcher_delivery_time_rows(
+            (
+                {
+                    "pitcher_id": "pitcher",
+                },
+            )
+        )
+
+
+def test_non_mapping_row_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must contain mappings",
+    ):
+        decode_pitcher_delivery_time_rows(
+            (object(),)
+        )
+
+
+def test_non_tuple_rows_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must be a tuple",
+    ):
+        decode_pitcher_delivery_time_rows(
+            []
+        )
+
+
+def test_invalid_numeric_type_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="seconds_to_plate must be numeric",
+    ):
+        normalize_pitcher_delivery_time(
+            object()
+        )
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        0.0,
+        -1.0,
+        math.inf,
+        math.nan,
+    ),
+)
+def test_invalid_measurement_is_rejected(value):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "seconds_to_plate must be positive and finite"
+        ),
+    ):
+        normalize_pitcher_delivery_time(value)
+
+
+def test_source_version_is_required():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalPitcherDeliveryTimeObservation(
+            pitcher_id="pitcher",
+            seconds_to_plate=1.30,
+            source_version="unavailable",
+        )
+
+
+def test_observation_is_deterministic():
+    assert observation() == observation()


### PR DESCRIPTION
## Summary
- add an immutable source-agnostic pitcher seconds-to-plate observation contract
- add explicit versioned normalization where faster measured delivery produces a higher unit score
- decode typed measurement rows with upstream source provenance
- reject missing, invalid, or duplicate pitcher measurements rather than averaging or supplying defaults

## Why
Canonical pitcher baserunning materialization requires delivery-time context. This boundary preserves the raw measured value and normalized score without falsely claiming a provider or inventing neutral timing.

## Safety
- no missing-value imputation
- no provider is claimed beyond supplied provenance
- legacy remains authoritative and production activation is unchanged

## Validation
- `91 passed, 1 warning in 1.05s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment