### PR TITLE
Source historical MLB baserunning counts

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -542,3 +542,16 @@ from .historical_baserunning_profile_materialization import (
     CanonicalHistoricalRunnerBaserunningCounts,
     materialize_historical_baserunning_profiles,
 )
+
+
+from .historical_mlb_baserunning_count_source import (
+    CANONICAL_HISTORICAL_MLB_BASERUNNING_COUNT_SOURCE_VERSION,
+    source_historical_mlb_baserunning_counts,
+)
+
+
+from .historical_mlb_baserunning_feed_source import (
+    CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION,
+    CanonicalHistoricalMlbBaserunningFeedEvidence,
+    source_historical_mlb_baserunning_feed_evidence,
+)

--- a/mlb_app/simulation/shadow/historical_mlb_baserunning_count_source.py
+++ b/mlb_app/simulation/shadow/historical_mlb_baserunning_count_source.py
@@ -1,0 +1,484 @@
+"""Source cutoff-safe MLB baserunning counts for historical replay."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, Dict, Mapping, Sequence, Tuple
+
+from .historical_baserunning_profile_materialization import (
+    CanonicalHistoricalCatcherBaserunningCounts,
+    CanonicalHistoricalPitcherBaserunningCounts,
+    CanonicalHistoricalRunnerBaserunningCounts,
+    materialize_historical_baserunning_profiles,
+)
+from .historical_baserunning_replay_evidence_source import (
+    CanonicalHistoricalBaserunningReplayEvidenceWindow,
+    source_historical_baserunning_replay_evidence,
+)
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+CANONICAL_HISTORICAL_MLB_BASERUNNING_COUNT_SOURCE_VERSION = (
+    "canonical_historical_mlb_baserunning_count_source_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+    ):
+        return value
+    return ()
+
+
+def _identifier(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        person = _mapping(value.get("person"))
+        value = (
+            person.get("id")
+            or value.get("id")
+            or value.get("player_id")
+        )
+
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _count(value: Any, name: str) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    try:
+        parsed_float = float(value)
+        parsed = int(parsed_float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        ) from exc
+
+    if parsed < 0 or parsed_float != parsed:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    return parsed
+
+
+def _statistics_rows(
+    payload: Mapping[str, Any],
+) -> Dict[str, Mapping[str, Any]]:
+    rows: Dict[str, Mapping[str, Any]] = {}
+
+    for block in _sequence(payload.get("stats")):
+        for split in _sequence(
+            _mapping(block).get("splits")
+        ):
+            split = _mapping(split)
+            player_id = _identifier(
+                split.get("player")
+            )
+
+            if player_id is None:
+                raise ValueError(
+                    "statistics split requires player identity"
+                )
+            if player_id in rows:
+                raise ValueError(
+                    "statistics player identities "
+                    "must be unique"
+                )
+
+            rows[player_id] = _mapping(
+                split.get("stat")
+            )
+
+    return rows
+
+
+def _normalize_game_pairs(
+    *,
+    values: Mapping[int, Tuple[str, str]],
+    expected_game_ids: set[int],
+    name: str,
+) -> Dict[int, Tuple[str, str]]:
+    normalized: Dict[int, Tuple[str, str]] = {}
+
+    if not isinstance(values, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+
+    for raw_game_pk, raw_pair in values.items():
+        try:
+            game_pk = int(raw_game_pk)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{name} game identifiers must be integers"
+            ) from exc
+
+        if (
+            not isinstance(raw_pair, tuple)
+            or len(raw_pair) != 2
+        ):
+            raise TypeError(
+                f"{name} values must be away-home tuples"
+            )
+
+        away_id = _identifier(raw_pair[0])
+        home_id = _identifier(raw_pair[1])
+
+        if away_id is None or home_id is None:
+            raise ValueError(
+                f"{name} identifiers are required"
+            )
+
+        normalized[game_pk] = (
+            away_id,
+            home_id,
+        )
+
+    if set(normalized) != expected_game_ids:
+        raise ValueError(
+            f"{name} must exactly cover historical games"
+        )
+
+    return normalized
+
+
+def source_historical_mlb_baserunning_counts(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    starting_pitcher_ids: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    starting_catcher_ids: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    statistics_payloads: Mapping[
+        str,
+        Mapping[str, Mapping[str, Any]],
+    ],
+    pitcher_pickoffs_by_cutoff: Mapping[
+        str,
+        Mapping[str, int],
+    ],
+    catcher_outcomes_by_cutoff: Mapping[
+        str,
+        Mapping[str, Tuple[int, int]],
+    ],
+) -> CanonicalHistoricalBaserunningReplayEvidenceWindow:
+    """
+    Decode direct MLB counts and build complete historical catalogs.
+
+    Statistics, pickoffs, and catcher outcomes must stop on the strict
+    previous calendar date. Target-game outcomes are not accepted.
+    """
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    games_by_id = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+    expected_game_ids = set(games_by_id)
+
+    starters = _normalize_game_pairs(
+        values=starting_pitcher_ids,
+        expected_game_ids=expected_game_ids,
+        name="starting pitchers",
+    )
+    catchers = _normalize_game_pairs(
+        values=starting_catcher_ids,
+        expected_game_ids=expected_game_ids,
+        name="starting catchers",
+    )
+
+    required_cutoffs = {
+        (
+            date.fromisoformat(value.game_date)
+            - timedelta(days=1)
+        ).isoformat()
+        for value in lineup_bullpen.games
+    }
+
+    for name, values in (
+        ("statistics payloads", statistics_payloads),
+        (
+            "pitcher pickoffs by cutoff",
+            pitcher_pickoffs_by_cutoff,
+        ),
+        (
+            "catcher outcomes by cutoff",
+            catcher_outcomes_by_cutoff,
+        ),
+    ):
+        if not isinstance(values, Mapping):
+            raise TypeError(f"{name} must be a mapping")
+        if set(values) != required_cutoffs:
+            raise ValueError(
+                f"{name} must exactly match "
+                "required prior-day cutoffs"
+            )
+
+    rows_by_cutoff = {}
+
+    for cutoff in sorted(required_cutoffs):
+        groups = statistics_payloads[cutoff]
+
+        if (
+            not isinstance(groups, Mapping)
+            or set(groups) != {"hitting", "pitching"}
+        ):
+            raise ValueError(
+                "each statistics cutoff requires "
+                "hitting and pitching payloads"
+            )
+
+        rows_by_cutoff[cutoff] = {
+            "hitting": _statistics_rows(
+                _mapping(groups["hitting"])
+            ),
+            "pitching": _statistics_rows(
+                _mapping(groups["pitching"])
+            ),
+        }
+
+    catalogs = {}
+    evidence_counts = {}
+    cutoffs_by_game = {}
+
+    for game in sorted(
+        lineup_bullpen.games,
+        key=lambda value: (
+            value.game_date,
+            value.game_pk,
+        ),
+    ):
+        if not game.ready:
+            raise ValueError(
+                "lineup-bullpen snapshots must be ready"
+            )
+
+        cutoff = (
+            date.fromisoformat(game.game_date)
+            - timedelta(days=1)
+        ).isoformat()
+        rows = rows_by_cutoff[cutoff]
+        away_starter, home_starter = (
+            starters[game.game_pk]
+        )
+        away_catcher, home_catcher = (
+            catchers[game.game_pk]
+        )
+
+        runner_ids = (
+            game.away_lineup_ids
+            + game.home_lineup_ids
+        )
+        pitcher_ids = tuple(
+            dict.fromkeys(
+                (
+                    away_starter,
+                    home_starter,
+                )
+                + game.away_bullpen_ids
+                + game.home_bullpen_ids
+            )
+        )
+
+        pickoffs = pitcher_pickoffs_by_cutoff[
+            cutoff
+        ]
+        catcher_outcomes = catcher_outcomes_by_cutoff[
+            cutoff
+        ]
+
+        if not isinstance(pickoffs, Mapping):
+            raise TypeError(
+                "pitcher cutoff values must be mappings"
+            )
+        if not isinstance(catcher_outcomes, Mapping):
+            raise TypeError(
+                "catcher cutoff values must be mappings"
+            )
+
+        missing_pitchers = (
+            set(pitcher_ids) - set(pickoffs)
+        )
+        if missing_pitchers:
+            raise ValueError(
+                "pitcher pickoff counts must cover "
+                "every required pitcher"
+            )
+
+        missing_catchers = {
+            away_catcher,
+            home_catcher,
+        } - set(catcher_outcomes)
+        if missing_catchers:
+            raise ValueError(
+                "catcher outcomes must cover "
+                "both starting catchers"
+            )
+
+        runner_counts = []
+
+        for runner_id in runner_ids:
+            stats = rows["hitting"].get(
+                runner_id,
+                {},
+            )
+            stolen_bases = _count(
+                stats.get("stolenBases"),
+                "hitting.stolenBases",
+            )
+            caught_stealing = _count(
+                stats.get("caughtStealing"),
+                "hitting.caughtStealing",
+            )
+            attempts = (
+                stolen_bases + caught_stealing
+            )
+            opportunities = max(
+                attempts,
+                (
+                    _count(
+                        stats.get("hits"),
+                        "hitting.hits",
+                    )
+                    + _count(
+                        stats.get("baseOnBalls"),
+                        "hitting.baseOnBalls",
+                    )
+                    + _count(
+                        stats.get("hitByPitch"),
+                        "hitting.hitByPitch",
+                    )
+                    - _count(
+                        stats.get("homeRuns"),
+                        "hitting.homeRuns",
+                    )
+                ),
+            )
+
+            runner_counts.append(
+                CanonicalHistoricalRunnerBaserunningCounts(
+                    runner_id=runner_id,
+                    opportunity_count=opportunities,
+                    stolen_bases=stolen_bases,
+                    caught_stealing=caught_stealing,
+                )
+            )
+
+        pitcher_counts = []
+
+        for pitcher_id in pitcher_ids:
+            stats = rows["pitching"].get(
+                pitcher_id,
+                {},
+            )
+
+            pitcher_counts.append(
+                CanonicalHistoricalPitcherBaserunningCounts(
+                    pitcher_id=pitcher_id,
+                    batters_faced=_count(
+                        stats.get("battersFaced"),
+                        "pitching.battersFaced",
+                    ),
+                    stolen_bases_allowed=_count(
+                        stats.get("stolenBases"),
+                        "pitching.stolenBases",
+                    ),
+                    caught_stealing=_count(
+                        stats.get("caughtStealing"),
+                        "pitching.caughtStealing",
+                    ),
+                    pickoffs=_count(
+                        pickoffs[pitcher_id],
+                        "pitching.pickoffs",
+                    ),
+                )
+            )
+
+        def catcher_counts(
+            catcher_id: str,
+            side: str,
+        ) -> CanonicalHistoricalCatcherBaserunningCounts:
+            raw = catcher_outcomes[catcher_id]
+
+            if (
+                not isinstance(raw, tuple)
+                or len(raw) != 2
+            ):
+                raise TypeError(
+                    "catcher outcomes must be "
+                    "stolen-base/caught-stealing tuples"
+                )
+
+            return CanonicalHistoricalCatcherBaserunningCounts(
+                catcher_id=catcher_id,
+                team_side=side,
+                stolen_bases_allowed=_count(
+                    raw[0],
+                    "catcher.stolen_bases_allowed",
+                ),
+                caught_stealing=_count(
+                    raw[1],
+                    "catcher.caught_stealing",
+                ),
+            )
+
+        materialized = (
+            materialize_historical_baserunning_profiles(
+                required_runner_ids=runner_ids,
+                required_pitcher_ids=pitcher_ids,
+                runner_counts=tuple(runner_counts),
+                pitcher_counts=tuple(pitcher_counts),
+                away_catcher_counts=catcher_counts(
+                    away_catcher,
+                    "away",
+                ),
+                home_catcher_counts=catcher_counts(
+                    home_catcher,
+                    "home",
+                ),
+            )
+        )
+
+        catalogs[game.game_pk] = materialized.catalog
+        evidence_counts[
+            game.game_pk
+        ] = materialized.evidence_counts
+        cutoffs_by_game[game.game_pk] = cutoff
+
+    return source_historical_baserunning_replay_evidence(
+        lineup_bullpen=lineup_bullpen,
+        catalogs=catalogs,
+        statistics_through_dates=cutoffs_by_game,
+        evidence_counts=evidence_counts,
+    )

--- a/mlb_app/simulation/shadow/historical_mlb_baserunning_feed_source.py
+++ b/mlb_app/simulation/shadow/historical_mlb_baserunning_feed_source.py
@@ -1,0 +1,703 @@
+"""Source cutoff-safe pickoff and catcher evidence from MLB feeds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Sequence, Tuple
+
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+
+
+CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION = (
+    "canonical_historical_mlb_baserunning_feed_source_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _sequence(value: Any) -> Sequence[Any]:
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+    ):
+        return value
+    return ()
+
+
+def _identifier(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        person = _mapping(value.get("person"))
+        value = (
+            person.get("id")
+            or value.get("id")
+            or value.get("player_id")
+        )
+
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _count(value: Any, name: str) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    try:
+        parsed_float = float(value)
+        parsed = int(parsed_float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        ) from exc
+
+    if parsed < 0 or parsed_float != parsed:
+        raise ValueError(
+            f"{name} must be a nonnegative integer"
+        )
+
+    return parsed
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _official_date(
+    feed: Mapping[str, Any],
+) -> str:
+    value = (
+        _mapping(
+            _mapping(feed.get("gameData"))
+            .get("datetime")
+        ).get("officialDate")
+    )
+
+    try:
+        parsed = date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game feed requires officialDate"
+        ) from exc
+
+    if parsed.isoformat() != value:
+        raise ValueError(
+            "game feed officialDate must use ISO format"
+        )
+
+    return value
+
+
+def _boxscore_teams(
+    feed: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return _mapping(
+        _mapping(
+            _mapping(feed.get("liveData"))
+            .get("boxscore")
+        ).get("teams")
+    )
+
+
+def _team_players(
+    feed: Mapping[str, Any],
+) -> Tuple[Mapping[str, Any], ...]:
+    players = []
+
+    for side in ("away", "home"):
+        team = _mapping(
+            _boxscore_teams(feed).get(side)
+        )
+
+        for player in _mapping(
+            team.get("players")
+        ).values():
+            if isinstance(player, Mapping):
+                players.append(player)
+
+    return tuple(players)
+
+
+def _starting_catcher(
+    team: Mapping[str, Any],
+    *,
+    game_pk: int,
+    side: str,
+) -> str:
+    candidates = []
+    starting_slots = []
+
+    for raw_player in _mapping(
+        team.get("players")
+    ).values():
+        player = _mapping(raw_player)
+        player_id = _identifier(player)
+        all_positions = tuple(
+            _mapping(raw_position)
+            for raw_position in _sequence(
+                player.get("allPositions")
+            )
+        )
+        starting_position = (
+            all_positions[0]
+            if all_positions
+            else _mapping(
+                player.get("position")
+            )
+        )
+        catcher_position_recorded = (
+            starting_position.get(
+                "abbreviation"
+            )
+            == "C"
+        )
+        batting_order = str(
+            player.get("battingOrder") or ""
+        ).strip()
+
+        if (
+            batting_order.isdigit()
+            and int(batting_order) % 100 == 0
+        ):
+            starting_slots.append(
+                {
+                    "player_id": player_id,
+                    "batting_order": batting_order,
+                    "position": (
+                        _mapping(
+                            player.get("position")
+                        ).get("abbreviation")
+                    ),
+                    "all_positions": tuple(
+                        _mapping(raw_position).get(
+                            "abbreviation"
+                        )
+                        for raw_position in _sequence(
+                            player.get("allPositions")
+                        )
+                    ),
+                }
+            )
+
+        if (
+            player_id is None
+            or not catcher_position_recorded
+            or not batting_order.isdigit()
+        ):
+            continue
+
+        numeric_order = int(batting_order)
+        if numeric_order % 100 != 0:
+            continue
+
+        candidates.append(
+            (numeric_order, player_id)
+        )
+
+    if len(candidates) != 1:
+        raise ValueError(
+            "historical game requires exactly one "
+            "starting catcher per team; "
+            f"game_pk={game_pk}; "
+            f"side={side}; "
+            f"candidate_count={len(candidates)}; "
+            f"starting_slots={starting_slots}"
+        )
+
+    return min(candidates)[1]
+
+
+def _normalize_starters(
+    *,
+    values: Mapping[int, Tuple[str, str]],
+    expected: set[int],
+) -> Dict[int, Tuple[str, str]]:
+    if not isinstance(values, Mapping):
+        raise TypeError(
+            "starting_pitcher_ids must be a mapping"
+        )
+
+    normalized = {}
+
+    for raw_game_pk, raw_pair in values.items():
+        try:
+            game_pk = int(raw_game_pk)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "starting pitcher game identifiers "
+                "must be integers"
+            ) from exc
+
+        if (
+            not isinstance(raw_pair, tuple)
+            or len(raw_pair) != 2
+        ):
+            raise TypeError(
+                "starting pitcher values must be "
+                "away-home tuples"
+            )
+
+        away_id = _identifier(raw_pair[0])
+        home_id = _identifier(raw_pair[1])
+
+        if away_id is None or home_id is None:
+            raise ValueError(
+                "starting pitcher identifiers are required"
+            )
+
+        normalized[game_pk] = (
+            away_id,
+            home_id,
+        )
+
+    if set(normalized) != expected:
+        raise ValueError(
+            "starting pitchers must exactly cover "
+            "historical games"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalMlbBaserunningFeedEvidence:
+    starting_catcher_records: Tuple[
+        Tuple[int, str, str],
+        ...,
+    ]
+    pitcher_pickoff_records: Tuple[
+        Tuple[str, Tuple[Tuple[str, int], ...]],
+        ...,
+    ]
+    catcher_outcome_records: Tuple[
+        Tuple[
+            str,
+            Tuple[
+                Tuple[str, Tuple[int, int]],
+                ...,
+            ],
+        ],
+        ...,
+    ]
+    digest: str
+    source_version: str = (
+        CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.starting_catcher_records:
+            raise ValueError(
+                "starting_catcher_records must not be empty"
+            )
+        if not self.pitcher_pickoff_records:
+            raise ValueError(
+                "pitcher_pickoff_records must not be empty"
+            )
+        if not self.catcher_outcome_records:
+            raise ValueError(
+                "catcher_outcome_records must not be empty"
+            )
+
+        if (
+            len(self.digest) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in self.digest
+            )
+        ):
+            raise ValueError(
+                "digest must be a SHA256 digest"
+            )
+
+        if self.source_version != (
+            CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical MLB "
+                "baserunning feed source version"
+            )
+
+    @property
+    def starting_catcher_ids(
+        self,
+    ) -> Dict[int, Tuple[str, str]]:
+        return {
+            game_pk: (away_id, home_id)
+            for game_pk, away_id, home_id
+            in self.starting_catcher_records
+        }
+
+    @property
+    def pitcher_pickoffs_by_cutoff(
+        self,
+    ) -> Dict[str, Dict[str, int]]:
+        return {
+            cutoff: dict(records)
+            for cutoff, records
+            in self.pitcher_pickoff_records
+        }
+
+    @property
+    def catcher_outcomes_by_cutoff(
+        self,
+    ) -> Dict[
+        str,
+        Dict[str, Tuple[int, int]],
+    ]:
+        return {
+            cutoff: dict(records)
+            for cutoff, records
+            in self.catcher_outcome_records
+        }
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.source_version,
+            "ready": True,
+            "game_count": len(
+                self.starting_catcher_records
+            ),
+            "cutoff_count": len(
+                self.pitcher_pickoff_records
+            ),
+            "digest": self.digest,
+            "source": "archived_mlb_game_feed_boxscore",
+            "starting_catcher_identity_from_target_feed": True,
+            "target_game_outcomes_used": False,
+            "prior_feed_outcomes_only": True,
+            "future_data_permitted": False,
+            "historical_replay_executed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def source_historical_mlb_baserunning_feed_evidence(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    starting_pitcher_ids: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    target_game_feeds: Mapping[
+        int,
+        Mapping[str, Any],
+    ],
+    prior_game_feeds_by_cutoff: Mapping[
+        str,
+        Mapping[int, Mapping[str, Any]],
+    ],
+) -> CanonicalHistoricalMlbBaserunningFeedEvidence:
+    """
+    Source catcher identity and prior-game defensive outcomes.
+
+    Target feeds contribute identity only. Pickoff and catcher outcomes are
+    aggregated exclusively from feeds whose officialDate is on or before
+    the strict prior-day cutoff.
+    """
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    games_by_id = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+    expected_games = set(games_by_id)
+    starters = _normalize_starters(
+        values=starting_pitcher_ids,
+        expected=expected_games,
+    )
+
+    if not isinstance(target_game_feeds, Mapping):
+        raise TypeError(
+            "target_game_feeds must be a mapping"
+        )
+    if set(target_game_feeds) != expected_games:
+        raise ValueError(
+            "target game feeds must exactly cover "
+            "historical games"
+        )
+
+    required_cutoffs = {
+        (
+            date.fromisoformat(value.game_date)
+            - timedelta(days=1)
+        ).isoformat()
+        for value in lineup_bullpen.games
+    }
+
+    if not isinstance(
+        prior_game_feeds_by_cutoff,
+        Mapping,
+    ):
+        raise TypeError(
+            "prior_game_feeds_by_cutoff must be a mapping"
+        )
+    if set(prior_game_feeds_by_cutoff) != required_cutoffs:
+        raise ValueError(
+            "prior game feed cutoffs must exactly match "
+            "required prior-day cutoffs"
+        )
+
+    catcher_records = []
+    catchers_by_game = {}
+
+    for game_pk in sorted(
+        expected_games,
+        key=lambda value: (
+            games_by_id[value].game_date,
+            value,
+        ),
+    ):
+        feed = target_game_feeds[game_pk]
+
+        if not isinstance(feed, Mapping):
+            raise TypeError(
+                "target game feed values must be mappings"
+            )
+        if _official_date(feed) != (
+            games_by_id[game_pk].game_date
+        ):
+            raise ValueError(
+                "target game feed officialDate must "
+                "match historical game_date"
+            )
+
+        teams = _boxscore_teams(feed)
+        away_catcher = _starting_catcher(
+            _mapping(teams.get("away")),
+            game_pk=game_pk,
+            side="away",
+        )
+        home_catcher = _starting_catcher(
+            _mapping(teams.get("home")),
+            game_pk=game_pk,
+            side="home",
+        )
+
+        catchers_by_game[game_pk] = (
+            away_catcher,
+            home_catcher,
+        )
+        catcher_records.append(
+            (
+                game_pk,
+                away_catcher,
+                home_catcher,
+            )
+        )
+
+    pickoff_records = []
+    outcome_records = []
+
+    for cutoff in sorted(required_cutoffs):
+        feeds = prior_game_feeds_by_cutoff[cutoff]
+
+        if not isinstance(feeds, Mapping):
+            raise TypeError(
+                "prior cutoff values must be mappings"
+            )
+
+        pitcher_totals: Dict[str, int] = {}
+        catcher_totals: Dict[
+            str,
+            Tuple[int, int],
+        ] = {}
+
+        for raw_game_pk, feed in sorted(
+            feeds.items(),
+            key=lambda value: int(value[0]),
+        ):
+            try:
+                game_pk = int(raw_game_pk)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "prior game feed identifiers "
+                    "must be integers"
+                ) from exc
+
+            if game_pk <= 0:
+                raise ValueError(
+                    "prior game feed identifiers "
+                    "must be positive"
+                )
+            if not isinstance(feed, Mapping):
+                raise TypeError(
+                    "prior game feed values "
+                    "must be mappings"
+                )
+            if date.fromisoformat(
+                _official_date(feed)
+            ) > date.fromisoformat(cutoff):
+                raise ValueError(
+                    "prior game feeds cannot exceed cutoff"
+                )
+
+            for player in _team_players(feed):
+                player_id = _identifier(player)
+
+                if player_id is None:
+                    continue
+
+                stats = _mapping(
+                    player.get("stats")
+                )
+                pitching = _mapping(
+                    stats.get("pitching")
+                )
+                fielding = _mapping(
+                    stats.get("fielding")
+                )
+                position = _mapping(
+                    player.get("position")
+                )
+
+                if pitching:
+                    pitcher_totals[player_id] = (
+                        pitcher_totals.get(
+                            player_id,
+                            0,
+                        )
+                        + _count(
+                            pitching.get("pickoffs"),
+                            "pitching.pickoffs",
+                        )
+                    )
+
+                if (
+                    position.get("abbreviation") == "C"
+                    and fielding
+                ):
+                    prior_sb, prior_cs = (
+                        catcher_totals.get(
+                            player_id,
+                            (0, 0),
+                        )
+                    )
+                    catcher_totals[player_id] = (
+                        prior_sb
+                        + _count(
+                            fielding.get("stolenBases"),
+                            "fielding.stolenBases",
+                        ),
+                        prior_cs
+                        + _count(
+                            fielding.get("caughtStealing"),
+                            "fielding.caughtStealing",
+                        ),
+                    )
+
+        games_at_cutoff = tuple(
+            game
+            for game in lineup_bullpen.games
+            if (
+                date.fromisoformat(game.game_date)
+                - timedelta(days=1)
+            ).isoformat() == cutoff
+        )
+
+        required_pitchers = set()
+        required_catchers = set()
+
+        for game in games_at_cutoff:
+            away_starter, home_starter = (
+                starters[game.game_pk]
+            )
+            required_pitchers.update(
+                (
+                    away_starter,
+                    home_starter,
+                )
+                + game.away_bullpen_ids
+                + game.home_bullpen_ids
+            )
+            required_catchers.update(
+                catchers_by_game[game.game_pk]
+            )
+
+        for pitcher_id in required_pitchers:
+            pitcher_totals.setdefault(
+                pitcher_id,
+                0,
+            )
+        for catcher_id in required_catchers:
+            catcher_totals.setdefault(
+                catcher_id,
+                (0, 0),
+            )
+
+        pickoff_records.append(
+            (
+                cutoff,
+                tuple(
+                    sorted(
+                        pitcher_totals.items(),
+                        key=lambda value: int(value[0]),
+                    )
+                ),
+            )
+        )
+        outcome_records.append(
+            (
+                cutoff,
+                tuple(
+                    sorted(
+                        catcher_totals.items(),
+                        key=lambda value: int(value[0]),
+                    )
+                ),
+            )
+        )
+
+    canonical = {
+        "schema_version": (
+            CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION
+        ),
+        "starting_catchers": catcher_records,
+        "pitcher_pickoffs": pickoff_records,
+        "catcher_outcomes": outcome_records,
+        "target_game_outcomes_used": False,
+    }
+
+    return CanonicalHistoricalMlbBaserunningFeedEvidence(
+        starting_catcher_records=tuple(
+            catcher_records
+        ),
+        pitcher_pickoff_records=tuple(
+            pickoff_records
+        ),
+        catcher_outcome_records=tuple(
+            outcome_records
+        ),
+        digest=_sha256(canonical),
+    )

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
 import json
+import sys
+import time
+from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
@@ -12,6 +15,8 @@ from mlb_app.simulation.shadow import (
     define_historical_probability_reconstruction_inputs,
     materialize_historical_probability_artifacts,
     reconstruct_historical_pa_probability_workspaces,
+    source_historical_mlb_baserunning_counts,
+    source_historical_mlb_baserunning_feed_evidence,
     source_historical_lineup_bullpen_snapshots,
     source_historical_probability_statistics,
     source_mlb_play_by_play_baserunning_window,
@@ -53,11 +58,46 @@ def _json(url, params=None):
         },
     )
 
-    with urlopen(
-        request,
-        timeout=120,
-    ) as response:
-        return json.load(response)
+    maximum_attempts = 6
+
+    for attempt in range(
+        1,
+        maximum_attempts + 1,
+    ):
+        try:
+            with urlopen(
+                request,
+                timeout=120,
+            ) as response:
+                return json.load(response)
+        except (
+            URLError,
+            TimeoutError,
+            ConnectionError,
+            json.JSONDecodeError,
+        ) as error:
+            if attempt == maximum_attempts:
+                raise
+
+            delay_seconds = min(
+                2 ** (attempt - 1),
+                16,
+            )
+            print(
+                (
+                    "historical_source_retry "
+                    f"attempt={attempt} "
+                    f"delay_seconds={delay_seconds} "
+                    f"error={type(error).__name__}"
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay_seconds)
+
+    raise RuntimeError(
+        "historical source retry loop exhausted"
+    )
 
 
 def _completed_game_ids(schedule):
@@ -88,6 +128,16 @@ def _feed(game_pk):
                 game_pk=game_pk
             )
         ),
+    )
+
+
+def _feed_official_date(feed):
+    return (
+        (
+            (feed.get("gameData") or {})
+            .get("datetime")
+            or {}
+        ).get("officialDate")
     )
 
 
@@ -215,10 +265,78 @@ def main():
         ):
             payloads[cutoff][group] = payload
 
+    history_schedule = _json(
+        _SCHEDULE_URL,
+        {
+            "sportId": 1,
+            "gameType": "R",
+            "startDate": "2026-03-01",
+            "endDate": max(cutoffs),
+        },
+    )
+    history_game_ids = _completed_game_ids(
+        history_schedule
+    )
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        history_feeds = dict(
+            executor.map(
+                _feed,
+                history_game_ids,
+            )
+        )
+
+    prior_game_feeds_by_cutoff = {
+        cutoff: {
+            game_pk: feed
+            for game_pk, feed in history_feeds.items()
+            if (
+                _feed_official_date(feed)
+                and _feed_official_date(feed)
+                <= cutoff
+            )
+        }
+        for cutoff in cutoffs
+    }
+
+    starting_pitchers = _starters(feeds)
+
+    feed_evidence = (
+        source_historical_mlb_baserunning_feed_evidence(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=starting_pitchers,
+            target_game_feeds=feeds,
+            prior_game_feeds_by_cutoff=(
+                prior_game_feeds_by_cutoff
+            ),
+        )
+    )
+
+    baserunning_evidence = (
+        source_historical_mlb_baserunning_counts(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=starting_pitchers,
+            starting_catcher_ids=(
+                feed_evidence.starting_catcher_ids
+            ),
+            statistics_payloads=payloads,
+            pitcher_pickoffs_by_cutoff=(
+                feed_evidence
+                .pitcher_pickoffs_by_cutoff
+            ),
+            catcher_outcomes_by_cutoff=(
+                feed_evidence
+                .catcher_outcomes_by_cutoff
+            ),
+        )
+    )
+
     statistics = (
         source_historical_probability_statistics(
             lineup_bullpen=roster_window,
-            starting_pitcher_ids=_starters(feeds),
+            starting_pitcher_ids=starting_pitchers,
             statistics_payloads=payloads,
         )
     )
@@ -254,6 +372,13 @@ def main():
         ),
         "workspaces": workspaces.to_diagnostics(),
         "artifacts": artifacts.to_diagnostics(),
+        "baserunning_feed_evidence": (
+            feed_evidence.to_diagnostics()
+        ),
+        "baserunning_replay_evidence": (
+            baserunning_evidence.to_diagnostics()
+        ),
+        "history_feed_count": len(history_feeds),
         "cutoff_count": len(cutoffs),
         "request_count": len(requests),
         "historical_replay_executed": False,

--- a/tests/test_canonical_historical_mlb_baserunning_count_source.py
+++ b/tests/test_canonical_historical_mlb_baserunning_count_source.py
@@ -1,0 +1,232 @@
+import hashlib
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_MLB_BASERUNNING_COUNT_SOURCE_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    source_historical_mlb_baserunning_counts,
+)
+
+
+DIGEST = hashlib.sha256(b"fixture").hexdigest()
+
+
+def lineup_window():
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST,
+        games=(
+            CanonicalHistoricalLineupBullpenGameSnapshot(
+                game_pk=11,
+                game_date="2026-04-20",
+                away_lineup_ids=tuple(
+                    str(value)
+                    for value in range(1, 10)
+                ),
+                home_lineup_ids=tuple(
+                    str(value)
+                    for value in range(11, 20)
+                ),
+                away_bullpen_ids=("101",),
+                home_bullpen_ids=("102",),
+                lineup_digest=DIGEST,
+                bullpen_digest=DIGEST,
+            ),
+        ),
+        digest=DIGEST,
+    )
+
+
+def split(player_id, role):
+    if role == "hitting":
+        stats = {
+            "hits": 10,
+            "baseOnBalls": 4,
+            "hitByPitch": 1,
+            "homeRuns": 2,
+            "stolenBases": (
+                3 if player_id == 1 else 0
+            ),
+            "caughtStealing": (
+                1 if player_id == 1 else 0
+            ),
+        }
+    else:
+        stats = {
+            "battersFaced": 100,
+            "stolenBases": 4,
+            "caughtStealing": 1,
+        }
+
+    return {
+        "player": {"id": player_id},
+        "stat": stats,
+    }
+
+
+def payload(role, player_ids):
+    return {
+        "stats": [
+            {
+                "splits": [
+                    split(player_id, role)
+                    for player_id in player_ids
+                ]
+            }
+        ]
+    }
+
+
+def source():
+    hitter_ids = tuple(range(1, 10)) + tuple(
+        range(11, 20)
+    )
+    pitcher_ids = (100, 103, 101, 102)
+
+    return source_historical_mlb_baserunning_counts(
+        lineup_bullpen=lineup_window(),
+        starting_pitcher_ids={
+            11: ("100", "103"),
+        },
+        starting_catcher_ids={
+            11: ("2", "12"),
+        },
+        statistics_payloads={
+            "2026-04-19": {
+                "hitting": payload(
+                    "hitting",
+                    hitter_ids,
+                ),
+                "pitching": payload(
+                    "pitching",
+                    pitcher_ids,
+                ),
+            }
+        },
+        pitcher_pickoffs_by_cutoff={
+            "2026-04-19": {
+                str(value): 1
+                for value in pitcher_ids
+            }
+        },
+        catcher_outcomes_by_cutoff={
+            "2026-04-19": {
+                "2": (8, 2),
+                "12": (6, 3),
+            }
+        },
+    )
+
+
+def test_sources_complete_guarded_window():
+    result = source()
+    diagnostics = result.to_diagnostics()
+    game = result.games[0]
+
+    assert result.ready is True
+    assert result.game_count == 1
+    assert len(game.catalog.runners) == 18
+    assert len(game.catalog.pitchers) == 4
+    assert game.catalog.away_catcher.catcher_id == "2"
+    assert game.catalog.home_catcher.catcher_id == "12"
+    assert game.statistics_through_date == "2026-04-19"
+    assert diagnostics["target_game_outcomes_used"] is False
+    assert diagnostics["future_data_permitted"] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_runner_counts_use_prior_statistics():
+    result = source()
+    runner = result.games[0].catalog.runners[0]
+
+    assert runner.runner_id == "1"
+    assert runner.attempt_rate == pytest.approx(
+        4 / 13
+    )
+    assert runner.success_rate == pytest.approx(
+        3 / 4
+    )
+
+
+def test_inputs_require_exact_cutoff_coverage():
+    with pytest.raises(
+        ValueError,
+        match="exactly match required prior-day cutoffs",
+    ):
+        source_historical_mlb_baserunning_counts(
+            lineup_bullpen=lineup_window(),
+            starting_pitcher_ids={
+                11: ("100", "103"),
+            },
+            starting_catcher_ids={
+                11: ("2", "12"),
+            },
+            statistics_payloads={},
+            pitcher_pickoffs_by_cutoff={},
+            catcher_outcomes_by_cutoff={},
+        )
+
+
+def test_pickoffs_require_all_pitchers():
+    hitter_ids = tuple(range(1, 10)) + tuple(
+        range(11, 20)
+    )
+    pitcher_ids = (100, 103, 101, 102)
+
+    with pytest.raises(
+        ValueError,
+        match="every required pitcher",
+    ):
+        source_historical_mlb_baserunning_counts(
+            lineup_bullpen=lineup_window(),
+            starting_pitcher_ids={
+                11: ("100", "103"),
+            },
+            starting_catcher_ids={
+                11: ("2", "12"),
+            },
+            statistics_payloads={
+                "2026-04-19": {
+                    "hitting": payload(
+                        "hitting",
+                        hitter_ids,
+                    ),
+                    "pitching": payload(
+                        "pitching",
+                        pitcher_ids,
+                    ),
+                }
+            },
+            pitcher_pickoffs_by_cutoff={
+                "2026-04-19": {
+                    "100": 1,
+                }
+            },
+            catcher_outcomes_by_cutoff={
+                "2026-04-19": {
+                    "2": (8, 2),
+                    "12": (6, 3),
+                }
+            },
+        )
+
+
+def test_source_is_deterministic():
+    first = source()
+    second = source()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_MLB_BASERUNNING_COUNT_SOURCE_VERSION
+        == "canonical_historical_mlb_baserunning_count_source_v1"
+    )

--- a/tests/test_canonical_historical_mlb_baserunning_feed_source.py
+++ b/tests/test_canonical_historical_mlb_baserunning_feed_source.py
@@ -1,0 +1,314 @@
+import hashlib
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    source_historical_mlb_baserunning_feed_evidence,
+)
+
+
+DIGEST = hashlib.sha256(b"fixture").hexdigest()
+
+
+def player(
+    player_id,
+    position,
+    batting_order=None,
+    *,
+    pickoffs=0,
+    stolen_bases=0,
+    caught_stealing=0,
+    all_positions=None,
+):
+    value = {
+        "person": {"id": player_id},
+        "position": {
+            "abbreviation": position,
+        },
+        "stats": {
+            "pitching": (
+                {"pickoffs": pickoffs}
+                if position == "P"
+                else {}
+            ),
+            "fielding": (
+                {
+                    "stolenBases": stolen_bases,
+                    "caughtStealing": caught_stealing,
+                }
+                if position == "C"
+                else {}
+            ),
+        },
+    }
+
+    if batting_order is not None:
+        value["battingOrder"] = batting_order
+
+    if all_positions is not None:
+        value["allPositions"] = [
+            {"abbreviation": abbreviation}
+            for abbreviation in all_positions
+        ]
+
+    return value
+
+
+def feed(
+    official_date,
+    away_players,
+    home_players,
+):
+    return {
+        "gameData": {
+            "datetime": {
+                "officialDate": official_date,
+            }
+        },
+        "liveData": {
+            "boxscore": {
+                "teams": {
+                    "away": {
+                        "players": away_players,
+                    },
+                    "home": {
+                        "players": home_players,
+                    },
+                }
+            }
+        },
+    }
+
+
+def lineup_window():
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST,
+        games=(
+            CanonicalHistoricalLineupBullpenGameSnapshot(
+                game_pk=11,
+                game_date="2026-04-20",
+                away_lineup_ids=tuple(
+                    str(value)
+                    for value in range(1, 10)
+                ),
+                home_lineup_ids=tuple(
+                    str(value)
+                    for value in range(11, 20)
+                ),
+                away_bullpen_ids=("101",),
+                home_bullpen_ids=("102",),
+                lineup_digest=DIGEST,
+                bullpen_digest=DIGEST,
+            ),
+        ),
+        digest=DIGEST,
+    )
+
+
+def target_feed():
+    return feed(
+        "2026-04-20",
+        {
+            "ID2": player(
+                2,
+                "C",
+                "200",
+            ),
+        },
+        {
+            "ID12": player(
+                12,
+                "C",
+                "200",
+            ),
+        },
+    )
+
+
+def prior_feed(
+    official_date="2026-04-19",
+):
+    return feed(
+        official_date,
+        {
+            "ID100": player(
+                100,
+                "P",
+                pickoffs=2,
+            ),
+            "ID2": player(
+                2,
+                "C",
+                stolen_bases=4,
+                caught_stealing=1,
+            ),
+        },
+        {
+            "ID103": player(
+                103,
+                "P",
+                pickoffs=1,
+            ),
+            "ID12": player(
+                12,
+                "C",
+                stolen_bases=3,
+                caught_stealing=2,
+            ),
+        },
+    )
+
+
+def source():
+    return source_historical_mlb_baserunning_feed_evidence(
+        lineup_bullpen=lineup_window(),
+        starting_pitcher_ids={
+            11: ("100", "103"),
+        },
+        target_game_feeds={
+            11: target_feed(),
+        },
+        prior_game_feeds_by_cutoff={
+            "2026-04-19": {
+                10: prior_feed(),
+            }
+        },
+    )
+
+
+def test_sources_identity_and_prior_outcomes():
+    result = source()
+    diagnostics = result.to_diagnostics()
+
+    assert result.starting_catcher_ids == {
+        11: ("2", "12"),
+    }
+    assert (
+        result.pitcher_pickoffs_by_cutoff[
+            "2026-04-19"
+        ]["100"]
+        == 2
+    )
+    assert (
+        result.pitcher_pickoffs_by_cutoff[
+            "2026-04-19"
+        ]["101"]
+        == 0
+    )
+    assert (
+        result.catcher_outcomes_by_cutoff[
+            "2026-04-19"
+        ]["2"]
+        == (4, 1)
+    )
+    assert diagnostics[
+        "starting_catcher_identity_from_target_feed"
+    ] is True
+    assert diagnostics["target_game_outcomes_used"] is False
+    assert diagnostics["prior_feed_outcomes_only"] is True
+    assert diagnostics["production_activation"] is False
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_future_feed_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="cannot exceed cutoff",
+    ):
+        source_historical_mlb_baserunning_feed_evidence(
+            lineup_bullpen=lineup_window(),
+            starting_pitcher_ids={
+                11: ("100", "103"),
+            },
+            target_game_feeds={
+                11: target_feed(),
+            },
+            prior_game_feeds_by_cutoff={
+                "2026-04-19": {
+                    10: prior_feed(
+                        "2026-04-20"
+                    ),
+                }
+            },
+        )
+
+
+def test_starting_catcher_is_required():
+    invalid = target_feed()
+    invalid["liveData"]["boxscore"]["teams"][
+        "away"
+    ]["players"]["ID2"]["battingOrder"] = "201"
+
+    with pytest.raises(
+        ValueError,
+        match="exactly one starting catcher",
+    ):
+        source_historical_mlb_baserunning_feed_evidence(
+            lineup_bullpen=lineup_window(),
+            starting_pitcher_ids={
+                11: ("100", "103"),
+            },
+            target_game_feeds={
+                11: invalid,
+            },
+            prior_game_feeds_by_cutoff={
+                "2026-04-19": {
+                    10: prior_feed(),
+                }
+            },
+        )
+
+
+def test_starting_catcher_uses_first_recorded_position():
+    target = target_feed()
+    target["liveData"]["boxscore"]["teams"][
+        "home"
+    ]["players"]["ID20"] = player(
+        20,
+        "C",
+        "100",
+        all_positions=("DH", "C"),
+    )
+
+    result = (
+        source_historical_mlb_baserunning_feed_evidence(
+            lineup_bullpen=lineup_window(),
+            starting_pitcher_ids={
+                11: ("100", "103"),
+            },
+            target_game_feeds={
+                11: target,
+            },
+            prior_game_feeds_by_cutoff={
+                "2026-04-19": {
+                    10: prior_feed(),
+                }
+            },
+        )
+    )
+
+    assert result.starting_catcher_ids == {
+        11: ("2", "12"),
+    }
+
+
+def test_source_is_deterministic():
+    first = source()
+    second = source()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_MLB_BASERUNNING_FEED_SOURCE_VERSION
+        == "canonical_historical_mlb_baserunning_feed_source_v1"
+    )


### PR DESCRIPTION
## Summary

- source cutoff-safe historical runner, pitcher, and catcher baserunning counts from MLB statistics and archived game feeds
- resolve starting-catcher identity from the target game while sourcing outcomes only from prior feeds
- materialize deterministic baserunning evidence and integrate it with the historical probability-statistics runner
- add bounded retry/backoff for transient MLB API failures
- preserve legacy production authority and keep stolen-base activation disabled

## Historical validation

- executed the complete deterministic 2026-04-20 through 2026-05-03 window successfully
- reconstructed all 185 games with `ready_game_count=185`
- preserved observed window digest `0f9eb719d8b513f5c7cf01275128533938eba6ddff9a902910f0feb1c1af08bb`
- verified prior-day-only evidence sourcing and handled the archived DH-to-catcher substitution case without misidentifying the starter
- `production_activation=false`
- `production_authority_changed=false`
- `authoritative_source=legacy`

## Checks

- 282 targeted historical, baserunning, simulation, projection, and scoring tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment