### PR TITLE
Audit historical shadow replay input coverage

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -421,3 +421,24 @@ from .historical_shadow_replay_discovery import (
     CanonicalHistoricalShadowReplayInputGame,
     discover_historical_shadow_replay_inputs,
 )
+
+
+from .historical_shadow_replay_input_audit import (
+    CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION,
+    CURRENT_ACTIVE_ROSTER_SOURCE,
+    HISTORICAL_BULLPEN_SOURCE,
+    HISTORICAL_LINEUP_SOURCE,
+    CanonicalHistoricalShadowReplayInputAudit,
+    CanonicalHistoricalShadowReplayInputEvidence,
+    audit_historical_shadow_replay_input_coverage,
+)
+
+__all__ += [
+    "CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION",
+    "CURRENT_ACTIVE_ROSTER_SOURCE",
+    "HISTORICAL_BULLPEN_SOURCE",
+    "HISTORICAL_LINEUP_SOURCE",
+    "CanonicalHistoricalShadowReplayInputAudit",
+    "CanonicalHistoricalShadowReplayInputEvidence",
+    "audit_historical_shadow_replay_input_coverage",
+]

--- a/mlb_app/simulation/shadow/historical_shadow_replay_input_audit.py
+++ b/mlb_app/simulation/shadow/historical_shadow_replay_input_audit.py
@@ -1,0 +1,366 @@
+"""Audit immutable historical shadow replay input coverage."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+from typing import Any, Dict, Optional, Tuple
+
+from .historical_shadow_replay_discovery import (
+    CanonicalHistoricalShadowReplayDiscovery,
+    CanonicalHistoricalShadowReplayInputGame,
+    discover_historical_shadow_replay_inputs,
+)
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION = (
+    "canonical_historical_shadow_replay_input_audit_v1"
+)
+
+HISTORICAL_LINEUP_SOURCE = (
+    "mlb_stats_boxscore_historical"
+)
+HISTORICAL_BULLPEN_SOURCE = (
+    "mlb_stats_roster_historical"
+)
+CURRENT_ACTIVE_ROSTER_SOURCE = (
+    "mlb_stats_active_roster"
+)
+
+
+def _available_text(value: Optional[str]) -> bool:
+    return bool(
+        isinstance(value, str)
+        and value.strip()
+        and value != "unavailable"
+    )
+
+
+def _validate_digest(
+    value: Optional[str],
+    *,
+    field_name: str,
+) -> None:
+    if value is None:
+        return
+
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{field_name} must be a string or None"
+        )
+
+    if len(value) != 64:
+        raise ValueError(
+            f"{field_name} must be a SHA-256 hex digest"
+        )
+
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be a SHA-256 hex digest"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalShadowReplayInputEvidence:
+    game_pk: int
+    game_date: str
+    lineup_source: str = "unavailable"
+    lineup_snapshot_digest: Optional[str] = None
+    bullpen_source: str = "unavailable"
+    bullpen_snapshot_digest: Optional[str] = None
+    probability_provider_identity: Optional[str] = None
+    exact_artifact_digest: Optional[str] = None
+    fallback_catalog_digest: Optional[str] = None
+    baserunning_catalog_digest: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        for field_name in (
+            "lineup_source",
+            "bullpen_source",
+        ):
+            if not isinstance(
+                getattr(self, field_name),
+                str,
+            ):
+                raise TypeError(
+                    f"{field_name} must be a string"
+                )
+
+        for field_name in (
+            "lineup_snapshot_digest",
+            "bullpen_snapshot_digest",
+            "exact_artifact_digest",
+            "fallback_catalog_digest",
+            "baserunning_catalog_digest",
+        ):
+            _validate_digest(
+                getattr(self, field_name),
+                field_name=field_name,
+            )
+
+    @property
+    def lineups_ready(self) -> bool:
+        return (
+            self.lineup_source
+            == HISTORICAL_LINEUP_SOURCE
+            and _available_text(
+                self.lineup_snapshot_digest
+            )
+        )
+
+    @property
+    def bullpens_ready(self) -> bool:
+        return (
+            self.bullpen_source
+            == HISTORICAL_BULLPEN_SOURCE
+            and _available_text(
+                self.bullpen_snapshot_digest
+            )
+        )
+
+    @property
+    def probability_provider_ready(self) -> bool:
+        return _available_text(
+            self.probability_provider_identity
+        )
+
+    @property
+    def exact_artifact_ready(self) -> bool:
+        return _available_text(
+            self.exact_artifact_digest
+        )
+
+    @property
+    def fallback_catalog_ready(self) -> bool:
+        return _available_text(
+            self.fallback_catalog_digest
+        )
+
+    @property
+    def baserunning_catalog_ready(self) -> bool:
+        return _available_text(
+            self.baserunning_catalog_digest
+        )
+
+    @property
+    def current_roster_substitution_rejected(
+        self,
+    ) -> bool:
+        return (
+            self.bullpen_source
+            == CURRENT_ACTIVE_ROSTER_SOURCE
+        )
+
+    def to_discovery_game(
+        self,
+    ) -> CanonicalHistoricalShadowReplayInputGame:
+        return CanonicalHistoricalShadowReplayInputGame(
+            game_pk=self.game_pk,
+            game_date=self.game_date,
+            lineups_ready=self.lineups_ready,
+            bullpens_ready=self.bullpens_ready,
+            probability_provider_ready=(
+                self.probability_provider_ready
+            ),
+            exact_artifact_ready=(
+                self.exact_artifact_ready
+            ),
+            fallback_catalog_ready=(
+                self.fallback_catalog_ready
+            ),
+            baserunning_catalog_ready=(
+                self.baserunning_catalog_ready
+            ),
+            probability_provider_identity=(
+                self.probability_provider_identity
+            ),
+            exact_artifact_digest=(
+                self.exact_artifact_digest
+            ),
+            fallback_catalog_digest=(
+                self.fallback_catalog_digest
+            ),
+            baserunning_catalog_digest=(
+                self.baserunning_catalog_digest
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalShadowReplayInputAudit:
+    discovery: CanonicalHistoricalShadowReplayDiscovery
+    observed_window_digest: str
+    evidence_digest: str
+    historical_lineup_game_count: int
+    historical_bullpen_game_count: int
+    rejected_current_roster_game_count: int
+    audit_version: str = (
+        CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.discovery,
+            CanonicalHistoricalShadowReplayDiscovery,
+        ):
+            raise TypeError(
+                "discovery must be "
+                "CanonicalHistoricalShadowReplayDiscovery"
+            )
+
+        for field_name in (
+            "observed_window_digest",
+            "evidence_digest",
+        ):
+            _validate_digest(
+                getattr(self, field_name),
+                field_name=field_name,
+            )
+
+        if self.audit_version != (
+            CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical shadow replay "
+                "input audit version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.discovery.ready
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.audit_version,
+            "ready": self.ready,
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "evidence_digest": self.evidence_digest,
+            "historical_lineup_game_count": (
+                self.historical_lineup_game_count
+            ),
+            "historical_bullpen_game_count": (
+                self.historical_bullpen_game_count
+            ),
+            "rejected_current_roster_game_count": (
+                self.rejected_current_roster_game_count
+            ),
+            "discovery": self.discovery.to_diagnostics(),
+            "current_active_roster_historical_eligible": (
+                False
+            ),
+            "historical_replay_permitted": self.ready,
+            "calibration_execution_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def audit_historical_shadow_replay_input_coverage(
+    *,
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+    evidence: Tuple[
+        CanonicalHistoricalShadowReplayInputEvidence,
+        ...,
+    ],
+) -> CanonicalHistoricalShadowReplayInputAudit:
+    """
+    Audit exact replay coverage without fetching or replacing inputs.
+
+    Current active-roster data is never accepted as historical bullpen
+    evidence. This function does not execute simulations or calibration.
+    """
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    if not isinstance(evidence, tuple):
+        raise TypeError("evidence must be a tuple")
+
+    if not evidence:
+        raise ValueError(
+            "evidence must contain replay input evidence"
+        )
+
+    for value in evidence:
+        if not isinstance(
+            value,
+            CanonicalHistoricalShadowReplayInputEvidence,
+        ):
+            raise TypeError(
+                "evidence must contain "
+                "CanonicalHistoricalShadowReplayInputEvidence"
+            )
+
+    ordered = tuple(
+        sorted(
+            evidence,
+            key=lambda value: (
+                value.game_date,
+                value.game_pk,
+            ),
+        )
+    )
+
+    discovery = (
+        discover_historical_shadow_replay_inputs(
+            observed=observed,
+            games=tuple(
+                value.to_discovery_game()
+                for value in ordered
+            ),
+        )
+    )
+
+    digest_payload = [
+        asdict(value)
+        for value in ordered
+    ]
+    evidence_digest = hashlib.sha256(
+        json.dumps(
+            digest_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    return CanonicalHistoricalShadowReplayInputAudit(
+        discovery=discovery,
+        observed_window_digest=observed.digest,
+        evidence_digest=evidence_digest,
+        historical_lineup_game_count=sum(
+            value.lineups_ready
+            for value in ordered
+        ),
+        historical_bullpen_game_count=sum(
+            value.bullpens_ready
+            for value in ordered
+        ),
+        rejected_current_roster_game_count=sum(
+            value.current_roster_substitution_rejected
+            for value in ordered
+        ),
+    )

--- a/tests/test_canonical_historical_shadow_replay_input_audit.py
+++ b/tests/test_canonical_historical_shadow_replay_input_audit.py
@@ -1,0 +1,238 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION,
+    CURRENT_ACTIVE_ROSTER_SOURCE,
+    HISTORICAL_BULLPEN_SOURCE,
+    HISTORICAL_LINEUP_SOURCE,
+    CanonicalHistoricalShadowReplayInputEvidence,
+    audit_historical_shadow_replay_input_coverage,
+)
+from mlb_app.simulation.shadow.mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+DIGEST_E = "e" * 64
+DIGEST_F = "f" * 64
+
+
+def observed():
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-04-21",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=2,
+                game_date="2026-04-21",
+                stolen_bases=0,
+                caught_stealing=1,
+            ),
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=1,
+                game_date="2026-04-20",
+                stolen_bases=1,
+                caught_stealing=0,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest=DIGEST_F,
+    )
+
+
+def complete(game_pk, game_date):
+    return CanonicalHistoricalShadowReplayInputEvidence(
+        game_pk=game_pk,
+        game_date=game_date,
+        lineup_source=HISTORICAL_LINEUP_SOURCE,
+        lineup_snapshot_digest=DIGEST_A,
+        bullpen_source=HISTORICAL_BULLPEN_SOURCE,
+        bullpen_snapshot_digest=DIGEST_B,
+        probability_provider_identity="provider:v1",
+        exact_artifact_digest=DIGEST_C,
+        fallback_catalog_digest=DIGEST_D,
+        baserunning_catalog_digest=DIGEST_E,
+    )
+
+
+def audit(*values):
+    return audit_historical_shadow_replay_input_coverage(
+        observed=observed(),
+        evidence=values,
+    )
+
+
+def test_complete_historical_inputs_are_ready():
+    result = audit(
+        complete(2, "2026-04-21"),
+        complete(1, "2026-04-20"),
+    )
+
+    assert result.ready is True
+    assert result.discovery.ready_game_count == 2
+    assert result.historical_lineup_game_count == 2
+    assert result.historical_bullpen_game_count == 2
+    assert result.rejected_current_roster_game_count == 0
+
+
+def test_current_active_roster_is_not_historical_evidence():
+    value = complete(1, "2026-04-20")
+    arguments = {
+        **value.__dict__,
+        "bullpen_source": CURRENT_ACTIVE_ROSTER_SOURCE,
+    }
+
+    result = audit(
+        CanonicalHistoricalShadowReplayInputEvidence(
+            **arguments
+        ),
+        complete(2, "2026-04-21"),
+    )
+
+    assert result.ready is False
+    assert (
+        result.rejected_current_roster_game_count
+        == 1
+    )
+    assert result.discovery.missing_requirement_counts == (
+        ("missing_bullpens", 1),
+    )
+
+
+def test_unversioned_lineup_source_is_blocked():
+    value = complete(1, "2026-04-20")
+    arguments = {
+        **value.__dict__,
+        "lineup_source": "mlb_stats_boxscore",
+    }
+
+    result = audit(
+        CanonicalHistoricalShadowReplayInputEvidence(
+            **arguments
+        ),
+        complete(2, "2026-04-21"),
+    )
+
+    assert result.ready is False
+    assert result.discovery.missing_requirement_counts == (
+        ("missing_lineups", 1),
+    )
+
+
+def test_missing_artifact_is_counted():
+    value = complete(1, "2026-04-20")
+    arguments = {
+        **value.__dict__,
+        "exact_artifact_digest": None,
+    }
+
+    result = audit(
+        CanonicalHistoricalShadowReplayInputEvidence(
+            **arguments
+        ),
+        complete(2, "2026-04-21"),
+    )
+
+    assert result.discovery.missing_requirement_counts == (
+        ("missing_exact_artifact", 1),
+    )
+
+
+def test_game_coverage_must_match_observed_window():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical replay games must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        audit(
+            complete(1, "2026-04-20"),
+        )
+
+
+def test_official_game_date_must_match():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical replay game_date must match "
+            "observed official game_date"
+        ),
+    ):
+        audit(
+            complete(1, "2026-04-21"),
+            complete(2, "2026-04-21"),
+        )
+
+
+def test_invalid_digest_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "lineup_snapshot_digest must be "
+            "a SHA-256 hex digest"
+        ),
+    ):
+        CanonicalHistoricalShadowReplayInputEvidence(
+            game_pk=1,
+            game_date="2026-04-20",
+            lineup_snapshot_digest="invalid",
+        )
+
+
+def test_audit_is_deterministic():
+    first = audit(
+        complete(2, "2026-04-21"),
+        complete(1, "2026-04-20"),
+    )
+    second = audit(
+        complete(1, "2026-04-20"),
+        complete(2, "2026-04-21"),
+    )
+
+    assert first == second
+    assert first.evidence_digest == second.evidence_digest
+    assert tuple(
+        value.game_pk
+        for value in first.discovery.games
+    ) == (1, 2)
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = audit(
+        complete(1, "2026-04-20"),
+        complete(2, "2026-04-21"),
+    ).to_diagnostics()
+
+    assert diagnostics["ready"] is True
+    assert (
+        diagnostics[
+            "current_active_roster_historical_eligible"
+        ]
+        is False
+    )
+    assert (
+        diagnostics["calibration_execution_permitted"]
+        is False
+    )
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_audit_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_SHADOW_REPLAY_INPUT_AUDIT_VERSION
+        == "canonical_historical_shadow_replay_input_audit_v1"
+    )


### PR DESCRIPTION
## Summary

- add a deterministic audit for historical shadow replay-input coverage
- bind the audit to the completed-game window digest and a canonical evidence digest
- require immutable historical lineup and bullpen snapshot provenance
- explicitly reject current active-roster data as historical bullpen evidence
- count historical lineup coverage, historical bullpen coverage, rejected substitutions, ready games, and each missing requirement

## Why

Historical calibration must use inputs that can be reproduced as of each game date. Current active-roster data cannot safely stand in for a historical bullpen snapshot, and missing provider or catalog artifacts must remain explicit blockers rather than being silently replaced.

## Production behavior

- no external inputs are fetched
- no historical simulations are executed
- no calibration gate is approved
- production activation remains disabled
- production authority remains `legacy`

## Validation

- 188 targeted tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable
- existing SQLAlchemy `MovedIn20Warning` remains unchanged