### PR TITLE
Stabilize canonical production trials

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -46,6 +46,14 @@ test('projections tab describes same-run coherence', async () => {
   )
   assert.match(
     source,
+    /view\.authoritative/,
+  )
+  assert.match(
+    source,
+    /Authoritative production/,
+  )
+  assert.match(
+    source,
     /Non-authoritative shadow/,
   )
 })

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -495,3 +495,33 @@ test('prefers top-level projection diagnostics when both paths exist', () => {
   assert.equal(view.available, true)
   assert.equal(view.runId, 'run-123')
 })
+
+
+
+test('recognizes activated production projections', () => {
+  const source = payload()
+  const shadow = (
+    source.diagnostics.canonical_shadow
+  )
+  const projections = shadow.player_projections
+
+  shadow.authoritative_source = (
+    'canonical_event_driven_calibrated_baserunning'
+  )
+  projections.simulation_count = 250
+  projections.authoritative = true
+  projections.authoritative_source = (
+    'canonical_event_driven_calibrated_baserunning'
+  )
+
+  const view = (
+    buildCanonicalProjectionsViewModel(source)
+  )
+
+  assert.equal(view.authoritative, true)
+  assert.equal(view.simulationCount, 250)
+  assert.equal(
+    view.authoritativeSource,
+    'canonical_event_driven_calibrated_baserunning',
+  )
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1010,8 +1010,18 @@ function ProjectionsTab({ game }) {
           </div>
         </div>
 
-        <Tag tone="diagnostic">
-          Non-authoritative shadow
+        <Tag
+          tone={
+            view.authoritative
+              ? 'success'
+              : 'diagnostic'
+          }
+        >
+          {
+            view.authoritative
+              ? 'Authoritative production'
+              : 'Non-authoritative shadow'
+          }
         </Tag>
       </div>
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -25,6 +25,7 @@ from mlb_app.simulation.shadow import (
     activate_calibrated_baserunning,
     apply_calibrated_baserunning_production_authority,
     attach_canonical_shadow,
+    build_canonical_production_trial_policy,
     build_canonical_shadow_bootstrap_readiness,
     discover_canonical_shadow_bullpens,
     discover_canonical_shadow_exact_artifact,
@@ -1020,6 +1021,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     )
                 )
 
+            canonical_production_trial_policy = (
+                build_canonical_production_trial_policy()
+            )
+
             canonical_live_baserunning_pair = (
                 execute_live_baserunning_shadow_pair(
                     game_pk=game_pk,
@@ -1048,6 +1053,10 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     ),
                     baserunning_evidence_discovery=(
                         canonical_baserunning_evidence_discovery
+                    ),
+                    simulation_count=(
+                        canonical_production_trial_policy
+                        .simulation_count
                     ),
                 )
             )
@@ -1100,6 +1109,13 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 "canonicalShadowExactArtifactDiscovery"
             ] = (
                 canonical_shadow_exact_artifact_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalProductionTrialPolicy"
+            ] = (
+                canonical_production_trial_policy
                 .to_diagnostics()
             )
 

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -640,3 +640,13 @@ from .baserunning_production_prior import (
     decode_baserunning_production_prior,
     load_baserunning_production_prior,
 )
+
+from .production_trial_policy import (
+    CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+    CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION,
+    DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT,
+    MAXIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT,
+    MINIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT,
+    CanonicalProductionTrialPolicy,
+    build_canonical_production_trial_policy,
+)

