### PR TITLE
Compose runner baserunning contexts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -309,3 +309,8 @@ from .runner_availability_evidence import (
     CanonicalRunnerAvailabilityObservation,
     decode_runner_availability_rows,
 )
+
+from .runner_baserunning_context_composition import (
+    CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION,
+    compose_runner_baserunning_contexts,
+)

--- a/mlb_app/simulation/shadow/runner_baserunning_context_composition.py
+++ b/mlb_app/simulation/shadow/runner_baserunning_context_composition.py
@@ -1,0 +1,174 @@
+"""
+Compose complete canonical runner baserunning contexts.
+
+A context is emitted only when sprint-speed, lead-quality, and
+availability evidence are all present for the same runner. Missing
+evidence is never replaced with a neutral value.
+"""
+
+from typing import Tuple
+
+from .runner_availability_evidence import (
+    CanonicalRunnerAvailabilityObservation,
+)
+from .runner_lead_quality_evidence import (
+    CanonicalRunnerLeadQualityObservation,
+)
+from .runner_sprint_speed_evidence import (
+    CanonicalRunnerSprintSpeedObservation,
+)
+from .statcast_baserunning_source import (
+    CanonicalRunnerBaserunningContext,
+)
+
+
+CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION = (
+    "canonical_runner_context_composition_v1"
+)
+
+
+def _validate_observations(
+    *,
+    values: tuple,
+    expected_type: type,
+    argument_name: str,
+) -> None:
+    if not isinstance(values, tuple):
+        raise TypeError(
+            f"{argument_name} must be a tuple"
+        )
+
+    if any(
+        not isinstance(value, expected_type)
+        for value in values
+    ):
+        raise TypeError(
+            f"{argument_name} must contain "
+            f"{expected_type.__name__}"
+        )
+
+    runner_ids = [
+        value.runner_id
+        for value in values
+    ]
+    if len(runner_ids) != len(set(runner_ids)):
+        raise ValueError(
+            f"{argument_name} runner identifiers "
+            "must be unique"
+        )
+
+
+def _context_source_version(
+    *,
+    sprint_speed: CanonicalRunnerSprintSpeedObservation,
+    lead_quality: CanonicalRunnerLeadQualityObservation,
+    availability: CanonicalRunnerAvailabilityObservation,
+) -> str:
+    return "|".join(
+        (
+            sprint_speed.source_version,
+            sprint_speed.normalization_version,
+            lead_quality.source_version,
+            lead_quality.evidence_version,
+            availability.source_version,
+            availability.evidence_version,
+            CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION,
+        )
+    )
+
+
+def compose_runner_baserunning_contexts(
+    *,
+    sprint_speed_observations: Tuple[
+        CanonicalRunnerSprintSpeedObservation,
+        ...,
+    ],
+    lead_quality_observations: Tuple[
+        CanonicalRunnerLeadQualityObservation,
+        ...,
+    ],
+    availability_observations: Tuple[
+        CanonicalRunnerAvailabilityObservation,
+        ...,
+    ],
+) -> Tuple[
+    CanonicalRunnerBaserunningContext,
+    ...,
+]:
+    """
+    Inner-join complete runner evidence into canonical contexts.
+
+    Output order follows sprint-speed observation order so composition
+    remains stable while incomplete runners are omitted.
+    """
+
+    _validate_observations(
+        values=sprint_speed_observations,
+        expected_type=(
+            CanonicalRunnerSprintSpeedObservation
+        ),
+        argument_name="sprint_speed_observations",
+    )
+    _validate_observations(
+        values=lead_quality_observations,
+        expected_type=(
+            CanonicalRunnerLeadQualityObservation
+        ),
+        argument_name="lead_quality_observations",
+    )
+    _validate_observations(
+        values=availability_observations,
+        expected_type=(
+            CanonicalRunnerAvailabilityObservation
+        ),
+        argument_name="availability_observations",
+    )
+
+    lead_by_runner = {
+        value.runner_id: value
+        for value in lead_quality_observations
+    }
+    availability_by_runner = {
+        value.runner_id: value
+        for value in availability_observations
+    }
+
+    contexts = []
+    for sprint_speed in sprint_speed_observations:
+        lead_quality = lead_by_runner.get(
+            sprint_speed.runner_id
+        )
+        availability = availability_by_runner.get(
+            sprint_speed.runner_id
+        )
+
+        if (
+            lead_quality is None
+            or availability is None
+        ):
+            continue
+
+        contexts.append(
+            CanonicalRunnerBaserunningContext(
+                runner_id=sprint_speed.runner_id,
+                speed_score=sprint_speed.speed_score,
+                lead_quality=(
+                    lead_quality.lead_quality_score
+                ),
+                fatigue_index=(
+                    availability.fatigue_score
+                ),
+                injury_limit_flag=(
+                    availability.injury_limit_flag
+                ),
+                context_source_version=(
+                    _context_source_version(
+                        sprint_speed=sprint_speed,
+                        lead_quality=lead_quality,
+                        availability=availability,
+                    )
+                ),
+            )
+        )
+
+    return tuple(contexts)

--- a/tests/test_canonical_runner_baserunning_context_composition.py
+++ b/tests/test_canonical_runner_baserunning_context_composition.py
@@ -1,0 +1,269 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION,
+    CanonicalRunnerAvailabilityObservation,
+    CanonicalRunnerLeadQualityObservation,
+    CanonicalRunnerSprintSpeedObservation,
+    compose_runner_baserunning_contexts,
+)
+
+
+def sprint(
+    runner_id="runner",
+    speed=28.0,
+):
+    return CanonicalRunnerSprintSpeedObservation(
+        runner_id=runner_id,
+        sprint_speed_ft_per_second=speed,
+    )
+
+
+def lead(
+    runner_id="runner",
+    score=0.60,
+):
+    return CanonicalRunnerLeadQualityObservation(
+        runner_id=runner_id,
+        lead_quality=score,
+        source_version="lead_source_v1",
+    )
+
+
+def availability(
+    runner_id="runner",
+    fatigue=0.20,
+    injury=False,
+):
+    return CanonicalRunnerAvailabilityObservation(
+        runner_id=runner_id,
+        fatigue_index=fatigue,
+        injury_limit_flag=injury,
+        source_version="availability_source_v1",
+    )
+
+
+def compose(
+    *,
+    speeds=None,
+    leads=None,
+    availabilities=None,
+):
+    return compose_runner_baserunning_contexts(
+        sprint_speed_observations=(
+            (sprint(),)
+            if speeds is None
+            else speeds
+        ),
+        lead_quality_observations=(
+            (lead(),)
+            if leads is None
+            else leads
+        ),
+        availability_observations=(
+            (availability(),)
+            if availabilities is None
+            else availabilities
+        ),
+    )
+
+
+def test_composes_complete_runner_context():
+    value = compose()[0]
+
+    assert value.runner_id == "runner"
+    assert value.speed_score == sprint().speed_score
+    assert value.lead_quality == 0.60
+    assert value.fatigue_index == 0.20
+    assert value.injury_limit_flag is False
+    assert (
+        CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION
+        in value.context_source_version
+    )
+
+
+def test_preserves_injury_limitation():
+    value = compose(
+        availabilities=(
+            availability(injury=True),
+        ),
+    )[0]
+
+    assert value.injury_limit_flag is True
+
+
+@pytest.mark.parametrize(
+    (
+        "speeds",
+        "leads",
+        "availabilities",
+    ),
+    (
+        ((), (lead(),), (availability(),)),
+        ((sprint(),), (), (availability(),)),
+        ((sprint(),), (lead(),), ()),
+    ),
+)
+def test_incomplete_runner_is_omitted(
+    speeds,
+    leads,
+    availabilities,
+):
+    assert compose(
+        speeds=speeds,
+        leads=leads,
+        availabilities=availabilities,
+    ) == ()
+
+
+def test_unmatched_runner_is_omitted():
+    assert compose(
+        leads=(lead(runner_id="other"),),
+    ) == ()
+
+
+def test_output_order_follows_sprint_observations():
+    values = compose(
+        speeds=(
+            sprint("runner_b", 29.0),
+            sprint("runner_a", 27.0),
+        ),
+        leads=(
+            lead("runner_a"),
+            lead("runner_b"),
+        ),
+        availabilities=(
+            availability("runner_a"),
+            availability("runner_b"),
+        ),
+    )
+
+    assert tuple(
+        value.runner_id
+        for value in values
+    ) == ("runner_b", "runner_a")
+
+
+@pytest.mark.parametrize(
+    (
+        "keyword",
+        "message",
+    ),
+    (
+        (
+            "sprint_speed_observations",
+            "sprint_speed_observations must be a tuple",
+        ),
+        (
+            "lead_quality_observations",
+            "lead_quality_observations must be a tuple",
+        ),
+        (
+            "availability_observations",
+            "availability_observations must be a tuple",
+        ),
+    ),
+)
+def test_non_tuple_input_is_rejected(
+    keyword,
+    message,
+):
+    arguments = {
+        "sprint_speed_observations": (sprint(),),
+        "lead_quality_observations": (lead(),),
+        "availability_observations": (
+            availability(),
+        ),
+    }
+    arguments[keyword] = []
+
+    with pytest.raises(TypeError, match=message):
+        compose_runner_baserunning_contexts(
+            **arguments
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "keyword",
+        "message",
+    ),
+    (
+        (
+            "sprint_speed_observations",
+            "must contain "
+            "CanonicalRunnerSprintSpeedObservation",
+        ),
+        (
+            "lead_quality_observations",
+            "must contain "
+            "CanonicalRunnerLeadQualityObservation",
+        ),
+        (
+            "availability_observations",
+            "must contain "
+            "CanonicalRunnerAvailabilityObservation",
+        ),
+    ),
+)
+def test_invalid_observation_is_rejected(
+    keyword,
+    message,
+):
+    arguments = {
+        "sprint_speed_observations": (sprint(),),
+        "lead_quality_observations": (lead(),),
+        "availability_observations": (
+            availability(),
+        ),
+    }
+    arguments[keyword] = (object(),)
+
+    with pytest.raises(TypeError, match=message):
+        compose_runner_baserunning_contexts(
+            **arguments
+        )
+
+
+@pytest.mark.parametrize(
+    "keyword",
+    (
+        "sprint_speed_observations",
+        "lead_quality_observations",
+        "availability_observations",
+    ),
+)
+def test_duplicate_runner_identifiers_are_rejected(
+    keyword,
+):
+    arguments = {
+        "sprint_speed_observations": (sprint(),),
+        "lead_quality_observations": (lead(),),
+        "availability_observations": (
+            availability(),
+        ),
+    }
+    duplicate = arguments[keyword][0]
+    arguments[keyword] = (
+        duplicate,
+        duplicate,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runner identifiers must be unique",
+    ):
+        compose_runner_baserunning_contexts(
+            **arguments
+        )
+
+
+def test_composition_is_deterministic():
+    assert compose() == compose()
+
+
+def test_composition_version_is_explicit():
+    assert (
+        CANONICAL_RUNNER_CONTEXT_COMPOSITION_VERSION
+        == "canonical_runner_context_composition_v1"
+    )


### PR DESCRIPTION
## Summary
- compose sprint-speed, lead-quality, and availability evidence into complete canonical runner baserunning contexts
- preserve deterministic sprint-observation ordering and explicit combined provenance
- omit runners missing any required evidence instead of imputing neutral values
- validate input contracts and reject duplicate runner identifiers

## Why
The canonical stolen-base path now has explicit runner speed, lead-quality, fatigue, and injury-limitation evidence. This slice joins those sources into the complete runner context required by Statcast runner observation materialization.

## Safety
- incomplete runner evidence produces no context
- no neutral speed, lead, fatigue, or injury values are substituted
- composition provenance is explicit and versioned
- legacy remains authoritative and production activation is unchanged

## Validation
- `173 passed, 1 warning in 1.22s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment