### PR TITLE
Report historical lineup and bullpen coverage

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -457,3 +457,16 @@ __all__ += [
     "CanonicalHistoricalLineupBullpenWindow",
     "source_historical_lineup_bullpen_snapshots",
 ]
+
+
+from .historical_lineup_bullpen_coverage_report import (
+    CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION,
+    CanonicalHistoricalLineupBullpenCoverageReport,
+    report_historical_lineup_bullpen_coverage,
+)
+
+__all__ += [
+    "CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION",
+    "CanonicalHistoricalLineupBullpenCoverageReport",
+    "report_historical_lineup_bullpen_coverage",
+]

--- a/mlb_app/simulation/shadow/historical_lineup_bullpen_coverage_report.py
+++ b/mlb_app/simulation/shadow/historical_lineup_bullpen_coverage_report.py
@@ -1,0 +1,261 @@
+"""Report historical lineup and bullpen snapshot coverage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Dict
+
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION = (
+    "canonical_historical_lineup_bullpen_coverage_report_v1"
+)
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalLineupBullpenCoverageReport:
+    observed_window_digest: str
+    source_window_digest: str
+    game_count: int
+    lineup_ready_game_count: int
+    bullpen_ready_game_count: int
+    ready_game_count: int
+    partial_game_count: int
+    unavailable_game_count: int
+    missing_away_lineup_count: int
+    missing_home_lineup_count: int
+    missing_away_bullpen_count: int
+    missing_home_bullpen_count: int
+    report_digest: str
+    report_version: str = (
+        CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.game_count <= 0:
+            raise ValueError(
+                "game_count must be positive"
+            )
+
+        counts = (
+            self.lineup_ready_game_count,
+            self.bullpen_ready_game_count,
+            self.ready_game_count,
+            self.partial_game_count,
+            self.unavailable_game_count,
+            self.missing_away_lineup_count,
+            self.missing_home_lineup_count,
+            self.missing_away_bullpen_count,
+            self.missing_home_bullpen_count,
+        )
+        if any(
+            value < 0 or value > self.game_count
+            for value in counts
+        ):
+            raise ValueError(
+                "coverage counts must be within game_count"
+            )
+
+        if (
+            self.ready_game_count
+            + self.partial_game_count
+            + self.unavailable_game_count
+            != self.game_count
+        ):
+            raise ValueError(
+                "status counts must equal game_count"
+            )
+
+        for field_name in (
+            "observed_window_digest",
+            "source_window_digest",
+            "report_digest",
+        ):
+            value = getattr(self, field_name)
+            if len(value) != 64:
+                raise ValueError(
+                    f"{field_name} must be a SHA-256 digest"
+                )
+
+        if self.report_version != (
+            CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical lineup-bullpen "
+                "coverage report version"
+            )
+
+    @property
+    def complete(self) -> bool:
+        return self.ready_game_count == self.game_count
+
+    @property
+    def lineup_coverage_rate(self) -> float:
+        return (
+            self.lineup_ready_game_count
+            / self.game_count
+        )
+
+    @property
+    def bullpen_coverage_rate(self) -> float:
+        return (
+            self.bullpen_ready_game_count
+            / self.game_count
+        )
+
+    @property
+    def complete_game_coverage_rate(self) -> float:
+        return (
+            self.ready_game_count
+            / self.game_count
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.report_version,
+            "complete": self.complete,
+            "game_count": self.game_count,
+            "lineup_ready_game_count": (
+                self.lineup_ready_game_count
+            ),
+            "bullpen_ready_game_count": (
+                self.bullpen_ready_game_count
+            ),
+            "ready_game_count": self.ready_game_count,
+            "partial_game_count": (
+                self.partial_game_count
+            ),
+            "unavailable_game_count": (
+                self.unavailable_game_count
+            ),
+            "missing_away_lineup_count": (
+                self.missing_away_lineup_count
+            ),
+            "missing_home_lineup_count": (
+                self.missing_home_lineup_count
+            ),
+            "missing_away_bullpen_count": (
+                self.missing_away_bullpen_count
+            ),
+            "missing_home_bullpen_count": (
+                self.missing_home_bullpen_count
+            ),
+            "lineup_coverage_rate": round(
+                self.lineup_coverage_rate,
+                6,
+            ),
+            "bullpen_coverage_rate": round(
+                self.bullpen_coverage_rate,
+                6,
+            ),
+            "complete_game_coverage_rate": round(
+                self.complete_game_coverage_rate,
+                6,
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "source_window_digest": (
+                self.source_window_digest
+            ),
+            "report_digest": self.report_digest,
+            "player_identifiers_exposed": False,
+            "current_active_roster_used": False,
+            "used_pitchers_substituted_for_bullpen": False,
+            "historical_replay_permitted": self.complete,
+            "historical_replay_executed": False,
+            "calibration_execution_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def report_historical_lineup_bullpen_coverage(
+    window: CanonicalHistoricalLineupBullpenWindow,
+) -> CanonicalHistoricalLineupBullpenCoverageReport:
+    """Summarize exact historical input coverage without replay."""
+
+    if not isinstance(
+        window,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "window must be "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    games = window.games
+    counts = {
+        "game_count": len(games),
+        "lineup_ready_game_count": sum(
+            value.lineups_ready
+            for value in games
+        ),
+        "bullpen_ready_game_count": sum(
+            value.bullpens_ready
+            for value in games
+        ),
+        "ready_game_count": sum(
+            value.status == "ready"
+            for value in games
+        ),
+        "partial_game_count": sum(
+            value.status == "partial"
+            for value in games
+        ),
+        "unavailable_game_count": sum(
+            value.status == "unavailable"
+            for value in games
+        ),
+        "missing_away_lineup_count": sum(
+            len(value.away_lineup_ids) != 9
+            for value in games
+        ),
+        "missing_home_lineup_count": sum(
+            len(value.home_lineup_ids) != 9
+            for value in games
+        ),
+        "missing_away_bullpen_count": sum(
+            not value.away_bullpen_ids
+            for value in games
+        ),
+        "missing_home_bullpen_count": sum(
+            not value.home_bullpen_ids
+            for value in games
+        ),
+    }
+
+    report_digest = _sha256(
+        {
+            "observed_window_digest": (
+                window.observed_window_digest
+            ),
+            "source_window_digest": window.digest,
+            **counts,
+        }
+    )
+
+    return CanonicalHistoricalLineupBullpenCoverageReport(
+        observed_window_digest=(
+            window.observed_window_digest
+        ),
+        source_window_digest=window.digest,
+        report_digest=report_digest,
+        **counts,
+    )

--- a/scripts/run_historical_lineup_bullpen_coverage_report.py
+++ b/scripts/run_historical_lineup_bullpen_coverage_report.py
@@ -1,0 +1,124 @@
+"""Report real historical lineup and bullpen smoke-window coverage."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+
+import requests
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+    report_historical_lineup_bullpen_coverage,
+    source_historical_lineup_bullpen_snapshots,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+_SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+
+
+def _json(url, *, params=None):
+    response = requests.get(
+        url,
+        params=params,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _completed_game_ids(schedule):
+    return tuple(
+        sorted(
+            {
+                int(game["gamePk"])
+                for date_row in schedule["dates"]
+                for game in date_row["games"]
+                if game["status"][
+                    "abstractGameState"
+                ]
+                == "Final"
+            }
+        )
+    )
+
+
+def _feed(game_pk):
+    return (
+        game_pk,
+        _json(
+            _FEED_URL.format(
+                game_pk=game_pk
+            )
+        ),
+    )
+
+
+def main() -> None:
+    schedule = _json(
+        _SCHEDULE_URL,
+        params={
+            "sportId": 1,
+            "startDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            "endDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        },
+    )
+    game_ids = _completed_game_ids(schedule)
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        feeds = dict(
+            executor.map(
+                _feed,
+                game_ids,
+            )
+        )
+
+    observed = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=schedule,
+            game_feeds=feeds,
+            window_start=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            window_end=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        )
+    )
+    source_window = (
+        source_historical_lineup_bullpen_snapshots(
+            observed=observed,
+            game_feeds=feeds,
+        )
+    )
+    report = (
+        report_historical_lineup_bullpen_coverage(
+            source_window
+        )
+    )
+
+    print(
+        json.dumps(
+            report.to_diagnostics(),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonical_historical_lineup_bullpen_coverage_report.py
+++ b/tests/test_canonical_historical_lineup_bullpen_coverage_report.py
@@ -1,0 +1,184 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    report_historical_lineup_bullpen_coverage,
+)
+
+
+def game(
+    *,
+    game_pk,
+    away_lineup=tuple(str(value) for value in range(1, 10)),
+    home_lineup=tuple(str(value) for value in range(11, 20)),
+    away_bullpen=("21", "22"),
+    home_bullpen=("31", "32"),
+):
+    lineups_ready = (
+        len(away_lineup) == 9
+        and len(home_lineup) == 9
+    )
+    bullpens_ready = bool(
+        away_bullpen
+        and home_bullpen
+    )
+
+    return CanonicalHistoricalLineupBullpenGameSnapshot(
+        game_pk=game_pk,
+        game_date=(
+            "2026-04-20"
+            if game_pk == 1
+            else "2026-04-21"
+        ),
+        away_lineup_ids=away_lineup,
+        home_lineup_ids=home_lineup,
+        away_bullpen_ids=away_bullpen,
+        home_bullpen_ids=home_bullpen,
+        lineup_digest=(
+            "a" * 64
+            if lineups_ready
+            else None
+        ),
+        bullpen_digest=(
+            "b" * 64
+            if bullpens_ready
+            else None
+        ),
+    )
+
+
+def window(*games):
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest="c" * 64,
+        games=games,
+        digest="d" * 64,
+    )
+
+
+def test_complete_coverage_is_reported():
+    result = report_historical_lineup_bullpen_coverage(
+        window(
+            game(game_pk=1),
+            game(game_pk=2),
+        )
+    )
+
+    assert result.complete is True
+    assert result.game_count == 2
+    assert result.lineup_ready_game_count == 2
+    assert result.bullpen_ready_game_count == 2
+    assert result.ready_game_count == 2
+    assert result.partial_game_count == 0
+    assert result.unavailable_game_count == 0
+    assert result.lineup_coverage_rate == 1.0
+    assert result.bullpen_coverage_rate == 1.0
+
+
+def test_partial_coverage_counts_each_blocker():
+    result = report_historical_lineup_bullpen_coverage(
+        window(
+            game(game_pk=1),
+            game(
+                game_pk=2,
+                away_bullpen=(),
+            ),
+        )
+    )
+
+    assert result.complete is False
+    assert result.lineup_ready_game_count == 2
+    assert result.bullpen_ready_game_count == 1
+    assert result.ready_game_count == 1
+    assert result.partial_game_count == 1
+    assert result.missing_away_bullpen_count == 1
+    assert result.missing_home_bullpen_count == 0
+    assert result.complete_game_coverage_rate == 0.5
+
+
+def test_unavailable_game_is_reported():
+    result = report_historical_lineup_bullpen_coverage(
+        window(
+            game(
+                game_pk=1,
+                away_lineup=(),
+                home_lineup=(),
+                away_bullpen=(),
+                home_bullpen=(),
+            ),
+        )
+    )
+
+    assert result.ready_game_count == 0
+    assert result.partial_game_count == 0
+    assert result.unavailable_game_count == 1
+    assert result.missing_away_lineup_count == 1
+    assert result.missing_home_lineup_count == 1
+    assert result.missing_away_bullpen_count == 1
+    assert result.missing_home_bullpen_count == 1
+
+
+def test_wrong_input_contract_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "window must be "
+            "CanonicalHistoricalLineupBullpenWindow"
+        ),
+    ):
+        report_historical_lineup_bullpen_coverage(
+            object()
+        )
+
+
+def test_report_is_deterministic():
+    source = window(
+        game(game_pk=1),
+        game(game_pk=2),
+    )
+
+    first = report_historical_lineup_bullpen_coverage(
+        source
+    )
+    second = report_historical_lineup_bullpen_coverage(
+        source
+    )
+
+    assert first == second
+    assert first.report_digest == second.report_digest
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = (
+        report_historical_lineup_bullpen_coverage(
+            window(game(game_pk=1))
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["complete"] is True
+    assert diagnostics["player_identifiers_exposed"] is False
+    assert diagnostics["current_active_roster_used"] is False
+    assert (
+        diagnostics[
+            "used_pitchers_substituted_for_bullpen"
+        ]
+        is False
+    )
+    assert diagnostics["historical_replay_executed"] is False
+    assert (
+        diagnostics["calibration_execution_permitted"]
+        is False
+    )
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_report_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_LINEUP_BULLPEN_COVERAGE_REPORT_VERSION
+        == (
+            "canonical_historical_lineup_bullpen_"
+            "coverage_report_v1"
+        )
+    )


### PR DESCRIPTION
## Summary

- add a deterministic historical lineup/bullpen coverage report
- add a standalone real-data runner for the canonical 2026-04-20 through 2026-05-03 smoke window
- report lineup, bullpen, complete-game, partial, unavailable, and side-specific missing-input counts
- preserve observed, source-window, and report SHA-256 lineage
- keep player identifiers out of diagnostics

## Real smoke-window result

- completed games: **185**
- historical lineups ready: **185/185 (100%)**
- historical bullpens ready: **185/185 (100%)**
- complete games: **185/185 (100%)**
- partial or unavailable games: **0**
- current active-roster substitutions: **0**
- used-pitcher substitutions: **0**
- observed window digest: `0f9eb719d8b513f5c7cf01275128533938eba6ddff9a902910f0feb1c1af08bb`
- source window digest: `33ab5eb5a406f5efb26272ebf815cb7f69d157e25344cafd9775c32968485e71`
- report digest: `9a5542a8d67040bc90e08b46e9a2c4fd080b1af4c5ea3a6e02c12003e94dd114`

## Production behavior

- no historical replay is executed
- no calibration gate is approved
- production activation remains disabled
- production authority remains `legacy`

## Validation

- 206 targeted tests passed
- real 185-game coverage runner exited successfully
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable
- existing SQLAlchemy `MovedIn20Warning` remains unchanged