### PR TITLE
Assemble complete baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -318,3 +318,8 @@ from .runner_baserunning_context_composition import (
 from .observed_baserunning_evidence import (
     discover_materialized_runner_baserunning_evidence,
 )
+
+from .baserunning_evidence_assembly import (
+    CANONICAL_BASERUNNING_EVIDENCE_ASSEMBLY_VERSION,
+    assemble_complete_canonical_baserunning_evidence,
+)

--- a/mlb_app/simulation/shadow/baserunning_evidence_assembly.py
+++ b/mlb_app/simulation/shadow/baserunning_evidence_assembly.py
@@ -1,0 +1,160 @@
+"""Assemble complete canonical baserunning evidence for shadow use."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .baserunning_evidence_discovery import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+)
+from .catcher_observation_composition import (
+    CanonicalCatcherObservationComposition,
+)
+from .observed_baserunning_evidence import (
+    discover_materialized_runner_baserunning_evidence,
+)
+from .pitcher_baserunning_context_composition import (
+    compose_pitcher_baserunning_contexts,
+)
+from .pitcher_delivery_time_evidence import (
+    CanonicalPitcherDeliveryTimeObservation,
+)
+from .pitcher_hold_evidence import (
+    adapt_statcast_pitcher_hold_evidence,
+)
+from .runner_availability_evidence import (
+    CanonicalRunnerAvailabilityObservation,
+)
+from .runner_baserunning_context_composition import (
+    compose_runner_baserunning_contexts,
+)
+from .runner_lead_quality_evidence import (
+    CanonicalRunnerLeadQualityObservation,
+)
+from .runner_sprint_speed_evidence import (
+    CanonicalRunnerSprintSpeedObservation,
+)
+from .statcast_baserunning_source import (
+    CanonicalStatcastPitcherBaserunningCounts,
+    CanonicalStatcastPitcherPickoffCounts,
+    CanonicalStatcastRunnerBaserunningCounts,
+)
+
+
+CANONICAL_BASERUNNING_EVIDENCE_ASSEMBLY_VERSION = (
+    "canonical_baserunning_evidence_assembly_v1"
+)
+
+
+def _assembly_error(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    error: Exception,
+) -> CanonicalShadowBaserunningEvidenceDiscovery:
+    return CanonicalShadowBaserunningEvidenceDiscovery(
+        requested_runner_count=len(
+            required_runner_ids
+        ),
+        requested_pitcher_count=len(
+            required_pitcher_ids
+        ),
+        status="error",
+        error_message=str(error),
+    )
+
+
+def assemble_complete_canonical_baserunning_evidence(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    catcher_composition: (
+        CanonicalCatcherObservationComposition
+    ),
+    runner_counts: Tuple[
+        CanonicalStatcastRunnerBaserunningCounts,
+        ...,
+    ] = (),
+    runner_sprint_speed_observations: Tuple[
+        CanonicalRunnerSprintSpeedObservation,
+        ...,
+    ] = (),
+    runner_lead_quality_observations: Tuple[
+        CanonicalRunnerLeadQualityObservation,
+        ...,
+    ] = (),
+    runner_availability_observations: Tuple[
+        CanonicalRunnerAvailabilityObservation,
+        ...,
+    ] = (),
+    pitcher_baserunning_counts: Tuple[
+        CanonicalStatcastPitcherBaserunningCounts,
+        ...,
+    ] = (),
+    pitcher_pickoff_counts: Tuple[
+        CanonicalStatcastPitcherPickoffCounts,
+        ...,
+    ] = (),
+    pitcher_delivery_time_observations: Tuple[
+        CanonicalPitcherDeliveryTimeObservation,
+        ...,
+    ] = (),
+) -> CanonicalShadowBaserunningEvidenceDiscovery:
+    """
+    Assemble all participant evidence into one canonical catalog.
+
+    Runner context requires sprint speed, lead quality, and availability.
+    Pitcher context requires exact attempt exposure and delivery time.
+    Catcher observations must already be composed from confirmed assignments.
+
+    Missing evidence is omitted by the underlying inner joins. Invalid inputs
+    fail open. Legacy production authority remains unchanged.
+    """
+
+    try:
+        runner_contexts = (
+            compose_runner_baserunning_contexts(
+                sprint_speed_observations=(
+                    runner_sprint_speed_observations
+                ),
+                lead_quality_observations=(
+                    runner_lead_quality_observations
+                ),
+                availability_observations=(
+                    runner_availability_observations
+                ),
+            )
+        )
+
+        pitcher_hold_observations = (
+            adapt_statcast_pitcher_hold_evidence(
+                pitcher_baserunning_counts
+            )
+        )
+
+        pitcher_contexts = (
+            compose_pitcher_baserunning_contexts(
+                hold_observations=(
+                    pitcher_hold_observations
+                ),
+                delivery_time_observations=(
+                    pitcher_delivery_time_observations
+                ),
+            )
+        )
+    except Exception as exc:
+        return _assembly_error(
+            required_runner_ids=required_runner_ids,
+            required_pitcher_ids=required_pitcher_ids,
+            error=exc,
+        )
+
+    return discover_materialized_runner_baserunning_evidence(
+        required_runner_ids=required_runner_ids,
+        required_pitcher_ids=required_pitcher_ids,
+        catcher_composition=catcher_composition,
+        runner_counts=runner_counts,
+        runner_contexts=runner_contexts,
+        pitcher_pickoff_counts=pitcher_pickoff_counts,
+        pitcher_contexts=pitcher_contexts,
+    )

--- a/tests/test_canonical_baserunning_evidence_assembly.py
+++ b/tests/test_canonical_baserunning_evidence_assembly.py
@@ -1,0 +1,289 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_EVIDENCE_ASSEMBLY_VERSION,
+    CanonicalCatcherBaserunningObservation,
+    CanonicalCatcherObservationComposition,
+    CanonicalPitcherDeliveryTimeObservation,
+    CanonicalRunnerAvailabilityObservation,
+    CanonicalRunnerLeadQualityObservation,
+    CanonicalRunnerSprintSpeedObservation,
+    CanonicalStatcastPitcherBaserunningCounts,
+    CanonicalStatcastPitcherPickoffCounts,
+    CanonicalStatcastRunnerBaserunningCounts,
+    assemble_complete_canonical_baserunning_evidence,
+)
+
+
+def catcher(
+    catcher_id,
+    team_side,
+):
+    return CanonicalCatcherBaserunningObservation(
+        catcher_id=catcher_id,
+        team_side=team_side,
+        steal_attempts_against=10,
+        caught_stealing=3,
+        pop_time_score=0.85,
+    )
+
+
+def catchers():
+    return CanonicalCatcherObservationComposition(
+        observations=(
+            catcher("away-catcher", "away"),
+            catcher("home-catcher", "home"),
+        ),
+        assignment_count=2,
+        count_record_count=2,
+        pop_time_count=2,
+        context_count=2,
+        status="ready",
+    )
+
+
+def runner_counts():
+    return CanonicalStatcastRunnerBaserunningCounts(
+        runner_id="runner",
+        eligible_opportunities=20,
+        stolen_bases=6,
+        caught_stealing=2,
+    )
+
+
+def sprint():
+    return CanonicalRunnerSprintSpeedObservation(
+        runner_id="runner",
+        sprint_speed_ft_per_second=28.0,
+    )
+
+
+def lead():
+    return CanonicalRunnerLeadQualityObservation(
+        runner_id="runner",
+        lead_quality=0.80,
+        source_version="lead_source_v1",
+    )
+
+
+def availability():
+    return CanonicalRunnerAvailabilityObservation(
+        runner_id="runner",
+        fatigue_index=0.10,
+        injury_limit_flag=False,
+        source_version="availability_source_v1",
+    )
+
+
+def pitcher_counts():
+    return CanonicalStatcastPitcherBaserunningCounts(
+        pitcher_id="pitcher",
+        eligible_opportunities=40,
+        stolen_bases_allowed=6,
+        caught_stealing=2,
+    )
+
+
+def pickoff_counts():
+    return CanonicalStatcastPitcherPickoffCounts(
+        pitcher_id="pitcher",
+        eligible_opportunities=40,
+        pickoff_attempts=8,
+        successful_pickoffs=2,
+    )
+
+
+def delivery():
+    return CanonicalPitcherDeliveryTimeObservation(
+        pitcher_id="pitcher",
+        seconds_to_plate=1.20,
+        source_version="delivery_source_v1",
+    )
+
+
+def assemble(
+    *,
+    runner_count_values=None,
+    sprint_values=None,
+    lead_values=None,
+    availability_values=None,
+    pitcher_count_values=None,
+    pickoff_values=None,
+    delivery_values=None,
+):
+    return (
+        assemble_complete_canonical_baserunning_evidence(
+            required_runner_ids=("runner",),
+            required_pitcher_ids=("pitcher",),
+            catcher_composition=catchers(),
+            runner_counts=(
+                (runner_counts(),)
+                if runner_count_values is None
+                else runner_count_values
+            ),
+            runner_sprint_speed_observations=(
+                (sprint(),)
+                if sprint_values is None
+                else sprint_values
+            ),
+            runner_lead_quality_observations=(
+                (lead(),)
+                if lead_values is None
+                else lead_values
+            ),
+            runner_availability_observations=(
+                (availability(),)
+                if availability_values is None
+                else availability_values
+            ),
+            pitcher_baserunning_counts=(
+                (pitcher_counts(),)
+                if pitcher_count_values is None
+                else pitcher_count_values
+            ),
+            pitcher_pickoff_counts=(
+                (pickoff_counts(),)
+                if pickoff_values is None
+                else pickoff_values
+            ),
+            pitcher_delivery_time_observations=(
+                (delivery(),)
+                if delivery_values is None
+                else delivery_values
+            ),
+        )
+    )
+
+
+def test_complete_evidence_builds_catalog():
+    result = assemble()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.catalog is not None
+    assert len(result.catalog.runners) == 1
+    assert len(result.catalog.pitchers) == 1
+
+    runner = result.catalog.runners[0]
+    pitcher = result.catalog.pitchers[0]
+
+    assert runner.runner_id == "runner"
+    assert runner.attempt_rate == 0.40
+    assert runner.success_rate == 0.75
+    assert runner.lead_quality == 0.80
+    assert runner.fatigue_index == 0.10
+
+    assert pitcher.pitcher_id == "pitcher"
+    assert pitcher.hold_score == 0.80
+    assert pitcher.delivery_time_score == 1.0
+    assert pitcher.pickoff_attempt_rate == 0.20
+    assert pitcher.pickoff_success_rate == 0.25
+
+
+def test_missing_runner_sprint_speed_is_unavailable():
+    result = assemble(
+        sprint_values=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_runner_count == 0
+
+
+def test_missing_runner_lead_quality_is_unavailable():
+    result = assemble(
+        lead_values=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_runner_count == 0
+
+
+def test_missing_runner_availability_is_unavailable():
+    result = assemble(
+        availability_values=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_runner_count == 0
+
+
+def test_missing_pitcher_hold_evidence_is_unavailable():
+    result = assemble(
+        pitcher_count_values=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_pitcher_count == 0
+
+
+def test_missing_pitcher_delivery_time_is_unavailable():
+    result = assemble(
+        delivery_values=(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.available_pitcher_count == 0
+
+
+def test_invalid_runner_evidence_fails_open():
+    result = assemble(
+        sprint_values=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.error_message == (
+        "sprint_speed_observations must contain "
+        "CanonicalRunnerSprintSpeedObservation"
+    )
+
+
+def test_invalid_pitcher_evidence_fails_open():
+    result = assemble(
+        pitcher_count_values=(object(),),
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.catalog is None
+    assert result.error_message == (
+        "counts must contain "
+        "CanonicalStatcastPitcherBaserunningCounts"
+    )
+
+
+def test_assembly_is_deterministic():
+    first = assemble()
+    second = assemble()
+
+    assert first.catalog is not None
+    assert second.catalog is not None
+    assert first.catalog.digest == second.catalog.digest
+    assert (
+        first.observation_digest
+        == second.observation_digest
+    )
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = assemble().to_diagnostics()
+
+    assert diagnostics["ready"] is True
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_assembly_version_is_explicit():
+    assert (
+        CANONICAL_BASERUNNING_EVIDENCE_ASSEMBLY_VERSION
+        == "canonical_baserunning_evidence_assembly_v1"
+    )


### PR DESCRIPTION
## Summary
- add one deterministic orchestration boundary for complete canonical baserunning evidence
- compose runner contexts from sprint speed, lead quality, and availability
- derive and compose pitcher hold and delivery-time contexts
- materialize runner and pitcher observations with composed catcher evidence into one catalog

## Why
The individual runner, pitcher, and catcher evidence paths are complete. This slice connects them through one fail-open assembly function so callers no longer need to manually coordinate each composition and materialization stage.

## Safety
- missing participant evidence remains omitted and leaves discovery unavailable
- invalid evidence fails open through a canonical error result
- no neutral evidence is imputed
- legacy remains authoritative and production activation is unchanged

## Validation
- `169 passed, 1 warning in 1.40s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment