### PR TITLE
Execute baserunning calibration artifacts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -360,3 +360,10 @@ from .baserunning_calibration_report import (
     CanonicalBaserunningCalibrationReport,
     assemble_baserunning_calibration_report,
 )
+
+from .baserunning_calibration_artifact import (
+    CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION,
+    CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION,
+    CanonicalBaserunningCalibrationArtifact,
+    execute_baserunning_calibration_artifact,
+)

--- a/mlb_app/simulation/shadow/baserunning_calibration_artifact.py
+++ b/mlb_app/simulation/shadow/baserunning_calibration_artifact.py
@@ -1,0 +1,338 @@
+"""Execute an immutable baserunning calibration artifact."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Mapping, Optional
+
+from .baserunning_calibration_comparison import (
+    CanonicalObservedBaserunningTotals,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationPolicy,
+)
+from .baserunning_calibration_report import (
+    CanonicalBaserunningCalibrationReport,
+    assemble_baserunning_calibration_report,
+)
+from .baserunning_output_validation import (
+    CanonicalBaserunningOutputValidation,
+)
+
+
+CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION = (
+    "canonical_baserunning_calibration_input_v1"
+)
+CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION = (
+    "canonical_baserunning_calibration_artifact_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningCalibrationArtifact:
+    status: str = "unavailable"
+    window_start: Optional[str] = None
+    window_end: Optional[str] = None
+    input_version: Optional[str] = None
+    report: Optional[
+        CanonicalBaserunningCalibrationReport
+    ] = None
+    error_message: Optional[str] = None
+    artifact_version: str = (
+        CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "artifact status"
+            )
+
+        if self.status == "ready" and (
+            self.report is None
+            or not self.report.ready
+        ):
+            raise ValueError(
+                "ready artifact requires ready report"
+            )
+
+        if self.artifact_version != (
+            CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "artifact version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    @property
+    def calibration_gate_passed(self) -> bool:
+        return bool(
+            self.report is not None
+            and self.report.calibration_gate_passed
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.artifact_version,
+            "status": self.status,
+            "ready": self.ready,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "input_version": self.input_version,
+            "calibration_gate_passed": (
+                self.calibration_gate_passed
+            ),
+            "report": (
+                self.report.to_diagnostics()
+                if self.report is not None
+                else None
+            ),
+            "error_message": self.error_message,
+            "external_fetch_performed": False,
+            "persistence_performed": False,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _mapping(
+    value: Any,
+    field_name: str,
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            f"{field_name} must be a mapping"
+        )
+    return value
+
+
+def _window_dates(
+    payload: Mapping[str, Any],
+) -> tuple[str, str]:
+    window = _mapping(
+        payload.get("window"),
+        "window",
+    )
+    start_value = window.get("start_date")
+    end_value = window.get("end_date")
+
+    if not isinstance(start_value, str):
+        raise TypeError(
+            "window.start_date must be a string"
+        )
+    if not isinstance(end_value, str):
+        raise TypeError(
+            "window.end_date must be a string"
+        )
+
+    start_date = date.fromisoformat(start_value)
+    end_date = date.fromisoformat(end_value)
+
+    if end_date < start_date:
+        raise ValueError(
+            "window.end_date must not precede "
+            "window.start_date"
+        )
+
+    return (
+        start_date.isoformat(),
+        end_date.isoformat(),
+    )
+
+
+def _validations(
+    payload: Mapping[str, Any],
+) -> tuple[
+    CanonicalBaserunningOutputValidation,
+    ...,
+]:
+    rows = payload.get("validations")
+
+    if not isinstance(rows, list):
+        raise TypeError(
+            "validations must be a list"
+        )
+
+    values = []
+    for row in rows:
+        item = _mapping(
+            row,
+            "validation",
+        )
+        warnings = item.get("warnings", [])
+
+        if not isinstance(warnings, list):
+            raise TypeError(
+                "validation.warnings must be a list"
+            )
+
+        values.append(
+            CanonicalBaserunningOutputValidation(
+                status=str(
+                    item.get("status", "unavailable")
+                ),
+                simulation_count=int(
+                    item.get("simulation_count", 0)
+                ),
+                catalog_digest=item.get(
+                    "catalog_digest"
+                ),
+                runner_projection_count=int(
+                    item.get(
+                        "runner_projection_count",
+                        0,
+                    )
+                ),
+                stolen_base_mean_total=float(
+                    item.get(
+                        "stolen_base_mean_total",
+                        0.0,
+                    )
+                ),
+                caught_stealing_mean_total=float(
+                    item.get(
+                        "caught_stealing_mean_total",
+                        0.0,
+                    )
+                ),
+                warnings=tuple(
+                    str(value)
+                    for value in warnings
+                ),
+                error_message=item.get(
+                    "error_message"
+                ),
+            )
+        )
+
+    return tuple(values)
+
+
+def _observed(
+    payload: Mapping[str, Any],
+) -> CanonicalObservedBaserunningTotals:
+    value = _mapping(
+        payload.get("observed"),
+        "observed",
+    )
+
+    return CanonicalObservedBaserunningTotals(
+        game_count=int(value["game_count"]),
+        stolen_bases=int(value["stolen_bases"]),
+        caught_stealing=int(
+            value["caught_stealing"]
+        ),
+        source_version=str(
+            value["source_version"]
+        ),
+    )
+
+
+def _policy(
+    payload: Mapping[str, Any],
+) -> CanonicalBaserunningCalibrationPolicy:
+    value = _mapping(
+        payload.get("policy"),
+        "policy",
+    )
+
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=int(
+            value["minimum_game_count"]
+        ),
+        maximum_stolen_base_error_per_game=float(
+            value[
+                "maximum_stolen_base_error_per_game"
+            ]
+        ),
+        maximum_caught_stealing_error_per_game=float(
+            value[
+                "maximum_caught_stealing_error_per_game"
+            ]
+        ),
+        maximum_attempt_error_per_game=float(
+            value[
+                "maximum_attempt_error_per_game"
+            ]
+        ),
+        maximum_success_rate_absolute_error=float(
+            value[
+                "maximum_success_rate_absolute_error"
+            ]
+        ),
+        policy_version=str(
+            value["policy_version"]
+        ),
+    )
+
+
+def execute_baserunning_calibration_artifact(
+    payload: Any,
+) -> CanonicalBaserunningCalibrationArtifact:
+    """
+    Decode and execute one immutable offline calibration payload.
+
+    No data is fetched or persisted. Production authority is unchanged.
+    """
+
+    window_start = None
+    window_end = None
+    input_version = None
+
+    try:
+        root = _mapping(payload, "payload")
+        input_version = root.get("schema_version")
+
+        if input_version != (
+            CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning calibration "
+                "input version"
+            )
+
+        window_start, window_end = _window_dates(root)
+
+        report = assemble_baserunning_calibration_report(
+            validations=_validations(root),
+            observed=_observed(root),
+            policy=_policy(root),
+        )
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        return CanonicalBaserunningCalibrationArtifact(
+            status="error",
+            window_start=window_start,
+            window_end=window_end,
+            input_version=(
+                str(input_version)
+                if input_version is not None
+                else None
+            ),
+            error_message=str(exc),
+        )
+
+    return CanonicalBaserunningCalibrationArtifact(
+        status=report.status,
+        window_start=window_start,
+        window_end=window_end,
+        input_version=str(input_version),
+        report=report,
+        error_message=report.error_message,
+    )

--- a/tests/test_canonical_baserunning_calibration_artifact.py
+++ b/tests/test_canonical_baserunning_calibration_artifact.py
@@ -1,0 +1,220 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION,
+    CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION,
+    execute_baserunning_calibration_artifact,
+)
+
+
+def validation(digest):
+    return {
+        "status": "ready",
+        "simulation_count": 100,
+        "catalog_digest": digest,
+        "runner_projection_count": 9,
+        "stolen_base_mean_total": 2.0,
+        "caught_stealing_mean_total": 0.5,
+        "warnings": [],
+        "error_message": None,
+    }
+
+
+def payload(**overrides):
+    value = {
+        "schema_version": (
+            CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION
+        ),
+        "window": {
+            "start_date": "2026-04-20",
+            "end_date": "2026-05-03",
+        },
+        "validations": [
+            validation("digest-a"),
+            validation("digest-b"),
+        ],
+        "observed": {
+            "game_count": 2,
+            "stolen_bases": 4,
+            "caught_stealing": 1,
+            "source_version": "statcast_observed_v1",
+        },
+        "policy": {
+            "minimum_game_count": 2,
+            "maximum_stolen_base_error_per_game": 0.25,
+            "maximum_caught_stealing_error_per_game": 0.25,
+            "maximum_attempt_error_per_game": 0.25,
+            "maximum_success_rate_absolute_error": 0.05,
+            "policy_version": (
+                "offline_baserunning_policy_v1"
+            ),
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def test_executes_complete_artifact():
+    result = execute_baserunning_calibration_artifact(
+        payload()
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.window_start == "2026-04-20"
+    assert result.window_end == "2026-05-03"
+    assert result.report is not None
+    assert result.calibration_gate_passed is True
+
+
+def test_failed_gate_remains_ready_artifact():
+    value = payload()
+    value["policy"]["minimum_game_count"] = 50
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.calibration_gate_passed is False
+    assert result.report is not None
+    assert result.report.gate is not None
+    assert result.report.gate.failures == (
+        "minimum_game_count_not_met",
+    )
+
+
+def test_unaligned_observed_window_is_unavailable():
+    value = payload()
+    value["observed"]["game_count"] = 3
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "unavailable"
+    assert result.ready is False
+    assert result.report is not None
+    assert result.error_message == (
+        "observed game_count must match "
+        "ready shadow validation count"
+    )
+
+
+def test_unsupported_input_version_fails_open():
+    result = execute_baserunning_calibration_artifact(
+        payload(schema_version="unsupported")
+    )
+
+    assert result.status == "error"
+    assert result.report is None
+    assert result.error_message == (
+        "unsupported baserunning calibration "
+        "input version"
+    )
+
+
+def test_invalid_window_fails_open():
+    value = payload()
+    value["window"] = {
+        "start_date": "2026-05-03",
+        "end_date": "2026-04-20",
+    }
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "window.end_date must not precede "
+        "window.start_date"
+    )
+
+
+def test_invalid_date_fails_open():
+    value = payload()
+    value["window"]["start_date"] = "not-a-date"
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "error"
+    assert result.report is None
+
+
+def test_non_mapping_payload_fails_open():
+    result = execute_baserunning_calibration_artifact(
+        object()
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "payload must be a mapping"
+    )
+
+
+def test_invalid_validation_fails_open():
+    value = payload()
+    value["validations"] = [object()]
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "validation must be a mapping"
+    )
+
+
+def test_missing_observed_field_fails_open():
+    value = payload()
+    del value["observed"]["stolen_bases"]
+
+    result = execute_baserunning_calibration_artifact(
+        value
+    )
+
+    assert result.status == "error"
+    assert result.error_message == "'stolen_bases'"
+
+
+def test_diagnostics_are_offline_only():
+    diagnostics = (
+        execute_baserunning_calibration_artifact(
+            payload()
+        ).to_diagnostics()
+    )
+
+    assert diagnostics[
+        "external_fetch_performed"
+    ] is False
+    assert diagnostics["persistence_performed"] is False
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_execution_is_deterministic():
+    first = execute_baserunning_calibration_artifact(
+        payload()
+    )
+    second = execute_baserunning_calibration_artifact(
+        payload()
+    )
+
+    assert first == second
+    assert first.to_diagnostics() == second.to_diagnostics()
+
+
+def test_artifact_version_is_explicit():
+    result = execute_baserunning_calibration_artifact(
+        payload()
+    )
+
+    assert result.artifact_version == (
+        CANONICAL_BASERUNNING_CALIBRATION_ARTIFACT_VERSION
+    )


### PR DESCRIPTION
## Summary

- add a versioned immutable input contract for offline baserunning calibration artifacts
- decode an explicit historical window, per-game shadow validations, observed SB/CS totals, and a versioned calibration policy
- execute the complete summary, comparison, and gate report pipeline
- preserve unavailable calibration results and fail open for malformed schemas, dates, validations, observed totals, or policies
- expose deterministic nested diagnostics and provenance

## Why

The calibration report pipeline is complete in memory. This artifact executor creates the reproducible boundary needed to supply a fixed historical window without coupling calibration to live fetches, database writes, or production execution.

## Production impact

None. The executor performs no external fetches or persistence and cannot activate canonical baserunning. Diagnostics explicitly preserve legacy authority and report no production authority change.

## Validation

- `131 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment