### PR TITLE
Define historical baserunning replay evidence

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -522,3 +522,23 @@ from .historical_probability_artifact_materialization import (
     CanonicalHistoricalProbabilityArtifactWindow,
     materialize_historical_probability_artifacts,
 )
+
+
+from .historical_baserunning_replay_evidence_source import (
+    CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION,
+    HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY,
+    HISTORICAL_BASERUNNING_EVIDENCE_QUALITY,
+    CanonicalHistoricalBaserunningReplayEvidenceGame,
+    CanonicalHistoricalBaserunningReplayEvidenceWindow,
+    source_historical_baserunning_replay_evidence,
+)
+
+
+from .historical_baserunning_profile_materialization import (
+    CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION,
+    CanonicalHistoricalBaserunningCatalogMaterialization,
+    CanonicalHistoricalCatcherBaserunningCounts,
+    CanonicalHistoricalPitcherBaserunningCounts,
+    CanonicalHistoricalRunnerBaserunningCounts,
+    materialize_historical_baserunning_profiles,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_profile_materialization.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_profile_materialization.py
@@ -1,0 +1,582 @@
+"""Materialize calibration-only historical baserunning profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+
+from .historical_baserunning_replay_evidence_source import (
+    HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY,
+    HISTORICAL_BASERUNNING_EVIDENCE_QUALITY,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION = (
+    "canonical_historical_baserunning_profile_materialization_v1"
+)
+
+_DEFAULT_RUNNER_ATTEMPT_RATE = 0.05
+_DEFAULT_RUNNER_SUCCESS_RATE = 0.75
+_DEFAULT_PITCHER_ALLOWED_ATTEMPT_RATE = 0.05
+_DEFAULT_PICKOFF_SUCCESS_RATE = 0.10
+_DEFAULT_CATCHER_THROWING_RATE = 0.25
+
+
+def _identifier(value: Any, name: str) -> str:
+    if value in (None, "") or isinstance(value, bool):
+        raise ValueError(f"{name} is required")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a positive integer string"
+        ) from exc
+
+    if parsed <= 0 or str(parsed) != str(value):
+        raise ValueError(
+            f"{name} must be a positive integer string"
+        )
+
+    return str(parsed)
+
+
+def _count(value: Any, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    try:
+        parsed = int(value)
+        parsed_float = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        ) from exc
+
+    if parsed < 0 or parsed_float != parsed:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    return parsed
+
+
+def _clamp(value: float) -> float:
+    return min(max(float(value), 0.0), 1.0)
+
+
+def _rate(
+    numerator: int,
+    denominator: int,
+    fallback: float,
+) -> float:
+    if denominator <= 0:
+        return fallback
+
+    return _clamp(numerator / denominator)
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalRunnerBaserunningCounts:
+    runner_id: str
+    opportunity_count: int
+    stolen_bases: int
+    caught_stealing: int
+
+    def __post_init__(self) -> None:
+        _identifier(self.runner_id, "runner_id")
+
+        for name, value in (
+            ("opportunity_count", self.opportunity_count),
+            ("stolen_bases", self.stolen_bases),
+            ("caught_stealing", self.caught_stealing),
+        ):
+            _count(value, name)
+
+        if (
+            self.stolen_bases + self.caught_stealing
+            > self.opportunity_count
+        ):
+            raise ValueError(
+                "runner attempts cannot exceed opportunities"
+            )
+
+    @property
+    def attempt_count(self) -> int:
+        return self.stolen_bases + self.caught_stealing
+
+    @property
+    def sample_available(self) -> bool:
+        return self.opportunity_count > 0
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalPitcherBaserunningCounts:
+    pitcher_id: str
+    batters_faced: int
+    stolen_bases_allowed: int
+    caught_stealing: int
+    pickoffs: int
+
+    def __post_init__(self) -> None:
+        _identifier(self.pitcher_id, "pitcher_id")
+
+        for name, value in (
+            ("batters_faced", self.batters_faced),
+            (
+                "stolen_bases_allowed",
+                self.stolen_bases_allowed,
+            ),
+            ("caught_stealing", self.caught_stealing),
+            ("pickoffs", self.pickoffs),
+        ):
+            _count(value, name)
+
+    @property
+    def attempt_count(self) -> int:
+        return (
+            self.stolen_bases_allowed
+            + self.caught_stealing
+        )
+
+    @property
+    def sample_available(self) -> bool:
+        return self.batters_faced > 0
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalCatcherBaserunningCounts:
+    catcher_id: str
+    team_side: str
+    stolen_bases_allowed: int
+    caught_stealing: int
+
+    def __post_init__(self) -> None:
+        _identifier(self.catcher_id, "catcher_id")
+
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        _count(
+            self.stolen_bases_allowed,
+            "stolen_bases_allowed",
+        )
+        _count(
+            self.caught_stealing,
+            "caught_stealing",
+        )
+
+    @property
+    def attempt_count(self) -> int:
+        return (
+            self.stolen_bases_allowed
+            + self.caught_stealing
+        )
+
+    @property
+    def sample_available(self) -> bool:
+        return self.attempt_count > 0
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningCatalogMaterialization:
+    catalog: CanonicalBaserunningEvidenceCatalog
+    direct_evidence_count: int
+    proxy_evidence_count: int
+    fallback_evidence_count: int
+    materialization_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.catalog,
+            CanonicalBaserunningEvidenceCatalog,
+        ):
+            raise TypeError(
+                "catalog must be "
+                "CanonicalBaserunningEvidenceCatalog"
+            )
+
+        for name, value in (
+            (
+                "direct_evidence_count",
+                self.direct_evidence_count,
+            ),
+            (
+                "proxy_evidence_count",
+                self.proxy_evidence_count,
+            ),
+            (
+                "fallback_evidence_count",
+                self.fallback_evidence_count,
+            ),
+        ):
+            _count(value, name)
+
+        if self.materialization_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "profile materialization version"
+            )
+
+    @property
+    def evidence_counts(self) -> Tuple[int, int, int]:
+        return (
+            self.direct_evidence_count,
+            self.proxy_evidence_count,
+            self.fallback_evidence_count,
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.materialization_version,
+            "ready": True,
+            "catalog_digest": self.catalog.digest,
+            "runner_count": len(self.catalog.runners),
+            "pitcher_count": len(self.catalog.pitchers),
+            "catcher_count": 2,
+            "direct_evidence_count": (
+                self.direct_evidence_count
+            ),
+            "proxy_evidence_count": (
+                self.proxy_evidence_count
+            ),
+            "fallback_evidence_count": (
+                self.fallback_evidence_count
+            ),
+            "evidence_quality": (
+                HISTORICAL_BASERUNNING_EVIDENCE_QUALITY
+            ),
+            "tracking_proxy_policy": (
+                HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY
+            ),
+            "direct_outcome_evidence": True,
+            "tracking_observations_available": False,
+            "zero_sample_rows_labeled_direct": False,
+            "target_game_outcomes_used": False,
+            "future_data_permitted": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def _runner_priors(
+    values: Tuple[
+        CanonicalHistoricalRunnerBaserunningCounts,
+        ...,
+    ],
+) -> Tuple[float, float]:
+    opportunities = sum(
+        value.opportunity_count
+        for value in values
+    )
+    attempts = sum(
+        value.attempt_count
+        for value in values
+    )
+    stolen_bases = sum(
+        value.stolen_bases
+        for value in values
+    )
+
+    return (
+        _rate(
+            attempts,
+            opportunities,
+            _DEFAULT_RUNNER_ATTEMPT_RATE,
+        ),
+        _rate(
+            stolen_bases,
+            attempts,
+            _DEFAULT_RUNNER_SUCCESS_RATE,
+        ),
+    )
+
+
+def _pitcher_priors(
+    values: Tuple[
+        CanonicalHistoricalPitcherBaserunningCounts,
+        ...,
+    ],
+) -> Tuple[float, float]:
+    batters_faced = sum(
+        value.batters_faced
+        for value in values
+    )
+    attempts = sum(
+        value.attempt_count
+        for value in values
+    )
+    pickoffs = sum(
+        value.pickoffs
+        for value in values
+    )
+
+    return (
+        _rate(
+            attempts,
+            batters_faced,
+            _DEFAULT_PITCHER_ALLOWED_ATTEMPT_RATE,
+        ),
+        _rate(
+            pickoffs,
+            pickoffs + attempts,
+            _DEFAULT_PICKOFF_SUCCESS_RATE,
+        ),
+    )
+
+
+def _catcher_prior(
+    values: Tuple[
+        CanonicalHistoricalCatcherBaserunningCounts,
+        ...,
+    ],
+) -> float:
+    attempts = sum(
+        value.attempt_count
+        for value in values
+    )
+    caught = sum(
+        value.caught_stealing
+        for value in values
+    )
+
+    return _rate(
+        caught,
+        attempts,
+        _DEFAULT_CATCHER_THROWING_RATE,
+    )
+
+
+def materialize_historical_baserunning_profiles(
+    *,
+    required_runner_ids: Tuple[str, ...],
+    required_pitcher_ids: Tuple[str, ...],
+    runner_counts: Tuple[
+        CanonicalHistoricalRunnerBaserunningCounts,
+        ...,
+    ],
+    pitcher_counts: Tuple[
+        CanonicalHistoricalPitcherBaserunningCounts,
+        ...,
+    ],
+    away_catcher_counts: (
+        CanonicalHistoricalCatcherBaserunningCounts
+    ),
+    home_catcher_counts: (
+        CanonicalHistoricalCatcherBaserunningCounts
+    ),
+) -> CanonicalHistoricalBaserunningCatalogMaterialization:
+    """
+    Convert cutoff-safe direct counts into one complete replay catalog.
+
+    Attempt, success, hold, and throwing rates use direct historical
+    outcomes. Tracking-only fields use explicit calibration proxies.
+    Zero-sample identities use window priors and are counted as fallbacks.
+    """
+
+    runner_ids = tuple(
+        _identifier(value, "runner_id")
+        for value in required_runner_ids
+    )
+    pitcher_ids = tuple(
+        _identifier(value, "pitcher_id")
+        for value in required_pitcher_ids
+    )
+
+    if len(runner_ids) != len(set(runner_ids)):
+        raise ValueError(
+            "required runner identifiers must be unique"
+        )
+    if len(pitcher_ids) != len(set(pitcher_ids)):
+        raise ValueError(
+            "required pitcher identifiers must be unique"
+        )
+
+    runners_by_id = {
+        value.runner_id: value
+        for value in runner_counts
+    }
+    pitchers_by_id = {
+        value.pitcher_id: value
+        for value in pitcher_counts
+    }
+
+    if len(runners_by_id) != len(runner_counts):
+        raise ValueError(
+            "runner count identifiers must be unique"
+        )
+    if len(pitchers_by_id) != len(pitcher_counts):
+        raise ValueError(
+            "pitcher count identifiers must be unique"
+        )
+    if set(runners_by_id) != set(runner_ids):
+        raise ValueError(
+            "runner counts must exactly cover required runners"
+        )
+    if set(pitchers_by_id) != set(pitcher_ids):
+        raise ValueError(
+            "pitcher counts must exactly cover required pitchers"
+        )
+
+    if away_catcher_counts.team_side != "away":
+        raise ValueError(
+            "away catcher counts must use away side"
+        )
+    if home_catcher_counts.team_side != "home":
+        raise ValueError(
+            "home catcher counts must use home side"
+        )
+
+    runner_attempt_prior, runner_success_prior = (
+        _runner_priors(runner_counts)
+    )
+    pitcher_attempt_prior, pickoff_success_prior = (
+        _pitcher_priors(pitcher_counts)
+    )
+    catcher_prior = _catcher_prior(
+        (
+            away_catcher_counts,
+            home_catcher_counts,
+        )
+    )
+
+    runner_profiles = []
+    for runner_id in runner_ids:
+        counts = runners_by_id[runner_id]
+        attempt_rate = _rate(
+            counts.attempt_count,
+            counts.opportunity_count,
+            runner_attempt_prior,
+        )
+        success_rate = _rate(
+            counts.stolen_bases,
+            counts.attempt_count,
+            runner_success_prior,
+        )
+
+        runner_profiles.append(
+            CanonicalRunnerBaserunningProfile(
+                runner_id=runner_id,
+                speed_score=_clamp(
+                    attempt_rate / 0.15
+                ),
+                attempt_rate=attempt_rate,
+                success_rate=success_rate,
+                lead_quality=success_rate,
+                fatigue_index=0.0,
+                injury_limit_flag=False,
+            )
+        )
+
+    pitcher_profiles = []
+    for pitcher_id in pitcher_ids:
+        counts = pitchers_by_id[pitcher_id]
+        allowed_attempt_rate = _rate(
+            counts.attempt_count,
+            counts.batters_faced,
+            pitcher_attempt_prior,
+        )
+        hold_score = 1.0 - _clamp(
+            allowed_attempt_rate / 0.10
+        )
+        pickoff_success_rate = _rate(
+            counts.pickoffs,
+            counts.pickoffs + counts.attempt_count,
+            pickoff_success_prior,
+        )
+
+        pitcher_profiles.append(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id=pitcher_id,
+                hold_score=hold_score,
+                delivery_time_score=hold_score,
+                pickoff_attempt_rate=_rate(
+                    counts.pickoffs,
+                    counts.batters_faced,
+                    0.0,
+                ),
+                pickoff_success_rate=(
+                    pickoff_success_rate
+                ),
+            )
+        )
+
+    def catcher_profile(
+        counts: (
+            CanonicalHistoricalCatcherBaserunningCounts
+        ),
+    ) -> CanonicalCatcherBaserunningProfile:
+        throwing_score = _rate(
+            counts.caught_stealing,
+            counts.attempt_count,
+            catcher_prior,
+        )
+
+        return CanonicalCatcherBaserunningProfile(
+            catcher_id=counts.catcher_id,
+            team_side=counts.team_side,
+            throwing_score=throwing_score,
+            pop_time_score=throwing_score,
+        )
+
+    catalog = CanonicalBaserunningEvidenceCatalog(
+        runners=tuple(runner_profiles),
+        pitchers=tuple(pitcher_profiles),
+        away_catcher=catcher_profile(
+            away_catcher_counts
+        ),
+        home_catcher=catcher_profile(
+            home_catcher_counts
+        ),
+    )
+
+    direct_count = sum(
+        value.sample_available
+        for value in runner_counts
+    )
+    direct_count += sum(
+        value.sample_available
+        for value in pitcher_counts
+    )
+    direct_count += sum(
+        value.sample_available
+        for value in (
+            away_catcher_counts,
+            home_catcher_counts,
+        )
+    )
+
+    identity_count = (
+        len(runner_counts)
+        + len(pitcher_counts)
+        + 2
+    )
+    fallback_count = identity_count - direct_count
+
+    proxy_count = (
+        len(runner_counts) * 3
+        + len(pitcher_counts) * 2
+        + 2
+    )
+
+    return CanonicalHistoricalBaserunningCatalogMaterialization(
+        catalog=catalog,
+        direct_evidence_count=direct_count,
+        proxy_evidence_count=proxy_count,
+        fallback_evidence_count=fallback_count,
+    )

--- a/mlb_app/simulation/shadow/historical_baserunning_replay_evidence_source.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_replay_evidence_source.py
@@ -1,0 +1,402 @@
+"""Source deterministic historical baserunning replay evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+)
+
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION = (
+    "canonical_historical_baserunning_replay_evidence_v1"
+)
+HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY = (
+    "historical_baserunning_calibration_proxy_v1"
+)
+HISTORICAL_BASERUNNING_EVIDENCE_QUALITY = "calibration_only"
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _iso_date(value: str, name: str) -> date:
+    try:
+        parsed = date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be an ISO date"
+        ) from exc
+
+    if parsed.isoformat() != value:
+        raise ValueError(
+            f"{name} must use ISO format"
+        )
+
+    return parsed
+
+
+def _digest(value: str, name: str) -> None:
+    if (
+        len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{name} must be a SHA256 digest"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningReplayEvidenceGame:
+    game_pk: int
+    game_date: str
+    statistics_through_date: str
+    catalog: CanonicalBaserunningEvidenceCatalog
+    evidence_digest: str
+    direct_evidence_count: int
+    proxy_evidence_count: int
+    fallback_evidence_count: int
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        game_date = _iso_date(
+            self.game_date,
+            "game_date",
+        )
+        cutoff = _iso_date(
+            self.statistics_through_date,
+            "statistics_through_date",
+        )
+
+        if cutoff != game_date - timedelta(days=1):
+            raise ValueError(
+                "statistics_through_date must be the "
+                "strict previous calendar date"
+            )
+
+        if not isinstance(
+            self.catalog,
+            CanonicalBaserunningEvidenceCatalog,
+        ):
+            raise TypeError(
+                "catalog must be "
+                "CanonicalBaserunningEvidenceCatalog"
+            )
+
+        _digest(
+            self.evidence_digest,
+            "evidence_digest",
+        )
+
+        for name, value in (
+            (
+                "direct_evidence_count",
+                self.direct_evidence_count,
+            ),
+            (
+                "proxy_evidence_count",
+                self.proxy_evidence_count,
+            ),
+            (
+                "fallback_evidence_count",
+                self.fallback_evidence_count,
+            ),
+        ):
+            if (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 0
+            ):
+                raise ValueError(
+                    f"{name} must be a nonnegative integer"
+                )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "statistics_through_date": (
+                self.statistics_through_date
+            ),
+            "catalog_digest": self.catalog.digest,
+            "evidence_digest": self.evidence_digest,
+            "direct_evidence_count": (
+                self.direct_evidence_count
+            ),
+            "proxy_evidence_count": (
+                self.proxy_evidence_count
+            ),
+            "fallback_evidence_count": (
+                self.fallback_evidence_count
+            ),
+            "evidence_quality": (
+                HISTORICAL_BASERUNNING_EVIDENCE_QUALITY
+            ),
+            "tracking_proxy_policy": (
+                HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY
+            ),
+            "target_game_outcomes_used": False,
+            "future_data_permitted": False,
+            "activation_permitted": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningReplayEvidenceWindow:
+    observed_window_digest: str
+    lineup_bullpen_window_digest: str
+    games: Tuple[
+        CanonicalHistoricalBaserunningReplayEvidenceGame,
+        ...,
+    ]
+    digest: str
+    source_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.games:
+            raise ValueError(
+                "games must contain replay evidence"
+            )
+
+        identities = tuple(
+            value.game_pk
+            for value in self.games
+        )
+        if len(identities) != len(set(identities)):
+            raise ValueError(
+                "evidence game identifiers must be unique"
+            )
+
+        for name, value in (
+            (
+                "observed_window_digest",
+                self.observed_window_digest,
+            ),
+            (
+                "lineup_bullpen_window_digest",
+                self.lineup_bullpen_window_digest,
+            ),
+            ("digest", self.digest),
+        ):
+            _digest(value, name)
+
+        if self.source_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "replay evidence version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def ready(self) -> bool:
+        return bool(self.games)
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "ready_game_count": self.game_count,
+            "direct_evidence_count": sum(
+                value.direct_evidence_count
+                for value in self.games
+            ),
+            "proxy_evidence_count": sum(
+                value.proxy_evidence_count
+                for value in self.games
+            ),
+            "fallback_evidence_count": sum(
+                value.fallback_evidence_count
+                for value in self.games
+            ),
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                self.lineup_bullpen_window_digest
+            ),
+            "evidence_window_digest": self.digest,
+            "evidence_quality": (
+                HISTORICAL_BASERUNNING_EVIDENCE_QUALITY
+            ),
+            "tracking_proxy_policy": (
+                HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY
+            ),
+            "statistics_cutoff_policy": (
+                "strict_previous_calendar_date"
+            ),
+            "target_game_outcomes_used": False,
+            "future_data_permitted": False,
+            "historical_replay_executed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def source_historical_baserunning_replay_evidence(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    catalogs: Mapping[
+        int,
+        CanonicalBaserunningEvidenceCatalog,
+    ],
+    statistics_through_dates: Mapping[int, str],
+    evidence_counts: Mapping[
+        int,
+        Tuple[int, int, int],
+    ],
+) -> CanonicalHistoricalBaserunningReplayEvidenceWindow:
+    """
+    Attach complete cutoff-safe catalogs to historical games.
+
+    Catalog construction remains separate from this alignment boundary.
+    Every game must be covered exactly. Target-game outcomes are never
+    accepted by this API.
+    """
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    games_by_id = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+
+    expected = set(games_by_id)
+    if (
+        set(catalogs) != expected
+        or set(statistics_through_dates) != expected
+        or set(evidence_counts) != expected
+    ):
+        raise ValueError(
+            "historical baserunning evidence inputs "
+            "must exactly cover lineup-bullpen games"
+        )
+
+    games = []
+
+    for game_pk in sorted(
+        expected,
+        key=lambda value: (
+            games_by_id[value].game_date,
+            value,
+        ),
+    ):
+        source_game = games_by_id[game_pk]
+        catalog = catalogs[game_pk]
+        cutoff = statistics_through_dates[game_pk]
+        counts = evidence_counts[game_pk]
+
+        if (
+            not isinstance(counts, tuple)
+            or len(counts) != 3
+        ):
+            raise TypeError(
+                "evidence counts must be "
+                "direct-proxy-fallback tuples"
+            )
+
+        evidence_digest = _sha256(
+            {
+                "game_pk": game_pk,
+                "game_date": source_game.game_date,
+                "statistics_through_date": cutoff,
+                "catalog_digest": catalog.digest,
+                "direct_evidence_count": counts[0],
+                "proxy_evidence_count": counts[1],
+                "fallback_evidence_count": counts[2],
+                "evidence_quality": (
+                    HISTORICAL_BASERUNNING_EVIDENCE_QUALITY
+                ),
+                "tracking_proxy_policy": (
+                    HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY
+                ),
+            }
+        )
+
+        games.append(
+            CanonicalHistoricalBaserunningReplayEvidenceGame(
+                game_pk=game_pk,
+                game_date=source_game.game_date,
+                statistics_through_date=cutoff,
+                catalog=catalog,
+                evidence_digest=evidence_digest,
+                direct_evidence_count=counts[0],
+                proxy_evidence_count=counts[1],
+                fallback_evidence_count=counts[2],
+            )
+        )
+
+    digest = _sha256(
+        {
+            "schema_version": (
+                CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION
+            ),
+            "observed_window_digest": (
+                lineup_bullpen.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                lineup_bullpen.digest
+            ),
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "evidence_digest": value.evidence_digest,
+                }
+                for value in games
+            ],
+        }
+    )
+
+    return CanonicalHistoricalBaserunningReplayEvidenceWindow(
+        observed_window_digest=(
+            lineup_bullpen.observed_window_digest
+        ),
+        lineup_bullpen_window_digest=(
+            lineup_bullpen.digest
+        ),
+        games=tuple(games),
+        digest=digest,
+    )

--- a/tests/test_canonical_historical_baserunning_profile_materialization.py
+++ b/tests/test_canonical_historical_baserunning_profile_materialization.py
@@ -1,0 +1,184 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION,
+    CanonicalHistoricalCatcherBaserunningCounts,
+    CanonicalHistoricalPitcherBaserunningCounts,
+    CanonicalHistoricalRunnerBaserunningCounts,
+    materialize_historical_baserunning_profiles,
+)
+
+
+def materialize():
+    return materialize_historical_baserunning_profiles(
+        required_runner_ids=("1", "2"),
+        required_pitcher_ids=("10",),
+        runner_counts=(
+            CanonicalHistoricalRunnerBaserunningCounts(
+                runner_id="1",
+                opportunity_count=100,
+                stolen_bases=8,
+                caught_stealing=2,
+            ),
+            CanonicalHistoricalRunnerBaserunningCounts(
+                runner_id="2",
+                opportunity_count=0,
+                stolen_bases=0,
+                caught_stealing=0,
+            ),
+        ),
+        pitcher_counts=(
+            CanonicalHistoricalPitcherBaserunningCounts(
+                pitcher_id="10",
+                batters_faced=200,
+                stolen_bases_allowed=6,
+                caught_stealing=2,
+                pickoffs=1,
+            ),
+        ),
+        away_catcher_counts=(
+            CanonicalHistoricalCatcherBaserunningCounts(
+                catcher_id="20",
+                team_side="away",
+                stolen_bases_allowed=9,
+                caught_stealing=3,
+            )
+        ),
+        home_catcher_counts=(
+            CanonicalHistoricalCatcherBaserunningCounts(
+                catcher_id="21",
+                team_side="home",
+                stolen_bases_allowed=0,
+                caught_stealing=0,
+            )
+        ),
+    )
+
+
+def test_materializes_complete_catalog():
+    result = materialize()
+
+    assert len(result.catalog.runners) == 2
+    assert len(result.catalog.pitchers) == 1
+    assert result.catalog.away_catcher.catcher_id == "20"
+    assert result.catalog.home_catcher.catcher_id == "21"
+    assert result.direct_evidence_count == 3
+    assert result.fallback_evidence_count == 2
+    assert result.proxy_evidence_count == 10
+
+
+def test_direct_rates_and_proxies_are_explicit():
+    result = materialize()
+    runner = result.catalog.runners[0]
+    pitcher = result.catalog.pitchers[0]
+    diagnostics = result.to_diagnostics()
+
+    assert runner.attempt_rate == pytest.approx(0.10)
+    assert runner.success_rate == pytest.approx(0.80)
+    assert runner.speed_score == pytest.approx(2 / 3)
+    assert runner.lead_quality == runner.success_rate
+    assert runner.fatigue_index == 0.0
+    assert runner.injury_limit_flag is False
+
+    assert pitcher.pickoff_attempt_rate == pytest.approx(
+        0.005
+    )
+    assert pitcher.delivery_time_score == (
+        pitcher.hold_score
+    )
+
+    assert diagnostics["direct_outcome_evidence"] is True
+    assert (
+        diagnostics["tracking_observations_available"]
+        is False
+    )
+    assert (
+        diagnostics["zero_sample_rows_labeled_direct"]
+        is False
+    )
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_zero_sample_uses_observed_prior():
+    result = materialize()
+    observed, fallback = result.catalog.runners
+
+    assert fallback.attempt_rate == observed.attempt_rate
+    assert fallback.success_rate == observed.success_rate
+
+
+def test_counts_must_exactly_cover_required_ids():
+    with pytest.raises(
+        ValueError,
+        match="exactly cover required runners",
+    ):
+        materialize_historical_baserunning_profiles(
+            required_runner_ids=("1", "2"),
+            required_pitcher_ids=("10",),
+            runner_counts=(
+                CanonicalHistoricalRunnerBaserunningCounts(
+                    runner_id="1",
+                    opportunity_count=10,
+                    stolen_bases=1,
+                    caught_stealing=0,
+                ),
+            ),
+            pitcher_counts=(
+                CanonicalHistoricalPitcherBaserunningCounts(
+                    pitcher_id="10",
+                    batters_faced=10,
+                    stolen_bases_allowed=0,
+                    caught_stealing=0,
+                    pickoffs=0,
+                ),
+            ),
+            away_catcher_counts=(
+                CanonicalHistoricalCatcherBaserunningCounts(
+                    catcher_id="20",
+                    team_side="away",
+                    stolen_bases_allowed=0,
+                    caught_stealing=0,
+                )
+            ),
+            home_catcher_counts=(
+                CanonicalHistoricalCatcherBaserunningCounts(
+                    catcher_id="21",
+                    team_side="home",
+                    stolen_bases_allowed=0,
+                    caught_stealing=0,
+                )
+            ),
+        )
+
+
+def test_runner_attempts_cannot_exceed_opportunities():
+    with pytest.raises(
+        ValueError,
+        match="cannot exceed opportunities",
+    ):
+        CanonicalHistoricalRunnerBaserunningCounts(
+            runner_id="1",
+            opportunity_count=1,
+            stolen_bases=2,
+            caught_stealing=0,
+        )
+
+
+def test_materialization_is_deterministic():
+    first = materialize()
+    second = materialize()
+
+    assert first == second
+    assert first.catalog.digest == second.catalog.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_PROFILE_MATERIALIZATION_VERSION
+        == "canonical_historical_baserunning_profile_materialization_v1"
+    )

--- a/tests/test_canonical_historical_baserunning_replay_evidence_source.py
+++ b/tests/test_canonical_historical_baserunning_replay_evidence_source.py
@@ -1,0 +1,204 @@
+from datetime import date, timedelta
+import hashlib
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+from mlb_app.simulation.shadow.historical_baserunning_replay_evidence_source import (
+    CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION,
+    HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY,
+    HISTORICAL_BASERUNNING_EVIDENCE_QUALITY,
+    source_historical_baserunning_replay_evidence,
+)
+from mlb_app.simulation.shadow.historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+DIGEST = hashlib.sha256(b"fixture").hexdigest()
+
+
+def catalog():
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id="1",
+                speed_score=0.5,
+                attempt_rate=0.1,
+                success_rate=0.75,
+                lead_quality=0.5,
+                fatigue_index=0.0,
+            ),
+        ),
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id="2",
+                hold_score=0.5,
+                delivery_time_score=0.5,
+                pickoff_attempt_rate=0.05,
+                pickoff_success_rate=0.1,
+            ),
+        ),
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="3",
+            team_side="away",
+            throwing_score=0.5,
+            pop_time_score=0.5,
+        ),
+        home_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="4",
+            team_side="home",
+            throwing_score=0.5,
+            pop_time_score=0.5,
+        ),
+    )
+
+
+def lineup_window():
+    games = []
+
+    for game_pk, game_date in (
+        (11, "2026-04-20"),
+        (12, "2026-04-21"),
+    ):
+        games.append(
+            CanonicalHistoricalLineupBullpenGameSnapshot(
+                game_pk=game_pk,
+                game_date=game_date,
+                away_lineup_ids=tuple(
+                    str(value)
+                    for value in range(1, 10)
+                ),
+                home_lineup_ids=tuple(
+                    str(value)
+                    for value in range(11, 20)
+                ),
+                away_bullpen_ids=("21",),
+                home_bullpen_ids=("22",),
+                lineup_digest=DIGEST,
+                bullpen_digest=DIGEST,
+            )
+        )
+
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST,
+        games=tuple(games),
+        digest=DIGEST,
+    )
+
+
+def source():
+    window = lineup_window()
+
+    return source_historical_baserunning_replay_evidence(
+        lineup_bullpen=window,
+        catalogs={
+            game.game_pk: catalog()
+            for game in window.games
+        },
+        statistics_through_dates={
+            game.game_pk: (
+                date.fromisoformat(game.game_date)
+                - timedelta(days=1)
+            ).isoformat()
+            for game in window.games
+        },
+        evidence_counts={
+            game.game_pk: (10, 5, 1)
+            for game in window.games
+        },
+    )
+
+
+def test_window_is_ready_and_guarded():
+    result = source()
+    diagnostics = result.to_diagnostics()
+
+    assert result.ready is True
+    assert result.game_count == 2
+    assert diagnostics["ready_game_count"] == 2
+    assert diagnostics["direct_evidence_count"] == 20
+    assert diagnostics["proxy_evidence_count"] == 10
+    assert diagnostics["fallback_evidence_count"] == 2
+    assert diagnostics["evidence_quality"] == (
+        HISTORICAL_BASERUNNING_EVIDENCE_QUALITY
+    )
+    assert diagnostics["tracking_proxy_policy"] == (
+        HISTORICAL_BASERUNNING_CALIBRATION_PROXY_POLICY
+    )
+    assert diagnostics["target_game_outcomes_used"] is False
+    assert diagnostics["future_data_permitted"] is False
+    assert diagnostics["historical_replay_executed"] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["production_authority_changed"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_inputs_must_exactly_cover_games():
+    window = lineup_window()
+
+    with pytest.raises(
+        ValueError,
+        match="exactly cover",
+    ):
+        source_historical_baserunning_replay_evidence(
+            lineup_bullpen=window,
+            catalogs={11: catalog()},
+            statistics_through_dates={
+                11: "2026-04-19",
+                12: "2026-04-20",
+            },
+            evidence_counts={
+                11: (1, 1, 0),
+                12: (1, 1, 0),
+            },
+        )
+
+
+def test_cutoff_must_be_previous_calendar_date():
+    window = lineup_window()
+
+    with pytest.raises(
+        ValueError,
+        match="strict previous calendar date",
+    ):
+        source_historical_baserunning_replay_evidence(
+            lineup_bullpen=window,
+            catalogs={
+                game.game_pk: catalog()
+                for game in window.games
+            },
+            statistics_through_dates={
+                11: "2026-04-20",
+                12: "2026-04-20",
+            },
+            evidence_counts={
+                11: (1, 1, 0),
+                12: (1, 1, 0),
+            },
+        )
+
+
+def test_source_is_deterministic():
+    first = source()
+    second = source()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVIDENCE_VERSION
+        == "canonical_historical_baserunning_replay_evidence_v1"
+    )


### PR DESCRIPTION
## Summary
- add a deterministic historical baserunning replay-evidence window with exact game coverage and strict previous-calendar-date cutoffs
- materialize complete runner, pitcher, and catcher profiles from historical outcome counts
- label tracking-derived fields and zero-sample fallbacks explicitly as calibration-only evidence
- expose deterministic catalog/evidence digests and direct, proxy, and fallback counts
- preserve legacy production authority and prohibit target-game outcome leakage, future data, replay execution, and activation in this layer

## Why
Historical stolen-base replay needs a guarded evidence boundary before production-shaped simulations can run. This change defines that boundary and the count-to-profile materialization policy without activating baserunning or using target-game outcomes.

## Validation
- `261 passed, 1 warning`
- Python compilation passed for both new modules, exports, and tests
- `git diff --cached --check` passed

## Scope
This PR defines and tests the evidence contracts and profile materialization. Raw MLB statistics/feed extraction and the 185-game replay execution remain follow-up work.