### PR TITLE
Summarize baserunning shadow validations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -334,3 +334,9 @@ from .baserunning_output_validation import (
     CanonicalBaserunningOutputValidation,
     validate_canonical_baserunning_shadow_outputs,
 )
+
+from .baserunning_shadow_summary import (
+    CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION,
+    CanonicalBaserunningShadowSummary,
+    summarize_canonical_baserunning_shadow_validations,
+)

--- a/mlb_app/simulation/shadow/baserunning_shadow_summary.py
+++ b/mlb_app/simulation/shadow/baserunning_shadow_summary.py
@@ -1,0 +1,262 @@
+"""Summarize canonical baserunning validation across games."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .baserunning_output_validation import (
+    CanonicalBaserunningOutputValidation,
+)
+
+
+CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION = (
+    "canonical_baserunning_shadow_summary_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningShadowSummary:
+    status: str = "unavailable"
+    validation_count: int = 0
+    ready_count: int = 0
+    unavailable_count: int = 0
+    error_count: int = 0
+    simulation_count_total: int = 0
+    runner_projection_count_total: int = 0
+    stolen_base_mean_total: float = 0.0
+    caught_stealing_mean_total: float = 0.0
+    active_validation_count: int = 0
+    catalog_digests: Tuple[str, ...] = ()
+    warnings: Tuple[str, ...] = ()
+    error_message: Optional[str] = None
+    summary_version: str = (
+        CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning shadow summary status"
+            )
+
+        counts = (
+            self.validation_count,
+            self.ready_count,
+            self.unavailable_count,
+            self.error_count,
+            self.simulation_count_total,
+            self.runner_projection_count_total,
+            self.active_validation_count,
+        )
+        if any(value < 0 for value in counts):
+            raise ValueError(
+                "baserunning shadow summary counts "
+                "must be nonnegative"
+            )
+
+        if (
+            self.ready_count
+            + self.unavailable_count
+            + self.error_count
+            != self.validation_count
+        ):
+            raise ValueError(
+                "validation status counts must match "
+                "validation_count"
+            )
+
+        if self.active_validation_count > self.ready_count:
+            raise ValueError(
+                "active_validation_count cannot exceed "
+                "ready_count"
+            )
+
+        if self.summary_version != (
+            CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning shadow summary version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    @property
+    def observed_activity(self) -> bool:
+        return self.active_validation_count > 0
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.summary_version,
+            "status": self.status,
+            "ready": self.ready,
+            "validation_count": self.validation_count,
+            "ready_count": self.ready_count,
+            "unavailable_count": self.unavailable_count,
+            "error_count": self.error_count,
+            "simulation_count_total": (
+                self.simulation_count_total
+            ),
+            "runner_projection_count_total": (
+                self.runner_projection_count_total
+            ),
+            "stolen_base_mean_total": (
+                self.stolen_base_mean_total
+            ),
+            "caught_stealing_mean_total": (
+                self.caught_stealing_mean_total
+            ),
+            "active_validation_count": (
+                self.active_validation_count
+            ),
+            "observed_activity": self.observed_activity,
+            "catalog_digests": self.catalog_digests,
+            "warnings": self.warnings,
+            "error_message": self.error_message,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def summarize_canonical_baserunning_shadow_validations(
+    validations: Any,
+) -> CanonicalBaserunningShadowSummary:
+    """
+    Aggregate per-game shadow validation into slate diagnostics.
+
+    This reports coverage and projected activity only. It does not
+    approve calibration or production activation.
+    """
+
+    if not isinstance(validations, tuple):
+        return CanonicalBaserunningShadowSummary(
+            status="error",
+            error_message="validations must be a tuple",
+        )
+
+    if not validations:
+        return CanonicalBaserunningShadowSummary(
+            status="unavailable",
+            error_message=(
+                "no baserunning shadow validations were supplied"
+            ),
+        )
+
+    if not all(
+        isinstance(
+            validation,
+            CanonicalBaserunningOutputValidation,
+        )
+        for validation in validations
+    ):
+        return CanonicalBaserunningShadowSummary(
+            status="error",
+            validation_count=len(validations),
+            error_count=len(validations),
+            error_message=(
+                "validations must contain "
+                "CanonicalBaserunningOutputValidation"
+            ),
+        )
+
+    ready = tuple(
+        value
+        for value in validations
+        if value.status == "ready"
+    )
+    unavailable_count = sum(
+        value.status == "unavailable"
+        for value in validations
+    )
+    error_count = sum(
+        value.status == "error"
+        for value in validations
+    )
+
+    warnings = set(
+        warning
+        for value in validations
+        for warning in value.warnings
+    )
+
+    if unavailable_count:
+        warnings.add(
+            "incomplete_baserunning_shadow_coverage"
+        )
+    if error_count:
+        warnings.add(
+            "baserunning_shadow_validation_errors"
+        )
+
+    catalog_digests = tuple(
+        sorted(
+            {
+                value.catalog_digest
+                for value in ready
+                if value.catalog_digest is not None
+            }
+        )
+    )
+
+    if not ready:
+        return CanonicalBaserunningShadowSummary(
+            status=(
+                "error"
+                if error_count
+                else "unavailable"
+            ),
+            validation_count=len(validations),
+            ready_count=0,
+            unavailable_count=unavailable_count,
+            error_count=error_count,
+            catalog_digests=catalog_digests,
+            warnings=tuple(sorted(warnings)),
+            error_message=(
+                "no ready baserunning shadow validations"
+            ),
+        )
+
+    return CanonicalBaserunningShadowSummary(
+        status="ready",
+        validation_count=len(validations),
+        ready_count=len(ready),
+        unavailable_count=unavailable_count,
+        error_count=error_count,
+        simulation_count_total=sum(
+            value.simulation_count
+            for value in ready
+        ),
+        runner_projection_count_total=sum(
+            value.runner_projection_count
+            for value in ready
+        ),
+        stolen_base_mean_total=round(
+            sum(
+                value.stolen_base_mean_total
+                for value in ready
+            ),
+            6,
+        ),
+        caught_stealing_mean_total=round(
+            sum(
+                value.caught_stealing_mean_total
+                for value in ready
+            ),
+            6,
+        ),
+        active_validation_count=sum(
+            value.observed_activity
+            for value in ready
+        ),
+        catalog_digests=catalog_digests,
+        warnings=tuple(sorted(warnings)),
+    )

--- a/tests/test_canonical_baserunning_shadow_summary.py
+++ b/tests/test_canonical_baserunning_shadow_summary.py
@@ -1,0 +1,240 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION,
+    CanonicalBaserunningOutputValidation,
+    summarize_canonical_baserunning_shadow_validations,
+)
+
+
+def validation(
+    *,
+    status="ready",
+    digest="digest-a",
+    simulation_count=100,
+    runner_count=9,
+    stolen_bases=1.25,
+    caught_stealing=0.25,
+    warnings=(),
+):
+    return CanonicalBaserunningOutputValidation(
+        status=status,
+        catalog_digest=digest,
+        simulation_count=simulation_count,
+        runner_projection_count=runner_count,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=caught_stealing,
+        warnings=warnings,
+    )
+
+
+def test_summarizes_ready_validations():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (
+                validation(),
+                validation(
+                    digest="digest-b",
+                    simulation_count=200,
+                    stolen_bases=2.0,
+                    caught_stealing=0.5,
+                ),
+            )
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.validation_count == 2
+    assert result.ready_count == 2
+    assert result.simulation_count_total == 300
+    assert result.runner_projection_count_total == 18
+    assert result.stolen_base_mean_total == 3.25
+    assert result.caught_stealing_mean_total == 0.75
+    assert result.active_validation_count == 2
+    assert result.observed_activity is True
+    assert result.catalog_digests == (
+        "digest-a",
+        "digest-b",
+    )
+
+
+def test_partial_coverage_is_reported():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (
+                validation(),
+                validation(
+                    status="unavailable",
+                    digest=None,
+                    simulation_count=0,
+                    runner_count=0,
+                    stolen_bases=0.0,
+                    caught_stealing=0.0,
+                ),
+            )
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.ready_count == 1
+    assert result.unavailable_count == 1
+    assert result.warnings == (
+        "incomplete_baserunning_shadow_coverage",
+    )
+
+
+def test_validation_errors_are_reported():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (
+                validation(),
+                validation(
+                    status="error",
+                    digest=None,
+                    simulation_count=0,
+                    runner_count=0,
+                    stolen_bases=0.0,
+                    caught_stealing=0.0,
+                ),
+            )
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.error_count == 1
+    assert result.warnings == (
+        "baserunning_shadow_validation_errors",
+    )
+
+
+def test_empty_input_is_unavailable():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            ()
+        )
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.error_message == (
+        "no baserunning shadow validations were supplied"
+    )
+
+
+def test_non_tuple_input_fails_open():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            []
+        )
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "validations must be a tuple"
+    )
+
+
+def test_invalid_member_fails_open():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (object(),)
+        )
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "validations must contain "
+        "CanonicalBaserunningOutputValidation"
+    )
+
+
+def test_no_ready_validation_is_unavailable():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (
+                validation(
+                    status="unavailable",
+                    digest=None,
+                    simulation_count=0,
+                    runner_count=0,
+                    stolen_bases=0.0,
+                    caught_stealing=0.0,
+                ),
+            )
+        )
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready_count == 0
+    assert result.unavailable_count == 1
+
+
+def test_zero_activity_is_preserved():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (
+                validation(
+                    stolen_bases=0.0,
+                    caught_stealing=0.0,
+                    warnings=(
+                        "zero_baserunning_activity_observed",
+                    ),
+                ),
+            )
+        )
+    )
+
+    assert result.observed_activity is False
+    assert result.active_validation_count == 0
+    assert result.warnings == (
+        "zero_baserunning_activity_observed",
+    )
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = (
+        summarize_canonical_baserunning_shadow_validations(
+            (validation(),)
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_summary_is_deterministic():
+    values = (
+        validation(digest="digest-b"),
+        validation(digest="digest-a"),
+    )
+
+    first = (
+        summarize_canonical_baserunning_shadow_validations(
+            values
+        )
+    )
+    second = (
+        summarize_canonical_baserunning_shadow_validations(
+            values
+        )
+    )
+
+    assert first == second
+    assert first.catalog_digests == (
+        "digest-a",
+        "digest-b",
+    )
+
+
+def test_summary_version_is_explicit():
+    result = (
+        summarize_canonical_baserunning_shadow_validations(
+            (validation(),)
+        )
+    )
+
+    assert result.summary_version == (
+        CANONICAL_BASERUNNING_SHADOW_SUMMARY_VERSION
+    )


### PR DESCRIPTION
## Summary

- add a deterministic slate-level summary for canonical baserunning shadow validations
- aggregate ready, unavailable, and error coverage across games
- report total simulation exposure, runner projection coverage, projected stolen bases, projected caught stealing, and the number of games with observed baserunning activity
- preserve unique catalog digests and propagate validation warnings
- fail open for empty, malformed, or fully unavailable validation collections

## Why

Per-game output validation now proves that canonical baserunning evidence reaches production-shaped shadow projections. The next activation gate needs slate-level observability so projected SB/CS activity and incomplete coverage can be evaluated across multiple games before historical calibration.

## Production impact

None. This is diagnostic aggregation only. It does not approve calibration or production activation. The legacy source remains authoritative, `activation_permitted` remains false, and `production_authority_changed` remains false.

## Validation

- `96 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment