### PR TITLE
Monitor live baserunning shadow

### DIFF
--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -600,3 +600,22 @@ from .historical_baserunning_holdout_validation import (
     build_historical_baserunning_holdout_plan,
     filter_historical_baserunning_holdout_schedule,
 )
+
+
+from .live_baserunning_shadow_monitoring import (
+    CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION,
+    CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION,
+    LIVE_BASERUNNING_SHADOW_MAXIMUM_DAY_SPAN,
+    LIVE_BASERUNNING_SHADOW_MINIMUM_DAY_SPAN,
+    LIVE_BASERUNNING_SHADOW_MINIMUM_GAME_COUNT,
+    CanonicalLiveBaserunningShadowMonitor,
+    CanonicalLiveBaserunningShadowObservation,
+    summarize_live_baserunning_shadow,
+)
+
+
+from .live_baserunning_shadow_execution import (
+    CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION,
+    CanonicalLiveBaserunningShadowExecution,
+    execute_live_baserunning_shadow_pair,
+)

--- a/mlb_app/simulation/shadow/live_baserunning_shadow_execution.py
+++ b/mlb_app/simulation/shadow/live_baserunning_shadow_execution.py
@@ -1,0 +1,261 @@
+"""Execute paired legacy and calibrated live baserunning shadows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Dict
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningProbabilityTransform,
+)
+
+from .baserunning_evidence_discovery import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+)
+from .baserunning_output_validation import (
+    validate_canonical_baserunning_shadow_outputs,
+)
+from .baserunning_production_execution import (
+    run_canonical_production_shadow_with_baserunning_discovery,
+)
+from .historical_baserunning_holdout_validation import (
+    HISTORICAL_BASERUNNING_SELECTED_ATTEMPT_MULTIPLIER,
+    HISTORICAL_BASERUNNING_SELECTED_SUCCESS_ADJUSTMENT,
+)
+from .live_baserunning_shadow_monitoring import (
+    CanonicalLiveBaserunningShadowObservation,
+)
+from .production_execution import (
+    CanonicalProductionShadowExecution,
+)
+
+
+CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION = (
+    "canonical_live_baserunning_shadow_execution_v1"
+)
+
+
+def _sha256(value: Dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class CanonicalLiveBaserunningShadowExecution:
+    legacy_execution: CanonicalProductionShadowExecution
+    calibrated_execution: CanonicalProductionShadowExecution
+    observation: CanonicalLiveBaserunningShadowObservation
+    execution_version: str = (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "legacy_execution",
+            "calibrated_execution",
+        ):
+            if not isinstance(
+                getattr(self, field_name),
+                CanonicalProductionShadowExecution,
+            ):
+                raise TypeError(
+                    f"{field_name} must be canonical"
+                )
+
+        if not isinstance(
+            self.observation,
+            CanonicalLiveBaserunningShadowObservation,
+        ):
+            raise TypeError(
+                "observation must be canonical"
+            )
+
+        if self.execution_version != (
+            CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION
+        ):
+            raise ValueError(
+                "unsupported live baserunning shadow "
+                "execution version"
+            )
+
+    @property
+    def production_execution(
+        self,
+    ) -> CanonicalProductionShadowExecution:
+        return self.legacy_execution
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.execution_version,
+            "legacy_execution": (
+                self.legacy_execution.to_diagnostics()
+            ),
+            "calibrated_execution": (
+                self.calibrated_execution.to_diagnostics()
+            ),
+            "observation": (
+                self.observation.to_diagnostics()
+            ),
+            "production_result": "legacy_execution",
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def execute_live_baserunning_shadow_pair(
+    *,
+    game_date: str,
+    baserunning_evidence_discovery: (
+        CanonicalShadowBaserunningEvidenceDiscovery
+    ),
+    **production_inputs: Any,
+) -> CanonicalLiveBaserunningShadowExecution:
+    if "baserunning_probability_transform" in production_inputs:
+        raise ValueError(
+            "live paired execution owns the calibrated "
+            "probability transform"
+        )
+
+    game_pk = int(production_inputs.get("game_pk"))
+    simulation_count = int(
+        production_inputs.get(
+            "simulation_count",
+            25,
+        )
+    )
+
+    transform = CanonicalBaserunningProbabilityTransform(
+        attempt_probability_multiplier=(
+            HISTORICAL_BASERUNNING_SELECTED_ATTEMPT_MULTIPLIER
+        ),
+        success_rate_adjustment=(
+            HISTORICAL_BASERUNNING_SELECTED_SUCCESS_ADJUSTMENT
+        ),
+    )
+
+    legacy_execution = (
+        run_canonical_production_shadow_with_baserunning_discovery(
+            baserunning_evidence_discovery=(
+                baserunning_evidence_discovery
+            ),
+            **production_inputs,
+        )
+    )
+    calibrated_execution = (
+        run_canonical_production_shadow_with_baserunning_discovery(
+            baserunning_evidence_discovery=(
+                baserunning_evidence_discovery
+            ),
+            baserunning_probability_transform=transform,
+            **production_inputs,
+        )
+    )
+
+    legacy_validation = (
+        validate_canonical_baserunning_shadow_outputs(
+            legacy_execution
+        )
+    )
+    calibrated_validation = (
+        validate_canonical_baserunning_shadow_outputs(
+            calibrated_execution
+        )
+    )
+
+    legacy_diagnostics = (
+        legacy_execution.to_diagnostics()
+    )
+    calibrated_diagnostics = (
+        calibrated_execution.to_diagnostics()
+    )
+
+    parity_fields = (
+        "provider_identity",
+        "exact_artifact_digest",
+        "fallback_catalog_digest",
+        "baserunning_evidence_catalog_digest",
+    )
+    input_parity_verified = (
+        legacy_execution.executed
+        and calibrated_execution.executed
+        and all(
+            legacy_diagnostics.get(field_name)
+            == calibrated_diagnostics.get(field_name)
+            for field_name in parity_fields
+        )
+    )
+    seed_parity_verified = (
+        input_parity_verified
+        and legacy_execution.simulation_count
+        == calibrated_execution.simulation_count
+        == simulation_count
+    )
+
+    paired_context_digest = _sha256(
+        {
+            "game_pk": game_pk,
+            "game_date": game_date,
+            "simulation_count": simulation_count,
+            "provider_identity": (
+                legacy_diagnostics.get(
+                    "provider_identity"
+                )
+            ),
+            "exact_artifact_digest": (
+                legacy_diagnostics.get(
+                    "exact_artifact_digest"
+                )
+            ),
+            "fallback_catalog_digest": (
+                legacy_diagnostics.get(
+                    "fallback_catalog_digest"
+                )
+            ),
+            "baserunning_evidence_catalog_digest": (
+                legacy_diagnostics.get(
+                    "baserunning_evidence_catalog_digest"
+                )
+            ),
+            "seed_policy": (
+                "canonical_trial_seed_same_game_config_v1"
+            ),
+        }
+    )
+
+    observation = (
+        CanonicalLiveBaserunningShadowObservation(
+            game_pk=game_pk,
+            game_date=game_date,
+            paired_context_digest=(
+                paired_context_digest
+            ),
+            calibrated_transform_digest=(
+                transform.digest
+            ),
+            legacy_validation=legacy_validation,
+            calibrated_validation=(
+                calibrated_validation
+            ),
+            input_parity_verified=(
+                input_parity_verified
+            ),
+            seed_parity_verified=(
+                seed_parity_verified
+            ),
+        )
+    )
+
+    return CanonicalLiveBaserunningShadowExecution(
+        legacy_execution=legacy_execution,
+        calibrated_execution=calibrated_execution,
+        observation=observation,
+    )

--- a/mlb_app/simulation/shadow/live_baserunning_shadow_monitoring.py
+++ b/mlb_app/simulation/shadow/live_baserunning_shadow_monitoring.py
@@ -1,0 +1,475 @@
+"""Monitor paired legacy and calibrated live baserunning shadows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict, Tuple
+
+from .baserunning_output_validation import (
+    CanonicalBaserunningOutputValidation,
+)
+
+
+CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION = (
+    "canonical_live_baserunning_shadow_observation_v1"
+)
+CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION = (
+    "canonical_live_baserunning_shadow_monitor_v1"
+)
+LIVE_BASERUNNING_SHADOW_MINIMUM_GAME_COUNT = 100
+LIVE_BASERUNNING_SHADOW_MINIMUM_DAY_SPAN = 7
+LIVE_BASERUNNING_SHADOW_MAXIMUM_DAY_SPAN = 14
+
+_PAIRED_SEED_POLICY = (
+    "canonical_trial_seed_same_game_config_v1"
+)
+
+
+def _sha256(value: Dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _digest(value: str, field_name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{field_name} must be a SHA-256 digest"
+        )
+
+
+@dataclass(frozen=True)
+class CanonicalLiveBaserunningShadowObservation:
+    game_pk: int
+    game_date: str
+    paired_context_digest: str
+    calibrated_transform_digest: str
+    legacy_validation: (
+        CanonicalBaserunningOutputValidation
+    )
+    calibrated_validation: (
+        CanonicalBaserunningOutputValidation
+    )
+    input_parity_verified: bool
+    seed_parity_verified: bool
+    observation_version: str = (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        try:
+            parsed_date = date.fromisoformat(
+                self.game_date
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "game_date must be an ISO date"
+            ) from exc
+
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        _digest(
+            self.paired_context_digest,
+            "paired_context_digest",
+        )
+        _digest(
+            self.calibrated_transform_digest,
+            "calibrated_transform_digest",
+        )
+
+        for field_name in (
+            "legacy_validation",
+            "calibrated_validation",
+        ):
+            if not isinstance(
+                getattr(self, field_name),
+                CanonicalBaserunningOutputValidation,
+            ):
+                raise TypeError(
+                    f"{field_name} must be canonical"
+                )
+
+        if (
+            self.legacy_validation.simulation_count
+            != self.calibrated_validation.simulation_count
+        ):
+            raise ValueError(
+                "paired validations must use the same "
+                "simulation count"
+            )
+
+        if (
+            self.legacy_validation.catalog_digest
+            != self.calibrated_validation.catalog_digest
+        ):
+            raise ValueError(
+                "paired validations must use the same "
+                "baserunning catalog"
+            )
+
+        if self.ready and (
+            not self.input_parity_verified
+            or not self.seed_parity_verified
+        ):
+            raise ValueError(
+                "ready paired observation requires input "
+                "and seed parity"
+            )
+
+        if self.observation_version != (
+            CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported live baserunning shadow "
+                "observation version"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.legacy_validation.ready
+            and self.calibrated_validation.ready
+        )
+
+    @property
+    def status(self) -> str:
+        if self.ready:
+            return "ready"
+        if (
+            self.legacy_validation.status == "error"
+            or self.calibrated_validation.status == "error"
+        ):
+            return "error"
+        return "unavailable"
+
+    @property
+    def simulation_count(self) -> int:
+        return self.legacy_validation.simulation_count
+
+    @property
+    def stolen_base_delta(self) -> float:
+        return round(
+            self.calibrated_validation
+            .stolen_base_mean_total
+            - self.legacy_validation
+            .stolen_base_mean_total,
+            6,
+        )
+
+    @property
+    def caught_stealing_delta(self) -> float:
+        return round(
+            self.calibrated_validation
+            .caught_stealing_mean_total
+            - self.legacy_validation
+            .caught_stealing_mean_total,
+            6,
+        )
+
+    @property
+    def digest(self) -> str:
+        return _sha256(
+            {
+                "observation_version": (
+                    self.observation_version
+                ),
+                "game_pk": self.game_pk,
+                "game_date": self.game_date,
+                "paired_context_digest": (
+                    self.paired_context_digest
+                ),
+                "calibrated_transform_digest": (
+                    self.calibrated_transform_digest
+                ),
+                "legacy_validation": (
+                    self.legacy_validation.to_diagnostics()
+                ),
+                "calibrated_validation": (
+                    self.calibrated_validation.to_diagnostics()
+                ),
+                "input_parity_verified": (
+                    self.input_parity_verified
+                ),
+                "seed_parity_verified": (
+                    self.seed_parity_verified
+                ),
+                "paired_seed_policy": (
+                    _PAIRED_SEED_POLICY
+                ),
+            }
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.observation_version,
+            "status": self.status,
+            "ready": self.ready,
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "simulation_count": self.simulation_count,
+            "paired_context_digest": (
+                self.paired_context_digest
+            ),
+            "calibrated_transform_digest": (
+                self.calibrated_transform_digest
+            ),
+            "input_parity_verified": (
+                self.input_parity_verified
+            ),
+            "seed_parity_verified": (
+                self.seed_parity_verified
+            ),
+            "paired_seed_policy": _PAIRED_SEED_POLICY,
+            "legacy_validation": (
+                self.legacy_validation.to_diagnostics()
+            ),
+            "calibrated_validation": (
+                self.calibrated_validation.to_diagnostics()
+            ),
+            "stolen_base_delta": self.stolen_base_delta,
+            "caught_stealing_delta": (
+                self.caught_stealing_delta
+            ),
+            "observation_digest": self.digest,
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalLiveBaserunningShadowMonitor:
+    observations: Tuple[
+        CanonicalLiveBaserunningShadowObservation,
+        ...
+    ] = ()
+    minimum_game_count: int = (
+        LIVE_BASERUNNING_SHADOW_MINIMUM_GAME_COUNT
+    )
+    minimum_day_span: int = (
+        LIVE_BASERUNNING_SHADOW_MINIMUM_DAY_SPAN
+    )
+    maximum_day_span: int = (
+        LIVE_BASERUNNING_SHADOW_MAXIMUM_DAY_SPAN
+    )
+    monitor_version: str = (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(
+                value,
+                CanonicalLiveBaserunningShadowObservation,
+            )
+            for value in self.observations
+        ):
+            raise TypeError(
+                "observations must be canonical"
+            )
+
+        game_ids = tuple(
+            value.game_pk
+            for value in self.observations
+        )
+        if len(set(game_ids)) != len(game_ids):
+            raise ValueError(
+                "live shadow game identifiers must be unique"
+            )
+
+        ordered = tuple(
+            sorted(
+                self.observations,
+                key=lambda value: (
+                    value.game_date,
+                    value.game_pk,
+                ),
+            )
+        )
+        if ordered != self.observations:
+            raise ValueError(
+                "live shadow observations must be ordered"
+            )
+
+        if self.minimum_game_count < 1:
+            raise ValueError(
+                "minimum_game_count must be positive"
+            )
+        if self.minimum_day_span < 1:
+            raise ValueError(
+                "minimum_day_span must be positive"
+            )
+        if self.maximum_day_span < self.minimum_day_span:
+            raise ValueError(
+                "maximum_day_span cannot be below minimum"
+            )
+        if self.monitor_version != (
+            CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION
+        ):
+            raise ValueError(
+                "unsupported live baserunning shadow "
+                "monitor version"
+            )
+
+    @property
+    def game_count(self) -> int:
+        return len(self.observations)
+
+    @property
+    def ready_count(self) -> int:
+        return sum(
+            value.ready
+            for value in self.observations
+        )
+
+    @property
+    def unavailable_count(self) -> int:
+        return sum(
+            value.status == "unavailable"
+            for value in self.observations
+        )
+
+    @property
+    def error_count(self) -> int:
+        return sum(
+            value.status == "error"
+            for value in self.observations
+        )
+
+    @property
+    def day_span(self) -> int:
+        if not self.observations:
+            return 0
+
+        start = date.fromisoformat(
+            self.observations[0].game_date
+        )
+        end = date.fromisoformat(
+            self.observations[-1].game_date
+        )
+        return (end - start).days + 1
+
+    @property
+    def live_shadow_complete(self) -> bool:
+        return (
+            self.game_count >= self.minimum_game_count
+            and self.day_span >= self.minimum_day_span
+            and self.day_span <= self.maximum_day_span
+            and self.ready_count == self.game_count
+            and self.error_count == 0
+            and self.unavailable_count == 0
+        )
+
+    @property
+    def digest(self) -> str:
+        return _sha256(
+            {
+                "monitor_version": self.monitor_version,
+                "minimum_game_count": (
+                    self.minimum_game_count
+                ),
+                "minimum_day_span": (
+                    self.minimum_day_span
+                ),
+                "maximum_day_span": (
+                    self.maximum_day_span
+                ),
+                "observation_digests": [
+                    value.digest
+                    for value in self.observations
+                ],
+            }
+        )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.monitor_version,
+            "game_count": self.game_count,
+            "ready_count": self.ready_count,
+            "unavailable_count": (
+                self.unavailable_count
+            ),
+            "error_count": self.error_count,
+            "day_span": self.day_span,
+            "minimum_game_count": (
+                self.minimum_game_count
+            ),
+            "minimum_day_span": self.minimum_day_span,
+            "maximum_day_span": self.maximum_day_span,
+            "live_shadow_complete": (
+                self.live_shadow_complete
+            ),
+            "stolen_base_delta_total": round(
+                sum(
+                    value.stolen_base_delta
+                    for value in self.observations
+                ),
+                6,
+            ),
+            "caught_stealing_delta_total": round(
+                sum(
+                    value.caught_stealing_delta
+                    for value in self.observations
+                ),
+                6,
+            ),
+            "observation_digests": tuple(
+                value.digest
+                for value in self.observations
+            ),
+            "monitor_digest": self.digest,
+            "eligible_for_activation_review": (
+                self.live_shadow_complete
+            ),
+            "activation_permitted": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def summarize_live_baserunning_shadow(
+    observations: Tuple[
+        CanonicalLiveBaserunningShadowObservation,
+        ...
+    ],
+) -> CanonicalLiveBaserunningShadowMonitor:
+    ordered = tuple(
+        sorted(
+            observations,
+            key=lambda value: (
+                value.game_date,
+                value.game_pk,
+            ),
+        )
+    )
+    return CanonicalLiveBaserunningShadowMonitor(
+        observations=ordered,
+    )

--- a/tests/test_canonical_live_baserunning_shadow_monitoring.py
+++ b/tests/test_canonical_live_baserunning_shadow_monitoring.py
@@ -1,0 +1,179 @@
+import hashlib
+from datetime import date, timedelta
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION,
+    CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION,
+    CanonicalBaserunningOutputValidation,
+    CanonicalLiveBaserunningShadowMonitor,
+    CanonicalLiveBaserunningShadowObservation,
+    summarize_live_baserunning_shadow,
+)
+
+
+DIGEST = hashlib.sha256(b"context").hexdigest()
+TRANSFORM_DIGEST = hashlib.sha256(
+    b"transform"
+).hexdigest()
+CATALOG_DIGEST = hashlib.sha256(
+    b"catalog"
+).hexdigest()
+
+
+def validation(
+    *,
+    stolen_bases,
+    caught_stealing,
+    status="ready",
+):
+    return CanonicalBaserunningOutputValidation(
+        status=status,
+        simulation_count=25,
+        catalog_digest=CATALOG_DIGEST,
+        runner_projection_count=18,
+        stolen_base_mean_total=stolen_bases,
+        caught_stealing_mean_total=caught_stealing,
+    )
+
+
+def observation(
+    game_pk=1,
+    game_date="2026-07-20",
+):
+    return CanonicalLiveBaserunningShadowObservation(
+        game_pk=game_pk,
+        game_date=game_date,
+        paired_context_digest=DIGEST,
+        calibrated_transform_digest=(
+            TRANSFORM_DIGEST
+        ),
+        legacy_validation=validation(
+            stolen_bases=2.0,
+            caught_stealing=1.0,
+        ),
+        calibrated_validation=validation(
+            stolen_bases=1.25,
+            caught_stealing=0.5,
+        ),
+        input_parity_verified=True,
+        seed_parity_verified=True,
+    )
+
+
+def test_paired_observation_reports_deltas():
+    value = observation()
+    diagnostics = value.to_diagnostics()
+
+    assert value.ready is True
+    assert value.status == "ready"
+    assert value.stolen_base_delta == -0.75
+    assert value.caught_stealing_delta == -0.5
+    assert diagnostics["input_parity_verified"] is True
+    assert diagnostics["seed_parity_verified"] is True
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_ready_observation_requires_pair_parity():
+    with pytest.raises(
+        ValueError,
+        match="requires input and seed parity",
+    ):
+        CanonicalLiveBaserunningShadowObservation(
+            game_pk=1,
+            game_date="2026-07-20",
+            paired_context_digest=DIGEST,
+            calibrated_transform_digest=(
+                TRANSFORM_DIGEST
+            ),
+            legacy_validation=validation(
+                stolen_bases=2.0,
+                caught_stealing=1.0,
+            ),
+            calibrated_validation=validation(
+                stolen_bases=1.25,
+                caught_stealing=0.5,
+            ),
+            input_parity_verified=False,
+            seed_parity_verified=True,
+        )
+
+
+def test_monitor_requires_unique_games():
+    value = observation()
+
+    with pytest.raises(
+        ValueError,
+        match="must be unique",
+    ):
+        CanonicalLiveBaserunningShadowMonitor(
+            observations=(value, value),
+        )
+
+
+def test_live_shadow_threshold_requires_100_games_and_7_days():
+    start = date(2026, 7, 1)
+    observations = tuple(
+        observation(
+            game_pk=index + 1,
+            game_date=(
+                start
+                + timedelta(days=index % 7)
+            ).isoformat(),
+        )
+        for index in range(100)
+    )
+
+    monitor = summarize_live_baserunning_shadow(
+        observations
+    )
+    diagnostics = monitor.to_diagnostics()
+
+    assert monitor.game_count == 100
+    assert monitor.ready_count == 100
+    assert monitor.day_span == 7
+    assert monitor.live_shadow_complete is True
+    assert (
+        diagnostics["eligible_for_activation_review"]
+        is True
+    )
+    assert diagnostics["activation_permitted"] is False
+
+
+def test_six_day_monitor_is_incomplete():
+    start = date(2026, 7, 1)
+    observations = tuple(
+        observation(
+            game_pk=index + 1,
+            game_date=(
+                start
+                + timedelta(days=index % 6)
+            ).isoformat(),
+        )
+        for index in range(100)
+    )
+
+    monitor = summarize_live_baserunning_shadow(
+        observations
+    )
+
+    assert monitor.day_span == 6
+    assert monitor.live_shadow_complete is False
+
+
+def test_versions_are_explicit():
+    assert (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_OBSERVATION_VERSION
+        == "canonical_live_baserunning_shadow_observation_v1"
+    )
+    assert (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_MONITOR_VERSION
+        == "canonical_live_baserunning_shadow_monitor_v1"
+    )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from mlb_app.simulation.box_score import (
     DRAFTKINGS_CLASSIC_BATTER_RULES,
     DRAFTKINGS_CLASSIC_PITCHER_RULES,
@@ -815,3 +817,153 @@ def test_output_validation_preserves_shadow_authority():
         "production_authority_changed"
     ] is False
     assert diagnostics["authoritative_source"] == "legacy"
+
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION,
+    execute_live_baserunning_shadow_pair,
+)
+
+
+def run_live_pair(**overrides):
+    kwargs = {
+        "game_pk": 123,
+        "game_date": "2026-07-26",
+        "lineups": lineups(),
+        "bullpens": bullpens(),
+        "provider_discovery": provider_discovery(),
+        "exact_artifact_discovery": (
+            exact_discovery()
+        ),
+        "fallback_catalog_discovery": (
+            fallback_discovery()
+        ),
+        "bootstrap_ready": True,
+        "simulation_count": 2,
+    }
+    kwargs.update(overrides)
+
+    return execute_live_baserunning_shadow_pair(
+        baserunning_evidence_discovery=(
+            baserunning_discovery()
+        ),
+        **kwargs,
+    )
+
+
+def test_live_pair_preserves_legacy_production_authority():
+    result = run_live_pair()
+    diagnostics = result.to_diagnostics()
+
+    assert result.production_execution is (
+        result.legacy_execution
+    )
+    assert diagnostics["production_result"] == (
+        "legacy_execution"
+    )
+    assert diagnostics["activation_permitted"] is False
+    assert diagnostics["production_activation"] is False
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert diagnostics["authoritative_source"] == "legacy"
+
+
+def test_live_pair_uses_identical_inputs_and_seeds():
+    result = run_live_pair()
+
+    assert result.legacy_execution.executed is True
+    assert result.calibrated_execution.executed is True
+    assert result.observation.ready is True
+    assert (
+        result.observation.input_parity_verified
+        is True
+    )
+    assert (
+        result.observation.seed_parity_verified
+        is True
+    )
+    assert result.observation.simulation_count == 2
+    assert (
+        result.observation.calibrated_transform_digest
+        != result.observation.paired_context_digest
+    )
+
+
+def test_live_pair_is_deterministic():
+    first = run_live_pair()
+    second = run_live_pair()
+
+    assert first.observation == second.observation
+    assert (
+        first.observation.digest
+        == second.observation.digest
+    )
+    assert (
+        CANONICAL_LIVE_BASERUNNING_SHADOW_EXECUTION_VERSION
+        == "canonical_live_baserunning_shadow_execution_v1"
+    )
+
+
+
+def test_live_pair_unavailable_evidence_fails_open():
+    result = execute_live_baserunning_shadow_pair(
+        game_pk=123,
+        game_date="2026-07-26",
+        lineups=lineups(),
+        bullpens=bullpens(),
+        provider_discovery=provider_discovery(),
+        exact_artifact_discovery=exact_discovery(),
+        fallback_catalog_discovery=(
+            fallback_discovery()
+        ),
+        bootstrap_ready=True,
+        simulation_count=2,
+        baserunning_evidence_discovery=(
+            baserunning_discovery(
+                status="unavailable",
+            )
+        ),
+    )
+
+    assert result.production_execution is (
+        result.legacy_execution
+    )
+    assert result.legacy_execution.status == "blocked"
+    assert (
+        result.calibrated_execution.status
+        == "blocked"
+    )
+    assert result.observation.status == "unavailable"
+    assert result.observation.ready is False
+    assert (
+        result.observation.input_parity_verified
+        is False
+    )
+    assert (
+        result.observation.seed_parity_verified
+        is False
+    )
+    assert (
+        result.to_diagnostics()[
+            "authoritative_source"
+        ]
+        == "legacy"
+    )
+
+
+def test_live_pair_rejects_external_transform():
+    from mlb_app.simulation.game import (
+        CanonicalBaserunningProbabilityTransform,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="owns the calibrated probability transform",
+    ):
+        run_live_pair(
+            baserunning_probability_transform=(
+                CanonicalBaserunningProbabilityTransform()
+            ),
+        )


### PR DESCRIPTION
## Summary

- define deterministic live baserunning shadow observations and rolling monitor summaries
- execute paired legacy and calibrated shadows with identical inputs and seed policy
- preserve the legacy execution as the sole production-facing result
- keep activation disabled while collecting the required 100-game, 7–14-day live sample
- fail open when live baserunning evidence is unavailable

## Calibration under observation

- attempt probability multiplier: `0.52`
- success-rate adjustment: `+0.09`
- production authority remains `legacy`
- production activation remains disabled

## Validation

- focused integration suite: `81 passed`
- branch-owned suite: `38 passed`
- compile checks passed
- `git diff --check` passed
- broad canonical/projection suite: `1096 passed`, with two confirmed pre-existing failures in untouched files:
  - `tests/test_canonical_game_context.py`
  - `tests/test_canonical_model_engine.py`

The paired runner is not yet connected to the production projection route. A subsequent PR will materialize complete live baserunning evidence before route integration.
