### PR TITLE
Enable Query Studio for flagged standard users

### DIFF
--- a/mlb_app/admin_access.py
+++ b/mlb_app/admin_access.py
@@ -32,6 +32,8 @@ USER_CAPABILITIES: Tuple[str, ...] = tuple(sorted({
     "dashboard.reports.paginate",
     "dashboard.reports.run",
     "dashboard.reports.sort",
+    "workbench.advanced",
+    "workbench.execute",
 }))
 
 ADMIN_CAPABILITIES: Tuple[str, ...] = tuple(sorted({

--- a/tests/test_workbench_query.py
+++ b/tests/test_workbench_query.py
@@ -190,7 +190,11 @@ def test_query_studio_auth_boundary_returns_401_403_and_owner_metadata(tmp_path,
         session.add_all([
             AppSession(user_id=owner.id, session_token="owner-token", created_at=now, last_seen_at=now, expires_at=now + dt.timedelta(hours=6)),
             AppSession(user_id=user.id, session_token="user-token", created_at=now, last_seen_at=now, expires_at=now + dt.timedelta(hours=6)),
-            AppFeatureFlag(flag_key="workbench_query_enabled", enabled=True, target_profiles_json=["owner_administrator"]),
+            AppFeatureFlag(
+                flag_key="workbench_query_enabled",
+                enabled=True,
+                target_profiles_json=["owner_administrator", "standard_user"],
+            ),
         ])
         session.commit()
 
@@ -201,9 +205,9 @@ def test_query_studio_auth_boundary_returns_401_403_and_owner_metadata(tmp_path,
     assert anonymous.value.status_code == 401
 
     standard = admin_access.current_dashboard_principal(None, "user-token")
-    with pytest.raises(HTTPException) as denied:
-        admin_access.require_capability("workbench.advanced")(standard)
-    assert denied.value.status_code == 403
+    assert admin_access.require_capability("workbench.advanced")(standard) == standard
+    standard_metadata = my_dashboard_routes.my_dashboard_query_studio_metadata(standard)
+    assert standard_metadata["enabled"] is True
 
     owner_principal = admin_access.current_dashboard_principal(None, "owner-token")
     metadata = my_dashboard_routes.my_dashboard_query_studio_metadata(owner_principal)


### PR DESCRIPTION
## What changed

- grants `workbench.advanced` and `workbench.execute` to the server-owned standard-user capability set
- keeps `workbench_query_enabled` and its profile targeting as the required runtime gate
- updates the authorization test to verify a targeted standard user can load Query Studio metadata

## Root cause

The Control Center flag was saved correctly, but standard users failed the capability guard before the feature-flag check could authorize them.

## Validation

- `python3 -m py_compile mlb_app/admin_access.py tests/test_workbench_query.py`
- `git diff --check`
- focused pytest suite could not run in the fresh workspace because `pytest` is not installed

After deployment, standard users targeted by the enabled Query Studio flag can access the studio; disabling or untargeting the flag still returns `403`.