### PR TITLE
Materialize play-by-play calibration records

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -403,3 +403,8 @@ from .mlb_play_by_play_baserunning_source import (
     CanonicalMlbPlayByPlayBaserunningSnapshot,
     source_mlb_play_by_play_baserunning_window,
 )
+
+from .historical_baserunning_game_materialization import (
+    CANONICAL_PLAY_BY_PLAY_BASERUNNING_MATERIALIZATION_VERSION,
+    materialize_play_by_play_baserunning_game_records,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_game_materialization.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_game_materialization.py
@@ -12,6 +12,9 @@ from .baserunning_calibration_payload import (
 from .baserunning_output_validation import (
     CanonicalBaserunningOutputValidation,
 )
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
 from .statcast_baserunning_source import (
     CanonicalStatcastBaserunningOutcome,
 )
@@ -22,6 +25,10 @@ CANONICAL_HISTORICAL_BASERUNNING_SHADOW_GAME_VERSION = (
 )
 CANONICAL_HISTORICAL_BASERUNNING_MATERIALIZATION_VERSION = (
     "canonical_historical_baserunning_materialization_v1"
+)
+
+CANONICAL_PLAY_BY_PLAY_BASERUNNING_MATERIALIZATION_VERSION = (
+    "canonical_play_by_play_baserunning_materialization_v1"
 )
 
 
@@ -253,6 +260,130 @@ def materialize_historical_baserunning_game_records(
                     observed_source_version
                 ),
             )
+        )
+
+    return tuple(records)
+
+
+def materialize_play_by_play_baserunning_game_records(
+    *,
+    shadow_games: Tuple[
+        CanonicalHistoricalBaserunningShadowGame,
+        ...,
+    ],
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+) -> Tuple[
+    CanonicalHistoricalBaserunningGame,
+    ...,
+]:
+    """
+    Join complete MLB play-by-play totals to shadow validations.
+
+    Exact game identity and official-date coverage are required. Statcast
+    description outcomes are intentionally not used as calibration truth.
+    """
+
+    if not isinstance(shadow_games, tuple):
+        raise TypeError(
+            "shadow_games must be a tuple"
+        )
+    if not shadow_games:
+        raise ValueError(
+            "shadow_games must contain records"
+        )
+
+    for value in shadow_games:
+        if not isinstance(
+            value,
+            CanonicalHistoricalBaserunningShadowGame,
+        ):
+            raise TypeError(
+                "shadow_games must contain "
+                "CanonicalHistoricalBaserunningShadowGame"
+            )
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    shadow_by_id = {}
+    for value in shadow_games:
+        if value.game_pk in shadow_by_id:
+            raise ValueError(
+                "historical shadow game identifiers "
+                "must be unique"
+            )
+        shadow_by_id[value.game_pk] = value
+
+    observed_by_id = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    if set(shadow_by_id) != set(observed_by_id):
+        raise ValueError(
+            "shadow games must exactly match "
+            "observed play-by-play games"
+        )
+
+    records = []
+    for game_pk in sorted(
+        shadow_by_id,
+        key=lambda value: (
+            shadow_by_id[value].game_date,
+            value,
+        ),
+    ):
+        shadow_game = shadow_by_id[game_pk]
+        observed_game = observed_by_id[game_pk]
+
+        if (
+            shadow_game.game_date
+            != observed_game.game_date
+        ):
+            raise ValueError(
+                "shadow game_date must match "
+                "observed official game_date"
+            )
+
+        records.append(
+            CanonicalHistoricalBaserunningGame(
+                game_pk=game_pk,
+                game_date=shadow_game.game_date,
+                validation=shadow_game.validation,
+                observed_stolen_bases=(
+                    observed_game.stolen_bases
+                ),
+                observed_caught_stealing=(
+                    observed_game.caught_stealing
+                ),
+                observed_source_version=(
+                    observed.source_version
+                ),
+            )
+        )
+
+    if sum(
+        value.observed_stolen_bases
+        for value in records
+    ) != observed.stolen_bases:
+        raise ValueError(
+            "materialized stolen-base total must "
+            "match observed snapshot"
+        )
+
+    if sum(
+        value.observed_caught_stealing
+        for value in records
+    ) != observed.caught_stealing:
+        raise ValueError(
+            "materialized caught-stealing total must "
+            "match observed snapshot"
         )
 
     return tuple(records)

--- a/tests/test_canonical_play_by_play_baserunning_materialization.py
+++ b/tests/test_canonical_play_by_play_baserunning_materialization.py
@@ -1,0 +1,332 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PLAY_BY_PLAY_BASERUNNING_MATERIALIZATION_VERSION,
+    CanonicalBaserunningCalibrationPolicy,
+    CanonicalBaserunningOutputValidation,
+    CanonicalHistoricalBaserunningShadowGame,
+    assemble_historical_baserunning_calibration_payload,
+    execute_baserunning_calibration_artifact,
+    materialize_play_by_play_baserunning_game_records,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+def validation(
+    *,
+    digest,
+    stolen_bases,
+    caught_stealing,
+):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=digest,
+        runner_projection_count=9,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=(
+            caught_stealing
+        ),
+    )
+
+
+def shadow_game(
+    *,
+    game_pk,
+    game_date,
+    digest,
+    stolen_bases,
+    caught_stealing,
+):
+    return CanonicalHistoricalBaserunningShadowGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        validation=validation(
+            digest=digest,
+            stolen_bases=stolen_bases,
+            caught_stealing=caught_stealing,
+        ),
+    )
+
+
+def schedule():
+    return {
+        "dates": [
+            {
+                "date": "2026-04-20",
+                "games": [
+                    {
+                        "gamePk": 1,
+                        "officialDate": "2026-04-20",
+                        "status": {
+                            "abstractGameState": "Final",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": "2026-04-21",
+                "games": [
+                    {
+                        "gamePk": 2,
+                        "officialDate": "2026-04-21",
+                        "status": {
+                            "abstractGameState": "Final",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def runner(
+    *,
+    runner_id,
+    event_type,
+):
+    return {
+        "movement": {
+            "start": "1B",
+            "end": "2B",
+            "isOut": (
+                "caught_stealing"
+                in event_type
+            ),
+        },
+        "details": {
+            "eventType": event_type,
+            "runner": {
+                "id": runner_id,
+            },
+        },
+    }
+
+
+def feed(*plays):
+    return {
+        "liveData": {
+            "plays": {
+                "allPlays": list(plays),
+            },
+        },
+    }
+
+
+def play(
+    *,
+    index,
+    runners,
+):
+    return {
+        "about": {
+            "atBatIndex": index,
+        },
+        "result": {
+            "eventType": "",
+        },
+        "runners": list(runners),
+    }
+
+
+def observed():
+    return source_mlb_play_by_play_baserunning_window(
+        schedule=schedule(),
+        game_feeds={
+            1: feed(
+                play(
+                    index=1,
+                    runners=(
+                        runner(
+                            runner_id=10,
+                            event_type="stolen_base_2b",
+                        ),
+                        runner(
+                            runner_id=11,
+                            event_type=(
+                                "caught_stealing_2b"
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            2: feed(),
+        },
+        window_start="2026-04-20",
+        window_end="2026-05-03",
+    )
+
+
+def shadow_games():
+    return (
+        shadow_game(
+            game_pk=2,
+            game_date="2026-04-21",
+            digest="digest-b",
+            stolen_bases=0.0,
+            caught_stealing=0.0,
+        ),
+        shadow_game(
+            game_pk=1,
+            game_date="2026-04-20",
+            digest="digest-a",
+            stolen_bases=1.0,
+            caught_stealing=1.0,
+        ),
+    )
+
+
+def materialize(**overrides):
+    arguments = {
+        "shadow_games": shadow_games(),
+        "observed": observed(),
+    }
+    arguments.update(overrides)
+
+    return (
+        materialize_play_by_play_baserunning_game_records(
+            **arguments
+        )
+    )
+
+
+def test_materializes_official_per_game_totals():
+    records = materialize()
+
+    assert tuple(
+        value.game_pk
+        for value in records
+    ) == (1, 2)
+    assert records[0].observed_stolen_bases == 1
+    assert records[0].observed_caught_stealing == 1
+    assert records[1].observed_stolen_bases == 0
+    assert records[1].observed_caught_stealing == 0
+    assert records[0].observed_source_version == (
+        observed().source_version
+    )
+
+
+def test_materialized_records_execute_artifact():
+    records = materialize()
+    policy = CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=2,
+        maximum_stolen_base_error_per_game=0.0,
+        maximum_caught_stealing_error_per_game=0.0,
+        maximum_attempt_error_per_game=0.0,
+        maximum_success_rate_absolute_error=0.0,
+        policy_version="smoke_policy_v1",
+    )
+    payload = (
+        assemble_historical_baserunning_calibration_payload(
+            window_start="2026-04-20",
+            window_end="2026-05-03",
+            games=records,
+            policy=policy,
+        )
+    )
+    artifact = execute_baserunning_calibration_artifact(
+        payload
+    )
+
+    assert artifact.status == "ready"
+    assert artifact.calibration_gate_passed is True
+
+
+def test_missing_shadow_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "shadow games must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        materialize(
+            shadow_games=(
+                shadow_games()[0],
+            )
+        )
+
+
+def test_extra_shadow_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "shadow games must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        materialize(
+            shadow_games=(
+                *shadow_games(),
+                shadow_game(
+                    game_pk=3,
+                    game_date="2026-04-22",
+                    digest="digest-c",
+                    stolen_bases=0.0,
+                    caught_stealing=0.0,
+                ),
+            )
+        )
+
+
+def test_mismatched_official_date_is_rejected():
+    games = list(shadow_games())
+    games[1] = shadow_game(
+        game_pk=1,
+        game_date="2026-04-22",
+        digest="digest-a",
+        stolen_bases=1.0,
+        caught_stealing=1.0,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "shadow game_date must match "
+            "observed official game_date"
+        ),
+    ):
+        materialize(
+            shadow_games=tuple(games)
+        )
+
+
+def test_duplicate_shadow_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical shadow game identifiers "
+            "must be unique"
+        ),
+    ):
+        materialize(
+            shadow_games=(
+                shadow_games()[0],
+                shadow_games()[0],
+            )
+        )
+
+
+def test_invalid_observed_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        ),
+    ):
+        materialize(observed=object())
+
+
+def test_materialization_is_deterministic():
+    first = materialize()
+    second = materialize()
+
+    assert first == second
+
+
+def test_materialization_version_is_explicit():
+    assert (
+        CANONICAL_PLAY_BY_PLAY_BASERUNNING_MATERIALIZATION_VERSION
+        == "canonical_play_by_play_baserunning_materialization_v1"
+    )


### PR DESCRIPTION
## Summary

- add an authoritative materialization path that joins official MLB play-by-play per-game SB/CS totals to historical shadow validations
- require exact completed-game identity and official-date alignment
- preserve games with zero observed baserunning activity
- verify materialized per-game totals reproduce the complete observed snapshot totals
- execute the resulting records through the existing immutable calibration payload and artifact contracts
- retain the older Statcast materializer for feature-evidence compatibility while removing it from the observed calibration path

## Why

The real smoke-window audit showed pitch-level Statcast descriptions captured only about 5.1% of observed attempts. Calibration must therefore consume the complete MLB play-by-play snapshot rather than incomplete decoded Statcast outcomes. This change establishes that authoritative join without altering downstream calibration contracts.

## Production impact

None. Materialization performs no fetching, persistence, simulation execution, authority change, or activation. Legacy remains authoritative.

## Validation

- `172 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- exact game/date coverage, zero-activity games, aggregate-total preservation, and end-to-end artifact execution are tested