### PR TITLE
Inject discovered baserunning evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -323,3 +323,8 @@ from .baserunning_evidence_assembly import (
     CANONICAL_BASERUNNING_EVIDENCE_ASSEMBLY_VERSION,
     assemble_complete_canonical_baserunning_evidence,
 )
+
+from .baserunning_production_execution import (
+    CANONICAL_BASERUNNING_PRODUCTION_ADAPTER_VERSION,
+    run_canonical_production_shadow_with_baserunning_discovery,
+)

--- a/mlb_app/simulation/shadow/baserunning_production_execution.py
+++ b/mlb_app/simulation/shadow/baserunning_production_execution.py
@@ -1,0 +1,105 @@
+"""
+Inject discovered baserunning evidence into production-shadow execution.
+
+This adapter is explicitly invoked and never changes legacy authority.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .baserunning_evidence_discovery import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+)
+from .production_execution import (
+    CanonicalProductionShadowExecution,
+    run_canonical_production_shadow,
+)
+
+
+CANONICAL_BASERUNNING_PRODUCTION_ADAPTER_VERSION = (
+    "canonical_baserunning_production_adapter_v1"
+)
+
+
+def run_canonical_production_shadow_with_baserunning_discovery(
+    *,
+    baserunning_evidence_discovery: (
+        CanonicalShadowBaserunningEvidenceDiscovery
+    ),
+    **production_inputs: Any,
+) -> CanonicalProductionShadowExecution:
+    """
+    Run canonical production shadow with one discovered evidence catalog.
+
+    A ready discovery injects its catalog. An unavailable discovery blocks
+    this explicit baserunning execution. An error discovery fails open.
+    Direct catalog injection through production_inputs is rejected so this
+    boundary has one unambiguous evidence source.
+    """
+
+    if not isinstance(
+        baserunning_evidence_discovery,
+        CanonicalShadowBaserunningEvidenceDiscovery,
+    ):
+        return CanonicalProductionShadowExecution(
+            status="error",
+            error_type="TypeError",
+            error_message=(
+                "baserunning_evidence_discovery must be "
+                "CanonicalShadowBaserunningEvidenceDiscovery"
+            ),
+        )
+
+    if (
+        "baserunning_evidence_catalog"
+        in production_inputs
+    ):
+        return CanonicalProductionShadowExecution(
+            status="error",
+            error_type="ValueError",
+            error_message=(
+                "baserunning_evidence_catalog must be "
+                "supplied through discovery"
+            ),
+        )
+
+    if baserunning_evidence_discovery.status == "error":
+        return CanonicalProductionShadowExecution(
+            status="error",
+            error_type=(
+                "BaserunningEvidenceDiscoveryError"
+            ),
+            error_message=(
+                baserunning_evidence_discovery.error_message
+                or "baserunning evidence discovery failed"
+            ),
+        )
+
+    if not baserunning_evidence_discovery.ready:
+        return CanonicalProductionShadowExecution(
+            status="blocked",
+            error_type=(
+                "BaserunningEvidenceUnavailable"
+            ),
+            error_message=(
+                "complete baserunning evidence is unavailable"
+            ),
+        )
+
+    catalog = baserunning_evidence_discovery.catalog
+
+    if catalog is None:
+        return CanonicalProductionShadowExecution(
+            status="error",
+            error_type="RuntimeError",
+            error_message=(
+                "ready baserunning discovery is missing "
+                "its catalog"
+            ),
+        )
+
+    return run_canonical_production_shadow(
+        baserunning_evidence_catalog=catalog,
+        **production_inputs,
+    )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -24,9 +24,11 @@ from mlb_app.simulation.shadow import (
     CanonicalShadowBullpenSideDiscovery,
     CanonicalShadowExactArtifactDiscovery,
     CanonicalShadowFallbackCatalogDiscovery,
+    CanonicalShadowBaserunningEvidenceDiscovery,
     CanonicalShadowLineupDiscovery,
     CanonicalShadowProbabilityProviderDiscovery,
     run_canonical_production_shadow,
+    run_canonical_production_shadow_with_baserunning_discovery,
 )
 
 
@@ -546,3 +548,164 @@ def test_invalid_production_baserunning_catalog_fails_open():
     assert result.executed is False
     assert result.material is None
     assert result.error_type == "TypeError"
+
+
+
+def baserunning_discovery(
+    *,
+    status="ready",
+    error_message=None,
+):
+    source = (
+        baserunning_catalog()
+        if status == "ready"
+        else None
+    )
+
+    return CanonicalShadowBaserunningEvidenceDiscovery(
+        catalog=source,
+        requested_runner_count=(
+            18
+            if status == "ready"
+            else 0
+        ),
+        available_runner_count=(
+            18
+            if status == "ready"
+            else 0
+        ),
+        requested_pitcher_count=(
+            4
+            if status == "ready"
+            else 0
+        ),
+        available_pitcher_count=(
+            4
+            if status == "ready"
+            else 0
+        ),
+        status=status,
+        error_message=error_message,
+    )
+
+
+def run_with_discovery(
+    discovery=None,
+    **overrides,
+):
+    kwargs = {
+        "game_pk": 123,
+        "lineups": lineups(),
+        "bullpens": bullpens(),
+        "provider_discovery": provider_discovery(),
+        "exact_artifact_discovery": (
+            exact_discovery()
+        ),
+        "fallback_catalog_discovery": (
+            fallback_discovery()
+        ),
+        "bootstrap_ready": True,
+        "simulation_count": 2,
+    }
+    kwargs.update(overrides)
+
+    return (
+        run_canonical_production_shadow_with_baserunning_discovery(
+            baserunning_evidence_discovery=(
+                baserunning_discovery()
+                if discovery is None
+                else discovery
+            ),
+            **kwargs,
+        )
+    )
+
+
+def test_ready_discovery_injects_catalog():
+    discovery = baserunning_discovery()
+    result = run_with_discovery(
+        discovery=discovery,
+    )
+
+    assert result.status == "executed"
+    assert result.executed is True
+    assert result.execution_inputs is not None
+    assert (
+        result.execution_inputs
+        .baserunning_evidence_catalog
+        is discovery.catalog
+    )
+    assert (
+        result.to_diagnostics()[
+            "baserunning_evidence_catalog_digest"
+        ]
+        == discovery.catalog.digest
+    )
+
+
+def test_unavailable_discovery_blocks_execution():
+    result = run_with_discovery(
+        discovery=baserunning_discovery(
+            status="unavailable",
+        ),
+    )
+
+    assert result.status == "blocked"
+    assert result.executed is False
+    assert result.material is None
+    assert result.error_type == (
+        "BaserunningEvidenceUnavailable"
+    )
+
+
+def test_error_discovery_fails_open():
+    result = run_with_discovery(
+        discovery=baserunning_discovery(
+            status="error",
+            error_message="source unavailable",
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.executed is False
+    assert result.material is None
+    assert result.error_type == (
+        "BaserunningEvidenceDiscoveryError"
+    )
+    assert result.error_message == "source unavailable"
+
+
+def test_invalid_discovery_contract_fails_open():
+    result = run_with_discovery(
+        discovery=object(),
+    )
+
+    assert result.status == "error"
+    assert result.executed is False
+    assert result.error_type == "TypeError"
+
+
+def test_direct_catalog_and_discovery_are_rejected():
+    result = run_with_discovery(
+        baserunning_evidence_catalog=(
+            baserunning_catalog()
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.executed is False
+    assert result.error_type == "ValueError"
+    assert result.error_message == (
+        "baserunning_evidence_catalog must be "
+        "supplied through discovery"
+    )
+
+
+def test_discovered_execution_preserves_shadow_authority():
+    diagnostics = run_with_discovery().to_diagnostics()
+
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"


### PR DESCRIPTION
## Summary
- add an explicit adapter from canonical baserunning discovery to production-shadow execution
- inject the discovered catalog only when evidence discovery is ready
- block unavailable evidence and fail open on discovery errors or invalid contracts
- reject ambiguous simultaneous direct-catalog and discovery injection

## Why
Complete baserunning evidence can now be assembled automatically, while production-shadow execution already accepts a catalog. This slice connects those boundaries so callers can safely execute shadow trials from a validated discovery result.

## Safety
- this adapter must be explicitly invoked
- unavailable discovery blocks the baserunning shadow path
- error discovery returns a fail-open execution result
- legacy remains authoritative and production activation is unchanged

## Validation
- `132 passed, 1 warning in 1.35s`
- `python -m py_compile` passed
- `git diff --check` passed
- Ruff unavailable in the local environment