### PR TITLE
Source runner availability evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -303,3 +303,9 @@ from .runner_lead_quality_evidence import (
     CanonicalRunnerLeadQualityObservation,
     decode_runner_lead_quality_rows,
 )
+
+from .runner_availability_evidence import (
+    CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION,
+    CanonicalRunnerAvailabilityObservation,
+    decode_runner_availability_rows,
+)

--- a/mlb_app/simulation/shadow/runner_availability_evidence.py
+++ b/mlb_app/simulation/shadow/runner_availability_evidence.py
@@ -1,0 +1,190 @@
+"""Adapt explicit runner fatigue and injury-limit evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Mapping, Tuple
+
+
+CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION = (
+    "canonical_runner_availability_evidence_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalRunnerAvailabilityObservation:
+    """One explicitly sourced runner availability snapshot."""
+
+    runner_id: str
+    fatigue_index: float
+    injury_limit_flag: bool
+    source_version: str
+    evidence_version: str = (
+        CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.runner_id, str):
+            raise TypeError(
+                "runner_id must be a string"
+            )
+        if not self.runner_id.strip():
+            raise ValueError(
+                "runner_id must identify a runner"
+            )
+
+        if not isinstance(
+            self.fatigue_index,
+            (int, float),
+        ):
+            raise TypeError(
+                "fatigue_index must be numeric"
+            )
+
+        fatigue = float(self.fatigue_index)
+        if (
+            not math.isfinite(fatigue)
+            or not 0.0 <= fatigue <= 1.0
+        ):
+            raise ValueError(
+                "fatigue_index must be finite and "
+                "between 0 and 1"
+            )
+
+        if not isinstance(
+            self.injury_limit_flag,
+            bool,
+        ):
+            raise TypeError(
+                "injury_limit_flag must be boolean"
+            )
+
+        if not isinstance(
+            self.source_version,
+            str,
+        ):
+            raise TypeError(
+                "source_version must be a string"
+            )
+        if (
+            not self.source_version.strip()
+            or self.source_version == "unavailable"
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+        if self.evidence_version != (
+            CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION
+        ):
+            raise ValueError(
+                "evidence_version must identify the canonical "
+                "runner availability evidence contract"
+            )
+
+    @property
+    def fatigue_score(self) -> float:
+        return round(
+            float(self.fatigue_index),
+            6,
+        )
+
+
+def decode_runner_availability_rows(
+    rows: Tuple[
+        Mapping[str, Any],
+        ...,
+    ],
+) -> Tuple[
+    CanonicalRunnerAvailabilityObservation,
+    ...,
+]:
+    """
+    Decode explicit runner fatigue and injury-limit rows.
+
+    All fields and source provenance are required. Missing availability
+    evidence is not interpreted as rested or unrestricted.
+    """
+
+    if not isinstance(rows, tuple):
+        raise TypeError(
+            "rows must be a tuple"
+        )
+
+    observations = []
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "rows must contain mappings"
+            )
+
+        runner_id = row.get("runner_id")
+        fatigue_index = row.get(
+            "fatigue_index"
+        )
+        injury_limit_flag = row.get(
+            "injury_limit_flag"
+        )
+        source_version = row.get(
+            "source_version"
+        )
+
+        if runner_id in (None, ""):
+            raise ValueError(
+                "runner_id is required"
+            )
+        if fatigue_index is None:
+            raise ValueError(
+                "fatigue_index is required"
+            )
+        if injury_limit_flag is None:
+            raise ValueError(
+                "injury_limit_flag is required"
+            )
+        if not isinstance(
+            injury_limit_flag,
+            bool,
+        ):
+            raise TypeError(
+                "injury_limit_flag must be boolean"
+            )
+        if source_version in (
+            None,
+            "",
+            "unavailable",
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+        observations.append(
+            CanonicalRunnerAvailabilityObservation(
+                runner_id=str(runner_id),
+                fatigue_index=float(
+                    fatigue_index
+                ),
+                injury_limit_flag=(
+                    injury_limit_flag
+                ),
+                source_version=str(
+                    source_version
+                ),
+            )
+        )
+
+    identifiers = [
+        value.runner_id
+        for value in observations
+    ]
+
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError(
+            "runner availability identifiers "
+            "must be unique"
+        )
+
+    return tuple(observations)

--- a/tests/test_canonical_runner_availability_evidence.py
+++ b/tests/test_canonical_runner_availability_evidence.py
@@ -1,0 +1,249 @@
+import math
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION,
+    CanonicalRunnerAvailabilityObservation,
+    decode_runner_availability_rows,
+)
+
+
+def observation(
+    *,
+    runner_id="runner",
+    fatigue_index=0.20,
+    injury_limit_flag=False,
+    source_version="runner_availability_v1",
+):
+    return CanonicalRunnerAvailabilityObservation(
+        runner_id=runner_id,
+        fatigue_index=fatigue_index,
+        injury_limit_flag=injury_limit_flag,
+        source_version=source_version,
+    )
+
+
+def test_preserves_explicit_availability():
+    value = observation()
+
+    assert value.runner_id == "runner"
+    assert value.fatigue_index == 0.20
+    assert value.fatigue_score == 0.20
+    assert value.injury_limit_flag is False
+    assert value.source_version == (
+        "runner_availability_v1"
+    )
+
+
+def test_preserves_explicit_injury_limitation():
+    value = observation(
+        fatigue_index=0.60,
+        injury_limit_flag=True,
+    )
+
+    assert value.fatigue_score == 0.60
+    assert value.injury_limit_flag is True
+
+
+def test_fatigue_score_is_rounded_deterministically():
+    value = observation(
+        fatigue_index=0.12345678,
+    )
+
+    assert value.fatigue_score == 0.123457
+
+
+def test_decoder_preserves_input_order():
+    values = decode_runner_availability_rows(
+        (
+            {
+                "runner_id": "second",
+                "fatigue_index": 0.30,
+                "injury_limit_flag": False,
+                "source_version": "source_v1",
+            },
+            {
+                "runner_id": "first",
+                "fatigue_index": 0.10,
+                "injury_limit_flag": True,
+                "source_version": "source_v1",
+            },
+        )
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in values
+    ) == ("second", "first")
+
+
+def test_empty_input_does_not_impute_availability():
+    assert decode_runner_availability_rows(
+        ()
+    ) == ()
+
+
+def test_missing_fatigue_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="fatigue_index is required",
+    ):
+        decode_runner_availability_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "injury_limit_flag": False,
+                    "source_version": "source_v1",
+                },
+            )
+        )
+
+
+def test_missing_injury_flag_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="injury_limit_flag is required",
+    ):
+        decode_runner_availability_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "fatigue_index": 0.20,
+                    "source_version": "source_v1",
+                },
+            )
+        )
+
+
+def test_non_boolean_injury_flag_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "injury_limit_flag must be boolean"
+        ),
+    ):
+        decode_runner_availability_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "fatigue_index": 0.20,
+                    "injury_limit_flag": 0,
+                    "source_version": "source_v1",
+                },
+            )
+        )
+
+
+def test_missing_source_provenance_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        decode_runner_availability_rows(
+            (
+                {
+                    "runner_id": "runner",
+                    "fatigue_index": 0.20,
+                    "injury_limit_flag": False,
+                },
+            )
+        )
+
+
+def test_duplicate_runner_identity_is_rejected():
+    row = {
+        "runner_id": "runner",
+        "fatigue_index": 0.20,
+        "injury_limit_flag": False,
+        "source_version": "source_v1",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "runner availability identifiers "
+            "must be unique"
+        ),
+    ):
+        decode_runner_availability_rows(
+            (row, row)
+        )
+
+
+def test_non_tuple_rows_are_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must be a tuple",
+    ):
+        decode_runner_availability_rows([])
+
+
+def test_non_mapping_row_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="rows must contain mappings",
+    ):
+        decode_runner_availability_rows(
+            (object(),)
+        )
+
+
+@pytest.mark.parametrize(
+    "fatigue_index",
+    (
+        -0.01,
+        1.01,
+        math.inf,
+        math.nan,
+    ),
+)
+def test_invalid_fatigue_is_rejected(
+    fatigue_index,
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "fatigue_index must be finite and "
+            "between 0 and 1"
+        ),
+    ):
+        observation(
+            fatigue_index=fatigue_index,
+        )
+
+
+def test_non_numeric_fatigue_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="fatigue_index must be numeric",
+    ):
+        observation(
+            fatigue_index="tired",
+        )
+
+
+def test_unavailable_source_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        observation(
+            source_version="unavailable",
+        )
+
+
+def test_evidence_version_is_explicit():
+    assert observation().evidence_version == (
+        CANONICAL_RUNNER_AVAILABILITY_EVIDENCE_VERSION
+    )
+
+
+def test_observation_is_deterministic():
+    assert observation() == observation()


### PR DESCRIPTION
## Summary
- add an immutable, versioned runner availability observation contract
- carry explicit fatigue and injury-limitation evidence together
- decode typed availability rows with required source provenance
- reject missing, invalid, unavailable, or duplicate evidence

## Why
Complete runner baserunning context requires fatigue and injury-limitation inputs in addition to sprint speed and lead quality. This slice establishes the final runner-context evidence boundary without treating missing availability data as rested or unrestricted.

## Safety
- fatigue and injury status must both be explicitly supplied
- missing evidence is never converted to neutral availability
- source provenance is mandatory
- legacy remains authoritative and production activation is unchanged

## Validation
- `155 passed, 1 warning in 1.35s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment