### PR TITLE
Compose pitcher baserunning contexts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -288,3 +288,8 @@ from .pitcher_hold_evidence import (
     CanonicalPitcherHoldObservation,
     adapt_statcast_pitcher_hold_evidence,
 )
+
+from .pitcher_baserunning_context_composition import (
+    CANONICAL_PITCHER_CONTEXT_COMPOSITION_VERSION,
+    compose_pitcher_baserunning_contexts,
+)

--- a/mlb_app/simulation/shadow/pitcher_baserunning_context_composition.py
+++ b/mlb_app/simulation/shadow/pitcher_baserunning_context_composition.py
@@ -1,0 +1,133 @@
+"""Compose complete canonical pitcher baserunning contexts."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .pitcher_delivery_time_evidence import (
+    CanonicalPitcherDeliveryTimeObservation,
+)
+from .pitcher_hold_evidence import (
+    CanonicalPitcherHoldObservation,
+)
+from .statcast_baserunning_source import (
+    CanonicalPitcherBaserunningContext,
+)
+
+
+CANONICAL_PITCHER_CONTEXT_COMPOSITION_VERSION = (
+    "canonical_pitcher_context_composition_v1"
+)
+
+
+def compose_pitcher_baserunning_contexts(
+    *,
+    hold_observations: Tuple[
+        CanonicalPitcherHoldObservation,
+        ...,
+    ],
+    delivery_time_observations: Tuple[
+        CanonicalPitcherDeliveryTimeObservation,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalPitcherBaserunningContext,
+    ...,
+]:
+    """
+    Join explicit hold and delivery-time evidence by pitcher.
+
+    A pitcher missing either evidence source is omitted. No neutral hold
+    or delivery-time score is supplied. Output order follows the hold
+    observations so composition remains deterministic.
+    """
+
+    if not isinstance(hold_observations, tuple):
+        raise TypeError(
+            "hold_observations must be a tuple"
+        )
+    if not isinstance(
+        delivery_time_observations,
+        tuple,
+    ):
+        raise TypeError(
+            "delivery_time_observations must be a tuple"
+        )
+
+    if any(
+        not isinstance(
+            value,
+            CanonicalPitcherHoldObservation,
+        )
+        for value in hold_observations
+    ):
+        raise TypeError(
+            "hold_observations must contain "
+            "CanonicalPitcherHoldObservation"
+        )
+
+    if any(
+        not isinstance(
+            value,
+            CanonicalPitcherDeliveryTimeObservation,
+        )
+        for value in delivery_time_observations
+    ):
+        raise TypeError(
+            "delivery_time_observations must contain "
+            "CanonicalPitcherDeliveryTimeObservation"
+        )
+
+    hold_ids = [
+        value.pitcher_id
+        for value in hold_observations
+    ]
+    delivery_ids = [
+        value.pitcher_id
+        for value in delivery_time_observations
+    ]
+
+    if len(hold_ids) != len(set(hold_ids)):
+        raise ValueError(
+            "pitcher hold observation identifiers "
+            "must be unique"
+        )
+    if len(delivery_ids) != len(set(delivery_ids)):
+        raise ValueError(
+            "pitcher delivery-time observation identifiers "
+            "must be unique"
+        )
+
+    delivery_by_id = {
+        value.pitcher_id: value
+        for value in delivery_time_observations
+    }
+
+    contexts = []
+
+    for hold in hold_observations:
+        delivery = delivery_by_id.get(
+            hold.pitcher_id
+        )
+        if delivery is None:
+            continue
+
+        contexts.append(
+            CanonicalPitcherBaserunningContext(
+                pitcher_id=hold.pitcher_id,
+                hold_score=hold.hold_score,
+                delivery_time_score=(
+                    delivery.delivery_time_score
+                ),
+                context_source_version=(
+                    f"{hold.source_version}+"
+                    f"{hold.evidence_version}+"
+                    f"{hold.normalization_version}+"
+                    f"{delivery.source_version}+"
+                    f"{delivery.normalization_version}+"
+                    f"{CANONICAL_PITCHER_CONTEXT_COMPOSITION_VERSION}"
+                ),
+            )
+        )
+
+    return tuple(contexts)

--- a/tests/test_canonical_pitcher_baserunning_context_composition.py
+++ b/tests/test_canonical_pitcher_baserunning_context_composition.py
@@ -1,0 +1,212 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PITCHER_CONTEXT_COMPOSITION_VERSION,
+    CanonicalPitcherDeliveryTimeObservation,
+    CanonicalPitcherHoldObservation,
+    compose_pitcher_baserunning_contexts,
+)
+
+
+def hold(
+    *,
+    pitcher_id="pitcher",
+    opportunities=10,
+    attempts=2,
+):
+    return CanonicalPitcherHoldObservation(
+        pitcher_id=pitcher_id,
+        eligible_opportunities=opportunities,
+        steal_attempts_against=attempts,
+        source_version="statcast_counts_v1",
+    )
+
+
+def delivery(
+    *,
+    pitcher_id="pitcher",
+    seconds_to_plate=1.20,
+):
+    return CanonicalPitcherDeliveryTimeObservation(
+        pitcher_id=pitcher_id,
+        seconds_to_plate=seconds_to_plate,
+        source_version="delivery_measurements_v1",
+    )
+
+
+def compose(
+    *,
+    holds=None,
+    deliveries=None,
+):
+    return compose_pitcher_baserunning_contexts(
+        hold_observations=(
+            (hold(),)
+            if holds is None
+            else holds
+        ),
+        delivery_time_observations=(
+            (delivery(),)
+            if deliveries is None
+            else deliveries
+        ),
+    )
+
+
+def test_composes_complete_pitcher_context():
+    context = compose()[0]
+
+    assert context.pitcher_id == "pitcher"
+    assert context.hold_score == 0.8
+    assert context.delivery_time_score == 1.0
+
+
+def test_composition_preserves_source_provenance():
+    context = compose()[0]
+
+    assert context.context_source_version == (
+        "statcast_counts_v1+"
+        "canonical_pitcher_hold_evidence_v1+"
+        "canonical_pitcher_hold_normalization_v1+"
+        "delivery_measurements_v1+"
+        "canonical_pitcher_delivery_time_normalization_v1+"
+        "canonical_pitcher_context_composition_v1"
+    )
+
+
+def test_missing_delivery_time_is_omitted():
+    assert compose(
+        deliveries=(),
+    ) == ()
+
+
+def test_missing_hold_evidence_is_omitted():
+    assert compose(
+        holds=(),
+    ) == ()
+
+
+def test_unmatched_pitcher_is_omitted():
+    assert compose(
+        holds=(
+            hold(pitcher_id="hold_pitcher"),
+        ),
+        deliveries=(
+            delivery(
+                pitcher_id="delivery_pitcher"
+            ),
+        ),
+    ) == ()
+
+
+def test_output_order_follows_hold_observations():
+    contexts = compose(
+        holds=(
+            hold(pitcher_id="second"),
+            hold(pitcher_id="first"),
+        ),
+        deliveries=(
+            delivery(pitcher_id="first"),
+            delivery(pitcher_id="second"),
+        ),
+    )
+
+    assert tuple(
+        value.pitcher_id
+        for value in contexts
+    ) == ("second", "first")
+
+
+def test_duplicate_hold_identifiers_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher hold observation identifiers "
+            "must be unique"
+        ),
+    ):
+        compose(
+            holds=(
+                hold(),
+                hold(),
+            ),
+        )
+
+
+def test_duplicate_delivery_identifiers_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "pitcher delivery-time observation "
+            "identifiers must be unique"
+        ),
+    ):
+        compose(
+            deliveries=(
+                delivery(),
+                delivery(),
+            ),
+        )
+
+
+def test_non_tuple_hold_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="hold_observations must be a tuple",
+    ):
+        compose_pitcher_baserunning_contexts(
+            hold_observations=[],
+            delivery_time_observations=(),
+        )
+
+
+def test_non_tuple_delivery_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "delivery_time_observations must be a tuple"
+        ),
+    ):
+        compose_pitcher_baserunning_contexts(
+            hold_observations=(),
+            delivery_time_observations=[],
+        )
+
+
+def test_invalid_hold_observation_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "hold_observations must contain "
+            "CanonicalPitcherHoldObservation"
+        ),
+    ):
+        compose_pitcher_baserunning_contexts(
+            hold_observations=(object(),),
+            delivery_time_observations=(),
+        )
+
+
+def test_invalid_delivery_observation_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "delivery_time_observations must contain "
+            "CanonicalPitcherDeliveryTimeObservation"
+        ),
+    ):
+        compose_pitcher_baserunning_contexts(
+            hold_observations=(),
+            delivery_time_observations=(object(),),
+        )
+
+
+def test_composition_is_deterministic():
+    assert compose() == compose()
+
+
+def test_composition_version_is_explicit():
+    assert (
+        CANONICAL_PITCHER_CONTEXT_COMPOSITION_VERSION
+        == "canonical_pitcher_context_composition_v1"
+    )


### PR DESCRIPTION
## Summary
- compose canonical pitcher hold and delivery-time observations by pitcher identity
- emit complete `CanonicalPitcherBaserunningContext` values with explicit combined provenance
- preserve deterministic hold-observation ordering
- omit pitchers missing either evidence source instead of supplying neutral defaults

## Why
The canonical pitcher materializer requires both hold and delivery-time scores. Those evidence contracts now exist independently; this slice joins them at a narrow, typed boundary so complete pitcher contexts can feed later observation discovery.

## Safety
- invalid and duplicate evidence contracts fail explicitly
- incomplete evidence is omitted rather than imputed
- legacy remains authoritative and production activation is unchanged

## Validation
- `163 passed, 1 warning in 1.22s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment