### PR TITLE
Define historical probability reconstruction inputs

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -487,3 +487,12 @@ __all__ += [
     "CanonicalHistoricalProbabilityArtifactRecord",
     "inventory_historical_probability_artifacts",
 ]
+
+from .historical_probability_reconstruction_input import (
+    CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION,
+    HISTORICAL_PROBABILITY_STATISTICS_SOURCE,
+    CanonicalHistoricalProbabilityReconstructionInput,
+    CanonicalHistoricalProbabilityReconstructionInputWindow,
+    CanonicalHistoricalProbabilityStatisticsSnapshot,
+    define_historical_probability_reconstruction_inputs,
+)

--- a/mlb_app/simulation/shadow/historical_probability_reconstruction_input.py
+++ b/mlb_app/simulation/shadow/historical_probability_reconstruction_input.py
@@ -1,0 +1,595 @@
+"""Define leakage-safe historical probability reconstruction inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION = (
+    "canonical_historical_probability_reconstruction_input_v1"
+)
+HISTORICAL_PROBABILITY_STATISTICS_SOURCE = (
+    "historical_probability_statistics_snapshot_v1"
+)
+
+
+def _date(value: str, name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be an ISO date"
+        ) from exc
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _validate_digest(
+    value: Optional[str],
+    name: str,
+) -> None:
+    if value is None:
+        return
+
+    if (
+        len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{name} must be a SHA256 digest"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityStatisticsSnapshot:
+    """Statistics frozen before one historical game."""
+
+    game_pk: int
+    game_date: str
+    statistics_through_date: str
+    source_version: str
+    snapshot_digest: str
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be positive"
+            )
+
+        game_date = _date(
+            self.game_date,
+            "game_date",
+        )
+        cutoff = _date(
+            self.statistics_through_date,
+            "statistics_through_date",
+        )
+
+        if cutoff >= game_date:
+            raise ValueError(
+                "statistics_through_date must be "
+                "before game_date"
+            )
+
+        if not self.source_version.strip():
+            raise ValueError(
+                "source_version is required"
+            )
+
+        _validate_digest(
+            self.snapshot_digest,
+            "snapshot_digest",
+        )
+
+    @property
+    def leakage_safe(self) -> bool:
+        return (
+            _date(
+                self.statistics_through_date,
+                "statistics_through_date",
+            )
+            < _date(
+                self.game_date,
+                "game_date",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityReconstructionInput:
+    """One game's immutable reconstruction-input provenance."""
+
+    game_pk: int
+    game_date: str
+    lineup_snapshot_digest: Optional[str]
+    bullpen_snapshot_digest: Optional[str]
+    statistics_through_date: Optional[str] = None
+    statistics_source_version: Optional[str] = None
+    statistics_snapshot_digest: Optional[str] = None
+    schema_version: str = (
+        CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be positive"
+            )
+
+        game_date = _date(
+            self.game_date,
+            "game_date",
+        )
+
+        for name, value in (
+            (
+                "lineup_snapshot_digest",
+                self.lineup_snapshot_digest,
+            ),
+            (
+                "bullpen_snapshot_digest",
+                self.bullpen_snapshot_digest,
+            ),
+            (
+                "statistics_snapshot_digest",
+                self.statistics_snapshot_digest,
+            ),
+        ):
+            _validate_digest(value, name)
+
+        statistics_values = (
+            self.statistics_through_date,
+            self.statistics_source_version,
+            self.statistics_snapshot_digest,
+        )
+
+        if (
+            any(value is not None for value in statistics_values)
+            and not all(
+                value is not None
+                for value in statistics_values
+            )
+        ):
+            raise ValueError(
+                "historical statistics provenance "
+                "must be complete"
+            )
+
+        if self.statistics_through_date is not None:
+            cutoff = _date(
+                self.statistics_through_date,
+                "statistics_through_date",
+            )
+            if cutoff >= game_date:
+                raise ValueError(
+                    "statistics_through_date must be "
+                    "before game_date"
+                )
+
+        if (
+            self.statistics_source_version is not None
+            and not self.statistics_source_version.strip()
+        ):
+            raise ValueError(
+                "statistics_source_version cannot be blank"
+            )
+
+        if self.schema_version != (
+            CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical probability "
+                "reconstruction-input version"
+            )
+
+    @property
+    def statistics_ready(self) -> bool:
+        return all(
+            value is not None
+            for value in (
+                self.statistics_through_date,
+                self.statistics_source_version,
+                self.statistics_snapshot_digest,
+            )
+        )
+
+    @property
+    def leakage_safe(self) -> bool:
+        return (
+            self.statistics_ready
+            and _date(
+                self.statistics_through_date or "",
+                "statistics_through_date",
+            )
+            < _date(
+                self.game_date,
+                "game_date",
+            )
+        )
+
+    @property
+    def missing_requirements(self) -> Tuple[str, ...]:
+        missing = []
+
+        if self.lineup_snapshot_digest is None:
+            missing.append(
+                "missing_historical_lineup_snapshot"
+            )
+        if self.bullpen_snapshot_digest is None:
+            missing.append(
+                "missing_historical_bullpen_snapshot"
+            )
+        if not self.statistics_ready:
+            missing.append(
+                "missing_historical_statistics_snapshot"
+            )
+
+        return tuple(missing)
+
+    @property
+    def ready(self) -> bool:
+        return (
+            not self.missing_requirements
+            and self.leakage_safe
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "ready": self.ready,
+            "leakage_safe": self.leakage_safe,
+            "lineup_snapshot_ready": (
+                self.lineup_snapshot_digest is not None
+            ),
+            "bullpen_snapshot_ready": (
+                self.bullpen_snapshot_digest is not None
+            ),
+            "statistics_snapshot_ready": (
+                self.statistics_ready
+            ),
+            "statistics_through_date": (
+                self.statistics_through_date
+            ),
+            "statistics_source_version": (
+                self.statistics_source_version
+            ),
+            "statistics_snapshot_digest": (
+                self.statistics_snapshot_digest
+            ),
+            "missing_requirements": (
+                self.missing_requirements
+            ),
+            "player_identifiers_exposed": False,
+            "probability_records_exposed": False,
+            "historical_replay_executed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityReconstructionInputWindow:
+    """Exact historical window of reconstruction-input provenance."""
+
+    observed_window_digest: str
+    lineup_bullpen_window_digest: str
+    inputs: Tuple[
+        CanonicalHistoricalProbabilityReconstructionInput,
+        ...,
+    ]
+    digest: str
+    schema_version: str = (
+        CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            (
+                "observed_window_digest",
+                self.observed_window_digest,
+            ),
+            (
+                "lineup_bullpen_window_digest",
+                self.lineup_bullpen_window_digest,
+            ),
+            ("digest", self.digest),
+        ):
+            _validate_digest(value, name)
+
+        if not self.inputs:
+            raise ValueError(
+                "inputs must contain historical games"
+            )
+
+        identities = tuple(
+            value.game_pk
+            for value in self.inputs
+        )
+        if len(identities) != len(set(identities)):
+            raise ValueError(
+                "reconstruction input game identifiers "
+                "must be unique"
+            )
+
+        if self.schema_version != (
+            CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical probability "
+                "reconstruction-input window version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.inputs)
+
+    @property
+    def ready_game_count(self) -> int:
+        return sum(
+            value.ready
+            for value in self.inputs
+        )
+
+    @property
+    def blocked_game_count(self) -> int:
+        return (
+            self.game_count
+            - self.ready_game_count
+        )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.ready_game_count
+            == self.game_count
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        missing_counts: Dict[str, int] = {}
+
+        for value in self.inputs:
+            for requirement in value.missing_requirements:
+                missing_counts[requirement] = (
+                    missing_counts.get(
+                        requirement,
+                        0,
+                    )
+                    + 1
+                )
+
+        return {
+            "schema_version": self.schema_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "ready_game_count": (
+                self.ready_game_count
+            ),
+            "blocked_game_count": (
+                self.blocked_game_count
+            ),
+            "missing_requirement_counts": (
+                missing_counts
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                self.lineup_bullpen_window_digest
+            ),
+            "reconstruction_input_digest": (
+                self.digest
+            ),
+            "inputs": tuple(
+                value.to_diagnostics()
+                for value in self.inputs
+            ),
+            "exact_game_coverage": True,
+            "future_data_permitted": False,
+            "player_identifiers_exposed": False,
+            "probability_records_exposed": False,
+            "probability_workspace_reconstructed": False,
+            "historical_replay_executed": False,
+            "historical_replay_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def define_historical_probability_reconstruction_inputs(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    statistics_snapshots: Sequence[
+        CanonicalHistoricalProbabilityStatisticsSnapshot
+    ] = (),
+) -> CanonicalHistoricalProbabilityReconstructionInputWindow:
+    """
+    Join exact roster snapshots to strictly pregame statistics snapshots.
+
+    Sparse statistics coverage remains explicit. This function does not
+    calculate probabilities, build artifacts, execute simulation, or permit
+    production activation.
+    """
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    if (
+        not isinstance(statistics_snapshots, Sequence)
+        or isinstance(
+            statistics_snapshots,
+            (str, bytes),
+        )
+    ):
+        raise TypeError(
+            "statistics_snapshots must be a sequence"
+        )
+
+    statistics_by_game = {}
+
+    for value in statistics_snapshots:
+        if not isinstance(
+            value,
+            CanonicalHistoricalProbabilityStatisticsSnapshot,
+        ):
+            raise TypeError(
+                "statistics_snapshots must contain "
+                "CanonicalHistoricalProbabilityStatisticsSnapshot"
+            )
+
+        if value.game_pk in statistics_by_game:
+            raise ValueError(
+                "statistics snapshot game identifiers "
+                "must be unique"
+            )
+
+        statistics_by_game[value.game_pk] = value
+
+    roster_by_game = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+
+    unknown_games = (
+        set(statistics_by_game)
+        - set(roster_by_game)
+    )
+    if unknown_games:
+        raise ValueError(
+            "statistics snapshots contain unknown games"
+        )
+
+    inputs = []
+
+    for roster in sorted(
+        lineup_bullpen.games,
+        key=lambda value: (
+            value.game_date,
+            value.game_pk,
+        ),
+    ):
+        statistics = statistics_by_game.get(
+            roster.game_pk
+        )
+
+        if (
+            statistics is not None
+            and statistics.game_date != roster.game_date
+        ):
+            raise ValueError(
+                "statistics snapshot game_date must "
+                "match historical roster game_date"
+            )
+
+        inputs.append(
+            CanonicalHistoricalProbabilityReconstructionInput(
+                game_pk=roster.game_pk,
+                game_date=roster.game_date,
+                lineup_snapshot_digest=(
+                    roster.lineup_digest
+                    if roster.lineups_ready
+                    else None
+                ),
+                bullpen_snapshot_digest=(
+                    roster.bullpen_digest
+                    if roster.bullpens_ready
+                    else None
+                ),
+                statistics_through_date=(
+                    statistics.statistics_through_date
+                    if statistics is not None
+                    else None
+                ),
+                statistics_source_version=(
+                    statistics.source_version
+                    if statistics is not None
+                    else None
+                ),
+                statistics_snapshot_digest=(
+                    statistics.snapshot_digest
+                    if statistics is not None
+                    else None
+                ),
+            )
+        )
+
+    digest = _digest(
+        {
+            "schema_version": (
+                CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+            ),
+            "observed_window_digest": (
+                lineup_bullpen.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                lineup_bullpen.digest
+            ),
+            "inputs": [
+                {
+                    "game_pk": value.game_pk,
+                    "game_date": value.game_date,
+                    "lineup_snapshot_digest": (
+                        value.lineup_snapshot_digest
+                    ),
+                    "bullpen_snapshot_digest": (
+                        value.bullpen_snapshot_digest
+                    ),
+                    "statistics_through_date": (
+                        value.statistics_through_date
+                    ),
+                    "statistics_source_version": (
+                        value.statistics_source_version
+                    ),
+                    "statistics_snapshot_digest": (
+                        value.statistics_snapshot_digest
+                    ),
+                }
+                for value in inputs
+            ],
+        }
+    )
+
+    return (
+        CanonicalHistoricalProbabilityReconstructionInputWindow(
+            observed_window_digest=(
+                lineup_bullpen.observed_window_digest
+            ),
+            lineup_bullpen_window_digest=(
+                lineup_bullpen.digest
+            ),
+            inputs=tuple(inputs),
+            digest=digest,
+        )
+    )

--- a/tests/test_canonical_historical_probability_reconstruction_input.py
+++ b/tests/test_canonical_historical_probability_reconstruction_input.py
@@ -1,0 +1,290 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION,
+    HISTORICAL_PROBABILITY_STATISTICS_SOURCE,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    CanonicalHistoricalProbabilityStatisticsSnapshot,
+    define_historical_probability_reconstruction_inputs,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+DIGEST_E = "e" * 64
+
+
+def roster_game(
+    *,
+    game_pk=1,
+    game_date="2026-04-20",
+    lineup_digest=DIGEST_A,
+    bullpen_digest=DIGEST_B,
+):
+    return CanonicalHistoricalLineupBullpenGameSnapshot(
+        game_pk=game_pk,
+        game_date=game_date,
+        away_lineup_ids=tuple(
+            str(value)
+            for value in range(1, 10)
+        ),
+        home_lineup_ids=tuple(
+            str(value)
+            for value in range(11, 20)
+        ),
+        away_bullpen_ids=("21", "22"),
+        home_bullpen_ids=("31", "32"),
+        lineup_digest=lineup_digest,
+        bullpen_digest=bullpen_digest,
+    )
+
+
+def roster_window(*games):
+    values = games or (roster_game(),)
+
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST_C,
+        games=tuple(values),
+        digest=DIGEST_D,
+    )
+
+
+def statistics(
+    *,
+    game_pk=1,
+    game_date="2026-04-20",
+    statistics_through_date="2026-04-19",
+    snapshot_digest=DIGEST_E,
+):
+    return CanonicalHistoricalProbabilityStatisticsSnapshot(
+        game_pk=game_pk,
+        game_date=game_date,
+        statistics_through_date=(
+            statistics_through_date
+        ),
+        source_version=(
+            HISTORICAL_PROBABILITY_STATISTICS_SOURCE
+        ),
+        snapshot_digest=snapshot_digest,
+    )
+
+
+def test_complete_inputs_are_ready():
+    result = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+            statistics_snapshots=(statistics(),),
+        )
+    )
+
+    assert result.ready is True
+    assert result.game_count == 1
+    assert result.ready_game_count == 1
+    assert result.blocked_game_count == 0
+    assert result.inputs[0].leakage_safe is True
+    assert result.inputs[0].missing_requirements == ()
+
+
+def test_missing_statistics_remain_explicit():
+    result = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+        )
+    )
+
+    assert result.ready is False
+    assert result.ready_game_count == 0
+    assert result.blocked_game_count == 1
+    assert result.inputs[0].missing_requirements == (
+        "missing_historical_statistics_snapshot",
+    )
+
+
+def test_sparse_statistics_preserve_exact_game_window():
+    result = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(
+                roster_game(),
+                roster_game(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                ),
+            ),
+            statistics_snapshots=(statistics(),),
+        )
+    )
+
+    assert tuple(
+        value.game_pk
+        for value in result.inputs
+    ) == (1, 2)
+    assert result.game_count == 2
+    assert result.ready_game_count == 1
+    assert result.blocked_game_count == 1
+
+
+@pytest.mark.parametrize(
+    "cutoff",
+    (
+        "2026-04-20",
+        "2026-04-21",
+    ),
+)
+def test_same_day_or_future_statistics_are_rejected(
+    cutoff,
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "statistics_through_date must be "
+            "before game_date"
+        ),
+    ):
+        statistics(
+            statistics_through_date=cutoff,
+        )
+
+
+def test_invalid_statistics_digest_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="snapshot_digest must be a SHA256 digest",
+    ):
+        statistics(
+            snapshot_digest="not-a-digest",
+        )
+
+
+def test_duplicate_statistics_games_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "statistics snapshot game identifiers "
+            "must be unique"
+        ),
+    ):
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+            statistics_snapshots=(
+                statistics(),
+                statistics(),
+            ),
+        )
+
+
+def test_unknown_statistics_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "statistics snapshots contain unknown games"
+        ),
+    ):
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+            statistics_snapshots=(
+                statistics(game_pk=99),
+            ),
+        )
+
+
+def test_statistics_game_date_must_match_roster():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "statistics snapshot game_date must match"
+        ),
+    ):
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+            statistics_snapshots=(
+                statistics(
+                    game_date="2026-04-21",
+                    statistics_through_date=(
+                        "2026-04-19"
+                    ),
+                ),
+            ),
+        )
+
+
+def test_order_and_digest_are_deterministic():
+    first = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(
+                roster_game(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                ),
+                roster_game(),
+            ),
+            statistics_snapshots=(
+                statistics(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                ),
+                statistics(),
+            ),
+        )
+    )
+    second = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(
+                roster_game(),
+                roster_game(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                ),
+            ),
+            statistics_snapshots=(
+                statistics(),
+                statistics(
+                    game_pk=2,
+                    game_date="2026-04-21",
+                ),
+            ),
+        )
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+    assert tuple(
+        value.game_pk
+        for value in first.inputs
+    ) == (1, 2)
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["ready"] is False
+    assert diagnostics[
+        "probability_workspace_reconstructed"
+    ] is False
+    assert diagnostics[
+        "historical_replay_permitted"
+    ] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+    assert diagnostics[
+        "player_identifiers_exposed"
+    ] is False
+    assert diagnostics[
+        "probability_records_exposed"
+    ] is False
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_PROBABILITY_RECONSTRUCTION_INPUT_VERSION
+        == (
+            "canonical_historical_probability_"
+            "reconstruction_input_v1"
+        )
+    )


### PR DESCRIPTION
## Summary

- add an immutable per-game contract for historical probability reconstruction inputs
- bind historical lineup and bullpen snapshot digests to an explicit statistics snapshot
- require the statistics cutoff to be strictly before the official game date
- preserve the complete historical game window when statistics coverage is sparse
- expose deterministic reconstruction-input digests and missing-requirement diagnostics

## Why

The historical probability artifact inventory proved that no eligible archived providers, exact artifacts, or fallback catalogs currently exist for the 185-game smoke window. Before reconstructing those probabilities, the pipeline needs an explicit evidence boundary that prevents current or future statistics from entering a historical replay.

This contract separates what was known before each game from what happened during the game. Same-day and future-dated statistical snapshots are rejected, while missing snapshots remain visible blockers rather than being silently replaced.

## Production behavior

- no probability distributions are generated
- no exact artifacts or fallback catalogs are created
- no historical simulation is executed
- incomplete coverage remains blocked
- production activation remains disabled
- production authority remains `legacy`

## Validation

- `227 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment
- exact-window preservation, sparse coverage, cutoff enforcement, duplicate and unknown-game rejection, date alignment, deterministic ordering/digests, and shadow-only diagnostics are tested