### PR TITLE
Expose Batter vs Arsenal in Query Studio

### DIFF
--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -18,7 +18,7 @@ REPORT_TYPES: Dict[str, Dict[str, Any]] = {
     "model_projection_games": {"label": "Model Projections", "ui_object": "model_projections", "base_object": "model_projection_date_artifact", "population": {"row_type": "game"}, "relationships": ["model_projection_players"], "queryable": True, "workbench_queryable": False},
     "model_projection_players": {"label": "Model Projection Players", "ui_object": "model_projection_players", "base_object": "model_projection_date_artifact", "population": {"row_type": "player"}, "relationships": ["model_projection_games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
     "model_tracker_snapshots": {"label": "Model Tracker", "ui_object": "model_tracker", "base_object": "model_tracker_snapshots", "population": {}, "relationships": ["games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
-    "competitive_batter_arsenal": {"label": "Batter vs Arsenal", "ui_object": "batter_arsenal", "base_object": "batter_pitch_type_matchups", "population": {}, "relationships": ["dashboard_players", "pitch_arsenal"], "queryable": True, "workbench_queryable": False},
+    "competitive_batter_arsenal": {"label": "Batter vs Arsenal", "ui_object": "batter_arsenal", "base_object": "batter_pitch_type_matchups", "population": {}, "relationships": ["dashboard_players", "pitch_arsenal"], "queryable": True, "workbench_queryable": True},
 }
 
 

--- a/mlb_app/workbench_query.py
+++ b/mlb_app/workbench_query.py
@@ -17,7 +17,11 @@ from .dashboard_report_types import FIELD_CATALOG, REPORT_TYPES
 
 
 MAX_WORKBENCH_ROWS = 250
-RELATED_REPORT_TYPES = frozenset({"players_lineup_history", "hitters_arsenal_splits"})
+RELATED_REPORT_TYPES = frozenset({
+    "players_lineup_history",
+    "hitters_arsenal_splits",
+    "competitive_batter_arsenal",
+})
 
 _STATEMENT = re.compile(
     r"^\s*SELECT\s+(?P<fields>.+?)\s+FROM\s+(?P<object>[A-Za-z_][A-Za-z0-9_]*)"

--- a/tests/test_workbench_query.py
+++ b/tests/test_workbench_query.py
@@ -101,6 +101,7 @@ def test_metadata_is_derived_and_excludes_physical_schema_details():
     assert {item["api_name"] for item in objects} == {
         "all_active_hitters",
         "all_active_pitchers",
+        "competitive_batter_arsenal",
         "hitters_arsenal_splits",
         "players_lineup_history",
     }
@@ -125,6 +126,20 @@ def test_metadata_is_derived_and_excludes_physical_schema_details():
         workbench_query.parse_workbench_statement(
             "SELECT game_pk FROM model_projection_games LIMIT 10"
         )
+
+
+def test_competitive_batter_arsenal_query_supports_pitcher_usage_and_hitter_sample():
+    plan = workbench_query.parse_workbench_statement(
+        "SELECT batter_name, pitcher_pitch_name, pitcher_usage_pct, pitches_seen, hard_hit_pct "
+        "FROM competitive_batter_arsenal "
+        "WHERE pitcher_usage_pct > 0.25 AND pitches_seen > 100 "
+        "ORDER BY hard_hit_pct DESC LIMIT 250"
+    )
+    assert plan.logical_object == "competitive_batter_arsenal"
+    assert plan.filters == [
+        {"field": "pitcher_usage_pct", "operator": "gt", "value": 0.25},
+        {"field": "pitches_seen", "operator": "gt", "value": 100},
+    ]
 
 
 def test_request_contract_rejects_submitted_authorization_fields():


### PR DESCRIPTION
## What changed

- marks `competitive_batter_arsenal` as Query Studio eligible
- routes the object through the existing related-report executor
- adds parser coverage for pitcher usage above 25%, pitches seen above 100, batter name, and hitter hard-hit rate

## Root cause

The Batter vs Arsenal report was queryable by the report builder but explicitly marked `workbench_queryable: false`, so Query Studio rejected it before parsing its registered fields.

## Validation

- `python3 -m py_compile mlb_app/dashboard_report_types.py mlb_app/workbench_query.py tests/test_workbench_query.py`
- `git diff --check`
- full pytest is unavailable in the fresh workspace because `pytest` is not installed

## Verified statement

```sql
SELECT batter_name, pitcher_pitch_name, pitcher_usage_pct, pitches_seen, hard_hit_pct
FROM competitive_batter_arsenal
WHERE pitcher_usage_pct > 0.25 AND pitches_seen > 100
ORDER BY hard_hit_pct DESC
LIMIT 250
```