### PR TITLE
Evaluate historical baserunning shadow replays

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -564,3 +564,12 @@ from .historical_baserunning_shadow_replay_execution import (
     CanonicalHistoricalBaserunningShadowReplayWindow,
     execute_historical_baserunning_shadow_replays,
 )
+
+
+from .historical_baserunning_replay_evaluation import (
+    CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION,
+    HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION,
+    CanonicalHistoricalBaserunningReplayEvaluation,
+    build_historical_baserunning_replay_review_policy,
+    evaluate_historical_baserunning_shadow_replays,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_replay_evaluation.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_replay_evaluation.py
@@ -1,0 +1,365 @@
+"""Evaluate historical baserunning shadow replays."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Dict, Tuple
+
+from .baserunning_calibration_artifact import (
+    CanonicalBaserunningCalibrationArtifact,
+    execute_baserunning_calibration_artifact,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationPolicy,
+)
+from .baserunning_calibration_payload import (
+    CanonicalHistoricalBaserunningGame,
+    assemble_historical_baserunning_calibration_payload,
+)
+from .historical_baserunning_game_materialization import (
+    materialize_play_by_play_baserunning_game_records,
+)
+from .historical_baserunning_shadow_replay_execution import (
+    CanonicalHistoricalBaserunningShadowReplayWindow,
+)
+from .historical_baserunning_shadow_validation import (
+    CanonicalHistoricalBaserunningExecutionGame,
+    collect_historical_baserunning_shadow_validations,
+)
+from .mlb_play_by_play_baserunning_source import (
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION = (
+    "canonical_historical_baserunning_replay_evaluation_v1"
+)
+HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION = (
+    "historical_baserunning_replay_review_policy_v1"
+)
+
+
+def build_historical_baserunning_replay_review_policy(
+) -> CanonicalBaserunningCalibrationPolicy:
+    """
+    Build the fixed first-pass historical review policy.
+
+    Passing this policy qualifies evidence for additional review only.
+    It does not permit simulator mutation or production activation.
+    """
+
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=150,
+        maximum_stolen_base_error_per_game=0.25,
+        maximum_caught_stealing_error_per_game=0.10,
+        maximum_attempt_error_per_game=0.30,
+        maximum_success_rate_absolute_error=0.10,
+        policy_version=(
+            HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION
+        ),
+    )
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _validate_digest(
+    value: str,
+    field_name: str,
+) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{field_name} must be a SHA256 digest"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningReplayEvaluation:
+    replay_window_digest: str
+    observed_snapshot_digest: str
+    games: Tuple[
+        CanonicalHistoricalBaserunningGame,
+        ...,
+    ]
+    artifact: CanonicalBaserunningCalibrationArtifact
+    digest: str
+    evaluation_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            (
+                "replay_window_digest",
+                self.replay_window_digest,
+            ),
+            (
+                "observed_snapshot_digest",
+                self.observed_snapshot_digest,
+            ),
+            ("digest", self.digest),
+        ):
+            _validate_digest(value, field_name)
+
+        if not self.games:
+            raise ValueError(
+                "games must contain evaluated records"
+            )
+
+        identities = tuple(
+            value.game_pk
+            for value in self.games
+        )
+        if len(identities) != len(set(identities)):
+            raise ValueError(
+                "evaluated game identifiers must be unique"
+            )
+
+        if not isinstance(
+            self.artifact,
+            CanonicalBaserunningCalibrationArtifact,
+        ):
+            raise TypeError(
+                "artifact must be "
+                "CanonicalBaserunningCalibrationArtifact"
+            )
+
+        if not self.artifact.ready:
+            raise ValueError(
+                "evaluation artifact must be ready"
+            )
+
+        if self.evaluation_version != (
+            CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "replay evaluation version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.artifact.ready
+
+    @property
+    def game_count(self) -> int:
+        return len(self.games)
+
+    @property
+    def calibration_gate_passed(self) -> bool:
+        return self.artifact.calibration_gate_passed
+
+    @property
+    def observed_stolen_bases(self) -> int:
+        return sum(
+            value.observed_stolen_bases
+            for value in self.games
+        )
+
+    @property
+    def observed_caught_stealing(self) -> int:
+        return sum(
+            value.observed_caught_stealing
+            for value in self.games
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        report = self.artifact.report
+
+        return {
+            "schema_version": self.evaluation_version,
+            "ready": self.ready,
+            "game_count": self.game_count,
+            "replay_window_digest": (
+                self.replay_window_digest
+            ),
+            "observed_snapshot_digest": (
+                self.observed_snapshot_digest
+            ),
+            "evaluation_digest": self.digest,
+            "observed_stolen_bases": (
+                self.observed_stolen_bases
+            ),
+            "observed_caught_stealing": (
+                self.observed_caught_stealing
+            ),
+            "observed_attempts": (
+                self.observed_stolen_bases
+                + self.observed_caught_stealing
+            ),
+            "calibration_gate_passed": (
+                self.calibration_gate_passed
+            ),
+            "report": (
+                report.to_diagnostics()
+                if report is not None
+                else None
+            ),
+            "eligible_for_activation_review": (
+                self.calibration_gate_passed
+            ),
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def evaluate_historical_baserunning_shadow_replays(
+    *,
+    replays: (
+        CanonicalHistoricalBaserunningShadowReplayWindow
+    ),
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+    policy: CanonicalBaserunningCalibrationPolicy,
+) -> CanonicalHistoricalBaserunningReplayEvaluation:
+    """
+    Compare one complete replay window to observed MLB outcomes.
+
+    Existing canonical validation, materialization, report, and gate
+    contracts remain authoritative. This function only assembles them.
+    It performs no fetch, persistence, optimization, or activation.
+    """
+
+    if not isinstance(
+        replays,
+        CanonicalHistoricalBaserunningShadowReplayWindow,
+    ):
+        raise TypeError(
+            "replays must be "
+            "CanonicalHistoricalBaserunningShadowReplayWindow"
+        )
+
+    if not replays.ready:
+        raise ValueError(
+            "historical replay window must be ready"
+        )
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be "
+            "CanonicalMlbPlayByPlayBaserunningSnapshot"
+        )
+
+    if not isinstance(
+        policy,
+        CanonicalBaserunningCalibrationPolicy,
+    ):
+        raise TypeError(
+            "policy must be "
+            "CanonicalBaserunningCalibrationPolicy"
+        )
+
+    replay_games = {
+        value.game_pk: value
+        for value in replays.games
+    }
+    observed_games = {
+        value.game_pk: value
+        for value in observed.games
+    }
+
+    if set(replay_games) != set(observed_games):
+        raise ValueError(
+            "replay games must exactly match "
+            "observed games"
+        )
+
+    execution_games = tuple(
+        CanonicalHistoricalBaserunningExecutionGame(
+            game_pk=value.game_pk,
+            game_date=value.game_date,
+            execution=value.execution,
+        )
+        for value in replays.games
+    )
+
+    validations = (
+        collect_historical_baserunning_shadow_validations(
+            execution_games=execution_games,
+            observed=observed,
+        )
+    )
+
+    games = materialize_play_by_play_baserunning_game_records(
+        shadow_games=validations,
+        observed=observed,
+    )
+
+    payload = (
+        assemble_historical_baserunning_calibration_payload(
+            window_start=observed.window_start,
+            window_end=observed.window_end,
+            games=games,
+            policy=policy,
+        )
+    )
+    artifact = execute_baserunning_calibration_artifact(
+        payload
+    )
+
+    if not artifact.ready:
+        raise ValueError(
+            "historical replay calibration artifact "
+            "is unavailable: "
+            + (
+                artifact.error_message
+                or artifact.status
+            )
+        )
+
+    evaluation_digest = _sha256(
+        {
+            "schema_version": (
+                CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION
+            ),
+            "replay_window_digest": replays.digest,
+            "observed_snapshot_digest": observed.digest,
+            "policy_version": policy.policy_version,
+            "games": [
+                {
+                    "game_pk": value.game_pk,
+                    "game_date": value.game_date,
+                    "observed_stolen_bases": (
+                        value.observed_stolen_bases
+                    ),
+                    "observed_caught_stealing": (
+                        value.observed_caught_stealing
+                    ),
+                    "validation": (
+                        value.validation.to_diagnostics()
+                    ),
+                }
+                for value in games
+            ],
+            "artifact": artifact.to_diagnostics(),
+        }
+    )
+
+    return CanonicalHistoricalBaserunningReplayEvaluation(
+        replay_window_digest=replays.digest,
+        observed_snapshot_digest=observed.digest,
+        games=games,
+        artifact=artifact,
+        digest=evaluation_digest,
+    )

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -12,7 +12,9 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 from mlb_app.simulation.shadow import (
+    build_historical_baserunning_replay_review_policy,
     define_historical_probability_reconstruction_inputs,
+    evaluate_historical_baserunning_shadow_replays,
     execute_historical_baserunning_shadow_replays,
     materialize_historical_probability_artifacts,
     reconstruct_historical_pa_probability_workspaces,
@@ -375,6 +377,16 @@ def main():
         )
     )
 
+    historical_evaluation = (
+        evaluate_historical_baserunning_shadow_replays(
+            replays=historical_replays,
+            observed=observed,
+            policy=(
+                build_historical_baserunning_replay_review_policy()
+            ),
+        )
+    )
+
     diagnostics = {
         "statistics": statistics.to_diagnostics(),
         "reconstruction": (
@@ -384,6 +396,9 @@ def main():
         "artifacts": artifacts.to_diagnostics(),
         "historical_baserunning_replays": (
             historical_replays.to_diagnostics()
+        ),
+        "historical_baserunning_evaluation": (
+            historical_evaluation.to_diagnostics()
         ),
         "baserunning_feed_evidence": (
             feed_evidence.to_diagnostics()

--- a/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
+++ b/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
@@ -17,11 +17,18 @@ from mlb_app.simulation.game import (
     CanonicalRunnerBaserunningProfile,
 )
 from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION,
     CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION,
+    HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION,
+    CanonicalBaserunningCalibrationPolicy,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
     CanonicalHistoricalLineupBullpenGameSnapshot,
     CanonicalHistoricalLineupBullpenWindow,
     CanonicalHistoricalProbabilityArtifactGame,
     CanonicalHistoricalProbabilityArtifactWindow,
+    build_historical_baserunning_replay_review_policy,
+    evaluate_historical_baserunning_shadow_replays,
     execute_historical_baserunning_shadow_replays,
     source_historical_baserunning_replay_evidence,
 )
@@ -315,4 +322,125 @@ def test_version_is_explicit():
     assert (
         CANONICAL_HISTORICAL_BASERUNNING_SHADOW_REPLAY_VERSION
         == "canonical_historical_baserunning_shadow_replay_v1"
+    )
+
+
+def observed_snapshot(
+    *,
+    game_pk=123,
+    game_date="2026-04-20",
+):
+    return CanonicalMlbPlayByPlayBaserunningSnapshot(
+        window_start="2026-04-20",
+        window_end="2026-04-20",
+        games=(
+            CanonicalMlbPlayByPlayBaserunningGame(
+                game_pk=game_pk,
+                game_date=game_date,
+                stolen_bases=1,
+                caught_stealing=1,
+            ),
+        ),
+        event_count=2,
+        stolen_bases=1,
+        caught_stealing=1,
+        duplicate_event_record_count=0,
+        digest=DIGEST,
+    )
+
+
+def evaluation_policy():
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=1,
+        maximum_stolen_base_error_per_game=10.0,
+        maximum_caught_stealing_error_per_game=10.0,
+        maximum_attempt_error_per_game=20.0,
+        maximum_success_rate_absolute_error=1.0,
+        policy_version=(
+            "historical_baserunning_replay_test_policy_v1"
+        ),
+    )
+
+
+def evaluate():
+    return evaluate_historical_baserunning_shadow_replays(
+        replays=execute(),
+        observed=observed_snapshot(),
+        policy=evaluation_policy(),
+    )
+
+
+def test_evaluates_replay_against_observed_outcomes():
+    result = evaluate()
+    diagnostics = result.to_diagnostics()
+
+    assert result.ready is True
+    assert result.game_count == 1
+    assert result.observed_stolen_bases == 1
+    assert result.observed_caught_stealing == 1
+    assert result.artifact.ready is True
+
+    assert diagnostics["observed_attempts"] == 2
+    assert diagnostics["report"]["ready"] is True
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["production_activation"] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics[
+        "authoritative_source"
+    ] == "legacy"
+
+
+def test_evaluation_requires_exact_observed_coverage():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "replay games must exactly match "
+            "observed games"
+        ),
+    ):
+        evaluate_historical_baserunning_shadow_replays(
+            replays=execute(),
+            observed=observed_snapshot(
+                game_pk=999,
+            ),
+            policy=evaluation_policy(),
+        )
+
+
+def test_evaluation_is_deterministic():
+    first = evaluate()
+    second = evaluate()
+
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_evaluation_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_REPLAY_EVALUATION_VERSION
+        == (
+            "canonical_historical_baserunning_"
+            "replay_evaluation_v1"
+        )
+    )
+
+
+def test_review_policy_is_explicit_and_non_authoritative():
+    policy = (
+        build_historical_baserunning_replay_review_policy()
+    )
+
+    assert policy.minimum_game_count == 150
+    assert (
+        policy.policy_version
+        == HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION
+    )
+    assert (
+        HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION
+        == "historical_baserunning_replay_review_policy_v1"
     )


### PR DESCRIPTION
## Summary

- evaluate completed historical baserunning shadow replays against observed play-by-play outcomes
- assemble the existing validation, materialization, calibration, report, and gate contracts into one deterministic evaluation artifact
- define an explicit, non-authoritative activation-review policy and expose evaluation diagnostics through the historical runner
- retain the legacy source as authoritative and prohibit production activation

## Historical evaluation

The 185-game replay window completed successfully with 4,625 simulated games and no unavailable or errored validations. The review gate correctly failed:

- projected attempts: 636.08; observed attempts: 331
- projected stolen bases: 402.28; observed stolen bases: 239
- projected caught stealing: 233.80; observed caught stealing: 92
- projected success rate: 0.632436; observed success rate: 0.722054
- failures: attempt, stolen-base, and caught-stealing error per game exceeded

This establishes the immutable pre-calibration baseline and shows that attempt frequency is the primary calibration target. It does not change production authority or activate stolen bases.

## Validation

- 321 canonical tests passed
- Python compilation passed
- `git diff --check` passed
- Ruff unavailable in the local environment