### PR TITLE
Materialize historical baserunning game records

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -374,3 +374,10 @@ from .baserunning_calibration_payload import (
     CanonicalHistoricalBaserunningGame,
     assemble_historical_baserunning_calibration_payload,
 )
+
+from .historical_baserunning_game_materialization import (
+    CANONICAL_HISTORICAL_BASERUNNING_MATERIALIZATION_VERSION,
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION,
+    CanonicalHistoricalBaserunningShadowGame,
+    materialize_historical_baserunning_game_records,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_game_materialization.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_game_materialization.py
@@ -1,0 +1,258 @@
+"""Materialize aligned historical baserunning game records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Optional, Tuple
+
+from .baserunning_calibration_payload import (
+    CanonicalHistoricalBaserunningGame,
+)
+from .baserunning_output_validation import (
+    CanonicalBaserunningOutputValidation,
+)
+from .statcast_baserunning_source import (
+    CanonicalStatcastBaserunningOutcome,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION = (
+    "canonical_historical_baserunning_shadow_game_v1"
+)
+CANONICAL_HISTORICAL_BASERUNNING_MATERIALIZATION_VERSION = (
+    "canonical_historical_baserunning_materialization_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningShadowGame:
+    game_pk: int
+    game_date: str
+    validation: CanonicalBaserunningOutputValidation
+    record_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        if not isinstance(self.game_date, str):
+            raise TypeError(
+                "game_date must be a string"
+            )
+
+        parsed_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        if not isinstance(
+            self.validation,
+            CanonicalBaserunningOutputValidation,
+        ):
+            raise TypeError(
+                "validation must be "
+                "CanonicalBaserunningOutputValidation"
+            )
+
+        if not self.validation.ready:
+            raise ValueError(
+                "historical shadow validation must be ready"
+            )
+
+        if self.record_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "shadow game version"
+            )
+
+
+def _outcome_identity(
+    value: CanonicalStatcastBaserunningOutcome,
+) -> Tuple[
+    int,
+    int,
+    int,
+    str,
+    str,
+    str,
+    str,
+]:
+    if value.game_pk is None:
+        raise ValueError(
+            "Statcast outcome requires game_pk"
+        )
+    if value.at_bat_number is None:
+        raise ValueError(
+            "Statcast outcome requires at_bat_number"
+        )
+    if value.pitch_number is None:
+        raise ValueError(
+            "Statcast outcome requires pitch_number"
+        )
+
+    return (
+        value.game_pk,
+        value.at_bat_number,
+        value.pitch_number,
+        value.runner_id,
+        value.event_type,
+        value.origin_base,
+        value.target_base,
+    )
+
+
+def materialize_historical_baserunning_game_records(
+    *,
+    shadow_games: Tuple[
+        CanonicalHistoricalBaserunningShadowGame,
+        ...,
+    ],
+    outcomes: Tuple[
+        CanonicalStatcastBaserunningOutcome,
+        ...,
+    ],
+    observed_source_version: str,
+) -> Tuple[
+    CanonicalHistoricalBaserunningGame,
+    ...,
+]:
+    """
+    Join per-game shadow validations to exact observed SB/CS outcomes.
+
+    Games without an observed attempt remain explicit zero-activity records.
+    No data is fetched, persisted, simulated, or activated.
+    """
+
+    if not isinstance(shadow_games, tuple):
+        raise TypeError(
+            "shadow_games must be a tuple"
+        )
+    if not shadow_games:
+        raise ValueError(
+            "shadow_games must contain records"
+        )
+
+    for value in shadow_games:
+        if not isinstance(
+            value,
+            CanonicalHistoricalBaserunningShadowGame,
+        ):
+            raise TypeError(
+                "shadow_games must contain "
+                "CanonicalHistoricalBaserunningShadowGame"
+            )
+
+    if not isinstance(outcomes, tuple):
+        raise TypeError(
+            "outcomes must be a tuple"
+        )
+
+    for value in outcomes:
+        if not isinstance(
+            value,
+            CanonicalStatcastBaserunningOutcome,
+        ):
+            raise TypeError(
+                "outcomes must contain "
+                "CanonicalStatcastBaserunningOutcome"
+            )
+
+    if (
+        not isinstance(observed_source_version, str)
+        or not observed_source_version.strip()
+        or observed_source_version == "unavailable"
+    ):
+        raise ValueError(
+            "observed_source_version must identify "
+            "an available source"
+        )
+
+    game_ids = tuple(
+        value.game_pk
+        for value in shadow_games
+    )
+    if len(game_ids) != len(set(game_ids)):
+        raise ValueError(
+            "historical shadow game identifiers "
+            "must be unique"
+        )
+
+    shadow_game_ids = set(game_ids)
+    outcome_identities = tuple(
+        _outcome_identity(value)
+        for value in outcomes
+    )
+
+    if len(outcome_identities) != len(
+        set(outcome_identities)
+    ):
+        raise ValueError(
+            "Statcast outcome identifiers must be unique"
+        )
+
+    for value in outcomes:
+        if value.game_pk not in shadow_game_ids:
+            raise ValueError(
+                "Statcast outcome game_pk must match "
+                "a historical shadow game"
+            )
+        if value.source_version != (
+            observed_source_version
+        ):
+            raise ValueError(
+                "Statcast outcome source_version must "
+                "match observed_source_version"
+            )
+
+    ordered_games = tuple(
+        sorted(
+            shadow_games,
+            key=lambda value: (
+                value.game_date,
+                value.game_pk,
+            ),
+        )
+    )
+
+    records = []
+    for shadow_game in ordered_games:
+        game_outcomes = tuple(
+            value
+            for value in outcomes
+            if value.game_pk == shadow_game.game_pk
+        )
+
+        records.append(
+            CanonicalHistoricalBaserunningGame(
+                game_pk=shadow_game.game_pk,
+                game_date=shadow_game.game_date,
+                validation=shadow_game.validation,
+                observed_stolen_bases=sum(
+                    value.event_type == "stolen_base"
+                    for value in game_outcomes
+                ),
+                observed_caught_stealing=sum(
+                    value.event_type == "caught_stealing"
+                    for value in game_outcomes
+                ),
+                observed_source_version=(
+                    observed_source_version
+                ),
+            )
+        )
+
+    return tuple(records)

--- a/tests/test_canonical_historical_baserunning_game_materialization.py
+++ b/tests/test_canonical_historical_baserunning_game_materialization.py
@@ -1,0 +1,265 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_MATERIALIZATION_VERSION,
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION,
+    CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalBaserunningOutputValidation,
+    CanonicalHistoricalBaserunningShadowGame,
+    CanonicalStatcastBaserunningOutcome,
+    materialize_historical_baserunning_game_records,
+)
+
+
+def validation(digest="digest"):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=digest,
+        runner_projection_count=9,
+        stolen_base_mean_total=1.0,
+        caught_stealing_mean_total=0.25,
+    )
+
+
+def shadow_game(
+    *,
+    game_pk=1,
+    game_date="2026-04-20",
+    digest="digest",
+):
+    return CanonicalHistoricalBaserunningShadowGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        validation=validation(digest),
+    )
+
+
+def outcome(
+    *,
+    game_pk=1,
+    at_bat_number=10,
+    pitch_number=3,
+    runner_id="runner",
+    event_type="stolen_base",
+    origin_base="first",
+    target_base="second",
+    source_version=(
+        CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+    ),
+):
+    return CanonicalStatcastBaserunningOutcome(
+        runner_id=runner_id,
+        event_type=event_type,
+        origin_base=origin_base,
+        target_base=target_base,
+        game_pk=game_pk,
+        at_bat_number=at_bat_number,
+        pitch_number=pitch_number,
+        source_version=source_version,
+    )
+
+
+def materialize(**overrides):
+    arguments = {
+        "shadow_games": (
+            shadow_game(
+                game_pk=2,
+                game_date="2026-04-21",
+                digest="digest-b",
+            ),
+            shadow_game(
+                game_pk=1,
+                game_date="2026-04-20",
+                digest="digest-a",
+            ),
+        ),
+        "outcomes": (
+            outcome(
+                game_pk=1,
+                runner_id="runner-a",
+            ),
+            outcome(
+                game_pk=1,
+                at_bat_number=20,
+                runner_id="runner-b",
+                event_type="caught_stealing",
+            ),
+        ),
+        "observed_source_version": (
+            CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+        ),
+    }
+    arguments.update(overrides)
+
+    return materialize_historical_baserunning_game_records(
+        **arguments
+    )
+
+
+def test_materializes_aligned_game_records():
+    records = materialize()
+
+    assert tuple(
+        value.game_pk
+        for value in records
+    ) == (1, 2)
+    assert records[0].observed_stolen_bases == 1
+    assert records[0].observed_caught_stealing == 1
+    assert records[1].observed_stolen_bases == 0
+    assert records[1].observed_caught_stealing == 0
+
+
+def test_counts_multiple_runners_on_one_pitch():
+    records = materialize(
+        shadow_games=(shadow_game(),),
+        outcomes=(
+            outcome(
+                runner_id="runner-a",
+            ),
+            outcome(
+                runner_id="runner-b",
+                origin_base="second",
+                target_base="third",
+            ),
+        ),
+    )
+
+    assert records[0].observed_stolen_bases == 2
+    assert records[0].observed_caught_stealing == 0
+
+
+def test_zero_activity_game_remains_present():
+    records = materialize(
+        shadow_games=(shadow_game(),),
+        outcomes=(),
+    )
+
+    assert len(records) == 1
+    assert records[0].observed_stolen_bases == 0
+    assert records[0].observed_caught_stealing == 0
+
+
+def test_duplicate_shadow_games_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical shadow game identifiers "
+            "must be unique"
+        ),
+    ):
+        materialize(
+            shadow_games=(
+                shadow_game(),
+                shadow_game(),
+            )
+        )
+
+
+def test_duplicate_outcomes_are_rejected():
+    value = outcome()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast outcome identifiers "
+            "must be unique"
+        ),
+    ):
+        materialize(
+            shadow_games=(shadow_game(),),
+            outcomes=(value, value),
+        )
+
+
+def test_unmatched_outcome_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast outcome game_pk must match "
+            "a historical shadow game"
+        ),
+    ):
+        materialize(
+            shadow_games=(shadow_game(),),
+            outcomes=(
+                outcome(game_pk=2),
+            ),
+        )
+
+
+def test_incomplete_outcome_identity_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast outcome requires "
+            "at_bat_number"
+        ),
+    ):
+        materialize(
+            shadow_games=(shadow_game(),),
+            outcomes=(
+                outcome(at_bat_number=None),
+            ),
+        )
+
+
+def test_invalid_shadow_game_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "shadow_games must contain "
+            "CanonicalHistoricalBaserunningShadowGame"
+        ),
+    ):
+        materialize(
+            shadow_games=(object(),),
+        )
+
+
+def test_invalid_outcome_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "outcomes must contain "
+            "CanonicalStatcastBaserunningOutcome"
+        ),
+    ):
+        materialize(
+            outcomes=(object(),),
+        )
+
+
+def test_unavailable_validation_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical shadow validation "
+            "must be ready"
+        ),
+    ):
+        CanonicalHistoricalBaserunningShadowGame(
+            game_pk=1,
+            game_date="2026-04-20",
+            validation=(
+                CanonicalBaserunningOutputValidation()
+            ),
+        )
+
+
+def test_materialization_is_deterministic():
+    first = materialize()
+    second = materialize()
+
+    assert first == second
+
+
+def test_versions_are_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION
+        == "canonical_historical_baserunning_shadow_game_v1"
+    )
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_MATERIALIZATION_VERSION
+        == "canonical_historical_baserunning_materialization_v1"
+    )


### PR DESCRIPTION
## Summary

- add a canonical historical shadow-game record carrying game identity, date, and a ready per-game validation
- materialize aligned historical calibration records by joining shadow games to decoded Statcast SB/CS outcomes
- preserve games with zero observed baserunning activity
- count distinct runners in multi-runner events without collapsing valid outcomes
- reject duplicate outcome identities, unmatched games, incomplete Statcast provenance, mixed sources, and invalid contracts

## Why

The historical calibration payload assembler requires exact per-game records. This change provides the audited bridge from decoded Statcast outcomes and per-game shadow validations to those records, including explicit zero-activity games.

## Production impact

None. Materialization performs no external fetches, persistence, simulation execution, calibration approval, authority change, or production activation. Legacy remains authoritative.

## Validation

- `200 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment