### PR TITLE
Source runner lead-quality evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -297,3 +297,9 @@ from .pitcher_baserunning_context_composition import (
 from .observed_baserunning_evidence import (
     discover_materialized_pitcher_baserunning_evidence,
 )
+
+from .runner_lead_quality_evidence import (
+    CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION,
+    CanonicalRunnerLeadQualityObservation,
+    decode_runner_lead_quality_rows,
+)

--- a/mlb_app/simulation/shadow/runner_lead_quality_evidence.py
+++ b/mlb_app/simulation/shadow/runner_lead_quality_evidence.py
@@ -1,0 +1,163 @@
+"""Adapt explicit runner lead-quality evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Mapping, Tuple
+
+
+CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION = (
+    "canonical_runner_lead_quality_evidence_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerLeadQualityObservation:
+    """One explicitly sourced runner lead-quality score."""
+
+    runner_id: str
+    lead_quality: float
+    source_version: str
+    evidence_version: str = (
+        CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.runner_id, str):
+            raise TypeError(
+                "runner_id must be a string"
+            )
+        if not self.runner_id.strip():
+            raise ValueError(
+                "runner_id must identify a runner"
+            )
+
+        if not isinstance(
+            self.lead_quality,
+            (int, float),
+        ):
+            raise TypeError(
+                "lead_quality must be numeric"
+            )
+
+        value = float(self.lead_quality)
+        if (
+            not math.isfinite(value)
+            or not 0.0 <= value <= 1.0
+        ):
+            raise ValueError(
+                "lead_quality must be finite and "
+                "between 0 and 1"
+            )
+
+        if not isinstance(
+            self.source_version,
+            str,
+        ):
+            raise TypeError(
+                "source_version must be a string"
+            )
+        if (
+            not self.source_version.strip()
+            or self.source_version == "unavailable"
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+        if self.evidence_version != (
+            CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION
+        ):
+            raise ValueError(
+                "evidence_version must identify the canonical "
+                "runner lead-quality evidence contract"
+            )
+
+    @property
+    def lead_quality_score(self) -> float:
+        return round(
+            float(self.lead_quality),
+            6,
+        )
+
+
+def decode_runner_lead_quality_rows(
+    rows: Tuple[
+        Mapping[str, Any],
+        ...,
+    ],
+) -> Tuple[
+    CanonicalRunnerLeadQualityObservation,
+    ...,
+]:
+    """
+    Decode explicitly normalized runner lead-quality rows.
+
+    The upstream source must supply runner identity, a unit-interval
+    lead-quality score, and source provenance. Missing evidence is not
+    converted to a neutral score.
+    """
+
+    if not isinstance(rows, tuple):
+        raise TypeError(
+            "rows must be a tuple"
+        )
+
+    observations = []
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "rows must contain mappings"
+            )
+
+        runner_id = row.get("runner_id")
+        lead_quality = row.get("lead_quality")
+        source_version = row.get(
+            "source_version"
+        )
+
+        if runner_id in (None, ""):
+            raise ValueError(
+                "runner_id is required"
+            )
+        if lead_quality is None:
+            raise ValueError(
+                "lead_quality is required"
+            )
+        if source_version in (
+            None,
+            "",
+            "unavailable",
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+        observations.append(
+            CanonicalRunnerLeadQualityObservation(
+                runner_id=str(runner_id),
+                lead_quality=float(
+                    lead_quality
+                ),
+                source_version=str(
+                    source_version
+                ),
+            )
+        )
+
+    identifiers = [
+        value.runner_id
+        for value in observations
+    ]
+
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError(
+            "runner lead-quality identifiers "
+            "must be unique"
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_runner_lead_quality_evidence.py
+++ b/tests/test_canonical_runner_lead_quality_evidence.py
@@ -1,0 +1,201 @@
+import math
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION,
+    CanonicalRunnerLeadQualityObservation,
+    decode_runner_lead_quality_rows,
+)
+
+
+def observation(
+    *,
+    runner_id="runner",
+    lead_quality=0.75,
+    source_version="measured_runner_lead_v1",
+):
+    return CanonicalRunnerLeadQualityObservation(
+        runner_id=runner_id,
+        lead_quality=lead_quality,
+        source_version=source_version,
+    )
+
+
+def test_preserves_explicit_lead_quality():
+    value = observation()
+
+    assert value.runner_id == "runner"
+    assert value.lead_quality == 0.75
+    assert value.lead_quality_score == 0.75
+    assert value.source_version == (
+        "measured_runner_lead_v1"
+    )
+
+
+def test_score_is_rounded_deterministically():
+    value = observation(
+        lead_quality=0.71234567,
+    )
+
+    assert value.lead_quality_score == 0.712346
+
+
+def test_decoder_preserves_input_order():
+    values = decode_runner_lead_quality_rows(
+        (
+            {
+                "runner_id": "second",
+                "lead_quality": 0.60,
+                "source_version": "source_v1",
+            },
+            {
+                "runner_id": "first",
+                "lead_quality": 0.80,
+                "source_version": "source_v1",
+            },
+        )
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in values
+    ) == ("second", "first")
+
+
+def test_empty_input_does_not_impute_evidence():
+    assert decode_runner_lead_quality_rows(
+        ()
+    ) == ()
+
+
+def test_missing_lead_quality_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="lead_quality is required",
+    ):
+        decode_runner_lead_quality_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "source_version": "source_v1",
+                },
+            )
+        )
+
+
+def test_missing_source_provenance_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        decode_runner_lead_quality_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "lead_quality": 0.70,
+                },
+            )
+        )
+
+
+def test_duplicate_runner_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "runner lead-quality identifiers "
+            "must be unique"
+        ),
+    ):
+        decode_runner_lead_quality_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "lead_quality": 0.70,
+                    "source_version": "source_v1",
+                },
+                {
+                    "runner_id": "runner",
+                    "lead_quality": 0.80,
+                    "source_version": "source_v1",
+                },
+            )
+        )
+
+
+def test_non_tuple_rows_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must be a tuple",
+    ):
+        decode_runner_lead_quality_rows([])
+
+
+def test_non_mapping_row_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must contain mappings",
+    ):
+        decode_runner_lead_quality_rows(
+            (object(),)
+        )
+
+
+@pytest.mark.parametrize(
+    "lead_quality",
+    (
+        -0.01,
+        1.01,
+        math.inf,
+        math.nan,
+    ),
+)
+def test_invalid_lead_quality_is_rejected(
+    lead_quality,
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "lead_quality must be finite and "
+            "between 0 and 1"
+        ),
+    ):
+        observation(
+            lead_quality=lead_quality,
+        )
+
+
+def test_non_numeric_lead_quality_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="lead_quality must be numeric",
+    ):
+        observation(
+            lead_quality="fast",
+        )
+
+
+def test_unavailable_source_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        observation(
+            source_version="unavailable",
+        )
+
+
+def test_evidence_version_is_explicit():
+    assert observation().evidence_version == (
+        CANONICAL_RUNNER_LEAD_QUALITY_EVIDENCE_VERSION
+    )
+
+
+def test_observation_is_deterministic():
+    assert observation() == observation()


### PR DESCRIPTION
## Summary
- add an immutable, versioned runner lead-quality observation contract
- decode explicitly normalized lead-quality rows with required source provenance
- reject missing, invalid, unavailable, or duplicate evidence
- preserve deterministic input ordering and score rounding

## Why
Runner materialization already has exact attempt counts and sourced sprint speed, but complete runner context also requires lead quality. This slice establishes that evidence boundary without deriving lead quality from steal outcomes or inventing neutral values.

## Safety
- missing lead evidence remains absent
- upstream source provenance is mandatory
- no attempt-rate feedback or outcome leakage is introduced
- legacy remains authoritative and production activation is unchanged

## Validation
- `149 passed, 1 warning in 1.27s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment