### PR TITLE
Execute historical baserunning shadow replays

### DIFF
--- a/mlb_app/simulation/game/baserunning_composition.py
+++ b/mlb_app/simulation/game/baserunning_composition.py
@@ -109,9 +109,38 @@ class CanonicalCatalogBaserunningResolverFactory:
             )
         )
 
-        return CanonicalBaserunningResolverAdapterFactory(
-            evidence_provider=evidence_provider,
-        )(context)
+        resolver = (
+            CanonicalBaserunningResolverAdapterFactory(
+                evidence_provider=evidence_provider,
+            )(context)
+        )
+
+        def resolve(
+            state,
+            batter_id,
+            sequence,
+        ):
+            event = resolver(
+                state,
+                batter_id,
+                sequence,
+            )
+
+            if event is None:
+                return None
+
+            event_recorder = getattr(
+                plate_appearance_resolver,
+                "record_baserunning_event",
+                None,
+            )
+
+            if callable(event_recorder):
+                event_recorder(event)
+
+            return event
+
+        return resolve
 
 
 def build_canonical_catalog_baserunning_resolver_factory(

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -215,6 +215,82 @@ class _CanonicalPlateAppearanceResolver:
             .pitcher_id
         )
 
+    def _register_automatic_runner(
+        self,
+        state: GameState,
+    ) -> None:
+        if self.pitching_manager is None:
+            return
+
+        automatic_runner_id = state.bases[1]
+        automatic_runner_key = (
+            state.inning,
+            state.half,
+            automatic_runner_id or "",
+        )
+
+        should_register = (
+            state.outs == 0
+            and state.plate_appearance_number >= 0
+            and automatic_runner_id is not None
+            and automatic_runner_key
+            not in self.registered_automatic_runner_keys
+            and state.inning
+            > self.context.regulation_innings
+        )
+
+        if not should_register:
+            return
+
+        self.pitching_manager.register_automatic_runner(
+            state=state,
+            runner_id=automatic_runner_id,
+        )
+
+        object.__setattr__(
+            self,
+            "registered_automatic_runner_keys",
+            (
+                self.registered_automatic_runner_keys
+                + (automatic_runner_key,)
+            ),
+        )
+
+    def record_baserunning_event(
+        self,
+        event: PlayEvent,
+    ) -> None:
+        """Synchronize a non-PA event with pitching state."""
+
+        if not isinstance(event, PlayEvent):
+            raise TypeError(
+                "event must be a PlayEvent"
+            )
+
+        if event.is_plate_appearance:
+            raise ValueError(
+                "baserunning event must not be a "
+                "plate appearance"
+            )
+
+        self._register_automatic_runner(
+            event.state_before
+        )
+
+        if self.pitching_manager is None:
+            return
+
+        self.pitching_manager.record_baserunning_event(
+            event
+        )
+
+        object.__setattr__(
+            self,
+            "scored_run_count",
+            self.scored_run_count
+            + len(event.runs_scored),
+        )
+
     def earned_run_reconstruction_complete(
         self,
     ) -> bool:
@@ -250,38 +326,7 @@ class _CanonicalPlateAppearanceResolver:
                 "state must be a GameState"
             )
 
-        if self.pitching_manager is not None:
-            automatic_runner_id = state.bases[1]
-            automatic_runner_key = (
-                state.inning,
-                state.half,
-                automatic_runner_id or "",
-            )
-
-            should_register = (
-                state.outs == 0
-                and state.plate_appearance_number >= 0
-                and automatic_runner_id is not None
-                and automatic_runner_key
-                not in self.registered_automatic_runner_keys
-                and state.inning
-                > self.context.regulation_innings
-            )
-
-            if should_register:
-                self.pitching_manager.register_automatic_runner(
-                    state=state,
-                    runner_id=automatic_runner_id,
-                )
-
-                object.__setattr__(
-                    self,
-                    "registered_automatic_runner_keys",
-                    (
-                        self.registered_automatic_runner_keys
-                        + (automatic_runner_key,)
-                    ),
-                )
+        self._register_automatic_runner(state)
 
         pitcher_id = (
             self.pitching_manager

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -280,6 +280,29 @@ class CanonicalPitchingManager:
             event,
         )
 
+        self._record_runner_event(event)
+
+        self._active[team_side] = updated
+        return updated
+
+    def record_baserunning_event(
+        self,
+        event: PlayEvent,
+    ) -> None:
+        """Apply a non-PA runner transition to the ledger."""
+
+        if event.is_plate_appearance:
+            raise ValueError(
+                "baserunning event must not be a "
+                "plate appearance"
+            )
+
+        self._record_runner_event(event)
+
+    def _record_runner_event(
+        self,
+        event: PlayEvent,
+    ) -> None:
         before = {
             value.runner_id: value
             for value in (
@@ -352,8 +375,6 @@ class CanonicalPitchingManager:
                     responsibility.runner_id
                 )
 
-        self._active[team_side] = updated
-        return updated
 
     def responsibility_for_runner(
         self,

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -555,3 +555,12 @@ from .historical_mlb_baserunning_feed_source import (
     CanonicalHistoricalMlbBaserunningFeedEvidence,
     source_historical_mlb_baserunning_feed_evidence,
 )
+
+
+from .historical_baserunning_shadow_replay_execution import (
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION,
+    DEFAULT_HISTORICAL_BASERUNNING_SIMULATION_COUNT,
+    CanonicalHistoricalBaserunningShadowReplayGame,
+    CanonicalHistoricalBaserunningShadowReplayWindow,
+    execute_historical_baserunning_shadow_replays,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_shadow_replay_execution.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_shadow_replay_execution.py
@@ -1,0 +1,725 @@
+"""Execute deterministic historical baserunning shadow replays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Tuple
+
+from .bullpen_discovery import (
+    CanonicalShadowBullpenDiscovery,
+    CanonicalShadowBullpenSideDiscovery,
+)
+from .exact_artifact_discovery import (
+    CanonicalShadowExactArtifactDiscovery,
+)
+from .fallback_catalog_discovery import (
+    CanonicalShadowFallbackCatalogDiscovery,
+)
+from .historical_baserunning_replay_evidence_source import (
+    CanonicalHistoricalBaserunningReplayEvidenceWindow,
+)
+from .historical_lineup_bullpen_source import (
+    CanonicalHistoricalLineupBullpenWindow,
+)
+from .historical_probability_artifact_materialization import (
+    CanonicalHistoricalProbabilityArtifactWindow,
+)
+from .lineup_discovery import (
+    CanonicalShadowLineupDiscovery,
+)
+from .probability_provider_discovery import (
+    CanonicalShadowProbabilityProviderDiscovery,
+    REQUIRED_WORKSPACE_MODELS,
+)
+from .production_execution import (
+    CanonicalProductionShadowExecution,
+    run_canonical_production_shadow,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION = (
+    "canonical_historical_baserunning_shadow_replay_v1"
+)
+DEFAULT_HISTORICAL_BASERUNNING_SIMULATION_COUNT = 25
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _validate_digest(value: str, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{name} must be a SHA256 digest"
+        )
+
+
+def _validate_date(value: str) -> None:
+    try:
+        parsed = date.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date must be an ISO date"
+        ) from exc
+
+    if parsed.isoformat() != value:
+        raise ValueError(
+            "game_date must use ISO format"
+        )
+
+
+def _normalize_starters(
+    values: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    *,
+    expected: set[int],
+) -> Dict[int, Tuple[str, str]]:
+    if not isinstance(values, Mapping):
+        raise TypeError(
+            "starting_pitcher_ids must be a mapping"
+        )
+
+    normalized = {}
+
+    for raw_game_pk, raw_pair in values.items():
+        try:
+            game_pk = int(raw_game_pk)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "starting pitcher game identifiers "
+                "must be integers"
+            ) from exc
+
+        if (
+            not isinstance(raw_pair, tuple)
+            or len(raw_pair) != 2
+        ):
+            raise TypeError(
+                "starting pitcher values must be "
+                "away-home tuples"
+            )
+
+        pair = []
+        for raw_identifier in raw_pair:
+            try:
+                identifier = int(raw_identifier)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "starting pitcher identifiers "
+                    "must be positive integers"
+                ) from exc
+
+            if identifier <= 0:
+                raise ValueError(
+                    "starting pitcher identifiers "
+                    "must be positive integers"
+                )
+
+            pair.append(str(identifier))
+
+        normalized[game_pk] = (
+            pair[0],
+            pair[1],
+        )
+
+    if set(normalized) != expected:
+        raise ValueError(
+            "starting pitchers must exactly cover "
+            "historical replay games"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningShadowReplayGame:
+    game_pk: int
+    game_date: str
+    execution: CanonicalProductionShadowExecution
+    probability_artifact_digest: str
+    baserunning_evidence_digest: str
+    output_digest: str
+    replay_digest: str
+    replay_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        _validate_date(self.game_date)
+
+        if not isinstance(
+            self.execution,
+            CanonicalProductionShadowExecution,
+        ):
+            raise TypeError(
+                "execution must be "
+                "CanonicalProductionShadowExecution"
+            )
+
+        for name, value in (
+            (
+                "probability_artifact_digest",
+                self.probability_artifact_digest,
+            ),
+            (
+                "baserunning_evidence_digest",
+                self.baserunning_evidence_digest,
+            ),
+            ("output_digest", self.output_digest),
+            ("replay_digest", self.replay_digest),
+        ):
+            _validate_digest(value, name)
+
+        if self.replay_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "shadow replay version"
+            )
+
+    @property
+    def executed(self) -> bool:
+        return (
+            self.execution.status == "executed"
+            and self.execution.executed
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "status": self.execution.status,
+            "executed": self.executed,
+            "simulation_count": (
+                self.execution.simulation_count
+            ),
+            "probability_artifact_digest": (
+                self.probability_artifact_digest
+            ),
+            "baserunning_evidence_digest": (
+                self.baserunning_evidence_digest
+            ),
+            "output_digest": self.output_digest,
+            "replay_digest": self.replay_digest,
+            "error_type": self.execution.error_type,
+            "error_message": (
+                self.execution.error_message
+            ),
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningShadowReplayWindow:
+    observed_window_digest: str
+    lineup_bullpen_window_digest: str
+    probability_artifact_window_digest: str
+    baserunning_evidence_window_digest: str
+    simulation_count: int
+    games: Tuple[
+        CanonicalHistoricalBaserunningShadowReplayGame,
+        ...,
+    ]
+    digest: str
+    replay_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.simulation_count, bool)
+            or self.simulation_count <= 0
+        ):
+            raise ValueError(
+                "simulation_count must be positive"
+            )
+
+        if not self.games:
+            raise ValueError(
+                "games must contain historical replays"
+            )
+
+        identities = tuple(
+            value.game_pk
+            for value in self.games
+        )
+        if len(identities) != len(set(identities)):
+            raise ValueError(
+                "historical replay game identifiers "
+                "must be unique"
+            )
+
+        for name, value in (
+            (
+                "observed_window_digest",
+                self.observed_window_digest,
+            ),
+            (
+                "lineup_bullpen_window_digest",
+                self.lineup_bullpen_window_digest,
+            ),
+            (
+                "probability_artifact_window_digest",
+                self.probability_artifact_window_digest,
+            ),
+            (
+                "baserunning_evidence_window_digest",
+                self.baserunning_evidence_window_digest,
+            ),
+            ("digest", self.digest),
+        ):
+            _validate_digest(value, name)
+
+        if self.replay_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical replay "
+                "window version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def executed_game_count(self) -> int:
+        return sum(
+            value.executed
+            for value in self.games
+        )
+
+    @property
+    def blocked_game_count(self) -> int:
+        return sum(
+            value.execution.status == "blocked"
+            for value in self.games
+        )
+
+    @property
+    def error_game_count(self) -> int:
+        return sum(
+            value.execution.status == "error"
+            for value in self.games
+        )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.executed_game_count
+            == self.game_count
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.replay_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "executed_game_count": (
+                self.executed_game_count
+            ),
+            "blocked_game_count": (
+                self.blocked_game_count
+            ),
+            "error_game_count": self.error_game_count,
+            "simulation_count": self.simulation_count,
+            "observed_window_digest": (
+                self.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                self.lineup_bullpen_window_digest
+            ),
+            "probability_artifact_window_digest": (
+                self.probability_artifact_window_digest
+            ),
+            "baserunning_evidence_window_digest": (
+                self.baserunning_evidence_window_digest
+            ),
+            "replay_window_digest": self.digest,
+            "games": tuple(
+                value.to_diagnostics()
+                for value in self.games
+            ),
+            "historical_replay_executed": (
+                self.executed_game_count > 0
+            ),
+            "external_fetch_performed": False,
+            "persistence_performed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def execute_historical_baserunning_shadow_replays(
+    *,
+    lineup_bullpen: CanonicalHistoricalLineupBullpenWindow,
+    probability_artifacts: (
+        CanonicalHistoricalProbabilityArtifactWindow
+    ),
+    baserunning_evidence: (
+        CanonicalHistoricalBaserunningReplayEvidenceWindow
+    ),
+    starting_pitcher_ids: Mapping[
+        int,
+        Tuple[str, str],
+    ],
+    simulation_count: int = (
+        DEFAULT_HISTORICAL_BASERUNNING_SIMULATION_COUNT
+    ),
+) -> CanonicalHistoricalBaserunningShadowReplayWindow:
+    """Run one production-shaped canonical shadow batch per game."""
+
+    if not isinstance(
+        lineup_bullpen,
+        CanonicalHistoricalLineupBullpenWindow,
+    ):
+        raise TypeError(
+            "lineup_bullpen must be a "
+            "CanonicalHistoricalLineupBullpenWindow"
+        )
+
+    if not isinstance(
+        probability_artifacts,
+        CanonicalHistoricalProbabilityArtifactWindow,
+    ):
+        raise TypeError(
+            "probability_artifacts must be a "
+            "CanonicalHistoricalProbabilityArtifactWindow"
+        )
+
+    if not isinstance(
+        baserunning_evidence,
+        CanonicalHistoricalBaserunningReplayEvidenceWindow,
+    ):
+        raise TypeError(
+            "baserunning_evidence must be a "
+            "CanonicalHistoricalBaserunningReplayEvidenceWindow"
+        )
+
+    if (
+        isinstance(simulation_count, bool)
+        or int(simulation_count) <= 0
+    ):
+        raise ValueError(
+            "simulation_count must be positive"
+        )
+    normalized_simulation_count = int(
+        simulation_count
+    )
+
+    if not (
+        lineup_bullpen.observed_window_digest
+        == probability_artifacts.observed_window_digest
+        == baserunning_evidence.observed_window_digest
+    ):
+        raise ValueError(
+            "observed window digests must match"
+        )
+
+    if (
+        baserunning_evidence.lineup_bullpen_window_digest
+        != lineup_bullpen.digest
+    ):
+        raise ValueError(
+            "lineup-bullpen window digests must match"
+        )
+
+    lineups_by_id = {
+        value.game_pk: value
+        for value in lineup_bullpen.games
+    }
+    artifacts_by_id = {
+        value.game_pk: value
+        for value in probability_artifacts.games
+    }
+    evidence_by_id = {
+        value.game_pk: value
+        for value in baserunning_evidence.games
+    }
+
+    expected = set(lineups_by_id)
+    if not (
+        expected
+        == set(artifacts_by_id)
+        == set(evidence_by_id)
+    ):
+        raise ValueError(
+            "historical replay inputs must exactly "
+            "cover the same games"
+        )
+
+    starters = _normalize_starters(
+        starting_pitcher_ids,
+        expected=expected,
+    )
+
+    replay_games = []
+
+    for game_pk in sorted(
+        expected,
+        key=lambda value: (
+            lineups_by_id[value].game_date,
+            value,
+        ),
+    ):
+        roster = lineups_by_id[game_pk]
+        artifact = artifacts_by_id[game_pk]
+        evidence = evidence_by_id[game_pk]
+        away_starter, home_starter = (
+            starters[game_pk]
+        )
+
+        if not (
+            roster.game_date
+            == artifact.game_date
+            == evidence.game_date
+        ):
+            raise ValueError(
+                "historical replay game dates must match"
+            )
+
+        lineups = CanonicalShadowLineupDiscovery(
+            away_player_ids=roster.away_lineup_ids,
+            home_player_ids=roster.home_lineup_ids,
+            away_source_count=len(
+                roster.away_lineup_ids
+            ),
+            home_source_count=len(
+                roster.home_lineup_ids
+            ),
+            status="ready",
+        )
+
+        bullpens = CanonicalShadowBullpenDiscovery(
+            away=CanonicalShadowBullpenSideDiscovery(
+                starter_id=away_starter,
+                bullpen_pitcher_ids=(
+                    roster.away_bullpen_ids
+                ),
+                source_record_count=(
+                    len(roster.away_bullpen_ids) + 1
+                ),
+                status="ready",
+            ),
+            home=CanonicalShadowBullpenSideDiscovery(
+                starter_id=home_starter,
+                bullpen_pitcher_ids=(
+                    roster.home_bullpen_ids
+                ),
+                source_record_count=(
+                    len(roster.home_bullpen_ids) + 1
+                ),
+                status="ready",
+            ),
+        )
+
+        provider = artifact.exact_artifact.provider
+        provider_discovery = (
+            CanonicalShadowProbabilityProviderDiscovery(
+                provider=provider,
+                model_versions=(
+                    provider.provider_version,
+                ),
+                valid_model_count=len(
+                    REQUIRED_WORKSPACE_MODELS
+                ),
+                status="ready",
+            )
+        )
+
+        away_ids = set(
+            roster.away_lineup_ids
+        )
+        home_ids = set(
+            roster.home_lineup_ids
+        )
+        exact_records = (
+            artifact.exact_artifact.records
+        )
+        away_record_count = sum(
+            record.batter_id in away_ids
+            for record in exact_records
+        )
+        home_record_count = sum(
+            record.batter_id in home_ids
+            for record in exact_records
+        )
+
+        exact_discovery = (
+            CanonicalShadowExactArtifactDiscovery(
+                artifact=artifact.exact_artifact,
+                away_record_count=away_record_count,
+                home_record_count=home_record_count,
+                away_real_profile_count=(
+                    away_record_count
+                ),
+                home_real_profile_count=(
+                    home_record_count
+                ),
+                status="ready",
+            )
+        )
+
+        fallback_discovery = (
+            CanonicalShadowFallbackCatalogDiscovery(
+                catalog=artifact.fallback_catalog,
+                source_model_count=len(
+                    REQUIRED_WORKSPACE_MODELS
+                ),
+                status="ready",
+            )
+        )
+
+        execution = run_canonical_production_shadow(
+            game_pk=game_pk,
+            lineups=lineups,
+            bullpens=bullpens,
+            provider_discovery=(
+                provider_discovery
+            ),
+            exact_artifact_discovery=(
+                exact_discovery
+            ),
+            fallback_catalog_discovery=(
+                fallback_discovery
+            ),
+            bootstrap_ready=True,
+            baserunning_evidence_catalog=(
+                evidence.catalog
+            ),
+            simulation_count=(
+                normalized_simulation_count
+            ),
+        )
+
+        output_payload = (
+            execution.material.canonical_payload
+            if execution.material is not None
+            else execution.to_diagnostics()
+        )
+        output_digest = _sha256(
+            output_payload
+        )
+        replay_digest = _sha256(
+            {
+                "game_pk": game_pk,
+                "game_date": roster.game_date,
+                "lineup_digest": (
+                    roster.lineup_digest
+                ),
+                "bullpen_digest": (
+                    roster.bullpen_digest
+                ),
+                "probability_artifact_digest": (
+                    artifact.digest
+                ),
+                "baserunning_evidence_digest": (
+                    evidence.evidence_digest
+                ),
+                "simulation_count": (
+                    normalized_simulation_count
+                ),
+                "output_digest": output_digest,
+                "status": execution.status,
+            }
+        )
+
+        replay_games.append(
+            CanonicalHistoricalBaserunningShadowReplayGame(
+                game_pk=game_pk,
+                game_date=roster.game_date,
+                execution=execution,
+                probability_artifact_digest=(
+                    artifact.digest
+                ),
+                baserunning_evidence_digest=(
+                    evidence.evidence_digest
+                ),
+                output_digest=output_digest,
+                replay_digest=replay_digest,
+            )
+        )
+
+    window_digest = _sha256(
+        {
+            "schema_version": (
+                CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+            ),
+            "observed_window_digest": (
+                lineup_bullpen.observed_window_digest
+            ),
+            "lineup_bullpen_window_digest": (
+                lineup_bullpen.digest
+            ),
+            "probability_artifact_window_digest": (
+                probability_artifacts.digest
+            ),
+            "baserunning_evidence_window_digest": (
+                baserunning_evidence.digest
+            ),
+            "simulation_count": (
+                normalized_simulation_count
+            ),
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "replay_digest": (
+                        value.replay_digest
+                    ),
+                }
+                for value in replay_games
+            ],
+        }
+    )
+
+    return CanonicalHistoricalBaserunningShadowReplayWindow(
+        observed_window_digest=(
+            lineup_bullpen.observed_window_digest
+        ),
+        lineup_bullpen_window_digest=(
+            lineup_bullpen.digest
+        ),
+        probability_artifact_window_digest=(
+            probability_artifacts.digest
+        ),
+        baserunning_evidence_window_digest=(
+            baserunning_evidence.digest
+        ),
+        simulation_count=(
+            normalized_simulation_count
+        ),
+        games=tuple(replay_games),
+        digest=window_digest,
+    )

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -13,6 +13,7 @@ from urllib.request import Request, urlopen
 
 from mlb_app.simulation.shadow import (
     define_historical_probability_reconstruction_inputs,
+    execute_historical_baserunning_shadow_replays,
     materialize_historical_probability_artifacts,
     reconstruct_historical_pa_probability_workspaces,
     source_historical_mlb_baserunning_counts,
@@ -361,7 +362,16 @@ def main():
             lineup_bullpen=roster_window,
             statistics=statistics,
             workspaces=workspaces,
-            starting_pitcher_ids=_starters(feeds),
+            starting_pitcher_ids=starting_pitchers,
+        )
+    )
+
+    historical_replays = (
+        execute_historical_baserunning_shadow_replays(
+            lineup_bullpen=roster_window,
+            probability_artifacts=artifacts,
+            baserunning_evidence=baserunning_evidence,
+            starting_pitcher_ids=starting_pitchers,
         )
     )
 
@@ -372,6 +382,9 @@ def main():
         ),
         "workspaces": workspaces.to_diagnostics(),
         "artifacts": artifacts.to_diagnostics(),
+        "historical_baserunning_replays": (
+            historical_replays.to_diagnostics()
+        ),
         "baserunning_feed_evidence": (
             feed_evidence.to_diagnostics()
         ),
@@ -381,7 +394,12 @@ def main():
         "history_feed_count": len(history_feeds),
         "cutoff_count": len(cutoffs),
         "request_count": len(requests),
-        "historical_replay_executed": False,
+        "historical_replay_executed": (
+            historical_replays.executed_game_count > 0
+        ),
+        "historical_replay_ready": (
+            historical_replays.ready
+        ),
         "production_activation": False,
         "production_authority_changed": False,
         "authoritative_source": "legacy",

--- a/tests/test_canonical_baserunning_composition.py
+++ b/tests/test_canonical_baserunning_composition.py
@@ -90,10 +90,14 @@ def opportunity_state():
 class PlateAppearanceResolver:
     def __init__(self):
         self.identity_states = []
+        self.baserunning_events = []
 
     def active_pitcher_id(self, state):
         self.identity_states.append(state)
         return "active-pitcher"
+
+    def record_baserunning_event(self, event):
+        self.baserunning_events.append(event)
 
     def __call__(self, state, batter_id, sequence):
         next_out = state.outs + 1
@@ -151,6 +155,17 @@ def test_composition_uses_trial_active_pitcher_identity():
         assert event.pitcher_id == "active-pitcher"
         assert event.state_before == state
         assert event.is_plate_appearance is False
+        assert (
+            plate_appearance_resolver
+            .baserunning_events
+            == [event]
+        )
+    else:
+        assert (
+            plate_appearance_resolver
+            .baserunning_events
+            == []
+        )
 
 
 def test_composed_resolver_replays_identically():

--- a/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
+++ b/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
@@ -1,0 +1,318 @@
+import hashlib
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalOutcomeProbability,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+    CanonicalRunnerBaserunningProfile,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION,
+    CanonicalHistoricalLineupBullpenGameSnapshot,
+    CanonicalHistoricalLineupBullpenWindow,
+    CanonicalHistoricalProbabilityArtifactGame,
+    CanonicalHistoricalProbabilityArtifactWindow,
+    execute_historical_baserunning_shadow_replays,
+    source_historical_baserunning_replay_evidence,
+)
+
+
+DIGEST = hashlib.sha256(b"fixture").hexdigest()
+
+PROVIDER = CanonicalProbabilityProviderIdentity(
+    provider_name="model_projections_pa_outcome",
+    provider_version="pa_outcome_v1",
+)
+
+
+def probability_points():
+    values = {
+        "out": 0.43,
+        "single": 0.15,
+        "double": 0.05,
+        "triple": 0.005,
+        "hr": 0.03,
+        "bb": 0.085,
+        "hbp": 0.01,
+        "k": 0.24,
+    }
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=values[outcome.value],
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def lineup_window():
+    return CanonicalHistoricalLineupBullpenWindow(
+        observed_window_digest=DIGEST,
+        games=(
+            CanonicalHistoricalLineupBullpenGameSnapshot(
+                game_pk=123,
+                game_date="2026-04-20",
+                away_lineup_ids=tuple(
+                    str(value)
+                    for value in range(1, 10)
+                ),
+                home_lineup_ids=tuple(
+                    str(value)
+                    for value in range(11, 20)
+                ),
+                away_bullpen_ids=("101",),
+                home_bullpen_ids=("201",),
+                lineup_digest=DIGEST,
+                bullpen_digest=DIGEST,
+            ),
+        ),
+        digest=DIGEST,
+    )
+
+
+def probability_window(
+    *,
+    observed_window_digest=DIGEST,
+):
+    records = tuple(
+        CanonicalProbabilityArtifactRecord(
+            batter_id=batter_id,
+            pitcher_id=pitcher_id,
+            probabilities=probability_points(),
+        )
+        for batter_id, pitcher_id in (
+            *(
+                (str(value), "200")
+                for value in range(1, 10)
+            ),
+            *(
+                (str(value), "100")
+                for value in range(11, 20)
+            ),
+        )
+    )
+    artifact = CanonicalProbabilityArtifact(
+        provider=PROVIDER,
+        records=records,
+    )
+    fallback = CanonicalProbabilityFallbackCatalog(
+        provider=PROVIDER,
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=(
+                    CanonicalProbabilityFallbackTier
+                    .GLOBAL
+                ),
+                identity=None,
+                probabilities=probability_points(),
+            ),
+        ),
+    )
+
+    return CanonicalHistoricalProbabilityArtifactWindow(
+        observed_window_digest=(
+            observed_window_digest
+        ),
+        statistics_window_digest=DIGEST,
+        workspace_window_digest=DIGEST,
+        games=(
+            CanonicalHistoricalProbabilityArtifactGame(
+                game_pk=123,
+                game_date="2026-04-20",
+                statistics_snapshot_digest=DIGEST,
+                workspace_digest=DIGEST,
+                exact_artifact=artifact,
+                fallback_catalog=fallback,
+                possible_matchup_count=18,
+                zero_sample_matchup_count=0,
+                digest=DIGEST,
+            ),
+        ),
+        digest=DIGEST,
+    )
+
+
+def baserunning_catalog():
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=tuple(
+            CanonicalRunnerBaserunningProfile(
+                runner_id=str(value),
+                speed_score=0.50,
+                attempt_rate=0.05,
+                success_rate=0.75,
+                lead_quality=0.50,
+                fatigue_index=0.0,
+            )
+            for value in (
+                *range(1, 10),
+                *range(11, 20),
+            )
+        ),
+        pitchers=tuple(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id=str(value),
+                hold_score=0.50,
+                delivery_time_score=0.50,
+                pickoff_attempt_rate=0.02,
+                pickoff_success_rate=0.10,
+            )
+            for value in (
+                100,
+                101,
+                200,
+                201,
+            )
+        ),
+        away_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="3",
+            team_side="away",
+            throwing_score=0.50,
+            pop_time_score=0.50,
+        ),
+        home_catcher=CanonicalCatcherBaserunningProfile(
+            catcher_id="13",
+            team_side="home",
+            throwing_score=0.50,
+            pop_time_score=0.50,
+        ),
+    )
+
+
+def evidence_window():
+    lineups = lineup_window()
+
+    return source_historical_baserunning_replay_evidence(
+        lineup_bullpen=lineups,
+        catalogs={
+            123: baserunning_catalog(),
+        },
+        statistics_through_dates={
+            123: "2026-04-19",
+        },
+        evidence_counts={
+            123: (10, 5, 1),
+        },
+    )
+
+
+def execute(
+    *,
+    lineups=None,
+    probabilities=None,
+    evidence=None,
+    starters=None,
+):
+    return execute_historical_baserunning_shadow_replays(
+        lineup_bullpen=(
+            lineups or lineup_window()
+        ),
+        probability_artifacts=(
+            probabilities or probability_window()
+        ),
+        baserunning_evidence=(
+            evidence or evidence_window()
+        ),
+        starting_pitcher_ids=(
+            {123: ("100", "200")}
+            if starters is None
+            else starters
+        ),
+        simulation_count=2,
+    )
+
+
+def test_executes_real_historical_shadow_replay():
+    result = execute()
+    game = result.games[0]
+    diagnostics = result.to_diagnostics()
+
+    assert result.ready is True
+    assert result.game_count == 1
+    assert result.executed_game_count == 1
+    assert result.blocked_game_count == 0
+    assert result.error_game_count == 0
+
+    assert game.executed is True
+    assert game.execution.material is not None
+    assert game.execution.execution_inputs is not None
+    assert game.execution.simulation_count == 2
+
+    assert diagnostics[
+        "historical_replay_executed"
+    ] is True
+    assert diagnostics[
+        "external_fetch_performed"
+    ] is False
+    assert diagnostics[
+        "persistence_performed"
+    ] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics[
+        "authoritative_source"
+    ] == "legacy"
+
+
+def test_baserunning_catalog_is_attached():
+    result = execute()
+    game = result.games[0]
+
+    assert (
+        game.execution.execution_inputs
+        .baserunning_evidence_catalog_digest
+        == baserunning_catalog().digest
+    )
+    assert len(game.output_digest) == 64
+    assert len(game.replay_digest) == 64
+    assert len(result.digest) == 64
+
+
+def test_inputs_must_exactly_cover_games():
+    with pytest.raises(
+        ValueError,
+        match="starting pitchers must exactly cover",
+    ):
+        execute(starters={})
+
+
+def test_observed_window_digests_must_match():
+    with pytest.raises(
+        ValueError,
+        match="observed window digests must match",
+    ):
+        execute(
+            probabilities=probability_window(
+                observed_window_digest="b" * 64,
+            )
+        )
+
+
+def test_replay_is_deterministic():
+    first = execute()
+    second = execute()
+
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
+        == "canonical_historical_baserunning_shadow_replay_v1"
+    )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -4,6 +4,7 @@ from mlb_app.simulation.events import (
     Base,
     GameState,
     RunnerMovement,
+    build_baserunning_event,
     build_play_event,
 )
 from mlb_app.simulation.game import (
@@ -744,3 +745,93 @@ def test_manager_reconstructs_same_play_home_run_batter():
     assert lines[0].pitcher_id == "home_starter"
     assert lines[0].runs_allowed == 1
     assert lines[0].earned_runs == 1
+
+
+def test_manager_applies_caught_stealing_to_responsibility():
+    value = manager()
+    state = GameState(
+        inning=4,
+        half="top",
+    )
+
+    reach = replace(
+        build_play_event(
+            sequence=0,
+            event_type="single",
+            batter_id="away_batter_0",
+            state_before=state,
+            runner_movements=(
+                RunnerMovement(
+                    runner_id="away_batter_0",
+                    start_base=Base.HOME,
+                    end_base=Base.FIRST,
+                ),
+            ),
+        ),
+        pitcher_id="home_starter",
+    )
+    value.record_plate_appearance(reach)
+
+    assert (
+        value.responsibility_for_runner(
+            "away_batter_0"
+        )
+        is not None
+    )
+
+    caught = build_baserunning_event(
+        sequence=1,
+        event_type="caught_stealing",
+        batter_id="away_batter_1",
+        pitcher_id="home_starter",
+        runner_id="away_batter_0",
+        state_before=reach.state_after,
+        origin_base=Base.FIRST,
+        target_base=Base.SECOND,
+    )
+    value.record_baserunning_event(caught)
+
+    assert (
+        value.responsibility_for_runner(
+            "away_batter_0"
+        )
+        is None
+    )
+
+
+def test_manager_preserves_runner_on_successful_steal():
+    value = manager()
+    state = GameState(
+        inning=10,
+        half="top",
+        bases=(None, "away_batter_8", None),
+    )
+
+    value.register_automatic_runner(
+        state=state,
+        runner_id="away_batter_8",
+    )
+
+    steal = build_baserunning_event(
+        sequence=1,
+        event_type="stolen_base",
+        batter_id="away_batter_0",
+        pitcher_id="home_starter",
+        runner_id="away_batter_8",
+        state_before=state,
+        origin_base=Base.SECOND,
+        target_base=Base.THIRD,
+    )
+    value.record_baserunning_event(steal)
+
+    responsibility = (
+        value.responsibility_for_runner(
+            "away_batter_8"
+        )
+    )
+
+    assert responsibility is not None
+    assert (
+        responsibility.responsible_pitcher_id
+        == "home_starter"
+    )


### PR DESCRIPTION
## Summary

- execute canonical historical baserunning shadow replays against reconstructed historical probability artifacts
- keep replay execution diagnostic-only with legacy production authority unchanged
- synchronize non-plate-appearance baserunning events with the trial-owned pitcher responsibility ledger
- register extra-inning automatic runners before a pre-PA steal can occur
- expose deterministic replay diagnostics and digests through the historical runner

## Root cause fixed

The first real replay executed 124 of 185 games and exposed 61 pitcher-responsibility lifecycle errors. Baserunning events changed canonical base state without updating the responsibility ledger. This left caught-stealing runners active in the ledger, while automatic runners who stole before the first plate appearance were never registered.

The resolver bridge now applies each emitted baserunning event to the pitching manager without reducing plate-appearance workload. Automatic-runner responsibility is registered from the event's pre-play state before that event is applied.

## Historical validation

The corrected historical replay completed the full observed window:

- 185 of 185 games executed
- 25 simulations per game
- 4,625 total simulated games
- 0 blocked games
- 0 errored games
- replay ready: true
- replay window digest: `5e8a198998ef2b39142da839ea6ed31ee2d5744009698b3c8078f5aaa9cc0dd1`

Production activation remains false, production authority is unchanged, and `legacy` remains authoritative.

## Validation

- 316 canonical regression tests passed
- focused lifecycle and replay tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment