### PR TITLE
Expand MyDashboard report objects and filtering

### DIFF
--- a/frontend/src/lib/dashboardReportBuilderState.mjs
+++ b/frontend/src/lib/dashboardReportBuilderState.mjs
@@ -3,13 +3,16 @@ import { queryPayload } from './dashboardQueryState.mjs'
 export const CANONICAL_REPORT_TYPES = {
   hitters: 'all_active_hitters',
   pitchers: 'all_active_pitchers',
+  teams: 'teams_daily_analysis',
+  totals: 'games_totals_analysis',
+  overall_players: 'overall_players_daily_analysis',
+  model_projections: 'model_projection_games',
+  model_projection_players: 'model_projection_players',
+  model_tracker: 'model_tracker_snapshots',
+  batter_arsenal: 'competitive_batter_arsenal',
 }
 
 const LEGACY_DEFAULT_FIELDS = ['rank', 'entity_name', 'team', 'opponent', 'score', 'confidence']
-
-function usesLegacyLineupDataset(objectKey, activeLineupsOnly) {
-  return Boolean(activeLineupsOnly && objectKey === 'overall_players')
-}
 
 export const DEFAULT_FIELDS_BY_OBJECT = {
   hitters: ['rank', 'full_name', 'team_name', 'model_score', 'confidence'],
@@ -17,6 +20,10 @@ export const DEFAULT_FIELDS_BY_OBJECT = {
   teams: LEGACY_DEFAULT_FIELDS,
   totals: ['rank', 'entity_name', 'score', 'confidence'],
   overall_players: LEGACY_DEFAULT_FIELDS,
+  model_projections: ['game_pk', 'away_team_name', 'home_team_name', 'away_win_probability', 'home_win_probability', 'projected_total'],
+  model_projection_players: ['full_name', 'player_type', 'team_name', 'projected_dfs_points', 'dfs_floor', 'dfs_ceiling'],
+  model_tracker: ['snapshot_date', 'pick_label', 'model_name', 'score', 'grade', 'result_status'],
+  batter_arsenal: ['batter_name', 'pitcher_pitch_name', 'pitcher_usage_pct', 'pitches_seen', 'xwoba', 'edge_score', 'matchup_confidence'],
 }
 
 export function defaultFieldsForObject(objectKey) {
@@ -34,13 +41,19 @@ export function initialFieldsByObject(objects, persisted = {}) {
 }
 
 export function reportFieldsForMode({ objectKey, activeLineupsOnly, selectedFields }) {
-  if (usesLegacyLineupDataset(objectKey, activeLineupsOnly)) return [...LEGACY_DEFAULT_FIELDS]
   return Array.isArray(selectedFields) && selectedFields.length
     ? [...selectedFields]
     : defaultFieldsForObject(objectKey)
 }
 
-export function canonicalSortField(field) {
+export function canonicalSortField(field, objectKey) {
+  if (field === 'score') {
+    if (objectKey === 'model_projections') return 'home_win_probability'
+    if (objectKey === 'model_projection_players') return 'projected_dfs_points'
+    if (objectKey === 'batter_arsenal') return 'pitches_seen'
+    if (objectKey === 'model_tracker') return 'score'
+  }
+  if (!['hitters', 'pitchers'].includes(objectKey)) return field
   return ({
     entity_name: 'full_name',
     team: 'team_name',
@@ -50,8 +63,7 @@ export function canonicalSortField(field) {
 }
 
 export function buildReportRequest({ objectKey, activeLineupsOnly, date, cleanedFilters, query }) {
-  const useLineups = usesLegacyLineupDataset(objectKey, activeLineupsOnly)
-  const reportType = useLineups ? null : CANONICAL_REPORT_TYPES[objectKey]
+  const reportType = CANONICAL_REPORT_TYPES[objectKey]
   const confirmedCanonicalHitters = Boolean(
     activeLineupsOnly && objectKey === 'hitters' && reportType,
   )
@@ -67,15 +79,20 @@ export function buildReportRequest({ objectKey, activeLineupsOnly, date, cleaned
         weights,
         page_size: query.page_size,
         page_number: query.page_number,
-        sort_by: canonicalSortField(query.sort_by),
+        sort_by: canonicalSortField(query.sort_by, objectKey),
         sort_direction: query.sort_direction,
         include_metadata: true,
-        confirmed_lineups_only: confirmedCanonicalHitters,
+        confirmed_lineups_only: Boolean(
+          activeLineupsOnly && (
+            confirmedCanonicalHitters ||
+            objectKey === 'overall_players'
+          )
+        ),
       },
     }
   }
   return {
-    path: useLineups ? '/my-dashboard/solver/active-lineups' : '/my-dashboard/solver',
+    path: '/my-dashboard/solver',
     reportType: null,
     payload: queryPayload({ date, component: objectKey, filters: cleanedFilters, query }),
   }
@@ -108,10 +125,10 @@ export function normalizeCanonicalPage(json, query) {
   const total = Number(json?.totalSize || 0)
   const records = Array.isArray(json?.records) ? json.records : []
   const pageCount = total ? Math.ceil(total / query.page_size) : 0
-  const hasNext = Boolean(json?.page_info?.has_next_page)
+  const hasNext = Boolean(json?.page_info?.has_next_page ?? json?.page_info?.has_next)
   return {
     ...json,
-    execution_path: 'dashboard_player_current_sql_query',
+    execution_path: json?.execution_path || 'catalog_report_query',
     page_info: {
       ...json?.page_info,
       page_number: query.page_number,
@@ -135,7 +152,9 @@ export function reportExecutionFacts(result) {
     ? 'Confirmed 1–9'
     : population.mode === 'all_active'
       ? 'All active players'
-      : 'Legacy report population'
+      : population.mode === 'daily_dataset'
+        ? 'Daily report population'
+        : 'Legacy report population'
   return {
     mode,
     lineupStatus: lineup.lineup_status || null,

--- a/frontend/src/lib/dashboardReportBuilderState.test.mjs
+++ b/frontend/src/lib/dashboardReportBuilderState.test.mjs
@@ -37,13 +37,18 @@ test('weights rerank canonical players without becoming filter criteria', () => 
   assert.deepEqual(request.payload.weights, { 'K%': 1.6 })
 })
 
-test('confirmed hitters use the canonical report population while noncanonical objects preserve legacy routes', () => {
-  assert.equal(buildReportRequest({ objectKey: 'teams', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query }).path, '/my-dashboard/solver')
+test('confirmed and expanded objects use registered report populations', () => {
+  const teams = buildReportRequest({ objectKey: 'teams', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query })
+  assert.equal(teams.path, '/my-dashboard/reports/query')
+  assert.equal(teams.payload.report_type, 'teams_daily_analysis')
   const hitters = buildReportRequest({ objectKey: 'hitters', activeLineupsOnly: true, date: '2026-07-16', cleanedFilters: {}, query })
   assert.equal(hitters.path, '/my-dashboard/reports/query')
   assert.equal(hitters.payload.report_type, 'all_active_hitters')
   assert.equal(hitters.payload.confirmed_lineups_only, true)
-  assert.equal(buildReportRequest({ objectKey: 'overall_players', activeLineupsOnly: true, date: '2026-07-16', cleanedFilters: {}, query }).path, '/my-dashboard/solver/active-lineups')
+  const overall = buildReportRequest({ objectKey: 'overall_players', activeLineupsOnly: true, date: '2026-07-16', cleanedFilters: {}, query })
+  assert.equal(overall.path, '/my-dashboard/reports/query')
+  assert.equal(overall.payload.report_type, 'overall_players_daily_analysis')
+  assert.equal(overall.payload.confirmed_lineups_only, true)
 })
 
 test('confirmed hitter reports preserve canonical fields', () => {
@@ -95,6 +100,18 @@ test('primary objects own independent default column selections', () => {
   assert.deepEqual(fields.pitchers, ['rank', 'full_name', 'team_name', 'model_score', 'confidence'])
   fields.hitters.push('xwoba')
   assert.equal(fields.pitchers.includes('xwoba'), false)
+})
+
+test('projection, tracker, and competitive objects use safe registered sort defaults', () => {
+  const projection = buildReportRequest({ objectKey: 'model_projections', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query })
+  const players = buildReportRequest({ objectKey: 'model_projection_players', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query })
+  const tracker = buildReportRequest({ objectKey: 'model_tracker', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query })
+  const arsenal = buildReportRequest({ objectKey: 'batter_arsenal', activeLineupsOnly: false, date: '2026-07-16', cleanedFilters: {}, query })
+  assert.equal(projection.payload.report_type, 'model_projection_games')
+  assert.equal(projection.payload.sort_by, 'home_win_probability')
+  assert.equal(players.payload.sort_by, 'projected_dfs_points')
+  assert.equal(tracker.payload.sort_by, 'score')
+  assert.equal(arsenal.payload.sort_by, 'pitches_seen')
 })
 
 test('canonical pagination is adapted to the Report Workspace contract', () => {

--- a/frontend/src/lib/dashboardWorkspaceRouteContract.test.mjs
+++ b/frontend/src/lib/dashboardWorkspaceRouteContract.test.mjs
@@ -19,13 +19,18 @@ test('the routed page owns both the signed-out landing and authenticated workspa
   assert.match(workspaceSource, /Build your report\./)
 })
 
-test('hitter and pitcher filters use the server catalog and persist match-all or match-any logic', () => {
+test('registered report objects use the server catalog and persist match-all or match-any logic', () => {
   assert.match(workspaceSource, /FILTER_LOGIC_OPTIONS/)
   assert.match(workspaceSource, /filterableReportFields\(fields\)/)
   assert.match(workspaceSource, /normalizeSavedFilters\(definition\.filters/)
   assert.match(workspaceSource, /schema_version: 4/)
   assert.match(adminSource, />Report</)
   assert.match(adminSource, /object\.filtering\?\.logic/)
+  assert.match(workspaceSource, /key: 'model_projections'/)
+  assert.match(workspaceSource, /key: 'model_projection_players'/)
+  assert.match(workspaceSource, /key: 'model_tracker'/)
+  assert.match(workspaceSource, /key: 'batter_arsenal'/)
+  assert.match(workspaceSource, /WEIGHTED_OBJECTS\.has\(objectKey\)/)
 })
 
 test('Query Studio visibility is capability-derived and the server remains the execution boundary', () => {

--- a/frontend/src/pages/MyDashboardReportBuilderPage.jsx
+++ b/frontend/src/pages/MyDashboardReportBuilderPage.jsx
@@ -17,8 +17,13 @@ const OBJECTS = [
   { key: 'teams', label: 'Teams', description: 'Team offense, projected runs, side edge, and matchup fields.' },
   { key: 'totals', label: 'Totals', description: 'Projected game totals, run environment, and simulation fields.' },
   { key: 'overall_players', label: 'Overall Players', description: 'Combined hitter and pitcher report.' },
+  { key: 'model_projections', label: 'Model Projections', description: 'Game-level projection probabilities, runs, teams, starters, and freshness.' },
+  { key: 'model_projection_players', label: 'Projection Players', description: 'Player-level projection rows related to each Model Projections game.' },
+  { key: 'model_tracker', label: 'Model Tracker', description: 'Read-only model snapshots, picks, outcomes, grades, and audit fields.' },
+  { key: 'batter_arsenal', label: 'Batter vs Arsenal', description: 'Pitch-type matchup history used by the competitive matchup overview.' },
 ]
 const ACTIVE_LINEUP_OBJECTS = new Set(['hitters', 'overall_players'])
+const WEIGHTED_OBJECTS = new Set(['hitters', 'pitchers', 'teams', 'totals', 'overall_players'])
 const DEFAULT_FIELDS = ['rank', 'entity_name', 'team', 'opponent', 'score', 'confidence']
 const BASE_FIELDS = [
   ['rank', 'Rank', 'Identity'], ['entity_name', 'Name', 'Identity'], ['entity_id', 'Entity ID', 'Identity'],
@@ -162,7 +167,9 @@ function CanonicalFilterPanel({ objectKey, filters, fields, setBasic, setWeight 
   const available = filterableReportFields(fields)
   const grouped = available.reduce((map, field) => ({ ...map, [field.group]: [...(map[field.group] || []), field] }), {})
   const conditions = Array.isArray(filters.conditions) ? filters.conditions : []
-  const metrics = fields.filter(field => field.group && !['Identity', 'Team', 'Audit'].includes(field.group) && field.dataType === 'double').slice(0, 6)
+  const metrics = WEIGHTED_OBJECTS.has(objectKey)
+    ? fields.filter(field => field.group && !['Identity', 'Team', 'Audit'].includes(field.group) && field.dataType === 'double').slice(0, 6)
+    : []
   function replaceConditions(next) { setBasic(objectKey, 'conditions', next) }
   function updateCondition(index, patch) { replaceConditions(conditions.map((condition, conditionIndex) => conditionIndex === index ? { ...condition, ...patch } : condition)) }
   return <section style={s.card}>
@@ -173,7 +180,7 @@ function CanonicalFilterPanel({ objectKey, filters, fields, setBasic, setWeight 
       const operators = field?.supportedOperators?.length ? field.supportedOperators : ['eq']
       const operator = operators.includes(condition.operator) ? condition.operator : defaultOperator(field)
       const needsValue = operatorNeedsValue(operator)
-      const confidenceValues = field?.accessor === 'confidence'
+      const confidenceValues = field?.accessor === 'confidence' && field?.dataType === 'string'
       return <div style={s.conditionCard} key={`${condition.field}-${index}`}>
         <span style={s.conditionNumber}>{index + 1}</span>
         <label style={s.filterControl}><span>Field</span><select style={s.input} value={field?.accessor || ''} onChange={event => {
@@ -186,7 +193,7 @@ function CanonicalFilterPanel({ objectKey, filters, fields, setBasic, setWeight 
       </div>
     })}</div>
     <button type="button" style={s.addCondition} disabled={!available.length} onClick={() => replaceConditions([...conditions, newFilterCondition(fields)])}>+ Add filter</button>
-    <div style={s.sectionLabel}>Scoring weights</div><div style={s.metricGrid}>{metrics.map(field => { const value = Number(filters.weights?.[field.accessor] ?? 1); return <label style={s.metricCard} key={`weight-${field.accessor}`}><span>{field.label}</span><input type="range" min="0" max="2" step="0.1" value={value} onChange={event => setWeight(objectKey, field.accessor, event.target.value)} /><b>{value.toFixed(1)}</b></label> })}</div>
+    {metrics.length ? <><div style={s.sectionLabel}>Scoring weights</div><div style={s.metricGrid}>{metrics.map(field => { const weightKey = field.accessor.startsWith('metrics.') ? field.accessor.slice(8) : field.accessor; const value = Number(filters.weights?.[weightKey] ?? 1); return <label style={s.metricCard} key={`weight-${field.accessor}`}><span>{field.label}</span><input type="range" min="0" max="2" step="0.1" value={value} onChange={event => setWeight(objectKey, weightKey, event.target.value)} /><b>{value.toFixed(1)}</b></label> })}</div></> : null}
   </section>
 }
 function FilterPanel({ objectKey, filters, fields, setBasic, setMetric, setWeight }) {

--- a/mlb_app/dashboard_player_report_query.py
+++ b/mlb_app/dashboard_player_report_query.py
@@ -41,7 +41,11 @@ def _field_map(report_type: str) -> Dict[str, Dict[str, Any]]:
 
 
 def _validate_report_type(report_type: str) -> Dict[str, Any]:
-    if report_type not in REPORT_TYPES or not REPORT_TYPES[report_type].get("queryable"):
+    if (
+        report_type not in REPORT_TYPES
+        or not REPORT_TYPES[report_type].get("queryable")
+        or REPORT_TYPES[report_type].get("base_object") != "dashboard_player_current"
+    ):
         raise ValueError(f"Unsupported queryable report type: {report_type}")
     return REPORT_TYPES[report_type]
 

--- a/mlb_app/dashboard_projection_report_query.py
+++ b/mlb_app/dashboard_projection_report_query.py
@@ -1,0 +1,412 @@
+"""Read-only report adapters over the shared Model Projections artifact."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .dashboard_report_types import FIELD_CATALOG, REPORT_TYPES, describe_report_type
+from .model_projection_routes import get_model_projection_payload
+
+
+REPORT_TYPES_SUPPORTED = {"model_projection_games", "model_projection_players"}
+PLAYER_METRICS = (
+    "plate_appearances", "singles", "doubles", "triples", "home_runs", "runs",
+    "rbi", "rbis", "walks", "stolen_bases", "strikeouts", "batters_faced",
+    "outs_recorded", "outs", "hits_allowed", "hits", "hit_by_pitch",
+    "hit_batters", "runs_allowed", "earned_runs", "earned_runs_allowed",
+)
+
+
+def _object(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _metric_mean(row: Dict[str, Any], *names: str) -> Optional[float]:
+    metrics = _object(row.get("metrics"))
+    for name in names:
+        metric = _object(metrics.get(name))
+        value = metric.get("mean")
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _projection_simulation(game: Dict[str, Any]) -> Dict[str, Any]:
+    outputs = _object(_object(game.get("sharedSimulation")).get("derived_outputs"))
+    return (
+        _object(outputs.get("bullpen_adjusted_game_simulation"))
+        or _object(outputs.get("game_simulation"))
+        or _object(_object(game.get("workspace")).get("bullpenAdjustedGameSimulation"))
+    )
+
+
+def _path(value: Any, *parts: str) -> Any:
+    current = value
+    for part in parts:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _projection_profiles(game: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    workspace = _object(game.get("workspace"))
+    shared = _object(game.get("sharedSimulation"))
+    direct = _object(shared.get("direct_inputs"))
+    return {
+        "away_pitcher": _object(direct.get("away_pitcher_profile") or workspace.get("awayPitcherProfile")),
+        "home_pitcher": _object(direct.get("home_pitcher_profile") or workspace.get("homePitcherProfile")),
+        "away_offense": _object(direct.get("away_offense_profile") or workspace.get("awayOffenseProfile")),
+        "home_offense": _object(direct.get("home_offense_profile") or workspace.get("homeOffenseProfile")),
+        "away_bullpen": _object(direct.get("away_bullpen_profile") or workspace.get("awayBullpenProfile")),
+        "home_bullpen": _object(direct.get("home_bullpen_profile") or workspace.get("homeBullpenProfile")),
+        "environment": _object(direct.get("environment_profile") or workspace.get("environmentProfile")),
+        "away_matchup": _object(workspace.get("awayMatchupAnalysis")),
+        "home_matchup": _object(workspace.get("homeMatchupAnalysis")),
+    }
+
+
+def _game_rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for game in payload.get("games") or []:
+        if not isinstance(game, dict):
+            continue
+        away_team = _object(game.get("away_team"))
+        home_team = _object(game.get("home_team"))
+        away_pitcher = _object(game.get("away_pitcher"))
+        home_pitcher = _object(game.get("home_pitcher"))
+        probability = _object(game.get("model_projection_probability") or game.get("probability"))
+        simulation = _projection_simulation(game)
+        profiles = _projection_profiles(game)
+        shared_meta = _object(_object(game.get("sharedSimulation")).get("meta"))
+        venue = game.get("venue")
+        if isinstance(venue, dict):
+            venue = venue.get("name")
+        away_runs = simulation.get("away_expected_runs")
+        if away_runs is None:
+            away_runs = simulation.get("away_runs_mean")
+        if away_runs is None:
+            away_runs = simulation.get("projected_away_runs")
+        home_runs = simulation.get("home_expected_runs")
+        if home_runs is None:
+            home_runs = simulation.get("home_runs_mean")
+        if home_runs is None:
+            home_runs = simulation.get("projected_home_runs")
+        total = simulation.get("total_expected_runs")
+        if total is None:
+            total = simulation.get("total_runs_mean")
+        if total is None:
+            total = simulation.get("projected_total")
+        if total is None and away_runs is not None and home_runs is not None:
+            total = float(away_runs) + float(home_runs)
+        totals = _object(
+            simulation.get("calibrated_total_probabilities")
+            or simulation.get("total_probabilities")
+        )
+        away_pitcher_profile = profiles["away_pitcher"]
+        home_pitcher_profile = profiles["home_pitcher"]
+        away_offense_profile = profiles["away_offense"]
+        home_offense_profile = profiles["home_offense"]
+        away_bullpen_profile = profiles["away_bullpen"]
+        home_bullpen_profile = profiles["home_bullpen"]
+        environment = profiles["environment"]
+        rows.append({
+            "game_pk": game.get("game_pk"),
+            "game_date": game.get("game_date") or payload.get("date"),
+            "game_time": game.get("game_time"),
+            "status": game.get("status"),
+            "venue": venue,
+            "away_team_id": away_team.get("id"),
+            "away_team_name": away_team.get("name"),
+            "home_team_id": home_team.get("id"),
+            "home_team_name": home_team.get("name"),
+            "away_pitcher_id": away_pitcher.get("id"),
+            "away_pitcher_name": away_pitcher.get("name"),
+            "home_pitcher_id": home_pitcher.get("id"),
+            "home_pitcher_name": home_pitcher.get("name"),
+            "away_win_probability": probability.get("away_win_probability") or game.get("away_win_probability"),
+            "home_win_probability": probability.get("home_win_probability") or game.get("home_win_probability"),
+            "projected_away_runs": away_runs,
+            "projected_home_runs": home_runs,
+            "projected_total": total,
+            "model_version": probability.get("model_version") or game.get("model_version"),
+            "probability_source": game.get("probability_source") or probability.get("source"),
+            "probability_is_fallback": game.get("probability_is_fallback") if game.get("probability_is_fallback") is not None else probability.get("is_fallback"),
+            "lineup_status": game.get("lineup_status"),
+            "data_confidence": game.get("data_confidence"),
+            "away_starter_k_rate": _path(away_pitcher_profile, "bat_missing", "k_rate"),
+            "away_starter_bb_rate": _path(away_pitcher_profile, "command_control", "bb_rate"),
+            "away_starter_xwoba_allowed": _path(away_pitcher_profile, "contact_management", "xwoba_allowed"),
+            "away_starter_hard_hit_rate_allowed": _path(away_pitcher_profile, "contact_management", "hard_hit_rate_allowed"),
+            "home_starter_k_rate": _path(home_pitcher_profile, "bat_missing", "k_rate"),
+            "home_starter_bb_rate": _path(home_pitcher_profile, "command_control", "bb_rate"),
+            "home_starter_xwoba_allowed": _path(home_pitcher_profile, "contact_management", "xwoba_allowed"),
+            "home_starter_hard_hit_rate_allowed": _path(home_pitcher_profile, "contact_management", "hard_hit_rate_allowed"),
+            "away_offense_k_rate": _path(away_offense_profile, "contact_skill", "k_rate"),
+            "away_offense_bb_rate": _path(away_offense_profile, "plate_discipline", "bb_rate"),
+            "away_offense_obp": _path(away_offense_profile, "plate_discipline", "on_base_pct"),
+            "away_offense_iso": _path(away_offense_profile, "power", "iso"),
+            "away_offense_slg": _path(away_offense_profile, "power", "slugging_pct"),
+            "home_offense_k_rate": _path(home_offense_profile, "contact_skill", "k_rate"),
+            "home_offense_bb_rate": _path(home_offense_profile, "plate_discipline", "bb_rate"),
+            "home_offense_obp": _path(home_offense_profile, "plate_discipline", "on_base_pct"),
+            "home_offense_iso": _path(home_offense_profile, "power", "iso"),
+            "home_offense_slg": _path(home_offense_profile, "power", "slugging_pct"),
+            "away_bullpen_k_rate": _path(away_bullpen_profile, "bat_missing", "k_rate"),
+            "away_bullpen_bb_rate": _path(away_bullpen_profile, "command_control", "bb_rate"),
+            "away_bullpen_xwoba_allowed": _path(away_bullpen_profile, "contact_management", "xwoba_allowed"),
+            "home_bullpen_k_rate": _path(home_bullpen_profile, "bat_missing", "k_rate"),
+            "home_bullpen_bb_rate": _path(home_bullpen_profile, "command_control", "bb_rate"),
+            "home_bullpen_xwoba_allowed": _path(home_bullpen_profile, "contact_management", "xwoba_allowed"),
+            "run_scoring_index": _path(environment, "run_environment", "run_scoring_index"),
+            "hr_boost_index": _path(environment, "run_environment", "hr_boost_index"),
+            "hit_boost_index": _path(environment, "run_environment", "hit_boost_index"),
+            "temperature_f": _path(environment, "weather", "temperature_f"),
+            "weather_condition": _path(environment, "weather", "condition"),
+            "wind_speed_mph": _path(environment, "weather", "wind_speed_mph"),
+            "wind_direction": _path(environment, "weather", "wind_direction"),
+            "away_matchup_biggest_edge": _path(profiles["away_matchup"], "summary", "biggest_edge"),
+            "away_matchup_confidence": _path(profiles["away_matchup"], "summary", "confidence"),
+            "home_matchup_biggest_edge": _path(profiles["home_matchup"], "summary", "biggest_edge"),
+            "home_matchup_confidence": _path(profiles["home_matchup"], "summary", "confidence"),
+            "simulation_count": shared_meta.get("simulation_count") or simulation.get("simulations") or _path(simulation, "metadata", "simulation_count"),
+            "tie_after_regulation_probability": simulation.get("tie_after_regulation_probability"),
+            "over_8_5_probability": totals.get("over_8.5"),
+            "under_8_5_probability": totals.get("under_8.5"),
+        })
+    return rows
+
+
+def _player_rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for game in payload.get("games") or []:
+        if not isinstance(game, dict):
+            continue
+        shared = _object(game.get("sharedSimulation"))
+        shared_diagnostics = _object(shared.get("diagnostics"))
+        top_diagnostics = _object(game.get("diagnostics"))
+        shadow = (
+            _object(top_diagnostics.get("canonical_shadow"))
+            or _object(shared_diagnostics.get("canonical_shadow"))
+        )
+        projections = _object(shadow.get("player_projections"))
+        for player in projections.get("players") or []:
+            if not isinstance(player, dict):
+                continue
+            record = {
+                "game_pk": game.get("game_pk"),
+                "game_date": game.get("game_date") or payload.get("date"),
+                "mlb_player_id": player.get("mlb_player_id") or player.get("player_id"),
+                "full_name": player.get("full_name"),
+                "player_type": player.get("player_type"),
+                "team_side": player.get("team_side"),
+                "team_id": player.get("team_id"),
+                "team_name": player.get("team_name"),
+                "primary_position": player.get("primary_position"),
+                "projected_dfs_points": player.get("projected_dfs_points"),
+                "dfs_floor": player.get("dfs_floor"),
+                "dfs_median": player.get("dfs_median"),
+                "dfs_ceiling": player.get("dfs_ceiling"),
+                "simulation_count": player.get("simulation_count") or projections.get("simulation_count"),
+            }
+            for metric in PLAYER_METRICS:
+                record[metric] = _metric_mean(player, metric)
+            record["rbi"] = record.get("rbi") if record.get("rbi") is not None else record.get("rbis")
+            record["outs_recorded"] = record.get("outs_recorded") if record.get("outs_recorded") is not None else record.get("outs")
+            record["hits_allowed"] = record.get("hits_allowed") if record.get("hits_allowed") is not None else record.get("hits")
+            record["hit_by_pitch"] = record.get("hit_by_pitch") if record.get("hit_by_pitch") is not None else record.get("hit_batters")
+            record["runs_allowed"] = record.get("runs_allowed") if record.get("runs_allowed") is not None else record.get("runs")
+            record["earned_runs"] = record.get("earned_runs") if record.get("earned_runs") is not None else record.get("earned_runs_allowed")
+            rows.append(record)
+    return rows
+
+
+def _coerce(field: Dict[str, Any], value: Any) -> Any:
+    data_type = field.get("data_type")
+    if data_type in {"id", "integer"}:
+        return int(value)
+    if data_type in {"double", "number", "float"}:
+        return float(value)
+    if data_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+        raise ValueError(f"Invalid boolean value for field '{field['name']}'")
+    return str(value)
+
+
+def _matches(row: Dict[str, Any], field: Dict[str, Any], operator: str, value: Any) -> bool:
+    current = row.get(field["name"])
+    if operator == "is_null":
+        return current is None
+    if operator == "is_not_null":
+        return current is not None
+    if operator == "in":
+        if not isinstance(value, (list, tuple, set)):
+            raise ValueError(f"Operator 'in' for field '{field['name']}' requires a list")
+        choices = [_coerce(field, item) for item in value]
+        return current is not None and _coerce(field, current) in choices
+    expected = _coerce(field, value)
+    if current is None:
+        return False
+    actual = _coerce(field, current)
+    if operator == "eq": return actual == expected
+    if operator == "neq": return actual != expected
+    if operator == "contains": return str(expected).lower() in str(actual).lower()
+    if operator == "gt": return actual > expected
+    if operator == "gte": return actual >= expected
+    if operator == "lt": return actual < expected
+    if operator == "lte": return actual <= expected
+    raise ValueError(f"Unsupported operator: {operator}")
+
+
+def _filter_rows(
+    rows: List[Dict[str, Any]],
+    report_type: str,
+    filters: Any,
+) -> Tuple[List[Dict[str, Any]], str, List[Dict[str, Any]]]:
+    if filters is None:
+        return rows, "and", []
+    if isinstance(filters, list):
+        logic, conditions = "and", filters
+    elif isinstance(filters, dict):
+        logic = str(filters.get("logic") or "and").strip().lower()
+        conditions = list(filters.get("conditions") or [])
+    else:
+        raise ValueError("filters must be an object or list of conditions")
+    if logic not in {"and", "or"}:
+        raise ValueError("filters.logic must be 'and' or 'or'")
+    catalog = {field["name"]: field for field in FIELD_CATALOG[report_type]}
+    predicates = []
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            raise ValueError("Each filter condition must be an object")
+        name = str(condition.get("field") or "")
+        operator = str(condition.get("operator") or "eq").lower()
+        field = catalog.get(name)
+        if not field or not field.get("filterable"):
+            raise ValueError(f"Unsupported filter field: {name}")
+        if operator not in field.get("supported_operators", []):
+            raise ValueError(f"Unsupported operator '{operator}' for field '{name}'")
+        predicates.append((field, operator, condition.get("value")))
+    if not predicates:
+        return rows, logic, conditions
+    matched = [
+        row for row in rows
+        if (any(_matches(row, *predicate) for predicate in predicates) if logic == "or"
+            else all(_matches(row, *predicate) for predicate in predicates))
+    ]
+    return matched, logic, conditions
+
+
+def _sort_key(value: Any) -> tuple:
+    if value is None or value == "":
+        return (1, 1, "")
+    if isinstance(value, (int, float)):
+        return (0, 0, value)
+    return (0, 1, str(value).lower())
+
+
+def query_projection_report(
+    report_type: str,
+    *,
+    date: str,
+    filters: Any = None,
+    weights: Any = None,
+    page_size: int = 50,
+    page_number: int = 1,
+    sort_by: Optional[str] = None,
+    sort_direction: str = "desc",
+    selected_fields: Optional[Iterable[str]] = None,
+    include_metadata: bool = True,
+) -> Dict[str, Any]:
+    if report_type not in REPORT_TYPES_SUPPORTED or not REPORT_TYPES[report_type].get("queryable"):
+        raise ValueError(f"Unsupported projection report type: {report_type}")
+    if weights:
+        raise ValueError("Weights are not supported for Model Projections report types")
+    if not isinstance(page_size, int) or page_size < 1 or page_size > 250:
+        raise ValueError("page_size must be between 1 and 250")
+    if not isinstance(page_number, int) or page_number < 1:
+        raise ValueError("page_number must be at least 1")
+    direction = str(sort_direction).lower()
+    if direction not in {"asc", "desc"}:
+        raise ValueError("sort_direction must be 'asc' or 'desc'")
+    target_date = dt.date.fromisoformat(str(date)[:10]).isoformat()
+    catalog = {field["name"]: field for field in FIELD_CATALOG[report_type]}
+    requested_fields = list(selected_fields or catalog)
+    invalid = [
+        name for name in requested_fields
+        if name not in catalog or not catalog[name].get("selectable", True)
+    ]
+    if invalid:
+        raise ValueError(f"Unsupported selected field(s): {', '.join(invalid)}")
+
+    payload = get_model_projection_payload(target_date)
+    source_rows = _game_rows(payload) if report_type == "model_projection_games" else _player_rows(payload)
+    rows, logic, applied = _filter_rows(source_rows, report_type, filters)
+    default_sort = "game_pk" if report_type == "model_projection_games" else "projected_dfs_points"
+    sort_name = str(sort_by or default_sort)
+    sort_field = catalog.get(sort_name)
+    if not sort_field or not sort_field.get("sortable"):
+        raise ValueError(f"Unsupported sort field: {sort_name}")
+    present = [row for row in rows if row.get(sort_name) not in (None, "")]
+    missing = [row for row in rows if row.get(sort_name) in (None, "")]
+    present.sort(
+        key=lambda row: (_sort_key(row.get(sort_name)), str(row.get("game_pk") or ""), str(row.get("mlb_player_id") or "")),
+        reverse=direction == "desc",
+    )
+    missing.sort(key=lambda row: (str(row.get("game_pk") or ""), str(row.get("mlb_player_id") or "")))
+    rows = present + missing
+    total_count = len(rows)
+    offset = (page_number - 1) * page_size
+    page = rows[offset:offset + page_size]
+    records = [{"rank": offset + index, **row} for index, row in enumerate(page, start=1)]
+    page_count = math.ceil(total_count / page_size) if total_count else 0
+    has_next = offset + len(records) < total_count
+    result: Dict[str, Any] = {
+        "report_type": report_type,
+        "component": REPORT_TYPES[report_type]["ui_object"],
+        "date": target_date,
+        "records": records,
+        "items": records,
+        "totalSize": total_count,
+        "total_count": total_count,
+        "done": not has_next,
+        "filters_applied": applied,
+        "filter_logic": logic,
+        "query_source": "model_projection_date_artifact",
+        "query": {
+            "source": "model_projection_date_artifact",
+            "sort_by": sort_name,
+            "sort_direction": direction,
+            "selected_fields": requested_fields,
+        },
+        "page_info": {
+            "page_number": page_number,
+            "page_size": page_size,
+            "page_count": page_count,
+            "record_count": len(records),
+            "total_count": total_count,
+            "has_next": has_next,
+            "has_previous": page_number > 1 and total_count > 0,
+        },
+        "provenance": {
+            "source_object": "model_projection_date_artifact",
+            "artifact": payload.get("artifact"),
+            "workspace_contract": payload.get("workspace_contract"),
+            "probability_contract": payload.get("probability_contract"),
+            "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        },
+    }
+    if include_metadata:
+        result["object_info"] = describe_report_type(report_type)
+    return result

--- a/mlb_app/dashboard_related_report_query.py
+++ b/mlb_app/dashboard_related_report_query.py
@@ -6,16 +6,19 @@ import datetime as dt
 import math
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from sqlalchemy import case, func
+from sqlalchemy import and_, case, func, or_
 
 from .dashboard_object_models import DashboardPlayer
 from .dashboard_report_types import FIELD_CATALOG, REPORT_TYPES, describe_report_type
-from .database import BatterPitchTypeMatchup
+from .database import BatterPitchTypeMatchup, PitchArsenal
+from .model_tracker import ModelTrackerSnapshot
 
 
 MODELS = {
     "players_lineup_history": DashboardPlayer,
     "hitters_arsenal_splits": BatterPitchTypeMatchup,
+    "competitive_batter_arsenal": BatterPitchTypeMatchup,
+    "model_tracker_snapshots": ModelTrackerSnapshot,
 }
 
 COLUMN_NAMES = {
@@ -30,21 +33,85 @@ COLUMN_NAMES = {
         "xwoba", "xba", "avg_exit_velocity", "avg_launch_angle", "hard_hit_pct",
         "whiff_pct", "k_pct", "source", "refreshed_at",
     ),
+    "competitive_batter_arsenal": (
+        "id", "batter_id", "batter_name", "batter_team_id", "opposing_pitcher_id",
+        "pitch_type", "game_pk", "target_date", "date_end", "pitches_seen", "pa_ended",
+        "xwoba", "xba", "avg_exit_velocity", "avg_launch_angle", "hard_hit_pct",
+        "whiff_pct", "k_pct", "source", "refreshed_at", "pitcher_pitch_name",
+        "pitcher_pitch_count", "pitcher_usage_pct", "pitcher_whiff_pct",
+        "pitcher_strikeout_pct", "pitcher_xwoba", "pitcher_hard_hit_pct",
+        "edge_score", "matchup_confidence",
+    ),
+    "model_tracker_snapshots": (
+        "id", "snapshot_date", "source", "source_component", "game_pk", "player_id",
+        "player_name", "team_name", "opponent_name", "away_team", "home_team",
+        "market_type", "pick_type", "pick_label", "model_name", "model_version",
+        "model_probability", "market_implied_probability", "edge", "score", "confidence",
+        "line", "price", "expected_value", "projected_total", "projected_home_runs",
+        "projected_away_runs", "home_win_probability", "away_win_probability",
+        "primary_reason", "game_status_at_snapshot", "result_status", "grade",
+        "grade_reason", "created_at", "updated_at", "last_compared_at",
+    ),
 }
 
 
 def _columns(report_type: str) -> Dict[str, Any]:
+    if report_type == "competitive_batter_arsenal":
+        pa = func.coalesce(BatterPitchTypeMatchup.pa_ended, BatterPitchTypeMatchup.pa, 0)
+        usage = func.coalesce(PitchArsenal.usage_pct, 0.0)
+        pa_component = case((pa >= 12, 1.0), else_=pa / 12.0)
+        usage_component = case(
+            (usage < 0.25, 0.25),
+            (usage > 1.0, 1.0),
+            else_=usage,
+        )
+        confidence = case(
+            (pa_component * usage_component + case((pa >= 3, 0.25), else_=0.0) > 1.0, 1.0),
+            else_=pa_component * usage_component + case((pa >= 3, 0.25), else_=0.0),
+        )
+        raw_edge = (
+            func.coalesce((BatterPitchTypeMatchup.batting_avg - 0.245) * 4.0, 0.0)
+            + func.coalesce((BatterPitchTypeMatchup.xwoba - 0.320) * 5.0, 0.0)
+            - func.coalesce((PitchArsenal.xwoba - 0.320) * 5.0, 0.0)
+            - func.coalesce((PitchArsenal.hard_hit_pct - 0.35) * 2.0, 0.0)
+        )
+        usage_weight = case(
+            (PitchArsenal.usage_pct.is_(None), 1.0),
+            (PitchArsenal.usage_pct < 0.35, 0.35),
+            (PitchArsenal.usage_pct > 1.0, 1.0),
+            else_=PitchArsenal.usage_pct,
+        )
+        columns = {
+            name: getattr(BatterPitchTypeMatchup, name)
+            for name in COLUMN_NAMES[report_type]
+            if hasattr(BatterPitchTypeMatchup, name)
+        }
+        columns.update({
+            "pitcher_pitch_name": PitchArsenal.pitch_name,
+            "pitcher_pitch_count": PitchArsenal.pitch_count,
+            "pitcher_usage_pct": PitchArsenal.usage_pct,
+            "pitcher_whiff_pct": PitchArsenal.whiff_pct,
+            "pitcher_strikeout_pct": PitchArsenal.strikeout_pct,
+            "pitcher_xwoba": PitchArsenal.xwoba,
+            "pitcher_hard_hit_pct": PitchArsenal.hard_hit_pct,
+            "edge_score": raw_edge * usage_weight,
+            "matchup_confidence": confidence,
+        })
+        return columns
     model = MODELS[report_type]
     return {name: getattr(model, name) for name in COLUMN_NAMES[report_type]}
 
 
-def _conditions(filters: Any, report_type: str) -> List[Dict[str, Any]]:
+def _conditions(filters: Any, report_type: str) -> Tuple[str, List[Dict[str, Any]]]:
     if filters is None:
-        return []
+        return "and", []
     if isinstance(filters, list):
-        return filters
+        return "and", filters
     if not isinstance(filters, dict):
         raise ValueError("filters must be an object or list of conditions")
+    logic = str(filters.get("logic") or "and").strip().lower()
+    if logic not in {"and", "or"}:
+        raise ValueError("filters.logic must be 'and' or 'or'")
     conditions = list(filters.get("conditions") or [])
     aliases = {
         "players_lineup_history": (
@@ -58,17 +125,25 @@ def _conditions(filters: Any, report_type: str) -> List[Dict[str, Any]]:
             ("pitch_type", "pitch_type", "eq"),
             ("min_pitches_seen", "pitches_seen", "gte"),
         ),
+        "competitive_batter_arsenal": (
+            ("search_text", "batter_name", "contains"),
+            ("team_id", "batter_team_id", "eq"),
+            ("pitch_type", "pitch_type", "eq"),
+            ("min_pitches_seen", "pitches_seen", "gte"),
+        ),
+        "model_tracker_snapshots": (),
     }[report_type]
     for key, field, operator in aliases:
         if filters.get(key) not in (None, "", "All"):
             conditions.append({"field": field, "operator": operator, "value": filters[key]})
-    return conditions
+    return logic, conditions
 
 
-def _apply_filters(query: Any, report_type: str, filters: Any) -> Tuple[Any, List[Dict[str, Any]]]:
+def _apply_filters(query: Any, report_type: str, filters: Any) -> Tuple[Any, str, List[Dict[str, Any]]]:
     columns = _columns(report_type)
     catalog = {field["name"]: field for field in FIELD_CATALOG[report_type]}
-    applied = _conditions(filters, report_type)
+    logic, applied = _conditions(filters, report_type)
+    expressions = []
     for condition in applied:
         if not isinstance(condition, dict):
             raise ValueError("Each filter condition must be an object")
@@ -94,8 +169,10 @@ def _apply_filters(query: Any, report_type: str, filters: Any) -> Tuple[Any, Lis
         elif operator == "is_null": expression = column.is_(None)
         elif operator == "is_not_null": expression = column.is_not(None)
         else: raise ValueError(f"Unsupported operator: {operator}")
-        query = query.filter(expression)
-    return query, applied
+        expressions.append(expression)
+    if expressions:
+        query = query.filter(or_(*expressions) if logic == "or" else and_(*expressions))
+    return query, logic, applied
 
 
 def _iso(value: Any) -> Any:
@@ -114,6 +191,7 @@ def query_related_report(
     sort_direction: str = "desc",
     selected_fields: Optional[Iterable[str]] = None,
     include_metadata: bool = True,
+    as_of_date: Optional[dt.date] = None,
 ) -> Dict[str, Any]:
     if report_type not in MODELS or not REPORT_TYPES[report_type].get("queryable"):
         raise ValueError(f"Unsupported related report type: {report_type}")
@@ -141,7 +219,7 @@ def query_related_report(
         )
         default_sort = "most_recent_lineup_date"
         tie_column = DashboardPlayer.mlb_player_id
-    else:
+    elif report_type in {"hitters_arsenal_splits", "competitive_batter_arsenal"}:
         query = session.query(model).join(
             DashboardPlayer, DashboardPlayer.mlb_player_id == BatterPitchTypeMatchup.batter_id
         ).filter(
@@ -151,8 +229,40 @@ def query_related_report(
         )
         default_sort = "pitches_seen"
         tie_column = BatterPitchTypeMatchup.id
+        if report_type == "competitive_batter_arsenal":
+            arsenal_season = (as_of_date or dt.date.today()).year
+            latest_arsenal = (
+                session.query(
+                    PitchArsenal.pitcher_id.label("pitcher_id"),
+                    PitchArsenal.pitch_type.label("pitch_type"),
+                    func.max(PitchArsenal.id).label("arsenal_id"),
+                )
+                .filter(PitchArsenal.season == arsenal_season)
+                .group_by(PitchArsenal.pitcher_id, PitchArsenal.pitch_type)
+                .subquery()
+            )
+            query = query.outerjoin(
+                latest_arsenal,
+                and_(
+                    latest_arsenal.c.pitcher_id == BatterPitchTypeMatchup.opposing_pitcher_id,
+                    latest_arsenal.c.pitch_type == BatterPitchTypeMatchup.pitch_type,
+                ),
+            ).outerjoin(PitchArsenal, PitchArsenal.id == latest_arsenal.c.arsenal_id)
+        if as_of_date is not None:
+            query = query.filter(
+                or_(
+                    BatterPitchTypeMatchup.target_date == as_of_date,
+                    BatterPitchTypeMatchup.target_date.is_(None),
+                )
+            )
+    else:
+        query = session.query(model)
+        default_sort = "snapshot_date"
+        tie_column = ModelTrackerSnapshot.id
+        if as_of_date is not None:
+            query = query.filter(ModelTrackerSnapshot.snapshot_date == as_of_date)
 
-    query, applied_filters = _apply_filters(query, report_type, filters)
+    query, filter_logic, applied_filters = _apply_filters(query, report_type, filters)
     total_count = query.count()
     sort_name = str(sort_by or default_sort)
     field = catalog.get(sort_name)
@@ -165,10 +275,32 @@ def query_related_report(
         tie_column.asc(),
     )
     offset = (page_number - 1) * page_size
-    rows = query.offset(offset).limit(page_size).all()
+    if report_type == "competitive_batter_arsenal":
+        extra_names = [
+            name for name in COLUMN_NAMES[report_type]
+            if not hasattr(BatterPitchTypeMatchup, name)
+        ]
+        rows = (
+            query.add_columns(*[columns[name].label(name) for name in extra_names])
+            .offset(offset)
+            .limit(page_size)
+            .all()
+        )
+    else:
+        extra_names = []
+        rows = query.offset(offset).limit(page_size).all()
     records = []
-    for index, row in enumerate(rows, start=offset + 1):
-        record = {name: _iso(getattr(row, name)) for name in columns}
+    for index, result_row in enumerate(rows, start=offset + 1):
+        if report_type == "competitive_batter_arsenal":
+            row = result_row[0]
+            extra_values = dict(zip(extra_names, result_row[1:]))
+            record = {
+                name: _iso(getattr(row, name)) if hasattr(row, name) else _iso(extra_values.get(name))
+                for name in columns
+            }
+        else:
+            row = result_row
+            record = {name: _iso(getattr(row, name)) for name in columns}
         record["rank"] = index
         records.append(record)
     page_count = math.ceil(total_count / page_size) if total_count else 0
@@ -183,6 +315,7 @@ def query_related_report(
         "done": not has_next,
         "query_source": REPORT_TYPES[report_type]["base_object"],
         "filters_applied": applied_filters,
+        "filter_logic": filter_logic,
         "query": {
             "source": REPORT_TYPES[report_type]["base_object"],
             "sort_by": sort_name,

--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -12,8 +12,13 @@ REPORT_TYPES: Dict[str, Dict[str, Any]] = {
     "hitters_current_matchup": {"label": "Hitters with Current Matchup Metrics", "ui_object": "hitters", "base_object": "dashboard_players", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["current_matchup_snapshot"]},
     "hitters_arsenal_splits": {"label": "Hitters with Arsenal Splits", "ui_object": "hitters", "base_object": "batter_pitch_type_matchups", "population": {"is_active": True, "player_type": "hitter"}, "relationships": ["dashboard_players"], "queryable": True},
     "players_lineup_history": {"label": "Players with Lineup History", "ui_object": "overall_players", "base_object": "dashboard_players", "population": {"lineup_appearance_count": {"gt": 0}}, "relationships": ["lineup_appearances"], "queryable": True},
-    "teams_daily_analysis": {"label": "Teams with Daily Analysis", "ui_object": "teams", "base_object": "teams", "population": {}, "relationships": ["daily_analytical_snapshot"]},
-    "games_totals_analysis": {"label": "Games with Totals Analysis", "ui_object": "totals", "base_object": "games", "population": {}, "relationships": ["totals_projection", "run_environment_snapshot"]},
+    "teams_daily_analysis": {"label": "Teams with Daily Analysis", "ui_object": "teams", "base_object": "my_dashboard_records", "population": {"component": "teams", "is_current": True}, "relationships": ["daily_analytical_snapshot"], "queryable": True, "workbench_queryable": False},
+    "games_totals_analysis": {"label": "Games with Totals Analysis", "ui_object": "totals", "base_object": "my_dashboard_records", "population": {"component": "totals", "is_current": True}, "relationships": ["totals_projection", "run_environment_snapshot"], "queryable": True, "workbench_queryable": False},
+    "overall_players_daily_analysis": {"label": "Overall Players", "ui_object": "overall_players", "base_object": "my_dashboard_records", "population": {"component": "overall_players", "is_current": True}, "relationships": ["dashboard_player_current"], "queryable": True, "workbench_queryable": False},
+    "model_projection_games": {"label": "Model Projections", "ui_object": "model_projections", "base_object": "model_projection_date_artifact", "population": {"row_type": "game"}, "relationships": ["model_projection_players"], "queryable": True, "workbench_queryable": False},
+    "model_projection_players": {"label": "Model Projection Players", "ui_object": "model_projection_players", "base_object": "model_projection_date_artifact", "population": {"row_type": "player"}, "relationships": ["model_projection_games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
+    "model_tracker_snapshots": {"label": "Model Tracker", "ui_object": "model_tracker", "base_object": "model_tracker_snapshots", "population": {}, "relationships": ["games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
+    "competitive_batter_arsenal": {"label": "Batter vs Arsenal", "ui_object": "batter_arsenal", "base_object": "batter_pitch_type_matchups", "population": {}, "relationships": ["dashboard_players", "pitch_arsenal"], "queryable": True, "workbench_queryable": False},
 }
 
 
@@ -31,6 +36,7 @@ def _field(
     description: str,
     freshness: str = "current_projection",
     weight_aliases: Optional[List[str]] = None,
+    source_object: str = "dashboard_player_current",
 ) -> Dict[str, Any]:
     return {
         "name": name,
@@ -41,14 +47,14 @@ def _field(
         "filterable": filterable,
         "selectable": selectable,
         "nillable": nillable,
-        "source_object": "dashboard_player_current",
+        "source_object": source_object,
         "relationship_path": None,
         "description": description,
         "supported_operators": operators or (
             ["eq", "in"]
             if data_type == "id"
             else (
-                ["eq", "neq", "in"]
+                ["eq", "neq", "contains", "in"]
                 if data_type == "string"
                 else ["eq", "gt", "gte", "lt", "lte", "is_null", "is_not_null"]
             )
@@ -127,6 +133,257 @@ ARSENAL_SPLIT_FIELDS: List[Dict[str, Any]] = [
 for field in ARSENAL_SPLIT_FIELDS:
     field["source_object"] = "batter_pitch_type_matchups"
 
+
+def _dataset_field(
+    name: str,
+    label: str,
+    data_type: str,
+    group: str,
+    *,
+    sortable: bool = True,
+    filterable: bool = True,
+    description: str,
+) -> Dict[str, Any]:
+    return _field(
+        name,
+        label,
+        data_type,
+        group,
+        sortable=sortable,
+        filterable=filterable,
+        description=description,
+        source_object="my_dashboard_records",
+        freshness="daily_dashboard_dataset",
+    )
+
+
+DATASET_FIELDS: List[Dict[str, Any]] = [
+    _dataset_field("entity_id", "Entity ID", "string", "Identity", description="Stable report entity identifier."),
+    _dataset_field("entity_name", "Name", "string", "Identity", description="Display name for the report row."),
+    _dataset_field("entity_type", "Entity Type", "string", "Identity", description="Server-owned row classification."),
+    _dataset_field("player_type", "Player Type", "string", "Identity", description="Hitter or pitcher classification when applicable."),
+    _dataset_field("team", "Team", "string", "Matchup", description="Team associated with the row."),
+    _dataset_field("opponent", "Opponent", "string", "Matchup", description="Opponent associated with the row."),
+    _dataset_field("game_pk", "Game PK", "id", "Matchup", description="Canonical MLB game identifier."),
+    _dataset_field("category", "Category", "string", "Classification", description="Server-owned report category."),
+    _dataset_field("score", "Score", "double", "Scoring", description="Current report score."),
+    _dataset_field("base_score", "Base Score", "double", "Scoring", description="Score before request-scoped weights."),
+    _dataset_field("adjusted_score", "Adjusted Score", "double", "Scoring", description="Score after request-scoped weights."),
+    _dataset_field("confidence", "Confidence", "string", "Scoring", description="Current confidence label."),
+    _dataset_field("source", "Source", "string", "Audit", description="Registered source contract."),
+    _dataset_field("primary_reason", "Primary Reason", "string", "Audit", sortable=False, description="Primary explanation attached to the row."),
+]
+
+DATASET_METRICS: Dict[str, List[tuple[str, str]]] = {
+    "teams_daily_analysis": [
+        ("Edge Score", "Edge Score"), ("Win Edge", "Win Edge"), ("Run Diff", "Run Differential"),
+        ("ISO", "ISO"), ("OBP", "OBP"), ("SLG", "SLG"),
+    ],
+    "games_totals_analysis": [
+        ("Projected Total", "Projected Total"), ("Raw Total", "Raw Total"),
+        ("Run Index", "Run Index"), ("Score", "Model Score"),
+    ],
+    "overall_players_daily_analysis": [
+        ("Score", "Model Score"), ("xwOBA", "xwOBA"), ("EV", "Exit Velocity"),
+        ("K%", "Strikeout Rate"), ("xwOBA Allowed", "xwOBA Allowed"),
+    ],
+}
+
+
+def _runtime_field(
+    name: str,
+    label: str,
+    data_type: str,
+    group: str,
+    source_object: str,
+    description: str,
+    *,
+    sortable: bool = True,
+    filterable: bool = True,
+    freshness: str,
+) -> Dict[str, Any]:
+    return _field(
+        name,
+        label,
+        data_type,
+        group,
+        sortable=sortable,
+        filterable=filterable,
+        description=description,
+        source_object=source_object,
+        freshness=freshness,
+    )
+
+
+MODEL_PROJECTION_GAME_FIELDS = [
+    _runtime_field("game_pk", "Game PK", "id", "Identity", "model_projection_date_artifact", "Canonical MLB game identifier.", freshness="projection_artifact"),
+    _runtime_field("game_date", "Game Date", "date", "Identity", "model_projection_date_artifact", "Projection game date.", freshness="projection_artifact"),
+    _runtime_field("game_time", "Game Time", "string", "Identity", "model_projection_date_artifact", "Scheduled game time.", freshness="projection_artifact"),
+    _runtime_field("status", "Game Status", "string", "Identity", "model_projection_date_artifact", "Game status captured by the projection.", freshness="projection_artifact"),
+    _runtime_field("venue", "Venue", "string", "Environment", "model_projection_date_artifact", "Scheduled venue.", freshness="projection_artifact"),
+    _runtime_field("away_team_id", "Away Team ID", "id", "Teams", "model_projection_date_artifact", "Away team identifier.", freshness="projection_artifact"),
+    _runtime_field("away_team_name", "Away Team", "string", "Teams", "model_projection_date_artifact", "Away team name.", freshness="projection_artifact"),
+    _runtime_field("home_team_id", "Home Team ID", "id", "Teams", "model_projection_date_artifact", "Home team identifier.", freshness="projection_artifact"),
+    _runtime_field("home_team_name", "Home Team", "string", "Teams", "model_projection_date_artifact", "Home team name.", freshness="projection_artifact"),
+    _runtime_field("away_pitcher_id", "Away Pitcher ID", "id", "Starters", "model_projection_date_artifact", "Away probable pitcher identifier.", freshness="projection_artifact"),
+    _runtime_field("away_pitcher_name", "Away Pitcher", "string", "Starters", "model_projection_date_artifact", "Away probable pitcher name.", freshness="projection_artifact"),
+    _runtime_field("home_pitcher_id", "Home Pitcher ID", "id", "Starters", "model_projection_date_artifact", "Home probable pitcher identifier.", freshness="projection_artifact"),
+    _runtime_field("home_pitcher_name", "Home Pitcher", "string", "Starters", "model_projection_date_artifact", "Home probable pitcher name.", freshness="projection_artifact"),
+    _runtime_field("away_win_probability", "Away Win Probability", "double", "Probability", "model_projection_date_artifact", "Displayed Model Projections away win probability.", freshness="projection_artifact"),
+    _runtime_field("home_win_probability", "Home Win Probability", "double", "Probability", "model_projection_date_artifact", "Displayed Model Projections home win probability.", freshness="projection_artifact"),
+    _runtime_field("projected_away_runs", "Projected Away Runs", "double", "Runs", "model_projection_date_artifact", "Projected away runs from the shared projection output.", freshness="projection_artifact"),
+    _runtime_field("projected_home_runs", "Projected Home Runs", "double", "Runs", "model_projection_date_artifact", "Projected home runs from the shared projection output.", freshness="projection_artifact"),
+    _runtime_field("projected_total", "Projected Total", "double", "Runs", "model_projection_date_artifact", "Projected combined runs.", freshness="projection_artifact"),
+    _runtime_field("model_version", "Model Version", "string", "Audit", "model_projection_date_artifact", "Displayed projection model version.", freshness="projection_artifact"),
+    _runtime_field("probability_source", "Probability Source", "string", "Audit", "model_projection_date_artifact", "Registered displayed probability source.", freshness="projection_artifact"),
+    _runtime_field("probability_is_fallback", "Fallback Probability", "boolean", "Audit", "model_projection_date_artifact", "Whether the displayed probability used a fallback.", freshness="projection_artifact"),
+    _runtime_field("lineup_status", "Lineup Status", "string", "Freshness", "model_projection_date_artifact", "Lineup readiness captured by the projection.", freshness="projection_artifact"),
+    _runtime_field("data_confidence", "Data Confidence", "string", "Freshness", "model_projection_date_artifact", "Projection data-confidence label.", freshness="projection_artifact"),
+]
+MODEL_PROJECTION_GAME_FIELDS.extend([
+    _runtime_field(name, label, data_type, group, "model_projection_date_artifact", description, freshness="projection_artifact")
+    for name, label, data_type, group, description in [
+        ("away_starter_k_rate", "Away Starter K Rate", "double", "Starting Pitchers", "Away starter strikeout rate."),
+        ("away_starter_bb_rate", "Away Starter Walk Rate", "double", "Starting Pitchers", "Away starter walk rate."),
+        ("away_starter_xwoba_allowed", "Away Starter xwOBA Allowed", "double", "Starting Pitchers", "Away starter expected weighted on-base average allowed."),
+        ("away_starter_hard_hit_rate_allowed", "Away Starter Hard-Hit Rate Allowed", "double", "Starting Pitchers", "Away starter hard-hit rate allowed."),
+        ("home_starter_k_rate", "Home Starter K Rate", "double", "Starting Pitchers", "Home starter strikeout rate."),
+        ("home_starter_bb_rate", "Home Starter Walk Rate", "double", "Starting Pitchers", "Home starter walk rate."),
+        ("home_starter_xwoba_allowed", "Home Starter xwOBA Allowed", "double", "Starting Pitchers", "Home starter expected weighted on-base average allowed."),
+        ("home_starter_hard_hit_rate_allowed", "Home Starter Hard-Hit Rate Allowed", "double", "Starting Pitchers", "Home starter hard-hit rate allowed."),
+        ("away_offense_k_rate", "Away Offense K Rate", "double", "Offense", "Away offense strikeout rate."),
+        ("away_offense_bb_rate", "Away Offense Walk Rate", "double", "Offense", "Away offense walk rate."),
+        ("away_offense_obp", "Away Offense OBP", "double", "Offense", "Away offense on-base percentage."),
+        ("away_offense_iso", "Away Offense ISO", "double", "Offense", "Away offense isolated power."),
+        ("away_offense_slg", "Away Offense SLG", "double", "Offense", "Away offense slugging percentage."),
+        ("home_offense_k_rate", "Home Offense K Rate", "double", "Offense", "Home offense strikeout rate."),
+        ("home_offense_bb_rate", "Home Offense Walk Rate", "double", "Offense", "Home offense walk rate."),
+        ("home_offense_obp", "Home Offense OBP", "double", "Offense", "Home offense on-base percentage."),
+        ("home_offense_iso", "Home Offense ISO", "double", "Offense", "Home offense isolated power."),
+        ("home_offense_slg", "Home Offense SLG", "double", "Offense", "Home offense slugging percentage."),
+        ("away_bullpen_k_rate", "Away Bullpen K Rate", "double", "Bullpens", "Away bullpen strikeout rate."),
+        ("away_bullpen_bb_rate", "Away Bullpen Walk Rate", "double", "Bullpens", "Away bullpen walk rate."),
+        ("away_bullpen_xwoba_allowed", "Away Bullpen xwOBA Allowed", "double", "Bullpens", "Away bullpen expected weighted on-base average allowed."),
+        ("home_bullpen_k_rate", "Home Bullpen K Rate", "double", "Bullpens", "Home bullpen strikeout rate."),
+        ("home_bullpen_bb_rate", "Home Bullpen Walk Rate", "double", "Bullpens", "Home bullpen walk rate."),
+        ("home_bullpen_xwoba_allowed", "Home Bullpen xwOBA Allowed", "double", "Bullpens", "Home bullpen expected weighted on-base average allowed."),
+        ("run_scoring_index", "Run Scoring Index", "double", "Environment", "Run-scoring environment index."),
+        ("hr_boost_index", "Home Run Boost Index", "double", "Environment", "Home-run environment index."),
+        ("hit_boost_index", "Hit Boost Index", "double", "Environment", "Hit environment index."),
+        ("temperature_f", "Temperature", "double", "Environment", "Game-time temperature in Fahrenheit."),
+        ("weather_condition", "Weather Condition", "string", "Environment", "Game-time weather condition."),
+        ("wind_speed_mph", "Wind Speed", "double", "Environment", "Game-time wind speed in miles per hour."),
+        ("wind_direction", "Wind Direction", "string", "Environment", "Game-time wind direction."),
+        ("away_matchup_biggest_edge", "Away Matchup Biggest Edge", "string", "Matchup", "Strongest pitch-type edge for the away offense."),
+        ("away_matchup_confidence", "Away Matchup Confidence", "double", "Matchup", "Away matchup-analysis confidence."),
+        ("home_matchup_biggest_edge", "Home Matchup Biggest Edge", "string", "Matchup", "Strongest pitch-type edge for the home offense."),
+        ("home_matchup_confidence", "Home Matchup Confidence", "double", "Matchup", "Home matchup-analysis confidence."),
+        ("simulation_count", "Simulation Count", "integer", "Simulation", "Trials in the shared game simulation."),
+        ("tie_after_regulation_probability", "Tie After Regulation", "double", "Simulation", "Probability of a tie after regulation."),
+        ("over_8_5_probability", "Over 8.5 Probability", "double", "Simulation", "Projected probability of more than 8.5 runs."),
+        ("under_8_5_probability", "Under 8.5 Probability", "double", "Simulation", "Projected probability of fewer than 8.5 runs."),
+    ]
+])
+
+MODEL_PROJECTION_PLAYER_FIELDS = [
+    _runtime_field("game_pk", "Game PK", "id", "Identity", "model_projection_date_artifact", "Parent projection game identifier.", freshness="projection_artifact"),
+    _runtime_field("game_date", "Game Date", "date", "Identity", "model_projection_date_artifact", "Parent projection game date.", freshness="projection_artifact"),
+    _runtime_field("mlb_player_id", "MLB Player ID", "id", "Identity", "model_projection_date_artifact", "Resolved MLBAM player identifier.", freshness="projection_artifact"),
+    _runtime_field("full_name", "Player Name", "string", "Identity", "model_projection_date_artifact", "Resolved player name.", freshness="projection_artifact"),
+    _runtime_field("player_type", "Player Type", "string", "Identity", "model_projection_date_artifact", "Batter or pitcher projection row.", freshness="projection_artifact"),
+    _runtime_field("team_side", "Team Side", "string", "Team", "model_projection_date_artifact", "Away or home side.", freshness="projection_artifact"),
+    _runtime_field("team_id", "Team ID", "id", "Team", "model_projection_date_artifact", "Resolved current team identifier.", freshness="projection_artifact"),
+    _runtime_field("team_name", "Team", "string", "Team", "model_projection_date_artifact", "Resolved current team name.", freshness="projection_artifact"),
+    _runtime_field("primary_position", "Primary Position", "string", "Identity", "model_projection_date_artifact", "Resolved primary position.", freshness="projection_artifact"),
+    _runtime_field("projected_dfs_points", "Projected DFS Points", "double", "Projection", "model_projection_date_artifact", "Mean projected fantasy points.", freshness="projection_artifact"),
+    _runtime_field("dfs_floor", "DFS Floor", "double", "Projection", "model_projection_date_artifact", "Tenth-percentile projected fantasy points.", freshness="projection_artifact"),
+    _runtime_field("dfs_median", "DFS Median", "double", "Projection", "model_projection_date_artifact", "Median projected fantasy points.", freshness="projection_artifact"),
+    _runtime_field("dfs_ceiling", "DFS Ceiling", "double", "Projection", "model_projection_date_artifact", "Ninetieth-percentile projected fantasy points.", freshness="projection_artifact"),
+    _runtime_field("simulation_count", "Simulation Count", "integer", "Audit", "model_projection_date_artifact", "Trials backing the player projection.", freshness="projection_artifact"),
+]
+MODEL_PROJECTION_PLAYER_FIELDS.extend([
+    _runtime_field(name, label, "double", group, "model_projection_date_artifact", description, freshness="projection_artifact")
+    for name, label, group, description in [
+        ("plate_appearances", "Plate Appearances", "Batter Projection", "Mean projected plate appearances."),
+        ("singles", "Singles", "Batter Projection", "Mean projected singles."),
+        ("doubles", "Doubles", "Batter Projection", "Mean projected doubles."),
+        ("triples", "Triples", "Batter Projection", "Mean projected triples."),
+        ("home_runs", "Home Runs", "Batter Projection", "Mean projected home runs."),
+        ("runs", "Runs", "Player Projection", "Mean projected runs."),
+        ("rbi", "RBI", "Batter Projection", "Mean projected runs batted in."),
+        ("walks", "Walks", "Player Projection", "Mean projected walks."),
+        ("stolen_bases", "Stolen Bases", "Batter Projection", "Mean projected stolen bases."),
+        ("strikeouts", "Strikeouts", "Player Projection", "Mean projected strikeouts."),
+        ("batters_faced", "Batters Faced", "Pitcher Projection", "Mean projected batters faced."),
+        ("outs_recorded", "Outs Recorded", "Pitcher Projection", "Mean projected outs recorded."),
+        ("hits_allowed", "Hits Allowed", "Pitcher Projection", "Mean projected hits allowed."),
+        ("hit_by_pitch", "Hit By Pitch", "Pitcher Projection", "Mean projected hit batters."),
+        ("runs_allowed", "Runs Allowed", "Pitcher Projection", "Mean projected runs allowed."),
+        ("earned_runs", "Earned Runs", "Pitcher Projection", "Mean projected earned runs."),
+    ]
+])
+
+MODEL_TRACKER_FIELDS = [
+    _runtime_field(name, label, data_type, group, "model_tracker_snapshots", description, freshness="tracker_snapshot")
+    for name, label, data_type, group, description in [
+        ("id", "Tracker Row ID", "id", "Identity", "Persistent tracker row identifier."),
+        ("snapshot_date", "Snapshot Date", "date", "Identity", "Date captured by the tracker."),
+        ("source", "Source", "string", "Source", "Registered product source."),
+        ("source_component", "Source Component", "string", "Source", "Registered source component."),
+        ("game_pk", "Game PK", "id", "Game", "Canonical MLB game identifier."),
+        ("player_id", "Player ID", "id", "Identity", "Canonical player identifier when applicable."),
+        ("player_name", "Player", "string", "Identity", "Player display name."),
+        ("team_name", "Team", "string", "Game", "Team associated with the tracked row."),
+        ("opponent_name", "Opponent", "string", "Game", "Opponent associated with the tracked row."),
+        ("away_team", "Away Team", "string", "Game", "Away team name."),
+        ("home_team", "Home Team", "string", "Game", "Home team name."),
+        ("market_type", "Market Type", "string", "Pick", "Tracked market classification."),
+        ("pick_type", "Pick Type", "string", "Pick", "Tracked pick classification."),
+        ("pick_label", "Pick", "string", "Pick", "Tracked pick label."),
+        ("model_name", "Model", "string", "Model", "Registered model name."),
+        ("model_version", "Model Version", "string", "Model", "Registered model version."),
+        ("model_probability", "Model Probability", "double", "Model", "Model probability at snapshot time."),
+        ("market_implied_probability", "Market Implied Probability", "double", "Model", "Market implied probability at snapshot time."),
+        ("edge", "Edge", "double", "Model", "Tracked model edge."),
+        ("score", "Score", "double", "Model", "Tracked score."),
+        ("confidence", "Confidence", "double", "Model", "Tracked numeric confidence."),
+        ("line", "Line", "double", "Market", "Tracked market line."),
+        ("price", "Price", "double", "Market", "Tracked market price."),
+        ("expected_value", "Expected Value", "double", "Market", "Tracked expected value."),
+        ("projected_total", "Projected Total", "double", "Projection", "Tracked projected total."),
+        ("projected_home_runs", "Projected Home Runs", "double", "Projection", "Tracked projected home runs."),
+        ("projected_away_runs", "Projected Away Runs", "double", "Projection", "Tracked projected away runs."),
+        ("home_win_probability", "Home Win Probability", "double", "Projection", "Tracked home win probability."),
+        ("away_win_probability", "Away Win Probability", "double", "Projection", "Tracked away win probability."),
+        ("primary_reason", "Primary Reason", "string", "Audit", "Primary tracked reasoning summary."),
+        ("game_status_at_snapshot", "Game Status", "string", "Result", "Game status at snapshot time."),
+        ("result_status", "Result Status", "string", "Result", "Result comparison status."),
+        ("grade", "Grade", "string", "Result", "Current tracker grade."),
+        ("grade_reason", "Grade Reason", "string", "Result", "Reason for the current grade."),
+        ("created_at", "Created At", "datetime", "Audit", "Snapshot creation time."),
+        ("updated_at", "Updated At", "datetime", "Audit", "Snapshot update time."),
+        ("last_compared_at", "Last Compared At", "datetime", "Audit", "Most recent result comparison time."),
+    ]
+]
+
+COMPETITIVE_ARSENAL_FIELDS = deepcopy(ARSENAL_SPLIT_FIELDS)
+for field in COMPETITIVE_ARSENAL_FIELDS:
+    field["freshness"] = "competitive_matchup_snapshot"
+COMPETITIVE_ARSENAL_FIELDS.extend([
+    _runtime_field(name, label, data_type, group, "pitch_arsenal", description, freshness="competitive_matchup_snapshot")
+    for name, label, data_type, group, description in [
+        ("pitcher_pitch_name", "Pitch Name", "string", "Pitcher Arsenal", "Opposing pitcher pitch name."),
+        ("pitcher_pitch_count", "Pitcher Pitch Count", "integer", "Pitcher Arsenal", "Opposing pitcher pitch count."),
+        ("pitcher_usage_pct", "Pitcher Usage", "double", "Pitcher Arsenal", "Opposing pitcher usage rate for the pitch type."),
+        ("pitcher_whiff_pct", "Pitcher Whiff Rate", "double", "Pitcher Arsenal", "Opposing pitcher whiff rate for the pitch type."),
+        ("pitcher_strikeout_pct", "Pitcher Strikeout Rate", "double", "Pitcher Arsenal", "Opposing pitcher strikeout rate for the pitch type."),
+        ("pitcher_xwoba", "Pitcher xwOBA", "double", "Pitcher Arsenal", "Opposing pitcher xwOBA allowed for the pitch type."),
+        ("pitcher_hard_hit_pct", "Pitcher Hard-Hit Rate", "double", "Pitcher Arsenal", "Opposing pitcher hard-hit rate allowed for the pitch type."),
+        ("edge_score", "Edge Score", "double", "Competitive Analysis", "Existing competitive edge formula over batter quality, pitcher quality, and pitch usage."),
+        ("matchup_confidence", "Matchup Confidence", "double", "Competitive Analysis", "Existing competitive sample-and-usage confidence."),
+    ]
+])
+
 FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {}
 for key, config in REPORT_TYPES.items():
     if config["base_object"] == "dashboard_player_current":
@@ -135,6 +392,26 @@ for key, config in REPORT_TYPES.items():
         FIELD_CATALOG[key] = deepcopy(LINEUP_HISTORY_FIELDS)
     elif key == "hitters_arsenal_splits":
         FIELD_CATALOG[key] = deepcopy(ARSENAL_SPLIT_FIELDS)
+    elif key in DATASET_METRICS:
+        FIELD_CATALOG[key] = deepcopy(DATASET_FIELDS)
+        FIELD_CATALOG[key].extend([
+            _dataset_field(
+                f"metrics.{metric}",
+                label,
+                "double",
+                "Metrics",
+                description=f"Registered {label.lower()} value from the daily report snapshot.",
+            )
+            for metric, label in DATASET_METRICS[key]
+        ])
+    elif key == "model_projection_games":
+        FIELD_CATALOG[key] = deepcopy(MODEL_PROJECTION_GAME_FIELDS)
+    elif key == "model_projection_players":
+        FIELD_CATALOG[key] = deepcopy(MODEL_PROJECTION_PLAYER_FIELDS)
+    elif key == "model_tracker_snapshots":
+        FIELD_CATALOG[key] = deepcopy(MODEL_TRACKER_FIELDS)
+    elif key == "competitive_batter_arsenal":
+        FIELD_CATALOG[key] = deepcopy(COMPETITIVE_ARSENAL_FIELDS)
     elif config["base_object"] == "dashboard_players":
         FIELD_CATALOG[key] = deepcopy(CURRENT_PLAYER_FIELDS[:6])
         for field in FIELD_CATALOG[key]:

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -184,6 +184,15 @@ def warm_model_projection_payload(target_date: str) -> Dict[str, Any]:
     }
 
 
+def get_model_projection_payload(target_date: str) -> Dict[str, Any]:
+    """Resolve the shared cached projection artifact for product and report readers."""
+    return get_or_set(
+        _projection_cache_key(target_date),
+        env_ttl("MODEL_PROJECTION_CACHE_TTL_SECONDS"),
+        lambda: _build_uncached_projection_payload(target_date),
+    )
+
+
 @router.get("/models/projections")
 def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
     target_date = date or datetime.date.today().isoformat()
@@ -196,11 +205,7 @@ def model_projections(date: Optional[str] = None) -> Dict[str, Any]:
             date=target_date,
             probability_source="model_projections",
         ):
-            payload = get_or_set(
-                cache_key,
-                env_ttl("MODEL_PROJECTION_CACHE_TTL_SECONDS"),
-                lambda: _build_uncached_projection_payload(target_date),
-            )
+            payload = get_model_projection_payload(target_date)
         record_probability_source("model_projections")
         record_span(
             "route.models.projections.payload_bytes",

--- a/mlb_app/my_dashboard_dataset_runtime.py
+++ b/mlb_app/my_dashboard_dataset_runtime.py
@@ -25,6 +25,7 @@ SUBSTANTIVE_FILTER_KEYS = {
     "min_confidence",
     "metrics",
     "weights",
+    "conditions",
 }
 
 
@@ -52,6 +53,10 @@ def has_substantive_filters(filters: Optional[Dict[str, Any]]) -> bool:
             if isinstance(value, dict) and any(
                 weight not in (None, "", 1, 1.0, "1", "1.0") for weight in value.values()
             ):
+                return True
+            continue
+        if key == "conditions":
+            if isinstance(value, list) and value:
                 return True
             continue
         if value not in (None, "", {}, []):
@@ -96,6 +101,8 @@ def run_dataset_query(
     include_metadata: bool,
     payload_builder: Callable[[], Dict[str, Any]],
     active_lineups: bool = False,
+    report_type: Optional[str] = None,
+    selected_fields: Optional[list[str]] = None,
 ) -> Dict[str, Any]:
     status = dashboard_dataset_status(
         session=session,
@@ -140,6 +147,8 @@ def run_dataset_query(
         sort_direction=sort_direction,
         include_metadata=include_metadata,
         active_lineups=active_lineups,
+        report_type=report_type,
+        selected_fields=selected_fields,
     )
     result.update({
         "execution_path": "my_dashboard_dataset_sql_query",

--- a/mlb_app/my_dashboard_routes.py
+++ b/mlb_app/my_dashboard_routes.py
@@ -14,6 +14,7 @@ from .admin_configuration import profile_key_for_role
 from .dashboard_canonical_status import canonical_dashboard_status
 from .dashboard_player_report_query import query_player_report
 from .dashboard_projection_operator import ensure_canonical_projection
+from .dashboard_projection_report_query import query_projection_report
 from .dashboard_related_report_query import query_related_report
 from .dashboard_report_types import list_report_types
 from .database import AppFeatureFlag, create_tables, get_engine, get_session
@@ -225,13 +226,79 @@ def my_dashboard_player_report_query(payload: DashboardPlayerReportRequest) -> D
     try:
         factory = session_factory()
         with factory() as session:
-            if payload.report_type in {"players_lineup_history", "hitters_arsenal_splits"}:
+            if payload.report_type in {
+                "players_lineup_history",
+                "hitters_arsenal_splits",
+                "competitive_batter_arsenal",
+                "model_tracker_snapshots",
+            }:
                 return query_related_report(
                     session, payload.report_type, filters=payload.filters, weights=payload.weights,
                     page_size=payload.page_size, page_number=payload.page_number,
                     sort_by=None if payload.sort_by == "model_score" else payload.sort_by,
                     sort_direction=payload.sort_direction,
                     selected_fields=payload.selected_fields, include_metadata=payload.include_metadata,
+                    as_of_date=payload.as_of_date,
+                )
+            if payload.report_type in {"model_projection_games", "model_projection_players"}:
+                return query_projection_report(
+                    payload.report_type,
+                    date=(payload.as_of_date or mlb_business_date()).isoformat(),
+                    filters=payload.filters,
+                    weights=payload.weights,
+                    page_size=payload.page_size,
+                    page_number=payload.page_number,
+                    sort_by=None if payload.sort_by == "model_score" else payload.sort_by,
+                    sort_direction=payload.sort_direction,
+                    selected_fields=payload.selected_fields,
+                    include_metadata=payload.include_metadata,
+                )
+            dataset_reports = {
+                "teams_daily_analysis": "teams",
+                "games_totals_analysis": "totals",
+                "overall_players_daily_analysis": "overall_players",
+            }
+            if payload.report_type in dataset_reports:
+                target_date = (payload.as_of_date or mlb_business_date()).isoformat()
+                filters = payload.filters
+                if isinstance(filters, list):
+                    filters = {"logic": "and", "conditions": filters}
+                filters = dict(filters or {})
+                if payload.weights:
+                    filters["weights"] = dict(payload.weights)
+                component = dataset_reports[payload.report_type]
+                active_lineups = bool(
+                    payload.confirmed_lineups_only
+                    and payload.report_type == "overall_players_daily_analysis"
+                )
+                if active_lineups:
+                    payload_builder = lambda: build_active_lineup_solver_payload(
+                        session=session,
+                        date=target_date,
+                        component=component,
+                        filters={},
+                    )
+                else:
+                    payload_builder = lambda: dashboard_solver.build_dashboard_solver_payload(
+                        session=session,
+                        date=target_date,
+                        component=component,
+                        filters={},
+                    )
+                return run_dataset_query(
+                    session=session,
+                    date=target_date,
+                    component=component,
+                    filters=filters,
+                    page_size=payload.page_size,
+                    page_number=payload.page_number,
+                    sort_by="score" if payload.sort_by == "model_score" else payload.sort_by,
+                    sort_direction=payload.sort_direction,
+                    include_metadata=payload.include_metadata,
+                    payload_builder=payload_builder,
+                    active_lineups=active_lineups,
+                    report_type=payload.report_type,
+                    selected_fields=payload.selected_fields,
                 )
             bootstrap = None
             lineup_index = None

--- a/mlb_app/my_dashboard_sql_query.py
+++ b/mlb_app/my_dashboard_sql_query.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import Float, and_, case, cast, func, or_
 
+from .dashboard_report_types import FIELD_CATALOG, describe_report_type
 from .my_dashboard_dataset import (
     DATASET_MODE_ACTIVE_LINEUPS,
     DATASET_MODE_STANDARD,
@@ -54,12 +55,23 @@ SORT_COLUMNS = {
     "lineup_source": MyDashboardRecord.lineup_source,
     "confirmed_lineup_date": MyDashboardRecord.confirmed_lineup_date,
 }
+DATASET_REPORT_TYPES = {
+    "teams": "teams_daily_analysis",
+    "totals": "games_totals_analysis",
+    "overall_players": "overall_players_daily_analysis",
+}
 
 
 def normalize_dataset_filters(filters: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     if not isinstance(filters, dict):
         return {}
     normalized: Dict[str, Any] = {}
+    if isinstance(filters.get("conditions"), list):
+        logic = str(filters.get("logic") or "and").strip().lower()
+        if logic not in {"and", "or"}:
+            raise ValueError("filters.logic must be 'and' or 'or'")
+        normalized["logic"] = logic
+        normalized["conditions"] = list(filters["conditions"])
     for key in [
         "search_text",
         "team",
@@ -126,8 +138,91 @@ def _confidence_expression():
     )
 
 
-def _apply_filters(query: Any, component: str, filters: Dict[str, Any]) -> Tuple[Any, List[str]]:
+def _condition_expression(component: str, report_type: str, condition: Dict[str, Any]):
+    if not isinstance(condition, dict):
+        raise ValueError("Each filter condition must be an object")
+    field_name = str(condition.get("field") or "")
+    operator = str(condition.get("operator") or "eq").lower()
+    field = {item["name"]: item for item in FIELD_CATALOG[report_type]}.get(field_name)
+    if not field or not field.get("filterable"):
+        raise ValueError(f"Unsupported filter field: {field_name}")
+    if operator not in field.get("supported_operators", []):
+        raise ValueError(f"Unsupported operator '{operator}' for field '{field_name}'")
+
+    if field_name.startswith("metrics."):
+        metric = field_name[8:]
+        if metric not in _metric_registry(component):
+            raise ValueError(f"Unsupported metric filter: {metric}")
+        column = _metric_expression(metric)
+    else:
+        column = SORT_COLUMNS.get(field_name)
+    if column is None:
+        raise ValueError(f"Unsupported filter field: {field_name}")
+
+    value = condition.get("value")
+    comparison = _confidence_expression() if field_name == "confidence" and operator in {"gt", "gte", "lt", "lte"} else column
+    if comparison is not column:
+        confidence_order = {"low": 1, "medium": 2, "high": 3}
+        try:
+            value = confidence_order[str(value).strip().lower()]
+        except KeyError as exc:
+            raise ValueError("confidence must be low, medium, or high") from exc
+    elif operator not in {"is_null", "is_not_null", "in"}:
+        if field.get("data_type") in {"id", "integer"}:
+            try:
+                value = int(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid integer value for field '{field_name}'") from exc
+        elif field.get("data_type") in {"double", "number", "float"}:
+            try:
+                value = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid numeric value for field '{field_name}'") from exc
+        else:
+            value = str(value)
+
+    if operator == "eq": return column == value
+    if operator == "neq": return column != value
+    if operator == "in":
+        if not isinstance(value, (list, tuple, set)):
+            raise ValueError(f"Operator 'in' for field '{field_name}' requires a list")
+        values = list(value)
+        try:
+            if field.get("data_type") in {"id", "integer"}:
+                values = [int(item) for item in values]
+            elif field.get("data_type") in {"double", "number", "float"}:
+                values = [float(item) for item in values]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid list value for field '{field_name}'") from exc
+        return column.in_(values)
+    if operator == "contains": return func.lower(column).contains(str(value).lower())
+    if operator == "gt": return comparison > value
+    if operator == "gte": return comparison >= value
+    if operator == "lt": return comparison < value
+    if operator == "lte": return comparison <= value
+    if operator == "is_null": return column.is_(None)
+    if operator == "is_not_null": return column.is_not(None)
+    raise ValueError(f"Unsupported operator: {operator}")
+
+
+def _apply_filters(
+    query: Any,
+    component: str,
+    filters: Dict[str, Any],
+    report_type: Optional[str] = None,
+) -> Tuple[Any, List[str], str, List[Dict[str, Any]]]:
     warnings: List[str] = []
+    filter_logic = str(filters.get("logic") or "and")
+    applied_conditions = list(filters.get("conditions") or [])
+    if applied_conditions:
+        resolved_report_type = report_type or DATASET_REPORT_TYPES.get(component)
+        if not resolved_report_type:
+            raise ValueError(f"No condition catalog is registered for component: {component}")
+        expressions = [
+            _condition_expression(component, resolved_report_type, condition)
+            for condition in applied_conditions
+        ]
+        query = query.filter(or_(*expressions) if filter_logic == "or" else and_(*expressions))
     search = filters.get("search_text")
     if search:
         pattern = f"%{search.lower()}%"
@@ -180,7 +275,7 @@ def _apply_filters(query: Any, component: str, filters: Dict[str, Any]) -> Tuple
             query = query.filter(expression >= rules["min"])
         if rules.get("max") is not None:
             query = query.filter(expression <= rules["max"])
-    return query, warnings
+    return query, warnings, filter_logic, applied_conditions
 
 
 def _sort_expression(component: str, sort_by: str, weighted_expression=None):
@@ -256,6 +351,8 @@ def query_dashboard_dataset(
     sort_direction: Any = "desc",
     include_metadata: bool = True,
     active_lineups: bool = False,
+    report_type: Optional[str] = None,
+    selected_fields: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     target_date = dt.date.fromisoformat(str(date)[:10])
     normalized_component = str(component or "").strip().lower()
@@ -263,6 +360,15 @@ def query_dashboard_dataset(
         raise ValueError(f"Unsupported dashboard component: {component}")
     query_contract = normalize_query(page_size, page_number, sort_by, sort_direction)
     normalized_filters = normalize_dataset_filters(filters)
+    resolved_report_type = report_type or DATASET_REPORT_TYPES.get(normalized_component)
+    if selected_fields is not None and resolved_report_type:
+        catalog = {field["name"]: field for field in FIELD_CATALOG[resolved_report_type]}
+        invalid = [
+            name for name in selected_fields
+            if name not in catalog or not catalog[name].get("selectable", True)
+        ]
+        if invalid:
+            raise ValueError(f"Unsupported selected field(s): {', '.join(invalid)}")
     weights, weight_warnings = normalize_weights(normalized_component, normalized_filters.get("weights"))
     if weights:
         normalized_filters["weights"] = weights
@@ -277,7 +383,12 @@ def query_dashboard_dataset(
             MyDashboardRecord.is_current.is_(True),
         )
     )
-    filtered_query, warnings = _apply_filters(base_query, normalized_component, normalized_filters)
+    filtered_query, warnings, filter_logic, applied_conditions = _apply_filters(
+        base_query,
+        normalized_component,
+        normalized_filters,
+        resolved_report_type,
+    )
     warnings.extend(weight_warnings)
     total_size = filtered_query.order_by(None).count()
     weighted_expression = weighted_score_expression(weights) if weights else None
@@ -319,6 +430,13 @@ def query_dashboard_dataset(
         "done": not has_next,
         "query": query_contract,
         "filters_applied": normalized_filters,
+        "filter_logic": filter_logic,
+        "conditions_applied": applied_conditions,
+        "population": {
+            "mode": "confirmed_lineup" if active_lineups else "daily_dataset",
+            "matched_current_count": status.get("dataset_row_count"),
+            "filtered_count": total_size,
+        },
         "filter_warnings": warnings,
         "weight_ranking": {
             "enabled": bool(weights),
@@ -341,7 +459,9 @@ def query_dashboard_dataset(
         "filtered_row_count": total_size,
         "page_record_count": len(records),
     }
-    if include_metadata:
+    if include_metadata and resolved_report_type:
+        result["object_info"] = describe_report_type(resolved_report_type)
+    elif include_metadata:
         object_info = dict(OBJECT_METADATA[normalized_component])
         object_info.update({
             "name": normalized_component,

--- a/mlb_app/workbench_query.py
+++ b/mlb_app/workbench_query.py
@@ -93,7 +93,7 @@ def queryable_objects() -> List[Dict[str, Any]]:
 
     objects: List[Dict[str, Any]] = []
     for api_name, definition in REPORT_TYPES.items():
-        if not definition.get("queryable"):
+        if not definition.get("queryable") or definition.get("workbench_queryable") is False:
             continue
         fields = []
         for field in FIELD_CATALOG[api_name]:
@@ -197,7 +197,11 @@ def parse_workbench_statement(statement: str) -> WorkbenchPlan:
 
     logical_object = match.group("object").lower()
     definition = REPORT_TYPES.get(logical_object)
-    if not definition or not definition.get("queryable"):
+    if (
+        not definition
+        or not definition.get("queryable")
+        or definition.get("workbench_queryable") is False
+    ):
         raise ValueError(f"Unsupported queryable logical object: {logical_object}")
     fields = _field_map(logical_object)
 

--- a/tests/test_dashboard_object_schema.py
+++ b/tests/test_dashboard_object_schema.py
@@ -63,7 +63,13 @@ def test_current_projection_has_one_row_per_canonical_player():
 
 
 def test_report_type_registry_is_explicit_and_describable():
-    assert set(REPORT_TYPES) == {"all_active_hitters", "all_active_pitchers", "hitters_current_matchup", "hitters_arsenal_splits", "players_lineup_history", "teams_daily_analysis", "games_totals_analysis"}
+    assert set(REPORT_TYPES) == {
+        "all_active_hitters", "all_active_pitchers", "hitters_current_matchup",
+        "hitters_arsenal_splits", "players_lineup_history", "teams_daily_analysis",
+        "games_totals_analysis", "overall_players_daily_analysis",
+        "model_projection_games", "model_projection_players",
+        "model_tracker_snapshots", "competitive_batter_arsenal",
+    }
     hitters = describe_report_type("all_active_hitters")
     assert hitters["population"] == {"is_active": True, "player_type": "hitter"}
     assert hitters["fields"][0]["name"] == "mlb_player_id"

--- a/tests/test_dashboard_projection_report_query.py
+++ b/tests/test_dashboard_projection_report_query.py
@@ -1,0 +1,182 @@
+import pytest
+
+from mlb_app import dashboard_projection_report_query as reports
+from mlb_app.dashboard_report_types import describe_report_type
+
+
+DATE = "2026-07-24"
+
+
+def projection_payload():
+    return {
+        "date": DATE,
+        "workspace_contract": "model_projection_workspace_v1",
+        "probability_contract": "model_projection_probability_v1",
+        "artifact": {"cache_key": f"model_projection:{DATE}"},
+        "games": [
+            {
+                "game_pk": 10,
+                "game_date": DATE,
+                "game_time": "19:05",
+                "status": "Preview",
+                "venue": {"name": "Wrigley Field"},
+                "away_team": {"id": 1, "name": "STL"},
+                "home_team": {"id": 2, "name": "CHC"},
+                "away_pitcher": {"id": 11, "name": "Away Arm"},
+                "home_pitcher": {"id": 12, "name": "Home Arm"},
+                "model_projection_probability": {
+                    "away_win_probability": 0.42,
+                    "home_win_probability": 0.58,
+                    "model_version": "projection-v1",
+                    "source": "model_projections",
+                    "is_fallback": False,
+                },
+                "lineup_status": "confirmed",
+                "data_confidence": "high",
+                "sharedSimulation": {
+                    "meta": {"simulation_count": 3000},
+                    "direct_inputs": {
+                        "away_pitcher_profile": {
+                            "bat_missing": {"k_rate": 0.24},
+                            "command_control": {"bb_rate": 0.08},
+                            "contact_management": {"xwoba_allowed": 0.31},
+                        },
+                        "home_offense_profile": {
+                            "contact_skill": {"k_rate": 0.19},
+                            "plate_discipline": {"bb_rate": 0.1, "on_base_pct": 0.34},
+                            "power": {"iso": 0.18, "slugging_pct": 0.44},
+                        },
+                        "environment_profile": {
+                            "run_environment": {"run_scoring_index": 1.08, "hr_boost_index": 1.1},
+                            "weather": {"temperature_f": 82, "wind_speed_mph": 12},
+                        },
+                    },
+                    "derived_outputs": {
+                        "bullpen_adjusted_game_simulation": {
+                            "away_expected_runs": 4.1,
+                            "home_expected_runs": 4.9,
+                            "total_expected_runs": 9.0,
+                            "tie_after_regulation_probability": 0.09,
+                            "calibrated_total_probabilities": {"over_8.5": 0.54, "under_8.5": 0.46},
+                        },
+                    },
+                    "diagnostics": {
+                        "canonical_shadow": {
+                            "player_projections": {
+                                "simulation_count": 1000,
+                                "players": [
+                                    {
+                                        "player_id": "101",
+                                        "mlb_player_id": 101,
+                                        "full_name": "Alpha Batter",
+                                        "player_type": "batter",
+                                        "team_side": "home",
+                                        "team_id": 2,
+                                        "team_name": "CHC",
+                                        "primary_position": "OF",
+                                        "projected_dfs_points": 12.5,
+                                        "dfs_floor": 4.0,
+                                        "dfs_median": 11.8,
+                                        "dfs_ceiling": 23.0,
+                                        "metrics": {
+                                            "plate_appearances": {"mean": 4.4},
+                                            "home_runs": {"mean": 0.3},
+                                            "rbi": {"mean": 0.8},
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+            {
+                "game_pk": 20,
+                "game_date": DATE,
+                "away_team": {"id": 3, "name": "MIL"},
+                "home_team": {"id": 4, "name": "CIN"},
+                "model_projection_probability": {
+                    "away_win_probability": 0.61,
+                    "home_win_probability": 0.39,
+                    "model_version": "projection-v1",
+                    "source": "model_projections",
+                    "is_fallback": True,
+                },
+                "lineup_status": "projected",
+                "data_confidence": "medium",
+                "sharedSimulation": {"derived_outputs": {}, "diagnostics": {}},
+            },
+        ],
+    }
+
+
+def test_projection_game_parent_filters_sorts_and_paginates(monkeypatch):
+    monkeypatch.setattr(reports, "get_model_projection_payload", lambda date: projection_payload())
+    result = reports.query_projection_report(
+        "model_projection_games",
+        date=DATE,
+        filters={
+            "logic": "or",
+            "conditions": [
+                {"field": "home_team_name", "operator": "eq", "value": "CHC"},
+                {"field": "probability_is_fallback", "operator": "eq", "value": True},
+            ],
+        },
+        sort_by="home_win_probability",
+        page_size=1,
+    )
+    assert result["filter_logic"] == "or"
+    assert result["totalSize"] == 2
+    assert result["records"][0]["game_pk"] == 10
+    assert result["records"][0]["projected_total"] == pytest.approx(9.0)
+    assert result["records"][0]["away_starter_k_rate"] == pytest.approx(0.24)
+    assert result["records"][0]["home_offense_obp"] == pytest.approx(0.34)
+    assert result["records"][0]["run_scoring_index"] == pytest.approx(1.08)
+    assert result["records"][0]["simulation_count"] == 3000
+    assert result["records"][0]["over_8_5_probability"] == pytest.approx(0.54)
+    assert result["page_info"]["has_next"] is True
+    assert result["object_info"]["relationships"] == ["model_projection_players"]
+
+
+def test_projection_player_child_uses_same_artifact_and_explicit_fields(monkeypatch):
+    monkeypatch.setattr(reports, "get_model_projection_payload", lambda date: projection_payload())
+    result = reports.query_projection_report(
+        "model_projection_players",
+        date=DATE,
+        filters={
+            "logic": "and",
+            "conditions": [
+                {"field": "player_type", "operator": "eq", "value": "batter"},
+                {"field": "projected_dfs_points", "operator": "gte", "value": 10},
+            ],
+        },
+        sort_by="projected_dfs_points",
+    )
+    assert result["totalSize"] == 1
+    row = result["records"][0]
+    assert row["full_name"] == "Alpha Batter"
+    assert row["plate_appearances"] == pytest.approx(4.4)
+    assert row["home_runs"] == pytest.approx(0.3)
+    assert row["rbi"] == pytest.approx(0.8)
+    assert result["query_source"] == "model_projection_date_artifact"
+
+
+def test_projection_reports_reject_weights_and_unknown_fields(monkeypatch):
+    monkeypatch.setattr(reports, "get_model_projection_payload", lambda date: projection_payload())
+    with pytest.raises(ValueError, match="Weights are not supported"):
+        reports.query_projection_report("model_projection_games", date=DATE, weights={"score": 2})
+    with pytest.raises(ValueError, match="Unsupported filter field"):
+        reports.query_projection_report(
+            "model_projection_games",
+            date=DATE,
+            filters={"conditions": [{"field": "physical_table", "operator": "eq", "value": "games"}]},
+        )
+
+
+def test_projection_catalogs_are_parent_child_and_do_not_expose_nested_payloads():
+    game = describe_report_type("model_projection_games")
+    player = describe_report_type("model_projection_players")
+    assert game["base_object"] == player["base_object"] == "model_projection_date_artifact"
+    assert "model_projection_players" in game["relationships"]
+    assert "model_projection_games" in player["relationships"]
+    assert all(field["data_type"] != "json" for field in game["fields"] + player["fields"])

--- a/tests/test_dashboard_related_report_query.py
+++ b/tests/test_dashboard_related_report_query.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import sessionmaker
 from mlb_app.dashboard_object_models import DashboardPlayer
 from mlb_app.dashboard_related_report_query import query_related_report
 from mlb_app.dashboard_report_types import describe_report_type
-from mlb_app.database import Base, BatterPitchTypeMatchup
+from mlb_app.database import Base, BatterPitchTypeMatchup, PitchArsenal
+from mlb_app.model_tracker import ModelTrackerSnapshot
 
 
 DATE = dt.date(2026, 7, 16)
@@ -70,3 +71,70 @@ def test_related_reports_reject_unsupported_fields_weights_and_filters():
         query_related_report(session, "players_lineup_history", selected_fields=["secret"])
     with pytest.raises(ValueError, match="Unsupported filter field"):
         query_related_report(session, "hitters_arsenal_splits", filters=[{"field": "secret", "value": 1}])
+
+
+def test_competitive_batter_arsenal_is_the_registered_matchup_object_and_supports_or():
+    session = make_session()
+    session.add(player(1, "Alpha", 3))
+    session.add_all([
+        BatterPitchTypeMatchup(batter_id=1, batter_name="Alpha", opposing_pitcher_id=9, pitch_type="FF", target_date=DATE, pitches_seen=80, xwoba=0.41),
+        BatterPitchTypeMatchup(batter_id=1, batter_name="Alpha", opposing_pitcher_id=9, pitch_type="SL", target_date=DATE, pitches_seen=20, xwoba=0.31),
+    ])
+    session.add_all([
+        PitchArsenal(season=DATE.year, pitcher_id=9, pitch_type="FF", pitch_name="Four-Seam Fastball", pitch_count=400, usage_pct=0.5, whiff_pct=0.24, strikeout_pct=0.27, xwoba=0.32, hard_hit_pct=0.35),
+        PitchArsenal(season=DATE.year, pitcher_id=9, pitch_type="SL", pitch_name="Slider", pitch_count=220, usage_pct=0.28, whiff_pct=0.36, strikeout_pct=0.32, xwoba=0.28, hard_hit_pct=0.30),
+    ])
+    session.commit()
+    result = query_related_report(
+        session,
+        "competitive_batter_arsenal",
+        as_of_date=DATE,
+        filters={
+            "logic": "or",
+            "conditions": [
+                {"field": "pitch_type", "operator": "eq", "value": "SL"},
+                {"field": "pitches_seen", "operator": "gte", "value": 50},
+            ],
+        },
+    )
+    assert result["filter_logic"] == "or"
+    assert result["totalSize"] == 2
+    assert result["object_info"]["api_name"] == "competitive_batter_arsenal"
+    assert result["query_source"] == "batter_pitch_type_matchups"
+    fastball = next(row for row in result["records"] if row["pitch_type"] == "FF")
+    assert fastball["pitcher_pitch_name"] == "Four-Seam Fastball"
+    assert fastball["pitcher_usage_pct"] == pytest.approx(0.5)
+    assert fastball["edge_score"] is not None
+    assert fastball["matchup_confidence"] is not None
+
+
+def test_model_tracker_report_exposes_safe_scalar_columns_only():
+    session = make_session()
+    session.add(ModelTrackerSnapshot(
+        tracker_key="fixture",
+        snapshot_date=DATE,
+        source="model_projections",
+        source_component="canonical_moneyline_side",
+        game_pk=123,
+        pick_label="CHC",
+        model_name="fixture_model",
+        score=0.73,
+        grade="won",
+        raw_payload_json='{"secret": "must-not-leak"}',
+        reasoning_json='{"private": "detail"}',
+    ))
+    session.commit()
+    result = query_related_report(
+        session,
+        "model_tracker_snapshots",
+        as_of_date=DATE,
+        filters={"logic": "and", "conditions": [{"field": "grade", "operator": "eq", "value": "won"}]},
+    )
+    assert result["totalSize"] == 1
+    row = result["records"][0]
+    assert row["pick_label"] == "CHC"
+    assert "raw_payload_json" not in row
+    assert "reasoning_json" not in row
+    fields = {field["name"] for field in result["object_info"]["fields"]}
+    assert "raw_payload_json" not in fields
+    assert "reasoning_json" not in fields

--- a/tests/test_dashboard_report_auto_bootstrap.py
+++ b/tests/test_dashboard_report_auto_bootstrap.py
@@ -70,6 +70,46 @@ def test_noncanonical_related_report_does_not_auto_bootstrap(monkeypatch):
     assert "population_bootstrap" not in result
 
 
+def test_expanded_report_types_dispatch_to_existing_authoritative_services(monkeypatch):
+    monkeypatch.setattr(routes, "session_factory", lambda: lambda: SessionContext())
+    captured = {}
+
+    def dataset(**kwargs):
+        captured["dataset"] = kwargs
+        return {"report_type": kwargs["report_type"], "records": [], "totalSize": 0}
+
+    def projection(report_type, **kwargs):
+        captured["projection"] = {"report_type": report_type, **kwargs}
+        return {"report_type": report_type, "records": [], "totalSize": 0}
+
+    monkeypatch.setattr(routes, "run_dataset_query", dataset)
+    monkeypatch.setattr(routes, "query_projection_report", projection)
+
+    overall = routes.my_dashboard_player_report_query(
+        routes.DashboardPlayerReportRequest(
+            report_type="overall_players_daily_analysis",
+            as_of_date=dt.date(2026, 7, 23),
+            filters={"logic": "or", "conditions": [{"field": "team", "operator": "eq", "value": "CHC"}]},
+            confirmed_lineups_only=True,
+        )
+    )
+    assert overall["report_type"] == "overall_players_daily_analysis"
+    assert captured["dataset"]["component"] == "overall_players"
+    assert captured["dataset"]["active_lineups"] is True
+    assert captured["dataset"]["filters"]["logic"] == "or"
+
+    games = routes.my_dashboard_player_report_query(
+        routes.DashboardPlayerReportRequest(
+            report_type="model_projection_games",
+            as_of_date=dt.date(2026, 7, 23),
+            sort_by="home_win_probability",
+        )
+    )
+    assert games["report_type"] == "model_projection_games"
+    assert captured["projection"]["date"] == "2026-07-23"
+    assert captured["projection"]["sort_by"] == "home_win_probability"
+
+
 def test_confirmed_hitters_query_full_canonical_id_population(monkeypatch):
     calls = {}
     monkeypatch.setattr(routes, "session_factory", lambda: lambda: SessionContext())

--- a/tests/test_my_dashboard_auth_and_admin.py
+++ b/tests/test_my_dashboard_auth_and_admin.py
@@ -543,10 +543,10 @@ def test_object_manager_response_is_derived_from_server_registry(monkeypatch):
     objects = list_report_types()
     monkeypatch.setattr(admin_routes, "list_report_types", lambda: objects)
     payload = admin_routes.admin_objects(_principal())
-    assert payload["totalSize"] == len(objects) == 7
+    assert payload["totalSize"] == len(objects) == 12
     assert payload["queryableSize"] == sum(
         bool(item.get("queryable")) for item in objects
-    ) == 4
+    ) == 11
     assert all(
         {
             "api_name",

--- a/tests/test_my_dashboard_sql_query.py
+++ b/tests/test_my_dashboard_sql_query.py
@@ -238,3 +238,94 @@ def test_standard_and_active_lineup_modes_are_isolated():
         assert active["totalSize"] == 1
         assert active["lineup_revision"] == "rev-1"
         assert active["model_state"] == "confirmed"
+
+
+def test_team_report_match_all_and_match_any_use_the_server_catalog_before_pagination():
+    Session = session_factory()
+    team_rows = [
+        {
+            "entity_id": "CHC", "entity_name": "Chicago Cubs", "entity_type": "team",
+            "team": "CHC", "opponent": "STL", "score": 0.91, "base_score": 0.91,
+            "confidence": "high", "metrics": {"Edge Score": 0.8, "Win Edge": 0.12},
+        },
+        {
+            "entity_id": "MIL", "entity_name": "Milwaukee Brewers", "entity_type": "team",
+            "team": "MIL", "opponent": "CIN", "score": 0.72, "base_score": 0.72,
+            "confidence": "medium", "metrics": {"Edge Score": 0.4, "Win Edge": 0.05},
+        },
+        {
+            "entity_id": "LAD", "entity_name": "Los Angeles Dodgers", "entity_type": "team",
+            "team": "LAD", "opponent": "SD", "score": 0.95, "base_score": 0.95,
+            "confidence": "high", "metrics": {"Edge Score": 0.9, "Win Edge": 0.14},
+        },
+    ]
+    with Session() as session:
+        hydrate_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="teams",
+            payload_builder=lambda: {"items": team_rows},
+        )
+        match_all = query_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="teams",
+            report_type="teams_daily_analysis",
+            filters={
+                "logic": "and",
+                "conditions": [
+                    {"field": "confidence", "operator": "eq", "value": "high"},
+                    {"field": "metrics.Edge Score", "operator": "gte", "value": "0.85"},
+                ],
+            },
+            page_size=1,
+        )
+        assert match_all["filter_logic"] == "and"
+        assert match_all["totalSize"] == 1
+        assert match_all["records"][0]["entity_id"] == "LAD"
+
+        match_any = query_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="teams",
+            report_type="teams_daily_analysis",
+            filters={
+                "logic": "or",
+                "conditions": [
+                    {"field": "team", "operator": "eq", "value": "MIL"},
+                    {"field": "metrics.Win Edge", "operator": "gt", "value": 0.1},
+                ],
+            },
+            page_size=2,
+        )
+        assert match_any["filter_logic"] == "or"
+        assert match_any["totalSize"] == 3
+        assert match_any["page_info"]["has_next"] is True
+        assert match_any["object_info"]["api_name"] == "teams_daily_analysis"
+
+
+def test_dataset_catalog_rejects_unknown_conditions_and_logic():
+    Session = session_factory()
+    with Session() as session:
+        hydrate_dashboard_dataset(
+            session=session,
+            date=DATE,
+            component="totals",
+            payload_builder=lambda: {"items": [{"entity_id": "10", "entity_name": "CHC @ STL", "score": 8.5, "metrics": {"Projected Total": 8.5}}]},
+        )
+        with pytest.raises(ValueError, match="Unsupported filter field"):
+            query_dashboard_dataset(
+                session=session,
+                date=DATE,
+                component="totals",
+                report_type="games_totals_analysis",
+                filters={"logic": "and", "conditions": [{"field": "physical_table", "operator": "eq", "value": "x"}]},
+            )
+        with pytest.raises(ValueError, match="filters.logic"):
+            query_dashboard_dataset(
+                session=session,
+                date=DATE,
+                component="totals",
+                report_type="games_totals_analysis",
+                filters={"logic": "xor", "conditions": []},
+            )

--- a/tests/test_workbench_query.py
+++ b/tests/test_workbench_query.py
@@ -106,6 +106,10 @@ def test_metadata_is_derived_and_excludes_physical_schema_details():
     }
     assert all("base_object" not in item for item in objects)
     assert all("source_object" not in field for item in objects for field in item["fields"])
+    with pytest.raises(ValueError, match="Unsupported queryable logical object"):
+        workbench_query.parse_workbench_statement(
+            "SELECT game_pk FROM model_projection_games LIMIT 10"
+        )
 
 
 def test_request_contract_rejects_submitted_authorization_fields():


### PR DESCRIPTION
Closes #1218.

## What changed

- Promotes Teams, Totals, and Overall Players into the catalog-driven MyDashboard report path.
- Adds Model Projections as a parent/core report object with a related player projection report.
- Adds Model Tracker as a safe scalar report type.
- Adds Batter vs Arsenal as a competitive-analysis report type.
- Extends the report builder and backend query contracts with validated AND/OR condition groups.
- Makes the registered field catalogs available for both report columns and filters.
- Preserves saved/reopened report definitions and the existing weighted-report behavior.

## Query and security boundaries

- Fields and operators come from the server-owned report catalog.
- Filters are applied before count, sorting, and pagination.
- Model Tracker excludes raw payloads, reasoning, and secrets.
- Query Studio does not advertise the new date-aware objects until its grammar can execute them safely.
- No user-authored SQL is executed.

## Validation

- Relevant MyDashboard backend suite: 155 passed.
- Affected frontend Node suite: 50 passed.
- Production frontend build passed.
- Python compilation passed.
- `git diff --check` passed.
- No new prohibited vendor terminology or raw SQL execution path was introduced.

The full frontend test command has one pre-existing Model Tracker ordering failure that is reproducible on the base and is outside this diff.

## Base audit

This branch was originally implemented from merge commit `e30ca69`. Current `main` has advanced with baserunning shadow/calibration work, but the GitHub compare shows no overlap with this PR's 20 MyDashboard files. GitHub can merge the disjoint histories normally; this PR intentionally does not modify the newer baserunning work.