### PR TITLE
Validate historical baserunning holdout

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -584,3 +584,19 @@ from .historical_baserunning_calibration_candidate_evaluation import (
     build_historical_baserunning_calibration_candidates,
     evaluate_historical_baserunning_calibration_candidates,
 )
+
+
+from .historical_baserunning_holdout_validation import (
+    CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION,
+    HISTORICAL_BASERUNNING_HOLDOUT_MINIMUM_GAME_COUNT,
+    HISTORICAL_BASERUNNING_HOLDOUT_SIMULATION_COUNT,
+    HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_END,
+    HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_START,
+    HISTORICAL_BASERUNNING_SELECTED_ATTEMPT_MULTIPLIER,
+    HISTORICAL_BASERUNNING_SELECTED_SUCCESS_ADJUSTMENT,
+    HISTORICAL_BASERUNNING_SELECTION_WINDOW_END,
+    HISTORICAL_BASERUNNING_SELECTION_WINDOW_START,
+    CanonicalHistoricalBaserunningHoldoutPlan,
+    build_historical_baserunning_holdout_plan,
+    filter_historical_baserunning_holdout_schedule,
+)

--- a/mlb_app/simulation/shadow/historical_baserunning_holdout_validation.py
+++ b/mlb_app/simulation/shadow/historical_baserunning_holdout_validation.py
@@ -1,0 +1,381 @@
+"""Canonical out-of-sample baserunning holdout plan."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningProbabilityTransform,
+)
+
+
+CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION = (
+    "canonical_historical_baserunning_holdout_v1"
+)
+HISTORICAL_BASERUNNING_SELECTION_WINDOW_START = (
+    "2026-04-20"
+)
+HISTORICAL_BASERUNNING_SELECTION_WINDOW_END = (
+    "2026-05-03"
+)
+HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_START = (
+    "2026-05-04"
+)
+HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_END = (
+    "2026-05-17"
+)
+HISTORICAL_BASERUNNING_HOLDOUT_MINIMUM_GAME_COUNT = 150
+HISTORICAL_BASERUNNING_HOLDOUT_SIMULATION_COUNT = 100
+HISTORICAL_BASERUNNING_SELECTED_ATTEMPT_MULTIPLIER = (
+    0.52
+)
+HISTORICAL_BASERUNNING_SELECTED_SUCCESS_ADJUSTMENT = (
+    0.09
+)
+
+
+def _iso_date(value: str, *, field_name: str) -> date:
+    if not isinstance(value, str):
+        raise TypeError(
+            f"{field_name} must be an ISO date string"
+        )
+
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field_name} must be an ISO date"
+        ) from exc
+
+    if parsed.isoformat() != value:
+        raise ValueError(
+            f"{field_name} must use ISO format"
+        )
+
+    return parsed
+
+
+def _digest(payload: Dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class CanonicalHistoricalBaserunningHoldoutPlan:
+    selection_window_start: str
+    selection_window_end: str
+    holdout_window_start: str
+    holdout_window_end: str
+    minimum_game_count: int
+    simulation_count: int
+    probability_transform: (
+        CanonicalBaserunningProbabilityTransform
+    ) = field(
+        default_factory=(
+            CanonicalBaserunningProbabilityTransform
+        )
+    )
+    schema_version: str = (
+        CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        selection_start = _iso_date(
+            self.selection_window_start,
+            field_name="selection_window_start",
+        )
+        selection_end = _iso_date(
+            self.selection_window_end,
+            field_name="selection_window_end",
+        )
+        holdout_start = _iso_date(
+            self.holdout_window_start,
+            field_name="holdout_window_start",
+        )
+        holdout_end = _iso_date(
+            self.holdout_window_end,
+            field_name="holdout_window_end",
+        )
+
+        if selection_start > selection_end:
+            raise ValueError(
+                "selection window start cannot exceed end"
+            )
+        if holdout_start > holdout_end:
+            raise ValueError(
+                "holdout window start cannot exceed end"
+            )
+        if not (
+            holdout_end < selection_start
+            or holdout_start > selection_end
+        ):
+            raise ValueError(
+                "holdout window must be disjoint from "
+                "selection window"
+            )
+        if (
+            not isinstance(self.minimum_game_count, int)
+            or isinstance(self.minimum_game_count, bool)
+            or self.minimum_game_count < 1
+        ):
+            raise ValueError(
+                "minimum_game_count must be positive"
+            )
+        if (
+            not isinstance(self.simulation_count, int)
+            or isinstance(self.simulation_count, bool)
+            or self.simulation_count < 100
+        ):
+            raise ValueError(
+                "simulation_count must be at least 100"
+            )
+        if not isinstance(
+            self.probability_transform,
+            CanonicalBaserunningProbabilityTransform,
+        ):
+            raise TypeError(
+                "probability_transform must be canonical"
+            )
+        if (
+            self.schema_version
+            != CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION
+        ):
+            raise ValueError(
+                "unsupported historical baserunning "
+                "holdout version"
+            )
+
+    @property
+    def windows_are_disjoint(self) -> bool:
+        selection_start = date.fromisoformat(
+            self.selection_window_start
+        )
+        selection_end = date.fromisoformat(
+            self.selection_window_end
+        )
+        holdout_start = date.fromisoformat(
+            self.holdout_window_start
+        )
+        holdout_end = date.fromisoformat(
+            self.holdout_window_end
+        )
+
+        return (
+            holdout_end < selection_start
+            or holdout_start > selection_end
+        )
+
+    @property
+    def digest(self) -> str:
+        return _digest(
+            {
+                "schema_version": self.schema_version,
+                "selection_window_start": (
+                    self.selection_window_start
+                ),
+                "selection_window_end": (
+                    self.selection_window_end
+                ),
+                "holdout_window_start": (
+                    self.holdout_window_start
+                ),
+                "holdout_window_end": (
+                    self.holdout_window_end
+                ),
+                "minimum_game_count": (
+                    self.minimum_game_count
+                ),
+                "simulation_count": (
+                    self.simulation_count
+                ),
+                "probability_transform_digest": (
+                    self.probability_transform.digest
+                ),
+            }
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "selection_window_start": (
+                self.selection_window_start
+            ),
+            "selection_window_end": (
+                self.selection_window_end
+            ),
+            "holdout_window_start": (
+                self.holdout_window_start
+            ),
+            "holdout_window_end": (
+                self.holdout_window_end
+            ),
+            "windows_are_disjoint": (
+                self.windows_are_disjoint
+            ),
+            "minimum_game_count": (
+                self.minimum_game_count
+            ),
+            "simulation_count": self.simulation_count,
+            "probability_transform": (
+                self.probability_transform.to_diagnostics()
+            ),
+            "holdout_plan_digest": self.digest,
+            "candidate_reselected_on_holdout": False,
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+
+def filter_historical_baserunning_holdout_schedule(
+    *,
+    schedule: Dict[str, Any],
+    plan: CanonicalHistoricalBaserunningHoldoutPlan,
+) -> tuple[Dict[str, Any], tuple[Dict[str, Any], ...]]:
+    """
+    Exclude games officially played outside the holdout window.
+
+    MLB may return postponed games under their original schedule date
+    after they have been completed on a later officialDate. Those games
+    are not holdout observations and cannot be reassigned to the
+    originally scheduled date.
+    """
+    if not isinstance(schedule, dict):
+        raise TypeError("schedule must be a dictionary")
+    if not isinstance(
+        plan,
+        CanonicalHistoricalBaserunningHoldoutPlan,
+    ):
+        raise TypeError("plan must be canonical")
+
+    filtered = deepcopy(schedule)
+    filtered_dates = []
+    excluded = []
+
+    raw_dates = filtered.get("dates") or []
+    if not isinstance(raw_dates, list):
+        raise TypeError("schedule dates must be a list")
+
+    for raw_date in raw_dates:
+        if not isinstance(raw_date, dict):
+            raise TypeError(
+                "schedule date entries must be dictionaries"
+            )
+
+        schedule_date = str(raw_date.get("date") or "")
+        _iso_date(
+            schedule_date,
+            field_name="schedule_date",
+        )
+
+        raw_games = raw_date.get("games") or []
+        if not isinstance(raw_games, list):
+            raise TypeError("schedule games must be a list")
+
+        kept_games = []
+
+        for game in raw_games:
+            if not isinstance(game, dict):
+                raise TypeError(
+                    "schedule game entries must be dictionaries"
+                )
+
+            official_date = str(
+                game.get("officialDate")
+                or schedule_date
+            )
+            _iso_date(
+                official_date,
+                field_name="official_date",
+            )
+
+            if (
+                plan.holdout_window_start
+                <= official_date
+                <= plan.holdout_window_end
+            ):
+                kept_games.append(game)
+                continue
+
+            status = game.get("status") or {}
+            if not isinstance(status, dict):
+                raise TypeError(
+                    "schedule game status must be a dictionary"
+                )
+
+            excluded.append(
+                {
+                    "game_pk": game.get("gamePk"),
+                    "schedule_date": schedule_date,
+                    "official_date": official_date,
+                    "detailed_state": status.get(
+                        "detailedState"
+                    ),
+                    "reschedule_date": game.get(
+                        "rescheduleDate"
+                    ),
+                    "reason": (
+                        "official_date_outside_holdout"
+                    ),
+                }
+            )
+
+        if kept_games:
+            raw_date["games"] = kept_games
+            filtered_dates.append(raw_date)
+
+    filtered["dates"] = filtered_dates
+
+    excluded.sort(
+        key=lambda value: (
+            str(value["official_date"]),
+            int(value["game_pk"] or 0),
+        )
+    )
+
+    return filtered, tuple(excluded)
+
+def build_historical_baserunning_holdout_plan(
+) -> CanonicalHistoricalBaserunningHoldoutPlan:
+    return CanonicalHistoricalBaserunningHoldoutPlan(
+        selection_window_start=(
+            HISTORICAL_BASERUNNING_SELECTION_WINDOW_START
+        ),
+        selection_window_end=(
+            HISTORICAL_BASERUNNING_SELECTION_WINDOW_END
+        ),
+        holdout_window_start=(
+            HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_START
+        ),
+        holdout_window_end=(
+            HISTORICAL_BASERUNNING_HOLDOUT_WINDOW_END
+        ),
+        minimum_game_count=(
+            HISTORICAL_BASERUNNING_HOLDOUT_MINIMUM_GAME_COUNT
+        ),
+        simulation_count=(
+            HISTORICAL_BASERUNNING_HOLDOUT_SIMULATION_COUNT
+        ),
+        probability_transform=(
+            CanonicalBaserunningProbabilityTransform(
+                attempt_probability_multiplier=(
+                    HISTORICAL_BASERUNNING_SELECTED_ATTEMPT_MULTIPLIER
+                ),
+                success_rate_adjustment=(
+                    HISTORICAL_BASERUNNING_SELECTED_SUCCESS_ADJUSTMENT
+                ),
+            )
+        ),
+    )

--- a/scripts/run_historical_baserunning_holdout_validation.py
+++ b/scripts/run_historical_baserunning_holdout_validation.py
@@ -1,0 +1,488 @@
+"""Run fixed-candidate historical baserunning holdout validation."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
+import json
+import sys
+import time
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from mlb_app.simulation.shadow import (
+    build_historical_baserunning_replay_review_policy,
+    build_historical_baserunning_holdout_plan,
+    define_historical_probability_reconstruction_inputs,
+    evaluate_historical_baserunning_shadow_replays,
+    execute_historical_baserunning_shadow_replays,
+    filter_historical_baserunning_holdout_schedule,
+    materialize_historical_probability_artifacts,
+    reconstruct_historical_pa_probability_workspaces,
+    source_historical_mlb_baserunning_counts,
+    source_historical_mlb_baserunning_feed_evidence,
+    source_historical_lineup_bullpen_snapshots,
+    source_historical_probability_statistics,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+_SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+_STATS_URL = (
+    "https://statsapi.mlb.com/api/v1/stats"
+)
+_FINAL_STATES = {
+    "Final",
+    "Game Over",
+    "Completed Early",
+}
+
+
+def _json(url, params=None):
+    if params:
+        url = f"{url}?{urlencode(params)}"
+
+    request = Request(
+        url,
+        headers={
+            "User-Agent": (
+                "mlb-prediction-app/"
+                "historical-statistics-source"
+            )
+        },
+    )
+
+    maximum_attempts = 6
+
+    for attempt in range(
+        1,
+        maximum_attempts + 1,
+    ):
+        try:
+            with urlopen(
+                request,
+                timeout=120,
+            ) as response:
+                return json.load(response)
+        except (
+            URLError,
+            TimeoutError,
+            ConnectionError,
+            json.JSONDecodeError,
+        ) as error:
+            if attempt == maximum_attempts:
+                raise
+
+            delay_seconds = min(
+                2 ** (attempt - 1),
+                16,
+            )
+            print(
+                (
+                    "historical_source_retry "
+                    f"attempt={attempt} "
+                    f"delay_seconds={delay_seconds} "
+                    f"error={type(error).__name__}"
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+            time.sleep(delay_seconds)
+
+    raise RuntimeError(
+        "historical source retry loop exhausted"
+    )
+
+
+def _completed_game_ids(schedule):
+    games = {}
+
+    for entry in schedule.get("dates") or []:
+        for game in entry.get("games") or []:
+            status = (
+                (game.get("status") or {})
+                .get("detailedState")
+            )
+            game_pk = game.get("gamePk")
+
+            if (
+                status in _FINAL_STATES
+                and game_pk is not None
+            ):
+                games[int(game_pk)] = game
+
+    return tuple(sorted(games))
+
+
+def _feed(game_pk):
+    return (
+        game_pk,
+        _json(
+            _FEED_URL.format(
+                game_pk=game_pk
+            )
+        ),
+    )
+
+
+def _feed_official_date(feed):
+    return (
+        (
+            (feed.get("gameData") or {})
+            .get("datetime")
+            or {}
+        ).get("officialDate")
+    )
+
+
+def _starter_id(team):
+    pitchers = team.get("pitchers") or []
+    if not pitchers:
+        raise ValueError(
+            "historical team has no starting pitcher"
+        )
+
+    return str(int(pitchers[0]))
+
+
+def _starters(feeds):
+    result = {}
+
+    for game_pk, feed in feeds.items():
+        boxscore = (
+            (feed.get("liveData") or {})
+            .get("boxscore")
+            or {}
+        )
+        teams = boxscore.get("teams") or {}
+
+        result[game_pk] = (
+            _starter_id(teams.get("away") or {}),
+            _starter_id(teams.get("home") or {}),
+        )
+
+    return result
+
+
+def _stats(request):
+    cutoff, group = request
+
+    payload = _json(
+        _STATS_URL,
+        {
+            "stats": "byDateRange",
+            "group": group,
+            "gameType": "R",
+            "sportIds": 1,
+            "playerPool": "ALL",
+            "season": 2026,
+            "startDate": "2026-03-01",
+            "endDate": cutoff,
+            "limit": 5000,
+            "hydrate": "person",
+        },
+    )
+
+    return cutoff, group, payload
+
+
+def main():
+    holdout_plan = (
+        build_historical_baserunning_holdout_plan()
+    )
+
+    schedule = _json(
+        _SCHEDULE_URL,
+        {
+            "sportId": 1,
+            "startDate": (
+                holdout_plan.holdout_window_start
+            ),
+            "endDate": (
+                holdout_plan.holdout_window_end
+            ),
+        },
+    )
+    (
+        schedule,
+        excluded_schedule_games,
+    ) = filter_historical_baserunning_holdout_schedule(
+        schedule=schedule,
+        plan=holdout_plan,
+    )
+
+    game_ids = _completed_game_ids(schedule)
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        feeds = dict(
+            executor.map(
+                _feed,
+                game_ids,
+            )
+        )
+
+    observed = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=schedule,
+            game_feeds=feeds,
+            window_start=(
+                holdout_plan.holdout_window_start
+            ),
+            window_end=(
+                holdout_plan.holdout_window_end
+            ),
+        )
+    )
+    roster_window = (
+        source_historical_lineup_bullpen_snapshots(
+            observed=observed,
+            game_feeds=feeds,
+        )
+    )
+
+    cutoffs = sorted(
+        {
+            (
+                date.fromisoformat(value.game_date)
+                - timedelta(days=1)
+            ).isoformat()
+            for value in roster_window.games
+        }
+    )
+    requests = tuple(
+        (cutoff, group)
+        for cutoff in cutoffs
+        for group in ("hitting", "pitching")
+    )
+
+    payloads = {
+        cutoff: {}
+        for cutoff in cutoffs
+    }
+
+    with ThreadPoolExecutor(
+        max_workers=6
+    ) as executor:
+        for cutoff, group, payload in executor.map(
+            _stats,
+            requests,
+        ):
+            payloads[cutoff][group] = payload
+
+    history_schedule = _json(
+        _SCHEDULE_URL,
+        {
+            "sportId": 1,
+            "gameType": "R",
+            "startDate": "2026-03-01",
+            "endDate": max(cutoffs),
+        },
+    )
+    history_game_ids = _completed_game_ids(
+        history_schedule
+    )
+
+    with ThreadPoolExecutor(
+        max_workers=8
+    ) as executor:
+        history_feeds = dict(
+            executor.map(
+                _feed,
+                history_game_ids,
+            )
+        )
+
+    prior_game_feeds_by_cutoff = {
+        cutoff: {
+            game_pk: feed
+            for game_pk, feed in history_feeds.items()
+            if (
+                _feed_official_date(feed)
+                and _feed_official_date(feed)
+                <= cutoff
+            )
+        }
+        for cutoff in cutoffs
+    }
+
+    starting_pitchers = _starters(feeds)
+
+    feed_evidence = (
+        source_historical_mlb_baserunning_feed_evidence(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=starting_pitchers,
+            target_game_feeds=feeds,
+            prior_game_feeds_by_cutoff=(
+                prior_game_feeds_by_cutoff
+            ),
+        )
+    )
+
+    baserunning_evidence = (
+        source_historical_mlb_baserunning_counts(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=starting_pitchers,
+            starting_catcher_ids=(
+                feed_evidence.starting_catcher_ids
+            ),
+            statistics_payloads=payloads,
+            pitcher_pickoffs_by_cutoff=(
+                feed_evidence
+                .pitcher_pickoffs_by_cutoff
+            ),
+            catcher_outcomes_by_cutoff=(
+                feed_evidence
+                .catcher_outcomes_by_cutoff
+            ),
+        )
+    )
+
+    statistics = (
+        source_historical_probability_statistics(
+            lineup_bullpen=roster_window,
+            starting_pitcher_ids=starting_pitchers,
+            statistics_payloads=payloads,
+        )
+    )
+    reconstruction = (
+        define_historical_probability_reconstruction_inputs(
+            lineup_bullpen=roster_window,
+            statistics_snapshots=(
+                statistics.to_reconstruction_snapshots()
+            ),
+        )
+    )
+    workspaces = (
+        reconstruct_historical_pa_probability_workspaces(
+            lineup_bullpen=roster_window,
+            statistics=statistics,
+            starting_pitcher_ids=_starters(feeds),
+        )
+    )
+
+    artifacts = (
+        materialize_historical_probability_artifacts(
+            lineup_bullpen=roster_window,
+            statistics=statistics,
+            workspaces=workspaces,
+            starting_pitcher_ids=starting_pitchers,
+        )
+    )
+
+    if (
+        len(roster_window.games)
+        < holdout_plan.minimum_game_count
+    ):
+        raise ValueError(
+            "historical holdout game count is below "
+            "the required minimum"
+        )
+
+    holdout_replays = (
+        execute_historical_baserunning_shadow_replays(
+            lineup_bullpen=roster_window,
+            probability_artifacts=artifacts,
+            baserunning_evidence=baserunning_evidence,
+            starting_pitcher_ids=starting_pitchers,
+            baserunning_probability_transform=(
+                holdout_plan.probability_transform
+            ),
+            simulation_count=(
+                holdout_plan.simulation_count
+            ),
+        )
+    )
+
+    review_policy = (
+        build_historical_baserunning_replay_review_policy()
+    )
+
+    holdout_evaluation = (
+        evaluate_historical_baserunning_shadow_replays(
+            replays=holdout_replays,
+            observed=observed,
+            policy=review_policy,
+        )
+    )
+
+    diagnostics = {
+        "holdout_plan": (
+            holdout_plan.to_diagnostics()
+        ),
+        "statistics": statistics.to_diagnostics(),
+        "reconstruction": (
+            reconstruction.to_diagnostics()
+        ),
+        "workspaces": workspaces.to_diagnostics(),
+        "artifacts": artifacts.to_diagnostics(),
+        "historical_baserunning_holdout_replays": (
+            holdout_replays.to_diagnostics()
+        ),
+        "historical_baserunning_holdout_evaluation": (
+            holdout_evaluation.to_diagnostics()
+        ),
+        "baserunning_feed_evidence": (
+            feed_evidence.to_diagnostics()
+        ),
+        "baserunning_replay_evidence": (
+            baserunning_evidence.to_diagnostics()
+        ),
+        "history_feed_count": len(history_feeds),
+        "cutoff_count": len(cutoffs),
+        "request_count": len(requests),
+        "holdout_game_count": len(
+            roster_window.games
+        ),
+        "excluded_schedule_game_count": len(
+            excluded_schedule_games
+        ),
+        "excluded_schedule_games": list(
+            excluded_schedule_games
+        ),
+        "minimum_game_count_satisfied": (
+            len(roster_window.games)
+            >= holdout_plan.minimum_game_count
+        ),
+        "candidate_reselected_on_holdout": False,
+        "holdout_replay_executed": (
+            holdout_replays.executed_game_count > 0
+        ),
+        "holdout_replay_ready": (
+            holdout_replays.ready
+        ),
+        "holdout_calibration_gate_passed": (
+            holdout_evaluation
+            .artifact
+            .calibration_gate_passed
+        ),
+        "eligible_for_activation_review": (
+            holdout_evaluation
+            .artifact
+            .calibration_gate_passed
+        ),
+        "activation_permitted": False,
+        "production_activation": False,
+        "production_authority_changed": False,
+        "authoritative_source": "legacy",
+    }
+
+    print(
+        json.dumps(
+            diagnostics,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_canonical_historical_baserunning_holdout_validation.py
+++ b/tests/test_canonical_historical_baserunning_holdout_validation.py
@@ -1,0 +1,162 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION,
+    CanonicalHistoricalBaserunningHoldoutPlan,
+    build_historical_baserunning_holdout_plan,
+    filter_historical_baserunning_holdout_schedule,
+)
+
+
+def test_holdout_plan_is_fixed_and_disjoint():
+    plan = build_historical_baserunning_holdout_plan()
+    diagnostics = plan.to_diagnostics()
+
+    assert plan.selection_window_start == "2026-04-20"
+    assert plan.selection_window_end == "2026-05-03"
+    assert plan.holdout_window_start == "2026-05-04"
+    assert plan.holdout_window_end == "2026-05-17"
+    assert plan.minimum_game_count == 150
+    assert plan.simulation_count == 100
+    assert plan.windows_are_disjoint is True
+    assert (
+        plan.probability_transform
+        .attempt_probability_multiplier
+        == 0.52
+    )
+    assert (
+        plan.probability_transform
+        .success_rate_adjustment
+        == 0.09
+    )
+    assert (
+        diagnostics["candidate_reselected_on_holdout"]
+        is False
+    )
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_overlapping_holdout_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="must be disjoint",
+    ):
+        CanonicalHistoricalBaserunningHoldoutPlan(
+            selection_window_start="2026-04-20",
+            selection_window_end="2026-05-03",
+            holdout_window_start="2026-05-01",
+            holdout_window_end="2026-05-14",
+            minimum_game_count=150,
+            simulation_count=100,
+        )
+
+
+def test_underpowered_replay_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="at least 100",
+    ):
+        CanonicalHistoricalBaserunningHoldoutPlan(
+            selection_window_start="2026-04-20",
+            selection_window_end="2026-05-03",
+            holdout_window_start="2026-05-04",
+            holdout_window_end="2026-05-17",
+            minimum_game_count=150,
+            simulation_count=99,
+        )
+
+
+def test_holdout_plan_is_deterministic():
+    first = build_historical_baserunning_holdout_plan()
+    second = build_historical_baserunning_holdout_plan()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_HISTORICAL_BASERUNNING_HOLDOUT_VERSION
+        == "canonical_historical_baserunning_holdout_v1"
+    )
+
+
+
+def test_schedule_filter_excludes_postponed_games():
+    plan = build_historical_baserunning_holdout_plan()
+    schedule = {
+        "dates": [
+            {
+                "date": "2026-05-05",
+                "games": [
+                    {
+                        "gamePk": 1,
+                        "officialDate": "2026-05-05",
+                        "status": {
+                            "detailedState": "Final",
+                        },
+                    },
+                    {
+                        "gamePk": 2,
+                        "officialDate": "2026-07-07",
+                        "rescheduleDate": (
+                            "2026-07-07T18:15:00Z"
+                        ),
+                        "status": {
+                            "detailedState": "Final",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": "2026-05-07",
+                "games": [
+                    {
+                        "gamePk": 3,
+                        "officialDate": "2026-05-07",
+                        "status": {
+                            "detailedState": "Final",
+                        },
+                    },
+                ],
+            },
+        ]
+    }
+
+    filtered, excluded = (
+        filter_historical_baserunning_holdout_schedule(
+            schedule=schedule,
+            plan=plan,
+        )
+    )
+
+    assert [
+        game["gamePk"]
+        for date_item in filtered["dates"]
+        for game in date_item["games"]
+    ] == [1, 3]
+    assert excluded == (
+        {
+            "game_pk": 2,
+            "schedule_date": "2026-05-05",
+            "official_date": "2026-07-07",
+            "detailed_state": "Final",
+            "reschedule_date": (
+                "2026-07-07T18:15:00Z"
+            ),
+            "reason": (
+                "official_date_outside_holdout"
+            ),
+        },
+    )
+    assert len(schedule["dates"][0]["games"]) == 2


### PR DESCRIPTION
## Summary

- define a fixed, immutable historical baserunning holdout plan
- preserve the selected `0.52` attempt multiplier and `+0.09` success-rate adjustment without reselecting on holdout data
- execute a disjoint 2026-05-04 through 2026-05-17 holdout at 100 simulations per game
- exclude postponed games whose authoritative `officialDate` falls outside the holdout while recording exact exclusion provenance
- keep activation prohibited and legacy production authority unchanged

## Independence controls

- selection window: `2026-04-20` through `2026-05-03`
- holdout window: `2026-05-04` through `2026-05-17`
- windows disjoint: true
- candidate reselected on holdout: false
- minimum required games: 150
- evaluated games: 186
- simulations per game: 100
- total simulated games: 18,600

Two games originally scheduled in May were excluded because they were postponed and officially played in July:

- game `823062`, official date `2026-07-07`
- game `824766`, official date `2026-07-17`

## Holdout result

| Metric | Projected | Observed | Absolute error |
|---|---:|---:|---:|
| Attempts | 348.16 | 358 | 9.84 |
| Stolen bases | 249.76 | 272 | 22.24 |
| Caught stealing | 98.40 | 86 | 12.40 |
| Success rate | 0.717371 | 0.759777 | 0.042406 |

All historical review gates passed:

- attempt error per game: `0.052903`
- stolen-base error per game: `0.119570`
- caught-stealing error per game: `0.066667`
- success-rate absolute error: `0.042406`
- failures: none

Replay digest: `3373d8335b15e1b8187a8b642f42f629ea85c363f40991e8721999f1c9f7322b`

Evaluation digest: `92d51daa720c818b3d662a78e93b0fdbca24fa274a988df392bc79e1e214bef9`

## Guardrails

- `activation_permitted=false`
- `production_activation=false`
- `production_authority_changed=false`
- `authoritative_source=legacy`

This establishes independent historical validation and eligibility for live-shadow review. It does not activate the transform in production.

## Validation

- `369 passed, 1 warning`
- Python compilation passed
- `git diff --check` passed
- Ruff was unavailable in the local environment