### PR TITLE
Source baserunning calibration smoke window

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -387,3 +387,19 @@ from .historical_baserunning_calibration_window import (
     CanonicalHistoricalBaserunningWindowExecution,
     execute_historical_baserunning_calibration_window,
 )
+
+from .statcast_baserunning_window_source import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+    CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION,
+    CanonicalStatcastBaserunningWindowSnapshot,
+    CanonicalStatcastBaserunningWindowSource,
+    source_statcast_baserunning_window,
+)
+
+from .mlb_play_by_play_baserunning_source import (
+    CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+    source_mlb_play_by_play_baserunning_window,
+)

--- a/mlb_app/simulation/shadow/mlb_play_by_play_baserunning_source.py
+++ b/mlb_app/simulation/shadow/mlb_play_by_play_baserunning_source.py
@@ -1,0 +1,507 @@
+"""Source complete observed baserunning from MLB play-by-play."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Mapping, Tuple
+
+
+CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION = (
+    "canonical_mlb_play_by_play_baserunning_source_v1"
+)
+
+_FINAL_ABSTRACT_STATES = {
+    "Final",
+}
+
+
+def _mapping(
+    value: Any,
+    field_name: str,
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            f"{field_name} must be a mapping"
+        )
+    return value
+
+
+def _list(
+    value: Any,
+    field_name: str,
+) -> list[Any]:
+    if not isinstance(value, list):
+        raise TypeError(
+            f"{field_name} must be a list"
+        )
+    return value
+
+
+def _positive_game_pk(value: Any) -> int:
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value <= 0
+    ):
+        raise ValueError(
+            "gamePk must be a positive integer"
+        )
+    return value
+
+
+def _runner_id(
+    details: Mapping[str, Any],
+) -> str:
+    runner = _mapping(
+        details.get("runner"),
+        "runner.details.runner",
+    )
+    value = runner.get("id")
+
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value <= 0
+    ):
+        raise ValueError(
+            "runner identity must be available"
+        )
+
+    return str(value)
+
+
+def _event_type(
+    *,
+    play: Mapping[str, Any],
+    runner: Mapping[str, Any],
+) -> str:
+    details = _mapping(
+        runner.get("details"),
+        "runner.details",
+    )
+    value = details.get("eventType")
+
+    if value in (None, ""):
+        result = _mapping(
+            play.get("result", {}),
+            "play.result",
+        )
+        value = result.get("eventType", "")
+
+    return str(value).strip().lower()
+
+
+def _classify_event(event_type: str) -> str | None:
+    normalized = event_type.replace("-", "_")
+
+    if normalized.startswith("stolen_base"):
+        return "stolen_base"
+
+    if "caught_stealing" in normalized:
+        return "caught_stealing"
+
+    return None
+
+
+@dataclass(frozen=True)
+class CanonicalMlbPlayByPlayBaserunningGame:
+    game_pk: int
+    game_date: str
+    stolen_bases: int
+    caught_stealing: int
+
+    def __post_init__(self) -> None:
+        if self.game_pk <= 0:
+            raise ValueError(
+                "game_pk must be positive"
+            )
+
+        parsed_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        for field_name in (
+            "stolen_bases",
+            "caught_stealing",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(
+                    f"{field_name} must be nonnegative"
+                )
+
+
+@dataclass(frozen=True)
+class CanonicalMlbPlayByPlayBaserunningSnapshot:
+    window_start: str
+    window_end: str
+    games: Tuple[
+        CanonicalMlbPlayByPlayBaserunningGame,
+        ...,
+    ]
+    event_count: int
+    stolen_bases: int
+    caught_stealing: int
+    duplicate_event_record_count: int
+    digest: str
+    source_version: str = (
+        CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain completed games"
+            )
+
+        game_ids = tuple(
+            value.game_pk
+            for value in self.games
+        )
+        if len(game_ids) != len(set(game_ids)):
+            raise ValueError(
+                "completed game identifiers must be unique"
+            )
+
+        if self.duplicate_event_record_count < 0:
+            raise ValueError(
+                "duplicate_event_record_count "
+                "must be nonnegative"
+            )
+
+        if self.event_count != (
+            self.stolen_bases
+            + self.caught_stealing
+        ):
+            raise ValueError(
+                "event_count must equal SB plus CS"
+            )
+
+        if len(self.digest) != 64:
+            raise ValueError(
+                "digest must be a SHA-256 hex digest"
+            )
+
+        if self.source_version != (
+            CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported MLB play-by-play "
+                "baserunning source version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "game_count": self.game_count,
+            "event_count": self.event_count,
+            "stolen_bases": self.stolen_bases,
+            "caught_stealing": self.caught_stealing,
+            "duplicate_event_record_count": (
+                self.duplicate_event_record_count
+            ),
+            "digest": self.digest,
+            "coverage_complete": True,
+            "calibration_observed_source_eligible": True,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _completed_games(
+    *,
+    schedule: Mapping[str, Any],
+    start_date: date,
+    end_date: date,
+) -> Tuple[Tuple[int, str], ...]:
+    games_by_id = {}
+
+    for date_row in _list(
+        schedule.get("dates"),
+        "schedule.dates",
+    ):
+        date_item = _mapping(
+            date_row,
+            "schedule date",
+        )
+        schedule_date = str(
+            date_item.get("date", "")
+        )
+        date.fromisoformat(
+            schedule_date
+        )
+
+        for game in _list(
+            date_item.get("games"),
+            "schedule games",
+        ):
+            game_item = _mapping(
+                game,
+                "schedule game",
+            )
+            status = _mapping(
+                game_item.get("status"),
+                "schedule game status",
+            )
+
+            if status.get(
+                "abstractGameState"
+            ) not in _FINAL_ABSTRACT_STATES:
+                continue
+
+            game_pk = _positive_game_pk(
+                game_item.get("gamePk")
+            )
+            game_date = str(
+                game_item.get(
+                    "officialDate",
+                    schedule_date,
+                )
+            )
+            parsed_game_date = date.fromisoformat(
+                game_date
+            )
+
+            if not (
+                start_date
+                <= parsed_game_date
+                <= end_date
+            ):
+                raise ValueError(
+                    "completed game officialDate "
+                    "must fall within source window"
+                )
+
+            existing_date = games_by_id.get(
+                game_pk
+            )
+            if (
+                existing_date is not None
+                and existing_date != game_date
+            ):
+                raise ValueError(
+                    "gamePk must map to one officialDate"
+                )
+
+            games_by_id[game_pk] = game_date
+
+    if not games_by_id:
+        raise ValueError(
+            "schedule contains no completed games"
+        )
+
+    return tuple(
+        sorted(
+            games_by_id.items(),
+            key=lambda value: (
+                value[1],
+                value[0],
+            ),
+        )
+    )
+
+def source_mlb_play_by_play_baserunning_window(
+    *,
+    schedule: Mapping[str, Any],
+    game_feeds: Mapping[int, Mapping[str, Any]],
+    window_start: str,
+    window_end: str,
+) -> CanonicalMlbPlayByPlayBaserunningSnapshot:
+    """
+    Source complete observed SB/CS events from MLB play-by-play feeds.
+
+    The caller owns network access. This function validates completed-game
+    coverage and creates deterministic per-game totals and provenance.
+    """
+
+    schedule = _mapping(
+        schedule,
+        "schedule",
+    )
+    game_feeds = _mapping(
+        game_feeds,
+        "game_feeds",
+    )
+
+    start_date = date.fromisoformat(
+        window_start
+    )
+    end_date = date.fromisoformat(
+        window_end
+    )
+
+    if end_date < start_date:
+        raise ValueError(
+            "window_end must not precede window_start"
+        )
+
+    completed_games = _completed_games(
+        schedule=schedule,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    completed_ids = {
+        game_pk
+        for game_pk, _ in completed_games
+    }
+
+    if set(game_feeds) != completed_ids:
+        raise ValueError(
+            "game_feeds must exactly cover "
+            "completed schedule games"
+        )
+
+    game_records = []
+    event_identities = []
+    seen_event_identities = set()
+    duplicate_event_record_count = 0
+
+    for game_pk, game_date in completed_games:
+        feed = _mapping(
+            game_feeds[game_pk],
+            "game feed",
+        )
+        live_data = _mapping(
+            feed.get("liveData"),
+            "game feed liveData",
+        )
+        plays = _mapping(
+            live_data.get("plays"),
+            "game feed plays",
+        )
+        all_plays = _list(
+            plays.get("allPlays"),
+            "game feed allPlays",
+        )
+
+        stolen_bases = 0
+        caught_stealing = 0
+
+        for fallback_index, play in enumerate(
+            all_plays
+        ):
+            play_item = _mapping(
+                play,
+                "play",
+            )
+            about = _mapping(
+                play_item.get("about", {}),
+                "play.about",
+            )
+            play_index = int(
+                about.get(
+                    "atBatIndex",
+                    fallback_index,
+                )
+            )
+
+            for runner in _list(
+                play_item.get("runners", []),
+                "play runners",
+            ):
+                runner_item = _mapping(
+                    runner,
+                    "runner",
+                )
+                details = _mapping(
+                    runner_item.get("details"),
+                    "runner.details",
+                )
+                classification = _classify_event(
+                    _event_type(
+                        play=play_item,
+                        runner=runner_item,
+                    )
+                )
+
+                if classification is None:
+                    continue
+
+                identity = (
+                    game_pk,
+                    play_index,
+                    _runner_id(details),
+                    classification,
+                )
+                if identity in seen_event_identities:
+                    duplicate_event_record_count += 1
+                    continue
+
+                seen_event_identities.add(identity)
+                event_identities.append(identity)
+
+                if classification == "stolen_base":
+                    stolen_bases += 1
+                else:
+                    caught_stealing += 1
+
+        game_records.append(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=game_pk,
+                game_date=game_date,
+                stolen_bases=stolen_bases,
+                caught_stealing=caught_stealing,
+            )
+        )
+
+    serialized = json.dumps(
+        {
+            "window_start": start_date.isoformat(),
+            "window_end": end_date.isoformat(),
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "game_date": value.game_date,
+                    "stolen_bases": value.stolen_bases,
+                    "caught_stealing": (
+                        value.caught_stealing
+                    ),
+                }
+                for value in game_records
+            ],
+            "events": event_identities,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()
+
+    stolen_base_total = sum(
+        value.stolen_bases
+        for value in game_records
+    )
+    caught_stealing_total = sum(
+        value.caught_stealing
+        for value in game_records
+    )
+
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start=start_date.isoformat(),
+        window_end=end_date.isoformat(),
+        games=tuple(game_records),
+        event_count=(
+            stolen_base_total
+            + caught_stealing_total
+        ),
+        stolen_bases=stolen_base_total,
+        caught_stealing=caught_stealing_total,
+        duplicate_event_record_count=(
+            duplicate_event_record_count
+        ),
+        digest=digest,
+    )

--- a/mlb_app/simulation/shadow/statcast_baserunning_window_source.py
+++ b/mlb_app/simulation/shadow/statcast_baserunning_window_source.py
@@ -1,0 +1,422 @@
+"""Source and fingerprint historical Statcast baserunning windows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+from .statcast_baserunning_source import (
+    CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION,
+    decode_statcast_baserunning_outcomes,
+)
+
+
+CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION = (
+    "canonical_statcast_baserunning_window_source_v1"
+)
+CANONICAL_BASERUNNING_SMOKE_WINDOW_START = "2026-04-20"
+CANONICAL_BASERUNNING_SMOKE_WINDOW_END = "2026-05-03"
+
+_REQUIRED_COLUMNS = (
+    "game_date",
+    "game_pk",
+    "at_bat_number",
+    "pitch_number",
+    "des",
+    "on_1b",
+    "on_2b",
+    "on_3b",
+    "pitcher",
+    "fielder_2",
+)
+
+
+def _missing(value: Any) -> bool:
+    if value is None:
+        return True
+
+    try:
+        return bool(value != value)
+    except (TypeError, ValueError):
+        return False
+
+
+def _integer(
+    value: Any,
+    field_name: str,
+) -> int:
+    if _missing(value) or isinstance(value, bool):
+        raise ValueError(
+            f"{field_name} must be an integer"
+        )
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{field_name} must be an integer"
+        ) from exc
+
+    if (
+        not math.isfinite(numeric)
+        or not numeric.is_integer()
+    ):
+        raise ValueError(
+            f"{field_name} must be an integer"
+        )
+
+    return int(numeric)
+
+
+def _date_string(
+    value: Any,
+    field_name: str,
+) -> str:
+    if isinstance(value, datetime):
+        parsed = value.date()
+    elif isinstance(value, date):
+        parsed = value
+    elif isinstance(value, str):
+        parsed = date.fromisoformat(
+            value[:10]
+        )
+    else:
+        raise TypeError(
+            f"{field_name} must identify a date"
+        )
+
+    return parsed.isoformat()
+
+
+def _json_value(value: Any) -> Any:
+    if _missing(value):
+        return None
+
+    if hasattr(value, "item"):
+        value = value.item()
+
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+
+    if isinstance(value, (str, int, float, bool)):
+        return value
+
+    return str(value)
+
+
+@dataclass(frozen=True)
+class CanonicalStatcastBaserunningWindowSnapshot:
+    window_start: str
+    window_end: str
+    game_keys: Tuple[
+        Tuple[int, str],
+        ...,
+    ]
+    row_count: int
+    outcome_count: int
+    stolen_bases: int
+    caught_stealing: int
+    digest: str
+    outcome_source_version: str = (
+        CANONICAL_STATCAST_BASERUNNING_SOURCE_VERSION
+    )
+    source_version: str = (
+        CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.row_count <= 0:
+            raise ValueError(
+                "row_count must be positive"
+            )
+
+        for field_name in (
+            "outcome_count",
+            "stolen_bases",
+            "caught_stealing",
+        ):
+            if getattr(self, field_name) < 0:
+                raise ValueError(
+                    f"{field_name} must be nonnegative"
+                )
+
+        if self.outcome_count != (
+            self.stolen_bases
+            + self.caught_stealing
+        ):
+            raise ValueError(
+                "outcome_count must equal SB plus CS"
+            )
+
+        if not self.game_keys:
+            raise ValueError(
+                "game_keys must contain games"
+            )
+
+        if (
+            len(self.game_keys)
+            != len(set(self.game_keys))
+        ):
+            raise ValueError(
+                "game_keys must be unique"
+            )
+
+        if (
+            not isinstance(self.digest, str)
+            or len(self.digest) != 64
+        ):
+            raise ValueError(
+                "digest must be a SHA-256 hex digest"
+            )
+
+        if self.source_version != (
+            CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported Statcast baserunning "
+                "window source version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.game_keys)
+
+    @property
+    def coverage_complete(self) -> bool:
+        return False
+
+    @property
+    def calibration_observed_source_eligible(
+        self,
+    ) -> bool:
+        return False
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "game_count": self.game_count,
+            "game_keys": self.game_keys,
+            "row_count": self.row_count,
+            "outcome_count": self.outcome_count,
+            "stolen_bases": self.stolen_bases,
+            "caught_stealing": self.caught_stealing,
+            "digest": self.digest,
+            "outcome_source_version": (
+                self.outcome_source_version
+            ),
+            "coverage_complete": (
+                self.coverage_complete
+            ),
+            "calibration_observed_source_eligible": (
+                self.calibration_observed_source_eligible
+            ),
+            "coverage_warning": (
+                "pitch-level Statcast descriptions "
+                "do not contain every baserunning event"
+            ),
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalStatcastBaserunningWindowSource:
+    snapshot: CanonicalStatcastBaserunningWindowSnapshot
+    rows: Tuple[
+        Mapping[str, Any],
+        ...,
+    ]
+
+    def __post_init__(self) -> None:
+        if len(self.rows) != self.snapshot.row_count:
+            raise ValueError(
+                "rows must match snapshot row_count"
+            )
+
+
+def source_statcast_baserunning_window(
+    *,
+    rows: Iterable[Mapping[str, Any]],
+    window_start: str,
+    window_end: str,
+) -> CanonicalStatcastBaserunningWindowSource:
+    """
+    Canonicalize and fingerprint one fetched Statcast window.
+
+    Fetching remains caller-owned. The returned rows are deterministic and
+    directly consumable by the historical calibration window executor.
+    """
+
+    start_date = date.fromisoformat(window_start)
+    end_date = date.fromisoformat(window_end)
+
+    if end_date < start_date:
+        raise ValueError(
+            "window_end must not precede window_start"
+        )
+
+    if isinstance(rows, (str, bytes, Mapping)):
+        raise TypeError(
+            "rows must be an iterable of mappings"
+        )
+
+    canonical_rows = []
+    row_keys = set()
+    game_dates = {}
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise TypeError(
+                "rows must contain mappings"
+            )
+
+        missing_columns = tuple(
+            column
+            for column in _REQUIRED_COLUMNS
+            if column not in row
+        )
+        if missing_columns:
+            raise ValueError(
+                "Statcast row missing required columns: "
+                + ",".join(missing_columns)
+            )
+
+        game_date = _date_string(
+            row["game_date"],
+            "game_date",
+        )
+        parsed_game_date = date.fromisoformat(
+            game_date
+        )
+        if not (
+            start_date
+            <= parsed_game_date
+            <= end_date
+        ):
+            raise ValueError(
+                "Statcast row game_date must fall "
+                "within source window"
+            )
+
+        game_pk = _integer(
+            row["game_pk"],
+            "game_pk",
+        )
+        at_bat_number = _integer(
+            row["at_bat_number"],
+            "at_bat_number",
+        )
+        pitch_number = _integer(
+            row["pitch_number"],
+            "pitch_number",
+        )
+
+        row_key = (
+            game_pk,
+            at_bat_number,
+            pitch_number,
+        )
+        if row_key in row_keys:
+            raise ValueError(
+                "Statcast pitch identifiers must be unique"
+            )
+        row_keys.add(row_key)
+
+        prior_date = game_dates.get(game_pk)
+        if (
+            prior_date is not None
+            and prior_date != game_date
+        ):
+            raise ValueError(
+                "game_pk must map to one game_date"
+            )
+        game_dates[game_pk] = game_date
+
+        canonical_row = {
+            column: _json_value(row[column])
+            for column in _REQUIRED_COLUMNS
+        }
+        canonical_row["game_date"] = game_date
+        canonical_row["game_pk"] = game_pk
+        canonical_row["at_bat_number"] = (
+            at_bat_number
+        )
+        canonical_row["pitch_number"] = (
+            pitch_number
+        )
+        canonical_rows.append(canonical_row)
+
+    if not canonical_rows:
+        raise ValueError(
+            "rows must contain Statcast records"
+        )
+
+    canonical_rows.sort(
+        key=lambda row: (
+            row["game_date"],
+            row["game_pk"],
+            row["at_bat_number"],
+            row["pitch_number"],
+        )
+    )
+
+    outcomes = tuple(
+        outcome
+        for row in canonical_rows
+        for outcome in (
+            decode_statcast_baserunning_outcomes(
+                row
+            )
+        )
+    )
+
+    serialized = json.dumps(
+        canonical_rows,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    digest = hashlib.sha256(
+        serialized.encode("utf-8")
+    ).hexdigest()
+
+    snapshot = (
+        CanonicalStatcastBaserunningWindowSnapshot(
+            window_start=start_date.isoformat(),
+            window_end=end_date.isoformat(),
+            game_keys=tuple(
+                sorted(
+                    (
+                        game_pk,
+                        game_date,
+                    )
+                    for game_pk, game_date
+                    in game_dates.items()
+                )
+            ),
+            row_count=len(canonical_rows),
+            outcome_count=len(outcomes),
+            stolen_bases=sum(
+                value.event_type == "stolen_base"
+                for value in outcomes
+            ),
+            caught_stealing=sum(
+                value.event_type
+                == "caught_stealing"
+                for value in outcomes
+            ),
+            digest=digest,
+        )
+    )
+
+    return CanonicalStatcastBaserunningWindowSource(
+        snapshot=snapshot,
+        rows=tuple(canonical_rows),
+    )

--- a/scripts/run_baserunning_calibration_smoke_window_source.py
+++ b/scripts/run_baserunning_calibration_smoke_window_source.py
@@ -1,0 +1,183 @@
+"""Compare Statcast descriptions with MLB play-by-play outcomes."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from pybaseball import statcast
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+    source_mlb_play_by_play_baserunning_window,
+    source_statcast_baserunning_window,
+)
+
+
+_SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+
+
+def _json(url, *, params=None):
+    response = requests.get(
+        url,
+        params=params,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _completed_game_ids(schedule):
+    return tuple(
+        sorted(
+            {
+                int(game["gamePk"])
+                for date_row in schedule["dates"]
+                for game in date_row["games"]
+                if game["status"][
+                    "abstractGameState"
+                ]
+                == "Final"
+            }
+        )
+    )
+
+
+def _feed(game_pk):
+    return (
+        game_pk,
+        _json(
+            _FEED_URL.format(
+                game_pk=game_pk
+            )
+        ),
+    )
+
+
+def main() -> None:
+    frame = statcast(
+        start_dt=(
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+        ),
+        end_dt=(
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+        ),
+    )
+    statcast_source = (
+        source_statcast_baserunning_window(
+            rows=frame.to_dict(
+                orient="records"
+            ),
+            window_start=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            window_end=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        )
+    )
+
+    schedule = _json(
+        _SCHEDULE_URL,
+        params={
+            "sportId": 1,
+            "startDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            "endDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        },
+    )
+    game_ids = _completed_game_ids(
+        schedule
+    )
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        feeds = dict(
+            executor.map(
+                _feed,
+                game_ids,
+            )
+        )
+
+    play_by_play = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=schedule,
+            game_feeds=feeds,
+            window_start=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            window_end=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        )
+    )
+
+    statcast_diagnostics = (
+        statcast_source.snapshot.to_diagnostics()
+    )
+    observed = play_by_play.to_diagnostics()
+
+    comparison = {
+        "window_start": (
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+        ),
+        "window_end": (
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+        ),
+        "statcast_description": (
+            statcast_diagnostics
+        ),
+        "mlb_play_by_play": observed,
+        "statcast_event_coverage_rate": round(
+            statcast_diagnostics["outcome_count"]
+            / observed["event_count"],
+            6,
+        ),
+        "statcast_stolen_base_coverage_rate": round(
+            statcast_diagnostics["stolen_bases"]
+            / observed["stolen_bases"],
+            6,
+        ),
+        "statcast_caught_stealing_coverage_rate": (
+            round(
+                statcast_diagnostics[
+                    "caught_stealing"
+                ]
+                / observed["caught_stealing"],
+                6,
+            )
+        ),
+        "statcast_description_coverage_complete": (
+            False
+        ),
+        "calibration_observed_source": (
+            observed["schema_version"]
+        ),
+        "production_activation": False,
+        "production_authority_changed": False,
+        "authoritative_source": "legacy",
+    }
+
+    print(
+        json.dumps(
+            comparison,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonical_mlb_play_by_play_baserunning_source.py
+++ b/tests/test_canonical_mlb_play_by_play_baserunning_source.py
@@ -1,0 +1,321 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+def schedule():
+    return {
+        "dates": [
+            {
+                "date": "2026-04-20",
+                "games": [
+                    {
+                        "gamePk": 1,
+                        "status": {
+                            "abstractGameState": "Final",
+                        },
+                    },
+                    {
+                        "gamePk": 2,
+                        "status": {
+                            "abstractGameState": "Live",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": "2026-04-21",
+                "games": [
+                    {
+                        "gamePk": 3,
+                        "status": {
+                            "abstractGameState": "Final",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def runner(
+    *,
+    runner_id,
+    event_type,
+):
+    return {
+        "movement": {
+            "start": "1B",
+            "end": "2B",
+            "isOut": (
+                "caught_stealing"
+                in event_type
+            ),
+        },
+        "details": {
+            "event": event_type,
+            "eventType": event_type,
+            "runner": {
+                "id": runner_id,
+            },
+        },
+    }
+
+
+def feed(*plays):
+    return {
+        "liveData": {
+            "plays": {
+                "allPlays": list(plays),
+            },
+        },
+    }
+
+
+def play(
+    *,
+    index,
+    runners,
+):
+    return {
+        "about": {
+            "atBatIndex": index,
+        },
+        "result": {
+            "eventType": "",
+        },
+        "runners": list(runners),
+    }
+
+
+def source(**overrides):
+    arguments = {
+        "schedule": schedule(),
+        "game_feeds": {
+            1: feed(
+                play(
+                    index=1,
+                    runners=(
+                        runner(
+                            runner_id=10,
+                            event_type=(
+                                "stolen_base_2b"
+                            ),
+                        ),
+                        runner(
+                            runner_id=11,
+                            event_type=(
+                                "stolen_base_3b"
+                            ),
+                        ),
+                    ),
+                ),
+                play(
+                    index=2,
+                    runners=(
+                        runner(
+                            runner_id=12,
+                            event_type=(
+                                "caught_stealing_2b"
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            3: feed(
+                play(
+                    index=1,
+                    runners=(),
+                ),
+            ),
+        },
+        "window_start": "2026-04-20",
+        "window_end": "2026-05-03",
+    }
+    arguments.update(overrides)
+
+    return (
+        source_mlb_play_by_play_baserunning_window(
+            **arguments
+        )
+    )
+
+
+def test_sources_completed_games_and_events():
+    result = source()
+
+    assert result.game_count == 2
+    assert result.event_count == 3
+    assert result.stolen_bases == 2
+    assert result.caught_stealing == 1
+    assert tuple(
+        value.game_pk
+        for value in result.games
+    ) == (1, 3)
+
+
+def test_zero_activity_completed_game_is_preserved():
+    result = source()
+
+    assert result.games[1].stolen_bases == 0
+    assert result.games[1].caught_stealing == 0
+
+
+def test_pickoff_caught_stealing_is_counted():
+    value = schedule()
+    feeds = {
+        1: feed(
+            play(
+                index=1,
+                runners=(
+                    runner(
+                        runner_id=10,
+                        event_type=(
+                            "pickoff_caught_stealing_2b"
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        3: feed(),
+    }
+
+    result = source(
+        schedule=value,
+        game_feeds=feeds,
+    )
+
+    assert result.stolen_bases == 0
+    assert result.caught_stealing == 1
+
+
+def test_incomplete_feed_coverage_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "game_feeds must exactly cover "
+            "completed schedule games"
+        ),
+    ):
+        source(
+            game_feeds={
+                1: feed(),
+            }
+        )
+
+
+def test_duplicate_feed_event_is_deduplicated():
+    value = runner(
+        runner_id=10,
+        event_type="stolen_base_2b",
+    )
+
+    result = source(
+        game_feeds={
+            1: feed(
+                play(
+                    index=1,
+                    runners=(value, value),
+                ),
+            ),
+            3: feed(),
+        }
+    )
+
+    assert result.event_count == 1
+    assert result.stolen_bases == 1
+    assert result.caught_stealing == 0
+    assert (
+        result.duplicate_event_record_count
+        == 1
+    )
+    assert result.to_diagnostics()[
+        "duplicate_event_record_count"
+    ] == 1
+
+
+def test_digest_is_deterministic():
+    first = source()
+    second = source()
+
+    assert first == second
+    assert first.digest == second.digest
+
+
+def test_diagnostics_mark_complete_observed_source():
+    diagnostics = source().to_diagnostics()
+
+    assert diagnostics["coverage_complete"] is True
+    assert diagnostics[
+        "calibration_observed_source_eligible"
+    ] is True
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_source_version_is_explicit():
+    assert (
+        CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+        == "canonical_mlb_play_by_play_baserunning_source_v1"
+    )
+
+
+def test_repeated_schedule_game_is_deduplicated():
+    value = schedule()
+    value["dates"].append(
+        {
+            "date": "2026-04-22",
+            "games": [
+                {
+                    "gamePk": 1,
+                    "officialDate": "2026-04-20",
+                    "status": {
+                        "abstractGameState": "Final",
+                    },
+                },
+            ],
+        }
+    )
+    value["dates"][0]["games"][0][
+        "officialDate"
+    ] = "2026-04-20"
+
+    result = source(schedule=value)
+
+    assert result.game_count == 2
+    assert tuple(
+        game.game_pk
+        for game in result.games
+    ) == (1, 3)
+
+
+def test_conflicting_official_dates_are_rejected():
+    value = schedule()
+    value["dates"].append(
+        {
+            "date": "2026-04-22",
+            "games": [
+                {
+                    "gamePk": 1,
+                    "officialDate": "2026-04-22",
+                    "status": {
+                        "abstractGameState": "Final",
+                    },
+                },
+            ],
+        }
+    )
+    value["dates"][0]["games"][0][
+        "officialDate"
+    ] = "2026-04-20"
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "gamePk must map to one officialDate"
+        ),
+    ):
+        source(schedule=value)

--- a/tests/test_canonical_statcast_baserunning_window_source.py
+++ b/tests/test_canonical_statcast_baserunning_window_source.py
@@ -1,0 +1,217 @@
+from datetime import datetime
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+    CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION,
+    source_statcast_baserunning_window,
+)
+
+
+def row(**overrides):
+    value = {
+        "game_date": "2026-04-20",
+        "game_pk": 1,
+        "at_bat_number": 10,
+        "pitch_number": 3,
+        "des": (
+            "Batter strikes out. "
+            "Runner steals (1) 2nd base."
+        ),
+        "on_1b": 300,
+        "on_2b": None,
+        "on_3b": None,
+        "pitcher": 100,
+        "fielder_2": 200,
+    }
+    value.update(overrides)
+    return value
+
+
+def source(rows=None):
+    return source_statcast_baserunning_window(
+        rows=(
+            rows
+            if rows is not None
+            else (
+                row(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                    at_bat_number=1,
+                    pitch_number=1,
+                    des="Batter grounds out.",
+                    on_1b=None,
+                ),
+                row(),
+                row(
+                    at_bat_number=20,
+                    on_1b=301,
+                    des=(
+                        "Runner caught stealing 2nd, "
+                        "catcher."
+                    ),
+                ),
+            )
+        ),
+        window_start=(
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+        ),
+        window_end=(
+            CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+        ),
+    )
+
+
+def test_sources_complete_window_snapshot():
+    result = source()
+
+    assert result.snapshot.game_count == 2
+    assert result.snapshot.row_count == 3
+    assert result.snapshot.outcome_count == 2
+    assert result.snapshot.stolen_bases == 1
+    assert result.snapshot.caught_stealing == 1
+    assert result.snapshot.game_keys == (
+        (1, "2026-04-20"),
+        (2, "2026-04-21"),
+    )
+
+
+def test_rows_are_sorted_deterministically():
+    result = source()
+
+    assert tuple(
+        (
+            value["game_pk"],
+            value["at_bat_number"],
+        )
+        for value in result.rows
+    ) == (
+        (1, 10),
+        (1, 20),
+        (2, 1),
+    )
+
+
+def test_datetime_game_date_is_canonicalized():
+    result = source(
+        rows=(
+            row(
+                game_date=datetime(
+                    2026,
+                    4,
+                    20,
+                    12,
+                    0,
+                )
+            ),
+        )
+    )
+
+    assert result.rows[0]["game_date"] == (
+        "2026-04-20"
+    )
+
+
+def test_duplicate_pitch_is_rejected():
+    value = row()
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast pitch identifiers "
+            "must be unique"
+        ),
+    ):
+        source(rows=(value, value))
+
+
+def test_out_of_window_row_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast row game_date must fall "
+            "within source window"
+        ),
+    ):
+        source(
+            rows=(
+                row(game_date="2026-04-19"),
+            )
+        )
+
+
+def test_missing_column_is_rejected():
+    value = row()
+    del value["fielder_2"]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Statcast row missing required columns: "
+            "fielder_2"
+        ),
+    ):
+        source(rows=(value,))
+
+
+def test_one_game_pk_cannot_have_multiple_dates():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "game_pk must map to one game_date"
+        ),
+    ):
+        source(
+            rows=(
+                row(),
+                row(
+                    game_date="2026-04-21",
+                    at_bat_number=11,
+                ),
+            )
+        )
+
+
+def test_snapshot_digest_is_deterministic():
+    first = source()
+    second = source()
+
+    assert first.snapshot.digest == (
+        second.snapshot.digest
+    )
+    assert first == second
+
+
+def test_diagnostics_preserve_legacy_authority():
+    diagnostics = source().snapshot.to_diagnostics()
+
+    assert diagnostics["coverage_complete"] is False
+    assert diagnostics[
+        "calibration_observed_source_eligible"
+    ] is False
+    assert diagnostics["coverage_warning"] == (
+        "pitch-level Statcast descriptions "
+        "do not contain every baserunning event"
+    )
+    assert diagnostics["production_activation"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_versions_and_window_are_explicit():
+    assert (
+        CANONICAL_STATCAST_BASERUNNING_WINDOW_SOURCE_VERSION
+        == "canonical_statcast_baserunning_window_source_v1"
+    )
+    assert (
+        CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+        == "2026-04-20"
+    )
+    assert (
+        CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+        == "2026-05-03"
+    )


### PR DESCRIPTION
## Summary

- add deterministic, versioned snapshots for the fixed April 20–May 3, 2026 baserunning smoke window
- source complete observed SB/CS outcomes from MLB play-by-play across every completed game
- retain pitch-level Statcast-description decoding as a reproducible diagnostic source while explicitly marking it incomplete and ineligible as calibration truth
- canonicalize suspended/resumed schedule duplicates by `gamePk` and `officialDate`
- deduplicate repeated MLB runner-event records deterministically and expose the removed-record count
- provide a runnable comparison script with immutable source digests and legacy-authority diagnostics

## Real smoke-window evidence

Across 185 completed games:

- MLB play-by-play: 239 stolen bases, 92 caught stealings, 331 attempts
- Statcast descriptions: 12 stolen bases, 5 caught stealings, 17 attempts
- Statcast attempt coverage: 5.136%
- Statcast stolen-base coverage: 5.021%
- Statcast caught-stealing coverage: 5.435%
- duplicate MLB feed records removed: 3
- MLB play-by-play digest: `0f9eb719d8b513f5c7cf01275128533938eba6ddff9a902910f0feb1c1af08bb`
- Statcast window digest: `4b00eabf1026a1042016b463b69a26f1614cddb8ad9a4bc9b8cd10263b365cc2`

This demonstrates that pitch-level Statcast descriptions are materially incomplete for observed calibration outcomes. MLB play-by-play is therefore the eligible observed source; Statcast remains available for feature evidence and coverage diagnostics.

## Production impact

None. These sources and diagnostics do not activate canonical baserunning, change production authority, persist fetched data, or alter live simulation behavior. Legacy remains authoritative.

## Validation

- `231 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- real smoke-window comparison completed successfully with exit code 0