### PR TITLE
Replay historical baserunning calibration candidate

### DIFF
--- a/mlb_app/simulation/game/__init__.py
+++ b/mlb_app/simulation/game/__init__.py
@@ -355,3 +355,9 @@ __all__ = [
     "validate_game_box_score_reconciliation",
     "validate_canonical_game",
 ]
+
+
+from .baserunning_probability_transform import (
+    CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION,
+    CanonicalBaserunningProbabilityTransform,
+)

--- a/mlb_app/simulation/game/baserunning_composition.py
+++ b/mlb_app/simulation/game/baserunning_composition.py
@@ -12,6 +12,9 @@ from .baserunning_evidence_catalog import (
     CanonicalBaserunningEvidenceCatalog,
     build_canonical_baserunning_state_provider,
 )
+from .baserunning_probability_transform import (
+    CanonicalBaserunningProbabilityTransform,
+)
 from .baserunning_resolver import (
     CanonicalBaserunningEvidenceQuery,
     CanonicalBaserunningResolverAdapterFactory,
@@ -41,6 +44,9 @@ class CanonicalCatalogBaserunningResolverFactory:
     """
 
     catalog: CanonicalBaserunningEvidenceCatalog
+    probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None
     composition_version: str = (
         CANONICAL_BASERUNNING_COMPOSITION_VERSION
     )
@@ -53,6 +59,19 @@ class CanonicalCatalogBaserunningResolverFactory:
             raise TypeError(
                 "catalog must be "
                 "CanonicalBaserunningEvidenceCatalog"
+            )
+
+        if (
+            self.probability_transform is not None
+            and not isinstance(
+                self.probability_transform,
+                CanonicalBaserunningProbabilityTransform,
+            )
+        ):
+            raise TypeError(
+                "probability_transform must be "
+                "CanonicalBaserunningProbabilityTransform "
+                "or None"
             )
 
         if self.composition_version != (
@@ -103,11 +122,26 @@ class CanonicalCatalogBaserunningResolverFactory:
                 ),
             )
         )
-        evidence_provider = (
+        baseline_evidence_provider = (
             build_canonical_baserunning_evidence_provider(
                 state_provider=state_provider,
             )
         )
+
+        def evidence_provider(query):
+            evidence = baseline_evidence_provider(
+                query
+            )
+
+            if (
+                evidence is None
+                or self.probability_transform is None
+            ):
+                return evidence
+
+            return self.probability_transform.apply(
+                evidence
+            )
 
         resolver = (
             CanonicalBaserunningResolverAdapterFactory(
@@ -146,9 +180,13 @@ class CanonicalCatalogBaserunningResolverFactory:
 def build_canonical_catalog_baserunning_resolver_factory(
     *,
     catalog: CanonicalBaserunningEvidenceCatalog,
+    probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None,
 ) -> CanonicalCoupledBaserunningResolverFactory:
     """Build an explicit coupled catalog-backed resolver factory."""
 
     return CanonicalCatalogBaserunningResolverFactory(
         catalog=catalog,
+        probability_transform=probability_transform,
     )

--- a/mlb_app/simulation/game/baserunning_probability_transform.py
+++ b/mlb_app/simulation/game/baserunning_probability_transform.py
@@ -1,0 +1,165 @@
+"""Explicit non-default transforms for baserunning probabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import math
+from typing import Any, Dict
+
+from .baserunning_resolver import (
+    CanonicalBaserunningEvidence,
+)
+
+
+CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION = (
+    "canonical_baserunning_probability_transform_v1"
+)
+
+
+def _finite_between(
+    value: float,
+    name: str,
+    lower: float,
+    upper: float,
+) -> float:
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be finite"
+        ) from exc
+
+    if (
+        not math.isfinite(normalized)
+        or normalized < lower
+        or normalized > upper
+    ):
+        raise ValueError(
+            f"{name} must be between "
+            f"{lower} and {upper}"
+        )
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProbabilityTransform:
+    """
+    Apply one explicit candidate transform to evaluator probabilities.
+
+    The identity defaults preserve existing behavior. Construction alone
+    does not activate the transform in production or shadow execution.
+    """
+
+    attempt_probability_multiplier: float = 1.0
+    success_rate_adjustment: float = 0.0
+    transform_version: str = (
+        CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        _finite_between(
+            self.attempt_probability_multiplier,
+            "attempt_probability_multiplier",
+            0.0,
+            1.0,
+        )
+        _finite_between(
+            self.success_rate_adjustment,
+            "success_rate_adjustment",
+            -1.0,
+            1.0,
+        )
+
+        if self.transform_version != (
+            CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning probability "
+                "transform version"
+            )
+
+    @property
+    def is_identity(self) -> bool:
+        return (
+            self.attempt_probability_multiplier == 1.0
+            and self.success_rate_adjustment == 0.0
+        )
+
+    @property
+    def digest(self) -> str:
+        parts = (
+            self.transform_version,
+            repr(self.attempt_probability_multiplier),
+            repr(self.success_rate_adjustment),
+        )
+
+        return hashlib.sha256(
+            "\x1f".join(parts).encode("utf-8")
+        ).hexdigest()
+
+    def apply(
+        self,
+        evidence: CanonicalBaserunningEvidence,
+    ) -> CanonicalBaserunningEvidence:
+        if not isinstance(
+            evidence,
+            CanonicalBaserunningEvidence,
+        ):
+            raise TypeError(
+                "evidence must be CanonicalBaserunningEvidence"
+            )
+
+        attempt_probability = round(
+            min(
+                max(
+                    evidence.attempt_probability
+                    * self.attempt_probability_multiplier,
+                    0.0,
+                ),
+                1.0,
+            ),
+            6,
+        )
+        success_probability = round(
+            min(
+                max(
+                    evidence.success_probability
+                    + self.success_rate_adjustment,
+                    0.0,
+                ),
+                1.0,
+            ),
+            6,
+        )
+
+        return CanonicalBaserunningEvidence(
+            pitcher_id=evidence.pitcher_id,
+            attempt_probability=attempt_probability,
+            success_probability=success_probability,
+            probability_provenance=(
+                evidence.probability_provenance
+                + "|"
+                + self.transform_version
+                + ":"
+                + self.digest
+            ),
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.transform_version,
+            "attempt_probability_multiplier": (
+                self.attempt_probability_multiplier
+            ),
+            "success_rate_adjustment": (
+                self.success_rate_adjustment
+            ),
+            "identity_transform": self.is_identity,
+            "transform_digest": self.digest,
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }

--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -15,6 +15,9 @@ from mlb_app.simulation.game.baserunning_composition import (
 from mlb_app.simulation.game.baserunning_evidence_catalog import (
     CanonicalBaserunningEvidenceCatalog,
 )
+from mlb_app.simulation.game.baserunning_probability_transform import (
+    CanonicalBaserunningProbabilityTransform,
+)
 from mlb_app.simulation.game.contracts import (
     CanonicalGameConfig,
 )
@@ -89,6 +92,9 @@ class CanonicalShadowExecutionBundleFactory:
     baserunning_evidence_catalog: Optional[
         CanonicalBaserunningEvidenceCatalog
     ] = None
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None
     fallback_policy: CanonicalProbabilityFallbackPolicy = field(
         default_factory=CanonicalProbabilityFallbackPolicy
     )
@@ -142,6 +148,19 @@ class CanonicalShadowExecutionBundleFactory:
             raise TypeError(
                 "baserunning_evidence_catalog must be "
                 "CanonicalBaserunningEvidenceCatalog or None"
+            )
+
+        if (
+            self.baserunning_probability_transform is not None
+            and not isinstance(
+                self.baserunning_probability_transform,
+                CanonicalBaserunningProbabilityTransform,
+            )
+        ):
+            raise TypeError(
+                "baserunning_probability_transform must be "
+                "CanonicalBaserunningProbabilityTransform "
+                "or None"
             )
 
         if not isinstance(
@@ -250,6 +269,9 @@ class CanonicalShadowExecutionBundleFactory:
                     catalog=(
                         self.baserunning_evidence_catalog
                     ),
+                    probability_transform=(
+                        self.baserunning_probability_transform
+                    ),
                 )
             )
 
@@ -288,6 +310,9 @@ class CanonicalShadowExecutionBundleFactory:
             baserunning_evidence_catalog=(
                 self.baserunning_evidence_catalog
             ),
+            baserunning_probability_transform=(
+                self.baserunning_probability_transform
+            ),
             fallback_policy=self.fallback_policy,
             game_config=self.game_config,
             batter_dfs_rules=self.batter_dfs_rules,
@@ -313,6 +338,9 @@ def build_canonical_shadow_execution_bundle_factory(
     baserunning_evidence_catalog: Optional[
         CanonicalBaserunningEvidenceCatalog
     ] = None,
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None,
     fallback_policy: Optional[
         CanonicalProbabilityFallbackPolicy
     ] = None,
@@ -334,6 +362,9 @@ def build_canonical_shadow_execution_bundle_factory(
         fallback_catalog=fallback_catalog,
         baserunning_evidence_catalog=(
             baserunning_evidence_catalog
+        ),
+        baserunning_probability_transform=(
+            baserunning_probability_transform
         ),
         fallback_policy=(
             fallback_policy

--- a/mlb_app/simulation/shadow/historical_baserunning_shadow_replay_execution.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_shadow_replay_execution.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 from datetime import date
 import hashlib
 import json
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningProbabilityTransform,
+)
 
 from .bullpen_discovery import (
     CanonicalShadowBullpenDiscovery,
@@ -395,6 +399,9 @@ def execute_historical_baserunning_shadow_replays(
         int,
         Tuple[str, str],
     ],
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None,
     simulation_count: int = (
         DEFAULT_HISTORICAL_BASERUNNING_SIMULATION_COUNT
     ),
@@ -438,6 +445,19 @@ def execute_historical_baserunning_shadow_replays(
     normalized_simulation_count = int(
         simulation_count
     )
+
+    if (
+        baserunning_probability_transform is not None
+        and not isinstance(
+            baserunning_probability_transform,
+            CanonicalBaserunningProbabilityTransform,
+        )
+    ):
+        raise TypeError(
+            "baserunning_probability_transform must be "
+            "CanonicalBaserunningProbabilityTransform "
+            "or None"
+        )
 
     if not (
         lineup_bullpen.observed_window_digest
@@ -618,6 +638,9 @@ def execute_historical_baserunning_shadow_replays(
             bootstrap_ready=True,
             baserunning_evidence_catalog=(
                 evidence.catalog
+            ),
+            baserunning_probability_transform=(
+                baserunning_probability_transform
             ),
             simulation_count=(
                 normalized_simulation_count

--- a/mlb_app/simulation/shadow/input_assembly.py
+++ b/mlb_app/simulation/shadow/input_assembly.py
@@ -13,6 +13,9 @@ from mlb_app.simulation.box_score import (
 from mlb_app.simulation.game.baserunning_evidence_catalog import (
     CanonicalBaserunningEvidenceCatalog,
 )
+from mlb_app.simulation.game.baserunning_probability_transform import (
+    CanonicalBaserunningProbabilityTransform,
+)
 from mlb_app.simulation.game.contracts import (
     CanonicalGameConfig,
 )
@@ -53,6 +56,9 @@ class CanonicalShadowExecutionInputs:
     fallback_catalog: CanonicalProbabilityFallbackCatalog
     baserunning_evidence_catalog: Optional[
         CanonicalBaserunningEvidenceCatalog
+    ] = None
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
     ] = None
     fallback_policy: CanonicalProbabilityFallbackPolicy = field(
         default_factory=CanonicalProbabilityFallbackPolicy
@@ -107,6 +113,19 @@ class CanonicalShadowExecutionInputs:
             raise TypeError(
                 "baserunning_evidence_catalog must be "
                 "CanonicalBaserunningEvidenceCatalog or None"
+            )
+
+        if (
+            self.baserunning_probability_transform is not None
+            and not isinstance(
+                self.baserunning_probability_transform,
+                CanonicalBaserunningProbabilityTransform,
+            )
+        ):
+            raise TypeError(
+                "baserunning_probability_transform must be "
+                "CanonicalBaserunningProbabilityTransform "
+                "or None"
             )
 
         if not isinstance(
@@ -231,6 +250,14 @@ class CanonicalShadowExecutionInputs:
                 self.baserunning_evidence_catalog_digest
                 or "baserunning_catalog:none"
             ),
+            (
+                self.baserunning_probability_transform.digest
+                if (
+                    self.baserunning_probability_transform
+                    is not None
+                )
+                else "baserunning_transform:none"
+            ),
             self.fallback_policy.policy_version,
             *(
                 tier.value
@@ -266,6 +293,9 @@ class CanonicalShadowExecutionInputs:
             baserunning_evidence_catalog=(
                 self.baserunning_evidence_catalog
             ),
+            baserunning_probability_transform=(
+                self.baserunning_probability_transform
+            ),
             fallback_policy=self.fallback_policy,
             game_config=self.game_config,
             batter_dfs_rules=self.batter_dfs_rules,
@@ -280,6 +310,9 @@ def assemble_canonical_shadow_execution_inputs(
     fallback_catalog: CanonicalProbabilityFallbackCatalog,
     baserunning_evidence_catalog: Optional[
         CanonicalBaserunningEvidenceCatalog
+    ] = None,
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
     ] = None,
     fallback_policy: Optional[
         CanonicalProbabilityFallbackPolicy
@@ -302,6 +335,9 @@ def assemble_canonical_shadow_execution_inputs(
         fallback_catalog=fallback_catalog,
         baserunning_evidence_catalog=(
             baserunning_evidence_catalog
+        ),
+        baserunning_probability_transform=(
+            baserunning_probability_transform
         ),
         fallback_policy=(
             fallback_policy

--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 
 from mlb_app.simulation.game import (
     CanonicalBaserunningEvidenceCatalog,
+    CanonicalBaserunningProbabilityTransform,
     CanonicalLineup,
     CanonicalMatchupInput,
     CanonicalPitchingPlan,
@@ -341,6 +342,9 @@ def run_canonical_production_shadow(
     baserunning_evidence_catalog: Optional[
         CanonicalBaserunningEvidenceCatalog
     ] = None,
+    baserunning_probability_transform: Optional[
+        CanonicalBaserunningProbabilityTransform
+    ] = None,
     simulation_count: int = (
         DEFAULT_PRODUCTION_SHADOW_SIMULATION_COUNT
     ),
@@ -430,6 +434,9 @@ def run_canonical_production_shadow(
                 fallback_catalog=fallback_catalog,
                 baserunning_evidence_catalog=(
                     baserunning_evidence_catalog
+                ),
+                baserunning_probability_transform=(
+                    baserunning_probability_transform
                 ),
                 fallback_policy=fallback_policy,
                 batter_dfs_rules=(

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -11,6 +11,9 @@ from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from mlb_app.simulation.game import (
+    CanonicalBaserunningProbabilityTransform,
+)
 from mlb_app.simulation.shadow import (
     build_historical_baserunning_replay_review_policy,
     define_historical_probability_reconstruction_inputs,
@@ -412,6 +415,44 @@ def main():
         )
     )
 
+    selected_candidate = (
+        historical_candidate_grid
+        .selected_result
+        .candidate
+    )
+    selected_transform = (
+        CanonicalBaserunningProbabilityTransform(
+            attempt_probability_multiplier=(
+                selected_candidate
+                .attempt_probability_multiplier
+            ),
+            success_rate_adjustment=(
+                selected_candidate
+                .success_rate_adjustment
+            ),
+        )
+    )
+
+    calibrated_replays = (
+        execute_historical_baserunning_shadow_replays(
+            lineup_bullpen=roster_window,
+            probability_artifacts=artifacts,
+            baserunning_evidence=baserunning_evidence,
+            starting_pitcher_ids=starting_pitchers,
+            baserunning_probability_transform=(
+                selected_transform
+            ),
+        )
+    )
+
+    calibrated_evaluation = (
+        evaluate_historical_baserunning_shadow_replays(
+            replays=calibrated_replays,
+            observed=observed,
+            policy=review_policy,
+        )
+    )
+
     diagnostics = {
         "statistics": statistics.to_diagnostics(),
         "reconstruction": (
@@ -427,6 +468,15 @@ def main():
         ),
         "historical_baserunning_calibration_candidates": (
             historical_candidate_grid.to_diagnostics()
+        ),
+        "historical_baserunning_selected_transform": (
+            selected_transform.to_diagnostics()
+        ),
+        "historical_baserunning_calibrated_replays": (
+            calibrated_replays.to_diagnostics()
+        ),
+        "historical_baserunning_calibrated_evaluation": (
+            calibrated_evaluation.to_diagnostics()
         ),
         "baserunning_feed_evidence": (
             feed_evidence.to_diagnostics()

--- a/tests/test_canonical_baserunning_probability_transform.py
+++ b/tests/test_canonical_baserunning_probability_transform.py
@@ -1,0 +1,71 @@
+import pytest
+
+from mlb_app.simulation.game import (
+    CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION,
+    CanonicalBaserunningProbabilityTransform,
+)
+from mlb_app.simulation.game.baserunning_resolver import (
+    CanonicalBaserunningEvidence,
+)
+
+
+def evidence():
+    return CanonicalBaserunningEvidence(
+        pitcher_id="100",
+        attempt_probability=0.40,
+        success_probability=0.65,
+        probability_provenance="fixture",
+    )
+
+
+def test_selected_candidate_transforms_final_probabilities():
+    transform = CanonicalBaserunningProbabilityTransform(
+        attempt_probability_multiplier=0.52,
+        success_rate_adjustment=0.09,
+    )
+
+    result = transform.apply(evidence())
+
+    assert result.attempt_probability == 0.208
+    assert result.success_probability == 0.74
+    assert transform.is_identity is False
+    assert transform.digest in (
+        result.probability_provenance
+    )
+
+
+def test_identity_transform_preserves_probabilities():
+    transform = CanonicalBaserunningProbabilityTransform()
+    result = transform.apply(evidence())
+
+    assert result.attempt_probability == 0.40
+    assert result.success_probability == 0.65
+    assert transform.is_identity is True
+
+
+def test_transform_clamps_success_probability():
+    transform = CanonicalBaserunningProbabilityTransform(
+        success_rate_adjustment=0.50,
+    )
+
+    assert (
+        transform.apply(evidence()).success_probability
+        == 1.0
+    )
+
+
+def test_invalid_transform_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="attempt_probability_multiplier",
+    ):
+        CanonicalBaserunningProbabilityTransform(
+            attempt_probability_multiplier=1.01,
+        )
+
+
+def test_transform_version_is_explicit():
+    assert (
+        CANONICAL_BASERUNNING_PROBABILITY_TRANSFORM_VERSION
+        == "canonical_baserunning_probability_transform_v1"
+    )

--- a/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
+++ b/tests/test_canonical_historical_baserunning_shadow_replay_execution.py
@@ -5,6 +5,7 @@ import pytest
 from mlb_app.simulation.game import (
     CANONICAL_PA_OUTCOME_ORDER,
     CanonicalBaserunningEvidenceCatalog,
+    CanonicalBaserunningProbabilityTransform,
     CanonicalCatcherBaserunningProfile,
     CanonicalOutcomeProbability,
     CanonicalPitcherBaserunningProfile,
@@ -219,6 +220,7 @@ def execute(
     probabilities=None,
     evidence=None,
     starters=None,
+    probability_transform=None,
 ):
     return execute_historical_baserunning_shadow_replays(
         lineup_bullpen=(
@@ -234,6 +236,9 @@ def execute(
             {123: ("100", "200")}
             if starters is None
             else starters
+        ),
+        baserunning_probability_transform=(
+            probability_transform
         ),
         simulation_count=2,
     )
@@ -444,3 +449,58 @@ def test_review_policy_is_explicit_and_non_authoritative():
         HISTORICAL_BASERUNNING_REPLAY_REVIEW_POLICY_VERSION
         == "historical_baserunning_replay_review_policy_v1"
     )
+
+
+
+def test_explicit_probability_transform_changes_replay_provenance():
+    transform = CanonicalBaserunningProbabilityTransform(
+        attempt_probability_multiplier=0.52,
+        success_rate_adjustment=0.09,
+    )
+
+    baseline = execute()
+    calibrated = execute(
+        probability_transform=transform,
+    )
+    calibrated_inputs = (
+        calibrated.games[0]
+        .execution
+        .execution_inputs
+    )
+
+    assert calibrated_inputs is not None
+    assert (
+        calibrated_inputs.baserunning_probability_transform
+        == transform
+    )
+    assert (
+        calibrated_inputs.assembly_digest
+        != baseline.games[0]
+        .execution
+        .execution_inputs
+        .assembly_digest
+    )
+    assert calibrated.digest != baseline.digest
+    assert calibrated.to_diagnostics()[
+        "production_activation"
+    ] is False
+    assert calibrated.to_diagnostics()[
+        "production_authority_changed"
+    ] is False
+
+
+def test_transformed_replay_is_deterministic():
+    transform = CanonicalBaserunningProbabilityTransform(
+        attempt_probability_multiplier=0.52,
+        success_rate_adjustment=0.09,
+    )
+
+    first = execute(
+        probability_transform=transform,
+    )
+    second = execute(
+        probability_transform=transform,
+    )
+
+    assert first == second
+    assert first.digest == second.digest

--- a/tests/test_canonical_shadow_execution_bundle_factory.py
+++ b/tests/test_canonical_shadow_execution_bundle_factory.py
@@ -418,7 +418,12 @@ def test_injected_catalog_attaches_coupled_resolver_per_trial(
     build_calls = []
     coupled_calls = []
 
-    def build_factory(*, catalog):
+    def build_factory(
+        *,
+        catalog,
+        probability_transform=None,
+    ):
+        assert probability_transform is None
         build_calls.append(catalog)
 
         def coupled_factory(


### PR DESCRIPTION
## Summary

- add a canonical, provenance-tracked baserunning probability transform
- propagate the transform through shadow input assembly, execution factories, production-shadow wiring, and historical replay execution
- replay the selected historical calibration candidate (`attempt_probability_multiplier=0.52`, `success_rate_adjustment=0.09`) separately from the unchanged baseline
- preserve legacy production authority and keep activation disabled

## Historical replay evidence

Both windows executed all 185 games with 25 simulations per game and zero blocked or errored games.

| Metric | Baseline | Calibrated | Observed |
|---|---:|---:|---:|
| Attempts | 636.08 | 338.16 | 331 |
| Stolen bases | 402.28 | 243.04 | 239 |
| Caught stealing | 233.80 | 95.12 | 92 |
| Success rate | 0.632436 | 0.718713 | 0.722054 |

The calibrated event-level replay passed every historical calibration gate:

- attempt error per game: `0.038703`
- stolen-base error per game: `0.021838`
- caught-stealing error per game: `0.016865`
- success-rate absolute error: `0.003341`
- failures: none

Calibrated replay digest: `3bafe4224a1617cbdda942a4ed570944c36ecf79df5d7c59b93a75e31671f72a`

Calibrated evaluation digest: `daf5d0383730db88e364db0b0cb510cd78aff1aae9681941fc56532478e82f96`

## Guardrails

- `production_activation=false`
- `production_authority_changed=false`
- `authoritative_source=legacy`
- passing the same-window replay gate makes the candidate eligible for activation review but does not activate it

## Validation

- `363 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment