### PR TITLE
Assemble baserunning calibration report

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -354,3 +354,9 @@ from .baserunning_calibration_gate import (
     CanonicalBaserunningCalibrationPolicy,
     evaluate_baserunning_calibration_gate,
 )
+
+from .baserunning_calibration_report import (
+    CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION,
+    CanonicalBaserunningCalibrationReport,
+    assemble_baserunning_calibration_report,
+)

--- a/mlb_app/simulation/shadow/baserunning_calibration_report.py
+++ b/mlb_app/simulation/shadow/baserunning_calibration_report.py
@@ -1,0 +1,186 @@
+"""Assemble canonical baserunning calibration diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from .baserunning_calibration_comparison import (
+    CanonicalBaserunningCalibrationComparison,
+    compare_baserunning_shadow_to_observed,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationGate,
+    evaluate_baserunning_calibration_gate,
+)
+from .baserunning_shadow_summary import (
+    CanonicalBaserunningShadowSummary,
+    summarize_canonical_baserunning_shadow_validations,
+)
+
+
+CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION = (
+    "canonical_baserunning_calibration_report_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCalibrationReport:
+    status: str = "unavailable"
+    summary: Optional[
+        CanonicalBaserunningShadowSummary
+    ] = None
+    comparison: Optional[
+        CanonicalBaserunningCalibrationComparison
+    ] = None
+    gate: Optional[
+        CanonicalBaserunningCalibrationGate
+    ] = None
+    error_message: Optional[str] = None
+    report_version: str = (
+        CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "report status"
+            )
+
+        if self.report_version != (
+            CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "report version"
+            )
+
+        if self.status == "ready" and (
+            self.summary is None
+            or self.comparison is None
+            or self.gate is None
+            or not self.summary.ready
+            or not self.comparison.ready
+            or not self.gate.ready
+        ):
+            raise ValueError(
+                "ready calibration report requires "
+                "ready summary, comparison, and gate"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    @property
+    def calibration_gate_passed(self) -> bool:
+        return bool(
+            self.gate is not None
+            and self.gate.calibration_gate_passed
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.report_version,
+            "status": self.status,
+            "ready": self.ready,
+            "calibration_gate_passed": (
+                self.calibration_gate_passed
+            ),
+            "summary": (
+                self.summary.to_diagnostics()
+                if self.summary is not None
+                else None
+            ),
+            "comparison": (
+                self.comparison.to_diagnostics()
+                if self.comparison is not None
+                else None
+            ),
+            "gate": (
+                self.gate.to_diagnostics()
+                if self.gate is not None
+                else None
+            ),
+            "error_message": self.error_message,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def assemble_baserunning_calibration_report(
+    *,
+    validations: Any,
+    observed: Any,
+    policy: Any,
+) -> CanonicalBaserunningCalibrationReport:
+    """
+    Run the complete offline baserunning calibration pipeline.
+
+    This packages diagnostic evidence only. It performs no fetching,
+    persistence, simulator mutation, or production activation.
+    """
+
+    summary = (
+        summarize_canonical_baserunning_shadow_validations(
+            validations
+        )
+    )
+
+    if not summary.ready:
+        return CanonicalBaserunningCalibrationReport(
+            status=summary.status,
+            summary=summary,
+            error_message=(
+                summary.error_message
+                or "baserunning shadow summary is unavailable"
+            ),
+        )
+
+    comparison = compare_baserunning_shadow_to_observed(
+        summary,
+        observed,
+    )
+
+    if not comparison.ready:
+        return CanonicalBaserunningCalibrationReport(
+            status=comparison.status,
+            summary=summary,
+            comparison=comparison,
+            error_message=(
+                comparison.error_message
+                or "baserunning comparison is unavailable"
+            ),
+        )
+
+    gate = evaluate_baserunning_calibration_gate(
+        comparison,
+        policy,
+    )
+
+    if not gate.ready:
+        return CanonicalBaserunningCalibrationReport(
+            status=gate.status,
+            summary=summary,
+            comparison=comparison,
+            gate=gate,
+            error_message=(
+                gate.error_message
+                or "baserunning calibration gate is unavailable"
+            ),
+        )
+
+    return CanonicalBaserunningCalibrationReport(
+        status="ready",
+        summary=summary,
+        comparison=comparison,
+        gate=gate,
+    )

--- a/tests/test_canonical_baserunning_calibration_report.py
+++ b/tests/test_canonical_baserunning_calibration_report.py
@@ -1,0 +1,216 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION,
+    CanonicalBaserunningCalibrationPolicy,
+    CanonicalBaserunningOutputValidation,
+    CanonicalObservedBaserunningTotals,
+    assemble_baserunning_calibration_report,
+)
+
+
+def validation(
+    *,
+    digest="digest",
+    stolen_bases=2.0,
+    caught_stealing=0.5,
+):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=digest,
+        runner_projection_count=9,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=caught_stealing,
+    )
+
+
+def observed(
+    *,
+    game_count=2,
+    stolen_bases=4,
+    caught_stealing=1,
+):
+    return CanonicalObservedBaserunningTotals(
+        game_count=game_count,
+        stolen_bases=stolen_bases,
+        caught_stealing=caught_stealing,
+        source_version="statcast_observed_v1",
+    )
+
+
+def policy(
+    *,
+    minimum_game_count=2,
+    maximum_stolen_base_error_per_game=0.25,
+    maximum_caught_stealing_error_per_game=0.25,
+    maximum_attempt_error_per_game=0.25,
+    maximum_success_rate_absolute_error=0.05,
+):
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=minimum_game_count,
+        maximum_stolen_base_error_per_game=(
+            maximum_stolen_base_error_per_game
+        ),
+        maximum_caught_stealing_error_per_game=(
+            maximum_caught_stealing_error_per_game
+        ),
+        maximum_attempt_error_per_game=(
+            maximum_attempt_error_per_game
+        ),
+        maximum_success_rate_absolute_error=(
+            maximum_success_rate_absolute_error
+        ),
+        policy_version="offline_baserunning_policy_v1",
+    )
+
+
+def assemble(**overrides):
+    arguments = {
+        "validations": (
+            validation(digest="digest-a"),
+            validation(digest="digest-b"),
+        ),
+        "observed": observed(),
+        "policy": policy(),
+    }
+    arguments.update(overrides)
+
+    return assemble_baserunning_calibration_report(
+        **arguments
+    )
+
+
+def test_assembles_passing_calibration_report():
+    report = assemble()
+
+    assert report.status == "ready"
+    assert report.ready is True
+    assert report.summary is not None
+    assert report.summary.ready_count == 2
+    assert report.comparison is not None
+    assert report.comparison.projected_attempts == 5.0
+    assert report.comparison.observed_attempts == 5
+    assert report.gate is not None
+    assert report.gate.calibration_gate_passed is True
+    assert report.calibration_gate_passed is True
+
+
+def test_failed_gate_remains_ready_diagnostic_evidence():
+    report = assemble(
+        policy=policy(
+            minimum_game_count=50,
+        )
+    )
+
+    assert report.status == "ready"
+    assert report.ready is True
+    assert report.gate is not None
+    assert report.gate.eligible is False
+    assert report.calibration_gate_passed is False
+    assert report.gate.failures == (
+        "minimum_game_count_not_met",
+    )
+
+
+def test_empty_validations_stop_at_summary():
+    report = assemble(
+        validations=(),
+    )
+
+    assert report.status == "unavailable"
+    assert report.ready is False
+    assert report.summary is not None
+    assert report.comparison is None
+    assert report.gate is None
+    assert report.error_message == (
+        "no baserunning shadow validations were supplied"
+    )
+
+
+def test_invalid_validation_stops_at_summary():
+    report = assemble(
+        validations=(object(),),
+    )
+
+    assert report.status == "error"
+    assert report.summary is not None
+    assert report.comparison is None
+    assert report.gate is None
+
+
+def test_unaligned_observed_totals_stop_at_comparison():
+    report = assemble(
+        observed=observed(game_count=3),
+    )
+
+    assert report.status == "unavailable"
+    assert report.summary is not None
+    assert report.comparison is not None
+    assert report.gate is None
+    assert report.error_message == (
+        "observed game_count must match "
+        "ready shadow validation count"
+    )
+
+
+def test_invalid_observed_contract_stops_at_comparison():
+    report = assemble(
+        observed=object(),
+    )
+
+    assert report.status == "error"
+    assert report.comparison is not None
+    assert report.gate is None
+    assert report.error_message == (
+        "observed must be "
+        "CanonicalObservedBaserunningTotals"
+    )
+
+
+def test_invalid_policy_contract_stops_at_gate():
+    report = assemble(
+        policy=object(),
+    )
+
+    assert report.status == "error"
+    assert report.summary is not None
+    assert report.comparison is not None
+    assert report.gate is not None
+    assert report.error_message == (
+        "policy must be "
+        "CanonicalBaserunningCalibrationPolicy"
+    )
+
+
+def test_diagnostics_preserve_all_stages():
+    diagnostics = assemble().to_diagnostics()
+
+    assert diagnostics["summary"]["ready"] is True
+    assert diagnostics["comparison"]["ready"] is True
+    assert diagnostics["gate"]["ready"] is True
+    assert diagnostics["calibration_gate_passed"] is True
+
+
+def test_diagnostics_never_permit_activation():
+    diagnostics = assemble().to_diagnostics()
+
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_report_is_deterministic():
+    first = assemble()
+    second = assemble()
+
+    assert first == second
+    assert first.to_diagnostics() == second.to_diagnostics()
+
+
+def test_report_version_is_explicit():
+    report = assemble()
+
+    assert report.report_version == (
+        CANONICAL_BASERUNNING_CALIBRATION_REPORT_VERSION
+    )


### PR DESCRIPTION
## Summary

- add one deterministic report contract for the complete offline baserunning calibration pipeline
- summarize per-game shadow validations, compare the aligned slate with observed SB/CS outcomes, and evaluate the explicit calibration policy
- preserve each intermediate diagnostic stage in the final report
- stop fail-open at the exact unavailable or erroneous stage
- expose a single calibration-gate result without granting production authority

## Why

The individual summary, historical comparison, and policy-gate contracts are now available. This integration layer packages them into one reproducible report that an offline historical-window runner can consume next.

## Production impact

None. This module performs no fetching, persistence, simulator mutation, or activation. Even a report with a passing calibration gate keeps `activation_permitted` false and the legacy source authoritative.

## Validation

- `119 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment