### PR TITLE
Compare baserunning shadow to observed outcomes

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -340,3 +340,10 @@ from .baserunning_shadow_summary import (
     CanonicalBaserunningShadowSummary,
     summarize_canonical_baserunning_shadow_validations,
 )
+
+from .baserunning_calibration_comparison import (
+    CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION,
+    CanonicalBaserunningCalibrationComparison,
+    CanonicalObservedBaserunningTotals,
+    compare_baserunning_shadow_to_observed,
+)

--- a/mlb_app/simulation/shadow/baserunning_calibration_comparison.py
+++ b/mlb_app/simulation/shadow/baserunning_calibration_comparison.py
@@ -1,0 +1,367 @@
+"""Compare baserunning shadow projections with observed outcomes."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .baserunning_shadow_summary import (
+    CanonicalBaserunningShadowSummary,
+)
+
+
+CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION = (
+    "canonical_baserunning_calibration_comparison_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+def _require_nonnegative_finite(
+    value: float,
+    field_name: str,
+) -> None:
+    if (
+        not math.isfinite(value)
+        or value < 0.0
+    ):
+        raise ValueError(
+            f"{field_name} must be nonnegative and finite"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalObservedBaserunningTotals:
+    game_count: int
+    stolen_bases: int
+    caught_stealing: int
+    source_version: str
+
+    def __post_init__(self) -> None:
+        if self.game_count <= 0:
+            raise ValueError(
+                "game_count must be positive"
+            )
+
+        if self.stolen_bases < 0:
+            raise ValueError(
+                "stolen_bases must be nonnegative"
+            )
+
+        if self.caught_stealing < 0:
+            raise ValueError(
+                "caught_stealing must be nonnegative"
+            )
+
+        if (
+            not isinstance(self.source_version, str)
+            or not self.source_version.strip()
+            or self.source_version == "unavailable"
+        ):
+            raise ValueError(
+                "source_version must identify "
+                "an available source"
+            )
+
+    @property
+    def attempts(self) -> int:
+        return self.stolen_bases + self.caught_stealing
+
+    @property
+    def success_rate(self) -> Optional[float]:
+        if self.attempts == 0:
+            return None
+
+        return round(
+            self.stolen_bases / self.attempts,
+            6,
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCalibrationComparison:
+    status: str = "unavailable"
+    game_count: int = 0
+    projected_stolen_bases: float = 0.0
+    observed_stolen_bases: int = 0
+    stolen_base_absolute_error: float = 0.0
+    projected_caught_stealing: float = 0.0
+    observed_caught_stealing: int = 0
+    caught_stealing_absolute_error: float = 0.0
+    projected_attempts: float = 0.0
+    observed_attempts: int = 0
+    attempt_absolute_error: float = 0.0
+    projected_success_rate: Optional[float] = None
+    observed_success_rate: Optional[float] = None
+    success_rate_absolute_error: Optional[float] = None
+    observed_source_version: Optional[str] = None
+    error_message: Optional[str] = None
+    comparison_version: str = (
+        CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning calibration status"
+            )
+
+        if self.game_count < 0:
+            raise ValueError(
+                "game_count must be nonnegative"
+            )
+
+        for field_name in (
+            "projected_stolen_bases",
+            "stolen_base_absolute_error",
+            "projected_caught_stealing",
+            "caught_stealing_absolute_error",
+            "projected_attempts",
+            "attempt_absolute_error",
+        ):
+            _require_nonnegative_finite(
+                float(getattr(self, field_name)),
+                field_name,
+            )
+
+        if self.observed_stolen_bases < 0:
+            raise ValueError(
+                "observed_stolen_bases must be nonnegative"
+            )
+
+        if self.observed_caught_stealing < 0:
+            raise ValueError(
+                "observed_caught_stealing must be nonnegative"
+            )
+
+        if self.observed_attempts < 0:
+            raise ValueError(
+                "observed_attempts must be nonnegative"
+            )
+
+        for field_name in (
+            "projected_success_rate",
+            "observed_success_rate",
+            "success_rate_absolute_error",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and (
+                not math.isfinite(value)
+                or value < 0.0
+                or value > 1.0
+            ):
+                raise ValueError(
+                    f"{field_name} must be between zero and one"
+                )
+
+        if self.comparison_version != (
+            CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "comparison version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.comparison_version,
+            "status": self.status,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "projected_stolen_bases": (
+                self.projected_stolen_bases
+            ),
+            "observed_stolen_bases": (
+                self.observed_stolen_bases
+            ),
+            "stolen_base_absolute_error": (
+                self.stolen_base_absolute_error
+            ),
+            "projected_caught_stealing": (
+                self.projected_caught_stealing
+            ),
+            "observed_caught_stealing": (
+                self.observed_caught_stealing
+            ),
+            "caught_stealing_absolute_error": (
+                self.caught_stealing_absolute_error
+            ),
+            "projected_attempts": self.projected_attempts,
+            "observed_attempts": self.observed_attempts,
+            "attempt_absolute_error": (
+                self.attempt_absolute_error
+            ),
+            "projected_success_rate": (
+                self.projected_success_rate
+            ),
+            "observed_success_rate": (
+                self.observed_success_rate
+            ),
+            "success_rate_absolute_error": (
+                self.success_rate_absolute_error
+            ),
+            "observed_source_version": (
+                self.observed_source_version
+            ),
+            "error_message": self.error_message,
+            "calibration_approved": False,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def compare_baserunning_shadow_to_observed(
+    summary: Any,
+    observed: Any,
+) -> CanonicalBaserunningCalibrationComparison:
+    """
+    Compare aligned slate projections and outcomes.
+
+    This computes descriptive errors only. It does not define passing
+    thresholds or permit production activation.
+    """
+
+    if not isinstance(
+        summary,
+        CanonicalBaserunningShadowSummary,
+    ):
+        return CanonicalBaserunningCalibrationComparison(
+            status="error",
+            error_message=(
+                "summary must be "
+                "CanonicalBaserunningShadowSummary"
+            ),
+        )
+
+    if not isinstance(
+        observed,
+        CanonicalObservedBaserunningTotals,
+    ):
+        return CanonicalBaserunningCalibrationComparison(
+            status="error",
+            error_message=(
+                "observed must be "
+                "CanonicalObservedBaserunningTotals"
+            ),
+        )
+
+    if not summary.ready:
+        return CanonicalBaserunningCalibrationComparison(
+            status=(
+                "error"
+                if summary.status == "error"
+                else "unavailable"
+            ),
+            error_message=(
+                summary.error_message
+                or "baserunning shadow summary is unavailable"
+            ),
+        )
+
+    if observed.game_count != summary.ready_count:
+        return CanonicalBaserunningCalibrationComparison(
+            status="unavailable",
+            game_count=summary.ready_count,
+            observed_source_version=(
+                observed.source_version
+            ),
+            error_message=(
+                "observed game_count must match "
+                "ready shadow validation count"
+            ),
+        )
+
+    projected_stolen_bases = round(
+        summary.stolen_base_mean_total,
+        6,
+    )
+    projected_caught_stealing = round(
+        summary.caught_stealing_mean_total,
+        6,
+    )
+    projected_attempts = round(
+        projected_stolen_bases
+        + projected_caught_stealing,
+        6,
+    )
+
+    projected_success_rate = None
+    if projected_attempts > 0.0:
+        projected_success_rate = round(
+            projected_stolen_bases
+            / projected_attempts,
+            6,
+        )
+
+    observed_success_rate = observed.success_rate
+
+    success_rate_absolute_error = None
+    if (
+        projected_success_rate is not None
+        and observed_success_rate is not None
+    ):
+        success_rate_absolute_error = round(
+            abs(
+                projected_success_rate
+                - observed_success_rate
+            ),
+            6,
+        )
+
+    return CanonicalBaserunningCalibrationComparison(
+        status="ready",
+        game_count=observed.game_count,
+        projected_stolen_bases=projected_stolen_bases,
+        observed_stolen_bases=observed.stolen_bases,
+        stolen_base_absolute_error=round(
+            abs(
+                projected_stolen_bases
+                - observed.stolen_bases
+            ),
+            6,
+        ),
+        projected_caught_stealing=(
+            projected_caught_stealing
+        ),
+        observed_caught_stealing=(
+            observed.caught_stealing
+        ),
+        caught_stealing_absolute_error=round(
+            abs(
+                projected_caught_stealing
+                - observed.caught_stealing
+            ),
+            6,
+        ),
+        projected_attempts=projected_attempts,
+        observed_attempts=observed.attempts,
+        attempt_absolute_error=round(
+            abs(
+                projected_attempts
+                - observed.attempts
+            ),
+            6,
+        ),
+        projected_success_rate=(
+            projected_success_rate
+        ),
+        observed_success_rate=(
+            observed_success_rate
+        ),
+        success_rate_absolute_error=(
+            success_rate_absolute_error
+        ),
+        observed_source_version=(
+            observed.source_version
+        ),
+    )

--- a/tests/test_canonical_baserunning_calibration_comparison.py
+++ b/tests/test_canonical_baserunning_calibration_comparison.py
@@ -1,0 +1,211 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION,
+    CanonicalBaserunningShadowSummary,
+    CanonicalObservedBaserunningTotals,
+    compare_baserunning_shadow_to_observed,
+)
+
+
+def summary(
+    *,
+    status="ready",
+    ready_count=2,
+    stolen_bases=3.5,
+    caught_stealing=1.0,
+    error_message=None,
+):
+    return CanonicalBaserunningShadowSummary(
+        status=status,
+        validation_count=ready_count,
+        ready_count=ready_count,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=caught_stealing,
+        error_message=error_message,
+    )
+
+
+def observed(
+    *,
+    game_count=2,
+    stolen_bases=4,
+    caught_stealing=1,
+):
+    return CanonicalObservedBaserunningTotals(
+        game_count=game_count,
+        stolen_bases=stolen_bases,
+        caught_stealing=caught_stealing,
+        source_version="statcast_observed_v1",
+    )
+
+
+def test_compares_aligned_shadow_and_observed_totals():
+    result = compare_baserunning_shadow_to_observed(
+        summary(),
+        observed(),
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.game_count == 2
+    assert result.projected_stolen_bases == 3.5
+    assert result.observed_stolen_bases == 4
+    assert result.stolen_base_absolute_error == 0.5
+    assert result.projected_caught_stealing == 1.0
+    assert result.observed_caught_stealing == 1
+    assert result.caught_stealing_absolute_error == 0.0
+    assert result.projected_attempts == 4.5
+    assert result.observed_attempts == 5
+    assert result.attempt_absolute_error == 0.5
+    assert result.projected_success_rate == 0.777778
+    assert result.observed_success_rate == 0.8
+    assert result.success_rate_absolute_error == 0.022222
+
+
+def test_zero_attempts_have_no_success_rate():
+    result = compare_baserunning_shadow_to_observed(
+        summary(
+            stolen_bases=0.0,
+            caught_stealing=0.0,
+        ),
+        observed(
+            stolen_bases=0,
+            caught_stealing=0,
+        ),
+    )
+
+    assert result.status == "ready"
+    assert result.projected_success_rate is None
+    assert result.observed_success_rate is None
+    assert result.success_rate_absolute_error is None
+
+
+def test_unaligned_game_counts_are_unavailable():
+    result = compare_baserunning_shadow_to_observed(
+        summary(ready_count=2),
+        observed(game_count=3),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.error_message == (
+        "observed game_count must match "
+        "ready shadow validation count"
+    )
+
+
+def test_unavailable_summary_fails_open():
+    result = compare_baserunning_shadow_to_observed(
+        CanonicalBaserunningShadowSummary(
+            status="unavailable",
+            error_message="summary unavailable",
+        ),
+        observed(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.error_message == "summary unavailable"
+
+
+def test_invalid_summary_contract_fails_open():
+    result = compare_baserunning_shadow_to_observed(
+        object(),
+        observed(),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "summary must be CanonicalBaserunningShadowSummary"
+    )
+
+
+def test_invalid_observed_contract_fails_open():
+    result = compare_baserunning_shadow_to_observed(
+        summary(),
+        object(),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "observed must be "
+        "CanonicalObservedBaserunningTotals"
+    )
+
+
+def test_observed_totals_require_positive_game_count():
+    with pytest.raises(
+        ValueError,
+        match="game_count must be positive",
+    ):
+        observed(game_count=0)
+
+
+def test_observed_totals_reject_negative_counts():
+    with pytest.raises(
+        ValueError,
+        match="stolen_bases must be nonnegative",
+    ):
+        observed(stolen_bases=-1)
+
+    with pytest.raises(
+        ValueError,
+        match="caught_stealing must be nonnegative",
+    ):
+        observed(caught_stealing=-1)
+
+
+def test_observed_source_must_be_available():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "source_version must identify "
+            "an available source"
+        ),
+    ):
+        CanonicalObservedBaserunningTotals(
+            game_count=1,
+            stolen_bases=1,
+            caught_stealing=0,
+            source_version="unavailable",
+        )
+
+
+def test_diagnostics_preserve_legacy_authority():
+    diagnostics = (
+        compare_baserunning_shadow_to_observed(
+            summary(),
+            observed(),
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["calibration_approved"] is False
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_comparison_is_deterministic():
+    first = compare_baserunning_shadow_to_observed(
+        summary(),
+        observed(),
+    )
+    second = compare_baserunning_shadow_to_observed(
+        summary(),
+        observed(),
+    )
+
+    assert first == second
+
+
+def test_comparison_version_is_explicit():
+    result = compare_baserunning_shadow_to_observed(
+        summary(),
+        observed(),
+    )
+
+    assert result.comparison_version == (
+        CANONICAL_BASERUNNING_CALIBRATION_COMPARISON_VERSION
+    )


### PR DESCRIPTION
## Summary

- add a canonical contract for aligned observed stolen-base and caught-stealing totals
- compare slate-level shadow projections with historical observed outcomes
- report absolute error for stolen bases, caught stealing, and total attempts
- compare projected and observed steal-success rates when attempts are present
- reject mismatched game coverage and fail open for unavailable or malformed inputs

## Why

Slate-level shadow validation now provides projected SB/CS totals across games. This comparison layer creates the first descriptive calibration evidence by aligning those projections with observed outcomes before any thresholds or activation decision are introduced.

## Production impact

None. This PR computes descriptive errors only. It does not define passing calibration thresholds, approve calibration, or activate canonical baserunning. The legacy source remains authoritative, `calibration_approved` remains false, and `activation_permitted` remains false.

## Validation

- `108 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment