### PR TITLE
Activate calibrated baserunning

### DIFF
--- a/data/baserunning/production_prior.json
+++ b/data/baserunning/production_prior.json
@@ -1,0 +1,7271 @@
+{
+  "artifact_digest": "852bb7b580abb2e1bb3fd9ab7e43fb2c14195ed4d624c372875efc9d7e24ac55",
+  "catchers": [
+    {
+      "catcher_id": "518595",
+      "pop_time_score": 0.2222222222222222,
+      "throwing_score": 0.2222222222222222
+    },
+    {
+      "catcher_id": "521692",
+      "pop_time_score": 0.4375,
+      "throwing_score": 0.4375
+    },
+    {
+      "catcher_id": "543309",
+      "pop_time_score": 0.25,
+      "throwing_score": 0.25
+    },
+    {
+      "catcher_id": "543510",
+      "pop_time_score": 0.15384615384615385,
+      "throwing_score": 0.15384615384615385
+    },
+    {
+      "catcher_id": "543877",
+      "pop_time_score": 0.4375,
+      "throwing_score": 0.4375
+    },
+    {
+      "catcher_id": "553869",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "592663",
+      "pop_time_score": 0.3076923076923077,
+      "throwing_score": 0.3076923076923077
+    },
+    {
+      "catcher_id": "595978",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "596117",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "596142",
+      "pop_time_score": 0.5,
+      "throwing_score": 0.5
+    },
+    {
+      "catcher_id": "605170",
+      "pop_time_score": 0.29411764705882354,
+      "throwing_score": 0.29411764705882354
+    },
+    {
+      "catcher_id": "605244",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "606992",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "608348",
+      "pop_time_score": 0.18181818181818182,
+      "throwing_score": 0.18181818181818182
+    },
+    {
+      "catcher_id": "620443",
+      "pop_time_score": 0.5714285714285714,
+      "throwing_score": 0.5714285714285714
+    },
+    {
+      "catcher_id": "623168",
+      "pop_time_score": 0.25,
+      "throwing_score": 0.25
+    },
+    {
+      "catcher_id": "624431",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "624512",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "640902",
+      "pop_time_score": 0.3333333333333333,
+      "throwing_score": 0.3333333333333333
+    },
+    {
+      "catcher_id": "641555",
+      "pop_time_score": 0.2,
+      "throwing_score": 0.2
+    },
+    {
+      "catcher_id": "641598",
+      "pop_time_score": 0.375,
+      "throwing_score": 0.375
+    },
+    {
+      "catcher_id": "641680",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "642851",
+      "pop_time_score": 0.09090909090909091,
+      "throwing_score": 0.09090909090909091
+    },
+    {
+      "catcher_id": "643376",
+      "pop_time_score": 0.3,
+      "throwing_score": 0.3
+    },
+    {
+      "catcher_id": "657136",
+      "pop_time_score": 0.2,
+      "throwing_score": 0.2
+    },
+    {
+      "catcher_id": "660688",
+      "pop_time_score": 0.15384615384615385,
+      "throwing_score": 0.15384615384615385
+    },
+    {
+      "catcher_id": "661388",
+      "pop_time_score": 0.5,
+      "throwing_score": 0.5
+    },
+    {
+      "catcher_id": "663698",
+      "pop_time_score": 0.15,
+      "throwing_score": 0.15
+    },
+    {
+      "catcher_id": "663728",
+      "pop_time_score": 0.3684210526315789,
+      "throwing_score": 0.3684210526315789
+    },
+    {
+      "catcher_id": "663743",
+      "pop_time_score": 0.07407407407407407,
+      "throwing_score": 0.07407407407407407
+    },
+    {
+      "catcher_id": "663886",
+      "pop_time_score": 0.2,
+      "throwing_score": 0.2
+    },
+    {
+      "catcher_id": "664731",
+      "pop_time_score": 0.25,
+      "throwing_score": 0.25
+    },
+    {
+      "catcher_id": "664954",
+      "pop_time_score": 0.1875,
+      "throwing_score": 0.1875
+    },
+    {
+      "catcher_id": "665561",
+      "pop_time_score": 0.5555555555555556,
+      "throwing_score": 0.5555555555555556
+    },
+    {
+      "catcher_id": "665804",
+      "pop_time_score": 0.25,
+      "throwing_score": 0.25
+    },
+    {
+      "catcher_id": "665861",
+      "pop_time_score": 0.5,
+      "throwing_score": 0.5
+    },
+    {
+      "catcher_id": "665966",
+      "pop_time_score": 0.3,
+      "throwing_score": 0.3
+    },
+    {
+      "catcher_id": "666023",
+      "pop_time_score": 0.4166666666666667,
+      "throwing_score": 0.4166666666666667
+    },
+    {
+      "catcher_id": "666310",
+      "pop_time_score": 0.1111111111111111,
+      "throwing_score": 0.1111111111111111
+    },
+    {
+      "catcher_id": "668670",
+      "pop_time_score": 0.23076923076923078,
+      "throwing_score": 0.23076923076923078
+    },
+    {
+      "catcher_id": "668939",
+      "pop_time_score": 0.3157894736842105,
+      "throwing_score": 0.3157894736842105
+    },
+    {
+      "catcher_id": "669127",
+      "pop_time_score": 0.2727272727272727,
+      "throwing_score": 0.2727272727272727
+    },
+    {
+      "catcher_id": "669134",
+      "pop_time_score": 0.3333333333333333,
+      "throwing_score": 0.3333333333333333
+    },
+    {
+      "catcher_id": "669224",
+      "pop_time_score": 0.3125,
+      "throwing_score": 0.3125
+    },
+    {
+      "catcher_id": "669257",
+      "pop_time_score": 0.16666666666666666,
+      "throwing_score": 0.16666666666666666
+    },
+    {
+      "catcher_id": "671056",
+      "pop_time_score": 0.0,
+      "throwing_score": 0.0
+    },
+    {
+      "catcher_id": "672275",
+      "pop_time_score": 0.17391304347826086,
+      "throwing_score": 0.17391304347826086
+    },
+    {
+      "catcher_id": "672515",
+      "pop_time_score": 0.6666666666666666,
+      "throwing_score": 0.6666666666666666
+    },
+    {
+      "catcher_id": "673237",
+      "pop_time_score": 0.07692307692307693,
+      "throwing_score": 0.07692307692307693
+    },
+    {
+      "catcher_id": "676439",
+      "pop_time_score": 0.14285714285714285,
+      "throwing_score": 0.14285714285714285
+    },
+    {
+      "catcher_id": "678218",
+      "pop_time_score": 0.4,
+      "throwing_score": 0.4
+    },
+    {
+      "catcher_id": "680728",
+      "pop_time_score": 0.25,
+      "throwing_score": 0.25
+    },
+    {
+      "catcher_id": "680777",
+      "pop_time_score": 0.2,
+      "throwing_score": 0.2
+    },
+    {
+      "catcher_id": "680779",
+      "pop_time_score": 0.3333333333333333,
+      "throwing_score": 0.3333333333333333
+    },
+    {
+      "catcher_id": "681351",
+      "pop_time_score": 0.24,
+      "throwing_score": 0.24
+    },
+    {
+      "catcher_id": "682626",
+      "pop_time_score": 0.1,
+      "throwing_score": 0.1
+    },
+    {
+      "catcher_id": "682663",
+      "pop_time_score": 0.1,
+      "throwing_score": 0.1
+    },
+    {
+      "catcher_id": "686452",
+      "pop_time_score": 0.3,
+      "throwing_score": 0.3
+    },
+    {
+      "catcher_id": "686780",
+      "pop_time_score": 0.3076923076923077,
+      "throwing_score": 0.3076923076923077
+    },
+    {
+      "catcher_id": "686948",
+      "pop_time_score": 0.17647058823529413,
+      "throwing_score": 0.17647058823529413
+    },
+    {
+      "catcher_id": "687221",
+      "pop_time_score": 0.23076923076923078,
+      "throwing_score": 0.23076923076923078
+    },
+    {
+      "catcher_id": "689414",
+      "pop_time_score": 0.041666666666666664,
+      "throwing_score": 0.041666666666666664
+    },
+    {
+      "catcher_id": "691011",
+      "pop_time_score": 0.14285714285714285,
+      "throwing_score": 0.14285714285714285
+    },
+    {
+      "catcher_id": "693307",
+      "pop_time_score": 0.3125,
+      "throwing_score": 0.3125
+    },
+    {
+      "catcher_id": "694208",
+      "pop_time_score": 0.4,
+      "throwing_score": 0.4
+    },
+    {
+      "catcher_id": "694212",
+      "pop_time_score": 0.3076923076923077,
+      "throwing_score": 0.3076923076923077
+    },
+    {
+      "catcher_id": "695600",
+      "pop_time_score": 0.3333333333333333,
+      "throwing_score": 0.3333333333333333
+    },
+    {
+      "catcher_id": "696100",
+      "pop_time_score": 0.14285714285714285,
+      "throwing_score": 0.14285714285714285
+    },
+    {
+      "catcher_id": "700337",
+      "pop_time_score": 0.4117647058823529,
+      "throwing_score": 0.4117647058823529
+    }
+  ],
+  "direct_evidence_count": 7196,
+  "fallback_evidence_count": 91,
+  "pitchers": [
+    {
+      "delivery_time_score": 0.41176470588235303,
+      "hold_score": 0.41176470588235303,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "445276"
+    },
+    {
+      "delivery_time_score": 0.8529411764705883,
+      "hold_score": 0.8529411764705883,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "453286"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11764705882352941,
+      "pitcher_id": "471911"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.09615384615384616,
+      "pitcher_id": "472610"
+    },
+    {
+      "delivery_time_score": 0.8095238095238095,
+      "hold_score": 0.8095238095238095,
+      "pickoff_attempt_rate": 0.009523809523809525,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "500779"
+    },
+    {
+      "delivery_time_score": 0.8113207547169812,
+      "hold_score": 0.8113207547169812,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "518585"
+    },
+    {
+      "delivery_time_score": 0.5945945945945945,
+      "hold_score": 0.5945945945945945,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "518876"
+    },
+    {
+      "delivery_time_score": 0.6153846153846154,
+      "hold_score": 0.6153846153846154,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "518886"
+    },
+    {
+      "delivery_time_score": 0.6491228070175439,
+      "hold_score": 0.6491228070175439,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "519141"
+    },
+    {
+      "delivery_time_score": 0.8170731707317074,
+      "hold_score": 0.8170731707317074,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "519242"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11764705882352941,
+      "pitcher_id": "527048"
+    },
+    {
+      "delivery_time_score": 0.14893617021276606,
+      "hold_score": 0.14893617021276606,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "542888"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06896551724137931,
+      "pitcher_id": "543056"
+    },
+    {
+      "delivery_time_score": 0.9421965317919075,
+      "hold_score": 0.9421965317919075,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "543135"
+    },
+    {
+      "delivery_time_score": 0.4318181818181819,
+      "hold_score": 0.4318181818181819,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "543243"
+    },
+    {
+      "delivery_time_score": 0.7222222222222223,
+      "hold_score": 0.7222222222222223,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "544150"
+    },
+    {
+      "delivery_time_score": 0.9390243902439024,
+      "hold_score": 0.9390243902439024,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "547179"
+    },
+    {
+      "delivery_time_score": 0.7297297297297297,
+      "hold_score": 0.7297297297297297,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "547973"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.14285714285714285,
+      "pitcher_id": "548384"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.17073170731707318,
+      "pitcher_id": "552640"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.037037037037037035,
+      "pitcher_id": "554430"
+    },
+    {
+      "delivery_time_score": 0.8717948717948718,
+      "hold_score": 0.8717948717948718,
+      "pickoff_attempt_rate": 0.01282051282051282,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "571510"
+    },
+    {
+      "delivery_time_score": 0.5098039215686274,
+      "hold_score": 0.5098039215686274,
+      "pickoff_attempt_rate": 0.0196078431372549,
+      "pickoff_success_rate": 0.2857142857142857,
+      "pitcher_id": "571578"
+    },
+    {
+      "delivery_time_score": 0.8425196850393701,
+      "hold_score": 0.8425196850393701,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "571927"
+    },
+    {
+      "delivery_time_score": 0.6850393700787402,
+      "hold_score": 0.6850393700787402,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "571945"
+    },
+    {
+      "delivery_time_score": 0.6551724137931034,
+      "hold_score": 0.6551724137931034,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "571948"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "572143"
+    },
+    {
+      "delivery_time_score": 0.8245614035087719,
+      "hold_score": 0.8245614035087719,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "572955"
+    },
+    {
+      "delivery_time_score": 0.8,
+      "hold_score": 0.8,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "573009"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0392156862745098,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "573124"
+    },
+    {
+      "delivery_time_score": 0.7222222222222223,
+      "hold_score": 0.7222222222222223,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "573204"
+    },
+    {
+      "delivery_time_score": 0.849624060150376,
+      "hold_score": 0.849624060150376,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "579328"
+    },
+    {
+      "delivery_time_score": 0.6875,
+      "hold_score": 0.6875,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "592094"
+    },
+    {
+      "delivery_time_score": 0.937888198757764,
+      "hold_score": 0.937888198757764,
+      "pickoff_attempt_rate": 0.006211180124223602,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "592332"
+    },
+    {
+      "delivery_time_score": 0.6178343949044587,
+      "hold_score": 0.6178343949044587,
+      "pickoff_attempt_rate": 0.006369426751592357,
+      "pickoff_success_rate": 0.14285714285714285,
+      "pitcher_id": "592662"
+    },
+    {
+      "delivery_time_score": 0.726027397260274,
+      "hold_score": 0.726027397260274,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "592773"
+    },
+    {
+      "delivery_time_score": 0.36170212765957455,
+      "hold_score": 0.36170212765957455,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "592791"
+    },
+    {
+      "delivery_time_score": 0.7121212121212122,
+      "hold_score": 0.7121212121212122,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "592826"
+    },
+    {
+      "delivery_time_score": 0.7872340425531915,
+      "hold_score": 0.7872340425531915,
+      "pickoff_attempt_rate": 0.02127659574468085,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "592836"
+    },
+    {
+      "delivery_time_score": 0.7202797202797203,
+      "hold_score": 0.7202797202797203,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "593958"
+    },
+    {
+      "delivery_time_score": 0.8461538461538461,
+      "hold_score": 0.8461538461538461,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "593974"
+    },
+    {
+      "delivery_time_score": 0.8412698412698413,
+      "hold_score": 0.8412698412698413,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "594580"
+    },
+    {
+      "delivery_time_score": 0.6747967479674797,
+      "hold_score": 0.6747967479674797,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "594798"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "595014"
+    },
+    {
+      "delivery_time_score": 0.8245614035087719,
+      "hold_score": 0.8245614035087719,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "595345"
+    },
+    {
+      "delivery_time_score": 0.8275862068965517,
+      "hold_score": 0.8275862068965517,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "596001"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.018867924528301886,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "596133"
+    },
+    {
+      "delivery_time_score": 0.5384615384615384,
+      "hold_score": 0.5384615384615384,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605130"
+    },
+    {
+      "delivery_time_score": 0.6296296296296297,
+      "hold_score": 0.6296296296296297,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605135"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0967741935483871,
+      "pitcher_id": "605218"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13043478260869565,
+      "pitcher_id": "605280"
+    },
+    {
+      "delivery_time_score": 0.7902097902097902,
+      "hold_score": 0.7902097902097902,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605288"
+    },
+    {
+      "delivery_time_score": 0.8571428571428572,
+      "hold_score": 0.8571428571428572,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605400"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06382978723404255,
+      "pitcher_id": "605441"
+    },
+    {
+      "delivery_time_score": 0.4285714285714286,
+      "hold_score": 0.4285714285714286,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605447"
+    },
+    {
+      "delivery_time_score": 0.7468354430379747,
+      "hold_score": 0.7468354430379747,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605488"
+    },
+    {
+      "delivery_time_score": 0.7391304347826086,
+      "hold_score": 0.7391304347826086,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "605540"
+    },
+    {
+      "delivery_time_score": 0.0625,
+      "hold_score": 0.0625,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "606303"
+    },
+    {
+      "delivery_time_score": 0.16666666666666674,
+      "hold_score": 0.16666666666666674,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "606965"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.014925373134328358,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "606996"
+    },
+    {
+      "delivery_time_score": 0.7887323943661972,
+      "hold_score": 0.7887323943661972,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "607067"
+    },
+    {
+      "delivery_time_score": 0.44444444444444453,
+      "hold_score": 0.44444444444444453,
+      "pickoff_attempt_rate": 0.006944444444444444,
+      "pickoff_success_rate": 0.1111111111111111,
+      "pitcher_id": "607192"
+    },
+    {
+      "delivery_time_score": 0.7761194029850746,
+      "hold_score": 0.7761194029850746,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "607200"
+    },
+    {
+      "delivery_time_score": 0.8639455782312926,
+      "hold_score": 0.8639455782312926,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "607259"
+    },
+    {
+      "delivery_time_score": 0.5522388059701493,
+      "hold_score": 0.5522388059701493,
+      "pickoff_attempt_rate": 0.014925373134328358,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "607455"
+    },
+    {
+      "delivery_time_score": 0.5833333333333334,
+      "hold_score": 0.5833333333333334,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "607481"
+    },
+    {
+      "delivery_time_score": 0.5402298850574713,
+      "hold_score": 0.5402298850574713,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "607536"
+    },
+    {
+      "delivery_time_score": 0.8850574712643678,
+      "hold_score": 0.8850574712643678,
+      "pickoff_attempt_rate": 0.005747126436781609,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "607625"
+    },
+    {
+      "delivery_time_score": 0.8305084745762712,
+      "hold_score": 0.8305084745762712,
+      "pickoff_attempt_rate": 0.011299435028248588,
+      "pickoff_success_rate": 0.4,
+      "pitcher_id": "608331"
+    },
+    {
+      "delivery_time_score": 0.7709923664122138,
+      "hold_score": 0.7709923664122138,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "608372"
+    },
+    {
+      "delivery_time_score": 0.7297297297297297,
+      "hold_score": 0.7297297297297297,
+      "pickoff_attempt_rate": 0.006756756756756757,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "608379"
+    },
+    {
+      "delivery_time_score": 0.6190476190476191,
+      "hold_score": 0.6190476190476191,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "608566"
+    },
+    {
+      "delivery_time_score": 0.49367088607594944,
+      "hold_score": 0.49367088607594944,
+      "pickoff_attempt_rate": 0.0379746835443038,
+      "pickoff_success_rate": 0.42857142857142855,
+      "pitcher_id": "608718"
+    },
+    {
+      "delivery_time_score": 0.5,
+      "hold_score": 0.5,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "615698"
+    },
+    {
+      "delivery_time_score": 0.7438376027066216,
+      "hold_score": 0.7438376027066216,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13114754098360656,
+      "pitcher_id": "621053"
+    },
+    {
+      "delivery_time_score": 0.6491228070175439,
+      "hold_score": 0.6491228070175439,
+      "pickoff_attempt_rate": 0.008771929824561403,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "621111"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "621112"
+    },
+    {
+      "delivery_time_score": 0.7744360902255639,
+      "hold_score": 0.7744360902255639,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "621121"
+    },
+    {
+      "delivery_time_score": 0.1228070175438597,
+      "hold_score": 0.1228070175438597,
+      "pickoff_attempt_rate": 0.017543859649122806,
+      "pickoff_success_rate": 0.16666666666666666,
+      "pitcher_id": "621237"
+    },
+    {
+      "delivery_time_score": 0.7872340425531915,
+      "hold_score": 0.7872340425531915,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "621366"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.21052631578947367,
+      "pitcher_id": "621381"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "621383"
+    },
+    {
+      "delivery_time_score": 0.7014925373134329,
+      "hold_score": 0.7014925373134329,
+      "pickoff_attempt_rate": 0.007462686567164179,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "622491"
+    },
+    {
+      "delivery_time_score": 0.8333333333333334,
+      "hold_score": 0.8333333333333334,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "622554"
+    },
+    {
+      "delivery_time_score": 0.8591549295774648,
+      "hold_score": 0.8591549295774648,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "622608"
+    },
+    {
+      "delivery_time_score": 0.8765432098765432,
+      "hold_score": 0.8765432098765432,
+      "pickoff_attempt_rate": 0.012345679012345678,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "622663"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06382978723404255,
+      "pitcher_id": "623149"
+    },
+    {
+      "delivery_time_score": 0.8305084745762712,
+      "hold_score": 0.8305084745762712,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "623211"
+    },
+    {
+      "delivery_time_score": 0.8275862068965517,
+      "hold_score": 0.8275862068965517,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "623437"
+    },
+    {
+      "delivery_time_score": 0.8795180722891567,
+      "hold_score": 0.8795180722891567,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "623454"
+    },
+    {
+      "delivery_time_score": 0.8113207547169812,
+      "hold_score": 0.8113207547169812,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "623474"
+    },
+    {
+      "delivery_time_score": 0.9242424242424242,
+      "hold_score": 0.9242424242424242,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "624133"
+    },
+    {
+      "delivery_time_score": 0.207920792079208,
+      "hold_score": 0.207920792079208,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "625643"
+    },
+    {
+      "delivery_time_score": 0.3548387096774194,
+      "hold_score": 0.3548387096774194,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "640448"
+    },
+    {
+      "delivery_time_score": 0.9029126213592233,
+      "hold_score": 0.9029126213592233,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "640455"
+    },
+    {
+      "delivery_time_score": 0.5238095238095238,
+      "hold_score": 0.5238095238095238,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641302"
+    },
+    {
+      "delivery_time_score": 0.8360655737704918,
+      "hold_score": 0.8360655737704918,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641312"
+    },
+    {
+      "delivery_time_score": 0.7959183673469388,
+      "hold_score": 0.7959183673469388,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641329"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13114754098360656,
+      "pitcher_id": "641401"
+    },
+    {
+      "delivery_time_score": 0.7927031509121062,
+      "hold_score": 0.7927031509121062,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.038461538461538464,
+      "pitcher_id": "641656"
+    },
+    {
+      "delivery_time_score": 0.5081967213114754,
+      "hold_score": 0.5081967213114754,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641743"
+    },
+    {
+      "delivery_time_score": 0.8181818181818182,
+      "hold_score": 0.8181818181818182,
+      "pickoff_attempt_rate": 0.01818181818181818,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "641745"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641755"
+    },
+    {
+      "delivery_time_score": 0.7540983606557377,
+      "hold_score": 0.7540983606557377,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641778"
+    },
+    {
+      "delivery_time_score": 0.8540145985401459,
+      "hold_score": 0.8540145985401459,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641793"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.007352941176470588,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "641816"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.037037037037037035,
+      "pitcher_id": "641835"
+    },
+    {
+      "delivery_time_score": 0.7452229299363058,
+      "hold_score": 0.7452229299363058,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641927"
+    },
+    {
+      "delivery_time_score": 0.6551724137931034,
+      "hold_score": 0.6551724137931034,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "641941"
+    },
+    {
+      "delivery_time_score": 0.4642857142857143,
+      "hold_score": 0.4642857142857143,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642100"
+    },
+    {
+      "delivery_time_score": 0.620253164556962,
+      "hold_score": 0.620253164556962,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642121"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642207"
+    },
+    {
+      "delivery_time_score": 0.34782608695652184,
+      "hold_score": 0.34782608695652184,
+      "pickoff_attempt_rate": 0.043478260869565216,
+      "pickoff_success_rate": 0.4,
+      "pitcher_id": "642232"
+    },
+    {
+      "delivery_time_score": 0.8214285714285714,
+      "hold_score": 0.8214285714285714,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642397"
+    },
+    {
+      "delivery_time_score": 0.6721311475409837,
+      "hold_score": 0.6721311475409837,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642528"
+    },
+    {
+      "delivery_time_score": 0.9390243902439024,
+      "hold_score": 0.9390243902439024,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642547"
+    },
+    {
+      "delivery_time_score": 0.6721311475409837,
+      "hold_score": 0.6721311475409837,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "642701"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06060606060606061,
+      "pitcher_id": "642759"
+    },
+    {
+      "delivery_time_score": 0.5161290322580645,
+      "hold_score": 0.5161290322580645,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "643377"
+    },
+    {
+      "delivery_time_score": 0.3548387096774194,
+      "hold_score": 0.3548387096774194,
+      "pickoff_attempt_rate": 0.016129032258064516,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "643410"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.09615384615384616,
+      "pitcher_id": "643511"
+    },
+    {
+      "delivery_time_score": 0.689119170984456,
+      "hold_score": 0.689119170984456,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "645261"
+    },
+    {
+      "delivery_time_score": 0.607843137254902,
+      "hold_score": 0.607843137254902,
+      "pickoff_attempt_rate": 0.0196078431372549,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "646241"
+    },
+    {
+      "delivery_time_score": 0.5588235294117647,
+      "hold_score": 0.5588235294117647,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "647336"
+    },
+    {
+      "delivery_time_score": 0.24528301886792458,
+      "hold_score": 0.24528301886792458,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "650556"
+    },
+    {
+      "delivery_time_score": 0.6855345911949686,
+      "hold_score": 0.6855345911949686,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "650633"
+    },
+    {
+      "delivery_time_score": 0.696969696969697,
+      "hold_score": 0.696969696969697,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "650644"
+    },
+    {
+      "delivery_time_score": 0.9444444444444444,
+      "hold_score": 0.9444444444444444,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "650911"
+    },
+    {
+      "delivery_time_score": 0.6491228070175439,
+      "hold_score": 0.6491228070175439,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656222"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "656234"
+    },
+    {
+      "delivery_time_score": 0.855072463768116,
+      "hold_score": 0.855072463768116,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656271"
+    },
+    {
+      "delivery_time_score": 0.7358066329398538,
+      "hold_score": 0.7358066329398538,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.04081632653061224,
+      "pitcher_id": "656288"
+    },
+    {
+      "delivery_time_score": 0.45783132530120485,
+      "hold_score": 0.45783132530120485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656302"
+    },
+    {
+      "delivery_time_score": 0.7163120567375887,
+      "hold_score": 0.7163120567375887,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656427"
+    },
+    {
+      "delivery_time_score": 0.6774193548387097,
+      "hold_score": 0.6774193548387097,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656464"
+    },
+    {
+      "delivery_time_score": 0.9386503067484663,
+      "hold_score": 0.9386503067484663,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656492"
+    },
+    {
+      "delivery_time_score": 0.7142857142857143,
+      "hold_score": 0.7142857142857143,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656546"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11764705882352941,
+      "pitcher_id": "656550"
+    },
+    {
+      "delivery_time_score": 0.50920245398773,
+      "hold_score": 0.50920245398773,
+      "pickoff_attempt_rate": 0.006134969325153374,
+      "pickoff_success_rate": 0.1111111111111111,
+      "pitcher_id": "656605"
+    },
+    {
+      "delivery_time_score": 0.21875,
+      "hold_score": 0.21875,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656638"
+    },
+    {
+      "delivery_time_score": 0.8387096774193549,
+      "hold_score": 0.8387096774193549,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656641"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06382978723404255,
+      "pitcher_id": "656686"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1951219512195122,
+      "pitcher_id": "656730"
+    },
+    {
+      "delivery_time_score": 0.625,
+      "hold_score": 0.625,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656794"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.037037037037037035,
+      "pitcher_id": "656848"
+    },
+    {
+      "delivery_time_score": 0.7916666666666667,
+      "hold_score": 0.7916666666666667,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656849"
+    },
+    {
+      "delivery_time_score": 0.5901639344262295,
+      "hold_score": 0.5901639344262295,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656876"
+    },
+    {
+      "delivery_time_score": 0.5918367346938775,
+      "hold_score": 0.5918367346938775,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656945"
+    },
+    {
+      "delivery_time_score": 0.2857142857142858,
+      "hold_score": 0.2857142857142858,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "656986"
+    },
+    {
+      "delivery_time_score": 0.6153846153846154,
+      "hold_score": 0.6153846153846154,
+      "pickoff_attempt_rate": 0.019230769230769232,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "657044"
+    },
+    {
+      "delivery_time_score": 0.6610169491525424,
+      "hold_score": 0.6610169491525424,
+      "pickoff_attempt_rate": 0.01694915254237288,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "657097"
+    },
+    {
+      "delivery_time_score": 0.6808510638297873,
+      "hold_score": 0.6808510638297873,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "657277"
+    },
+    {
+      "delivery_time_score": 0.4,
+      "hold_score": 0.4,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "657424"
+    },
+    {
+      "delivery_time_score": 0.6296296296296297,
+      "hold_score": 0.6296296296296297,
+      "pickoff_attempt_rate": 0.018518518518518517,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "657514"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "657612"
+    },
+    {
+      "delivery_time_score": 0.4193548387096774,
+      "hold_score": 0.4193548387096774,
+      "pickoff_attempt_rate": 0.0064516129032258064,
+      "pickoff_success_rate": 0.1,
+      "pitcher_id": "657746"
+    },
+    {
+      "delivery_time_score": 0.5652173913043479,
+      "hold_score": 0.5652173913043479,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "657756"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "660271"
+    },
+    {
+      "delivery_time_score": 0.7668161434977578,
+      "hold_score": 0.7668161434977578,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "660604"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.058823529411764705,
+      "pitcher_id": "660761"
+    },
+    {
+      "delivery_time_score": 0.8275862068965517,
+      "hold_score": 0.8275862068965517,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "660825"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.043478260869565216,
+      "pitcher_id": "660853"
+    },
+    {
+      "delivery_time_score": 0.8461538461538461,
+      "hold_score": 0.8461538461538461,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "661563"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.21052631578947367,
+      "pitcher_id": "662253"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0851063829787234,
+      "pitcher_id": "663158"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.04081632653061224,
+      "pitcher_id": "663362"
+    },
+    {
+      "delivery_time_score": 0.49367088607594944,
+      "hold_score": 0.49367088607594944,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663372"
+    },
+    {
+      "delivery_time_score": 0.7222222222222223,
+      "hold_score": 0.7222222222222223,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663436"
+    },
+    {
+      "delivery_time_score": 0.635036496350365,
+      "hold_score": 0.635036496350365,
+      "pickoff_attempt_rate": 0.014598540145985401,
+      "pickoff_success_rate": 0.2857142857142857,
+      "pitcher_id": "663460"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.14583333333333334,
+      "pitcher_id": "663485"
+    },
+    {
+      "delivery_time_score": 0.5081967213114754,
+      "hold_score": 0.5081967213114754,
+      "pickoff_attempt_rate": 0.01639344262295082,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "663542"
+    },
+    {
+      "delivery_time_score": 0.5726495726495726,
+      "hold_score": 0.5726495726495726,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663554"
+    },
+    {
+      "delivery_time_score": 0.5041322314049587,
+      "hold_score": 0.5041322314049587,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663556"
+    },
+    {
+      "delivery_time_score": 0.868421052631579,
+      "hold_score": 0.868421052631579,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663558"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663567"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.03773584905660377,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "663574"
+    },
+    {
+      "delivery_time_score": 0.6103896103896105,
+      "hold_score": 0.6103896103896105,
+      "pickoff_attempt_rate": 0.006493506493506494,
+      "pickoff_success_rate": 0.14285714285714285,
+      "pitcher_id": "663623"
+    },
+    {
+      "delivery_time_score": 0.8863636363636364,
+      "hold_score": 0.8863636363636364,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663687"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.16981132075471697,
+      "pitcher_id": "663738"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "663765"
+    },
+    {
+      "delivery_time_score": 0.7297297297297297,
+      "hold_score": 0.7297297297297297,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663767"
+    },
+    {
+      "delivery_time_score": 0.696969696969697,
+      "hold_score": 0.696969696969697,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663855"
+    },
+    {
+      "delivery_time_score": 0.803921568627451,
+      "hold_score": 0.803921568627451,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663903"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05555555555555555,
+      "pitcher_id": "663947"
+    },
+    {
+      "delivery_time_score": 0.1250000000000001,
+      "hold_score": 0.1250000000000001,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663969"
+    },
+    {
+      "delivery_time_score": 0.921875,
+      "hold_score": 0.921875,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "663978"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "663992"
+    },
+    {
+      "delivery_time_score": 0.44444444444444453,
+      "hold_score": 0.44444444444444453,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664076"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.018518518518518517,
+      "pitcher_id": "664126"
+    },
+    {
+      "delivery_time_score": 0.8507462686567164,
+      "hold_score": 0.8507462686567164,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664141"
+    },
+    {
+      "delivery_time_score": 0.5,
+      "hold_score": 0.5,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664192"
+    },
+    {
+      "delivery_time_score": 0.8412698412698413,
+      "hold_score": 0.8412698412698413,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664199"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06382978723404255,
+      "pitcher_id": "664208"
+    },
+    {
+      "delivery_time_score": 0.7109826589595376,
+      "hold_score": 0.7109826589595376,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664285"
+    },
+    {
+      "delivery_time_score": 0.7800471327572663,
+      "hold_score": 0.7800471327572663,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.034482758620689655,
+      "pitcher_id": "664744"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "664854"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "664875"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "664991"
+    },
+    {
+      "delivery_time_score": 0.6296296296296297,
+      "hold_score": 0.6296296296296297,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "665622"
+    },
+    {
+      "delivery_time_score": 0.44444444444444453,
+      "hold_score": 0.44444444444444453,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "665795"
+    },
+    {
+      "delivery_time_score": 0.8809523809523809,
+      "hold_score": 0.8809523809523809,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "665871"
+    },
+    {
+      "delivery_time_score": 0.6376811594202898,
+      "hold_score": 0.6376811594202898,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666142"
+    },
+    {
+      "delivery_time_score": 0.48051948051948057,
+      "hold_score": 0.48051948051948057,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666171"
+    },
+    {
+      "delivery_time_score": 0.6551724137931034,
+      "hold_score": 0.6551724137931034,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666200"
+    },
+    {
+      "delivery_time_score": 0.5161290322580645,
+      "hold_score": 0.5161290322580645,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666277"
+    },
+    {
+      "delivery_time_score": 0.7142857142857143,
+      "hold_score": 0.7142857142857143,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666374"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666619"
+    },
+    {
+      "delivery_time_score": 0.8360655737704918,
+      "hold_score": 0.8360655737704918,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666661"
+    },
+    {
+      "delivery_time_score": 0.21568627450980393,
+      "hold_score": 0.21568627450980393,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666808"
+    },
+    {
+      "delivery_time_score": 0.21052631578947378,
+      "hold_score": 0.21052631578947378,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "666974"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "667297"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.03389830508474576,
+      "pitcher_id": "667463"
+    },
+    {
+      "delivery_time_score": 0.8159509202453987,
+      "hold_score": 0.8159509202453987,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "667755"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05555555555555555,
+      "pitcher_id": "668390"
+    },
+    {
+      "delivery_time_score": 0.8275862068965517,
+      "hold_score": 0.8275862068965517,
+      "pickoff_attempt_rate": 0.034482758620689655,
+      "pickoff_success_rate": 0.6666666666666666,
+      "pitcher_id": "668674"
+    },
+    {
+      "delivery_time_score": 0.9290780141843972,
+      "hold_score": 0.9290780141843972,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "668678"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "668834"
+    },
+    {
+      "delivery_time_score": 0.8148148148148149,
+      "hold_score": 0.8148148148148149,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "668873"
+    },
+    {
+      "delivery_time_score": 0.8245614035087719,
+      "hold_score": 0.8245614035087719,
+      "pickoff_attempt_rate": 0.011695906432748537,
+      "pickoff_success_rate": 0.4,
+      "pitcher_id": "668909"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "668933"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "668941"
+    },
+    {
+      "delivery_time_score": 0.8795180722891567,
+      "hold_score": 0.8795180722891567,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "668964"
+    },
+    {
+      "delivery_time_score": 0.8360655737704918,
+      "hold_score": 0.8360655737704918,
+      "pickoff_attempt_rate": 0.01639344262295082,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "668984"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.03773584905660377,
+      "pitcher_id": "669020"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05555555555555555,
+      "pitcher_id": "669022"
+    },
+    {
+      "delivery_time_score": 0.33333333333333337,
+      "hold_score": 0.33333333333333337,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669062"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.01639344262295082,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "669084"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.04081632653061224,
+      "pitcher_id": "669093"
+    },
+    {
+      "delivery_time_score": 0.46153846153846156,
+      "hold_score": 0.46153846153846156,
+      "pickoff_attempt_rate": 0.007692307692307693,
+      "pickoff_success_rate": 0.125,
+      "pitcher_id": "669160"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "669165"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.03773584905660377,
+      "pitcher_id": "669194"
+    },
+    {
+      "delivery_time_score": 0.5238095238095238,
+      "hold_score": 0.5238095238095238,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669199"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "669211"
+    },
+    {
+      "delivery_time_score": 0.7674418604651163,
+      "hold_score": 0.7674418604651163,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669212"
+    },
+    {
+      "delivery_time_score": 0.7777777777777778,
+      "hold_score": 0.7777777777777778,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669270"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "669276"
+    },
+    {
+      "delivery_time_score": 0.6875,
+      "hold_score": 0.6875,
+      "pickoff_attempt_rate": 0.00625,
+      "pickoff_success_rate": 0.16666666666666666,
+      "pitcher_id": "669302"
+    },
+    {
+      "delivery_time_score": 0.6923076923076923,
+      "hold_score": 0.6923076923076923,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669330"
+    },
+    {
+      "delivery_time_score": 0.9333333333333333,
+      "hold_score": 0.9333333333333333,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669358"
+    },
+    {
+      "delivery_time_score": 0.7560975609756098,
+      "hold_score": 0.7560975609756098,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669372"
+    },
+    {
+      "delivery_time_score": 0.9397590361445783,
+      "hold_score": 0.9397590361445783,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669373"
+    },
+    {
+      "delivery_time_score": 0.935064935064935,
+      "hold_score": 0.935064935064935,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669387"
+    },
+    {
+      "delivery_time_score": 0.7540983606557377,
+      "hold_score": 0.7540983606557377,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669432"
+    },
+    {
+      "delivery_time_score": 0.4303797468354431,
+      "hold_score": 0.4303797468354431,
+      "pickoff_attempt_rate": 0.006329113924050633,
+      "pickoff_success_rate": 0.1,
+      "pitcher_id": "669461"
+    },
+    {
+      "delivery_time_score": 0.7101449275362319,
+      "hold_score": 0.7101449275362319,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669467"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.15217391304347827,
+      "pitcher_id": "669620"
+    },
+    {
+      "delivery_time_score": 0.16666666666666674,
+      "hold_score": 0.16666666666666674,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669622"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669711"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "669724"
+    },
+    {
+      "delivery_time_score": 0.7800471327572663,
+      "hold_score": 0.7800471327572663,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.034482758620689655,
+      "pitcher_id": "669920"
+    },
+    {
+      "delivery_time_score": 0.8876404494382022,
+      "hold_score": 0.8876404494382022,
+      "pickoff_attempt_rate": 0.0056179775280898875,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "669923"
+    },
+    {
+      "delivery_time_score": 0.8936170212765957,
+      "hold_score": 0.8936170212765957,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "669947"
+    },
+    {
+      "delivery_time_score": 0.8461538461538461,
+      "hold_score": 0.8461538461538461,
+      "pickoff_attempt_rate": 0.015384615384615385,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "670036"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.14545454545454545,
+      "pitcher_id": "670059"
+    },
+    {
+      "delivery_time_score": 0.8076923076923077,
+      "hold_score": 0.8076923076923077,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "670167"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.043478260869565216,
+      "pitcher_id": "670183"
+    },
+    {
+      "delivery_time_score": 0.8958333333333334,
+      "hold_score": 0.8958333333333334,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "670245"
+    },
+    {
+      "delivery_time_score": 0.8360655737704918,
+      "hold_score": 0.8360655737704918,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "670280"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.17073170731707318,
+      "pitcher_id": "670329"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.037037037037037035,
+      "pitcher_id": "670950"
+    },
+    {
+      "delivery_time_score": 0.5774647887323944,
+      "hold_score": 0.5774647887323944,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "670970"
+    },
+    {
+      "delivery_time_score": 0.7727272727272727,
+      "hold_score": 0.7727272727272727,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "670990"
+    },
+    {
+      "delivery_time_score": 0.49367088607594944,
+      "hold_score": 0.49367088607594944,
+      "pickoff_attempt_rate": 0.006329113924050633,
+      "pickoff_success_rate": 0.1111111111111111,
+      "pitcher_id": "671096"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "671109"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11538461538461539,
+      "pitcher_id": "671111"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.029411764705882353,
+      "pitcher_id": "671382"
+    },
+    {
+      "delivery_time_score": 0.8850574712643678,
+      "hold_score": 0.8850574712643678,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "671737"
+    },
+    {
+      "delivery_time_score": 0.8461538461538461,
+      "hold_score": 0.8461538461538461,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "671922"
+    },
+    {
+      "delivery_time_score": 0.7619047619047619,
+      "hold_score": 0.7619047619047619,
+      "pickoff_attempt_rate": 0.005952380952380952,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "672282"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06896551724137931,
+      "pitcher_id": "672335"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05555555555555555,
+      "pitcher_id": "672456"
+    },
+    {
+      "delivery_time_score": 0.41176470588235303,
+      "hold_score": 0.41176470588235303,
+      "pickoff_attempt_rate": 0.0196078431372549,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "672582"
+    },
+    {
+      "delivery_time_score": 0.3902439024390244,
+      "hold_score": 0.3902439024390244,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "672782"
+    },
+    {
+      "delivery_time_score": 0.8780487804878049,
+      "hold_score": 0.8780487804878049,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "673540"
+    },
+    {
+      "delivery_time_score": 0.6774193548387097,
+      "hold_score": 0.6774193548387097,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "673929"
+    },
+    {
+      "delivery_time_score": 0.7222222222222223,
+      "hold_score": 0.7222222222222223,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "674370"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1951219512195122,
+      "pitcher_id": "675660"
+    },
+    {
+      "delivery_time_score": 0.8611111111111112,
+      "hold_score": 0.8611111111111112,
+      "pickoff_attempt_rate": 0.013888888888888888,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "675848"
+    },
+    {
+      "delivery_time_score": 0.8167379352474038,
+      "hold_score": 0.8167379352474038,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11764705882352941,
+      "pitcher_id": "675911"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "675989"
+    },
+    {
+      "delivery_time_score": 0.6240601503759399,
+      "hold_score": 0.6240601503759399,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676083"
+    },
+    {
+      "delivery_time_score": 0.8742138364779874,
+      "hold_score": 0.8742138364779874,
+      "pickoff_attempt_rate": 0.006289308176100629,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "676106"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.044444444444444446,
+      "pitcher_id": "676254"
+    },
+    {
+      "delivery_time_score": 0.6491228070175439,
+      "hold_score": 0.6491228070175439,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676263"
+    },
+    {
+      "delivery_time_score": 0.5172413793103449,
+      "hold_score": 0.5172413793103449,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676282"
+    },
+    {
+      "delivery_time_score": 0.6428571428571429,
+      "hold_score": 0.6428571428571429,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676428"
+    },
+    {
+      "delivery_time_score": 0.803921568627451,
+      "hold_score": 0.803921568627451,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676440"
+    },
+    {
+      "delivery_time_score": 0.7222222222222223,
+      "hold_score": 0.7222222222222223,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676467"
+    },
+    {
+      "delivery_time_score": 0.803921568627451,
+      "hold_score": 0.803921568627451,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676477"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07894736842105263,
+      "pitcher_id": "676510"
+    },
+    {
+      "delivery_time_score": 0.6226415094339623,
+      "hold_score": 0.6226415094339623,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676534"
+    },
+    {
+      "delivery_time_score": 0.7797101449275362,
+      "hold_score": 0.7797101449275362,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "676568"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676571"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.015384615384615385,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "676617"
+    },
+    {
+      "delivery_time_score": 0.7767601602747567,
+      "hold_score": 0.7767601602747567,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "676702"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.20689655172413793,
+      "pitcher_id": "676742"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.013888888888888888,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "676755"
+    },
+    {
+      "delivery_time_score": 0.875,
+      "hold_score": 0.875,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676760"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.044444444444444446,
+      "pitcher_id": "676775"
+    },
+    {
+      "delivery_time_score": 0.8913043478260869,
+      "hold_score": 0.8913043478260869,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676879"
+    },
+    {
+      "delivery_time_score": 0.7202797202797203,
+      "hold_score": 0.7202797202797203,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676917"
+    },
+    {
+      "delivery_time_score": 0.5833333333333334,
+      "hold_score": 0.5833333333333334,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676962"
+    },
+    {
+      "delivery_time_score": 0.8701298701298701,
+      "hold_score": 0.8701298701298701,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676974"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "676979"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.037037037037037035,
+      "pitcher_id": "677053"
+    },
+    {
+      "delivery_time_score": 0.782608695652174,
+      "hold_score": 0.782608695652174,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677161"
+    },
+    {
+      "delivery_time_score": 0.863013698630137,
+      "hold_score": 0.863013698630137,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677865"
+    },
+    {
+      "delivery_time_score": 0.6951219512195121,
+      "hold_score": 0.6951219512195121,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677944"
+    },
+    {
+      "delivery_time_score": 0.5652173913043479,
+      "hold_score": 0.5652173913043479,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677952"
+    },
+    {
+      "delivery_time_score": 0.15254237288135597,
+      "hold_score": 0.15254237288135597,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677955"
+    },
+    {
+      "delivery_time_score": 0.6062992125984252,
+      "hold_score": 0.6062992125984252,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677958"
+    },
+    {
+      "delivery_time_score": 0.8734177215189873,
+      "hold_score": 0.8734177215189873,
+      "pickoff_attempt_rate": 0.006329113924050633,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "677960"
+    },
+    {
+      "delivery_time_score": 0.6923076923076923,
+      "hold_score": 0.6923076923076923,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "677961"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "678020"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13114754098360656,
+      "pitcher_id": "678022"
+    },
+    {
+      "delivery_time_score": 0.849624060150376,
+      "hold_score": 0.849624060150376,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "678394"
+    },
+    {
+      "delivery_time_score": 0.863013698630137,
+      "hold_score": 0.863013698630137,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "678606"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.012195121951219513,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "678906"
+    },
+    {
+      "delivery_time_score": 0.5081967213114754,
+      "hold_score": 0.5081967213114754,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "679358"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07692307692307693,
+      "pitcher_id": "679775"
+    },
+    {
+      "delivery_time_score": 0.5454545454545454,
+      "hold_score": 0.5454545454545454,
+      "pickoff_attempt_rate": 0.022727272727272728,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "679883"
+    },
+    {
+      "delivery_time_score": 0.68944099378882,
+      "hold_score": 0.68944099378882,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680573"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11538461538461539,
+      "pitcher_id": "680604"
+    },
+    {
+      "delivery_time_score": 0.6815286624203822,
+      "hold_score": 0.6815286624203822,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680694"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680704"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "680730"
+    },
+    {
+      "delivery_time_score": 0.4871794871794872,
+      "hold_score": 0.4871794871794872,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680732"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "680736"
+    },
+    {
+      "delivery_time_score": 0.4871794871794872,
+      "hold_score": 0.4871794871794872,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680742"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.03076923076923077,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "680755"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0851063829787234,
+      "pitcher_id": "680767"
+    },
+    {
+      "delivery_time_score": 0.9056603773584906,
+      "hold_score": 0.9056603773584906,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "680802"
+    },
+    {
+      "delivery_time_score": 0.31034482758620696,
+      "hold_score": 0.31034482758620696,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681035"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681151"
+    },
+    {
+      "delivery_time_score": 0.781021897810219,
+      "hold_score": 0.781021897810219,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681190"
+    },
+    {
+      "delivery_time_score": 0.2592592592592593,
+      "hold_score": 0.2592592592592593,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681217"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.04,
+      "pitcher_id": "681252"
+    },
+    {
+      "delivery_time_score": 0.504950495049505,
+      "hold_score": 0.504950495049505,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681293"
+    },
+    {
+      "delivery_time_score": 0.8816568047337279,
+      "hold_score": 0.8816568047337279,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681347"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "681402"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "681432"
+    },
+    {
+      "delivery_time_score": 0.7014925373134329,
+      "hold_score": 0.7014925373134329,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681517"
+    },
+    {
+      "delivery_time_score": 0.6153846153846154,
+      "hold_score": 0.6153846153846154,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681676"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13043478260869565,
+      "pitcher_id": "681810"
+    },
+    {
+      "delivery_time_score": 0.4642857142857143,
+      "hold_score": 0.4642857142857143,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681867"
+    },
+    {
+      "delivery_time_score": 0.6491228070175439,
+      "hold_score": 0.6491228070175439,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681870"
+    },
+    {
+      "delivery_time_score": 0.8076923076923077,
+      "hold_score": 0.8076923076923077,
+      "pickoff_attempt_rate": 0.019230769230769232,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "681892"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "681895"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "681911"
+    },
+    {
+      "delivery_time_score": 0.5161290322580645,
+      "hold_score": 0.5161290322580645,
+      "pickoff_attempt_rate": 0.016129032258064516,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "681982"
+    },
+    {
+      "delivery_time_score": 0.5205479452054795,
+      "hold_score": 0.5205479452054795,
+      "pickoff_attempt_rate": 0.00684931506849315,
+      "pickoff_success_rate": 0.125,
+      "pitcher_id": "682052"
+    },
+    {
+      "delivery_time_score": 0.13043478260869568,
+      "hold_score": 0.13043478260869568,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "682120"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "682227"
+    },
+    {
+      "delivery_time_score": 0.8275862068965517,
+      "hold_score": 0.8275862068965517,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "682254"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05555555555555555,
+      "pitcher_id": "682608"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "682825"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.02,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "682842"
+    },
+    {
+      "delivery_time_score": 0.7101449275362319,
+      "hold_score": 0.7101449275362319,
+      "pickoff_attempt_rate": 0.007246376811594203,
+      "pickoff_success_rate": 0.2,
+      "pitcher_id": "683004"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "683175"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.21052631578947367,
+      "pitcher_id": "683232"
+    },
+    {
+      "delivery_time_score": 0.23076923076923073,
+      "hold_score": 0.23076923076923073,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "683409"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "683618"
+    },
+    {
+      "delivery_time_score": 0.44444444444444453,
+      "hold_score": 0.44444444444444453,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "683742"
+    },
+    {
+      "delivery_time_score": 0.6774193548387097,
+      "hold_score": 0.6774193548387097,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "683769"
+    },
+    {
+      "delivery_time_score": 0.8742138364779874,
+      "hold_score": 0.8742138364779874,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "684007"
+    },
+    {
+      "delivery_time_score": 0.8360655737704918,
+      "hold_score": 0.8360655737704918,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "685299"
+    },
+    {
+      "delivery_time_score": 0.1428571428571429,
+      "hold_score": 0.1428571428571429,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "685801"
+    },
+    {
+      "delivery_time_score": 0.8484848484848485,
+      "hold_score": 0.8484848484848485,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "686218"
+    },
+    {
+      "delivery_time_score": 0.09090909090909094,
+      "hold_score": 0.09090909090909094,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "686560"
+    },
+    {
+      "delivery_time_score": 0.7924080664294187,
+      "hold_score": 0.7924080664294187,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07894736842105263,
+      "pitcher_id": "686790"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13043478260869565,
+      "pitcher_id": "686799"
+    },
+    {
+      "delivery_time_score": 0.5384615384615384,
+      "hold_score": 0.5384615384615384,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "686973"
+    },
+    {
+      "delivery_time_score": 0.736842105263158,
+      "hold_score": 0.736842105263158,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "686993"
+    },
+    {
+      "delivery_time_score": 0.5588235294117647,
+      "hold_score": 0.5588235294117647,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687064"
+    },
+    {
+      "delivery_time_score": 0.6521739130434783,
+      "hold_score": 0.6521739130434783,
+      "pickoff_attempt_rate": 0.02608695652173913,
+      "pickoff_success_rate": 0.42857142857142855,
+      "pitcher_id": "687075"
+    },
+    {
+      "delivery_time_score": 0.7452606635071091,
+      "hold_score": 0.7452606635071091,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0851063829787234,
+      "pitcher_id": "687209"
+    },
+    {
+      "delivery_time_score": 0.6226415094339623,
+      "hold_score": 0.6226415094339623,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687330"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1951219512195122,
+      "pitcher_id": "687377"
+    },
+    {
+      "delivery_time_score": 0.7058823529411765,
+      "hold_score": 0.7058823529411765,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687396"
+    },
+    {
+      "delivery_time_score": 0.5,
+      "hold_score": 0.5,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687562"
+    },
+    {
+      "delivery_time_score": 0.8214285714285714,
+      "hold_score": 0.8214285714285714,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687570"
+    },
+    {
+      "delivery_time_score": 0.5918367346938775,
+      "hold_score": 0.5918367346938775,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687606"
+    },
+    {
+      "delivery_time_score": 0.8333333333333334,
+      "hold_score": 0.8333333333333334,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "687911"
+    },
+    {
+      "delivery_time_score": 0.8529411764705883,
+      "hold_score": 0.8529411764705883,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "688158"
+    },
+    {
+      "delivery_time_score": 0.8837209302325582,
+      "hold_score": 0.8837209302325582,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "688642"
+    },
+    {
+      "delivery_time_score": 0.8181818181818182,
+      "hold_score": 0.8181818181818182,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "688883"
+    },
+    {
+      "delivery_time_score": 0.803921568627451,
+      "hold_score": 0.803921568627451,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "689147"
+    },
+    {
+      "delivery_time_score": 0.8148148148148149,
+      "hold_score": 0.8148148148148149,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "689254"
+    },
+    {
+      "delivery_time_score": 0.7014925373134329,
+      "hold_score": 0.7014925373134329,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "689296"
+    },
+    {
+      "delivery_time_score": 0.7714285714285715,
+      "hold_score": 0.7714285714285715,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.16981132075471697,
+      "pitcher_id": "689546"
+    },
+    {
+      "delivery_time_score": 0.6836982968369829,
+      "hold_score": 0.6836982968369829,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07142857142857142,
+      "pitcher_id": "690928"
+    },
+    {
+      "delivery_time_score": 0.75,
+      "hold_score": 0.75,
+      "pickoff_attempt_rate": 0.008333333333333333,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "690986"
+    },
+    {
+      "delivery_time_score": 0.934640522875817,
+      "hold_score": 0.934640522875817,
+      "pickoff_attempt_rate": 0.006535947712418301,
+      "pickoff_success_rate": 0.5,
+      "pitcher_id": "690997"
+    },
+    {
+      "delivery_time_score": 0.2405063291139241,
+      "hold_score": 0.2405063291139241,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "691587"
+    },
+    {
+      "delivery_time_score": 0.924812030075188,
+      "hold_score": 0.924812030075188,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "691725"
+    },
+    {
+      "delivery_time_score": 0.8049087476400252,
+      "hold_score": 0.8049087476400252,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.16216216216216217,
+      "pitcher_id": "691769"
+    },
+    {
+      "delivery_time_score": 0.863013698630137,
+      "hold_score": 0.863013698630137,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "691799"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "692230"
+    },
+    {
+      "delivery_time_score": 0.7142857142857143,
+      "hold_score": 0.7142857142857143,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "693312"
+    },
+    {
+      "delivery_time_score": 0.8795180722891567,
+      "hold_score": 0.8795180722891567,
+      "pickoff_attempt_rate": 0.006024096385542169,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "693433"
+    },
+    {
+      "delivery_time_score": 0.8076923076923077,
+      "hold_score": 0.8076923076923077,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "693645"
+    },
+    {
+      "delivery_time_score": 0.8529411764705883,
+      "hold_score": 0.8529411764705883,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "693686"
+    },
+    {
+      "delivery_time_score": 0.8837209302325582,
+      "hold_score": 0.8837209302325582,
+      "pickoff_attempt_rate": 0.005813953488372093,
+      "pickoff_success_rate": 0.3333333333333333,
+      "pitcher_id": "693821"
+    },
+    {
+      "delivery_time_score": 0.8412698412698413,
+      "hold_score": 0.8412698412698413,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "693855"
+    },
+    {
+      "delivery_time_score": 0.4736842105263158,
+      "hold_score": 0.4736842105263158,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694037"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.06382978723404255,
+      "pitcher_id": "694297"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.07547169811320754,
+      "pitcher_id": "694335"
+    },
+    {
+      "delivery_time_score": 0.7898089171974523,
+      "hold_score": 0.7898089171974523,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "694346"
+    },
+    {
+      "delivery_time_score": 0.4545454545454546,
+      "hold_score": 0.4545454545454546,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694361"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "694363"
+    },
+    {
+      "delivery_time_score": 0.8245614035087719,
+      "hold_score": 0.8245614035087719,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694477"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694680"
+    },
+    {
+      "delivery_time_score": 0.9371069182389937,
+      "hold_score": 0.9371069182389937,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694738"
+    },
+    {
+      "delivery_time_score": 0.710806697108067,
+      "hold_score": 0.710806697108067,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.03389830508474576,
+      "pitcher_id": "694795"
+    },
+    {
+      "delivery_time_score": 0.935483870967742,
+      "hold_score": 0.935483870967742,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694819"
+    },
+    {
+      "delivery_time_score": 0.7916666666666667,
+      "hold_score": 0.7916666666666667,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694851"
+    },
+    {
+      "delivery_time_score": 0.44444444444444453,
+      "hold_score": 0.44444444444444453,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "694918"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "694973"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05660377358490566,
+      "pitcher_id": "695076"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0196078431372549,
+      "pitcher_id": "695243"
+    },
+    {
+      "delivery_time_score": 0.23076923076923073,
+      "hold_score": 0.23076923076923073,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "695380"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1951219512195122,
+      "pitcher_id": "695418"
+    },
+    {
+      "delivery_time_score": 0.635036496350365,
+      "hold_score": 0.635036496350365,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "695505"
+    },
+    {
+      "delivery_time_score": 0.5,
+      "hold_score": 0.5,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "695684"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.20512820512820512,
+      "pitcher_id": "696062"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.08333333333333333,
+      "pitcher_id": "696070"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.21052631578947367,
+      "pitcher_id": "696131"
+    },
+    {
+      "delivery_time_score": 0.5588235294117647,
+      "hold_score": 0.5588235294117647,
+      "pickoff_attempt_rate": 0.014705882352941176,
+      "pickoff_success_rate": 0.25,
+      "pitcher_id": "696147"
+    },
+    {
+      "delivery_time_score": 0.9230769230769231,
+      "hold_score": 0.9230769230769231,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "696149"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.04081632653061224,
+      "pitcher_id": "699134"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0196078431372549,
+      "pitcher_id": "699823"
+    },
+    {
+      "delivery_time_score": 0.9319727891156463,
+      "hold_score": 0.9319727891156463,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "700241"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.175,
+      "pitcher_id": "700249"
+    },
+    {
+      "delivery_time_score": 0.7014925373134329,
+      "hold_score": 0.7014925373134329,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "700669"
+    },
+    {
+      "delivery_time_score": 0.7468354430379747,
+      "hold_score": 0.7468354430379747,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "700712"
+    },
+    {
+      "delivery_time_score": 0.9342105263157895,
+      "hold_score": 0.9342105263157895,
+      "pickoff_attempt_rate": 0.013157894736842105,
+      "pickoff_success_rate": 0.6666666666666666,
+      "pitcher_id": "701542"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1951219512195122,
+      "pitcher_id": "701552"
+    },
+    {
+      "delivery_time_score": 0.0,
+      "hold_score": 0.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "701656"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.043478260869565216,
+      "pitcher_id": "701719"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.09615384615384616,
+      "pitcher_id": "702056"
+    },
+    {
+      "delivery_time_score": 0.9305555555555556,
+      "hold_score": 0.9305555555555556,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "702070"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.1388888888888889,
+      "pitcher_id": "702153"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.11764705882352941,
+      "pitcher_id": "702193"
+    },
+    {
+      "delivery_time_score": 0.6470588235294118,
+      "hold_score": 0.6470588235294118,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "702273"
+    },
+    {
+      "delivery_time_score": 0.803921568627451,
+      "hold_score": 0.803921568627451,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "702275"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.08823529411764706,
+      "pitcher_id": "702303"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.014814814814814815,
+      "pickoff_success_rate": 1.0,
+      "pitcher_id": "800048"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0851063829787234,
+      "pitcher_id": "800311"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "801139"
+    },
+    {
+      "delivery_time_score": 0.7435897435897436,
+      "hold_score": 0.7435897435897436,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "801403"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.09615384615384616,
+      "pitcher_id": "804619"
+    },
+    {
+      "delivery_time_score": 0.6341463414634148,
+      "hold_score": 0.6341463414634148,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "805123"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.03773584905660377,
+      "pitcher_id": "805299"
+    },
+    {
+      "delivery_time_score": 0.6709006928406467,
+      "hold_score": 0.6709006928406467,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "806188"
+    },
+    {
+      "delivery_time_score": 0.7761194029850746,
+      "hold_score": 0.7761194029850746,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "808963"
+    },
+    {
+      "delivery_time_score": 0.8639455782312926,
+      "hold_score": 0.8639455782312926,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.0,
+      "pitcher_id": "808967"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.05,
+      "pitcher_id": "813349"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13043478260869565,
+      "pitcher_id": "815083"
+    },
+    {
+      "delivery_time_score": 1.0,
+      "hold_score": 1.0,
+      "pickoff_attempt_rate": 0.0,
+      "pickoff_success_rate": 0.13043478260869565,
+      "pitcher_id": "820862"
+    }
+  ],
+  "proxy_evidence_count": 17534,
+  "runners": [
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8214285714285714,
+      "runner_id": "457705",
+      "speed_score": 0.0,
+      "success_rate": 0.8214285714285714
+    },
+    {
+      "attempt_rate": 0.058823529411764705,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "500743",
+      "speed_score": 0.39215686274509803,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7419354838709677,
+      "runner_id": "502054",
+      "speed_score": 0.0,
+      "success_rate": 0.7419354838709677
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7586206896551724,
+      "runner_id": "502671",
+      "speed_score": 0.0,
+      "success_rate": 0.7586206896551724
+    },
+    {
+      "attempt_rate": 0.06818181818181818,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.3333333333333333,
+      "runner_id": "514888",
+      "speed_score": 0.45454545454545453,
+      "success_rate": 0.3333333333333333
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "516782",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "518595",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9047619047619048,
+      "runner_id": "518692",
+      "speed_score": 0.0,
+      "success_rate": 0.9047619047619048
+    },
+    {
+      "attempt_rate": 0.04,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "519317",
+      "speed_score": 0.26666666666666666,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7407407407407407,
+      "runner_id": "521692",
+      "speed_score": 0.0,
+      "success_rate": 0.7407407407407407
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "542303",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8214285714285714,
+      "runner_id": "543309",
+      "speed_score": 0.0,
+      "success_rate": 0.8214285714285714
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7419354838709677,
+      "runner_id": "543510",
+      "speed_score": 0.0,
+      "success_rate": 0.7419354838709677
+    },
+    {
+      "attempt_rate": 0.14705882352941177,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "543760",
+      "speed_score": 0.9803921568627452,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.1,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "543807",
+      "speed_score": 0.6666666666666667,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7837837837837838,
+      "runner_id": "543877",
+      "speed_score": 0.0,
+      "success_rate": 0.7837837837837838
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "545121",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8461538461538461,
+      "runner_id": "545341",
+      "speed_score": 0.0,
+      "success_rate": 0.8461538461538461
+    },
+    {
+      "attempt_rate": 0.08928571428571429,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "545361",
+      "speed_score": 0.5952380952380952,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.06976744186046512,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "547180",
+      "speed_score": 0.46511627906976744,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "553869",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8043478260869565,
+      "runner_id": "553993",
+      "speed_score": 0.0,
+      "success_rate": 0.8043478260869565
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "571448",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6153846153846154,
+      "runner_id": "571657",
+      "speed_score": 0.0,
+      "success_rate": 0.6153846153846154
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9047619047619048,
+      "runner_id": "571970",
+      "speed_score": 0.0,
+      "success_rate": 0.9047619047619048
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7837837837837838,
+      "runner_id": "572233",
+      "speed_score": 0.0,
+      "success_rate": 0.7837837837837838
+    },
+    {
+      "attempt_rate": 0.03571428571428571,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "573262",
+      "speed_score": 0.23809523809523808,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7837837837837838,
+      "runner_id": "575929",
+      "speed_score": 0.0,
+      "success_rate": 0.7837837837837838
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7428571428571429,
+      "runner_id": "592206",
+      "speed_score": 0.0,
+      "success_rate": 0.7428571428571429
+    },
+    {
+      "attempt_rate": 0.15555555555555556,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7142857142857143,
+      "runner_id": "592450",
+      "speed_score": 1.0,
+      "success_rate": 0.7142857142857143
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "592518",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7272727272727273,
+      "runner_id": "592626",
+      "speed_score": 0.0,
+      "success_rate": 0.7272727272727273
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "592663",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.075,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "593428",
+      "speed_score": 0.5,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.09523809523809523,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "595879",
+      "speed_score": 0.6349206349206349,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "595978",
+      "speed_score": 0.0,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.10344827586206896,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "596019",
+      "speed_score": 0.6896551724137931,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "596103",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.06451612903225806,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "596115",
+      "speed_score": 0.43010752688172044,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8297872340425532,
+      "runner_id": "596117",
+      "speed_score": 0.0,
+      "success_rate": 0.8297872340425532
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7397260273972602,
+      "runner_id": "596142",
+      "speed_score": 0.0,
+      "success_rate": 0.7397260273972602
+    },
+    {
+      "attempt_rate": 0.058823529411764705,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "602104",
+      "speed_score": 0.39215686274509803,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7931034482758621,
+      "runner_id": "605137",
+      "speed_score": 0.0,
+      "success_rate": 0.7931034482758621
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7948717948717948,
+      "runner_id": "605170",
+      "speed_score": 0.0,
+      "success_rate": 0.7948717948717948
+    },
+    {
+      "attempt_rate": 0.07282913165266107,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8076923076923077,
+      "runner_id": "605244",
+      "speed_score": 0.4855275443510738,
+      "success_rate": 0.8076923076923077
+    },
+    {
+      "attempt_rate": 0.029411764705882353,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "606192",
+      "speed_score": 0.19607843137254902,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "606466",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "606992",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.04,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "607043",
+      "speed_score": 0.26666666666666666,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.075,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "607208",
+      "speed_score": 0.5,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.29545454545454547,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "608070",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.020833333333333332,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "608324",
+      "speed_score": 0.1388888888888889,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "608348",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.02631578947368421,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "608369",
+      "speed_score": 0.17543859649122806,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7407407407407407,
+      "runner_id": "608701",
+      "speed_score": 0.0,
+      "success_rate": 0.7407407407407407
+    },
+    {
+      "attempt_rate": 0.07407407407407407,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "609280",
+      "speed_score": 0.49382716049382713,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "620443",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "621020",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.02127659574468085,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "621043",
+      "speed_score": 0.14184397163120568,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "621438",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.02857142857142857,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "621439",
+      "speed_score": 0.19047619047619047,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.03125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "621493",
+      "speed_score": 0.20833333333333334,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "621566",
+      "speed_score": 0.0,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.2727272727272727,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "622761",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7948717948717948,
+      "runner_id": "623168",
+      "speed_score": 0.0,
+      "success_rate": 0.7948717948717948
+    },
+    {
+      "attempt_rate": 0.02564102564102564,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "624413",
+      "speed_score": 0.17094017094017094,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8181818181818182,
+      "runner_id": "624424",
+      "speed_score": 0.0,
+      "success_rate": 0.8181818181818182
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "624428",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "624431",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8076923076923077,
+      "runner_id": "624512",
+      "speed_score": 0.0,
+      "success_rate": 0.8076923076923077
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "624585",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.08333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "624641",
+      "speed_score": 0.5555555555555556,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "628451",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.034482758620689655,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "630105",
+      "speed_score": 0.22988505747126436,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0648854961832061,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "640492",
+      "speed_score": 0.43256997455470736,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.1005586592178771,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7407407407407407,
+      "runner_id": "640902",
+      "speed_score": 0.670391061452514,
+      "success_rate": 0.7407407407407407
+    },
+    {
+      "attempt_rate": 0.12121212121212122,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "641343",
+      "speed_score": 0.8080808080808082,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.10869565217391304,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "641355",
+      "speed_score": 0.7246376811594203,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "641487",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7586206896551724,
+      "runner_id": "641555",
+      "speed_score": 0.0,
+      "success_rate": 0.7586206896551724
+    },
+    {
+      "attempt_rate": 0.09523809523809523,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "641584",
+      "speed_score": 0.6349206349206349,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7222222222222222,
+      "runner_id": "641598",
+      "speed_score": 0.0,
+      "success_rate": 0.7222222222222222
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "641680",
+      "speed_score": 0.0,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "641857",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "641933",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6071428571428571,
+      "runner_id": "642086",
+      "speed_score": 0.0,
+      "success_rate": 0.6071428571428571
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "642201",
+      "speed_score": 0.0,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "642215",
+      "speed_score": 1.0,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7586206896551724,
+      "runner_id": "642708",
+      "speed_score": 0.0,
+      "success_rate": 0.7586206896551724
+    },
+    {
+      "attempt_rate": 0.06896551724137931,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "642715",
+      "speed_score": 0.45977011494252873,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "642851",
+      "speed_score": 0.0,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7428571428571429,
+      "runner_id": "643217",
+      "speed_score": 0.0,
+      "success_rate": 0.7428571428571429
+    },
+    {
+      "attempt_rate": 0.02564102564102564,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "643289",
+      "speed_score": 0.17094017094017094,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.05,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "643376",
+      "speed_score": 0.33333333333333337,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.2222222222222222,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "643396",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.07317073170731707,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.3333333333333333,
+      "runner_id": "643446",
+      "speed_score": 0.4878048780487805,
+      "success_rate": 0.3333333333333333
+    },
+    {
+      "attempt_rate": 0.06382978723404255,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "645277",
+      "speed_score": 0.425531914893617,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "646240",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.17647058823529413,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "647304",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.08695652173913043,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "650333",
+      "speed_score": 0.5797101449275363,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.896551724137931,
+      "runner_id": "650391",
+      "speed_score": 0.0,
+      "success_rate": 0.896551724137931
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7272727272727273,
+      "runner_id": "650402",
+      "speed_score": 0.0,
+      "success_rate": 0.7272727272727273
+    },
+    {
+      "attempt_rate": 0.14814814814814814,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "650489",
+      "speed_score": 0.9876543209876543,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.019230769230769232,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "650490",
+      "speed_score": 0.12820512820512822,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.037037037037037035,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "650859",
+      "speed_score": 0.24691358024691357,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.15384615384615385,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "655316",
+      "speed_score": 1.0,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.021739130434782608,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "656305",
+      "speed_score": 0.14492753623188406,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7931034482758621,
+      "runner_id": "656484",
+      "speed_score": 0.0,
+      "success_rate": 0.7931034482758621
+    },
+    {
+      "attempt_rate": 0.5833333333333334,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5714285714285714,
+      "runner_id": "656537",
+      "speed_score": 1.0,
+      "success_rate": 0.5714285714285714
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "656555",
+      "speed_score": 0.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "656582",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.42105263157894735,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "656775",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.02,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "656811",
+      "speed_score": 0.13333333333333333,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "656941",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.15384615384615385,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "657041",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.07142857142857142,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "657136",
+      "speed_score": 0.47619047619047616,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.08571428571428572,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "657656",
+      "speed_score": 0.5714285714285715,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.047619047619047616,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "657757",
+      "speed_score": 0.31746031746031744,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "660162",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.08,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "660271",
+      "speed_score": 0.5333333333333333,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.21153846153846154,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6363636363636364,
+      "runner_id": "660670",
+      "speed_score": 1.0,
+      "success_rate": 0.6363636363636364
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7397260273972602,
+      "runner_id": "660688",
+      "speed_score": 0.0,
+      "success_rate": 0.7397260273972602
+    },
+    {
+      "attempt_rate": 0.038461538461538464,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "660821",
+      "speed_score": 0.25641025641025644,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.07692307692307693,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "660844",
+      "speed_score": 0.5128205128205129,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7397260273972602,
+      "runner_id": "661388",
+      "speed_score": 0.0,
+      "success_rate": 0.7397260273972602
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "662139",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "663330",
+      "speed_score": 1.0,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.09090909090909091,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663368",
+      "speed_score": 0.6060606060606061,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.13725490196078433,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663538",
+      "speed_score": 0.9150326797385622,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.08108108108108109,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663586",
+      "speed_score": 0.5405405405405406,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.16129032258064516,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663604",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.02702702702702703,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663616",
+      "speed_score": 0.1801801801801802,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.86,
+      "runner_id": "663647",
+      "speed_score": 0.0,
+      "success_rate": 0.86
+    },
+    {
+      "attempt_rate": 0.06976744186046512,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663656",
+      "speed_score": 0.46511627906976744,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "663698",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.09375,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "663728",
+      "speed_score": 0.625,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "663743",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.06060606060606061,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "663757",
+      "speed_score": 0.4040404040404041,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663837",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.86,
+      "runner_id": "663886",
+      "speed_score": 0.0,
+      "success_rate": 0.86
+    },
+    {
+      "attempt_rate": 0.21739130434782608,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "663968",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "663993",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.022222222222222223,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "664023",
+      "speed_score": 0.14814814814814817,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.07692307692307693,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "664034",
+      "speed_score": 0.5128205128205129,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "664040",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "664059",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.5,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "664238",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "664702",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.19230769230769232,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "664728",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8043478260869565,
+      "runner_id": "664731",
+      "speed_score": 0.0,
+      "success_rate": 0.8043478260869565
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "664761",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.06666666666666667,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "664770",
+      "speed_score": 0.4444444444444445,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "664954",
+      "speed_score": 0.0,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.36363636363636365,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "664983",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.2727272727272727,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "665019",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.2391304347826087,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8181818181818182,
+      "runner_id": "665487",
+      "speed_score": 1.0,
+      "success_rate": 0.8181818181818182
+    },
+    {
+      "attempt_rate": 0.03508771929824561,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "665489",
+      "speed_score": 0.23391812865497075,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8125,
+      "runner_id": "665561",
+      "speed_score": 0.0,
+      "success_rate": 0.8125
+    },
+    {
+      "attempt_rate": 0.06451612903225806,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "665742",
+      "speed_score": 0.43010752688172044,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.06896551724137931,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "665750",
+      "speed_score": 0.45977011494252873,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7419354838709677,
+      "runner_id": "665804",
+      "speed_score": 0.0,
+      "success_rate": 0.7419354838709677
+    },
+    {
+      "attempt_rate": 0.3157894736842105,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "665833",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "665861",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.3142857142857143,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8181818181818182,
+      "runner_id": "665862",
+      "speed_score": 1.0,
+      "success_rate": 0.8181818181818182
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9047619047619048,
+      "runner_id": "665877",
+      "speed_score": 0.0,
+      "success_rate": 0.9047619047619048
+    },
+    {
+      "attempt_rate": 0.5,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "665923",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.13793103448275862,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "665926",
+      "speed_score": 0.9195402298850575,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "665953",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "665966",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "666018",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.05555555555555555,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "666023",
+      "speed_score": 0.37037037037037035,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "666126",
+      "speed_score": 0.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666139",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.2727272727272727,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "666152",
+      "speed_score": 1.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.03571428571428571,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666160",
+      "speed_score": 0.23809523809523808,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.04878048780487805,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666176",
+      "speed_score": 0.3252032520325204,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.13333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "666181",
+      "speed_score": 0.888888888888889,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.02631578947368421,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666182",
+      "speed_score": 0.17543859649122806,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.08333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666211",
+      "speed_score": 0.5555555555555556,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7894736842105263,
+      "runner_id": "666310",
+      "speed_score": 0.0,
+      "success_rate": 0.7894736842105263
+    },
+    {
+      "attempt_rate": 0.11428571428571428,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "666397",
+      "speed_score": 0.7619047619047619,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "666464",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "666624",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.02631578947368421,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "666969",
+      "speed_score": 0.17543859649122806,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "666971",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.05555555555555555,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "667472",
+      "speed_score": 0.37037037037037035,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.14285714285714285,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "667670",
+      "speed_score": 0.9523809523809523,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.16,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.875,
+      "runner_id": "668227",
+      "speed_score": 1.0,
+      "success_rate": 0.875
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "668670",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "668709",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.030303030303030304,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "668715",
+      "speed_score": 0.20202020202020204,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.07142857142857142,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "668723",
+      "speed_score": 0.47619047619047616,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.017241379310344827,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "668804",
+      "speed_score": 0.11494252873563218,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.18604651162790697,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "668885",
+      "speed_score": 1.0,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "668901",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.1,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "668904",
+      "speed_score": 0.6666666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.17307692307692307,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "668930",
+      "speed_score": 1.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "668939",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.1951219512195122,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.625,
+      "runner_id": "669003",
+      "speed_score": 1.0,
+      "success_rate": 0.625
+    },
+    {
+      "attempt_rate": 0.09090909090909091,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "669004",
+      "speed_score": 0.6060606060606061,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.09375,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "669016",
+      "speed_score": 0.625,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "669065",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "669127",
+      "speed_score": 0.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.813953488372093,
+      "runner_id": "669134",
+      "speed_score": 0.0,
+      "success_rate": 0.813953488372093
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "669224",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.08333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "669236",
+      "speed_score": 0.5555555555555556,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8723404255319149,
+      "runner_id": "669257",
+      "speed_score": 0.0,
+      "success_rate": 0.8723404255319149
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7307692307692307,
+      "runner_id": "669288",
+      "speed_score": 0.0,
+      "success_rate": 0.7307692307692307
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8809523809523809,
+      "runner_id": "669289",
+      "speed_score": 0.0,
+      "success_rate": 0.8809523809523809
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "669326",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8723404255319149,
+      "runner_id": "669357",
+      "speed_score": 0.0,
+      "success_rate": 0.8723404255319149
+    },
+    {
+      "attempt_rate": 0.08620689655172414,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "669364",
+      "speed_score": 0.574712643678161,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.8333333333333334,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "669369",
+      "speed_score": 1.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8214285714285714,
+      "runner_id": "669394",
+      "speed_score": 0.0,
+      "success_rate": 0.8214285714285714
+    },
+    {
+      "attempt_rate": 0.058823529411764705,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "669477",
+      "speed_score": 0.39215686274509803,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.059770114942528735,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7307692307692307,
+      "runner_id": "669699",
+      "speed_score": 0.3984674329501916,
+      "success_rate": 0.7307692307692307
+    },
+    {
+      "attempt_rate": 0.09375,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "669701",
+      "speed_score": 0.625,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.09441233140655106,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7346938775510204,
+      "runner_id": "669717",
+      "speed_score": 0.6294155427103404,
+      "success_rate": 0.7346938775510204
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "669720",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.06666666666666667,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "669743",
+      "speed_score": 0.4444444444444445,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.043478260869565216,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "670042",
+      "speed_score": 0.2898550724637681,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.037037037037037035,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "670242",
+      "speed_score": 0.24691358024691357,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.01818181818181818,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "670541",
+      "speed_score": 0.12121212121212122,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7837837837837838,
+      "runner_id": "670623",
+      "speed_score": 0.0,
+      "success_rate": 0.7837837837837838
+    },
+    {
+      "attempt_rate": 0.2608695652173913,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "670764",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.11764705882352941,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "670770",
+      "speed_score": 0.7843137254901961,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.01694915254237288,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "671056",
+      "speed_score": 0.11299435028248588,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "671218",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.07142857142857142,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "671277",
+      "speed_score": 0.47619047619047616,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.14285714285714285,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "671289",
+      "speed_score": 0.9523809523809523,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8518518518518519,
+      "runner_id": "671655",
+      "speed_score": 0.0,
+      "success_rate": 0.8518518518518519
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "671732",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "671739",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "671976",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7017543859649122,
+      "runner_id": "672012",
+      "speed_score": 0.0,
+      "success_rate": 0.7017543859649122
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "672275",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7428571428571429,
+      "runner_id": "672284",
+      "speed_score": 0.0,
+      "success_rate": 0.7428571428571429
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "672515",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.11627906976744186,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6,
+      "runner_id": "672580",
+      "speed_score": 0.7751937984496124,
+      "success_rate": 0.6
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "672640",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.225,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "672695",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.1935483870967742,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "672724",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.25,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "672761",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7948717948717948,
+      "runner_id": "672820",
+      "speed_score": 0.0,
+      "success_rate": 0.7948717948717948
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7948717948717948,
+      "runner_id": "672960",
+      "speed_score": 0.0,
+      "success_rate": 0.7948717948717948
+    },
+    {
+      "attempt_rate": 0.04,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "673237",
+      "speed_score": 0.26666666666666666,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.13793103448275862,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "673357",
+      "speed_score": 0.9195402298850575,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "673548",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.046511627906976744,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "673962",
+      "speed_score": 0.31007751937984496,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 1.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "675659",
+      "speed_score": 1.0,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "676356",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.023809523809523808,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "676391",
+      "speed_score": 0.15873015873015872,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.74,
+      "runner_id": "676439",
+      "speed_score": 0.0,
+      "success_rate": 0.74
+    },
+    {
+      "attempt_rate": 0.02127659574468085,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "676475",
+      "speed_score": 0.14184397163120568,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.48484848484848486,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "676609",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7931034482758621,
+      "runner_id": "676914",
+      "speed_score": 0.0,
+      "success_rate": 0.7931034482758621
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6,
+      "runner_id": "677587",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 0.6
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7397260273972602,
+      "runner_id": "677588",
+      "speed_score": 0.0,
+      "success_rate": 0.7397260273972602
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "677592",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.08695652173913043,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "677594",
+      "speed_score": 0.5797101449275363,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "677595",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "677649",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0425531914893617,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "677800",
+      "speed_score": 0.28368794326241137,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "677870",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.2222222222222222,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "677942",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.2222222222222222,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "677950",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.23076923076923078,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "677951",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7608695652173914,
+      "runner_id": "677956",
+      "speed_score": 0.0,
+      "success_rate": 0.7608695652173914
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7931034482758621,
+      "runner_id": "678218",
+      "speed_score": 0.0,
+      "success_rate": 0.7931034482758621
+    },
+    {
+      "attempt_rate": 0.11363636363636363,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "678246",
+      "speed_score": 0.7575757575757576,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.03571428571428571,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "678391",
+      "speed_score": 0.23809523809523808,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "678489",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.10526315789473684,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "678554",
+      "speed_score": 0.7017543859649122,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.06451612903225806,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "678662",
+      "speed_score": 0.43010752688172044,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.25,
+      "runner_id": "678882",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 0.25
+    },
+    {
+      "attempt_rate": 0.025,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "679529",
+      "speed_score": 0.16666666666666669,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "679845",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7142857142857143,
+      "runner_id": "680574",
+      "speed_score": 1.0,
+      "success_rate": 0.7142857142857143
+    },
+    {
+      "attempt_rate": 0.3,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "680700",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8205128205128205,
+      "runner_id": "680728",
+      "speed_score": 0.0,
+      "success_rate": 0.8205128205128205
+    },
+    {
+      "attempt_rate": 0.06666666666666667,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "680757",
+      "speed_score": 0.4444444444444445,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.19230769230769232,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "680776",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.02702702702702703,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "680777",
+      "speed_score": 0.1801801801801802,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "680779",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.2222222222222222,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "680869",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.24,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "681082",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6176470588235294,
+      "runner_id": "681198",
+      "speed_score": 0.0,
+      "success_rate": 0.6176470588235294
+    },
+    {
+      "attempt_rate": 0.058823529411764705,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "681297",
+      "speed_score": 0.39215686274509803,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7714285714285715,
+      "runner_id": "681351",
+      "speed_score": 0.0,
+      "success_rate": 0.7714285714285715
+    },
+    {
+      "attempt_rate": 0.08108108108108109,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "681393",
+      "speed_score": 0.5405405405405406,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8214285714285714,
+      "runner_id": "681481",
+      "speed_score": 0.0,
+      "success_rate": 0.8214285714285714
+    },
+    {
+      "attempt_rate": 0.8,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "681546",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.11627906976744186,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "681624",
+      "speed_score": 0.7751937984496124,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.2,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "681715",
+      "speed_score": 1.0,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "681807",
+      "speed_score": 0.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.13333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "682177",
+      "speed_score": 0.888888888888889,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.78125,
+      "runner_id": "682626",
+      "speed_score": 0.0,
+      "success_rate": 0.78125
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7575757575757576,
+      "runner_id": "682641",
+      "speed_score": 0.0,
+      "success_rate": 0.7575757575757576
+    },
+    {
+      "attempt_rate": 0.28,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7142857142857143,
+      "runner_id": "682657",
+      "speed_score": 1.0,
+      "success_rate": 0.7142857142857143
+    },
+    {
+      "attempt_rate": 0.10256410256410256,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "682663",
+      "speed_score": 0.6837606837606838,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.35,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8571428571428571,
+      "runner_id": "682668",
+      "speed_score": 1.0,
+      "success_rate": 0.8571428571428571
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7948717948717948,
+      "runner_id": "682818",
+      "speed_score": 0.0,
+      "success_rate": 0.7948717948717948
+    },
+    {
+      "attempt_rate": 0.2682926829268293,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7272727272727273,
+      "runner_id": "682829",
+      "speed_score": 1.0,
+      "success_rate": 0.7272727272727273
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8064516129032258,
+      "runner_id": "682877",
+      "speed_score": 0.0,
+      "success_rate": 0.8064516129032258
+    },
+    {
+      "attempt_rate": 0.14583333333333334,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7142857142857143,
+      "runner_id": "682928",
+      "speed_score": 0.9722222222222223,
+      "success_rate": 0.7142857142857143
+    },
+    {
+      "attempt_rate": 0.038461538461538464,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "682985",
+      "speed_score": 0.25641025641025644,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.09302325581395349,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "682998",
+      "speed_score": 0.6201550387596899,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1875,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "683002",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.45714285714285713,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.875,
+      "runner_id": "683083",
+      "speed_score": 1.0,
+      "success_rate": 0.875
+    },
+    {
+      "attempt_rate": 0.11538461538461539,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "683146",
+      "speed_score": 0.7692307692307693,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.045454545454545456,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "683357",
+      "speed_score": 0.30303030303030304,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "683737",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8378378378378378,
+      "runner_id": "683766",
+      "speed_score": 0.0,
+      "success_rate": 0.8378378378378378
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "683953",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "686217",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7017543859649122,
+      "runner_id": "686452",
+      "speed_score": 0.0,
+      "success_rate": 0.7017543859649122
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7407407407407407,
+      "runner_id": "686469",
+      "speed_score": 0.0,
+      "success_rate": 0.7407407407407407
+    },
+    {
+      "attempt_rate": 0.09090909090909091,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "686527",
+      "speed_score": 0.6060606060606061,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.0967741935483871,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.3333333333333333,
+      "runner_id": "686555",
+      "speed_score": 0.6451612903225806,
+      "success_rate": 0.3333333333333333
+    },
+    {
+      "attempt_rate": 0.3333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7777777777777778,
+      "runner_id": "686668",
+      "speed_score": 1.0,
+      "success_rate": 0.7777777777777778
+    },
+    {
+      "attempt_rate": 0.07142857142857142,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "686681",
+      "speed_score": 0.47619047619047616,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "686780",
+      "speed_score": 0.6666666666666667,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0967741935483871,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "686797",
+      "speed_score": 0.6451612903225806,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.046341463414634146,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7894736842105263,
+      "runner_id": "686823",
+      "speed_score": 0.3089430894308943,
+      "success_rate": 0.7894736842105263
+    },
+    {
+      "attempt_rate": 0.043478260869565216,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "686894",
+      "speed_score": 0.2898550724637681,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.018867924528301886,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "686948",
+      "speed_score": 0.12578616352201258,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7906976744186046,
+      "runner_id": "687093",
+      "speed_score": 0.0,
+      "success_rate": 0.7906976744186046
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9047619047619048,
+      "runner_id": "687221",
+      "speed_score": 0.0,
+      "success_rate": 0.9047619047619048
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "687231",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.20833333333333334,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7,
+      "runner_id": "687263",
+      "speed_score": 1.0,
+      "success_rate": 0.7
+    },
+    {
+      "attempt_rate": 0.35,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7142857142857143,
+      "runner_id": "687363",
+      "speed_score": 1.0,
+      "success_rate": 0.7142857142857143
+    },
+    {
+      "attempt_rate": 0.2857142857142857,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "687401",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8392857142857143,
+      "runner_id": "687462",
+      "speed_score": 0.0,
+      "success_rate": 0.8392857142857143
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "687515",
+      "speed_score": 0.0,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.74,
+      "runner_id": "687551",
+      "speed_score": 0.0,
+      "success_rate": 0.74
+    },
+    {
+      "attempt_rate": 0.23076923076923078,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "687597",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.08,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "687637",
+      "speed_score": 0.5333333333333333,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.05128205128205128,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "687859",
+      "speed_score": 0.3418803418803419,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.23529411764705882,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "687957",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "688363",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.03125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "689414",
+      "speed_score": 0.20833333333333334,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7272727272727273,
+      "runner_id": "690291",
+      "speed_score": 0.0,
+      "success_rate": 0.7272727272727273
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9047619047619048,
+      "runner_id": "690976",
+      "speed_score": 0.0,
+      "success_rate": 0.9047619047619048
+    },
+    {
+      "attempt_rate": 0.08649789029535865,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "690984",
+      "speed_score": 0.5766526019690577,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.02702702702702703,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "690993",
+      "speed_score": 0.1801801801801802,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7428571428571429,
+      "runner_id": "691011",
+      "speed_score": 0.0,
+      "success_rate": 0.7428571428571429
+    },
+    {
+      "attempt_rate": 0.027777777777777776,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691016",
+      "speed_score": 0.18518518518518517,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.16666666666666666,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8571428571428571,
+      "runner_id": "691023",
+      "speed_score": 1.0,
+      "success_rate": 0.8571428571428571
+    },
+    {
+      "attempt_rate": 0.0975609756097561,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691026",
+      "speed_score": 0.6504065040650407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7368421052631579,
+      "runner_id": "691176",
+      "speed_score": 0.0,
+      "success_rate": 0.7368421052631579
+    },
+    {
+      "attempt_rate": 0.05405405405405406,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "691406",
+      "speed_score": 0.3603603603603604,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "691594",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.23684210526315788,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "691718",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.05555555555555555,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691720",
+      "speed_score": 0.37037037037037035,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.05555555555555555,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691723",
+      "speed_score": 0.37037037037037035,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.10344827586206896,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "691777",
+      "speed_score": 0.6896551724137931,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.03225806451612903,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691781",
+      "speed_score": 0.21505376344086022,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.07407407407407407,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "691785",
+      "speed_score": 0.49382716049382713,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0625,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "693304",
+      "speed_score": 0.4166666666666667,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7272727272727273,
+      "runner_id": "693307",
+      "speed_score": 0.0,
+      "success_rate": 0.7272727272727273
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7857142857142857,
+      "runner_id": "694025",
+      "speed_score": 0.0,
+      "success_rate": 0.7857142857142857
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8,
+      "runner_id": "694208",
+      "speed_score": 0.0,
+      "success_rate": 0.8
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7586206896551724,
+      "runner_id": "694212",
+      "speed_score": 0.0,
+      "success_rate": 0.7586206896551724
+    },
+    {
+      "attempt_rate": 0.1,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "694374",
+      "speed_score": 0.6666666666666667,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.82,
+      "runner_id": "694377",
+      "speed_score": 0.0,
+      "success_rate": 0.82
+    },
+    {
+      "attempt_rate": 0.02702702702702703,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "694384",
+      "speed_score": 0.1801801801801802,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.16129032258064516,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "694497",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.09523809523809523,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "694671",
+      "speed_score": 0.6349206349206349,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "694728",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8070175438596491,
+      "runner_id": "695020",
+      "speed_score": 0.0,
+      "success_rate": 0.8070175438596491
+    },
+    {
+      "attempt_rate": 1.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "695257",
+      "speed_score": 1.0,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.07692307692307693,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "695336",
+      "speed_score": 0.5128205128205129,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.030303030303030304,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "695506",
+      "speed_score": 0.20202020202020204,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "695578",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7407407407407407,
+      "runner_id": "695600",
+      "speed_score": 0.0,
+      "success_rate": 0.7407407407407407
+    },
+    {
+      "attempt_rate": 0.05405405405405406,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "695657",
+      "speed_score": 0.3603603603603604,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.09090909090909091,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.25,
+      "runner_id": "695734",
+      "speed_score": 0.6060606060606061,
+      "success_rate": 0.25
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "696030",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.06060606060606061,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "696100",
+      "speed_score": 0.4040404040404041,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.06666666666666667,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "696285",
+      "speed_score": 0.4444444444444445,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.06896551724137931,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "699912",
+      "speed_score": 0.45977011494252873,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.041666666666666664,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "700250",
+      "speed_score": 0.2777777777777778,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.045454545454545456,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "700337",
+      "speed_score": 0.30303030303030304,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "700932",
+      "speed_score": 0.0,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.045454545454545456,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701350",
+      "speed_score": 0.30303030303030304,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1111111111111111,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701358",
+      "speed_score": 0.7407407407407407,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.17073170731707318,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701398",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.15151515151515152,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701538",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.13636363636363635,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701675",
+      "speed_score": 0.9090909090909091,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8214285714285714,
+      "runner_id": "701678",
+      "speed_score": 0.0,
+      "success_rate": 0.8214285714285714
+    },
+    {
+      "attempt_rate": 0.07017543859649122,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "701762",
+      "speed_score": 0.4678362573099415,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.2727272727272727,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "701807",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.11428571428571428,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "702222",
+      "speed_score": 0.7619047619047619,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.09302325581395349,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.5,
+      "runner_id": "702284",
+      "speed_score": 0.6201550387596899,
+      "success_rate": 0.5
+    },
+    {
+      "attempt_rate": 0.13333333333333333,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.75,
+      "runner_id": "702332",
+      "speed_score": 0.888888888888889,
+      "success_rate": 0.75
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8048780487804879,
+      "runner_id": "800050",
+      "speed_score": 0.0,
+      "success_rate": 0.8048780487804879
+    },
+    {
+      "attempt_rate": 0.0851063829787234,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "802139",
+      "speed_score": 0.5673758865248227,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.32608695652173914,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.7333333333333333,
+      "runner_id": "802415",
+      "speed_score": 1.0,
+      "success_rate": 0.7333333333333333
+    },
+    {
+      "attempt_rate": 0.1,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "803011",
+      "speed_score": 0.6666666666666667,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.20588235294117646,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "804606",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.2619047619047619,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.9090909090909091,
+      "runner_id": "805300",
+      "speed_score": 1.0,
+      "success_rate": 0.9090909090909091
+    },
+    {
+      "attempt_rate": 0.022727272727272728,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "805367",
+      "speed_score": 0.15151515151515152,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.024390243902439025,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "805779",
+      "speed_score": 0.1626016260162602,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.05263157894736842,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "805808",
+      "speed_score": 0.3508771929824561,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.1891891891891892,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "807712",
+      "speed_score": 1.0,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.125,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.6666666666666666,
+      "runner_id": "807713",
+      "speed_score": 0.8333333333333334,
+      "success_rate": 0.6666666666666666
+    },
+    {
+      "attempt_rate": 0.045454545454545456,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "807799",
+      "speed_score": 0.30303030303030304,
+      "success_rate": 1.0
+    },
+    {
+      "attempt_rate": 0.04878048780487805,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.0,
+      "runner_id": "808959",
+      "speed_score": 0.3252032520325204,
+      "success_rate": 0.0
+    },
+    {
+      "attempt_rate": 0.2608695652173913,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.8333333333333334,
+      "runner_id": "808975",
+      "speed_score": 1.0,
+      "success_rate": 0.8333333333333334
+    },
+    {
+      "attempt_rate": 0.0,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 0.717391304347826,
+      "runner_id": "808982",
+      "speed_score": 0.0,
+      "success_rate": 0.717391304347826
+    },
+    {
+      "attempt_rate": 0.10714285714285714,
+      "fatigue_index": 0.0,
+      "injury_limit_flag": false,
+      "lead_quality": 1.0,
+      "runner_id": "810938",
+      "speed_score": 0.7142857142857143,
+      "success_rate": 1.0
+    }
+  ],
+  "schema_version": "canonical_baserunning_production_prior_v1",
+  "source_through_date": "2026-05-02"
+}

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -21,13 +21,19 @@ from mlb_app.simulation.projections import (
     enrich_canonical_player_projection_rows,
 )
 from mlb_app.simulation.shadow import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+    activate_calibrated_baserunning,
+    apply_calibrated_baserunning_production_authority,
+    attach_canonical_shadow,
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
     discover_canonical_shadow_exact_artifact,
     discover_canonical_shadow_fallback_catalog,
     discover_canonical_shadow_lineups,
-    attach_canonical_shadow,
     discover_canonical_shadow_probability_provider,
+    discover_confirmed_catcher_assignments,
+    execute_live_baserunning_shadow_pair,
+    load_baserunning_production_prior,
     run_canonical_production_shadow,
 )
 
@@ -73,8 +79,10 @@ def _build_game_state_realism_diagnostics() -> dict:
             "status": "diagnostic_only",
             "final_probability_replacement": False,
         },
-        "steals_model_status": "deferred_not_active",
-        "steals_projection_wiring_status": "status_only_no_behavioral_effect",
+        "steals_model_status": "canonical_calibrated_active",
+        "steals_projection_wiring_status": (
+            "canonical_event_driven_production_authority"
+        ),
     }
 
 
@@ -891,7 +899,7 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             )
 
-            canonical_production_shadow_execution = (
+            canonical_legacy_fallback_execution = (
                 run_canonical_production_shadow(
                     game_pk=game_pk,
                     lineups=(
@@ -914,6 +922,150 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                         .get("ready")
                     ),
                 )
+            )
+
+            canonical_catcher_assignment_discovery = (
+                discover_confirmed_catcher_assignments(
+                    game_pk=game_pk,
+                )
+            )
+
+            try:
+                production_prior = (
+                    load_baserunning_production_prior()
+                )
+
+                if not (
+                    canonical_catcher_assignment_discovery
+                    .ready
+                ):
+                    raise ValueError(
+                        "confirmed catcher assignments "
+                        "are unavailable"
+                    )
+
+                catcher_ids = {
+                    value.team_side: value.catcher_id
+                    for value in (
+                        canonical_catcher_assignment_discovery
+                        .assignments
+                    )
+                }
+
+                required_runner_ids = tuple(
+                    dict.fromkeys(
+                        (
+                            canonical_shadow_lineup_discovery
+                            .away_player_ids
+                        )
+                        + (
+                            canonical_shadow_lineup_discovery
+                            .home_player_ids
+                        )
+                    )
+                )
+
+                required_pitcher_ids = tuple(
+                    dict.fromkeys(
+                        (
+                            canonical_shadow_bullpen_discovery
+                            .away
+                            .starter_id,
+                        )
+                        + (
+                            canonical_shadow_bullpen_discovery
+                            .away
+                            .bullpen_pitcher_ids
+                        )
+                        + (
+                            canonical_shadow_bullpen_discovery
+                            .home
+                            .starter_id,
+                        )
+                        + (
+                            canonical_shadow_bullpen_discovery
+                            .home
+                            .bullpen_pitcher_ids
+                        )
+                    )
+                )
+
+                canonical_baserunning_evidence_discovery = (
+                    production_prior.discover_matchup(
+                        required_runner_ids=(
+                            required_runner_ids
+                        ),
+                        required_pitcher_ids=(
+                            required_pitcher_ids
+                        ),
+                        away_catcher_id=(
+                            catcher_ids["away"]
+                        ),
+                        home_catcher_id=(
+                            catcher_ids["home"]
+                        ),
+                        allow_fallback_profiles=True,
+                    )
+                )
+            except Exception as baserunning_exc:
+                canonical_baserunning_evidence_discovery = (
+                    CanonicalShadowBaserunningEvidenceDiscovery(
+                        status="error",
+                        error_type=(
+                            type(baserunning_exc).__name__
+                        ),
+                        error_message=str(
+                            baserunning_exc
+                        ),
+                    )
+                )
+
+            canonical_live_baserunning_pair = (
+                execute_live_baserunning_shadow_pair(
+                    game_pk=game_pk,
+                    game_date=str(
+                        matchup.get("game_date")
+                        or target_date
+                    ),
+                    lineups=(
+                        canonical_shadow_lineup_discovery
+                    ),
+                    bullpens=(
+                        canonical_shadow_bullpen_discovery
+                    ),
+                    provider_discovery=(
+                        canonical_shadow_probability_provider_discovery
+                    ),
+                    exact_artifact_discovery=(
+                        canonical_shadow_exact_artifact_discovery
+                    ),
+                    fallback_catalog_discovery=(
+                        canonical_shadow_fallback_catalog_discovery
+                    ),
+                    bootstrap_ready=bool(
+                        canonical_shadow_bootstrap_readiness
+                        .get("ready")
+                    ),
+                    baserunning_evidence_discovery=(
+                        canonical_baserunning_evidence_discovery
+                    ),
+                )
+            )
+
+            canonical_baserunning_activation = (
+                activate_calibrated_baserunning(
+                    fallback_execution=(
+                        canonical_legacy_fallback_execution
+                    ),
+                    paired_execution=(
+                        canonical_live_baserunning_pair
+                    ),
+                )
+            )
+
+            canonical_production_shadow_execution = (
+                canonical_baserunning_activation
+                .production_execution
             )
 
             workspace[
@@ -985,6 +1137,46 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     ),
                 )
             )
+
+            shared_simulation = (
+                apply_calibrated_baserunning_production_authority(
+                    legacy_result=shared_simulation,
+                    activation=(
+                        canonical_baserunning_activation
+                    ),
+                )
+            )
+
+            if isinstance(shared_simulation, dict):
+                baserunning_diagnostics = (
+                    shared_simulation.setdefault(
+                        "diagnostics",
+                        {},
+                    )
+                )
+
+                if isinstance(
+                    baserunning_diagnostics,
+                    dict,
+                ):
+                    baserunning_diagnostics[
+                        "canonical_catcher_assignment_discovery"
+                    ] = (
+                        canonical_catcher_assignment_discovery
+                        .to_diagnostics()
+                    )
+                    baserunning_diagnostics[
+                        "canonical_baserunning_evidence_discovery"
+                    ] = (
+                        canonical_baserunning_evidence_discovery
+                        .to_diagnostics()
+                    )
+                    baserunning_diagnostics[
+                        "canonical_live_baserunning_shadow"
+                    ] = (
+                        canonical_live_baserunning_pair
+                        .to_diagnostics()
+                    )
 
             shared_simulation = (
                 _enrich_game_workspace_player_projections(
@@ -1101,6 +1293,22 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 ),
                 "canonical_shadow_production_execution": (
                     canonical_production_shadow_execution
+                    .to_diagnostics()
+                ),
+                "canonical_catcher_assignment_discovery": (
+                    canonical_catcher_assignment_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_baserunning_evidence_discovery": (
+                    canonical_baserunning_evidence_discovery
+                    .to_diagnostics()
+                ),
+                "canonical_live_baserunning_shadow": (
+                    canonical_live_baserunning_pair
+                    .to_diagnostics()
+                ),
+                "canonical_baserunning_activation": (
+                    canonical_baserunning_activation
                     .to_diagnostics()
                 ),
                 "canonical_shadow_bootstrap_readiness": (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -619,3 +619,24 @@ from .live_baserunning_shadow_execution import (
     CanonicalLiveBaserunningShadowExecution,
     execute_live_baserunning_shadow_pair,
 )
+
+
+from .calibrated_baserunning_activation import (
+    CALIBRATED_BASERUNNING_ENABLED_ENV,
+    CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION,
+    CanonicalCalibratedBaserunningActivation,
+    activate_calibrated_baserunning,
+    apply_calibrated_baserunning_production_authority,
+    calibrated_baserunning_enabled,
+)
+
+
+from .baserunning_production_prior import (
+    CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION,
+    DEFAULT_BASERUNNING_PRODUCTION_PRIOR_PATH,
+    CanonicalBaserunningProductionPrior,
+    CanonicalBaserunningProductionPriorCatcher,
+    build_baserunning_production_prior,
+    decode_baserunning_production_prior,
+    load_baserunning_production_prior,
+)

--- a/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
+++ b/mlb_app/simulation/shadow/baserunning_evidence_discovery.py
@@ -38,6 +38,10 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
     status: str = "unavailable"
     error_message: Optional[str] = None
     observation_digest: Optional[str] = None
+    fallback_runner_count: int = 0
+    fallback_pitcher_count: int = 0
+    fallback_catcher_count: int = 0
+    fallback_policy_version: Optional[str] = None
     discovery_version: str = (
         CANONICAL_SHADOW_BASERUNNING_DISCOVERY_VERSION
     )
@@ -64,6 +68,18 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
             (
                 "available_pitcher_count",
                 self.available_pitcher_count,
+            ),
+            (
+                "fallback_runner_count",
+                self.fallback_runner_count,
+            ),
+            (
+                "fallback_pitcher_count",
+                self.fallback_pitcher_count,
+            ),
+            (
+                "fallback_catcher_count",
+                self.fallback_catcher_count,
             ),
         ):
             if value < 0:
@@ -107,6 +123,26 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
                 "non-ready discovery cannot expose a catalog"
             )
 
+        fallback_count = (
+            self.fallback_runner_count
+            + self.fallback_pitcher_count
+            + self.fallback_catcher_count
+        )
+        if (
+            fallback_count > 0
+            and not self.fallback_policy_version
+        ):
+            raise ValueError(
+                "fallback evidence requires a policy version"
+            )
+        if (
+            fallback_count == 0
+            and self.fallback_policy_version is not None
+        ):
+            raise ValueError(
+                "fallback policy requires fallback evidence"
+            )
+
         if (
             self.observation_digest is not None
             and not self.observation_digest
@@ -121,6 +157,14 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
             raise ValueError(
                 "unsupported baserunning discovery version"
             )
+
+    @property
+    def fallback_evidence_count(self) -> int:
+        return (
+            self.fallback_runner_count
+            + self.fallback_pitcher_count
+            + self.fallback_catcher_count
+        )
 
     @property
     def ready(self) -> bool:
@@ -153,6 +197,23 @@ class CanonicalShadowBaserunningEvidenceDiscovery:
             ),
             "observation_digest": (
                 self.observation_digest
+            ),
+            "fallback_runner_count": (
+                self.fallback_runner_count
+            ),
+            "fallback_pitcher_count": (
+                self.fallback_pitcher_count
+            ),
+            "fallback_catcher_count": (
+                self.fallback_catcher_count
+            ),
+            "fallback_evidence_count": (
+                self.fallback_runner_count
+                + self.fallback_pitcher_count
+                + self.fallback_catcher_count
+            ),
+            "fallback_policy_version": (
+                self.fallback_policy_version
             ),
             "error_message": self.error_message,
             "production_activation": False,

--- a/mlb_app/simulation/shadow/baserunning_production_prior.py
+++ b/mlb_app/simulation/shadow/baserunning_production_prior.py
@@ -1,0 +1,700 @@
+"""Versioned production prior for calibrated baserunning evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, Tuple
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+
+from .baserunning_evidence_discovery import (
+    CanonicalShadowBaserunningEvidenceDiscovery,
+)
+from .historical_baserunning_replay_evidence_source import (
+    CanonicalHistoricalBaserunningReplayEvidenceWindow,
+)
+
+
+CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION = (
+    "canonical_baserunning_production_prior_v1"
+)
+BASERUNNING_PRODUCTION_FALLBACK_POLICY_VERSION = (
+    "baserunning_production_fallback_policy_v1"
+)
+
+_FALLBACK_RUNNER_ATTEMPT_RATE = 0.05
+_FALLBACK_RUNNER_SUCCESS_RATE = 0.75
+_FALLBACK_PITCHER_ALLOWED_ATTEMPT_RATE = 0.05
+_FALLBACK_PICKOFF_SUCCESS_RATE = 0.10
+_FALLBACK_CATCHER_THROWING_RATE = 0.25
+
+DEFAULT_BASERUNNING_PRODUCTION_PRIOR_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "data"
+    / "baserunning"
+    / "production_prior.json"
+)
+
+
+def _sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _identifier(value: Any, name: str) -> str:
+    if value in (None, "") or isinstance(value, bool):
+        raise ValueError(f"{name} is required")
+
+    normalized = str(value).strip()
+
+    if not normalized:
+        raise ValueError(f"{name} is required")
+
+    return normalized
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProductionPriorCatcher:
+    catcher_id: str
+    throwing_score: float
+    pop_time_score: float
+
+    def __post_init__(self) -> None:
+        _identifier(self.catcher_id, "catcher_id")
+
+        for name, value in (
+            ("throwing_score", self.throwing_score),
+            ("pop_time_score", self.pop_time_score),
+        ):
+            if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+                or not 0.0 <= float(value) <= 1.0
+            ):
+                raise ValueError(
+                    f"{name} must be between 0 and 1"
+                )
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProductionPrior:
+    source_through_date: str
+    runners: Tuple[
+        CanonicalRunnerBaserunningProfile,
+        ...,
+    ]
+    pitchers: Tuple[
+        CanonicalPitcherBaserunningProfile,
+        ...,
+    ]
+    catchers: Tuple[
+        CanonicalBaserunningProductionPriorCatcher,
+        ...,
+    ]
+    direct_evidence_count: int
+    proxy_evidence_count: int
+    fallback_evidence_count: int
+    prior_version: str = (
+        CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not self.source_through_date:
+            raise ValueError(
+                "source_through_date is required"
+            )
+
+        for name, values, value_type, id_name in (
+            (
+                "runners",
+                self.runners,
+                CanonicalRunnerBaserunningProfile,
+                "runner_id",
+            ),
+            (
+                "pitchers",
+                self.pitchers,
+                CanonicalPitcherBaserunningProfile,
+                "pitcher_id",
+            ),
+            (
+                "catchers",
+                self.catchers,
+                CanonicalBaserunningProductionPriorCatcher,
+                "catcher_id",
+            ),
+        ):
+            if not isinstance(values, tuple):
+                raise TypeError(
+                    f"{name} must be a tuple"
+                )
+            if any(
+                not isinstance(value, value_type)
+                for value in values
+            ):
+                raise TypeError(
+                    f"{name} must contain canonical values"
+                )
+
+            identifiers = tuple(
+                getattr(value, id_name)
+                for value in values
+            )
+            if len(identifiers) != len(set(identifiers)):
+                raise ValueError(
+                    f"{name} identifiers must be unique"
+                )
+
+        for name, value in (
+            (
+                "direct_evidence_count",
+                self.direct_evidence_count,
+            ),
+            (
+                "proxy_evidence_count",
+                self.proxy_evidence_count,
+            ),
+            (
+                "fallback_evidence_count",
+                self.fallback_evidence_count,
+            ),
+        ):
+            if (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 0
+            ):
+                raise ValueError(
+                    f"{name} must be nonnegative"
+                )
+
+        if self.prior_version != (
+            CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION
+        ):
+            raise ValueError(
+                "unsupported baserunning production "
+                "prior version"
+            )
+
+    def _content(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.prior_version,
+            "source_through_date": (
+                self.source_through_date
+            ),
+            "runners": [
+                {
+                    "runner_id": value.runner_id,
+                    "speed_score": value.speed_score,
+                    "attempt_rate": value.attempt_rate,
+                    "success_rate": value.success_rate,
+                    "lead_quality": value.lead_quality,
+                    "fatigue_index": value.fatigue_index,
+                    "injury_limit_flag": (
+                        value.injury_limit_flag
+                    ),
+                }
+                for value in self.runners
+            ],
+            "pitchers": [
+                {
+                    "pitcher_id": value.pitcher_id,
+                    "hold_score": value.hold_score,
+                    "delivery_time_score": (
+                        value.delivery_time_score
+                    ),
+                    "pickoff_attempt_rate": (
+                        value.pickoff_attempt_rate
+                    ),
+                    "pickoff_success_rate": (
+                        value.pickoff_success_rate
+                    ),
+                }
+                for value in self.pitchers
+            ],
+            "catchers": [
+                {
+                    "catcher_id": value.catcher_id,
+                    "throwing_score": (
+                        value.throwing_score
+                    ),
+                    "pop_time_score": (
+                        value.pop_time_score
+                    ),
+                }
+                for value in self.catchers
+            ],
+            "direct_evidence_count": (
+                self.direct_evidence_count
+            ),
+            "proxy_evidence_count": (
+                self.proxy_evidence_count
+            ),
+            "fallback_evidence_count": (
+                self.fallback_evidence_count
+            ),
+        }
+
+    @property
+    def digest(self) -> str:
+        return _sha256(self._content())
+
+    def to_payload(self) -> Dict[str, Any]:
+        payload = self._content()
+        payload["artifact_digest"] = self.digest
+        return payload
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.prior_version,
+            "source_through_date": (
+                self.source_through_date
+            ),
+            "runner_count": len(self.runners),
+            "pitcher_count": len(self.pitchers),
+            "catcher_count": len(self.catchers),
+            "direct_evidence_count": (
+                self.direct_evidence_count
+            ),
+            "proxy_evidence_count": (
+                self.proxy_evidence_count
+            ),
+            "fallback_evidence_count": (
+                self.fallback_evidence_count
+            ),
+            "artifact_digest": self.digest,
+            "production_activation": False,
+            "authoritative_source": "legacy",
+        }
+
+    def discover_matchup(
+        self,
+        *,
+        required_runner_ids: Tuple[str, ...],
+        required_pitcher_ids: Tuple[str, ...],
+        away_catcher_id: str,
+        home_catcher_id: str,
+        allow_fallback_profiles: bool = False,
+    ) -> CanonicalShadowBaserunningEvidenceDiscovery:
+        if not isinstance(
+            allow_fallback_profiles,
+            bool,
+        ):
+            raise TypeError(
+                "allow_fallback_profiles must be a bool"
+            )
+        runner_ids = tuple(
+            _identifier(value, "runner_id")
+            for value in required_runner_ids
+        )
+        pitcher_ids = tuple(
+            _identifier(value, "pitcher_id")
+            for value in required_pitcher_ids
+        )
+        away_id = _identifier(
+            away_catcher_id,
+            "away_catcher_id",
+        )
+        home_id = _identifier(
+            home_catcher_id,
+            "home_catcher_id",
+        )
+
+        runners_by_id = {
+            value.runner_id: value
+            for value in self.runners
+        }
+        pitchers_by_id = {
+            value.pitcher_id: value
+            for value in self.pitchers
+        }
+        catchers_by_id = {
+            value.catcher_id: value
+            for value in self.catchers
+        }
+
+        available_runners = tuple(
+            runners_by_id[value]
+            for value in runner_ids
+            if value in runners_by_id
+        )
+        available_pitchers = tuple(
+            pitchers_by_id[value]
+            for value in pitcher_ids
+            if value in pitchers_by_id
+        )
+
+        away = catchers_by_id.get(away_id)
+        home = catchers_by_id.get(home_id)
+
+        missing_runner_ids = tuple(
+            value
+            for value in runner_ids
+            if value not in runners_by_id
+        )
+        missing_pitcher_ids = tuple(
+            value
+            for value in pitcher_ids
+            if value not in pitchers_by_id
+        )
+        missing_catcher_ids = tuple(
+            value
+            for value in (away_id, home_id)
+            if value not in catchers_by_id
+        )
+
+        complete = not (
+            missing_runner_ids
+            or missing_pitcher_ids
+            or missing_catcher_ids
+        )
+
+        if not complete and not allow_fallback_profiles:
+            return CanonicalShadowBaserunningEvidenceDiscovery(
+                requested_runner_count=len(runner_ids),
+                available_runner_count=len(
+                    available_runners
+                ),
+                requested_pitcher_count=len(
+                    pitcher_ids
+                ),
+                available_pitcher_count=len(
+                    available_pitchers
+                ),
+                status="unavailable",
+                observation_digest=self.digest,
+            )
+
+        if allow_fallback_profiles:
+            for runner_id in missing_runner_ids:
+                runners_by_id[runner_id] = (
+                    CanonicalRunnerBaserunningProfile(
+                        runner_id=runner_id,
+                        speed_score=(
+                            _FALLBACK_RUNNER_ATTEMPT_RATE
+                            / 0.15
+                        ),
+                        attempt_rate=(
+                            _FALLBACK_RUNNER_ATTEMPT_RATE
+                        ),
+                        success_rate=(
+                            _FALLBACK_RUNNER_SUCCESS_RATE
+                        ),
+                        lead_quality=(
+                            _FALLBACK_RUNNER_SUCCESS_RATE
+                        ),
+                        fatigue_index=0.0,
+                        injury_limit_flag=False,
+                    )
+                )
+
+            fallback_hold_score = 1.0 - (
+                _FALLBACK_PITCHER_ALLOWED_ATTEMPT_RATE
+                / 0.10
+            )
+            for pitcher_id in missing_pitcher_ids:
+                pitchers_by_id[pitcher_id] = (
+                    CanonicalPitcherBaserunningProfile(
+                        pitcher_id=pitcher_id,
+                        hold_score=fallback_hold_score,
+                        delivery_time_score=(
+                            fallback_hold_score
+                        ),
+                        pickoff_attempt_rate=0.0,
+                        pickoff_success_rate=(
+                            _FALLBACK_PICKOFF_SUCCESS_RATE
+                        ),
+                    )
+                )
+
+            for catcher_id in missing_catcher_ids:
+                catchers_by_id[catcher_id] = (
+                    CanonicalBaserunningProductionPriorCatcher(
+                        catcher_id=catcher_id,
+                        throwing_score=(
+                            _FALLBACK_CATCHER_THROWING_RATE
+                        ),
+                        pop_time_score=(
+                            _FALLBACK_CATCHER_THROWING_RATE
+                        ),
+                    )
+                )
+
+            away = catchers_by_id[away_id]
+            home = catchers_by_id[home_id]
+
+        catalog = CanonicalBaserunningEvidenceCatalog(
+            runners=tuple(
+                runners_by_id[value]
+                for value in runner_ids
+            ),
+            pitchers=tuple(
+                pitchers_by_id[value]
+                for value in pitcher_ids
+            ),
+            away_catcher=(
+                CanonicalCatcherBaserunningProfile(
+                    catcher_id=away.catcher_id,
+                    team_side="away",
+                    throwing_score=(
+                        away.throwing_score
+                    ),
+                    pop_time_score=(
+                        away.pop_time_score
+                    ),
+                )
+            ),
+            home_catcher=(
+                CanonicalCatcherBaserunningProfile(
+                    catcher_id=home.catcher_id,
+                    team_side="home",
+                    throwing_score=(
+                        home.throwing_score
+                    ),
+                    pop_time_score=(
+                        home.pop_time_score
+                    ),
+                )
+            ),
+        )
+
+        return CanonicalShadowBaserunningEvidenceDiscovery(
+            catalog=catalog,
+            requested_runner_count=len(runner_ids),
+            available_runner_count=len(runner_ids),
+            requested_pitcher_count=len(pitcher_ids),
+            available_pitcher_count=len(
+                pitcher_ids
+            ),
+            status="ready",
+            observation_digest=(
+                _sha256(
+                    {
+                        "production_prior_digest": (
+                            self.digest
+                        ),
+                        "catalog_digest": catalog.digest,
+                        "fallback_runner_ids": (
+                            missing_runner_ids
+                        ),
+                        "fallback_pitcher_ids": (
+                            missing_pitcher_ids
+                        ),
+                        "fallback_catcher_ids": (
+                            missing_catcher_ids
+                        ),
+                        "fallback_policy_version": (
+                            BASERUNNING_PRODUCTION_FALLBACK_POLICY_VERSION
+                            if not complete
+                            else None
+                        ),
+                    }
+                )
+                if not complete
+                else self.digest
+            ),
+            fallback_runner_count=len(
+                missing_runner_ids
+            ),
+            fallback_pitcher_count=len(
+                missing_pitcher_ids
+            ),
+            fallback_catcher_count=len(
+                missing_catcher_ids
+            ),
+            fallback_policy_version=(
+                BASERUNNING_PRODUCTION_FALLBACK_POLICY_VERSION
+                if not complete
+                else None
+            ),
+        )
+
+
+
+def build_baserunning_production_prior(
+    evidence: (
+        CanonicalHistoricalBaserunningReplayEvidenceWindow
+    ),
+) -> CanonicalBaserunningProductionPrior:
+    """
+    Materialize a deterministic production prior.
+
+    Games are ordered by their cutoff-safe statistics date.
+    The latest available profile wins for each identity.
+    Catcher profiles are stored without matchup-specific team
+    assignment and are reassigned during matchup discovery.
+    """
+
+    if not isinstance(
+        evidence,
+        CanonicalHistoricalBaserunningReplayEvidenceWindow,
+    ):
+        raise TypeError(
+            "evidence must be a "
+            "CanonicalHistoricalBaserunningReplayEvidenceWindow"
+        )
+
+    runners = {}
+    pitchers = {}
+    catchers = {}
+
+    ordered_games = sorted(
+        evidence.games,
+        key=lambda value: (
+            value.statistics_through_date,
+            value.game_date,
+            value.game_pk,
+        ),
+    )
+
+    for game in ordered_games:
+        catalog = game.catalog
+
+        for runner in catalog.runners:
+            runners[runner.runner_id] = runner
+
+        for pitcher in catalog.pitchers:
+            pitchers[pitcher.pitcher_id] = pitcher
+
+        for catcher in (
+            catalog.away_catcher,
+            catalog.home_catcher,
+        ):
+            catchers[catcher.catcher_id] = (
+                CanonicalBaserunningProductionPriorCatcher(
+                    catcher_id=catcher.catcher_id,
+                    throwing_score=(
+                        catcher.throwing_score
+                    ),
+                    pop_time_score=(
+                        catcher.pop_time_score
+                    ),
+                )
+            )
+
+    return CanonicalBaserunningProductionPrior(
+        source_through_date=max(
+            value.statistics_through_date
+            for value in ordered_games
+        ),
+        runners=tuple(
+            runners[value]
+            for value in sorted(runners)
+        ),
+        pitchers=tuple(
+            pitchers[value]
+            for value in sorted(pitchers)
+        ),
+        catchers=tuple(
+            catchers[value]
+            for value in sorted(catchers)
+        ),
+        direct_evidence_count=sum(
+            value.direct_evidence_count
+            for value in ordered_games
+        ),
+        proxy_evidence_count=sum(
+            value.proxy_evidence_count
+            for value in ordered_games
+        ),
+        fallback_evidence_count=sum(
+            value.fallback_evidence_count
+            for value in ordered_games
+        ),
+    )
+
+def decode_baserunning_production_prior(
+    payload: Mapping[str, Any],
+) -> CanonicalBaserunningProductionPrior:
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            "production-prior payload must be a mapping"
+        )
+
+    expected_digest = payload.get(
+        "artifact_digest"
+    )
+
+    prior = CanonicalBaserunningProductionPrior(
+        source_through_date=str(
+            payload.get("source_through_date") or ""
+        ),
+        runners=tuple(
+            CanonicalRunnerBaserunningProfile(
+                **dict(value)
+            )
+            for value in payload.get("runners", ())
+        ),
+        pitchers=tuple(
+            CanonicalPitcherBaserunningProfile(
+                **dict(value)
+            )
+            for value in payload.get("pitchers", ())
+        ),
+        catchers=tuple(
+            CanonicalBaserunningProductionPriorCatcher(
+                **dict(value)
+            )
+            for value in payload.get("catchers", ())
+        ),
+        direct_evidence_count=int(
+            payload.get("direct_evidence_count", 0)
+        ),
+        proxy_evidence_count=int(
+            payload.get("proxy_evidence_count", 0)
+        ),
+        fallback_evidence_count=int(
+            payload.get("fallback_evidence_count", 0)
+        ),
+        prior_version=str(
+            payload.get("schema_version") or ""
+        ),
+    )
+
+    if expected_digest != prior.digest:
+        raise ValueError(
+            "production-prior artifact digest mismatch"
+        )
+
+    return prior
+
+
+
+@lru_cache(maxsize=4)
+def load_baserunning_production_prior(
+    path: Any = (
+        DEFAULT_BASERUNNING_PRODUCTION_PRIOR_PATH
+    ),
+) -> CanonicalBaserunningProductionPrior:
+    """
+    Load and digest-verify one immutable production prior.
+
+    Cache entries are keyed by the resolved artifact path. Missing,
+    malformed, or tampered artifacts raise at this boundary so callers
+    can fail open to legacy production authority.
+    """
+
+    artifact_path = Path(path).expanduser().resolve()
+    payload = json.loads(
+        artifact_path.read_text(
+            encoding="utf-8"
+        )
+    )
+
+    return decode_baserunning_production_prior(
+        payload
+    )

--- a/mlb_app/simulation/shadow/calibrated_baserunning_activation.py
+++ b/mlb_app/simulation/shadow/calibrated_baserunning_activation.py
@@ -1,0 +1,464 @@
+"""Select calibrated baserunning with an immediate legacy rollback."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import os
+from typing import Any, Dict, Mapping, Optional
+
+from .live_baserunning_shadow_execution import (
+    CanonicalLiveBaserunningShadowExecution,
+)
+from .production_execution import (
+    CanonicalProductionShadowExecution,
+)
+
+
+CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION = (
+    "canonical_calibrated_baserunning_activation_v1"
+)
+CALIBRATED_BASERUNNING_ENABLED_ENV = (
+    "MLB_CALIBRATED_BASERUNNING_ENABLED"
+)
+_FALSE_VALUES = {
+    "",
+    "0",
+    "false",
+    "no",
+    "off",
+}
+
+
+def calibrated_baserunning_enabled(
+    value: Optional[Any] = None,
+) -> bool:
+    """
+    Resolve explicit override, environment rollback, then active default.
+
+    The calibrated model is active after this release unless the rollback
+    flag is explicitly disabled.
+    """
+
+    raw = (
+        value
+        if value is not None
+        else os.getenv(
+            CALIBRATED_BASERUNNING_ENABLED_ENV,
+            "true",
+        )
+    )
+
+    if isinstance(raw, bool):
+        return raw
+
+    return (
+        str(raw).strip().lower()
+        not in _FALSE_VALUES
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalCalibratedBaserunningActivation:
+    fallback_execution: CanonicalProductionShadowExecution
+    paired_execution: (
+        CanonicalLiveBaserunningShadowExecution
+    )
+    activation_requested: bool
+    activation_version: str = (
+        CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.fallback_execution,
+            CanonicalProductionShadowExecution,
+        ):
+            raise TypeError(
+                "fallback_execution must be canonical"
+            )
+
+        if not isinstance(
+            self.paired_execution,
+            CanonicalLiveBaserunningShadowExecution,
+        ):
+            raise TypeError(
+                "paired_execution must be canonical"
+            )
+
+        if not isinstance(
+            self.activation_requested,
+            bool,
+        ):
+            raise TypeError(
+                "activation_requested must be boolean"
+            )
+
+        if self.activation_version != (
+            CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported calibrated baserunning "
+                "activation version"
+            )
+
+    @property
+    def calibrated_ready(self) -> bool:
+        return (
+            self.paired_execution
+            .calibrated_execution
+            .executed
+            and self.paired_execution.observation.ready
+            and self.paired_execution
+            .observation
+            .input_parity_verified
+            and self.paired_execution
+            .observation
+            .seed_parity_verified
+        )
+
+    @property
+    def activated(self) -> bool:
+        return (
+            self.activation_requested
+            and self.calibrated_ready
+        )
+
+    @property
+    def production_execution(
+        self,
+    ) -> CanonicalProductionShadowExecution:
+        if self.activated:
+            return (
+                self.paired_execution
+                .calibrated_execution
+            )
+
+        return self.fallback_execution
+
+    @property
+    def fallback_reason(self) -> Optional[str]:
+        if self.activated:
+            return None
+        if not self.activation_requested:
+            return "rollback_flag_disabled"
+        return "calibrated_baserunning_unavailable"
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.activation_version,
+            "activation_requested": (
+                self.activation_requested
+            ),
+            "calibrated_ready": (
+                self.calibrated_ready
+            ),
+            "production_activation": self.activated,
+            "fallback_used": not self.activated,
+            "fallback_reason": self.fallback_reason,
+            "selected_execution": (
+                "calibrated"
+                if self.activated
+                else "legacy_fallback"
+            ),
+            "probability_transform": {
+                "attempt_probability_multiplier": 0.52,
+                "success_rate_adjustment": 0.09,
+                "transform_digest": (
+                    self.paired_execution
+                    .observation
+                    .calibrated_transform_digest
+                ),
+                "frozen_during_monitoring_window": True,
+            },
+            "post_activation_monitoring_target": {
+                "game_count": 100,
+                "parameters_may_reselect": False,
+            },
+            "rollback_environment_variable": (
+                CALIBRATED_BASERUNNING_ENABLED_ENV
+            ),
+            "production_authority_changed": (
+                self.activated
+            ),
+            "authoritative_source": (
+                "canonical_calibrated_baserunning"
+                if self.activated
+                else "legacy"
+            ),
+        }
+
+
+def activate_calibrated_baserunning(
+    *,
+    fallback_execution: (
+        CanonicalProductionShadowExecution
+    ),
+    paired_execution: (
+        CanonicalLiveBaserunningShadowExecution
+    ),
+    enabled: Optional[Any] = None,
+) -> CanonicalCalibratedBaserunningActivation:
+    return CanonicalCalibratedBaserunningActivation(
+        fallback_execution=fallback_execution,
+        paired_execution=paired_execution,
+        activation_requested=(
+            calibrated_baserunning_enabled(enabled)
+        ),
+    )
+
+
+
+def _distribution_mean(
+    values: Mapping[str, Any],
+) -> float:
+    if not isinstance(values, Mapping) or not values:
+        raise ValueError(
+            "canonical run distribution is required"
+        )
+
+    return round(
+        sum(
+            float(run_value) * float(probability)
+            for run_value, probability
+            in values.items()
+        ),
+        6,
+    )
+
+
+def apply_calibrated_baserunning_production_authority(
+    *,
+    legacy_result: Dict[str, Any],
+    activation: CanonicalCalibratedBaserunningActivation,
+) -> Dict[str, Any]:
+    """
+    Promote a ready calibrated canonical execution into production.
+
+    The existing production envelope and direct inputs are preserved.
+    Only the simulation outputs selected by Model Projections are replaced.
+    Rollback or unavailable canonical evidence preserves legacy outputs.
+    """
+
+    if not isinstance(legacy_result, dict):
+        raise TypeError(
+            "legacy_result must be a dictionary"
+        )
+    if not isinstance(
+        activation,
+        CanonicalCalibratedBaserunningActivation,
+    ):
+        raise TypeError(
+            "activation must be canonical"
+        )
+
+    output = deepcopy(legacy_result)
+    diagnostics = output.setdefault(
+        "diagnostics",
+        {},
+    )
+
+    if not isinstance(diagnostics, dict):
+        diagnostics = {
+            "legacy_diagnostics": deepcopy(
+                diagnostics
+            )
+        }
+        output["diagnostics"] = diagnostics
+
+    activation_diagnostics = (
+        activation.to_diagnostics()
+    )
+    diagnostics[
+        "calibrated_baserunning_activation"
+    ] = activation_diagnostics
+
+    if not activation.activated:
+        return output
+
+    material = (
+        activation.production_execution.material
+    )
+
+    if material is None:
+        raise RuntimeError(
+            "activated canonical execution has no material"
+        )
+
+    canonical_payload = material.canonical_payload
+    outcomes = canonical_payload.get("outcomes")
+
+    if not isinstance(outcomes, Mapping):
+        raise ValueError(
+            "canonical production outcomes are required"
+        )
+
+    away_distribution = outcomes.get(
+        "away_run_distribution"
+    )
+    home_distribution = outcomes.get(
+        "home_run_distribution"
+    )
+    total_distribution = outcomes.get(
+        "total_run_distribution"
+    )
+
+    away_expected_runs = _distribution_mean(
+        away_distribution
+    )
+    home_expected_runs = _distribution_mean(
+        home_distribution
+    )
+    total_expected_runs = _distribution_mean(
+        total_distribution
+    )
+
+    canonical_simulation = {
+        "simulation_count": int(
+            outcomes["simulation_count"]
+        ),
+        "away_win_probability": float(
+            outcomes["away_win_probability"]
+        ),
+        "home_win_probability": float(
+            outcomes["home_win_probability"]
+        ),
+        "tie_probability": float(
+            outcomes["tie_probability"]
+        ),
+        "extra_innings_probability": float(
+            outcomes[
+                "extra_innings_probability"
+            ]
+        ),
+        "walk_off_probability": float(
+            outcomes["walk_off_probability"]
+        ),
+        "away_expected_runs": away_expected_runs,
+        "home_expected_runs": home_expected_runs,
+        "total_expected_runs": total_expected_runs,
+        "expected_total_runs": total_expected_runs,
+        "away_run_distribution": dict(
+            away_distribution
+        ),
+        "home_run_distribution": dict(
+            home_distribution
+        ),
+        "total_run_distribution": dict(
+            total_distribution
+        ),
+        "team_total_probabilities": dict(
+            outcomes["team_total_probabilities"]
+        ),
+        "total_probabilities": dict(
+            outcomes["total_probabilities"]
+        ),
+        "model_version": canonical_payload[
+            "model_version"
+        ],
+        "run_id": canonical_payload["run_id"],
+        "source": (
+            "canonical_event_driven_simulation"
+        ),
+        "production_activation": True,
+        "production_authority_changed": True,
+        "authoritative_source": (
+            "canonical_event_driven_"
+            "calibrated_baserunning"
+        ),
+    }
+
+    derived_outputs = output.setdefault(
+        "derived_outputs",
+        {},
+    )
+
+    if not isinstance(derived_outputs, dict):
+        derived_outputs = {}
+        output["derived_outputs"] = derived_outputs
+
+    legacy_game = derived_outputs.get(
+        "game_simulation"
+    )
+    legacy_bullpen = derived_outputs.get(
+        "bullpen_adjusted_game_simulation"
+    )
+
+    diagnostics[
+        "pre_activation_legacy_simulation"
+    ] = {
+        "game_simulation_model_version": (
+            legacy_game.get("model_version")
+            if isinstance(legacy_game, dict)
+            else None
+        ),
+        "bullpen_adjusted_model_version": (
+            legacy_bullpen.get("model_version")
+            if isinstance(legacy_bullpen, dict)
+            else None
+        ),
+        "preserved_for_rollback": True,
+    }
+
+    derived_outputs[
+        "game_simulation"
+    ] = deepcopy(canonical_simulation)
+    derived_outputs[
+        "bullpen_adjusted_game_simulation"
+    ] = deepcopy(canonical_simulation)
+
+    metadata = output.get("meta")
+
+    if not isinstance(metadata, dict):
+        metadata = {}
+        output["meta"] = metadata
+
+    metadata.update(
+        {
+            "model_version": canonical_payload[
+                "model_version"
+            ],
+            "canonical_run_id": canonical_payload[
+                "run_id"
+            ],
+            "production_activation": True,
+            "authoritative_source": (
+                "canonical_event_driven_"
+                "calibrated_baserunning"
+            ),
+        }
+    )
+
+    canonical_shadow = diagnostics.get(
+        "canonical_shadow"
+    )
+
+    if isinstance(canonical_shadow, dict):
+        canonical_shadow[
+            "authoritative_source"
+        ] = (
+            "canonical_event_driven_"
+            "calibrated_baserunning"
+        )
+        canonical_shadow[
+            "production_activation"
+        ] = True
+
+        player_projections = (
+            canonical_shadow.get(
+                "player_projections"
+            )
+        )
+
+        if isinstance(player_projections, dict):
+            player_projections[
+                "authoritative"
+            ] = True
+            player_projections[
+                "authoritative_source"
+            ] = (
+                "canonical_event_driven_"
+                "calibrated_baserunning"
+            )
+
+    return output

--- a/mlb_app/simulation/shadow/catcher_assignment_discovery.py
+++ b/mlb_app/simulation/shadow/catcher_assignment_discovery.py
@@ -129,6 +129,36 @@ class CanonicalCatcherAssignmentDiscovery:
             == {"away", "home"}
         )
 
+    def to_diagnostics(self):
+        return {
+            "schema_version": (
+                self.discovery_version
+            ),
+            "status": self.status,
+            "ready": self.ready,
+            "assignment_count": len(
+                self.assignments
+            ),
+            "away_candidate_count": (
+                self.away_candidate_count
+            ),
+            "home_candidate_count": (
+                self.home_candidate_count
+            ),
+            "assignment_source_versions": sorted(
+                {
+                    value.assignment_source_version
+                    for value in self.assignments
+                }
+            ),
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "player_identifiers_exposed": False,
+            "production_activation": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
 
 def discover_confirmed_catcher_assignments(
     *,

--- a/scripts/run_historical_probability_statistics_source.py
+++ b/scripts/run_historical_probability_statistics_source.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, timedelta
 import json
+import os
+from pathlib import Path
 import sys
 import time
 from urllib.error import URLError
@@ -15,6 +17,7 @@ from mlb_app.simulation.game import (
     CanonicalBaserunningProbabilityTransform,
 )
 from mlb_app.simulation.shadow import (
+    build_baserunning_production_prior,
     build_historical_baserunning_replay_review_policy,
     define_historical_probability_reconstruction_inputs,
     evaluate_historical_baserunning_calibration_candidates,
@@ -340,6 +343,42 @@ def main():
         )
     )
 
+    production_prior = (
+        build_baserunning_production_prior(
+            baserunning_evidence
+        )
+    )
+
+    production_prior_output = os.getenv(
+        "MLB_BASERUNNING_PRODUCTION_PRIOR_PATH",
+        "",
+    ).strip()
+    production_prior_written = False
+
+    if production_prior_output:
+        output_path = Path(
+            production_prior_output
+        ).expanduser()
+        output_path.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+
+        temporary_path = output_path.with_name(
+            f".{output_path.name}.tmp"
+        )
+        temporary_path.write_text(
+            json.dumps(
+                production_prior.to_payload(),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(output_path)
+        production_prior_written = True
+
     statistics = (
         source_historical_probability_statistics(
             lineup_bullpen=roster_window,
@@ -483,6 +522,12 @@ def main():
         ),
         "baserunning_replay_evidence": (
             baserunning_evidence.to_diagnostics()
+        ),
+        "baserunning_production_prior": (
+            production_prior.to_diagnostics()
+        ),
+        "baserunning_production_prior_written": (
+            production_prior_written
         ),
         "history_feed_count": len(history_feeds),
         "cutoff_count": len(cutoffs),

--- a/tests/test_canonical_baserunning_production_prior.py
+++ b/tests/test_canonical_baserunning_production_prior.py
@@ -1,0 +1,435 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.game import (
+    CanonicalBaserunningEvidenceCatalog,
+    CanonicalCatcherBaserunningProfile,
+    CanonicalPitcherBaserunningProfile,
+    CanonicalRunnerBaserunningProfile,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION,
+    CanonicalBaserunningProductionPrior,
+    CanonicalBaserunningProductionPriorCatcher,
+    CanonicalHistoricalBaserunningReplayEvidenceGame,
+    CanonicalHistoricalBaserunningReplayEvidenceWindow,
+    build_baserunning_production_prior,
+    decode_baserunning_production_prior,
+    load_baserunning_production_prior,
+)
+
+
+def prior():
+    return CanonicalBaserunningProductionPrior(
+        source_through_date="2026-07-25",
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id="1",
+                speed_score=0.6,
+                attempt_rate=0.08,
+                success_rate=0.78,
+                lead_quality=0.7,
+                fatigue_index=0.0,
+            ),
+            CanonicalRunnerBaserunningProfile(
+                runner_id="2",
+                speed_score=0.4,
+                attempt_rate=0.04,
+                success_rate=0.72,
+                lead_quality=0.6,
+                fatigue_index=0.0,
+            ),
+        ),
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id="10",
+                hold_score=0.55,
+                delivery_time_score=0.55,
+                pickoff_attempt_rate=0.02,
+                pickoff_success_rate=0.10,
+            ),
+        ),
+        catchers=(
+            CanonicalBaserunningProductionPriorCatcher(
+                catcher_id="20",
+                throwing_score=0.30,
+                pop_time_score=0.30,
+            ),
+            CanonicalBaserunningProductionPriorCatcher(
+                catcher_id="21",
+                throwing_score=0.25,
+                pop_time_score=0.25,
+            ),
+        ),
+        direct_evidence_count=5,
+        proxy_evidence_count=8,
+        fallback_evidence_count=0,
+    )
+
+
+def test_prior_round_trips_with_digest():
+    source = prior()
+    decoded = decode_baserunning_production_prior(
+        source.to_payload()
+    )
+
+    assert decoded == source
+    assert decoded.digest == source.digest
+
+
+def test_prior_discovers_complete_matchup():
+    source = prior()
+    discovery = source.discover_matchup(
+        required_runner_ids=("1", "2"),
+        required_pitcher_ids=("10",),
+        away_catcher_id="20",
+        home_catcher_id="21",
+    )
+
+    assert discovery.ready is True
+    assert discovery.catalog is not None
+    assert discovery.catalog.away_catcher.team_side == (
+        "away"
+    )
+    assert discovery.catalog.home_catcher.team_side == (
+        "home"
+    )
+    assert discovery.observation_digest == source.digest
+
+
+def test_missing_identity_is_unavailable():
+    discovery = prior().discover_matchup(
+        required_runner_ids=("1", "999"),
+        required_pitcher_ids=("10",),
+        away_catcher_id="20",
+        home_catcher_id="21",
+    )
+
+    assert discovery.ready is False
+    assert discovery.status == "unavailable"
+    assert discovery.requested_runner_count == 2
+    assert discovery.available_runner_count == 1
+
+
+def test_tampered_artifact_is_rejected():
+    payload = copy.deepcopy(prior().to_payload())
+    payload["runners"][0]["attempt_rate"] = 0.99
+
+    with pytest.raises(
+        ValueError,
+        match="digest mismatch",
+    ):
+        decode_baserunning_production_prior(
+            payload
+        )
+
+
+def test_prior_is_deterministic():
+    first = prior()
+    second = prior()
+
+    assert first == second
+    assert first.digest == second.digest
+    assert first.to_payload() == second.to_payload()
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_BASERUNNING_PRODUCTION_PRIOR_VERSION
+        == "canonical_baserunning_production_prior_v1"
+    )
+
+
+DIGEST = "a" * 64
+
+
+def evidence_catalog(
+    *,
+    runner_attempt_rate,
+    pitcher_hold_score,
+    away_throwing_score,
+):
+    return CanonicalBaserunningEvidenceCatalog(
+        runners=(
+            CanonicalRunnerBaserunningProfile(
+                runner_id="2",
+                speed_score=0.5,
+                attempt_rate=runner_attempt_rate,
+                success_rate=0.75,
+                lead_quality=0.65,
+                fatigue_index=0.0,
+            ),
+            CanonicalRunnerBaserunningProfile(
+                runner_id="1",
+                speed_score=0.6,
+                attempt_rate=0.08,
+                success_rate=0.78,
+                lead_quality=0.70,
+                fatigue_index=0.0,
+            ),
+        ),
+        pitchers=(
+            CanonicalPitcherBaserunningProfile(
+                pitcher_id="10",
+                hold_score=pitcher_hold_score,
+                delivery_time_score=0.55,
+                pickoff_attempt_rate=0.02,
+                pickoff_success_rate=0.10,
+            ),
+        ),
+        away_catcher=(
+            CanonicalCatcherBaserunningProfile(
+                catcher_id="20",
+                team_side="away",
+                throwing_score=away_throwing_score,
+                pop_time_score=away_throwing_score,
+            )
+        ),
+        home_catcher=(
+            CanonicalCatcherBaserunningProfile(
+                catcher_id="21",
+                team_side="home",
+                throwing_score=0.25,
+                pop_time_score=0.25,
+            )
+        ),
+    )
+
+
+def evidence_game(
+    *,
+    game_pk,
+    game_date,
+    cutoff,
+    catalog,
+    counts,
+):
+    return CanonicalHistoricalBaserunningReplayEvidenceGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        statistics_through_date=cutoff,
+        catalog=catalog,
+        evidence_digest=DIGEST,
+        direct_evidence_count=counts[0],
+        proxy_evidence_count=counts[1],
+        fallback_evidence_count=counts[2],
+    )
+
+
+def evidence_window(*games):
+    return CanonicalHistoricalBaserunningReplayEvidenceWindow(
+        observed_window_digest=DIGEST,
+        lineup_bullpen_window_digest=DIGEST,
+        games=tuple(games),
+        digest=DIGEST,
+    )
+
+
+def test_build_prior_uses_latest_cutoff_safe_profiles():
+    earlier = evidence_game(
+        game_pk=1,
+        game_date="2026-04-20",
+        cutoff="2026-04-19",
+        catalog=evidence_catalog(
+            runner_attempt_rate=0.04,
+            pitcher_hold_score=0.40,
+            away_throwing_score=0.20,
+        ),
+        counts=(3, 2, 1),
+    )
+    later = evidence_game(
+        game_pk=2,
+        game_date="2026-04-21",
+        cutoff="2026-04-20",
+        catalog=evidence_catalog(
+            runner_attempt_rate=0.09,
+            pitcher_hold_score=0.70,
+            away_throwing_score=0.35,
+        ),
+        counts=(5, 4, 2),
+    )
+
+    result = build_baserunning_production_prior(
+        evidence_window(later, earlier)
+    )
+
+    assert result.source_through_date == "2026-04-20"
+    assert tuple(
+        value.runner_id
+        for value in result.runners
+    ) == ("1", "2")
+    assert result.runners[1].attempt_rate == 0.09
+    assert result.pitchers[0].hold_score == 0.70
+    assert result.catchers[0].catcher_id == "20"
+    assert result.catchers[0].throwing_score == 0.35
+    assert result.direct_evidence_count == 8
+    assert result.proxy_evidence_count == 6
+    assert result.fallback_evidence_count == 3
+
+
+def test_build_prior_is_independent_of_window_order():
+    earlier = evidence_game(
+        game_pk=1,
+        game_date="2026-04-20",
+        cutoff="2026-04-19",
+        catalog=evidence_catalog(
+            runner_attempt_rate=0.04,
+            pitcher_hold_score=0.40,
+            away_throwing_score=0.20,
+        ),
+        counts=(3, 2, 1),
+    )
+    later = evidence_game(
+        game_pk=2,
+        game_date="2026-04-21",
+        cutoff="2026-04-20",
+        catalog=evidence_catalog(
+            runner_attempt_rate=0.09,
+            pitcher_hold_score=0.70,
+            away_throwing_score=0.35,
+        ),
+        counts=(5, 4, 2),
+    )
+
+    first = build_baserunning_production_prior(
+        evidence_window(earlier, later)
+    )
+    second = build_baserunning_production_prior(
+        evidence_window(later, earlier)
+    )
+
+    assert first == second
+    assert first.digest == second.digest
+    assert first.to_payload() == second.to_payload()
+
+
+def test_build_prior_rejects_noncanonical_evidence():
+    with pytest.raises(
+        TypeError,
+        match="evidence must be",
+    ):
+        build_baserunning_production_prior(
+            object()
+        )
+
+
+
+def test_prior_loader_verifies_checked_payload(
+    tmp_path,
+):
+    artifact_path = tmp_path / "prior.json"
+    artifact_path.write_text(
+        __import__("json").dumps(
+            prior().to_payload()
+        ),
+        encoding="utf-8",
+    )
+
+    load_baserunning_production_prior.cache_clear()
+    loaded = load_baserunning_production_prior(
+        artifact_path
+    )
+
+    assert loaded == prior()
+    assert loaded.digest == prior().digest
+
+
+def test_prior_loader_rejects_tampered_payload(
+    tmp_path,
+):
+    payload = prior().to_payload()
+    payload["runners"][0]["attempt_rate"] = 0.99
+    artifact_path = tmp_path / "prior.json"
+    artifact_path.write_text(
+        __import__("json").dumps(payload),
+        encoding="utf-8",
+    )
+
+    load_baserunning_production_prior.cache_clear()
+
+    with pytest.raises(
+        ValueError,
+        match="digest mismatch",
+    ):
+        load_baserunning_production_prior(
+            artifact_path
+        )
+
+
+
+def test_missing_identity_can_use_explicit_fallback():
+    source = prior()
+
+    first = source.discover_matchup(
+        required_runner_ids=("1", "999"),
+        required_pitcher_ids=("10", "998"),
+        away_catcher_id="20",
+        home_catcher_id="997",
+        allow_fallback_profiles=True,
+    )
+    second = source.discover_matchup(
+        required_runner_ids=("1", "999"),
+        required_pitcher_ids=("10", "998"),
+        away_catcher_id="20",
+        home_catcher_id="997",
+        allow_fallback_profiles=True,
+    )
+
+    assert first.ready is True
+    assert first == second
+    assert first.catalog is not None
+    assert first.catalog.digest == second.catalog.digest
+    assert first.observation_digest == (
+        second.observation_digest
+    )
+    assert first.observation_digest != source.digest
+    assert first.fallback_runner_count == 1
+    assert first.fallback_pitcher_count == 1
+    assert first.fallback_catcher_count == 1
+    assert first.fallback_policy_version == (
+        "baserunning_production_fallback_policy_v1"
+    )
+
+    runners = {
+        value.runner_id: value
+        for value in first.catalog.runners
+    }
+    pitchers = {
+        value.pitcher_id: value
+        for value in first.catalog.pitchers
+    }
+
+    assert runners["999"].attempt_rate == 0.05
+    assert runners["999"].success_rate == 0.75
+    assert runners["999"].lead_quality == 0.75
+    assert pitchers["998"].hold_score == 0.5
+    assert pitchers["998"].delivery_time_score == 0.5
+    assert pitchers["998"].pickoff_attempt_rate == 0.0
+    assert pitchers["998"].pickoff_success_rate == 0.10
+    assert (
+        first.catalog.home_catcher.throwing_score
+        == 0.25
+    )
+    assert (
+        first.catalog.home_catcher.pop_time_score
+        == 0.25
+    )
+
+    diagnostics = first.to_diagnostics()
+    assert diagnostics["fallback_evidence_count"] == 3
+    assert diagnostics["fallback_runner_count"] == 1
+    assert diagnostics["fallback_pitcher_count"] == 1
+    assert diagnostics["fallback_catcher_count"] == 1
+
+
+def test_fallback_profiles_must_be_explicitly_enabled():
+    discovery = prior().discover_matchup(
+        required_runner_ids=("1", "999"),
+        required_pitcher_ids=("10",),
+        away_catcher_id="20",
+        home_catcher_id="21",
+    )
+
+    assert discovery.ready is False
+    assert discovery.fallback_evidence_count == 0

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -967,3 +967,226 @@ def test_live_pair_rejects_external_transform():
                 CanonicalBaserunningProbabilityTransform()
             ),
         )
+
+
+from mlb_app.simulation.shadow import (
+    CALIBRATED_BASERUNNING_ENABLED_ENV,
+    CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION,
+    activate_calibrated_baserunning,
+    apply_calibrated_baserunning_production_authority,
+    calibrated_baserunning_enabled,
+)
+
+
+def test_calibrated_baserunning_is_active_by_default(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        CALIBRATED_BASERUNNING_ENABLED_ENV,
+        raising=False,
+    )
+
+    fallback = run()
+    paired = run_live_pair()
+    activation = activate_calibrated_baserunning(
+        fallback_execution=fallback,
+        paired_execution=paired,
+    )
+
+    assert calibrated_baserunning_enabled() is True
+    assert activation.calibrated_ready is True
+    assert activation.activated is True
+    assert activation.production_execution is (
+        paired.calibrated_execution
+    )
+
+    diagnostics = activation.to_diagnostics()
+
+    assert diagnostics["production_activation"] is True
+    assert diagnostics[
+        "production_authority_changed"
+    ] is True
+    assert diagnostics["authoritative_source"] == (
+        "canonical_calibrated_baserunning"
+    )
+    assert diagnostics[
+        "post_activation_monitoring_target"
+    ]["game_count"] == 100
+    assert diagnostics[
+        "probability_transform"
+    ]["frozen_during_monitoring_window"] is True
+
+
+def test_calibrated_baserunning_rollback_uses_legacy():
+    fallback = run()
+    paired = run_live_pair()
+    activation = activate_calibrated_baserunning(
+        fallback_execution=fallback,
+        paired_execution=paired,
+        enabled=False,
+    )
+
+    assert activation.activated is False
+    assert activation.production_execution is fallback
+    assert activation.fallback_reason == (
+        "rollback_flag_disabled"
+    )
+    assert (
+        activation.to_diagnostics()[
+            "authoritative_source"
+        ]
+        == "legacy"
+    )
+
+
+def test_unavailable_calibrated_evidence_falls_back():
+    fallback = run()
+    paired = execute_live_baserunning_shadow_pair(
+        game_pk=123,
+        game_date="2026-07-26",
+        lineups=lineups(),
+        bullpens=bullpens(),
+        provider_discovery=provider_discovery(),
+        exact_artifact_discovery=exact_discovery(),
+        fallback_catalog_discovery=(
+            fallback_discovery()
+        ),
+        bootstrap_ready=True,
+        simulation_count=2,
+        baserunning_evidence_discovery=(
+            baserunning_discovery(
+                status="unavailable",
+            )
+        ),
+    )
+    activation = activate_calibrated_baserunning(
+        fallback_execution=fallback,
+        paired_execution=paired,
+        enabled=True,
+    )
+
+    assert fallback.executed is True
+    assert activation.calibrated_ready is False
+    assert activation.activated is False
+    assert activation.production_execution is fallback
+    assert activation.fallback_reason == (
+        "calibrated_baserunning_unavailable"
+    )
+
+
+def test_activation_version_is_explicit():
+    assert (
+        CANONICAL_CALIBRATED_BASERUNNING_ACTIVATION_VERSION
+        == "canonical_calibrated_baserunning_activation_v1"
+    )
+
+
+
+def legacy_shared_simulation():
+    return {
+        "status": "ok",
+        "derived_outputs": {
+            "game_simulation": {
+                "away_win_probability": 0.40,
+                "home_win_probability": 0.60,
+                "model_version": "legacy-base-v1",
+            },
+            "bullpen_adjusted_game_simulation": {
+                "away_win_probability": 0.42,
+                "home_win_probability": 0.58,
+                "model_version": "legacy-bullpen-v1",
+            },
+        },
+        "diagnostics": {},
+        "meta": {
+            "model_version": "shared-simulation-v1",
+        },
+    }
+
+
+def test_ready_activation_promotes_canonical_outcomes():
+    legacy = legacy_shared_simulation()
+    paired = run_live_pair()
+    activation = activate_calibrated_baserunning(
+        fallback_execution=run(),
+        paired_execution=paired,
+        enabled=True,
+    )
+
+    result = (
+        apply_calibrated_baserunning_production_authority(
+            legacy_result=legacy,
+            activation=activation,
+        )
+    )
+
+    canonical = (
+        paired.calibrated_execution
+        .material
+        .canonical_payload
+    )
+    outcomes = canonical["outcomes"]
+    selected = result["derived_outputs"][
+        "bullpen_adjusted_game_simulation"
+    ]
+
+    assert selected["away_win_probability"] == (
+        outcomes["away_win_probability"]
+    )
+    assert selected["home_win_probability"] == (
+        outcomes["home_win_probability"]
+    )
+    assert selected["source"] == (
+        "canonical_event_driven_simulation"
+    )
+    assert selected["production_activation"] is True
+    assert selected[
+        "production_authority_changed"
+    ] is True
+    assert result["meta"]["canonical_run_id"] == (
+        canonical["run_id"]
+    )
+    assert result["diagnostics"][
+        "calibrated_baserunning_activation"
+    ]["production_activation"] is True
+
+    assert legacy["derived_outputs"][
+        "bullpen_adjusted_game_simulation"
+    ]["home_win_probability"] == 0.58
+
+
+def test_rollback_preserves_legacy_simulation_outputs():
+    legacy = legacy_shared_simulation()
+    activation = activate_calibrated_baserunning(
+        fallback_execution=run(),
+        paired_execution=run_live_pair(),
+        enabled=False,
+    )
+
+    result = (
+        apply_calibrated_baserunning_production_authority(
+            legacy_result=legacy,
+            activation=activation,
+        )
+    )
+
+    assert result["derived_outputs"] == (
+        legacy["derived_outputs"]
+    )
+    assert result["meta"] == legacy["meta"]
+    assert result["diagnostics"][
+        "calibrated_baserunning_activation"
+    ]["fallback_reason"] == (
+        "rollback_flag_disabled"
+    )
+
+
+def test_authority_adapter_rejects_invalid_activation():
+    with pytest.raises(
+        TypeError,
+        match="activation must be canonical",
+    ):
+        apply_calibrated_baserunning_production_authority(
+            legacy_result={},
+            activation=object(),
+        )

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -368,5 +368,10 @@ def test_realism_payload_exposes_frontend_capability_aliases():
         is True
     )
     assert realism["steals_model_status"] == (
-        "deferred_not_active"
+        "canonical_calibrated_active"
+    )
+    assert realism[
+        "steals_projection_wiring_status"
+    ] == (
+        "canonical_event_driven_production_authority"
     )


### PR DESCRIPTION
## Summary

- activate the calibrated canonical event-driven baserunning model in Model Projections
- preserve the existing simulation as an immediate environment-controlled rollback
- load a digest-verified, cutoff-safe production baserunning prior
- complete missing current-roster identities with explicit deterministic fallback profiles
- expose fallback counts, policy provenance, activation state, and production authority diagnostics
- freeze the selected `0.52` attempt multiplier and `+0.09` success adjustment during the next 100-game monitoring window
- retain paired legacy/calibrated shadow execution for continued evidence collection

## Production behavior

When all canonical guards pass, Model Projections selects the canonical event-driven simulation as production authority. Setting `MLB_CALIBRATED_BASERUNNING_ENABLED=0` immediately restores the legacy simulation output.

The production prior is sourced through `2026-05-02` and digest verified. Missing identities use the explicit historical fallback policy already used by canonical profile materialization.

## Runtime validation

A real route smoke for game `823711` on `2026-05-03` verified:

- complete evidence discovery for 18 runners and 26 pitchers
- six explicit pitcher fallback profiles
- paired input and seed parity
- calibrated activation selected
- canonical event model promoted to production authority
- rollback flag restored the legacy model and original probabilities

## Validation

- 1,110 canonical and Model Projection tests passed
- focused activation, prior, monitoring, and authority tests passed
- Python compilation passed
- production-prior digest and artifact validation passed
- `git diff --check` passed
- Ruff was unavailable
- two known unrelated baseline failures were excluded: `tests/test_canonical_game_context.py` and `tests/test_canonical_model_engine.py`