### PR TITLE
Source pitcher hold evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -281,3 +281,10 @@ __all__ = [
     "probability_resolution_diagnostics_to_dict",
     "shadow_diagnostics_to_dict",
 ]
+
+from .pitcher_hold_evidence import (
+    CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION,
+    CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION,
+    CanonicalPitcherHoldObservation,
+    adapt_statcast_pitcher_hold_evidence,
+)

--- a/mlb_app/simulation/shadow/pitcher_hold_evidence.py
+++ b/mlb_app/simulation/shadow/pitcher_hold_evidence.py
@@ -1,0 +1,156 @@
+"""Canonical pitcher hold evidence derived from exact attempt exposure."""
+
+from dataclasses import dataclass
+import math
+from typing import Tuple
+
+from .statcast_baserunning_source import (
+    CanonicalStatcastPitcherBaserunningCounts,
+)
+
+
+CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION = (
+    "canonical_pitcher_hold_evidence_v1"
+)
+CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION = (
+    "canonical_pitcher_hold_normalization_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherHoldObservation:
+    """Observed pitcher steal-attempt deterrence."""
+
+    pitcher_id: str
+    eligible_opportunities: int
+    steal_attempts_against: int
+    source_version: str
+    evidence_version: str = (
+        CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION
+    )
+    normalization_version: str = (
+        CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pitcher_id, str):
+            raise TypeError("pitcher_id must be a string")
+        if not self.pitcher_id.strip():
+            raise ValueError("pitcher_id must identify a pitcher")
+
+        if not isinstance(self.eligible_opportunities, int):
+            raise TypeError(
+                "eligible_opportunities must be an integer"
+            )
+        if self.eligible_opportunities <= 0:
+            raise ValueError(
+                "eligible_opportunities must be positive"
+            )
+
+        if not isinstance(self.steal_attempts_against, int):
+            raise TypeError(
+                "steal_attempts_against must be an integer"
+            )
+        if not (
+            0
+            <= self.steal_attempts_against
+            <= self.eligible_opportunities
+        ):
+            raise ValueError(
+                "steal_attempts_against must be between zero "
+                "and eligible_opportunities"
+            )
+
+        if not isinstance(self.source_version, str):
+            raise TypeError("source_version must be a string")
+        if not self.source_version.strip():
+            raise ValueError(
+                "source_version must identify an available source"
+            )
+
+        if (
+            self.evidence_version
+            != CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION
+        ):
+            raise ValueError(
+                "evidence_version must identify the canonical "
+                "pitcher hold evidence contract"
+            )
+        if (
+            self.normalization_version
+            != CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION
+        ):
+            raise ValueError(
+                "normalization_version must identify the canonical "
+                "pitcher hold normalization"
+            )
+
+    @property
+    def attempt_rate(self) -> float:
+        return round(
+            self.steal_attempts_against
+            / self.eligible_opportunities,
+            6,
+        )
+
+    @property
+    def hold_score(self) -> float:
+        value = 1.0 - self.attempt_rate
+        if not math.isfinite(value):
+            raise ValueError("hold_score must be finite")
+        return round(min(1.0, max(0.0, value)), 6)
+
+
+def adapt_statcast_pitcher_hold_evidence(
+    counts: Tuple[
+        CanonicalStatcastPitcherBaserunningCounts,
+        ...,
+    ],
+) -> Tuple[CanonicalPitcherHoldObservation, ...]:
+    """
+    Convert exact Statcast exposure into pitcher hold evidence.
+
+    Stolen bases and caught stealing both represent attempts against
+    the pitcher. Caught stealing does not provide extra pitcher credit,
+    and pickoff behavior remains a separate evidence contract.
+    """
+
+    if not isinstance(counts, tuple):
+        raise TypeError("counts must be a tuple")
+
+    if any(
+        not isinstance(
+            value,
+            CanonicalStatcastPitcherBaserunningCounts,
+        )
+        for value in counts
+    ):
+        raise TypeError(
+            "counts must contain "
+            "CanonicalStatcastPitcherBaserunningCounts"
+        )
+
+    pitcher_ids = [
+        value.pitcher_id
+        for value in counts
+    ]
+    if len(pitcher_ids) != len(set(pitcher_ids)):
+        raise ValueError(
+            "pitcher baserunning count identifiers must be unique"
+        )
+
+    return tuple(
+        CanonicalPitcherHoldObservation(
+            pitcher_id=value.pitcher_id,
+            eligible_opportunities=(
+                value.eligible_opportunities
+            ),
+            steal_attempts_against=(
+                value.stolen_bases_allowed
+                + value.caught_stealing
+            ),
+            source_version=value.source_version,
+        )
+        for value in counts
+        if value.eligible_opportunities > 0
+    )

--- a/tests/test_canonical_pitcher_hold_evidence.py
+++ b/tests/test_canonical_pitcher_hold_evidence.py
@@ -1,0 +1,173 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION,
+    CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION,
+    CanonicalPitcherHoldObservation,
+    CanonicalStatcastPitcherBaserunningCounts,
+    adapt_statcast_pitcher_hold_evidence,
+)
+
+
+def counts(
+    *,
+    pitcher_id="pitcher",
+    opportunities=10,
+    stolen_bases=2,
+    caught_stealing=1,
+):
+    return CanonicalStatcastPitcherBaserunningCounts(
+        pitcher_id=pitcher_id,
+        eligible_opportunities=opportunities,
+        stolen_bases_allowed=stolen_bases,
+        caught_stealing=caught_stealing,
+    )
+
+
+def test_adapts_exact_attempt_exposure():
+    observation = adapt_statcast_pitcher_hold_evidence(
+        (counts(),)
+    )[0]
+
+    assert observation.pitcher_id == "pitcher"
+    assert observation.eligible_opportunities == 10
+    assert observation.steal_attempts_against == 3
+    assert observation.attempt_rate == 0.3
+    assert observation.hold_score == 0.7
+
+
+def test_caught_stealing_counts_only_as_an_attempt():
+    stolen = adapt_statcast_pitcher_hold_evidence(
+        (
+            counts(
+                pitcher_id="stolen",
+                stolen_bases=3,
+                caught_stealing=0,
+            ),
+        )
+    )[0]
+    caught = adapt_statcast_pitcher_hold_evidence(
+        (
+            counts(
+                pitcher_id="caught",
+                stolen_bases=0,
+                caught_stealing=3,
+            ),
+        )
+    )[0]
+
+    assert stolen.steal_attempts_against == 3
+    assert caught.steal_attempts_against == 3
+    assert stolen.hold_score == caught.hold_score
+
+
+def test_zero_attempts_produce_maximum_observed_hold():
+    observation = adapt_statcast_pitcher_hold_evidence(
+        (
+            counts(
+                stolen_bases=0,
+                caught_stealing=0,
+            ),
+        )
+    )[0]
+
+    assert observation.attempt_rate == 0.0
+    assert observation.hold_score == 1.0
+
+
+def test_zero_opportunity_counts_are_omitted():
+    value = counts(
+        opportunities=0,
+        stolen_bases=0,
+        caught_stealing=0,
+    )
+
+    assert adapt_statcast_pitcher_hold_evidence(
+        (value,)
+    ) == ()
+
+
+def test_input_order_is_preserved():
+    observations = adapt_statcast_pitcher_hold_evidence(
+        (
+            counts(pitcher_id="first"),
+            counts(pitcher_id="second"),
+        )
+    )
+
+    assert tuple(
+        value.pitcher_id
+        for value in observations
+    ) == ("first", "second")
+
+
+def test_duplicate_pitcher_identifiers_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher baserunning count identifiers "
+            "must be unique"
+        ),
+    ):
+        adapt_statcast_pitcher_hold_evidence(
+            (
+                counts(),
+                counts(),
+            )
+        )
+
+
+def test_non_tuple_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="counts must be a tuple",
+    ):
+        adapt_statcast_pitcher_hold_evidence([])
+
+
+def test_invalid_count_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "counts must contain "
+            "CanonicalStatcastPitcherBaserunningCounts"
+        ),
+    ):
+        adapt_statcast_pitcher_hold_evidence(
+            (object(),)
+        )
+
+
+def test_observation_versions_are_explicit():
+    observation = adapt_statcast_pitcher_hold_evidence(
+        (counts(),)
+    )[0]
+
+    assert observation.evidence_version == (
+        CANONICAL_PITCHER_HOLD_EVIDENCE_VERSION
+    )
+    assert observation.normalization_version == (
+        CANONICAL_PITCHER_HOLD_NORMALIZATION_VERSION
+    )
+    assert observation.source_version == counts().source_version
+
+
+def test_observation_is_deterministic():
+    assert adapt_statcast_pitcher_hold_evidence(
+        (counts(),)
+    ) == adapt_statcast_pitcher_hold_evidence(
+        (counts(),)
+    )
+
+
+def test_direct_observation_requires_positive_exposure():
+    with pytest.raises(
+        ValueError,
+        match="eligible_opportunities must be positive",
+    ):
+        CanonicalPitcherHoldObservation(
+            pitcher_id="pitcher",
+            eligible_opportunities=0,
+            steal_attempts_against=0,
+            source_version="source_v1",
+        )


### PR DESCRIPTION
## Summary
- add an immutable, versioned pitcher hold observation contract
- derive steal-attempt exposure from exact Statcast pitcher baserunning counts
- normalize observed deterrence into a deterministic hold score
- preserve caught stealing as an attempt only while keeping pickoff evidence separate

## Why
Canonical pitcher baserunning materialization now has explicit delivery-time evidence but still needs hold-quality evidence. This slice supplies that missing input without assigning catcher outcomes or pickoff behavior to pitcher hold quality.

## Safety
- zero-exposure records are omitted rather than imputed
- duplicate and invalid contracts fail explicitly
- legacy remains authoritative and production activation is unchanged

## Validation
- `149 passed, 1 warning in 1.21s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment