### PR TITLE
Execute historical baserunning calibration windows

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -381,3 +381,9 @@ from .historical_baserunning_game_materialization import (
     CanonicalHistoricalBaserunningShadowGame,
     materialize_historical_baserunning_game_records,
 )
+
+from .historical_baserunning_calibration_window import (
+    CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION,
+    CanonicalHistoricalBaserunningWindowExecution,
+    execute_historical_baserunning_calibration_window,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_calibration_window.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_calibration_window.py
@@ -1,0 +1,305 @@
+"""Execute one aligned historical baserunning calibration window."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from .baserunning_calibration_artifact import (
+    CanonicalBaserunningCalibrationArtifact,
+    execute_baserunning_calibration_artifact,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationPolicy,
+)
+from .baserunning_calibration_payload import (
+    assemble_historical_baserunning_calibration_payload,
+)
+from .historical_baserunning_game_materialization import (
+    CanonicalHistoricalBaserunningShadowGame,
+    materialize_historical_baserunning_game_records,
+)
+from .statcast_baserunning_source import (
+    decode_statcast_baserunning_outcomes,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION = (
+    "canonical_historical_baserunning_window_v1"
+)
+
+_VALID_STATUSES = {
+    "ready",
+    "unavailable",
+    "error",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningWindowExecution:
+    status: str = "unavailable"
+    window_start: Optional[str] = None
+    window_end: Optional[str] = None
+    game_count: int = 0
+    statcast_row_count: int = 0
+    observed_outcome_count: int = 0
+    artifact: Optional[
+        CanonicalBaserunningCalibrationArtifact
+    ] = None
+    error_message: Optional[str] = None
+    execution_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in _VALID_STATUSES:
+            raise ValueError(
+                "unsupported historical baserunning "
+                "window status"
+            )
+
+        for field_name in (
+            "game_count",
+            "statcast_row_count",
+            "observed_outcome_count",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(
+                    f"{field_name} must be nonnegative"
+                )
+
+        if self.status == "ready" and (
+            self.artifact is None
+            or not self.artifact.ready
+        ):
+            raise ValueError(
+                "ready window execution requires "
+                "ready artifact"
+            )
+
+        if self.execution_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "window version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    @property
+    def calibration_gate_passed(self) -> bool:
+        return bool(
+            self.artifact is not None
+            and self.artifact.calibration_gate_passed
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.execution_version,
+            "status": self.status,
+            "ready": self.ready,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "game_count": self.game_count,
+            "statcast_row_count": (
+                self.statcast_row_count
+            ),
+            "observed_outcome_count": (
+                self.observed_outcome_count
+            ),
+            "calibration_gate_passed": (
+                self.calibration_gate_passed
+            ),
+            "artifact": (
+                self.artifact.to_diagnostics()
+                if self.artifact is not None
+                else None
+            ),
+            "error_message": self.error_message,
+            "external_fetch_performed": False,
+            "persistence_performed": False,
+            "activation_permitted": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _game_pk(row: Mapping[str, Any]) -> int:
+    value = row.get("game_pk")
+
+    if value is None or isinstance(value, bool):
+        raise ValueError(
+            "Statcast row requires game_pk"
+        )
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "Statcast row requires integer game_pk"
+        ) from exc
+
+    if (
+        not math.isfinite(numeric)
+        or not numeric.is_integer()
+        or numeric <= 0
+    ):
+        raise ValueError(
+            "Statcast row requires integer game_pk"
+        )
+
+    return int(numeric)
+
+
+def execute_historical_baserunning_calibration_window(
+    *,
+    window_start: str,
+    window_end: str,
+    shadow_games: Tuple[
+        CanonicalHistoricalBaserunningShadowGame,
+        ...,
+    ],
+    statcast_rows: Tuple[
+        Mapping[str, Any],
+        ...,
+    ],
+    policy: CanonicalBaserunningCalibrationPolicy,
+    observed_source_version: str,
+) -> CanonicalHistoricalBaserunningWindowExecution:
+    """
+    Execute the complete offline calibration pipeline for one window.
+
+    Every shadow game must have Statcast row coverage, including games with
+    zero decoded SB/CS outcomes. No fetching, persistence, or activation is
+    performed.
+    """
+
+    game_count = 0
+    statcast_row_count = 0
+    observed_outcome_count = 0
+
+    try:
+        if not isinstance(shadow_games, tuple):
+            raise TypeError(
+                "shadow_games must be a tuple"
+            )
+        if not shadow_games:
+            raise ValueError(
+                "shadow_games must contain records"
+            )
+
+        for value in shadow_games:
+            if not isinstance(
+                value,
+                CanonicalHistoricalBaserunningShadowGame,
+            ):
+                raise TypeError(
+                    "shadow_games must contain "
+                    "CanonicalHistoricalBaserunningShadowGame"
+                )
+
+        if not isinstance(statcast_rows, tuple):
+            raise TypeError(
+                "statcast_rows must be a tuple"
+            )
+        if not statcast_rows:
+            raise ValueError(
+                "statcast_rows must contain records"
+            )
+
+        game_count = len(shadow_games)
+        statcast_row_count = len(statcast_rows)
+
+        shadow_game_ids = {
+            value.game_pk
+            for value in shadow_games
+        }
+        row_game_ids = set()
+        outcomes = []
+
+        for row in statcast_rows:
+            if not isinstance(row, Mapping):
+                raise TypeError(
+                    "statcast_rows must contain mappings"
+                )
+
+            row_game_pk = _game_pk(row)
+            row_game_ids.add(row_game_pk)
+
+            if row_game_pk not in shadow_game_ids:
+                raise ValueError(
+                    "Statcast row game_pk must match "
+                    "a historical shadow game"
+                )
+
+            outcomes.extend(
+                decode_statcast_baserunning_outcomes(
+                    row
+                )
+            )
+
+        missing_game_ids = (
+            shadow_game_ids - row_game_ids
+        )
+        if missing_game_ids:
+            raise ValueError(
+                "every historical shadow game must "
+                "have Statcast row coverage"
+            )
+
+        observed_outcome_count = len(outcomes)
+
+        game_records = (
+            materialize_historical_baserunning_game_records(
+                shadow_games=shadow_games,
+                outcomes=tuple(outcomes),
+                observed_source_version=(
+                    observed_source_version
+                ),
+            )
+        )
+
+        payload = (
+            assemble_historical_baserunning_calibration_payload(
+                window_start=window_start,
+                window_end=window_end,
+                games=game_records,
+                policy=policy,
+            )
+        )
+        artifact = execute_baserunning_calibration_artifact(
+            payload
+        )
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        return CanonicalHistoricalBaserunningWindowExecution(
+            status="error",
+            window_start=window_start,
+            window_end=window_end,
+            game_count=game_count,
+            statcast_row_count=statcast_row_count,
+            observed_outcome_count=(
+                observed_outcome_count
+            ),
+            error_message=str(exc),
+        )
+
+    return CanonicalHistoricalBaserunningWindowExecution(
+        status=artifact.status,
+        window_start=window_start,
+        window_end=window_end,
+        game_count=len(game_records),
+        statcast_row_count=statcast_row_count,
+        observed_outcome_count=(
+            observed_outcome_count
+        ),
+        artifact=artifact,
+        error_message=artifact.error_message,
+    )

--- a/tests/test_canonical_historical_baserunning_calibration_window.py
+++ b/tests/test_canonical_historical_baserunning_calibration_window.py
@@ -1,0 +1,297 @@
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION,
+    CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    CanonicalBaserunningCalibrationPolicy,
+    CanonicalBaserunningOutputValidation,
+    CanonicalHistoricalBaserunningShadowGame,
+    execute_historical_baserunning_calibration_window,
+)
+
+
+def validation(
+    *,
+    digest,
+    stolen_bases,
+    caught_stealing,
+):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=digest,
+        runner_projection_count=9,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=(
+            caught_stealing
+        ),
+    )
+
+
+def shadow_game(
+    *,
+    game_pk,
+    game_date,
+    digest,
+    stolen_bases,
+    caught_stealing,
+):
+    return CanonicalHistoricalBaserunningShadowGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        validation=validation(
+            digest=digest,
+            stolen_bases=stolen_bases,
+            caught_stealing=caught_stealing,
+        ),
+    )
+
+
+def row(**overrides):
+    value = {
+        "game_pk": 1,
+        "at_bat_number": 10,
+        "pitch_number": 3,
+        "pitcher": 100,
+        "fielder_2": 200,
+        "on_1b": 300,
+        "on_2b": None,
+        "on_3b": None,
+        "des": (
+            "Batter strikes out swinging. "
+            "Runner steals (1) 2nd base."
+        ),
+    }
+    value.update(overrides)
+    return value
+
+
+def policy(**overrides):
+    arguments = {
+        "minimum_game_count": 2,
+        "maximum_stolen_base_error_per_game": 0.0,
+        "maximum_caught_stealing_error_per_game": 0.0,
+        "maximum_attempt_error_per_game": 0.0,
+        "maximum_success_rate_absolute_error": 0.0,
+        "policy_version": (
+            "historical_smoke_policy_v1"
+        ),
+    }
+    arguments.update(overrides)
+
+    return CanonicalBaserunningCalibrationPolicy(
+        **arguments
+    )
+
+
+def execute(**overrides):
+    arguments = {
+        "window_start": "2026-04-20",
+        "window_end": "2026-05-03",
+        "shadow_games": (
+            shadow_game(
+                game_pk=1,
+                game_date="2026-04-20",
+                digest="digest-a",
+                stolen_bases=1.0,
+                caught_stealing=1.0,
+            ),
+            shadow_game(
+                game_pk=2,
+                game_date="2026-04-21",
+                digest="digest-b",
+                stolen_bases=0.0,
+                caught_stealing=0.0,
+            ),
+        ),
+        "statcast_rows": (
+            row(),
+            row(
+                at_bat_number=20,
+                on_1b=301,
+                des=(
+                    "Batter strikes out swinging and "
+                    "Runner caught stealing 2nd, "
+                    "catcher."
+                ),
+            ),
+            row(
+                game_pk=2,
+                at_bat_number=1,
+                pitch_number=1,
+                on_1b=None,
+                des="Batter grounds out.",
+            ),
+        ),
+        "policy": policy(),
+        "observed_source_version": (
+            CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+        ),
+    }
+    arguments.update(overrides)
+
+    return (
+        execute_historical_baserunning_calibration_window(
+            **arguments
+        )
+    )
+
+
+def test_executes_complete_historical_window():
+    result = execute()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.game_count == 2
+    assert result.statcast_row_count == 3
+    assert result.observed_outcome_count == 2
+    assert result.artifact is not None
+    assert result.calibration_gate_passed is True
+
+
+def test_failed_gate_remains_ready_execution():
+    result = execute(
+        policy=policy(
+            minimum_game_count=50,
+        )
+    )
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.calibration_gate_passed is False
+    assert result.artifact is not None
+    assert result.artifact.report is not None
+    assert result.artifact.report.gate is not None
+    assert result.artifact.report.gate.failures == (
+        "minimum_game_count_not_met",
+    )
+
+
+def test_zero_activity_game_is_included():
+    result = execute()
+
+    assert result.artifact is not None
+    assert result.artifact.report is not None
+    assert result.artifact.report.comparison is not None
+    assert (
+        result.artifact.report.comparison.game_count
+        == 2
+    )
+
+
+def test_missing_statcast_game_coverage_fails_open():
+    result = execute(
+        statcast_rows=(
+            row(),
+            row(
+                at_bat_number=20,
+                on_1b=301,
+                des=(
+                    "Runner caught stealing 2nd, "
+                    "catcher."
+                ),
+            ),
+        )
+    )
+
+    assert result.status == "error"
+    assert result.ready is False
+    assert result.artifact is None
+    assert result.error_message == (
+        "every historical shadow game must "
+        "have Statcast row coverage"
+    )
+
+
+def test_unmatched_statcast_game_fails_open():
+    result = execute(
+        statcast_rows=(
+            row(game_pk=3),
+        )
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "Statcast row game_pk must match "
+        "a historical shadow game"
+    )
+
+
+def test_invalid_statcast_row_fails_open():
+    result = execute(
+        statcast_rows=(object(),)
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "statcast_rows must contain mappings"
+    )
+
+
+def test_missing_game_pk_fails_open():
+    value = row()
+    del value["game_pk"]
+
+    result = execute(
+        statcast_rows=(value,)
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "Statcast row requires game_pk"
+    )
+
+
+def test_duplicate_decoded_outcome_fails_open():
+    duplicate = row()
+
+    result = execute(
+        shadow_games=(
+            shadow_game(
+                game_pk=1,
+                game_date="2026-04-20",
+                digest="digest-a",
+                stolen_bases=1.0,
+                caught_stealing=0.0,
+            ),
+        ),
+        statcast_rows=(
+            duplicate,
+            duplicate,
+        ),
+        policy=policy(
+            minimum_game_count=1,
+        ),
+    )
+
+    assert result.status == "error"
+    assert result.error_message == (
+        "Statcast outcome identifiers must be unique"
+    )
+
+
+def test_diagnostics_preserve_legacy_authority():
+    diagnostics = execute().to_diagnostics()
+
+    assert diagnostics[
+        "external_fetch_performed"
+    ] is False
+    assert diagnostics["persistence_performed"] is False
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_execution_is_deterministic():
+    first = execute()
+    second = execute()
+
+    assert first == second
+    assert first.to_diagnostics() == second.to_diagnostics()
+
+
+def test_execution_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_WINDOW_VERSION
+        == "canonical_historical_baserunning_window_v1"
+    )


### PR DESCRIPTION
## Summary

- add a fail-open executor for one aligned historical baserunning calibration window
- verify every shadow game has Statcast row coverage, including zero-activity games
- decode observed SB/CS outcomes, materialize per-game records, assemble the immutable payload, and execute the existing calibration artifact
- expose deterministic nested diagnostics for window size, source-row count, observed outcomes, artifact status, and gate result
- reject malformed rows, missing or unmatched games, and duplicate decoded outcomes

## Why

The individual calibration contracts are complete. This change composes them into one reusable window boundary so a fixed historical dataset can produce an auditable calibration result without duplicating decoding, alignment, comparison, or gate rules.

## Production impact

None. The executor performs no external fetches, persistence, live simulation mutation, authority change, or production activation. A passing gate remains diagnostic and legacy remains authoritative.

## Validation

- `211 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment