### PR TITLE
Evaluate baserunning calibration gate

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -347,3 +347,10 @@ from .baserunning_calibration_comparison import (
     CanonicalObservedBaserunningTotals,
     compare_baserunning_shadow_to_observed,
 )
+
+from .baserunning_calibration_gate import (
+    CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION,
+    CanonicalBaserunningCalibrationGate,
+    CanonicalBaserunningCalibrationPolicy,
+    evaluate_baserunning_calibration_gate,
+)

--- a/mlb_app/simulation/shadow/baserunning_calibration_gate.py
+++ b/mlb_app/simulation/shadow/baserunning_calibration_gate.py
@@ -1,0 +1,323 @@
+"""Evaluate canonical baserunning calibration evidence."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .baserunning_calibration_comparison import (
+    CanonicalBaserunningCalibrationComparison,
+)
+
+
+CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION = (
+    "canonical_baserunning_calibration_gate_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+def _validate_limit(
+    value: float,
+    field_name: str,
+    *,
+    bounded_rate: bool = False,
+) -> None:
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(
+            f"{field_name} must be nonnegative and finite"
+        )
+
+    if bounded_rate and value > 1.0:
+        raise ValueError(
+            f"{field_name} must not exceed one"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCalibrationPolicy:
+    minimum_game_count: int
+    maximum_stolen_base_error_per_game: float
+    maximum_caught_stealing_error_per_game: float
+    maximum_attempt_error_per_game: float
+    maximum_success_rate_absolute_error: float
+    policy_version: str
+
+    def __post_init__(self) -> None:
+        if self.minimum_game_count <= 0:
+            raise ValueError(
+                "minimum_game_count must be positive"
+            )
+
+        _validate_limit(
+            self.maximum_stolen_base_error_per_game,
+            "maximum_stolen_base_error_per_game",
+        )
+        _validate_limit(
+            self.maximum_caught_stealing_error_per_game,
+            "maximum_caught_stealing_error_per_game",
+        )
+        _validate_limit(
+            self.maximum_attempt_error_per_game,
+            "maximum_attempt_error_per_game",
+        )
+        _validate_limit(
+            self.maximum_success_rate_absolute_error,
+            "maximum_success_rate_absolute_error",
+            bounded_rate=True,
+        )
+
+        if (
+            not isinstance(self.policy_version, str)
+            or not self.policy_version.strip()
+            or self.policy_version == "unavailable"
+        ):
+            raise ValueError(
+                "policy_version must identify "
+                "an available policy"
+            )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCalibrationGate:
+    status: str = "unavailable"
+    eligible: bool = False
+    calibration_gate_passed: bool = False
+    game_count: int = 0
+    stolen_base_error_per_game: float = 0.0
+    caught_stealing_error_per_game: float = 0.0
+    attempt_error_per_game: float = 0.0
+    success_rate_absolute_error: Optional[float] = None
+    failures: Tuple[str, ...] = ()
+    policy_version: Optional[str] = None
+    comparison_version: Optional[str] = None
+    error_message: Optional[str] = None
+    gate_version: str = (
+        CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning calibration gate status"
+            )
+
+        if self.game_count < 0:
+            raise ValueError(
+                "game_count must be nonnegative"
+            )
+
+        for field_name in (
+            "stolen_base_error_per_game",
+            "caught_stealing_error_per_game",
+            "attempt_error_per_game",
+        ):
+            _validate_limit(
+                float(getattr(self, field_name)),
+                field_name,
+            )
+
+        if self.success_rate_absolute_error is not None:
+            _validate_limit(
+                self.success_rate_absolute_error,
+                "success_rate_absolute_error",
+                bounded_rate=True,
+            )
+
+        if self.calibration_gate_passed and (
+            not self.eligible
+            or self.status != "ready"
+            or self.failures
+        ):
+            raise ValueError(
+                "passing calibration gate must be "
+                "ready, eligible, and failure-free"
+            )
+
+        if self.gate_version != (
+            CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning calibration gate version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.gate_version,
+            "status": self.status,
+            "ready": self.ready,
+            "eligible": self.eligible,
+            "calibration_gate_passed": (
+                self.calibration_gate_passed
+            ),
+            "game_count": self.game_count,
+            "stolen_base_error_per_game": (
+                self.stolen_base_error_per_game
+            ),
+            "caught_stealing_error_per_game": (
+                self.caught_stealing_error_per_game
+            ),
+            "attempt_error_per_game": (
+                self.attempt_error_per_game
+            ),
+            "success_rate_absolute_error": (
+                self.success_rate_absolute_error
+            ),
+            "failures": self.failures,
+            "policy_version": self.policy_version,
+            "comparison_version": self.comparison_version,
+            "error_message": self.error_message,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def evaluate_baserunning_calibration_gate(
+    comparison: Any,
+    policy: Any,
+) -> CanonicalBaserunningCalibrationGate:
+    """
+    Evaluate descriptive calibration against an explicit policy.
+
+    A passing result is calibration evidence only. Production activation
+    remains prohibited by this contract.
+    """
+
+    if not isinstance(
+        comparison,
+        CanonicalBaserunningCalibrationComparison,
+    ):
+        return CanonicalBaserunningCalibrationGate(
+            status="error",
+            error_message=(
+                "comparison must be "
+                "CanonicalBaserunningCalibrationComparison"
+            ),
+        )
+
+    if not isinstance(
+        policy,
+        CanonicalBaserunningCalibrationPolicy,
+    ):
+        return CanonicalBaserunningCalibrationGate(
+            status="error",
+            comparison_version=(
+                comparison.comparison_version
+            ),
+            error_message=(
+                "policy must be "
+                "CanonicalBaserunningCalibrationPolicy"
+            ),
+        )
+
+    if not comparison.ready:
+        return CanonicalBaserunningCalibrationGate(
+            status=(
+                "error"
+                if comparison.status == "error"
+                else "unavailable"
+            ),
+            game_count=comparison.game_count,
+            policy_version=policy.policy_version,
+            comparison_version=(
+                comparison.comparison_version
+            ),
+            error_message=(
+                comparison.error_message
+                or "calibration comparison is unavailable"
+            ),
+        )
+
+    game_count = comparison.game_count
+    stolen_base_error_per_game = round(
+        comparison.stolen_base_absolute_error
+        / game_count,
+        6,
+    )
+    caught_stealing_error_per_game = round(
+        comparison.caught_stealing_absolute_error
+        / game_count,
+        6,
+    )
+    attempt_error_per_game = round(
+        comparison.attempt_absolute_error
+        / game_count,
+        6,
+    )
+
+    failures = []
+
+    if game_count < policy.minimum_game_count:
+        failures.append("minimum_game_count_not_met")
+
+    if stolen_base_error_per_game > (
+        policy.maximum_stolen_base_error_per_game
+    ):
+        failures.append(
+            "stolen_base_error_per_game_exceeded"
+        )
+
+    if caught_stealing_error_per_game > (
+        policy.maximum_caught_stealing_error_per_game
+    ):
+        failures.append(
+            "caught_stealing_error_per_game_exceeded"
+        )
+
+    if attempt_error_per_game > (
+        policy.maximum_attempt_error_per_game
+    ):
+        failures.append(
+            "attempt_error_per_game_exceeded"
+        )
+
+    success_rate_error = (
+        comparison.success_rate_absolute_error
+    )
+    if success_rate_error is None:
+        failures.append(
+            "success_rate_error_unavailable"
+        )
+    elif success_rate_error > (
+        policy.maximum_success_rate_absolute_error
+    ):
+        failures.append(
+            "success_rate_absolute_error_exceeded"
+        )
+
+    eligible = (
+        game_count >= policy.minimum_game_count
+        and success_rate_error is not None
+    )
+
+    return CanonicalBaserunningCalibrationGate(
+        status="ready",
+        eligible=eligible,
+        calibration_gate_passed=(
+            eligible and not failures
+        ),
+        game_count=game_count,
+        stolen_base_error_per_game=(
+            stolen_base_error_per_game
+        ),
+        caught_stealing_error_per_game=(
+            caught_stealing_error_per_game
+        ),
+        attempt_error_per_game=attempt_error_per_game,
+        success_rate_absolute_error=success_rate_error,
+        failures=tuple(failures),
+        policy_version=policy.policy_version,
+        comparison_version=(
+            comparison.comparison_version
+        ),
+    )

--- a/tests/test_canonical_baserunning_calibration_gate.py
+++ b/tests/test_canonical_baserunning_calibration_gate.py
@@ -1,0 +1,241 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION,
+    CanonicalBaserunningCalibrationComparison,
+    CanonicalBaserunningCalibrationPolicy,
+    evaluate_baserunning_calibration_gate,
+)
+
+
+def comparison(
+    *,
+    status="ready",
+    game_count=100,
+    stolen_base_error=10.0,
+    caught_stealing_error=5.0,
+    attempt_error=12.0,
+    success_rate_error=0.03,
+    error_message=None,
+):
+    return CanonicalBaserunningCalibrationComparison(
+        status=status,
+        game_count=game_count,
+        stolen_base_absolute_error=stolen_base_error,
+        caught_stealing_absolute_error=(
+            caught_stealing_error
+        ),
+        attempt_absolute_error=attempt_error,
+        success_rate_absolute_error=success_rate_error,
+        error_message=error_message,
+    )
+
+
+def policy(
+    *,
+    minimum_game_count=50,
+    maximum_stolen_base_error_per_game=0.20,
+    maximum_caught_stealing_error_per_game=0.10,
+    maximum_attempt_error_per_game=0.20,
+    maximum_success_rate_absolute_error=0.05,
+):
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=minimum_game_count,
+        maximum_stolen_base_error_per_game=(
+            maximum_stolen_base_error_per_game
+        ),
+        maximum_caught_stealing_error_per_game=(
+            maximum_caught_stealing_error_per_game
+        ),
+        maximum_attempt_error_per_game=(
+            maximum_attempt_error_per_game
+        ),
+        maximum_success_rate_absolute_error=(
+            maximum_success_rate_absolute_error
+        ),
+        policy_version="offline_baserunning_policy_v1",
+    )
+
+
+def test_passing_evidence_satisfies_gate():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(),
+        policy(),
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.eligible is True
+    assert result.calibration_gate_passed is True
+    assert result.stolen_base_error_per_game == 0.1
+    assert result.caught_stealing_error_per_game == 0.05
+    assert result.attempt_error_per_game == 0.12
+    assert result.success_rate_absolute_error == 0.03
+    assert result.failures == ()
+
+
+def test_minimum_sample_failure_is_explicit():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(
+            game_count=25,
+            stolen_base_error=2.5,
+            caught_stealing_error=1.25,
+            attempt_error=3.0,
+        ),
+        policy(minimum_game_count=50),
+    )
+
+    assert result.status == "ready"
+    assert result.eligible is False
+    assert result.calibration_gate_passed is False
+    assert result.failures == (
+        "minimum_game_count_not_met",
+    )
+
+
+def test_each_error_threshold_is_evaluated():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(
+            stolen_base_error=30.0,
+            caught_stealing_error=20.0,
+            attempt_error=40.0,
+            success_rate_error=0.10,
+        ),
+        policy(),
+    )
+
+    assert result.calibration_gate_passed is False
+    assert result.failures == (
+        "stolen_base_error_per_game_exceeded",
+        "caught_stealing_error_per_game_exceeded",
+        "attempt_error_per_game_exceeded",
+        "success_rate_absolute_error_exceeded",
+    )
+
+
+def test_missing_success_rate_is_not_eligible():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(success_rate_error=None),
+        policy(),
+    )
+
+    assert result.eligible is False
+    assert result.calibration_gate_passed is False
+    assert result.failures == (
+        "success_rate_error_unavailable",
+    )
+
+
+def test_unavailable_comparison_fails_open():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(
+            status="unavailable",
+            game_count=0,
+            stolen_base_error=0.0,
+            caught_stealing_error=0.0,
+            attempt_error=0.0,
+            success_rate_error=None,
+            error_message="comparison unavailable",
+        ),
+        policy(),
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.error_message == "comparison unavailable"
+
+
+def test_invalid_comparison_contract_fails_open():
+    result = evaluate_baserunning_calibration_gate(
+        object(),
+        policy(),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "comparison must be "
+        "CanonicalBaserunningCalibrationComparison"
+    )
+
+
+def test_invalid_policy_contract_fails_open():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(),
+        object(),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "policy must be "
+        "CanonicalBaserunningCalibrationPolicy"
+    )
+
+
+def test_policy_requires_positive_sample():
+    with pytest.raises(
+        ValueError,
+        match="minimum_game_count must be positive",
+    ):
+        policy(minimum_game_count=0)
+
+
+def test_policy_rejects_invalid_limits():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "maximum_attempt_error_per_game "
+            "must be nonnegative and finite"
+        ),
+    ):
+        policy(
+            maximum_attempt_error_per_game=-0.1
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "maximum_success_rate_absolute_error "
+            "must not exceed one"
+        ),
+    ):
+        policy(
+            maximum_success_rate_absolute_error=1.1
+        )
+
+
+def test_diagnostics_never_permit_activation():
+    diagnostics = evaluate_baserunning_calibration_gate(
+        comparison(),
+        policy(),
+    ).to_diagnostics()
+
+    assert diagnostics["calibration_gate_passed"] is True
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_gate_is_deterministic():
+    first = evaluate_baserunning_calibration_gate(
+        comparison(),
+        policy(),
+    )
+    second = evaluate_baserunning_calibration_gate(
+        comparison(),
+        policy(),
+    )
+
+    assert first == second
+
+
+def test_gate_version_is_explicit():
+    result = evaluate_baserunning_calibration_gate(
+        comparison(),
+        policy(),
+    )
+
+    assert result.gate_version == (
+        CANONICAL_BASERUNNING_CALIBRATION_GATE_VERSION
+    )


### PR DESCRIPTION
## Summary

- add an explicit, versioned policy contract for baserunning calibration thresholds
- evaluate minimum historical game coverage and per-game SB, CS, and attempt errors
- evaluate steal-success-rate absolute error when the rate is available
- return deterministic eligibility, pass/fail status, and specific failure reasons
- fail open for unavailable comparisons or malformed contracts

## Why

The shadow-versus-observed comparison now produces descriptive calibration errors. This gate makes those errors evaluable without guessing or hard-coding policy thresholds: callers must provide a complete versioned policy and adequate sample-size requirement.

## Production impact

None. A passing gate is calibration evidence only. It cannot authorize production activation. Diagnostics keep `activation_permitted` false, preserve legacy authority, and report that production authority has not changed.

## Validation

- `108 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment