### PR TITLE
Discover historical shadow replay inputs

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -414,3 +414,10 @@ from .historical_baserunning_shadow_validation import (
     CanonicalHistoricalBaserunningExecutionGame,
     collect_historical_baserunning_shadow_validations,
 )
+
+from .historical_shadow_replay_discovery import (
+    CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION,
+    CanonicalHistoricalShadowReplayDiscovery,
+    CanonicalHistoricalShadowReplayInputGame,
+    discover_historical_shadow_replay_inputs,
+)

--- a/mlb_app/simulation/shadow/historical_shadow_replay_discovery.py
+++ b/mlb_app/simulation/shadow/historical_shadow_replay_discovery.py
@@ -1,0 +1,367 @@
+"""Discover reproducible historical shadow replay inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Optional, Tuple
+
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION = (
+    "canonical_historical_shadow_replay_discovery_v1"
+)
+
+_INPUT_REQUIREMENTS = (
+    ("lineups_ready", "missing_lineups"),
+    ("bullpens_ready", "missing_bullpens"),
+    (
+        "probability_provider_ready",
+        "missing_probability_provider",
+    ),
+    (
+        "exact_artifact_ready",
+        "missing_exact_artifact",
+    ),
+    (
+        "fallback_catalog_ready",
+        "missing_fallback_catalog",
+    ),
+    (
+        "baserunning_catalog_ready",
+        "missing_baserunning_catalog",
+    ),
+)
+
+_PROVENANCE_REQUIREMENTS = (
+    (
+        "probability_provider_identity",
+        "missing_probability_provider_identity",
+    ),
+    (
+        "exact_artifact_digest",
+        "missing_exact_artifact_digest",
+    ),
+    (
+        "fallback_catalog_digest",
+        "missing_fallback_catalog_digest",
+    ),
+    (
+        "baserunning_catalog_digest",
+        "missing_baserunning_catalog_digest",
+    ),
+)
+
+
+def _available_text(value: Optional[str]) -> bool:
+    return bool(
+        isinstance(value, str)
+        and value.strip()
+        and value != "unavailable"
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalShadowReplayInputGame:
+    game_pk: int
+    game_date: str
+    lineups_ready: bool
+    bullpens_ready: bool
+    probability_provider_ready: bool
+    exact_artifact_ready: bool
+    fallback_catalog_ready: bool
+    baserunning_catalog_ready: bool
+    probability_provider_identity: Optional[str] = None
+    exact_artifact_digest: Optional[str] = None
+    fallback_catalog_digest: Optional[str] = None
+    baserunning_catalog_digest: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        if not isinstance(self.game_date, str):
+            raise TypeError(
+                "game_date must be a string"
+            )
+
+        parsed_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        for field_name, _ in _INPUT_REQUIREMENTS:
+            if not isinstance(
+                getattr(self, field_name),
+                bool,
+            ):
+                raise TypeError(
+                    f"{field_name} must be boolean"
+                )
+
+    @property
+    def missing_requirements(self) -> Tuple[str, ...]:
+        missing = [
+            reason
+            for field_name, reason
+            in _INPUT_REQUIREMENTS
+            if not getattr(self, field_name)
+        ]
+
+        if not missing:
+            missing.extend(
+                reason
+                for field_name, reason
+                in _PROVENANCE_REQUIREMENTS
+                if not _available_text(
+                    getattr(self, field_name)
+                )
+            )
+
+        return tuple(missing)
+
+    @property
+    def ready(self) -> bool:
+        return not self.missing_requirements
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "ready": self.ready,
+            "missing_requirements": (
+                self.missing_requirements
+            ),
+            "lineups_ready": self.lineups_ready,
+            "bullpens_ready": self.bullpens_ready,
+            "probability_provider_ready": (
+                self.probability_provider_ready
+            ),
+            "exact_artifact_ready": (
+                self.exact_artifact_ready
+            ),
+            "fallback_catalog_ready": (
+                self.fallback_catalog_ready
+            ),
+            "baserunning_catalog_ready": (
+                self.baserunning_catalog_ready
+            ),
+            "probability_provider_identity": (
+                self.probability_provider_identity
+            ),
+            "exact_artifact_digest": (
+                self.exact_artifact_digest
+            ),
+            "fallback_catalog_digest": (
+                self.fallback_catalog_digest
+            ),
+            "baserunning_catalog_digest": (
+                self.baserunning_catalog_digest
+            ),
+            "lineup_identifiers_exposed": False,
+            "probability_records_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalShadowReplayDiscovery:
+    games: Tuple[
+        CanonicalHistoricalShadowReplayInputGame,
+        ...,
+    ]
+    missing_requirement_counts: Tuple[
+        Tuple[str, int],
+        ...,
+    ]
+    discovery_version: str = (
+        CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain replay inputs"
+            )
+
+        if self.discovery_version != (
+            CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical shadow "
+                "replay discovery version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def ready_game_count(self) -> int:
+        return sum(
+            value.ready
+            for value in self.games
+        )
+
+    @property
+    def blocked_game_count(self) -> int:
+        return (
+            self.game_count
+            - self.ready_game_count
+        )
+
+    @property
+    def ready(self) -> bool:
+        return self.blocked_game_count == 0
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.discovery_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "ready_game_count": (
+                self.ready_game_count
+            ),
+            "blocked_game_count": (
+                self.blocked_game_count
+            ),
+            "missing_requirement_counts": dict(
+                self.missing_requirement_counts
+            ),
+            "games": tuple(
+                value.to_diagnostics()
+                for value in self.games
+            ),
+            "historical_replay_permitted": (
+                self.ready
+            ),
+            "calibration_execution_permitted": (
+                False
+            ),
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def discover_historical_shadow_replay_inputs(
+    *,
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+    games: Tuple[
+        CanonicalHistoricalShadowReplayInputGame,
+        ...,
+    ],
+) -> CanonicalHistoricalShadowReplayDiscovery:
+    """
+    Audit exact historical replay readiness for a complete observed window.
+
+    This does not fetch inputs, manufacture fallbacks, execute simulations,
+    approve calibration, or alter production authority.
+    """
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    if not isinstance(games, tuple):
+        raise TypeError(
+            "games must be a tuple"
+        )
+    if not games:
+        raise ValueError(
+            "games must contain replay inputs"
+        )
+
+    for value in games:
+        if not isinstance(
+            value,
+            CanonicalHistoricalShadowReplayInputGame,
+        ):
+            raise TypeError(
+                "games must contain "
+                "CanonicalHistoricalShadowReplayInputGame"
+            )
+
+    games_by_id = {}
+    for value in games:
+        if value.game_pk in games_by_id:
+            raise ValueError(
+                "historical replay game identifiers "
+                "must be unique"
+            )
+        games_by_id[value.game_pk] = value
+
+    observed_by_id = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    if set(games_by_id) != set(observed_by_id):
+        raise ValueError(
+            "historical replay games must exactly match "
+            "observed play-by-play games"
+        )
+
+    ordered = []
+    for game_pk in sorted(
+        games_by_id,
+        key=lambda value: (
+            games_by_id[value].game_date,
+            value,
+        ),
+    ):
+        replay_game = games_by_id[game_pk]
+        observed_game = observed_by_id[game_pk]
+
+        if (
+            replay_game.game_date
+            != observed_game.game_date
+        ):
+            raise ValueError(
+                "historical replay game_date must "
+                "match observed official game_date"
+            )
+
+        ordered.append(replay_game)
+
+    reasons = sorted(
+        {
+            reason
+            for value in ordered
+            for reason in value.missing_requirements
+        }
+    )
+    counts = tuple(
+        (
+            reason,
+            sum(
+                reason
+                in value.missing_requirements
+                for value in ordered
+            ),
+        )
+        for reason in reasons
+    )
+
+    return CanonicalHistoricalShadowReplayDiscovery(
+        games=tuple(ordered),
+        missing_requirement_counts=counts,
+    )

--- a/tests/test_canonical_historical_shadow_replay_discovery.py
+++ b/tests/test_canonical_historical_shadow_replay_discovery.py
@@ -1,0 +1,236 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION,
+    CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION,
+    CanonicalHistoricalShadowReplayInputGame,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+    discover_historical_shadow_replay_inputs,
+)
+
+
+def observed():
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-05-03",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=1,
+                game_date="2026-04-20",
+                stolen_bases=1,
+                caught_stealing=0,
+            ),
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=2,
+                game_date="2026-04-21",
+                stolen_bases=0,
+                caught_stealing=1,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest="a" * 64,
+        source_version=(
+            CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+        ),
+    )
+
+
+def game(
+    *,
+    game_pk,
+    game_date,
+    ready=True,
+    **overrides,
+):
+    arguments = {
+        "game_pk": game_pk,
+        "game_date": game_date,
+        "lineups_ready": ready,
+        "bullpens_ready": ready,
+        "probability_provider_ready": ready,
+        "exact_artifact_ready": ready,
+        "fallback_catalog_ready": ready,
+        "baserunning_catalog_ready": ready,
+        "probability_provider_identity": (
+            "provider-v1" if ready else None
+        ),
+        "exact_artifact_digest": (
+            "a" * 64 if ready else None
+        ),
+        "fallback_catalog_digest": (
+            "b" * 64 if ready else None
+        ),
+        "baserunning_catalog_digest": (
+            "c" * 64 if ready else None
+        ),
+    }
+    arguments.update(overrides)
+
+    return CanonicalHistoricalShadowReplayInputGame(
+        **arguments
+    )
+
+
+def games():
+    return (
+        game(
+            game_pk=2,
+            game_date="2026-04-21",
+        ),
+        game(
+            game_pk=1,
+            game_date="2026-04-20",
+        ),
+    )
+
+
+def discover(**overrides):
+    arguments = {
+        "observed": observed(),
+        "games": games(),
+    }
+    arguments.update(overrides)
+
+    return discover_historical_shadow_replay_inputs(
+        **arguments
+    )
+
+
+def test_complete_window_is_replay_ready():
+    result = discover()
+
+    assert result.ready is True
+    assert result.game_count == 2
+    assert result.ready_game_count == 2
+    assert result.blocked_game_count == 0
+    assert result.missing_requirement_counts == ()
+
+
+def test_missing_inputs_are_counted_by_reason():
+    result = discover(
+        games=(
+            game(
+                game_pk=1,
+                game_date="2026-04-20",
+                ready=False,
+                lineups_ready=True,
+            ),
+            game(
+                game_pk=2,
+                game_date="2026-04-21",
+                ready=False,
+            ),
+        )
+    )
+
+    assert result.ready is False
+    assert result.ready_game_count == 0
+    assert result.blocked_game_count == 2
+    assert dict(
+        result.missing_requirement_counts
+    )["missing_bullpens"] == 2
+    assert dict(
+        result.missing_requirement_counts
+    )["missing_lineups"] == 1
+
+
+def test_ready_flags_require_provenance():
+    result = discover(
+        games=(
+            game(
+                game_pk=1,
+                game_date="2026-04-20",
+                exact_artifact_digest=None,
+            ),
+            game(
+                game_pk=2,
+                game_date="2026-04-21",
+            ),
+        )
+    )
+
+    assert result.ready is False
+    assert result.games[0].missing_requirements == (
+        "missing_exact_artifact_digest",
+    )
+
+
+def test_exact_observed_coverage_is_required():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical replay games must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        discover(games=(games()[0],))
+
+
+def test_official_date_alignment_is_required():
+    values = list(games())
+    values[1] = game(
+        game_pk=1,
+        game_date="2026-04-22",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical replay game_date must "
+            "match observed official game_date"
+        ),
+    ):
+        discover(games=tuple(values))
+
+
+def test_duplicate_game_is_rejected():
+    value = games()[0]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical replay game identifiers "
+            "must be unique"
+        ),
+    ):
+        discover(games=(value, value))
+
+
+def test_diagnostics_do_not_expose_input_records():
+    diagnostics = discover().to_diagnostics()
+
+    assert diagnostics[
+        "calibration_execution_permitted"
+    ] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+    assert all(
+        value["lineup_identifiers_exposed"] is False
+        for value in diagnostics["games"]
+    )
+    assert all(
+        value["probability_records_exposed"] is False
+        for value in diagnostics["games"]
+    )
+
+
+def test_discovery_is_deterministic():
+    first = discover()
+    second = discover()
+
+    assert first == second
+    assert first.to_diagnostics() == second.to_diagnostics()
+
+
+def test_discovery_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_SHADOW_REPLAY_DISCOVERY_VERSION
+        == "canonical_historical_shadow_replay_discovery_v1"
+    )


### PR DESCRIPTION
## Summary

- add a deterministic per-game discovery manifest for historical shadow replay inputs
- audit lineup, bullpen, probability-provider, exact-artifact, fallback-catalog, and baserunning-catalog readiness
- require provider identity and artifact/catalog digests whenever an input is marked ready
- enforce exact game and official-date coverage against the MLB play-by-play window
- expose deterministic readiness totals and missing-requirement counts without leaking lineup identifiers or probability records

## Why

Before executing the 185-game historical baserunning calibration window, the replay pipeline needs an evidence-backed inventory of which games have complete, reproducible inputs. This prevents partial-window execution and avoids fabricating replacements for missing historical artifacts.

## Production behavior

- no historical replay is executed
- no calibration gate is approved
- production activation remains disabled
- production authority remains `legacy`

## Validation

- 178 targeted tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable
- existing SQLAlchemy `MovedIn20Warning` remains unchanged