--- a/mlb_app/simulation/shadow/calibrated_baserunning_activation.py
+++ b/mlb_app/simulation/shadow/calibrated_baserunning_activation.py
@@ -421,7 +421,11 @@ def apply_calibrated_baserunning_production_authority(
             "canonical_run_id": canonical_payload[
                 "run_id"
             ],
+            "simulation_count": int(
+                outcomes["simulation_count"]
+            ),
             "production_activation": True,
+            "production_authority_changed": True,
             "authoritative_source": (
                 "canonical_event_driven_"
                 "calibrated_baserunning"

--- a/mlb_app/simulation/shadow/production_trial_policy.py
+++ b/mlb_app/simulation/shadow/production_trial_policy.py
@@ -1,0 +1,109 @@
+"""Versioned canonical production trial-count policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any, Dict
+
+
+CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION = (
+    "canonical_production_trial_policy_v1"
+)
+CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV = (
+    "MLB_CANONICAL_PRODUCTION_SIMULATION_COUNT"
+)
+DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT = 250
+MINIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT = 25
+MAXIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT = 10000
+
+
+@dataclass(frozen=True)
+class CanonicalProductionTrialPolicy:
+    simulation_count: int = (
+        DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT
+    )
+    policy_version: str = (
+        CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.simulation_count, int)
+            or isinstance(self.simulation_count, bool)
+            or not (
+                MINIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT
+                <= self.simulation_count
+                <= MAXIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT
+            )
+        ):
+            raise ValueError(
+                "simulation_count must be an integer "
+                "between 25 and 10000"
+            )
+
+        if self.policy_version != (
+            CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION
+        ):
+            raise ValueError(
+                "unsupported canonical production "
+                "trial policy version"
+            )
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.policy_version,
+            "simulation_count": self.simulation_count,
+            "environment_variable": (
+                CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV
+            ),
+            "default_simulation_count": (
+                DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT
+            ),
+            "minimum_simulation_count": (
+                MINIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT
+            ),
+            "maximum_simulation_count": (
+                MAXIMUM_CANONICAL_PRODUCTION_SIMULATION_COUNT
+            ),
+            "configured_from_environment": (
+                CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV
+                in os.environ
+            ),
+        }
+
+
+def build_canonical_production_trial_policy(
+    value: Any = None,
+) -> CanonicalProductionTrialPolicy:
+    raw_value = (
+        value
+        if value is not None
+        else os.getenv(
+            CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+            str(
+                DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT
+            ),
+        )
+    )
+
+    if isinstance(raw_value, bool):
+        raise ValueError(
+            "production simulation count must be an integer"
+        )
+
+    try:
+        simulation_count = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "production simulation count must be an integer"
+        ) from exc
+
+    if str(simulation_count) != str(raw_value).strip():
+        raise ValueError(
+            "production simulation count must be an integer"
+        )
+
+    return CanonicalProductionTrialPolicy(
+        simulation_count=simulation_count,
+    )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1146,6 +1146,12 @@ def test_ready_activation_promotes_canonical_outcomes():
     assert result["meta"]["canonical_run_id"] == (
         canonical["run_id"]
     )
+    assert result["meta"]["simulation_count"] == (
+        outcomes["simulation_count"]
+    )
+    assert result["meta"][
+        "production_authority_changed"
+    ] is True
     assert result["diagnostics"][
         "calibrated_baserunning_activation"
     ]["production_activation"] is True

--- a/tests/test_canonical_production_trial_policy.py
+++ b/tests/test_canonical_production_trial_policy.py
@@ -1,0 +1,118 @@
+import pytest
+
+from mlb_app.simulation.shadow import (
+    CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+    CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION,
+    DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT,
+    CanonicalProductionTrialPolicy,
+    build_canonical_production_trial_policy,
+)
+
+
+def test_default_production_count_is_stable(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+        raising=False,
+    )
+
+    policy = build_canonical_production_trial_policy()
+
+    assert policy.simulation_count == 250
+    assert (
+        policy.simulation_count
+        == DEFAULT_CANONICAL_PRODUCTION_SIMULATION_COUNT
+    )
+    assert (
+        policy.policy_version
+        == CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION
+    )
+    assert (
+        policy.to_diagnostics()[
+            "configured_from_environment"
+        ]
+        is False
+    )
+
+
+def test_environment_can_override_production_count(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+        "250",
+    )
+
+    policy = build_canonical_production_trial_policy()
+
+    assert policy.simulation_count == 250
+    assert (
+        policy.to_diagnostics()[
+            "configured_from_environment"
+        ]
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "24",
+        "10001",
+        "not-an-integer",
+        "100.5",
+        True,
+    ),
+)
+def test_invalid_production_count_is_rejected(
+    value,
+):
+    with pytest.raises(
+        ValueError,
+        match="simulation count|simulation_count",
+    ):
+        build_canonical_production_trial_policy(
+            value
+        )
+
+
+def test_policy_is_deterministic():
+    first = CanonicalProductionTrialPolicy(
+        simulation_count=250
+    )
+    second = CanonicalProductionTrialPolicy(
+        simulation_count=250
+    )
+
+    assert first == second
+    assert (
+        first.to_diagnostics()
+        == second.to_diagnostics()
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_PRODUCTION_TRIAL_POLICY_VERSION
+        == "canonical_production_trial_policy_v1"
+    )
+
+
+
+def test_default_balances_precision_and_route_latency(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        CANONICAL_PRODUCTION_SIMULATION_COUNT_ENV,
+        raising=False,
+    )
+
+    policy = build_canonical_production_trial_policy()
+    diagnostics = policy.to_diagnostics()
+
+    assert policy.simulation_count == 250
+    assert 1 / policy.simulation_count == 0.004
+    assert diagnostics[
+        "default_simulation_count"
+    ] == 250


### PR DESCRIPTION
## Summary

- raise the canonical event-driven production trial count from 25 to a stable default of 250
- introduce a versioned production trial policy with an environment override from 25 through 10,000 trials
- propagate the authoritative canonical simulation count and authority metadata through shared output and player projections
- display `Authoritative production` for activated canonical player projections while preserving the non-authoritative shadow state
- retain calibrated baserunning activation, rollback behavior, paired input parity, and seed parity

## Runtime policy

The default production count is now 250 trials. It can be overridden with:

```text
MLB_CANONICAL_PRODUCTION_SIMULATION_COUNT
```

Accepted values are 25–10,000.

A real-route benchmark for game 823711 measured approximately:

- 25 trials: 3.35 seconds
- 100 trials: 5.90 seconds
- 250 trials: 11.33 seconds
- 500 trials: 20.73 seconds
- 1,000 trials: 39.57 seconds

The 250-trial default improves probability granularity from 4% to 0.4% without imposing the synchronous latency of 1,000 trials. Higher trial counts remain available for warmed, cached, or asynchronous execution.

## Validation

- 1,120 backend canonical and projection tests passed
- 34 branch-owned frontend tests passed
- frontend production build passed
- Python compilation passed
- `git diff --check` passed
- real-route smoke confirmed 250 canonical trials, authoritative player projections, calibrated activation, and verified input/seed parity

Existing unrelated frontend build warnings and the SQLAlchemy/date-time deprecation warnings remain unchanged.