### PR TITLE
Collect historical baserunning shadow validations

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -408,3 +408,9 @@ from .historical_baserunning_game_materialization import (
     CANONICAL_PLAY_BY_PLAY_BASERUNNING_MATERIALIZATION_VERSION,
     materialize_play_by_play_baserunning_game_records,
 )
+
+from .historical_baserunning_shadow_validation import (
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_COLLECTION_VERSION,
+    CanonicalHistoricalBaserunningExecutionGame,
+    collect_historical_baserunning_shadow_validations,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_shadow_validation.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_shadow_validation.py
@@ -1,0 +1,177 @@
+"""Collect aligned historical baserunning shadow validations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Tuple
+
+from .baserunning_output_validation import (
+    validate_canonical_baserunning_shadow_outputs,
+)
+from .historical_baserunning_game_materialization import (
+    CanonicalHistoricalBaserunningShadowGame,
+)
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+from .production_execution import (
+    CanonicalProductionShadowExecution,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_SHADOW_COLLECTION_VERSION = (
+    "canonical_historical_baserunning_shadow_collection_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningExecutionGame:
+    game_pk: int
+    game_date: str
+    execution: CanonicalProductionShadowExecution
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        if not isinstance(self.game_date, str):
+            raise TypeError(
+                "game_date must be a string"
+            )
+
+        parsed_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        if not isinstance(
+            self.execution,
+            CanonicalProductionShadowExecution,
+        ):
+            raise TypeError(
+                "execution must be "
+                "CanonicalProductionShadowExecution"
+            )
+
+
+def collect_historical_baserunning_shadow_validations(
+    *,
+    execution_games: Tuple[
+        CanonicalHistoricalBaserunningExecutionGame,
+        ...,
+    ],
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+) -> Tuple[
+    CanonicalHistoricalBaserunningShadowGame,
+    ...,
+]:
+    """
+    Validate one production-shaped shadow execution per completed game.
+
+    Exact game/date coverage is required. Failed, blocked, unavailable, or
+    incomplete executions do not become historical calibration evidence.
+    """
+
+    if not isinstance(execution_games, tuple):
+        raise TypeError(
+            "execution_games must be a tuple"
+        )
+    if not execution_games:
+        raise ValueError(
+            "execution_games must contain records"
+        )
+
+    for value in execution_games:
+        if not isinstance(
+            value,
+            CanonicalHistoricalBaserunningExecutionGame,
+        ):
+            raise TypeError(
+                "execution_games must contain "
+                "CanonicalHistoricalBaserunningExecutionGame"
+            )
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    executions_by_id = {}
+    for value in execution_games:
+        if value.game_pk in executions_by_id:
+            raise ValueError(
+                "historical execution game identifiers "
+                "must be unique"
+            )
+        executions_by_id[value.game_pk] = value
+
+    observed_by_id = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    if set(executions_by_id) != set(observed_by_id):
+        raise ValueError(
+            "historical executions must exactly match "
+            "observed play-by-play games"
+        )
+
+    collected = []
+    for game_pk in sorted(
+        executions_by_id,
+        key=lambda value: (
+            executions_by_id[value].game_date,
+            value,
+        ),
+    ):
+        execution_game = executions_by_id[game_pk]
+        observed_game = observed_by_id[game_pk]
+
+        if (
+            execution_game.game_date
+            != observed_game.game_date
+        ):
+            raise ValueError(
+                "historical execution game_date must "
+                "match observed official game_date"
+            )
+
+        validation = (
+            validate_canonical_baserunning_shadow_outputs(
+                execution_game.execution
+            )
+        )
+
+        if not validation.ready:
+            raise ValueError(
+                "historical baserunning shadow validation "
+                f"unavailable for game_pk {game_pk}: "
+                + (
+                    validation.error_message
+                    or validation.status
+                )
+            )
+
+        collected.append(
+            CanonicalHistoricalBaserunningShadowGame(
+                game_pk=game_pk,
+                game_date=execution_game.game_date,
+                validation=validation,
+            )
+        )
+
+    return tuple(collected)

--- a/tests/test_canonical_historical_baserunning_shadow_validation.py
+++ b/tests/test_canonical_historical_baserunning_shadow_validation.py
@@ -1,0 +1,251 @@
+import pytest
+
+import mlb_app.simulation.shadow.historical_baserunning_shadow_validation as target
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_COLLECTION_VERSION,
+    CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION,
+    CanonicalBaserunningOutputValidation,
+    CanonicalHistoricalBaserunningExecutionGame,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+    CanonicalProductionShadowExecution,
+    collect_historical_baserunning_shadow_validations,
+)
+
+
+def observed():
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-05-03",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=1,
+                game_date="2026-04-20",
+                stolen_bases=1,
+                caught_stealing=0,
+            ),
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=2,
+                game_date="2026-04-21",
+                stolen_bases=0,
+                caught_stealing=1,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest="a" * 64,
+        source_version=(
+            CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+        ),
+    )
+
+
+def execution_game(
+    *,
+    game_pk,
+    game_date,
+    status="executed",
+):
+    return CanonicalHistoricalBaserunningExecutionGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        execution=CanonicalProductionShadowExecution(
+            status=status,
+            simulation_count=100,
+        ),
+    )
+
+
+def execution_games():
+    return (
+        execution_game(
+            game_pk=2,
+            game_date="2026-04-21",
+        ),
+        execution_game(
+            game_pk=1,
+            game_date="2026-04-20",
+        ),
+    )
+
+
+def ready_validation(execution):
+    return CanonicalBaserunningOutputValidation(
+        status="ready",
+        simulation_count=100,
+        catalog_digest=(
+            f"digest-{execution.status}"
+        ),
+        runner_projection_count=9,
+        stolen_base_mean_total=1.0,
+        caught_stealing_mean_total=0.25,
+    )
+
+
+def collect(monkeypatch, **overrides):
+    monkeypatch.setattr(
+        target,
+        "validate_canonical_baserunning_shadow_outputs",
+        ready_validation,
+    )
+
+    arguments = {
+        "execution_games": execution_games(),
+        "observed": observed(),
+    }
+    arguments.update(overrides)
+
+    return (
+        collect_historical_baserunning_shadow_validations(
+            **arguments
+        )
+    )
+
+
+def test_collects_aligned_ready_validations(
+    monkeypatch,
+):
+    records = collect(monkeypatch)
+
+    assert tuple(
+        value.game_pk
+        for value in records
+    ) == (1, 2)
+    assert all(
+        value.validation.ready
+        for value in records
+    )
+
+
+def test_exact_game_coverage_is_required(
+    monkeypatch,
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical executions must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        collect(
+            monkeypatch,
+            execution_games=(
+                execution_games()[0],
+            ),
+        )
+
+
+def test_duplicate_execution_game_is_rejected(
+    monkeypatch,
+):
+    value = execution_games()[0]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical execution game identifiers "
+            "must be unique"
+        ),
+    ):
+        collect(
+            monkeypatch,
+            execution_games=(value, value),
+        )
+
+
+def test_official_date_alignment_is_required(
+    monkeypatch,
+):
+    values = list(execution_games())
+    values[1] = execution_game(
+        game_pk=1,
+        game_date="2026-04-22",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical execution game_date must "
+            "match observed official game_date"
+        ),
+    ):
+        collect(
+            monkeypatch,
+            execution_games=tuple(values),
+        )
+
+
+def test_unavailable_validation_is_rejected(
+    monkeypatch,
+):
+    def unavailable(execution):
+        return CanonicalBaserunningOutputValidation(
+            status="unavailable",
+            error_message="catalog unavailable",
+        )
+
+    monkeypatch.setattr(
+        target,
+        "validate_canonical_baserunning_shadow_outputs",
+        unavailable,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical baserunning shadow validation "
+            "unavailable for game_pk 1: "
+            "catalog unavailable"
+        ),
+    ):
+        collect_historical_baserunning_shadow_validations(
+            execution_games=execution_games(),
+            observed=observed(),
+        )
+
+
+def test_default_validator_rejects_unexecuted_material():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical baserunning shadow validation "
+            "unavailable for game_pk 1"
+        ),
+    ):
+        collect_historical_baserunning_shadow_validations(
+            execution_games=execution_games(),
+            observed=observed(),
+        )
+
+
+def test_invalid_execution_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "execution must be "
+            "CanonicalProductionShadowExecution"
+        ),
+    ):
+        CanonicalHistoricalBaserunningExecutionGame(
+            game_pk=1,
+            game_date="2026-04-20",
+            execution=object(),
+        )
+
+
+def test_collection_is_deterministic(
+    monkeypatch,
+):
+    first = collect(monkeypatch)
+    second = collect(monkeypatch)
+
+    assert first == second
+
+
+def test_collection_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_COLLECTION_VERSION
+        == "canonical_historical_baserunning_shadow_collection_v1"
+    )


### PR DESCRIPTION
## Summary

- add a canonical historical execution-game contract carrying game identity, official date, and a production-shaped shadow execution
- validate each execution through the existing canonical baserunning output validator
- require exact game and official-date coverage against the complete MLB play-by-play snapshot
- reject duplicate, missing, extra, blocked, unavailable, failed, or incomplete game executions
- emit deterministically ordered historical shadow-game records for the authoritative play-by-play materializer

## Why

The observed side of the smoke window is now complete and authoritative. Calibration also requires one valid shadow projection per completed game. This collector establishes that exact evidence boundary without allowing partial windows or unavailable executions to enter the calibration artifact.

## Production impact

None. The collector performs no fetching, persistence, live execution, authority change, or activation. It validates caller-supplied shadow executions and legacy remains authoritative.

## Validation

- `169 passed, 1 warning`
- targeted Python compilation passed
- `git diff --check` passed
- exact coverage, official-date alignment, duplicate rejection, unavailable validation rejection, deterministic ordering, and direct canonical-validator behavior are tested