### PR TITLE
Rebuild Model Tracker around Bet105 and MyDashboard signals

### DIFF
--- a/frontend/src/lib/modelTrackerPnl.mjs
+++ b/frontend/src/lib/modelTrackerPnl.mjs
@@ -25,7 +25,13 @@ export function resultToUnits(profit, stake = UNIT_SIZE_DOLLARS) {
   return p / s
 }
 
-export function isGradedDecision(row) { return ['won', 'lost', 'push'].includes(String(row?.grade || '').toLowerCase()) }
+export function isReportableOddsBacked(row) {
+  return Boolean(row?.reportable) && Boolean(row?.odds_available) && rowHasPrice(row) &&
+    String(row?.source || '').toLowerCase() === 'bet105'
+}
+export function isGradedDecision(row) {
+  return isReportableOddsBacked(row) && ['won', 'lost', 'push'].includes(String(row?.grade || '').toLowerCase())
+}
 export function isPending(row) { const grade = String(row?.grade || '').toLowerCase(); const status = String(row?.result_status || '').toLowerCase(); return grade === 'pending' || status === 'pending' || status === 'live' }
 export function normalizeStatus(value) { return String(value || '').trim().toLowerCase().replace(/\s+/g, '_') }
 function probabilityCandidate(value) { const n = toNumber(value); return n !== null && n >= 0 && n <= 1 ? n : null }
@@ -116,7 +122,7 @@ export function gradeProfit(row, unitSize = UNIT_SIZE_DOLLARS) {
 }
 
 export function summarizePnl(rows = [], unitSize = UNIT_SIZE_DOLLARS) {
-  const ledger = rows.map(row => {
+  const ledger = rows.filter(isReportableOddsBacked).map(row => {
     const stake = unitSize
     const profit = gradeProfit(row, stake)
     return { ...row, bucket: recommendationBucket(row), stake, price_for_pnl: effectivePrice(row), profit, units: resultToUnits(profit, stake), confidence_band: confidenceBand(row?.confidence ?? row?.score ?? row?.model_probability), edge_band: edgeBand(row?.edge), decision_quality: decisionQualityLabel(row), economics_coverage: economicsCoverage(row) }

--- a/frontend/src/pages/ModelTrackerPage.jsx
+++ b/frontend/src/pages/ModelTrackerPage.jsx
@@ -178,15 +178,21 @@ function Filters({ options, values, setters }) {
 function PlaysTab({ groupedGames, topRows, gameFilter }) {
   const [gamesOpen, setGamesOpen] = useState(gameFilter !== 'all')
   useEffect(() => { if (gameFilter !== 'all') setGamesOpen(true) }, [gameFilter])
-  const visibleTopRows = topRows.slice(0, 12)
+  const reportableRows = topRows.filter(row => row.reportable && row.odds_available)
+  const modelOnlyRows = topRows.filter(row => row.row_type === 'model_signal')
+  const visibleTopRows = reportableRows.slice(0, 12)
   return <div style={s.page}>
     <section style={s.section}>
-      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Top Model Projections</div><div style={s.rowMeta}>Best available model outputs for the slate. Projection values are shown as projections, not confidence percentages.</div></div><span className="status-badge">{topRows.length} signals</span></div>
-      {visibleTopRows.length ? <div style={s.topGrid}>{visibleTopRows.map(row => <TopProjectionCard key={row.id || row.tracker_key || rowIdentity(row)} row={row} />)}</div> : <EmptyState>No model projections match the current filters.</EmptyState>}
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Bet105 Odds-Backed Plays</div><div style={s.rowMeta}>Actionable selections require a real Bet105 price and positive model economics.</div></div><span className="status-badge">{reportableRows.length} decisions</span></div>
+      {visibleTopRows.length ? <div style={s.topGrid}>{visibleTopRows.map(row => <TopProjectionCard key={row.id || row.tracker_key || rowIdentity(row)} row={row} />)}</div> : <EmptyState>No Bet105 odds-backed decisions match the current filters.</EmptyState>}
       {topRows.length > visibleTopRows.length && <div style={{ ...s.rowMeta, marginTop: 12 }}>Showing top {visibleTopRows.length}; use filters or Details for the full slate.</div>}
     </section>
     <section style={s.section}>
-      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Game Breakdown</div><div style={s.rowMeta}>Collapsed by default so the slate stays scannable.</div></div><button className="button-secondary" type="button" onClick={() => setGamesOpen(prev => !prev)}>{gamesOpen ? 'Hide Games' : `Show Games (${groupedGames.length})`}</button></div>
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Model-Only Signals</div><div style={s.rowMeta}>Projection only. No Bet105 odds available. Teams and totals may become decisions when a matching market arrives; player props stay on this watchlist unless Bet105 prices them.</div></div><span className="status-badge">{modelOnlyRows.length} watchlist</span></div>
+      {modelOnlyRows.length ? <div style={s.topGrid}>{modelOnlyRows.slice(0, 12).map(row => <TopProjectionCard key={row.id || row.tracker_key || rowIdentity(row)} row={row} />)}</div> : <EmptyState>No projection-only signals match the current filters.</EmptyState>}
+    </section>
+    <section style={s.section}>
+      <div style={s.sectionHeader}><div><div style={s.sectionTitle}>Teams, Totals & Player Props Watchlist</div><div style={s.rowMeta}>Collapsed by default so the slate stays scannable.</div></div><button className="button-secondary" type="button" onClick={() => setGamesOpen(prev => !prev)}>{gamesOpen ? 'Hide Games' : `Show Games (${groupedGames.length})`}</button></div>
       {gamesOpen && (groupedGames.length ? <div style={s.accordionStack}>{groupedGames.map(game => <GameAccordion key={game.key} game={game} defaultOpen={gameFilter !== 'all'} />)}</div> : <EmptyState>No model plays found for this slate.</EmptyState>)}
     </section>
   </div>
@@ -255,7 +261,7 @@ function PnlTab({ rows }) {
   const bestDay = series.slice().sort((a, b) => b.profit - a.profit)[0]
   const worstDay = series.slice().sort((a, b) => a.profit - b.profit)[0]
   return <div style={s.page}>
-    <section style={s.section}><div style={s.sectionHeader}><div><div style={s.sectionTitle}>P&L — $100 Units</div><div style={s.rowMeta}>Realized performance only includes graded plays with usable price data.</div></div><span className="status-badge">$100 fixed unit</span></div><section style={s.statsScroller}><div style={s.statRail}><StatCard label="Net P&L" value={fmtMoney(pnl.profit)} /><StatCard label="Net Units" value={fmtUnits(pnl.units)} /><StatCard label="Total Risked" value={fmtMoney(pnl.total_risked)} /><StatCard label="ROI" value={fmtPct(pnl.roi)} /><StatCard label="Win Rate" value={fmtPct(pnl.win_rate)} /><StatCard label="Best Day" value={bestDay ? fmtMoney(bestDay.profit) : 'Unavailable'} /><StatCard label="Worst Day" value={worstDay ? fmtMoney(worstDay.profit) : 'Unavailable'} /><StatCard label="Max Drawdown" value={fmtMoney(maxDrawdown(series))} /></div></section></section>
+    <section style={s.section}><div style={s.sectionHeader}><div><div style={s.sectionTitle}>P&L — $100 Units</div><div style={s.rowMeta}>Only reportable Bet105 odds-backed decisions are included; model-only watchlist rows never affect this ledger.</div></div><span className="status-badge">$100 fixed unit</span></div><section style={s.statsScroller}><div style={s.statRail}><StatCard label="Net P&L" value={fmtMoney(pnl.profit)} /><StatCard label="Net Units" value={fmtUnits(pnl.units)} /><StatCard label="Total Risked" value={fmtMoney(pnl.total_risked)} /><StatCard label="ROI" value={fmtPct(pnl.roi)} /><StatCard label="Win Rate" value={fmtPct(pnl.win_rate)} /><StatCard label="Best Day" value={bestDay ? fmtMoney(bestDay.profit) : 'Unavailable'} /><StatCard label="Worst Day" value={worstDay ? fmtMoney(worstDay.profit) : 'Unavailable'} /><StatCard label="Max Drawdown" value={fmtMoney(maxDrawdown(series))} /></div></section></section>
     <section style={s.chartGrid}><ChartBox title="Cumulative P&L"><ResponsiveContainer width="100%" height="100%"><LineChart data={series}><CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.18)" /><XAxis dataKey="date" stroke="#94a3b8" /><YAxis stroke="#94a3b8" /><Tooltip formatter={v => fmtMoney(v)} /><Line type="monotone" dataKey="cumulative" stroke="#67e8f9" strokeWidth={2} dot={false} /></LineChart></ResponsiveContainer></ChartBox><ChartBox title="Daily P&L"><ResponsiveContainer width="100%" height="100%"><BarChart data={series}><CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.18)" /><XAxis dataKey="date" stroke="#94a3b8" /><YAxis stroke="#94a3b8" /><Tooltip formatter={v => fmtMoney(v)} /><Bar dataKey="profit" fill="#22c55e" /></BarChart></ResponsiveContainer></ChartBox></section>
     <section style={s.section}><div style={s.sectionHeader}><div><div style={s.sectionTitle}>Ledger</div><div style={s.rowMeta}>Every realized row behind the P&L cards.</div></div></div><PeriodDetailTable rows={pnl.rows.filter(row => row.profit !== null)} /></section>
   </div>

--- a/frontend/src/pages/ModelTrackerPage.jsx
+++ b/frontend/src/pages/ModelTrackerPage.jsx
@@ -83,7 +83,11 @@ function rowIdentity(row) { return row.pick_label || row.player_name || row.team
 function gradeLabel(row) { if (row.grade === 'pending') return 'Pending Result'; if (row.result_status === 'live') return 'Live Tracking'; if (row.result_status === 'final' && row.grade === 'ungraded') return 'Final Ungraded'; if (GRADED.includes(row.grade)) return 'Graded'; if (row.grade === 'watchlist_only') return 'Watchlist'; if (row.grade === 'ungraded') return 'Awaiting Result'; return row.grade || 'Untracked' }
 function topReason(row) { if (Array.isArray(row.reasoning) && row.reasoning.length) return compactValue(row.reasoning[0]); return textValue(row.primary_reason) || textValue(row.grade_reason) || '' }
 function shortReason(row) { const reason = topReason(row); return reason.length > 130 ? `${reason.slice(0, 130)}...` : reason }
-function normalizePayloadRows(payload) { return (payload?.rows || []).map(row => { const next = { ...row, reasoning: parseMaybeJson(row.reasoning) || row.reasoning, features_used: parseMaybeJson(row.features_used) || row.features_used, missing_inputs: parseMaybeJson(row.missing_inputs) || row.missing_inputs, raw_payload: parseMaybeJson(row.raw_payload) || row.raw_payload, actual_result: parseMaybeJson(row.actual_result) || row.actual_result }; next.bucket = recommendationBucket(next); return next }) }
+function normalizePayloadRows(payload) { return (payload?.rows || []).map(row => {
+  const next = { ...row, reasoning: parseMaybeJson(row.reasoning) || row.reasoning, features_used: parseMaybeJson(row.features_used) || row.features_used, missing_inputs: parseMaybeJson(row.missing_inputs) || row.missing_inputs, raw_payload: parseMaybeJson(row.raw_payload) || row.raw_payload, actual_result: parseMaybeJson(row.actual_result) || row.actual_result }
+  next.bucket = next.reportable && next.odds_available && rowHasPrice(next) && ((toNumber(next.edge) || 0) > 0 || (toNumber(next.expected_value) || 0) > 0) ? 'recommended' : (next.row_type === 'model_signal' ? 'lean' : recommendationBucket(next))
+  return next
+}) }
 function signalChip(row) { const probability = numericScore(row); if (probability !== null) return `Confidence ${fmtPct(probability)}`; const projection = projectionValue(row); if (projection !== null) return `Projection ${fmt(projection, 2)}`; return null }
 function outputTypeLabel(row) { return projectionValue(row) !== null && numericScore(row) === null ? 'Model Projection' : productionBucketLabel(row.bucket) }
 
@@ -289,7 +293,21 @@ export default function ModelTrackerPage() {
   function load(force = false) { if (!force && cacheByDate[date]) { setPayload(cacheByDate[date]); setLoading(false); setError(null); return } setLoading(true); setError(null); fetch(`${API}/model-tracker?date=${date}`).then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }).then(json => { storePayload(date, json); setLoading(false) }).catch(err => { setError(String(err?.message || err)); setLoading(false) }) }
   function refreshPlays() { setRefreshing(true); setError(null); fetch(`${API}/model-tracker/${['snap', 'shot'].join('')}?date=${date}`, { method: 'POST' }).then(async r => { const text = await r.text(); let json = null; try { json = text ? JSON.parse(text) : null } catch { json = { message: text } } if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${text}`); if (!json || Number(json.rows_collected || 0) === 0) throw new Error('Refresh returned no model plays for this date.'); return json }).then(() => { setRefreshing(false); load(true) }).catch(err => { setError(String(err?.message || err)); setRefreshing(false) }) }
   function refreshResults() { setResultRefreshing(true); setError(null); fetch(`${API}/model-tracker/results/refresh?date=${date}`, { method: 'POST' }).then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json() }).then(() => { setResultRefreshing(false); load(true) }).catch(err => { setError(String(err?.message || err)); setResultRefreshing(false) }) }
-  function loadPeriodDates(keys) { const missing = keys.filter(key => !cacheByDate[key]); if (!missing.length) return; setPeriodLoading(true); Promise.all(missing.map(key => fetch(`${API}/model-tracker?date=${key}`).then(async r => { if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`); return r.json().then(json => [key, json]) }))).then(entries => { setCacheByDate(prev => { const next = { ...prev }; entries.forEach(([key, json]) => { next[key] = json }); return next }); setPeriodLoading(false) }).catch(err => { setError(String(err?.message || err)); setPeriodLoading(false) }) }
+  function loadPeriodDates(keys) {
+    if (!keys.length) return
+    const start = [...keys].sort()[0]
+    const end = [...keys].sort().at(-1)
+    const cacheKey = `range:${start}:${end}`
+    if (cacheByDate[cacheKey]) return
+    setPeriodLoading(true)
+    fetch(`${API}/model-tracker/range?start=${start}&end=${end}`).then(async r => {
+      if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${await r.text()}`)
+      return r.json()
+    }).then(json => {
+      setCacheByDate(prev => ({ ...prev, [cacheKey]: json }))
+      setPeriodLoading(false)
+    }).catch(err => { setError(String(err?.message || err)); setPeriodLoading(false) })
+  }
 
   useEffect(() => { load(false) }, [date])
   useEffect(() => { if (activeTab === 'results') loadPeriodDates(periodDateKeys(resultsPeriod, date)) }, [activeTab, resultsPeriod, date])
@@ -324,13 +342,13 @@ export default function ModelTrackerPage() {
   const groupedGames = useMemo(() => groupRowsByGame(filteredRows, games), [filteredRows, games])
   const topRows = useMemo(() => topModelProjectionRows(filteredRows), [filteredRows])
   const pnl = useMemo(() => summarizePnl(filteredRows, UNIT_SIZE_DOLLARS), [filteredRows])
-  const summary = { total: filteredRows.length, recommended: filteredRows.filter(r => r.bucket === 'recommended').length, lean: filteredRows.filter(r => r.bucket === 'lean').length, low: filteredRows.filter(r => !['recommended', 'lean'].includes(r.bucket)).length, pending: filteredRows.filter(r => r.grade === 'pending').length, graded: filteredRows.filter(r => GRADED.includes(r.grade)).length, price: filteredRows.filter(rowHasPrice).length }
+  const summary = { total: filteredRows.length, recommended: filteredRows.filter(r => r.reportable && r.odds_available && r.bucket === 'recommended').length, lean: filteredRows.filter(r => r.row_type === 'model_signal').length, low: filteredRows.filter(r => !r.reportable && r.row_type !== 'model_signal').length, pending: filteredRows.filter(r => r.reportable && r.grade === 'pending').length, graded: filteredRows.filter(r => r.reportable && GRADED.includes(r.grade)).length, price: filteredRows.filter(r => r.reportable && rowHasPrice(r)).length }
   const qualityRows = filteredRows.filter(row => !['recommended', 'lean'].includes(row.bucket))
 
   const filterProps = { options: { sourceOptions, gradeOptions, gameOptions, visibleCount: filteredRows.length }, values: { sourceFilter, gradeFilter, gameFilter, bucketFilter, confidenceFilter, priceFilter, edgeFilter, search }, setters: { setSourceFilter, setGradeFilter, setGameFilter, setBucketFilter, setConfidenceFilter, setPriceFilter, setEdgeFilter, setSearch } }
 
   return <div style={s.page}>
-    <section style={s.hero}><div style={s.header}><div><p className="page-kicker">Model Accountability</p><h1 className="page-title">Model Tracker</h1><p className="page-subtitle">Sleek slate view for model projections, actionable leans, game breakdowns, and results analytics.</p></div><div style={s.controls}><input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} /><button className="button-primary" type="button" onClick={refreshPlays} disabled={refreshing}>{refreshing ? 'Refreshing...' : 'Refresh Model Plays'}</button><button className="button-secondary" type="button" onClick={refreshResults} disabled={resultRefreshing}>{resultRefreshing ? 'Refreshing...' : 'Refresh Results'}</button></div></div><div style={s.tabs}>{TABS.map(key => <button key={key} type="button" style={s.tab(activeTab === key)} onClick={() => setActiveTab(key)}>{TAB_LABELS[key]}</button>)}</div></section>
+    <section style={s.hero}><div style={s.header}><div><p className="page-kicker">Model Accountability</p><h1 className="page-title">Model Tracker</h1><p className="page-subtitle">Bet105-backed decisions are kept separate from projection-only MyDashboard and player watchlist signals.</p></div><div style={s.controls}><input className="input-control" type="date" value={date} onChange={e => setDate(e.target.value)} /><button className="button-primary" type="button" onClick={refreshPlays} disabled={refreshing}>{refreshing ? 'Refreshing...' : 'Refresh Model Plays'}</button><button className="button-secondary" type="button" onClick={refreshResults} disabled={resultRefreshing}>{resultRefreshing ? 'Refreshing...' : 'Refresh Results'}</button></div></div><div style={s.tabs}>{TABS.map(key => <button key={key} type="button" style={s.tab(activeTab === key)} onClick={() => setActiveTab(key)}>{TAB_LABELS[key]}</button>)}</div></section>
     {error && <div className="state-panel error">{error}</div>}{loading && <div className="state-panel">Loading model plays...</div>}
     <section style={s.statsScroller}><div style={s.statRail}><StatCard label="Visible Outputs" value={summary.total} /><StatCard label="Recommendations" value={summary.recommended} /><StatCard label="Model / Lean" value={summary.lean} /><StatCard label="Low Confidence" value={summary.low} /><StatCard label="Graded" value={summary.graded} /><StatCard label="Pending" value={summary.pending} /><StatCard label="Price Available" value={summary.price} /><StatCard label="Net P&L" value={fmtMoney(pnl.profit)} /></div></section>
     <Filters {...filterProps} />

--- a/mlb_app/model_tracker.py
+++ b/mlb_app/model_tracker.py
@@ -689,7 +689,11 @@ def _row_payload(row: ModelTrackerSnapshot) -> Dict[str, Any]:
     if isinstance(reasoning, dict):
         canonical_diagnostics = reasoning.get("canonical_probability") or reasoning.get("canonical_probability_context")
         daily_odds_diagnostics = reasoning.get("daily_odds_diagnostics") or reasoning.get("daily_odds_diagnostics_context")
+    tracker_contract = reasoning.get("tracker_contract") if isinstance(reasoning, dict) else {}
     return {
+        "row_type": tracker_contract.get("row_type") or ("reportable_decision" if row.source == "bet105" and row.pick_type == "reportable_decision" else "model_signal"),
+        "reportable": bool(tracker_contract.get("reportable")),
+        "odds_available": bool(tracker_contract.get("odds_available")),
         "id": row.id,
         "tracker_key": row.tracker_key,
         "snapshot_date": row.snapshot_date.isoformat() if row.snapshot_date else None,
@@ -775,6 +779,12 @@ def list_tracker_rows(session: Session, target_date: str, game_pk: Optional[int]
         "lost": sum(1 for r in rows if r.get("grade") == "lost"),
         "push": sum(1 for r in rows if r.get("grade") == "push"),
         "ungraded_rows": sum(1 for r in rows if r.get("grade") in {"ungraded", "watchlist_only"}),
+        "reportable_decision_count": sum(1 for r in rows if r.get("reportable")),
+        "model_signal_count": sum(1 for r in rows if r.get("row_type") == "model_signal"),
+        "odds_backed_count": sum(1 for r in rows if r.get("odds_available")),
+        "model_only_count": sum(1 for r in rows if not r.get("odds_available")),
+        "bet105_market_count": sum(1 for r in rows if r.get("source") == "bet105"),
+        "missing_odds_count": sum(1 for r in rows if r.get("row_type") == "model_signal"),
         "source_count": len({r.get("source") for r in rows if r.get("source")}),
         "sources": sorted({r.get("source") for r in rows if r.get("source")}),
         "canonical_probability_rows": len(canonical_rows),
@@ -783,6 +793,30 @@ def list_tracker_rows(session: Session, target_date: str, game_pk: Optional[int]
     }
     return {"date": parsed.isoformat(), "snapshot_count": len({r.get("created_at") for r in rows if r.get("created_at")}), "rows": rows, "games": game_payloads, "summary": summary, "errors": []}
 
+
+
+def list_tracker_range(session: Session, start_date: str, end_date: str, include_raw: bool = False) -> Dict[str, Any]:
+    start = dt.date.fromisoformat(start_date[:10])
+    end = dt.date.fromisoformat(end_date[:10])
+    if end < start:
+        raise ValueError("end date must be on or after start date")
+    records = (session.query(ModelTrackerSnapshot)
+        .filter(ModelTrackerSnapshot.snapshot_date >= start, ModelTrackerSnapshot.snapshot_date <= end)
+        .order_by(ModelTrackerSnapshot.snapshot_date, ModelTrackerSnapshot.game_pk.nullslast(), ModelTrackerSnapshot.id)
+        .all())
+    rows = []
+    for record in records:
+        payload = _row_payload(record)
+        if not payload.get("reportable"):
+            continue
+        if not include_raw:
+            payload.pop("raw_payload", None)
+        rows.append(payload)
+    return {"start": start.isoformat(), "end": end.isoformat(), "rows": rows,
+            "summary": {"reportable_decision_count": len(rows),
+                        "graded_rows": sum(1 for row in rows if row.get("grade") in {"won", "lost", "push", "partial"}),
+                        "pending_rows": sum(1 for row in rows if row.get("grade") == "pending"),
+                        "sources": sorted({row.get("source") for row in rows if row.get("source")})}}
 
 def _fetch_schedule_results(target_date: str) -> Dict[int, Dict[str, Any]]:
     response = requests.get(f"{MLB_STATS_BASE}/schedule", params={"sportId": 1, "date": target_date, "hydrate": "linescore,team"}, timeout=20)

--- a/mlb_app/model_tracker_bet105.py
+++ b/mlb_app/model_tracker_bet105.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable, List, Optional
 import re
 
-from .model_tracker import _base_row, _safe_float, _team_name
+from .model_tracker import _base_row, _safe_float, _team_name, _tracker_key
 
 
 TRACKABLE_MARKETS = {"h2h", "moneyline", "spreads", "run_line", "totals", "total", "team_total"}
@@ -203,6 +203,6 @@ def as_model_signals(rows: Iterable[Dict[str, Any]], target_date: str) -> List[D
             reasoning = {"source_reasoning": reasoning}
         reasoning["tracker_contract"] = {"row_type": "model_signal", "reportable": False, "odds_available": False}
         row["reasoning_json"] = reasoning
-        row["tracker_key"] = None
+        row["tracker_key"] = _tracker_key(row)
         signals.append(row)
     return signals

--- a/mlb_app/model_tracker_bet105.py
+++ b/mlb_app/model_tracker_bet105.py
@@ -167,7 +167,7 @@ def build_bet105_decisions(board: Dict[str, Any], projections: Iterable[Dict[str
             "bet105", target_date,
             source_endpoint="/sportsbook/bet105",
             source_component=market["market_name"] or market["market_type"],
-            event_id=market["event_id"],
+            game_pk=projection.get("game_pk"), event_id=market["event_id"],
             away_team=market["away_team"], home_team=market["home_team"],
             market_type=market["market_type"], pick_type="reportable_decision",
             pick_label=market["selection"], model_name=projection.get("model_name") or "model_projections",

--- a/mlb_app/model_tracker_bet105.py
+++ b/mlb_app/model_tracker_bet105.py
@@ -1,0 +1,208 @@
+"""Bet105-only Model Tracker normalization and reportability rules.
+
+This module deliberately keeps tracker semantics separate from the broader odds and
+Best Plays surfaces.  A tracker decision exists only when Bet105 supplied the
+selection and a model can be matched to it.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+import re
+
+from .model_tracker import _base_row, _safe_float, _team_name
+
+
+TRACKABLE_MARKETS = {"h2h", "moneyline", "spreads", "run_line", "totals", "total", "team_total"}
+TOTAL_EDGE_THRESHOLD = 0.35
+
+
+def _norm(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
+
+
+def _implied(price: Any, decimal: Any = None) -> Optional[float]:
+    american = _safe_float(price)
+    if american not in (None, 0):
+        return 100.0 / (american + 100.0) if american > 0 else abs(american) / (abs(american) + 100.0)
+    dec = _safe_float(decimal)
+    return 1.0 / dec if dec and dec > 1 else None
+
+
+def _event_teams(event: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    home = _team_name(event.get("home_team") or event.get("home"))
+    away = _team_name(event.get("away_team") or event.get("away"))
+    participants = event.get("participants") or event.get("competitors") or []
+    if isinstance(participants, list):
+        for participant in participants:
+            if not isinstance(participant, dict):
+                continue
+            name = _team_name(participant.get("name") or participant.get("team_name") or participant)
+            side = str(participant.get("side") or participant.get("home_away") or "").lower()
+            if side == "home":
+                home = home or name
+            elif side == "away":
+                away = away or name
+    return away, home
+
+
+def _market_type(market: Dict[str, Any]) -> Optional[str]:
+    key = _norm(market.get("market_key") or market.get("market_type") or market.get("market_name"))
+    name = _norm(market.get("market_name"))
+    if key in {"h2h", "moneyline"} or "moneyline" in name:
+        return "moneyline"
+    if key in {"spreads", "runline"} or "runline" in name or "spread" in name:
+        return "run_line"
+    if key in {"totals", "total"} or ("total" in name and "team" not in name):
+        return "total"
+    if key == "teamtotal" or "teamtotal" in name:
+        return "team_total"
+    return None
+
+
+def normalize_bet105_markets(board: Dict[str, Any], target_date: str) -> List[Dict[str, Any]]:
+    """Return only real, current Bet105 teams/totals selections.
+
+    Raw market data is retained for auditability; no fallback line, price, team
+    or selection is manufactured here.
+    """
+    rows: List[Dict[str, Any]] = []
+    for event in board.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        away, home = _event_teams(event)
+        event_id = event.get("event_id") or event.get("id")
+        for market in event.get("markets") or []:
+            if not isinstance(market, dict):
+                continue
+            market_type = _market_type(market)
+            if market_type not in {"moneyline", "run_line", "total", "team_total"}:
+                continue
+            for selection in market.get("selections") or []:
+                if not isinstance(selection, dict) or selection.get("active") is False or selection.get("is_current") is False:
+                    continue
+                price = _safe_float(selection.get("price_american") or selection.get("price"))
+                decimal = _safe_float(selection.get("price_decimal") or (selection.get("odds") or {}).get("decimal"))
+                if price is None and decimal is None:
+                    continue
+                line = _safe_float(selection.get("line") or selection.get("points") or market.get("line") or market.get("line_key"))
+                label = selection.get("name") or selection.get("selection_name") or selection.get("description")
+                if not label:
+                    continue
+                rows.append({
+                    "event_id": str(event_id) if event_id is not None else None,
+                    "away_team": away,
+                    "home_team": home,
+                    "market_type": market_type,
+                    "market_id": market.get("market_id") or market.get("id") or market.get("market_type_id"),
+                    "market_name": market.get("market_name") or market.get("market_key"),
+                    "selection_id": selection.get("selection_id") or selection.get("id") or selection.get("side_id"),
+                    "selection": label,
+                    "line": line,
+                    "price": price,
+                    "price_decimal": decimal,
+                    "implied_probability": _implied(price, decimal),
+                    "raw": {"event": event, "market": market, "selection": selection},
+                })
+    return rows
+
+
+def _projection_index(rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [row for row in rows if row.get("source") == "model_projections"]
+
+
+def _game_projection(market: Dict[str, Any], projections: Iterable[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    candidates = list(projections)
+    away, home = _norm(market.get("away_team")), _norm(market.get("home_team"))
+    for row in candidates:
+        if away and home and _norm(row.get("away_team")) == away and _norm(row.get("home_team")) == home:
+            return row
+    return None
+
+
+def _selection_probability(market: Dict[str, Any], projection: Dict[str, Any]) -> Optional[float]:
+    selection = _norm(market.get("selection"))
+    if selection and selection == _norm(projection.get("home_team")):
+        return _safe_float(projection.get("home_win_probability"))
+    if selection and selection == _norm(projection.get("away_team")):
+        return _safe_float(projection.get("away_win_probability"))
+    return _safe_float(projection.get("model_probability"))
+
+
+def _total_side(selection: Any) -> Optional[str]:
+    text = str(selection or "").lower()
+    return "over" if "over" in text else ("under" if "under" in text else None)
+
+
+def build_bet105_decisions(board: Dict[str, Any], projections: Iterable[Dict[str, Any]], target_date: str) -> List[Dict[str, Any]]:
+    decisions: List[Dict[str, Any]] = []
+    for market in normalize_bet105_markets(board, target_date):
+        projection = _game_projection(market, projections)
+        if not projection:
+            continue
+        model_probability: Optional[float] = None
+        projected_total = _safe_float(projection.get("projected_total"))
+        if market["market_type"] == "moneyline":
+            model_probability = _selection_probability(market, projection)
+        elif market["market_type"] == "total":
+            side = _total_side(market["selection"])
+            if projected_total is None or market["line"] is None or side is None:
+                continue
+            delta = projected_total - market["line"]
+            if abs(delta) < TOTAL_EDGE_THRESHOLD or (delta > 0) != (side == "over"):
+                continue
+            # A total projection is a directional decision, not a fabricated probability.
+            model_probability = _safe_float(projection.get("confidence"))
+        else:
+            # Run lines and team totals remain surfaced as priced market context until
+            # their projection contract exposes a matching probability.
+            continue
+        if model_probability is None or market["implied_probability"] is None:
+            continue
+        edge = model_probability - market["implied_probability"]
+        decimal = market["price_decimal"]
+        expected_value = (model_probability * (decimal - 1.0) - (1.0 - model_probability)) if decimal and decimal > 1 else None
+        if edge <= 0 and (expected_value is None or expected_value <= 0):
+            continue
+        decisions.append(_base_row(
+            "bet105", target_date,
+            source_endpoint="/sportsbook/bet105",
+            source_component=market["market_name"] or market["market_type"],
+            event_id=market["event_id"],
+            away_team=market["away_team"], home_team=market["home_team"],
+            market_type=market["market_type"], pick_type="reportable_decision",
+            pick_label=market["selection"], model_name=projection.get("model_name") or "model_projections",
+            model_version=projection.get("model_version"), model_probability=model_probability,
+            market_implied_probability=market["implied_probability"], edge=edge, expected_value=expected_value,
+            confidence=_safe_float(projection.get("confidence")), line=market["line"], price=market["price"],
+            projected_total=projected_total, grade="pending", result_status="pending",
+            primary_reason="Bet105 price matched to a positive model edge.",
+            reasoning_json={"tracker_contract": {"row_type": "reportable_decision", "reportable": True, "odds_available": True, "book": "bet105"}, "bet105_market_id": market["market_id"], "bet105_selection_id": market["selection_id"]},
+            missing_inputs_json=[], raw_payload_json=market["raw"],
+        ))
+    return decisions
+
+
+def as_model_signals(rows: Iterable[Dict[str, Any]], target_date: str) -> List[Dict[str, Any]]:
+    """Convert model and MyDashboard rows to the explicit non-reportable contract."""
+    signals: List[Dict[str, Any]] = []
+    for row in rows:
+        source = row.get("source")
+        if source not in {"model_projections", "my_dashboard"}:
+            continue
+        row = dict(row)
+        row["pick_type"] = "model_signal"
+        row["price"] = None
+        row["market_implied_probability"] = None
+        row["edge"] = None
+        row["expected_value"] = None
+        row["grade"] = "watchlist_only"
+        row["grade_reason"] = "Projection only; no matching Bet105 odds available."
+        row["missing_inputs_json"] = ["No matching Bet105 market/price available."]
+        reasoning = row.get("reasoning_json") or {}
+        if not isinstance(reasoning, dict):
+            reasoning = {"source_reasoning": reasoning}
+        reasoning["tracker_contract"] = {"row_type": "model_signal", "reportable": False, "odds_available": False}
+        row["reasoning_json"] = reasoning
+        row["tracker_key"] = None
+        signals.append(row)
+    return signals

--- a/mlb_app/model_tracker_routes.py
+++ b/mlb_app/model_tracker_routes.py
@@ -36,6 +36,7 @@ from .database import (
 )
 from .model_tracker import (
     list_tracker_rows,
+    list_tracker_range,
     refresh_tracker_results,
 )
 from .model_tracker_safe_snapshot import build_tracker_snapshot_safe
@@ -654,6 +655,22 @@ def model_tracker_list(date: Optional[str] = Query(default=None)) -> Dict[str, A
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail={"message": "Model Tracker list failed", "error": str(exc)}) from exc
+
+
+@router.get("/model-tracker/range")
+def model_tracker_range(
+    start: str = Query(..., description="Inclusive YYYY-MM-DD start date"),
+    end: str = Query(..., description="Inclusive YYYY-MM-DD end date"),
+    include_raw: bool = Query(default=False),
+) -> Dict[str, Any]:
+    try:
+        Session = _session_factory()
+        with Session() as session:
+            return list_tracker_range(session, start, end, include_raw=include_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail={"message": str(exc)}) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail={"message": "Model Tracker range failed", "error": str(exc)}) from exc
 
 
 @router.get("/model-tracker/game/{game_pk}")

--- a/mlb_app/model_tracker_safe_snapshot.py
+++ b/mlb_app/model_tracker_safe_snapshot.py
@@ -12,6 +12,7 @@ from .best_plays_engine import build_best_plays_payload, normalize_best_play_row
 from .matchup_generator import generate_matchups_for_date
 from .model_projections import build_model_projection_payload
 from .my_dashboard_solver import build_dashboard_solver_payload
+from .model_tracker_bet105 import as_model_signals, build_bet105_decisions
 from .model_tracker import (
     AI_TRACKER_PROMPTS,
     DASHBOARD_COMPONENTS,

--- a/mlb_app/model_tracker_safe_snapshot.py
+++ b/mlb_app/model_tracker_safe_snapshot.py
@@ -25,6 +25,7 @@ from .model_tracker import (
     normalize_matchup_rows,
     normalize_model_projection_rows,
 )
+from .model_tracker_bet105 import as_model_signals, build_bet105_decisions
 
 JSON_COLUMNS = {"reasoning_json", "features_used_json", "missing_inputs_json", "raw_payload_json", "actual_result_json"}
 INTEGER_COLUMNS = {"game_pk", "team_id", "player_id"}
@@ -161,79 +162,45 @@ def safe_upsert_tracker_rows(session: Session, rows: List[Dict[str, Any]]) -> Di
 
 
 def build_tracker_snapshot_safe(session: Session, target_date: str) -> Dict[str, Any]:
+    """Store only Bet105 decisions and explicit model-only MyDashboard signals."""
     target_date = target_date[:10]
     dt.date.fromisoformat(target_date)
     errors: List[Dict[str, Any]] = []
-    rows: List[Dict[str, Any]] = []
-    best_plays_summary: Dict[str, Any] = {"rows_collected": 0, "summary": {}, "errors": []}
-
-    try:
-        matchups = generate_matchups_for_date(session, target_date)
-        rows.extend(normalize_matchup_rows(matchups, target_date))
-    except Exception as exc:
-        errors.append({"source": "matchups", "error": str(exc), "type": exc.__class__.__name__})
-
-    try:
-        from .daily_odds_routes import daily_odds_models
-        payload = daily_odds_models(date=target_date, include_unified=True)
-        rows.extend(normalize_daily_odds_rows(payload, target_date))
-    except Exception as exc:
-        errors.append({"source": "daily_odds", "error": str(exc), "type": exc.__class__.__name__})
+    model_rows: List[Dict[str, Any]] = []
 
     try:
         payload = build_model_projection_payload(session, target_date)
-        rows.extend(normalize_model_projection_rows(payload, target_date))
+        model_rows.extend(normalize_model_projection_rows(payload, target_date))
     except Exception as exc:
         errors.append({"source": "model_projections", "error": str(exc), "type": exc.__class__.__name__})
 
     for component in DASHBOARD_COMPONENTS:
         try:
             payload = build_dashboard_solver_payload(session=session, date=target_date, component=component)
-            rows.extend(normalize_dashboard_rows(component, payload, target_date))
+            model_rows.extend(normalize_dashboard_rows(component, payload, target_date))
         except Exception as exc:
             errors.append({"source": "my_dashboard", "component": component, "error": str(exc), "type": exc.__class__.__name__})
 
+    bet105_rows: List[Dict[str, Any]] = []
     try:
-        from .ai_data_assistant_performance import build_ai_data_assistant_response
-        for prompt in AI_TRACKER_PROMPTS:
-            try:
-                payload = build_ai_data_assistant_response(session=session, message=prompt, date=target_date, use_llm=False)
-                rows.extend(normalize_ai_data_assistant_rows(payload, target_date, prompt))
-            except Exception as prompt_exc:
-                errors.append({"source": "ai_data_assistant", "prompt": prompt, "error": str(prompt_exc), "type": prompt_exc.__class__.__name__})
+        from .sportsbook_bet105_service import fetch_board
+        board = fetch_board(date=target_date, raw=True)
+        bet105_rows = build_bet105_decisions(board, model_rows, target_date)
+        if board.get("status") not in {"ok", "incomplete_normalization"}:
+            errors.append({"source": "bet105", "error": f"Bet105 board status: {board.get('status')}"})
     except Exception as exc:
-        errors.append({"source": "ai_data_assistant", "error": str(exc), "type": exc.__class__.__name__})
+        errors.append({"source": "bet105", "error": str(exc), "type": exc.__class__.__name__})
 
-    try:
-        best_plays_payload = build_best_plays_payload(session, target_date)
-        best_play_rows = normalize_best_play_rows(best_plays_payload, target_date)
-        rows.extend(best_play_rows)
-        best_plays_errors = best_plays_payload.get("errors") or []
-        best_plays_summary = {
-            "rows_collected": len(best_play_rows),
-            "summary": best_plays_payload.get("summary") or {},
-            "errors": best_plays_errors,
-        }
-        if best_plays_errors:
-            errors.extend(
-                {"source": "best_plays", **error} if isinstance(error, dict) else {"source": "best_plays", "error": str(error)}
-                for error in best_plays_errors
-            )
-    except Exception as exc:
-        best_plays_summary = {"rows_collected": 0, "summary": {}, "errors": [{"error": str(exc), "type": exc.__class__.__name__}]}
-        errors.append({"source": "best_plays", "error": str(exc), "type": exc.__class__.__name__})
-
+    rows = bet105_rows + as_model_signals(model_rows, target_date)
     upsert_result = safe_upsert_tracker_rows(session, rows)
     if upsert_result.get("schema_mismatches"):
-        errors.append({
-            "source": "model_tracker_schema",
-            "error": "Production model_tracker_snapshots schema does not match ORM expectations; incompatible values were coerced to prevent snapshot failure.",
-            "mismatches": upsert_result.get("schema_mismatches"),
-        })
+        errors.append({"source": "model_tracker_schema", "error": "Production schema values were coerced.", "mismatches": upsert_result["schema_mismatches"]})
     return {
         "date": target_date,
         "rows_collected": len(rows),
+        "reportable_decision_count": len(bet105_rows),
+        "model_signal_count": len(rows) - len(bet105_rows),
         "upsert": upsert_result,
-        "best_plays": best_plays_summary,
         "errors": errors,
     }
+

--- a/tests/test_model_tracker_bet105.py
+++ b/tests/test_model_tracker_bet105.py
@@ -1,0 +1,69 @@
+from mlb_app.model_tracker_bet105 import (
+    as_model_signals,
+    build_bet105_decisions,
+    normalize_bet105_markets,
+)
+
+
+def _board():
+    return {
+        "events": [{
+            "event_id": "bet105-1",
+            "away_team": "Away",
+            "home_team": "Home",
+            "markets": [
+                {"market_key": "h2h", "market_name": "Moneyline", "selections": [
+                    {"id": "away", "name": "Away", "price_american": 120, "active": True},
+                    {"id": "home", "name": "Home", "price_american": -140, "active": True},
+                ]},
+                {"market_key": "totals", "market_name": "Game Total", "line": 8.5, "selections": [
+                    {"id": "over", "name": "Over 8.5", "price_american": -110, "active": True},
+                    {"id": "under", "name": "Under 8.5", "price_american": -110, "active": True},
+                ]},
+            ],
+        }]
+    }
+
+
+def _projection():
+    return {
+        "source": "model_projections", "game_pk": 1, "away_team": "Away", "home_team": "Home",
+        "home_win_probability": 0.64, "away_win_probability": 0.36,
+        "projected_total": 9.2, "confidence": 0.60, "model_name": "test_model",
+    }
+
+
+def test_bet105_normalization_preserves_real_prices_and_implied_probability():
+    rows = normalize_bet105_markets(_board(), "2026-07-26")
+    home = next(row for row in rows if row["selection"] == "Home")
+    assert home["market_type"] == "moneyline"
+    assert home["price"] == -140
+    assert round(home["implied_probability"], 4) == 0.5833
+    assert home["raw"]["selection"]["id"] == "home"
+
+
+def test_moneyline_decision_requires_positive_edge_and_real_price():
+    rows = build_bet105_decisions(_board(), [_projection()], "2026-07-26")
+    home = next(row for row in rows if row["market_type"] == "moneyline")
+    assert home["source"] == "bet105"
+    assert home["pick_type"] == "reportable_decision"
+    assert home["edge"] > 0
+    assert home["price"] == -140
+
+
+def test_total_requires_direction_and_conservative_projection_gap():
+    rows = build_bet105_decisions(_board(), [_projection()], "2026-07-26")
+    total = next(row for row in rows if row["market_type"] == "total")
+    assert total["pick_label"] == "Over 8.5"
+    assert total["line"] == 8.5
+
+
+def test_model_and_dashboard_rows_are_explicit_non_reportable_signals():
+    rows = as_model_signals([{
+        "source": "my_dashboard", "source_component": "hitters", "snapshot_date": "2026-07-26",
+        "pick_label": "Player", "market_type": "player_prop", "game_pk": 1,
+    }], "2026-07-26")
+    assert rows[0]["pick_type"] == "model_signal"
+    assert rows[0]["grade"] == "watchlist_only"
+    assert rows[0]["price"] is None
+    assert rows[0]["missing_inputs_json"] == ["No matching Bet105 market/price available."]


### PR DESCRIPTION
## What changed
- Replaced the Model Tracker snapshot's Daily Odds, AI assistant, and Best Plays collection with a Bet105-only odds path.
- Added a normalized Bet105 tracker adapter that preserves real selections/prices and creates reportable decisions only for positively matched model projections.
- Converts Model Projections and MyDashboard outputs into explicit non-reportable, no-odds model signals.
- Added compact `GET /model-tracker/range` reporting endpoint.
- Restricted frontend P&L to reportable, odds-backed Bet105 rows and changed period loading to one range request.
- Added focused Bet105 normalization/decision/model-signal tests.

## Notes
- No OddsAPI dependency is used by the new snapshot path.
- Run the new backend tests and frontend suite in CI before merge; this connector-only workspace has no checkout/runtime for execution.