### PR TITLE
Inventory historical probability artifacts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -470,3 +470,20 @@ __all__ += [
     "CanonicalHistoricalLineupBullpenCoverageReport",
     "report_historical_lineup_bullpen_coverage",
 ]
+
+
+from .historical_probability_artifact_inventory import (
+    CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION,
+    HISTORICAL_PROBABILITY_ARTIFACT_SOURCE,
+    CanonicalHistoricalProbabilityArtifactInventory,
+    CanonicalHistoricalProbabilityArtifactRecord,
+    inventory_historical_probability_artifacts,
+)
+
+__all__ += [
+    "CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION",
+    "HISTORICAL_PROBABILITY_ARTIFACT_SOURCE",
+    "CanonicalHistoricalProbabilityArtifactInventory",
+    "CanonicalHistoricalProbabilityArtifactRecord",
+    "inventory_historical_probability_artifacts",
+]

--- a/mlb_app/simulation/shadow/historical_probability_artifact_inventory.py
+++ b/mlb_app/simulation/shadow/historical_probability_artifact_inventory.py
@@ -1,0 +1,485 @@
+"""Inventory immutable historical probability artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict, Optional, Tuple
+
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION = (
+    "canonical_historical_probability_artifact_inventory_v1"
+)
+HISTORICAL_PROBABILITY_ARTIFACT_SOURCE = (
+    "historical_probability_artifact_archive_v1"
+)
+
+
+def _available(value: Optional[str]) -> bool:
+    return bool(
+        isinstance(value, str)
+        and value.strip()
+        and value != "unavailable"
+    )
+
+
+def _validate_digest(
+    value: Optional[str],
+    *,
+    field_name: str,
+) -> None:
+    if value is None:
+        return
+
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{field_name} must be a string or None"
+        )
+
+    if len(value) != 64:
+        raise ValueError(
+            f"{field_name} must be a SHA-256 hex digest"
+        )
+
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be a SHA-256 hex digest"
+        ) from exc
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityArtifactRecord:
+    game_pk: int
+    game_date: str
+    source: str = "unavailable"
+    artifact_as_of_date: Optional[str] = None
+    provider_identity: Optional[str] = None
+    exact_artifact_digest: Optional[str] = None
+    fallback_catalog_digest: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        parsed_game_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_game_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        if self.artifact_as_of_date is not None:
+            parsed_artifact_date = date.fromisoformat(
+                self.artifact_as_of_date
+            )
+            if (
+                parsed_artifact_date.isoformat()
+                != self.artifact_as_of_date
+            ):
+                raise ValueError(
+                    "artifact_as_of_date must use ISO format"
+                )
+
+        for field_name in (
+            "exact_artifact_digest",
+            "fallback_catalog_digest",
+        ):
+            _validate_digest(
+                getattr(self, field_name),
+                field_name=field_name,
+            )
+
+    @property
+    def source_ready(self) -> bool:
+        return (
+            self.source
+            == HISTORICAL_PROBABILITY_ARTIFACT_SOURCE
+        )
+
+    @property
+    def as_of_date_ready(self) -> bool:
+        return (
+            self.source_ready
+            and self.artifact_as_of_date
+            == self.game_date
+        )
+
+    @property
+    def future_data_rejected(self) -> bool:
+        return bool(
+            self.artifact_as_of_date
+            and self.artifact_as_of_date
+            > self.game_date
+        )
+
+    @property
+    def provider_ready(self) -> bool:
+        return (
+            self.as_of_date_ready
+            and _available(self.provider_identity)
+        )
+
+    @property
+    def exact_artifact_ready(self) -> bool:
+        return (
+            self.as_of_date_ready
+            and _available(
+                self.exact_artifact_digest
+            )
+        )
+
+    @property
+    def fallback_catalog_ready(self) -> bool:
+        return (
+            self.as_of_date_ready
+            and _available(
+                self.fallback_catalog_digest
+            )
+        )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.provider_ready
+            and self.exact_artifact_ready
+            and self.fallback_catalog_ready
+        )
+
+    @property
+    def missing_requirements(self) -> Tuple[str, ...]:
+        missing = []
+
+        if not self.source_ready:
+            missing.append(
+                "missing_historical_artifact_source"
+            )
+        elif not self.as_of_date_ready:
+            missing.append(
+                "artifact_as_of_date_mismatch"
+            )
+
+        if not self.provider_ready:
+            missing.append(
+                "missing_probability_provider"
+            )
+        if not self.exact_artifact_ready:
+            missing.append(
+                "missing_exact_artifact"
+            )
+        if not self.fallback_catalog_ready:
+            missing.append(
+                "missing_fallback_catalog"
+            )
+
+        return tuple(missing)
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "source": self.source,
+            "artifact_as_of_date": (
+                self.artifact_as_of_date
+            ),
+            "ready": self.ready,
+            "provider_ready": self.provider_ready,
+            "exact_artifact_ready": (
+                self.exact_artifact_ready
+            ),
+            "fallback_catalog_ready": (
+                self.fallback_catalog_ready
+            ),
+            "missing_requirements": (
+                self.missing_requirements
+            ),
+            "future_data_rejected": (
+                self.future_data_rejected
+            ),
+            "provider_identity": (
+                self.provider_identity
+            ),
+            "exact_artifact_digest": (
+                self.exact_artifact_digest
+            ),
+            "fallback_catalog_digest": (
+                self.fallback_catalog_digest
+            ),
+            "probability_records_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityArtifactInventory:
+    observed_window_digest: str
+    games: Tuple[
+        CanonicalHistoricalProbabilityArtifactRecord,
+        ...,
+    ]
+    missing_requirement_counts: Tuple[
+        Tuple[str, int],
+        ...,
+    ]
+    inventory_digest: str
+    inventory_version: str = (
+        CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain inventory records"
+            )
+
+        for field_name in (
+            "observed_window_digest",
+            "inventory_digest",
+        ):
+            _validate_digest(
+                getattr(self, field_name),
+                field_name=field_name,
+            )
+
+        if self.inventory_version != (
+            CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical probability "
+                "artifact inventory version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def provider_ready_game_count(self) -> int:
+        return sum(
+            value.provider_ready
+            for value in self.games
+        )
+
+    @property
+    def exact_artifact_ready_game_count(
+        self,
+    ) -> int:
+        return sum(
+            value.exact_artifact_ready
+            for value in self.games
+        )
+
+    @property
+    def fallback_catalog_ready_game_count(
+        self,
+    ) -> int:
+        return sum(
+            value.fallback_catalog_ready
+            for value in self.games
+        )
+
+    @property
+    def ready_game_count(self) -> int:
+        return sum(
+            value.ready
+            for value in self.games
+        )
+
+    @property
+    def ready(self) -> bool:
+        return self.ready_game_count == self.game_count
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.inventory_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "provider_ready_game_count": (
+                self.provider_ready_game_count
+            ),
+            "exact_artifact_ready_game_count": (
+                self.exact_artifact_ready_game_count
+            ),
+            "fallback_catalog_ready_game_count": (
+                self.fallback_catalog_ready_game_count
+            ),
+            "ready_game_count": self.ready_game_count,
+            "blocked_game_count": (
+                self.game_count
+                - self.ready_game_count
+            ),
+            "missing_requirement_counts": dict(
+                self.missing_requirement_counts
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "inventory_digest": (
+                self.inventory_digest
+            ),
+            "games": tuple(
+                value.to_diagnostics()
+                for value in self.games
+            ),
+            "probability_records_exposed": False,
+            "historical_reconstruction_required": (
+                not self.ready
+            ),
+            "historical_replay_permitted": self.ready,
+            "historical_replay_executed": False,
+            "calibration_execution_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def inventory_historical_probability_artifacts(
+    *,
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+    artifacts: Tuple[
+        CanonicalHistoricalProbabilityArtifactRecord,
+        ...,
+    ] = (),
+) -> CanonicalHistoricalProbabilityArtifactInventory:
+    """
+    Inventory archived artifacts without constructing replacements.
+
+    Missing games are materialized as unavailable inventory rows. Current
+    workspaces, in-memory caches, and future-dated data are not accepted.
+    """
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    if not isinstance(artifacts, tuple):
+        raise TypeError("artifacts must be a tuple")
+
+    by_id = {}
+
+    for value in artifacts:
+        if not isinstance(
+            value,
+            CanonicalHistoricalProbabilityArtifactRecord,
+        ):
+            raise TypeError(
+                "artifacts must contain "
+                "CanonicalHistoricalProbabilityArtifactRecord"
+            )
+
+        if value.game_pk in by_id:
+            raise ValueError(
+                "historical probability artifact "
+                "game identifiers must be unique"
+            )
+
+        by_id[value.game_pk] = value
+
+    observed_by_id = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    unknown_ids = set(by_id) - set(observed_by_id)
+    if unknown_ids:
+        raise ValueError(
+            "historical probability artifacts must "
+            "belong to the observed window"
+        )
+
+    ordered = []
+
+    for game_pk, observed_game in sorted(
+        observed_by_id.items(),
+        key=lambda item: (
+            item[1].game_date,
+            item[0],
+        ),
+    ):
+        value = by_id.get(game_pk)
+
+        if value is None:
+            value = (
+                CanonicalHistoricalProbabilityArtifactRecord(
+                    game_pk=game_pk,
+                    game_date=observed_game.game_date,
+                )
+            )
+        elif value.game_date != observed_game.game_date:
+            raise ValueError(
+                "historical probability artifact "
+                "game_date must match observed game_date"
+            )
+
+        ordered.append(value)
+
+    reasons = tuple(
+        sorted(
+            {
+                reason
+                for value in ordered
+                for reason in value.missing_requirements
+            }
+        )
+    )
+    missing_counts = tuple(
+        (
+            reason,
+            sum(
+                reason in value.missing_requirements
+                for value in ordered
+            ),
+        )
+        for reason in reasons
+    )
+
+    inventory_digest = _sha256(
+        {
+            "observed_window_digest": observed.digest,
+            "games": [
+                asdict(value)
+                for value in ordered
+            ],
+            "missing_requirement_counts": (
+                missing_counts
+            ),
+        }
+    )
+
+    return CanonicalHistoricalProbabilityArtifactInventory(
+        observed_window_digest=observed.digest,
+        games=tuple(ordered),
+        missing_requirement_counts=missing_counts,
+        inventory_digest=inventory_digest,
+    )

--- a/scripts/run_historical_probability_artifact_inventory.py
+++ b/scripts/run_historical_probability_artifact_inventory.py
@@ -1,0 +1,187 @@
+"""Inventory historical probability artifacts for the smoke window."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+from pathlib import Path
+
+import requests
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+    CanonicalHistoricalProbabilityArtifactRecord,
+    inventory_historical_probability_artifacts,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+_SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+_DEFAULT_MANIFEST = Path(
+    "data/historical_probability_artifacts.json"
+)
+
+
+def _json(url, *, params=None):
+    response = requests.get(
+        url,
+        params=params,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _completed_game_ids(schedule):
+    return tuple(
+        sorted(
+            {
+                int(game["gamePk"])
+                for date_row in schedule["dates"]
+                for game in date_row["games"]
+                if game["status"][
+                    "abstractGameState"
+                ]
+                == "Final"
+            }
+        )
+    )
+
+
+def _feed(game_pk):
+    return (
+        game_pk,
+        _json(
+            _FEED_URL.format(
+                game_pk=game_pk
+            )
+        ),
+    )
+
+
+def _manifest_records(path):
+    if not path.exists():
+        return ()
+
+    payload = json.loads(
+        path.read_text(encoding="utf-8")
+    )
+    rows = (
+        payload.get("records", ())
+        if isinstance(payload, dict)
+        else payload
+    )
+
+    if not isinstance(rows, list):
+        raise ValueError(
+            "historical probability artifact manifest "
+            "records must be a list"
+        )
+
+    return tuple(
+        CanonicalHistoricalProbabilityArtifactRecord(
+            game_pk=int(row["game_pk"]),
+            game_date=str(row["game_date"]),
+            source=str(
+                row.get("source") or "unavailable"
+            ),
+            artifact_as_of_date=(
+                row.get("artifact_as_of_date")
+            ),
+            provider_identity=(
+                row.get("provider_identity")
+            ),
+            exact_artifact_digest=(
+                row.get("exact_artifact_digest")
+            ),
+            fallback_catalog_digest=(
+                row.get("fallback_catalog_digest")
+            ),
+        )
+        for row in rows
+    )
+
+
+def main() -> None:
+    schedule = _json(
+        _SCHEDULE_URL,
+        params={
+            "sportId": 1,
+            "startDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            "endDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        },
+    )
+    game_ids = _completed_game_ids(schedule)
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        feeds = dict(
+            executor.map(
+                _feed,
+                game_ids,
+            )
+        )
+
+    observed = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=schedule,
+            game_feeds=feeds,
+            window_start=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            window_end=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        )
+    )
+
+    manifest_path = Path(
+        os.getenv(
+            "HISTORICAL_PROBABILITY_ARTIFACT_MANIFEST",
+            str(_DEFAULT_MANIFEST),
+        )
+    )
+    records = _manifest_records(manifest_path)
+
+    inventory = (
+        inventory_historical_probability_artifacts(
+            observed=observed,
+            artifacts=records,
+        )
+    )
+    diagnostics = inventory.to_diagnostics()
+    diagnostics["manifest_present"] = (
+        manifest_path.exists()
+    )
+    diagnostics["manifest_record_count"] = len(
+        records
+    )
+    diagnostics["database_artifact_row_count"] = 0
+    diagnostics["in_memory_cache_historical_eligible"] = (
+        False
+    )
+
+    print(
+        json.dumps(
+            diagnostics,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonical_historical_probability_artifact_inventory.py
+++ b/tests/test_canonical_historical_probability_artifact_inventory.py
@@ -1,0 +1,194 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION,
+    HISTORICAL_PROBABILITY_ARTIFACT_SOURCE,
+    CanonicalHistoricalProbabilityArtifactRecord,
+    inventory_historical_probability_artifacts,
+)
+from mlb_app.simulation.shadow.mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+def observed():
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-04-21",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=2,
+                game_date="2026-04-21",
+                stolen_bases=0,
+                caught_stealing=1,
+            ),
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=1,
+                game_date="2026-04-20",
+                stolen_bases=1,
+                caught_stealing=0,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest="f" * 64,
+    )
+
+
+def complete(game_pk, game_date):
+    return CanonicalHistoricalProbabilityArtifactRecord(
+        game_pk=game_pk,
+        game_date=game_date,
+        source=HISTORICAL_PROBABILITY_ARTIFACT_SOURCE,
+        artifact_as_of_date=game_date,
+        provider_identity="provider:v1",
+        exact_artifact_digest="a" * 64,
+        fallback_catalog_digest="b" * 64,
+    )
+
+
+def inventory(*records):
+    return inventory_historical_probability_artifacts(
+        observed=observed(),
+        artifacts=records,
+    )
+
+
+def test_complete_archive_is_ready():
+    result = inventory(
+        complete(2, "2026-04-21"),
+        complete(1, "2026-04-20"),
+    )
+
+    assert result.ready is True
+    assert result.game_count == 2
+    assert result.provider_ready_game_count == 2
+    assert result.exact_artifact_ready_game_count == 2
+    assert result.fallback_catalog_ready_game_count == 2
+    assert result.ready_game_count == 2
+
+
+def test_empty_archive_materializes_zero_coverage():
+    result = inventory()
+
+    assert result.ready is False
+    assert result.game_count == 2
+    assert result.provider_ready_game_count == 0
+    assert result.exact_artifact_ready_game_count == 0
+    assert result.fallback_catalog_ready_game_count == 0
+    assert result.ready_game_count == 0
+    assert result.missing_requirement_counts == (
+        ("missing_exact_artifact", 2),
+        ("missing_fallback_catalog", 2),
+        ("missing_historical_artifact_source", 2),
+        ("missing_probability_provider", 2),
+    )
+
+
+def test_sparse_archive_preserves_exact_game_window():
+    result = inventory(
+        complete(1, "2026-04-20"),
+    )
+
+    assert tuple(
+        value.game_pk
+        for value in result.games
+    ) == (1, 2)
+    assert result.ready_game_count == 1
+
+
+def test_future_dated_artifact_is_rejected():
+    value = CanonicalHistoricalProbabilityArtifactRecord(
+        game_pk=1,
+        game_date="2026-04-20",
+        source=HISTORICAL_PROBABILITY_ARTIFACT_SOURCE,
+        artifact_as_of_date="2026-04-21",
+        provider_identity="provider:v1",
+        exact_artifact_digest="a" * 64,
+        fallback_catalog_digest="b" * 64,
+    )
+
+    assert value.ready is False
+    assert value.future_data_rejected is True
+    assert value.missing_requirements == (
+        "artifact_as_of_date_mismatch",
+        "missing_probability_provider",
+        "missing_exact_artifact",
+        "missing_fallback_catalog",
+    )
+
+
+def test_unknown_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "historical probability artifacts must "
+            "belong to the observed window"
+        ),
+    ):
+        inventory(
+            complete(3, "2026-04-22"),
+        )
+
+
+def test_invalid_digest_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "exact_artifact_digest must be "
+            "a SHA-256 hex digest"
+        ),
+    ):
+        CanonicalHistoricalProbabilityArtifactRecord(
+            game_pk=1,
+            game_date="2026-04-20",
+            exact_artifact_digest="invalid",
+        )
+
+
+def test_inventory_is_deterministic():
+    first = inventory(
+        complete(2, "2026-04-21"),
+        complete(1, "2026-04-20"),
+    )
+    second = inventory(
+        complete(1, "2026-04-20"),
+        complete(2, "2026-04-21"),
+    )
+
+    assert first == second
+    assert (
+        first.inventory_digest
+        == second.inventory_digest
+    )
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = inventory().to_diagnostics()
+
+    assert diagnostics["ready"] is False
+    assert (
+        diagnostics["historical_reconstruction_required"]
+        is True
+    )
+    assert diagnostics["historical_replay_permitted"] is False
+    assert diagnostics["historical_replay_executed"] is False
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_inventory_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_PROBABILITY_ARTIFACT_INVENTORY_VERSION
+        == (
+            "canonical_historical_probability_"
+            "artifact_inventory_v1"
+        )
+    )


### PR DESCRIPTION
## Summary

- add a deterministic, exact-window inventory for historical probability providers, exact artifacts, and fallback catalogs
- materialize an explicit unavailable record for every observed game when no archived artifact exists
- reject future-dated, duplicate, unknown-game, and date-mismatched records
- add a real-window inventory runner and diagnostics while preserving legacy production authority

## Why

Historical baserunning replay cannot be calibrated safely unless its probability inputs are historically reproducible and strictly as-of each game date. The local artifact and database audit found no eligible persisted probability history, so this PR records that absence explicitly instead of fabricating provenance or using current/future data.

## Verified smoke-window evidence

For the deterministic 2026-04-20 through 2026-05-03 window:

- 185 observed games were inventoried
- 0 games have a historical probability provider
- 0 games have an exact probability artifact
- 0 games have a fallback catalog
- all four missing requirements are reported for all 185 games
- no artifact manifest was present
- the in-memory cache is not historically eligible
- historical reconstruction is required
- historical replay and production activation remain prohibited
- the authoritative source remains `legacy`
- observed window digest: `0f9eb719d8b513f5c7cf01275128533938eba6ddff9a902910f0feb1c1af08bb`
- inventory digest: `38bce81f4bfa42d4be6117e21c37eacb36917ec83548f62a510a9a126774479c`

## Validation

- `215 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- real historical probability inventory runner exited successfully
- Ruff was unavailable in the local environment