### PR TITLE
Source historical probability statistics

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -496,3 +496,13 @@ from .historical_probability_reconstruction_input import (
     CanonicalHistoricalProbabilityStatisticsSnapshot,
     define_historical_probability_reconstruction_inputs,
 )
+
+from .historical_probability_statistics_source import (
+    CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION,
+    HITTING_STAT_KEYS,
+    PITCHING_STAT_KEYS,
+    CanonicalHistoricalProbabilityGameStatistics,
+    CanonicalHistoricalProbabilityPlayerStatistics,
+    CanonicalHistoricalProbabilityStatisticsWindow,
+    source_historical_probability_statistics,
+)

--- a/mlb_app/simulation/shadow/historical_probability_statistics_source.py
+++ b/mlb_app/simulation/shadow/historical_probability_statistics_source.py
@@ -1,0 +1,732 @@
+"""Source cutoff-safe historical probability statistics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Sequence, Tuple
+
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+from .historical_probability_reconstruction_input import (
+    HISTORICAL_PROBABILITY_STATISTICS_SOURCE,
+    CanonicalHistoricalProbabilityStatisticsSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION = (
+    "canonical_historical_probability_statistics_source_v1"
+)
+
+HITTING_STAT_KEYS = (
+    ("pa", "plateAppearances"),
+    ("ab", "atBats"),
+    ("hits", "hits"),
+    ("double", "doubles"),
+    ("triple", "triples"),
+    ("hr", "homeRuns"),
+    ("bb", "baseOnBalls"),
+    ("k", "strikeOuts"),
+    ("hbp", "hitByPitch"),
+)
+
+PITCHING_STAT_KEYS = (
+    ("batters_faced", "battersFaced"),
+    ("ab", "atBats"),
+    ("hits", "hits"),
+    ("double", "doubles"),
+    ("triple", "triples"),
+    ("hr", "homeRuns"),
+    ("bb", "baseOnBalls"),
+    ("k", "strikeOuts"),
+    ("hbp", "hitBatsmen"),
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+    ):
+        return value
+    return ()
+
+
+def _identifier(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        value = (
+            _mapping(value.get("person")).get("id")
+            or value.get("id")
+            or value.get("player_id")
+        )
+
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _iso_date(value: str, name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be an ISO date"
+        ) from exc
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _count(value: Any, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    try:
+        parsed_float = float(value)
+        parsed = int(parsed_float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        ) from exc
+
+    if parsed < 0 or parsed_float != parsed:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    return parsed
+
+
+def _rows(
+    *,
+    payload: Mapping[str, Any],
+    role: str,
+) -> Dict[str, Tuple[Tuple[str, int], ...]]:
+    keys = (
+        HITTING_STAT_KEYS
+        if role == "hitting"
+        else PITCHING_STAT_KEYS
+    )
+    rows: Dict[str, Tuple[Tuple[str, int], ...]] = {}
+
+    for block in _sequence(payload.get("stats")):
+        for split in _sequence(
+            _mapping(block).get("splits")
+        ):
+            split_data = _mapping(split)
+            player_id = _identifier(
+                split_data.get("player")
+            )
+
+            if player_id is None:
+                raise ValueError(
+                    "statistics split requires player identity"
+                )
+            if player_id in rows:
+                raise ValueError(
+                    "statistics player identities must be unique "
+                    f"within {role}"
+                )
+
+            statistics = _mapping(
+                split_data.get("stat")
+            )
+            counts = []
+
+            for canonical, source in keys:
+                if source not in statistics:
+                    raise ValueError(
+                        f"{role} statistics missing {source}"
+                    )
+
+                counts.append(
+                    (
+                        canonical,
+                        _count(
+                            statistics[source],
+                            f"{role}.{source}",
+                        ),
+                    )
+                )
+
+            rows[player_id] = tuple(counts)
+
+    return rows
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityPlayerStatistics:
+    player_id: str
+    role: str
+    counts: Tuple[Tuple[str, int], ...]
+    sample_available: bool
+
+    def __post_init__(self) -> None:
+        if _identifier(self.player_id) != self.player_id:
+            raise ValueError(
+                "player_id must be a positive integer string"
+            )
+        if self.role not in {"hitting", "pitching"}:
+            raise ValueError(
+                "role must be hitting or pitching"
+            )
+
+        expected = tuple(
+            key
+            for key, _ in (
+                HITTING_STAT_KEYS
+                if self.role == "hitting"
+                else PITCHING_STAT_KEYS
+            )
+        )
+
+        if tuple(
+            key for key, _ in self.counts
+        ) != expected:
+            raise ValueError(
+                "counts must use canonical role order"
+            )
+
+        for key, value in self.counts:
+            _count(value, f"{self.role}.{key}")
+
+        if not isinstance(
+            self.sample_available,
+            bool,
+        ):
+            raise TypeError(
+                "sample_available must be boolean"
+            )
+
+        if (
+            not self.sample_available
+            and any(value != 0 for _, value in self.counts)
+        ):
+            raise ValueError(
+                "zero-sample records must contain zero counts"
+            )
+
+    @property
+    def record_key(self) -> Tuple[str, str]:
+        return self.role, self.player_id
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityGameStatistics:
+    game_pk: int
+    game_date: str
+    statistics_through_date: str
+    players: Tuple[
+        CanonicalHistoricalProbabilityPlayerStatistics,
+        ...,
+    ]
+    snapshot_digest: str
+    source_version: str = (
+        HISTORICAL_PROBABILITY_STATISTICS_SOURCE
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be positive"
+            )
+
+        if _iso_date(
+            self.statistics_through_date,
+            "statistics_through_date",
+        ) >= _iso_date(
+            self.game_date,
+            "game_date",
+        ):
+            raise ValueError(
+                "statistics_through_date must be "
+                "before game_date"
+            )
+
+        keys = tuple(
+            value.record_key
+            for value in self.players
+        )
+        if not keys:
+            raise ValueError(
+                "players must contain required statistics"
+            )
+        if len(keys) != len(set(keys)):
+            raise ValueError(
+                "player-role statistics must be unique"
+            )
+
+        if (
+            len(self.snapshot_digest) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.snapshot_digest
+            )
+        ):
+            raise ValueError(
+                "snapshot_digest must be a SHA256 digest"
+            )
+
+        if not self.source_version.strip():
+            raise ValueError(
+                "source_version is required"
+            )
+
+    @property
+    def observed_sample_count(self) -> int:
+        return sum(
+            value.sample_available
+            for value in self.players
+        )
+
+    @property
+    def zero_sample_count(self) -> int:
+        return (
+            len(self.players)
+            - self.observed_sample_count
+        )
+
+    def to_reconstruction_snapshot(
+        self,
+    ) -> CanonicalHistoricalProbabilityStatisticsSnapshot:
+        return CanonicalHistoricalProbabilityStatisticsSnapshot(
+            game_pk=self.game_pk,
+            game_date=self.game_date,
+            statistics_through_date=(
+                self.statistics_through_date
+            ),
+            source_version=self.source_version,
+            snapshot_digest=self.snapshot_digest,
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "statistics_through_date": (
+                self.statistics_through_date
+            ),
+            "required_player_role_count": len(
+                self.players
+            ),
+            "observed_sample_count": (
+                self.observed_sample_count
+            ),
+            "zero_sample_count": (
+                self.zero_sample_count
+            ),
+            "snapshot_digest": self.snapshot_digest,
+            "ready": True,
+            "leakage_safe": True,
+            "player_identifiers_exposed": False,
+            "probability_records_exposed": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalProbabilityStatisticsWindow:
+    observed_window_digest: str
+    lineup_bullpen_window_digest: str
+    games: Tuple[
+        CanonicalHistoricalProbabilityGameStatistics,
+        ...,
+    ]
+    digest: str
+    source_version: str = (
+        CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain statistics snapshots"
+            )
+
+        identities = tuple(
+            value.game_pk
+            for value in self.games
+        )
+        if len(identities) != len(set(identities)):
+            raise ValueError(
+                "statistics game identifiers must be unique"
+            )
+
+        for name, value in (
+            (
+                "observed_window_digest",
+                self.observed_window_digest,
+            ),
+            (
+                "lineup_bullpen_window_digest",
+                self.lineup_bullpen_window_digest,
+            ),
+            ("digest", self.digest),
+        ):
+            if (
+                len(value) != 64
+                or any(
+                    character not in "0123456789abcdef"
+                    for character in value
+                )
+            ):
+                raise ValueError(
+                    f"{name} must be a SHA256 digest"
+                )
+
+        if self.source_version != (
+            CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical probability "
+                "statistics source version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def zero_sample_count(self) -> int:
+        return sum(
+            value.zero_sample_count
+            for value in self.games
+        )
+
+    def to_reconstruction_snapshots(
+        self,
+    ) -> Tuple[
+        CanonicalHistoricalProbabilityStatisticsSnapshot,
+        ...,
+    ]:
+        return tuple(
+            value.to_reconstruction_snapshot()
+            for value in self.games
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "ready": True,
+            "game_count": self.game_count,
+            "ready_game_count": self.game_count,
+            "zero_sample_player_role_count": (
+                self.zero_sample_count
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                self.lineup_bullpen_window_digest
+            ),
+            "statistics_window_digest": self.digest,
+            "games": tuple(
+                value.to_diagnostics()
+                for value in self.games
+            ),
+            "statistics_cutoff_policy": (
+                "strict_previous_calendar_date"
+            ),
+            "doubleheader_same_cutoff": True,
+            "future_data_permitted": False,
+            "player_identifiers_exposed": False,
+            "probability_records_exposed": False,
+            "probability_workspace_reconstructed": False,
+            "historical_replay_executed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def source_historical_probability_statistics(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    starting_pitcher_ids: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    statistics_payloads: Mapping[
+        str,
+        Mapping[str, Mapping[str, Any]],
+    ],
+) -> CanonicalHistoricalProbabilityStatisticsWindow:
+    """
+    Source exact prior-day player statistics for historical reconstruction.
+
+    A valid full-player response that omits a required player represents an
+    explicit zero-prior-sample record. Missing dates or groups are errors.
+    """
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+    if not isinstance(starting_pitcher_ids, Mapping):
+        raise TypeError(
+            "starting_pitcher_ids must be a mapping"
+        )
+    if not isinstance(statistics_payloads, Mapping):
+        raise TypeError(
+            "statistics_payloads must be a mapping"
+        )
+
+    games_by_id = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+
+    normalized_starters = {}
+    for raw_game_pk, raw_ids in (
+        starting_pitcher_ids.items()
+    ):
+        try:
+            game_pk = int(raw_game_pk)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "starting pitcher game identifiers "
+                "must be integers"
+            ) from exc
+
+        if game_pk not in games_by_id:
+            raise ValueError(
+                "starting pitchers contain unknown games"
+            )
+        if (
+            not isinstance(raw_ids, tuple)
+            or len(raw_ids) != 2
+        ):
+            raise TypeError(
+                "starting pitcher values must be "
+                "away-home tuples"
+            )
+
+        away_id = _identifier(raw_ids[0])
+        home_id = _identifier(raw_ids[1])
+        if away_id is None or home_id is None:
+            raise ValueError(
+                "starting pitcher identifiers are required"
+            )
+
+        normalized_starters[game_pk] = (
+            away_id,
+            home_id,
+        )
+
+    if set(normalized_starters) != set(games_by_id):
+        raise ValueError(
+            "starting pitchers must exactly cover "
+            "historical games"
+        )
+
+    required_cutoffs = {
+        (
+            _iso_date(value.game_date, "game_date")
+            - timedelta(days=1)
+        ).isoformat()
+        for value in lineup_bullpen.games
+    }
+
+    if set(statistics_payloads) != required_cutoffs:
+        raise ValueError(
+            "statistics payload dates must exactly match "
+            "required prior-day cutoffs"
+        )
+
+    rows_by_cutoff = {}
+
+    for cutoff in sorted(required_cutoffs):
+        groups = statistics_payloads[cutoff]
+        if not isinstance(groups, Mapping):
+            raise TypeError(
+                "statistics cutoff values must be mappings"
+            )
+        if set(groups) != {"hitting", "pitching"}:
+            raise ValueError(
+                "each cutoff requires hitting and "
+                "pitching payloads"
+            )
+
+        rows_by_cutoff[cutoff] = {
+            "hitting": _rows(
+                payload=_mapping(groups["hitting"]),
+                role="hitting",
+            ),
+            "pitching": _rows(
+                payload=_mapping(groups["pitching"]),
+                role="pitching",
+            ),
+        }
+
+    snapshots = []
+
+    for game in sorted(
+        lineup_bullpen.games,
+        key=lambda value: (
+            value.game_date,
+            value.game_pk,
+        ),
+    ):
+        if not game.ready:
+            raise ValueError(
+                "lineup and bullpen snapshots must be ready"
+            )
+
+        cutoff = (
+            _iso_date(game.game_date, "game_date")
+            - timedelta(days=1)
+        ).isoformat()
+        source_rows = rows_by_cutoff[cutoff]
+        away_starter, home_starter = (
+            normalized_starters[game.game_pk]
+        )
+
+        required = {
+            ("hitting", player_id)
+            for player_id in (
+                game.away_lineup_ids
+                + game.home_lineup_ids
+            )
+        }
+        required.update(
+            {
+                ("pitching", player_id)
+                for player_id in (
+                    (away_starter, home_starter)
+                    + game.away_bullpen_ids
+                    + game.home_bullpen_ids
+                )
+            }
+        )
+
+        player_records = []
+
+        for role, player_id in sorted(
+            required,
+            key=lambda value: (
+                value[0],
+                int(value[1]),
+            ),
+        ):
+            counts = source_rows[role].get(player_id)
+            sample_available = counts is not None
+
+            if counts is None:
+                keys = (
+                    HITTING_STAT_KEYS
+                    if role == "hitting"
+                    else PITCHING_STAT_KEYS
+                )
+                counts = tuple(
+                    (canonical, 0)
+                    for canonical, _ in keys
+                )
+
+            player_records.append(
+                CanonicalHistoricalProbabilityPlayerStatistics(
+                    player_id=player_id,
+                    role=role,
+                    counts=counts,
+                    sample_available=sample_available,
+                )
+            )
+
+        snapshot_digest = _sha256(
+            {
+                "game_pk": game.game_pk,
+                "game_date": game.game_date,
+                "statistics_through_date": cutoff,
+                "source_version": (
+                    HISTORICAL_PROBABILITY_STATISTICS_SOURCE
+                ),
+                "players": [
+                    {
+                        "player_id": value.player_id,
+                        "role": value.role,
+                        "counts": value.counts,
+                        "sample_available": (
+                            value.sample_available
+                        ),
+                    }
+                    for value in player_records
+                ],
+            }
+        )
+
+        snapshots.append(
+            CanonicalHistoricalProbabilityGameStatistics(
+                game_pk=game.game_pk,
+                game_date=game.game_date,
+                statistics_through_date=cutoff,
+                players=tuple(player_records),
+                snapshot_digest=snapshot_digest,
+            )
+        )
+
+    digest = _sha256(
+        {
+            "schema_version": (
+                CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION
+            ),
+            "observed_window_digest": (
+                lineup_bullpen.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                lineup_bullpen.digest
+            ),
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "game_date": value.game_date,
+                    "statistics_through_date": (
+                        value.statistics_through_date
+                    ),
+                    "snapshot_digest": (
+                        value.snapshot_digest
+                    ),
+                }
+                for value in snapshots
+            ],
+        }
+    )
+
+    return CanonicalHistoricalProbabilityStatisticsWindow(
+        observed_window_digest=(
+            lineup_bullpen.observed_window_digest
+        ),
+        lineup_bullpen_window_digest=(
+            lineup_bullpen.digest
+        ),
+        games=tuple(snapshots),
+        digest=digest,
+    )

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -1,0 +1,255 @@
+"""Run the real historical probability-statistics source."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
+import json
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from mlb_app.simulation.shadow import (
+    define_historical_probability_reconstruction_inputs,
+    source_historical_lineup_bullpen_snapshots,
+    source_historical_probability_statistics,
+    source_mlb_play_by_play_baserunning_window,
+)
+from mlb_app.simulation.shadow.statcast_baserunning_window_source import (
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_END,
+    CANONICAL_BASERUNNING_SMOKE_WINDOW_START,
+)
+
+
+_SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+_STATS_URL = (
+    "https://statsapi.mlb.com/api/v1/stats"
+)
+_FINAL_STATES = {
+    "Final",
+    "Game Over",
+    "Completed Early",
+}
+
+
+def _json(url, params=None):
+    if params:
+        url = f"{url}?{urlencode(params)}"
+
+    request = Request(
+        url,
+        headers={
+            "User-Agent": (
+                "mlb-prediction-app/"
+                "historical-statistics-source"
+            )
+        },
+    )
+
+    with urlopen(
+        request,
+        timeout=120,
+    ) as response:
+        return json.load(response)
+
+
+def _completed_game_ids(schedule):
+    games = {}
+
+    for entry in schedule.get("dates") or []:
+        for game in entry.get("games") or []:
+            status = (
+                (game.get("status") or {})
+                .get("detailedState")
+            )
+            game_pk = game.get("gamePk")
+
+            if (
+                status in _FINAL_STATES
+                and game_pk is not None
+            ):
+                games[int(game_pk)] = game
+
+    return tuple(sorted(games))
+
+
+def _feed(game_pk):
+    return (
+        game_pk,
+        _json(
+            _FEED_URL.format(
+                game_pk=game_pk
+            )
+        ),
+    )
+
+
+def _starter_id(team):
+    pitchers = team.get("pitchers") or []
+    if not pitchers:
+        raise ValueError(
+            "historical team has no starting pitcher"
+        )
+
+    return str(int(pitchers[0]))
+
+
+def _starters(feeds):
+    result = {}
+
+    for game_pk, feed in feeds.items():
+        boxscore = (
+            (feed.get("liveData") or {})
+            .get("boxscore")
+            or {}
+        )
+        teams = boxscore.get("teams") or {}
+
+        result[game_pk] = (
+            _starter_id(teams.get("away") or {}),
+            _starter_id(teams.get("home") or {}),
+        )
+
+    return result
+
+
+def _stats(request):
+    cutoff, group = request
+
+    payload = _json(
+        _STATS_URL,
+        {
+            "stats": "byDateRange",
+            "group": group,
+            "gameType": "R",
+            "sportIds": 1,
+            "playerPool": "ALL",
+            "season": 2026,
+            "startDate": "2026-03-01",
+            "endDate": cutoff,
+            "limit": 5000,
+            "hydrate": "person",
+        },
+    )
+
+    return cutoff, group, payload
+
+
+def main():
+    schedule = _json(
+        _SCHEDULE_URL,
+        {
+            "sportId": 1,
+            "startDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            "endDate": (
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        },
+    )
+    game_ids = _completed_game_ids(schedule)
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        feeds = dict(
+            executor.map(
+                _feed,
+                game_ids,
+            )
+        )
+
+    observed = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=schedule,
+            game_feeds=feeds,
+            window_start=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_START
+            ),
+            window_end=(
+                CANONICAL_BASERUNNING_SMOKE_WINDOW_END
+            ),
+        )
+    )
+    roster_window = (
+        source_historical_lineup_bullpen_snapshots(
+            observed=observed,
+            game_feeds=feeds,
+        )
+    )
+
+    cutoffs = sorted(
+        {
+            (
+                date.fromisoformat(value.game_date)
+                - timedelta(days=1)
+            ).isoformat()
+            for value in roster_window.games
+        }
+    )
+    requests = tuple(
+        (cutoff, group)
+        for cutoff in cutoffs
+        for group in ("hitting", "pitching")
+    )
+
+    payloads = {
+        cutoff: {}
+        for cutoff in cutoffs
+    }
+
+    with ThreadPoolExecutor(
+        max_workers=6
+    ) as executor:
+        for cutoff, group, payload in executor.map(
+            _stats,
+            requests,
+        ):
+            payloads[cutoff][group] = payload
+
+    statistics = (
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=_starters(feeds),
+            statistics_payloads=payloads,
+        )
+    )
+    reconstruction = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window,
+            statistics_snapshots=(
+                statistics.to_reconstruction_snapshots()
+            ),
+        )
+    )
+
+    diagnostics = {
+        "statistics": statistics.to_diagnostics(),
+        "reconstruction": (
+            reconstruction.to_diagnostics()
+        ),
+        "cutoff_count": len(cutoffs),
+        "request_count": len(requests),
+        "historical_replay_executed": False,
+        "production_activation": False,
+        "production_authority_changed": False,
+        "authoritative_source": "legacy",
+    }
+
+    print(
+        json.dumps(
+            diagnostics,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonical_historical_probability_statistics_source.py
+++ b/tests/test_canonical_historical_probability_statistics_source.py
@@ -1,0 +1,379 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    define_historical_probability_reconstruction_inputs,
+    source_historical_probability_statistics,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+
+
+def roster_game(
+    *,
+    game_pk=1,
+    game_date="2026-04-20",
+):
+    return CanonicalHistoricalLineupBullpenGameSnapshot(
+        game_pk=game_pk,
+        game_date=game_date,
+        away_lineup_ids=tuple(
+            str(value)
+            for value in range(1, 10)
+        ),
+        home_lineup_ids=tuple(
+            str(value)
+            for value in range(11, 20)
+        ),
+        away_bullpen_ids=("22", "23"),
+        home_bullpen_ids=("32", "33"),
+        lineup_digest=DIGEST_A,
+        bullpen_digest=DIGEST_B,
+    )
+
+
+def roster_window(*games):
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST_C,
+        games=tuple(games or (roster_game(),)),
+        digest=DIGEST_D,
+    )
+
+
+def hitting_stat(value=1):
+    return {
+        "plateAppearances": value,
+        "atBats": value,
+        "hits": value,
+        "doubles": 0,
+        "triples": 0,
+        "homeRuns": 0,
+        "baseOnBalls": 0,
+        "strikeOuts": 0,
+        "hitByPitch": 0,
+    }
+
+
+def pitching_stat(value=1):
+    return {
+        "battersFaced": value,
+        "atBats": value,
+        "hits": 0,
+        "doubles": 0,
+        "triples": 0,
+        "homeRuns": 0,
+        "baseOnBalls": 0,
+        "strikeOuts": value,
+        "hitBatsmen": 0,
+    }
+
+
+def payload(role, player_ids):
+    builder = (
+        hitting_stat
+        if role == "hitting"
+        else pitching_stat
+    )
+
+    return {
+        "stats": [
+            {
+                "splits": [
+                    {
+                        "player": {
+                            "id": int(player_id)
+                        },
+                        "stat": builder(),
+                    }
+                    for player_id in player_ids
+                ]
+            }
+        ]
+    }
+
+
+def payloads(
+    *,
+    cutoff="2026-04-19",
+    hitter_ids=tuple(
+        str(value)
+        for value in range(1, 20)
+    ),
+    pitcher_ids=(
+        "20",
+        "21",
+        "22",
+        "23",
+        "30",
+        "31",
+        "32",
+        "33",
+    ),
+):
+    return {
+        cutoff: {
+            "hitting": payload(
+                "hitting",
+                hitter_ids,
+            ),
+            "pitching": payload(
+                "pitching",
+                pitcher_ids,
+            ),
+        }
+    }
+
+
+def starters():
+    return {1: ("20", "30")}
+
+
+def test_complete_source_is_ready():
+    result = source_historical_probability_statistics(
+        lineup_bullpen=roster_window(),
+        starting_pitcher_ids=starters(),
+        statistics_payloads=payloads(),
+    )
+
+    assert result.game_count == 1
+    assert result.zero_sample_count == 0
+    assert result.games[0].observed_sample_count == 24
+    assert result.games[0].zero_sample_count == 0
+
+
+def test_absent_player_is_explicit_zero_sample():
+    result = source_historical_probability_statistics(
+        lineup_bullpen=roster_window(),
+        starting_pitcher_ids=starters(),
+        statistics_payloads=payloads(
+            hitter_ids=tuple(
+                str(value)
+                for value in range(1, 19)
+            ),
+        ),
+    )
+
+    missing = [
+        value
+        for value in result.games[0].players
+        if value.player_id == "19"
+    ]
+
+    assert len(missing) == 1
+    assert missing[0].sample_available is False
+    assert all(
+        value == 0
+        for _, value in missing[0].counts
+    )
+    assert result.zero_sample_count == 1
+
+
+def test_starters_and_bullpens_are_required():
+    result = source_historical_probability_statistics(
+        lineup_bullpen=roster_window(),
+        starting_pitcher_ids=starters(),
+        statistics_payloads=payloads(),
+    )
+
+    pitcher_ids = {
+        value.player_id
+        for value in result.games[0].players
+        if value.role == "pitching"
+    }
+
+    assert pitcher_ids == {
+        "20",
+        "22",
+        "23",
+        "30",
+        "32",
+        "33",
+    }
+
+
+def test_snapshot_makes_reconstruction_ready():
+    statistics = (
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids=starters(),
+            statistics_payloads=payloads(),
+        )
+    )
+
+    reconstruction = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window(),
+            statistics_snapshots=(
+                statistics.to_reconstruction_snapshots()
+            ),
+        )
+    )
+
+    assert reconstruction.ready is True
+    assert reconstruction.ready_game_count == 1
+
+
+def test_doubleheader_games_share_prior_day_cutoff():
+    window = roster_window(
+        roster_game(),
+        roster_game(
+            game_pk=2,
+            game_date="2026-04-20",
+        ),
+    )
+
+    result = source_historical_probability_statistics(
+        lineup_bullpen=window,
+        starting_pitcher_ids={
+            1: ("20", "30"),
+            2: ("20", "30"),
+        },
+        statistics_payloads=payloads(),
+    )
+
+    assert tuple(
+        value.statistics_through_date
+        for value in result.games
+    ) == (
+        "2026-04-19",
+        "2026-04-19",
+    )
+
+
+def test_missing_cutoff_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "statistics payload dates must exactly match"
+        ),
+    ):
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids=starters(),
+            statistics_payloads={},
+        )
+
+
+def test_missing_group_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "each cutoff requires hitting and pitching"
+        ),
+    ):
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids=starters(),
+            statistics_payloads={
+                "2026-04-19": {
+                    "hitting": payload(
+                        "hitting",
+                        ("1",),
+                    ),
+                }
+            },
+        )
+
+
+def test_unknown_starter_game_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "starting pitchers contain unknown games"
+        ),
+    ):
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids={
+                1: ("20", "30"),
+                99: ("20", "30"),
+            },
+            statistics_payloads=payloads(),
+        )
+
+
+def test_missing_required_stat_key_is_rejected():
+    invalid = payloads()
+    del invalid["2026-04-19"]["hitting"][
+        "stats"
+    ][0]["splits"][0]["stat"][
+        "plateAppearances"
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "hitting statistics missing "
+            "plateAppearances"
+        ),
+    ):
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids=starters(),
+            statistics_payloads=invalid,
+        )
+
+
+def test_order_and_digest_are_deterministic():
+    first = source_historical_probability_statistics(
+        lineup_bullpen=roster_window(),
+        starting_pitcher_ids=starters(),
+        statistics_payloads=payloads(),
+    )
+    second = source_historical_probability_statistics(
+        lineup_bullpen=roster_window(),
+        starting_pitcher_ids=starters(),
+        statistics_payloads=payloads(
+            hitter_ids=tuple(
+                reversed(
+                    tuple(
+                        str(value)
+                        for value in range(1, 20)
+                    )
+                )
+            ),
+        ),
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+
+
+def test_diagnostics_preserve_shadow_authority():
+    diagnostics = (
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window(),
+            starting_pitcher_ids=starters(),
+            statistics_payloads=payloads(),
+        ).to_diagnostics()
+    )
+
+    assert diagnostics["ready"] is True
+    assert diagnostics["future_data_permitted"] is False
+    assert diagnostics[
+        "doubleheader_same_cutoff"
+    ] is True
+    assert diagnostics[
+        "probability_workspace_reconstructed"
+    ] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+    assert diagnostics[
+        "player_identifiers_exposed"
+    ] is False
+
+
+def test_source_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_PROBABILITY_STATISTICS_SOURCE_VERSION
+        == (
+            "canonical_historical_probability_"
+            "statistics_source_v1"
+        )
+    )


### PR DESCRIPTION
## Summary

- source deterministic prior-day hitting and pitching statistics from MLB `byDateRange` responses
- include historical starting pitchers, bullpen pitchers, and both confirmed lineups in every game snapshot
- represent players absent from a valid full-player response as explicit zero-prior-sample records
- use one strictly previous-calendar-date cutoff for both games of a doubleheader
- produce per-game and full-window SHA-256 digests and adapt the results into the historical reconstruction-input contract
- add a real 185-game source runner

## Why

Archived MLB game-feed boxscores do not expose historical hitter statistics or per-game pitcher statistics, and the smoke window contains a doubleheader. Deriving pregame values from postgame boxscores would therefore be incomplete and could leak same-day results.

MLB's cutoff-aware `byDateRange` endpoint supplies the required outcome counts for the complete player pool. This establishes leakage-safe statistical inputs before probability workspaces or artifacts are reconstructed.

## Verified smoke-window evidence

For April 20 through May 3, 2026:

- 185/185 statistics game snapshots are ready
- 185/185 reconstruction inputs are ready
- 14 unique prior-day cutoffs
- 28 MLB statistics requests: hitting and pitching for each cutoff
- 69 player-role records have an explicit zero prior sample
- 0 reconstruction inputs are blocked
- future data is prohibited
- statistics-window digest: `8a0d1dc08affc91412feed479a9acd70583f112614fa5131ea944faf64f66ff7`
- reconstruction-input digest: `faa3870da3f9be0014b733d3c7cac54529e093b6ae4df13011698c121ab1cc7a`

## Production behavior

- no probabilities or artifacts are generated
- no historical replay is executed
- production activation remains disabled
- production authority remains `legacy`

## Validation

- `239 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- real 28-request historical source completed successfully
- Ruff was unavailable in the local environment