### PR TITLE
Assemble historical baserunning calibration payload

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -367,3 +367,10 @@ from .baserunning_calibration_artifact import (
     CanonicalBaserunningCalibrationArtifact,
     execute_baserunning_calibration_artifact,
 )
+
+from .baserunning_calibration_payload import (
+    CANONICAL_BASERUNNING_CALIBRATION_PAYLOAD_VERSION,
+    CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION,
+    CanonicalHistoricalBaserunningGame,
+    assemble_historical_baserunning_calibration_payload,
+)

--- a/mlb_app/simulation/shadow/baserunning_calibration_payload.py
+++ b/mlb_app/simulation/shadow/baserunning_calibration_payload.py
@@ -1,0 +1,302 @@
+"""Assemble immutable historical baserunning calibration inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Tuple
+
+from .baserunning_calibration_artifact import (
+    CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationPolicy,
+)
+from .baserunning_output_validation import (
+    CanonicalBaserunningOutputValidation,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION = (
+    "canonical_historical_baserunning_game_v1"
+)
+CANONICAL_BASERUNNING_CALIBRATION_PAYLOAD_VERSION = (
+    "canonical_baserunning_calibration_payload_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningGame:
+    game_pk: int
+    game_date: str
+    validation: CanonicalBaserunningOutputValidation
+    observed_stolen_bases: int
+    observed_caught_stealing: int
+    observed_source_version: str
+    record_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        if not isinstance(self.game_date, str):
+            raise TypeError(
+                "game_date must be a string"
+            )
+
+        parsed_date = date.fromisoformat(self.game_date)
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        if not isinstance(
+            self.validation,
+            CanonicalBaserunningOutputValidation,
+        ):
+            raise TypeError(
+                "validation must be "
+                "CanonicalBaserunningOutputValidation"
+            )
+
+        if not self.validation.ready:
+            raise ValueError(
+                "historical game validation must be ready"
+            )
+
+        for field_name in (
+            "observed_stolen_bases",
+            "observed_caught_stealing",
+        ):
+            value = getattr(self, field_name)
+            if (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 0
+            ):
+                raise ValueError(
+                    f"{field_name} must be a "
+                    "nonnegative integer"
+                )
+
+        if (
+            not isinstance(
+                self.observed_source_version,
+                str,
+            )
+            or not self.observed_source_version.strip()
+            or self.observed_source_version
+            == "unavailable"
+        ):
+            raise ValueError(
+                "observed_source_version must identify "
+                "an available source"
+            )
+
+        if self.record_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "game version"
+            )
+
+
+def _iso_date(
+    value: Any,
+    field_name: str,
+) -> date:
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{field_name} must be a string"
+        )
+
+    parsed = date.fromisoformat(value)
+    if parsed.isoformat() != value:
+        raise ValueError(
+            f"{field_name} must use ISO format"
+        )
+
+    return parsed
+
+
+def _validation_payload(
+    value: CanonicalBaserunningOutputValidation,
+) -> Dict[str, Any]:
+    return {
+        "status": value.status,
+        "simulation_count": value.simulation_count,
+        "catalog_digest": value.catalog_digest,
+        "runner_projection_count": (
+            value.runner_projection_count
+        ),
+        "stolen_base_mean_total": (
+            value.stolen_base_mean_total
+        ),
+        "caught_stealing_mean_total": (
+            value.caught_stealing_mean_total
+        ),
+        "warnings": list(value.warnings),
+        "error_message": value.error_message,
+    }
+
+
+def _policy_payload(
+    value: CanonicalBaserunningCalibrationPolicy,
+) -> Dict[str, Any]:
+    return {
+        "minimum_game_count": value.minimum_game_count,
+        "maximum_stolen_base_error_per_game": (
+            value.maximum_stolen_base_error_per_game
+        ),
+        "maximum_caught_stealing_error_per_game": (
+            value.maximum_caught_stealing_error_per_game
+        ),
+        "maximum_attempt_error_per_game": (
+            value.maximum_attempt_error_per_game
+        ),
+        "maximum_success_rate_absolute_error": (
+            value.maximum_success_rate_absolute_error
+        ),
+        "policy_version": value.policy_version,
+    }
+
+
+def assemble_historical_baserunning_calibration_payload(
+    *,
+    window_start: str,
+    window_end: str,
+    games: Tuple[
+        CanonicalHistoricalBaserunningGame,
+        ...,
+    ],
+    policy: CanonicalBaserunningCalibrationPolicy,
+) -> Dict[str, Any]:
+    """
+    Assemble the exact offline artifact input from aligned game records.
+
+    The function performs no fetching, persistence, simulation execution,
+    calibration approval, or production activation.
+    """
+
+    start_date = _iso_date(
+        window_start,
+        "window_start",
+    )
+    end_date = _iso_date(
+        window_end,
+        "window_end",
+    )
+
+    if end_date < start_date:
+        raise ValueError(
+            "window_end must not precede window_start"
+        )
+
+    if not isinstance(games, tuple):
+        raise TypeError(
+            "games must be a tuple"
+        )
+
+    if not games:
+        raise ValueError(
+            "games must contain historical records"
+        )
+
+    for value in games:
+        if not isinstance(
+            value,
+            CanonicalHistoricalBaserunningGame,
+        ):
+            raise TypeError(
+                "games must contain "
+                "CanonicalHistoricalBaserunningGame"
+            )
+
+    if not isinstance(
+        policy,
+        CanonicalBaserunningCalibrationPolicy,
+    ):
+        raise TypeError(
+            "policy must be "
+            "CanonicalBaserunningCalibrationPolicy"
+        )
+
+    game_ids = tuple(
+        value.game_pk
+        for value in games
+    )
+    if len(game_ids) != len(set(game_ids)):
+        raise ValueError(
+            "historical game identifiers must be unique"
+        )
+
+    source_versions = {
+        value.observed_source_version
+        for value in games
+    }
+    if len(source_versions) != 1:
+        raise ValueError(
+            "observed source versions must be identical"
+        )
+
+    ordered_games = tuple(
+        sorted(
+            games,
+            key=lambda value: (
+                value.game_date,
+                value.game_pk,
+            ),
+        )
+    )
+
+    for value in ordered_games:
+        record_date = date.fromisoformat(
+            value.game_date
+        )
+        if not (
+            start_date
+            <= record_date
+            <= end_date
+        ):
+            raise ValueError(
+                "historical game date must fall "
+                "within calibration window"
+            )
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION
+        ),
+        "window": {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        },
+        "validations": [
+            _validation_payload(value.validation)
+            for value in ordered_games
+        ],
+        "observed": {
+            "game_count": len(ordered_games),
+            "stolen_bases": sum(
+                value.observed_stolen_bases
+                for value in ordered_games
+            ),
+            "caught_stealing": sum(
+                value.observed_caught_stealing
+                for value in ordered_games
+            ),
+            "source_version": next(
+                iter(source_versions)
+            ),
+        },
+        "policy": _policy_payload(policy),
+    }

--- a/tests/test_canonical_baserunning_calibration_payload.py
+++ b/tests/test_canonical_baserunning_calibration_payload.py
@@ -1,0 +1,260 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION,
+    CANONICAL_BASERUNNING_CALIBRATION_PAYLOAD_VERSION,
+    CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION,
+    CanonicalBaserunningCalibrationPolicy,
+    CanonicalBaserunningOutputValidation,
+    CanonicalHistoricalBaserunningGame,
+    assemble_historical_baserunning_calibration_payload,
+    execute_baserunning_calibration_artifact,
+)
+
+
+def validation(
+    *,
+    digest="digest",
+    stolen_bases=1.0,
+    caught_stealing=0.0,
+):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=digest,
+        runner_projection_count=9,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=caught_stealing,
+    )
+
+
+def game(
+    *,
+    game_pk=1,
+    game_date="2026-04-20",
+    digest="digest",
+    predicted_stolen_bases=1.0,
+    predicted_caught_stealing=0.0,
+    observed_stolen_bases=1,
+    observed_caught_stealing=0,
+    observed_source_version="statcast_observed_v1",
+):
+    return CanonicalHistoricalBaserunningGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        validation=validation(
+            digest=digest,
+            stolen_bases=predicted_stolen_bases,
+            caught_stealing=(
+                predicted_caught_stealing
+            ),
+        ),
+        observed_stolen_bases=(
+            observed_stolen_bases
+        ),
+        observed_caught_stealing=(
+            observed_caught_stealing
+        ),
+        observed_source_version=(
+            observed_source_version
+        ),
+    )
+
+
+def policy():
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=2,
+        maximum_stolen_base_error_per_game=0.25,
+        maximum_caught_stealing_error_per_game=0.25,
+        maximum_attempt_error_per_game=0.25,
+        maximum_success_rate_absolute_error=0.05,
+        policy_version="offline_baserunning_policy_v1",
+    )
+
+
+def assemble(**overrides):
+    arguments = {
+        "window_start": "2026-04-20",
+        "window_end": "2026-05-03",
+        "games": (
+            game(
+                game_pk=2,
+                game_date="2026-04-21",
+                digest="digest-b",
+                predicted_stolen_bases=2.0,
+                predicted_caught_stealing=1.0,
+                observed_stolen_bases=2,
+                observed_caught_stealing=1,
+            ),
+            game(
+                game_pk=1,
+                game_date="2026-04-20",
+                digest="digest-a",
+            ),
+        ),
+        "policy": policy(),
+    }
+    arguments.update(overrides)
+
+    return (
+        assemble_historical_baserunning_calibration_payload(
+            **arguments
+        )
+    )
+
+
+def test_assembles_exact_artifact_input():
+    payload = assemble()
+
+    assert payload["schema_version"] == (
+        CANONICAL_BASERUNNING_CALIBRATION_INPUT_VERSION
+    )
+    assert payload["window"] == {
+        "start_date": "2026-04-20",
+        "end_date": "2026-05-03",
+    }
+    assert payload["observed"] == {
+        "game_count": 2,
+        "stolen_bases": 3,
+        "caught_stealing": 1,
+        "source_version": "statcast_observed_v1",
+    }
+    assert [
+        row["catalog_digest"]
+        for row in payload["validations"]
+    ] == [
+        "digest-a",
+        "digest-b",
+    ]
+
+
+def test_payload_executes_complete_artifact():
+    artifact = execute_baserunning_calibration_artifact(
+        assemble()
+    )
+
+    assert artifact.status == "ready"
+    assert artifact.ready is True
+    assert artifact.calibration_gate_passed is True
+
+
+def test_duplicate_game_identifiers_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical game identifiers "
+            "must be unique"
+        ),
+    ):
+        assemble(
+            games=(
+                game(game_pk=1),
+                game(
+                    game_pk=1,
+                    game_date="2026-04-21",
+                ),
+            )
+        )
+
+
+def test_out_of_window_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical game date must fall "
+            "within calibration window"
+        ),
+    ):
+        assemble(
+            games=(
+                game(
+                    game_pk=1,
+                    game_date="2026-04-19",
+                ),
+            )
+        )
+
+
+def test_unavailable_validation_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical game validation "
+            "must be ready"
+        ),
+    ):
+        CanonicalHistoricalBaserunningGame(
+            game_pk=1,
+            game_date="2026-04-20",
+            validation=(
+                CanonicalBaserunningOutputValidation()
+            ),
+            observed_stolen_bases=0,
+            observed_caught_stealing=0,
+            observed_source_version=(
+                "statcast_observed_v1"
+            ),
+        )
+
+
+def test_mixed_observed_sources_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "observed source versions "
+            "must be identical"
+        ),
+    ):
+        assemble(
+            games=(
+                game(game_pk=1),
+                game(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                    observed_source_version=(
+                        "another_source_v1"
+                    ),
+                ),
+            )
+        )
+
+
+def test_invalid_game_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "games must contain "
+            "CanonicalHistoricalBaserunningGame"
+        ),
+    ):
+        assemble(
+            games=(object(),)
+        )
+
+
+def test_empty_game_window_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "games must contain historical records"
+        ),
+    ):
+        assemble(games=())
+
+
+def test_assembly_is_deterministic():
+    first = assemble()
+    second = assemble()
+
+    assert first == second
+
+
+def test_versions_are_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_GAME_VERSION
+        == "canonical_historical_baserunning_game_v1"
+    )
+    assert (
+        CANONICAL_BASERUNNING_CALIBRATION_PAYLOAD_VERSION
+        == "canonical_baserunning_calibration_payload_v1"
+    )


### PR DESCRIPTION
## Summary

- add a canonical historical game record for aligned shadow validation and observed SB/CS outcomes
- assemble deterministically ordered game records into the exact immutable calibration input schema
- enforce unique game identifiers, window containment, ready validations, and one observed source version
- serialize the caller-supplied calibration policy without introducing guessed thresholds
- verify the assembled payload executes through the complete calibration artifact pipeline

## Why

The calibration artifact executor now has a validated bridge from aligned historical game records to its immutable input contract. This prepares the fixed historical smoke window without coupling the core calibration pipeline to external fetching or persistence.

## Production impact

None. This assembler performs no fetching, persistence, simulation execution, authority change, or activation. Canonical baserunning remains shadow-only and legacy remains authoritative.

## Validation

- `141 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment