### PR TITLE
Source historical lineup and bullpen snapshots

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -442,3 +442,18 @@ __all__ += [
     "CanonicalHistoricalShadowReplayInputEvidence",
     "audit_historical_shadow_replay_input_coverage",
 ]
+
+
+from .historical_lineup_bullpen_source import (
+    CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    source_historical_lineup_bullpen_snapshots,
+)
+
+__all__ += [
+    "CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION",
+    "CanonicalHistoricalLineupBullpenGameSnapshot",
+    "CanonicalHistoricalLineupBullpenWindow",
+    "source_historical_lineup_bullpen_snapshots",
+]

--- a/mlb_app/simulation/shadow/historical_lineup_bullpen_source.py
+++ b/mlb_app/simulation/shadow/historical_lineup_bullpen_source.py
@@ -1,0 +1,510 @@
+"""Source immutable historical lineup and bullpen snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from .historical_shadow_replay_input_audit import (
+    HISTORICAL_BULLPEN_SOURCE,
+    HISTORICAL_LINEUP_SOURCE,
+    CanonicalHistoricalShadowReplayInputEvidence,
+)
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION = (
+    "canonical_historical_lineup_bullpen_source_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+    ):
+        return value
+    return ()
+
+
+def _identifier(value: Any) -> Optional[str]:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    if isinstance(value, Mapping):
+        person = _mapping(value.get("person"))
+        value = (
+            person.get("id")
+            or value.get("id")
+            or value.get("player_id")
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _starting_lineup(
+    team: Mapping[str, Any],
+) -> Tuple[str, ...]:
+    players = _mapping(team.get("players"))
+    slots: Dict[int, str] = {}
+
+    for raw_player in players.values():
+        player = _mapping(raw_player)
+        player_id = _identifier(player)
+        batting_order = str(
+            player.get("battingOrder") or ""
+        ).strip()
+
+        if player_id is None or not batting_order.isdigit():
+            continue
+
+        numeric_order = int(batting_order)
+        if numeric_order % 100 != 0:
+            continue
+
+        slot = numeric_order // 100
+        if slot < 1 or slot > 9:
+            continue
+
+        if (
+            slot in slots
+            and slots[slot] != player_id
+        ):
+            return ()
+
+        slots[slot] = player_id
+
+    if set(slots) == set(range(1, 10)):
+        return tuple(
+            slots[slot]
+            for slot in range(1, 10)
+        )
+
+    explicit = tuple(
+        value
+        for value in (
+            _identifier(raw)
+            for raw in _sequence(
+                team.get("battingOrder")
+            )
+        )
+        if value is not None
+    )
+
+    if (
+        len(explicit) == 9
+        and len(set(explicit)) == 9
+    ):
+        return explicit
+
+    return ()
+
+
+def _historical_bullpen(
+    team: Mapping[str, Any],
+) -> Tuple[str, ...]:
+    explicit = _sequence(team.get("bullpen"))
+    pitcher_order = tuple(
+        value
+        for value in (
+            _identifier(raw)
+            for raw in _sequence(
+                team.get("pitchers")
+            )
+        )
+        if value is not None
+    )
+    starter_id = (
+        pitcher_order[0]
+        if pitcher_order
+        else None
+    )
+
+    bullpen_ids = {
+        value
+        for value in (
+            _identifier(raw)
+            for raw in explicit
+        )
+        if (
+            value is not None
+            and value != starter_id
+        )
+    }
+
+    return tuple(
+        sorted(
+            bullpen_ids,
+            key=int,
+        )
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalLineupBullpenGameSnapshot:
+    game_pk: int
+    game_date: str
+    away_lineup_ids: Tuple[str, ...]
+    home_lineup_ids: Tuple[str, ...]
+    away_bullpen_ids: Tuple[str, ...]
+    home_bullpen_ids: Tuple[str, ...]
+    lineup_digest: Optional[str]
+    bullpen_digest: Optional[str]
+
+    @property
+    def lineups_ready(self) -> bool:
+        return (
+            len(self.away_lineup_ids) == 9
+            and len(self.home_lineup_ids) == 9
+            and len(set(self.away_lineup_ids)) == 9
+            and len(set(self.home_lineup_ids)) == 9
+        )
+
+    @property
+    def bullpens_ready(self) -> bool:
+        return bool(
+            self.away_bullpen_ids
+            and self.home_bullpen_ids
+        )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.lineups_ready
+            and self.bullpens_ready
+            and self.lineup_digest is not None
+            and self.bullpen_digest is not None
+        )
+
+    @property
+    def status(self) -> str:
+        if self.ready:
+            return "ready"
+        if self.lineups_ready or self.bullpens_ready:
+            return "partial"
+        return "unavailable"
+
+    def to_replay_input_evidence(
+        self,
+        *,
+        probability_provider_identity: Optional[str] = None,
+        exact_artifact_digest: Optional[str] = None,
+        fallback_catalog_digest: Optional[str] = None,
+        baserunning_catalog_digest: Optional[str] = None,
+    ) -> CanonicalHistoricalShadowReplayInputEvidence:
+        return CanonicalHistoricalShadowReplayInputEvidence(
+            game_pk=self.game_pk,
+            game_date=self.game_date,
+            lineup_source=(
+                HISTORICAL_LINEUP_SOURCE
+                if self.lineups_ready
+                else "unavailable"
+            ),
+            lineup_snapshot_digest=(
+                self.lineup_digest
+                if self.lineups_ready
+                else None
+            ),
+            bullpen_source=(
+                HISTORICAL_BULLPEN_SOURCE
+                if self.bullpens_ready
+                else "unavailable"
+            ),
+            bullpen_snapshot_digest=(
+                self.bullpen_digest
+                if self.bullpens_ready
+                else None
+            ),
+            probability_provider_identity=(
+                probability_provider_identity
+            ),
+            exact_artifact_digest=(
+                exact_artifact_digest
+            ),
+            fallback_catalog_digest=(
+                fallback_catalog_digest
+            ),
+            baserunning_catalog_digest=(
+                baserunning_catalog_digest
+            ),
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "status": self.status,
+            "ready": self.ready,
+            "lineups_ready": self.lineups_ready,
+            "bullpens_ready": self.bullpens_ready,
+            "away_lineup_count": len(
+                self.away_lineup_ids
+            ),
+            "home_lineup_count": len(
+                self.home_lineup_ids
+            ),
+            "away_bullpen_count": len(
+                self.away_bullpen_ids
+            ),
+            "home_bullpen_count": len(
+                self.home_bullpen_ids
+            ),
+            "lineup_digest": self.lineup_digest,
+            "bullpen_digest": self.bullpen_digest,
+            "player_identifiers_exposed": False,
+            "current_active_roster_used": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalLineupBullpenWindow:
+    observed_window_digest: str
+    games: Tuple[
+        CanonicalHistoricalLineupBullpenGameSnapshot,
+        ...,
+    ]
+    digest: str
+    source_version: str = (
+        CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain historical snapshots"
+            )
+        if self.source_version != (
+            CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical lineup-bullpen "
+                "source version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def ready_game_count(self) -> int:
+        return sum(
+            value.ready
+            for value in self.games
+        )
+
+    @property
+    def ready(self) -> bool:
+        return self.ready_game_count == self.game_count
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "ready_game_count": self.ready_game_count,
+            "blocked_game_count": (
+                self.game_count
+                - self.ready_game_count
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "digest": self.digest,
+            "games": tuple(
+                value.to_diagnostics()
+                for value in self.games
+            ),
+            "source": "archived_mlb_game_feed_boxscore",
+            "current_active_roster_used": False,
+            "historical_replay_executed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def source_historical_lineup_bullpen_snapshots(
+    *,
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+    game_feeds: Mapping[int, Mapping[str, Any]],
+) -> CanonicalHistoricalLineupBullpenWindow:
+    """
+    Decode historical game-feed boxscores without current-roster fallback.
+
+    Missing lineups or explicit bullpen arrays remain unavailable. Used
+    pitchers are not substituted for a missing historical bullpen roster.
+    """
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    if not isinstance(game_feeds, Mapping):
+        raise TypeError("game_feeds must be a mapping")
+
+    normalized_feeds: Dict[int, Mapping[str, Any]] = {}
+    for raw_game_pk, raw_feed in game_feeds.items():
+        try:
+            game_pk = int(raw_game_pk)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "game feed identifiers must be integers"
+            ) from exc
+
+        if game_pk in normalized_feeds:
+            raise ValueError(
+                "game feed identifiers must be unique"
+            )
+        if not isinstance(raw_feed, Mapping):
+            raise TypeError(
+                "game feed values must be mappings"
+            )
+
+        normalized_feeds[game_pk] = raw_feed
+
+    observed_by_id = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    if set(normalized_feeds) != set(observed_by_id):
+        raise ValueError(
+            "historical game feeds must exactly match "
+            "observed play-by-play games"
+        )
+
+    snapshots = []
+
+    for game_pk, observed_game in sorted(
+        observed_by_id.items(),
+        key=lambda item: (
+            item[1].game_date,
+            item[0],
+        ),
+    ):
+        feed = normalized_feeds[game_pk]
+        game_data = _mapping(feed.get("gameData"))
+        datetime_data = _mapping(
+            game_data.get("datetime")
+        )
+        official_date = str(
+            datetime_data.get("officialDate") or ""
+        ).strip()
+
+        if official_date != observed_game.game_date:
+            raise ValueError(
+                "historical game feed officialDate must "
+                "match observed game_date"
+            )
+
+        live_data = _mapping(feed.get("liveData"))
+        boxscore = _mapping(
+            live_data.get("boxscore")
+        )
+        teams = _mapping(boxscore.get("teams"))
+        away = _mapping(teams.get("away"))
+        home = _mapping(teams.get("home"))
+
+        away_lineup = _starting_lineup(away)
+        home_lineup = _starting_lineup(home)
+        away_bullpen = _historical_bullpen(away)
+        home_bullpen = _historical_bullpen(home)
+
+        lineups_ready = (
+            len(away_lineup) == 9
+            and len(home_lineup) == 9
+        )
+        bullpens_ready = bool(
+            away_bullpen
+            and home_bullpen
+        )
+
+        lineup_digest = (
+            _sha256(
+                {
+                    "game_pk": game_pk,
+                    "game_date": observed_game.game_date,
+                    "away": away_lineup,
+                    "home": home_lineup,
+                }
+            )
+            if lineups_ready
+            else None
+        )
+        bullpen_digest = (
+            _sha256(
+                {
+                    "game_pk": game_pk,
+                    "game_date": observed_game.game_date,
+                    "away": away_bullpen,
+                    "home": home_bullpen,
+                }
+            )
+            if bullpens_ready
+            else None
+        )
+
+        snapshots.append(
+            CanonicalHistoricalLineupBullpenGameSnapshot(
+                game_pk=game_pk,
+                game_date=observed_game.game_date,
+                away_lineup_ids=away_lineup,
+                home_lineup_ids=home_lineup,
+                away_bullpen_ids=away_bullpen,
+                home_bullpen_ids=home_bullpen,
+                lineup_digest=lineup_digest,
+                bullpen_digest=bullpen_digest,
+            )
+        )
+
+    digest = _sha256(
+        {
+            "observed_window_digest": observed.digest,
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "game_date": value.game_date,
+                    "lineup_digest": value.lineup_digest,
+                    "bullpen_digest": value.bullpen_digest,
+                    "status": value.status,
+                }
+                for value in snapshots
+            ],
+        }
+    )
+
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=observed.digest,
+        games=tuple(snapshots),
+        digest=digest,
+    )

--- a/tests/test_canonical_historical_lineup_bullpen_source.py
+++ b/tests/test_canonical_historical_lineup_bullpen_source.py
@@ -1,0 +1,270 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION,
+    HISTORICAL_BULLPEN_SOURCE,
+    HISTORICAL_LINEUP_SOURCE,
+    source_historical_lineup_bullpen_snapshots,
+)
+from mlb_app.simulation.shadow.mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+def observed():
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-04-21",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=2,
+                game_date="2026-04-21",
+                stolen_bases=0,
+                caught_stealing=1,
+            ),
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=1,
+                game_date="2026-04-20",
+                stolen_bases=1,
+                caught_stealing=0,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest="f" * 64,
+    )
+
+
+def team(base):
+    players = {}
+
+    for slot in range(1, 10):
+        player_id = base + slot
+        players[f"ID{player_id}"] = {
+            "person": {"id": player_id},
+            "battingOrder": str(slot * 100),
+        }
+
+    substitute_id = base + 90
+    players[f"ID{substitute_id}"] = {
+        "person": {"id": substitute_id},
+        "battingOrder": "101",
+    }
+
+    return {
+        "players": players,
+        "pitchers": [
+            base + 40,
+            base + 41,
+        ],
+        "bullpen": [
+            {"id": base + 42},
+            {"person": {"id": base + 41}},
+            {"id": base + 40},
+        ],
+    }
+
+
+def feed(game_date):
+    return {
+        "gameData": {
+            "datetime": {
+                "officialDate": game_date,
+            },
+        },
+        "liveData": {
+            "boxscore": {
+                "teams": {
+                    "away": team(1000),
+                    "home": team(2000),
+                },
+            },
+        },
+    }
+
+
+def source(feeds=None):
+    return source_historical_lineup_bullpen_snapshots(
+        observed=observed(),
+        game_feeds=(
+            feeds
+            if feeds is not None
+            else {
+                2: feed("2026-04-21"),
+                1: feed("2026-04-20"),
+            }
+        ),
+    )
+
+
+def test_complete_archived_feeds_are_ready():
+    result = source()
+
+    assert result.ready is True
+    assert result.game_count == 2
+    assert result.ready_game_count == 2
+    assert tuple(
+        value.game_pk
+        for value in result.games
+    ) == (1, 2)
+
+    first = result.games[0]
+    assert first.away_lineup_ids == tuple(
+        str(1000 + slot)
+        for slot in range(1, 10)
+    )
+    assert first.away_bullpen_ids == (
+        "1041",
+        "1042",
+    )
+    assert len(first.lineup_digest) == 64
+    assert len(first.bullpen_digest) == 64
+
+
+def test_substitutes_are_not_starting_lineup_members():
+    first = source().games[0]
+
+    assert "1090" not in first.away_lineup_ids
+    assert len(first.away_lineup_ids) == 9
+
+
+def test_probable_starter_is_excluded_from_bullpen():
+    first = source().games[0]
+
+    assert "1040" not in first.away_bullpen_ids
+    assert first.away_bullpen_ids == (
+        "1041",
+        "1042",
+    )
+
+
+def test_missing_explicit_bullpen_fails_closed():
+    first_feed = feed("2026-04-20")
+    del first_feed[
+        "liveData"
+    ]["boxscore"]["teams"]["away"]["bullpen"]
+
+    result = source(
+        {
+            1: first_feed,
+            2: feed("2026-04-21"),
+        }
+    )
+
+    first = result.games[0]
+    assert first.ready is False
+    assert first.lineups_ready is True
+    assert first.bullpens_ready is False
+    assert first.bullpen_digest is None
+    assert result.ready is False
+
+
+def test_used_pitchers_do_not_replace_missing_bullpen():
+    first_feed = feed("2026-04-20")
+    first_feed[
+        "liveData"
+    ]["boxscore"]["teams"]["away"]["bullpen"] = []
+
+    first = source(
+        {
+            1: first_feed,
+            2: feed("2026-04-21"),
+        }
+    ).games[0]
+
+    assert first.away_bullpen_ids == ()
+    assert first.bullpens_ready is False
+
+
+def test_snapshot_converts_to_audit_evidence():
+    first = source().games[0]
+    evidence = first.to_replay_input_evidence()
+
+    assert evidence.lineup_source == (
+        HISTORICAL_LINEUP_SOURCE
+    )
+    assert evidence.bullpen_source == (
+        HISTORICAL_BULLPEN_SOURCE
+    )
+    assert evidence.lineups_ready is True
+    assert evidence.bullpens_ready is True
+    assert (
+        evidence.probability_provider_ready
+        is False
+    )
+
+
+def test_game_feed_coverage_must_be_exact():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical game feeds must exactly match "
+            "observed play-by-play games"
+        ),
+    ):
+        source(
+            {
+                1: feed("2026-04-20"),
+            }
+        )
+
+
+def test_official_date_must_match_observed_date():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical game feed officialDate must "
+            "match observed game_date"
+        ),
+    ):
+        source(
+            {
+                1: feed("2026-04-21"),
+                2: feed("2026-04-21"),
+            }
+        )
+
+
+def test_source_is_deterministic():
+    first = source(
+        {
+            2: feed("2026-04-21"),
+            1: feed("2026-04-20"),
+        }
+    )
+    second = source(
+        {
+            1: feed("2026-04-20"),
+            2: feed("2026-04-21"),
+        }
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+
+
+def test_diagnostics_hide_player_identifiers():
+    diagnostics = source().to_diagnostics()
+    first = diagnostics["games"][0]
+
+    assert first["player_identifiers_exposed"] is False
+    assert first["current_active_roster_used"] is False
+    assert "away_lineup_ids" not in first
+    assert "away_bullpen_ids" not in first
+    assert diagnostics["historical_replay_executed"] is False
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_source_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_LINEUP_BULLPEN_SOURCE_VERSION
+        == "canonical_historical_lineup_bullpen_source_v1"
+    )


### PR DESCRIPTION
## Summary

- decode deterministic historical lineup and bullpen snapshots from archived MLB game-feed boxscores
- require exact game coverage and official-date agreement with the observed play-by-play window
- identify confirmed nine-player starting orders while excluding substitutions
- use only explicit game-specific bullpen arrays and exclude the probable starter
- produce per-game lineup and bullpen SHA-256 digests plus a deterministic window digest
- convert valid snapshots into the historical replay-input audit contract without exposing player identifiers in diagnostics

## Why

Historical replay cannot use today's active rosters or infer bullpen availability from pitchers who happened to appear. Missing historical bullpen arrays and incomplete batting orders must remain explicit blockers.

## Production behavior

- no current active-roster source is used
- used pitchers do not replace missing bullpen evidence
- incomplete inputs fail closed
- no historical replay or calibration is executed
- production activation remains disabled
- production authority remains `legacy`

## Validation

- 199 targeted tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable
- existing SQLAlchemy `MovedIn20Warning` remains unchanged