### PR TITLE
Materialize canonical production monitoring

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
@@ -113,3 +113,29 @@ test('not-run state renders bootstrap readiness blockers', async () => {
     /Diagnostic only\. Readiness does not permit/,
   )
 })
+
+
+test('diagnostics distinguishes production monitoring', async () => {
+  const source = await readFile(
+    new URL(
+      '../pages/ModelProjectionsPage.jsx',
+      import.meta.url,
+    ),
+    'utf8',
+  )
+
+  assert.match(
+    source,
+    /Production Baserunning Monitoring/,
+  )
+  assert.match(
+    source,
+    /Frozen 100-game evidence window/,
+  )
+  assert.match(source, /status\.productionActive/)
+  assert.match(
+    source,
+    /Global Profile Fallback Rate/,
+  )
+  assert.match(source, /Parameter Reselection/)
+})

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -680,6 +680,63 @@ function buildProvenance(shadow) {
   }
 }
 
+
+function buildProductionMonitoring(sharedSimulation) {
+  const diagnostics = objectValue(
+    sharedSimulation.diagnostics
+  )
+  const report = objectValue(
+    diagnostics
+      .canonical_baserunning_production_monitoring
+  )
+  const summary = objectValue(report.summary)
+  const eligibility = objectValue(
+    report.eligibility
+  )
+
+  return {
+    available: Object.keys(report).length > 0,
+    schemaVersion:
+      report.schema_version || null,
+    recorded: report.recorded === true,
+    recordCreated:
+      report.record_created === true,
+    observationDigest:
+      report.observation_digest || null,
+    eligible: eligibility.eligible === true,
+    eligibilityFailures: arrayValue(
+      eligibility.failures
+    ).map(String),
+    targetGameCount: finiteNumber(
+      summary.target_game_count
+    ),
+    readyGameCount: finiteNumber(
+      summary.ready_game_count
+    ),
+    remainingGameCount: finiteNumber(
+      summary.remaining_game_count
+    ),
+    storedObservationCount: finiteNumber(
+      summary.stored_observation_count
+    ),
+    uniqueGameCount: finiteNumber(
+      summary.unique_game_count
+    ),
+    progressRate: finiteNumber(
+      summary.progress_rate
+    ),
+    monitoringComplete:
+      summary.monitoring_complete === true,
+    transformFrozen:
+      summary.transform_frozen === true,
+    transformDigests: arrayValue(
+      summary.transform_digests
+    ).map(String),
+    parameterReselectionPermitted:
+      summary.parameter_reselection_permitted === true,
+  }
+}
+
 function buildWarnings(shadow) {
   const probabilityResolution = objectValue(
     shadow.probability_resolution
@@ -728,6 +785,9 @@ export function buildCanonicalDiagnosticsViewModel(
 
   const productionExecution = (
     buildProductionExecution(shared)
+  )
+  const productionMonitoring = (
+    buildProductionMonitoring(shared)
   )
 
   const canonicalAvailable = Boolean(
@@ -811,6 +871,12 @@ export function buildCanonicalDiagnosticsViewModel(
       canonicalAvailable,
       authoritativeSource:
         shadow.authoritative_source || 'legacy',
+      productionActive: (
+        metadata.production_activation === true ||
+        shadow.production_activation === true ||
+        shadow.authoritative_source ===
+          'canonical_event_driven_calibrated_baserunning'
+      ),
       legacySimulationCount: finiteNumber(
         shadow.legacy_simulation_count
       ),
@@ -834,6 +900,7 @@ export function buildCanonicalDiagnosticsViewModel(
 
     bootstrapReadiness,
     productionExecution,
+    productionMonitoring,
     realism: buildRealism(shared, shadow),
     coverage: buildCoverage(shadow),
     integrity: buildIntegrity(shadow),

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -603,3 +603,75 @@ test('preserves blocked readiness presentation', () => {
     /7 missing production requirements/,
   )
 })
+
+
+test('exposes canonical production monitoring progress', () => {
+  const source = sharedSimulation()
+
+  source.meta = {
+    ...(source.meta || {}),
+    production_activation: true,
+  }
+  source.diagnostics.canonical_shadow = {
+    ...source.diagnostics.canonical_shadow,
+    production_activation: true,
+    authoritative_source:
+      'canonical_event_driven_calibrated_baserunning',
+  }
+  source.diagnostics[
+    'canonical_baserunning_production_monitoring'
+  ] = {
+    schema_version:
+      'canonical_baserunning_production_monitoring_v1',
+    recorded: true,
+    record_created: true,
+    observation_digest: 'digest-1',
+    eligibility: {
+      eligible: true,
+      failures: [],
+    },
+    summary: {
+      target_game_count: 100,
+      ready_game_count: 1,
+      remaining_game_count: 99,
+      stored_observation_count: 1,
+      unique_game_count: 1,
+      progress_rate: 0.01,
+      monitoring_complete: false,
+      transform_frozen: true,
+      transform_digests: ['transform-1'],
+      parameter_reselection_permitted: false,
+    },
+  }
+
+  const view = (
+    buildCanonicalDiagnosticsViewModel(source)
+  )
+
+  assert.equal(view.status.productionActive, true)
+  assert.equal(
+    view.productionMonitoring.available,
+    true,
+  )
+  assert.equal(
+    view.productionMonitoring.readyGameCount,
+    1,
+  )
+  assert.equal(
+    view.productionMonitoring.remainingGameCount,
+    99,
+  )
+  assert.equal(
+    view.productionMonitoring.progressRate,
+    0.01,
+  )
+  assert.equal(
+    view.productionMonitoring.transformFrozen,
+    true,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .parameterReselectionPermitted,
+    false,
+  )
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1242,6 +1242,7 @@ function DiagnosticsTab({ game }) {
   const status = view.status
   const bootstrap = view.bootstrapReadiness
   const coverage = view.coverage
+  const monitoring = view.productionMonitoring
   const integrity = view.integrity
   const provenance = view.provenance
 
@@ -1266,8 +1267,8 @@ function DiagnosticsTab({ game }) {
               marginTop: '5px',
             }}
           >
-            Coverage, integrity, realism, and provenance for the
-            event-driven shadow simulation.
+            Coverage, integrity, realism, provenance, and
+            production monitoring for the event-driven simulation.
           </div>
         </div>
 
@@ -1418,8 +1419,16 @@ function DiagnosticsTab({ game }) {
               status.modelVersion ||
               'Canonical shadow simulation'
             }
-            tag="Shadow"
-            tagTone="diagnostic"
+            tag={
+              status.productionActive
+                ? 'Production'
+                : 'Shadow'
+            }
+            tagTone={
+              status.productionActive
+                ? 'success'
+                : 'diagnostic'
+            }
           >
             <StatRow
               k="Status"
@@ -1469,7 +1478,7 @@ function DiagnosticsTab({ game }) {
             format="pct"
           />
           <StatRow
-            k="Fallback Rate"
+            k="Global Profile Fallback Rate"
             v={coverage.fallbackRate}
             format="pct"
           />
@@ -1479,7 +1488,7 @@ function DiagnosticsTab({ game }) {
             format="num"
           />
           <StatRow
-            k="Fallback Resolutions"
+            k="Global Profile Resolutions"
             v={coverage.fallbackResolutions}
             format="num"
           />
@@ -1503,6 +1512,70 @@ function DiagnosticsTab({ game }) {
           </GenericPanel>
         </div>
       )}
+
+
+      {monitoring.available ? (
+        <div style={{ marginTop: '18px' }}>
+          <GenericPanel
+            title="Production Baserunning Monitoring"
+            subtitle="Frozen 100-game evidence window"
+            tag={
+              monitoring.monitoringComplete
+                ? 'Review ready'
+                : 'Collecting'
+            }
+            tagTone={
+              monitoring.monitoringComplete
+                ? 'success'
+                : 'diagnostic'
+            }
+          >
+            <StatRow
+              k="Progress"
+              v={monitoring.progressRate}
+              format="pct"
+            />
+            <StatRow
+              k="Ready Games"
+              v={monitoring.readyGameCount}
+              format="num"
+            />
+            <StatRow
+              k="Target Games"
+              v={monitoring.targetGameCount}
+              format="num"
+            />
+            <StatRow
+              k="Games Remaining"
+              v={monitoring.remainingGameCount}
+              format="num"
+            />
+            <StatRow
+              k="Current Snapshot Recorded"
+              v={monitoring.recorded ? 'Yes' : 'No'}
+              format="text"
+            />
+            <StatRow
+              k="Transform Frozen"
+              v={
+                monitoring.transformFrozen
+                  ? 'Yes'
+                  : 'No'
+              }
+              format="text"
+            />
+            <StatRow
+              k="Parameter Reselection"
+              v={
+                monitoring.parameterReselectionPermitted
+                  ? 'Permitted'
+                  : 'Locked'
+              }
+              format="text"
+            />
+          </GenericPanel>
+        </div>
+      ) : null}
 
       <h3 style={s.sectionTitle}>
         Game-State Realism

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -378,6 +378,87 @@ class AppAccessProfile(Base):
     updated_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
 
 
+
+class CanonicalBaserunningProductionObservation(Base):
+    """Immutable canonical production-monitoring observation."""
+
+    __tablename__ = (
+        "canonical_baserunning_production_observations"
+    )
+
+    id: int = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+    )
+    game_pk: int = Column(
+        Integer,
+        nullable=False,
+        index=True,
+    )
+    game_date: date = Column(
+        Date,
+        nullable=False,
+        index=True,
+    )
+    canonical_run_id: str = Column(
+        String(128),
+        nullable=False,
+    )
+    observation_digest: str = Column(
+        String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    paired_context_digest: str = Column(
+        String(64),
+        nullable=False,
+    )
+    calibrated_transform_digest: str = Column(
+        String(64),
+        nullable=False,
+        index=True,
+    )
+    simulation_count: int = Column(
+        Integer,
+        nullable=False,
+    )
+    status: str = Column(
+        String(24),
+        nullable=False,
+    )
+    ready: bool = Column(
+        Boolean,
+        nullable=False,
+    )
+    production_activation: bool = Column(
+        Boolean,
+        nullable=False,
+    )
+    authoritative_source: str = Column(
+        String(96),
+        nullable=False,
+    )
+    payload_json = Column(
+        JSON,
+        nullable=False,
+    )
+    created_at: datetime = Column(
+        DateTime,
+        default=datetime.utcnow,
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_canonical_baserunning_monitor_game",
+            "game_date",
+            "game_pk",
+        ),
+    )
+
+
 class AppGlobalSetting(Base):
     __tablename__ = "app_global_settings"
 

--- a/mlb_app/model_projection_routes.py
+++ b/mlb_app/model_projection_routes.py
@@ -147,6 +147,7 @@ def _build_uncached_projection_payload(target_date: str) -> Dict[str, Any]:
             probability_source="model_projections",
         ):
             payload = build_model_projection_payload(session, target_date)
+            session.commit()
     payload = _apply_projection_probability_contract(payload, target_date)
     payload = _attach_projection_artifact_metadata(payload, target_date)
     record_probability_source("model_projections")

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -5,6 +5,12 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+from mlb_app.simulation.shadow.production_monitoring_ledger import (
+    CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
+    CanonicalBaserunningProductionMonitoringRecord,
+    evaluate_canonical_production_monitoring_eligibility,
+    materialize_canonical_baserunning_production_monitoring,
+)
 
 from .canonical_game_context import build_canonical_game_context
 from .db_utils import get_pitch_arsenal_with_fallback, get_team_split
@@ -80,6 +86,8 @@ def _build_game_state_realism_diagnostics() -> dict:
             "status": "diagnostic_only",
             "final_probability_replacement": False,
         },
+        "stolen_bases": True,
+        "stolen_base_model": True,
         "steals_model_status": "canonical_calibrated_active",
         "steals_projection_wiring_status": (
             "canonical_event_driven_production_authority"
@@ -1012,9 +1020,6 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 canonical_baserunning_evidence_discovery = (
                     CanonicalShadowBaserunningEvidenceDiscovery(
                         status="error",
-                        error_type=(
-                            type(baserunning_exc).__name__
-                        ),
                         error_message=str(
                             baserunning_exc
                         ),
@@ -1200,6 +1205,154 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     shared_simulation=shared_simulation,
                 )
             )
+
+            activation_diagnostics = (
+                canonical_baserunning_activation
+                .to_diagnostics()
+            )
+            observation = (
+                canonical_live_baserunning_pair
+                .observation
+            )
+            observation_diagnostics = (
+                observation.to_diagnostics()
+            )
+            shared_meta = (
+                shared_simulation.get("meta", {})
+                if isinstance(shared_simulation, dict)
+                else {}
+            )
+            if not isinstance(shared_meta, dict):
+                shared_meta = {}
+
+            monitoring_eligibility = (
+                evaluate_canonical_production_monitoring_eligibility(
+                    game_date=str(
+                        matchup.get("game_date")
+                        or target_date
+                    ),
+                    game_status=str(
+                        matchup.get("status") or ""
+                    ),
+                    activation_requested=bool(
+                        activation_diagnostics.get(
+                            "activation_requested"
+                        )
+                    ),
+                    production_activation=bool(
+                        activation_diagnostics.get(
+                            "production_activation"
+                        )
+                    ),
+                    selected_execution=str(
+                        activation_diagnostics.get(
+                            "selected_execution"
+                        )
+                        or ""
+                    ),
+                    observation_ready=(
+                        observation.ready
+                    ),
+                    input_parity_verified=(
+                        observation.input_parity_verified
+                    ),
+                    seed_parity_verified=(
+                        observation.seed_parity_verified
+                    ),
+                    authoritative_source=str(
+                        shared_meta.get(
+                            "authoritative_source"
+                        )
+                        or ""
+                    ),
+                )
+            )
+
+            monitoring_record = None
+            if monitoring_eligibility["eligible"]:
+                monitoring_record = (
+                    CanonicalBaserunningProductionMonitoringRecord(
+                        game_pk=game_pk,
+                        game_date=str(
+                            matchup.get("game_date")
+                            or target_date
+                        ),
+                        canonical_run_id=str(
+                            shared_meta.get(
+                                "canonical_run_id"
+                            )
+                        ),
+                        observation_digest=(
+                            observation.digest
+                        ),
+                        paired_context_digest=(
+                            observation
+                            .paired_context_digest
+                        ),
+                        calibrated_transform_digest=(
+                            observation
+                            .calibrated_transform_digest
+                        ),
+                        simulation_count=int(
+                            shared_meta.get(
+                                "simulation_count"
+                            )
+                        ),
+                        status=observation.status,
+                        ready=observation.ready,
+                        production_activation=True,
+                        authoritative_source=(
+                            CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+                        ),
+                        payload={
+                            "observation": (
+                                observation_diagnostics
+                            ),
+                            "activation": (
+                                activation_diagnostics
+                            ),
+                            "production_execution": (
+                                canonical_production_shadow_execution
+                                .to_diagnostics()
+                            ),
+                            "trial_policy": (
+                                canonical_production_trial_policy
+                                .to_diagnostics()
+                            ),
+                            "evidence_discovery": (
+                                canonical_baserunning_evidence_discovery
+                                .to_diagnostics()
+                            ),
+                        },
+                    )
+                )
+
+            production_monitoring = (
+                materialize_canonical_baserunning_production_monitoring(
+                    session,
+                    eligibility=monitoring_eligibility,
+                    record=monitoring_record,
+                )
+            )
+            workspace[
+                "canonicalBaserunningProductionMonitoring"
+            ] = production_monitoring
+
+            if isinstance(shared_simulation, dict):
+                monitoring_diagnostics = (
+                    shared_simulation.setdefault(
+                        "diagnostics",
+                        {},
+                    )
+                )
+                if isinstance(
+                    monitoring_diagnostics,
+                    dict,
+                ):
+                    monitoring_diagnostics[
+                        "canonical_baserunning_"
+                        "production_monitoring"
+                    ] = production_monitoring
 
             if isinstance(shared_simulation, dict):
                 shared_diagnostics = (

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -650,3 +650,17 @@ from .production_trial_policy import (
     CanonicalProductionTrialPolicy,
     build_canonical_production_trial_policy,
 )
+
+
+from .production_monitoring_ledger import (
+    CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION,
+    CanonicalBaserunningProductionMonitoringRecord,
+    evaluate_canonical_production_monitoring_eligibility,
+    load_canonical_baserunning_production_observations,
+    materialize_canonical_baserunning_production_monitoring,
+    store_canonical_baserunning_production_observation,
+    summarize_canonical_baserunning_production_monitoring,
+)

--- a/mlb_app/simulation/shadow/production_monitoring_ledger.py
+++ b/mlb_app/simulation/shadow/production_monitoring_ledger.py
@@ -1,0 +1,448 @@
+"""Persistent canonical production-monitoring ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import hashlib
+import json
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from mlb_app.database import (
+    CanonicalBaserunningProductionObservation,
+)
+
+
+CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION = (
+    "canonical_baserunning_production_monitoring_v1"
+)
+CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET = 100
+CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE = (
+    "2026-07-26"
+)
+CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY = (
+    "canonical_event_driven_calibrated_baserunning"
+)
+_CANONICAL_PRODUCTION_MONITORING_PREGAME_STATUSES = (
+    "scheduled",
+    "preview",
+    "pre-game",
+    "pregame",
+    "warmup",
+)
+
+
+def _sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProductionMonitoringRecord:
+    game_pk: int
+    game_date: str
+    canonical_run_id: str
+    observation_digest: str
+    paired_context_digest: str
+    calibrated_transform_digest: str
+    simulation_count: int
+    status: str
+    ready: bool
+    production_activation: bool
+    authoritative_source: str
+    payload: Mapping[str, Any]
+    schema_version: str = (
+        CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError("game_pk must be positive")
+
+        date.fromisoformat(self.game_date)
+
+        for name, value in (
+            ("canonical_run_id", self.canonical_run_id),
+            ("observation_digest", self.observation_digest),
+            (
+                "paired_context_digest",
+                self.paired_context_digest,
+            ),
+            (
+                "calibrated_transform_digest",
+                self.calibrated_transform_digest,
+            ),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be non-empty")
+
+        if (
+            not isinstance(self.simulation_count, int)
+            or isinstance(self.simulation_count, bool)
+            or self.simulation_count <= 0
+        ):
+            raise ValueError(
+                "simulation_count must be positive"
+            )
+
+        if self.production_activation is not True:
+            raise ValueError(
+                "production monitoring requires activation"
+            )
+
+        if self.authoritative_source != (
+            CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        ):
+            raise ValueError(
+                "production monitoring requires canonical authority"
+            )
+
+        if self.schema_version != (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+        ):
+            raise ValueError(
+                "unsupported production monitoring version"
+            )
+
+    @property
+    def digest(self) -> str:
+        return _sha256(self.to_payload())
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "canonical_run_id": self.canonical_run_id,
+            "observation_digest": self.observation_digest,
+            "paired_context_digest": (
+                self.paired_context_digest
+            ),
+            "calibrated_transform_digest": (
+                self.calibrated_transform_digest
+            ),
+            "simulation_count": self.simulation_count,
+            "status": self.status,
+            "ready": self.ready,
+            "production_activation": (
+                self.production_activation
+            ),
+            "authoritative_source": (
+                self.authoritative_source
+            ),
+            "payload": dict(self.payload),
+        }
+
+
+
+def evaluate_canonical_production_monitoring_eligibility(
+    *,
+    game_date: str,
+    game_status: str,
+    activation_requested: bool,
+    production_activation: bool,
+    selected_execution: str,
+    observation_ready: bool,
+    input_parity_verified: bool,
+    seed_parity_verified: bool,
+    authoritative_source: str,
+) -> Dict[str, Any]:
+    parsed_game_date = date.fromisoformat(game_date)
+    monitoring_start = date.fromisoformat(
+        CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE
+    )
+    normalized_status = str(
+        game_status or ""
+    ).strip().lower()
+
+    checks = {
+        "inside_monitoring_window": (
+            parsed_game_date >= monitoring_start
+        ),
+        "pregame_status": (
+            normalized_status
+            in _CANONICAL_PRODUCTION_MONITORING_PREGAME_STATUSES
+        ),
+        "activation_requested": (
+            activation_requested is True
+        ),
+        "production_activation": (
+            production_activation is True
+        ),
+        "calibrated_selected": (
+            selected_execution == "calibrated"
+        ),
+        "observation_ready": observation_ready is True,
+        "input_parity_verified": (
+            input_parity_verified is True
+        ),
+        "seed_parity_verified": (
+            seed_parity_verified is True
+        ),
+        "canonical_authority": (
+            authoritative_source
+            == CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        ),
+    }
+    failures = tuple(
+        key
+        for key, passed in checks.items()
+        if not passed
+    )
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+        ),
+        "eligible": not failures,
+        "failures": failures,
+        "checks": checks,
+        "game_date": game_date,
+        "game_status": game_status,
+        "normalized_game_status": normalized_status,
+        "monitoring_start_date": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE
+        ),
+        "target_game_count": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "parameter_reselection_permitted": False,
+    }
+
+def store_canonical_baserunning_production_observation(
+    session: Session,
+    record: CanonicalBaserunningProductionMonitoringRecord,
+) -> Tuple[
+    CanonicalBaserunningProductionObservation,
+    bool,
+]:
+    if not isinstance(
+        record,
+        CanonicalBaserunningProductionMonitoringRecord,
+    ):
+        raise TypeError("record must be canonical")
+
+    existing = (
+        session.query(
+            CanonicalBaserunningProductionObservation
+        )
+        .filter(
+            CanonicalBaserunningProductionObservation
+            .observation_digest
+            == record.observation_digest
+        )
+        .first()
+    )
+
+    if existing is not None:
+        return existing, False
+
+    row = CanonicalBaserunningProductionObservation(
+        game_pk=record.game_pk,
+        game_date=date.fromisoformat(record.game_date),
+        canonical_run_id=record.canonical_run_id,
+        observation_digest=record.observation_digest,
+        paired_context_digest=(
+            record.paired_context_digest
+        ),
+        calibrated_transform_digest=(
+            record.calibrated_transform_digest
+        ),
+        simulation_count=record.simulation_count,
+        status=record.status,
+        ready=record.ready,
+        production_activation=(
+            record.production_activation
+        ),
+        authoritative_source=(
+            record.authoritative_source
+        ),
+        payload_json=record.to_payload(),
+    )
+    try:
+        with session.begin_nested():
+            session.add(row)
+            session.flush()
+    except IntegrityError:
+        existing = (
+            session.query(
+                CanonicalBaserunningProductionObservation
+            )
+            .filter(
+                CanonicalBaserunningProductionObservation
+                .observation_digest
+                == record.observation_digest
+            )
+            .first()
+        )
+        if existing is None:
+            raise
+        return existing, False
+
+    return row, True
+
+
+
+def materialize_canonical_baserunning_production_monitoring(
+    session: Session,
+    *,
+    eligibility: Mapping[str, Any],
+    record: Optional[
+        CanonicalBaserunningProductionMonitoringRecord
+    ] = None,
+) -> Dict[str, Any]:
+    if not isinstance(eligibility, Mapping):
+        raise TypeError("eligibility must be a mapping")
+
+    recorded = False
+    record_created = False
+    observation_digest = None
+
+    if eligibility.get("eligible") is True:
+        if not isinstance(
+            record,
+            CanonicalBaserunningProductionMonitoringRecord,
+        ):
+            raise TypeError(
+                "eligible monitoring requires a canonical record"
+            )
+
+        _, record_created = (
+            store_canonical_baserunning_production_observation(
+                session,
+                record,
+            )
+        )
+        recorded = True
+        observation_digest = record.observation_digest
+
+    rows = (
+        load_canonical_baserunning_production_observations(
+            session
+        )
+    )
+    summary = (
+        summarize_canonical_baserunning_production_monitoring(
+            rows
+        )
+    )
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+        ),
+        "recorded": recorded,
+        "record_created": record_created,
+        "observation_digest": observation_digest,
+        "eligibility": dict(eligibility),
+        "summary": summary,
+        "parameter_reselection_permitted": False,
+    }
+
+def load_canonical_baserunning_production_observations(
+    session: Session,
+) -> Tuple[
+    CanonicalBaserunningProductionObservation,
+    ...
+]:
+    return tuple(
+        session.query(
+            CanonicalBaserunningProductionObservation
+        )
+        .order_by(
+            CanonicalBaserunningProductionObservation
+            .game_date,
+            CanonicalBaserunningProductionObservation
+            .game_pk,
+            CanonicalBaserunningProductionObservation
+            .id,
+        )
+        .all()
+    )
+
+
+def summarize_canonical_baserunning_production_monitoring(
+    rows: Tuple[
+        CanonicalBaserunningProductionObservation,
+        ...
+    ],
+) -> Dict[str, Any]:
+    games: Dict[int, Any] = {}
+
+    for row in rows:
+        games.setdefault(row.game_pk, row)
+
+    selected = tuple(games.values())
+    ready_games = tuple(
+        row
+        for row in selected
+        if (
+            row.ready is True
+            and row.production_activation is True
+            and row.authoritative_source
+            == CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        )
+    )
+    transform_digests = tuple(
+        sorted(
+            {
+                row.calibrated_transform_digest
+                for row in selected
+            }
+        )
+    )
+    game_count = len(selected)
+    ready_game_count = len(ready_games)
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+        ),
+        "target_game_count": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "stored_observation_count": len(rows),
+        "unique_game_count": game_count,
+        "ready_game_count": ready_game_count,
+        "duplicate_observation_count": (
+            len(rows) - game_count
+        ),
+        "remaining_game_count": max(
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+            - ready_game_count,
+            0,
+        ),
+        "progress_rate": round(
+            min(
+                ready_game_count
+                / CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+                1.0,
+            ),
+            6,
+        ),
+        "monitoring_complete": (
+            ready_game_count
+            >= CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "transform_digests": transform_digests,
+        "transform_frozen": (
+            len(transform_digests) <= 1
+        ),
+        "parameter_reselection_permitted": False,
+        "production_activation": True,
+        "authoritative_source": (
+            CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        ),
+    }

--- a/tests/test_canonical_baserunning_production_monitoring_ledger.py
+++ b/tests/test_canonical_baserunning_production_monitoring_ledger.py
@@ -1,0 +1,296 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from mlb_app.database import Base
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION,
+    CanonicalBaserunningProductionMonitoringRecord,
+    evaluate_canonical_production_monitoring_eligibility,
+    load_canonical_baserunning_production_observations,
+    materialize_canonical_baserunning_production_monitoring,
+    store_canonical_baserunning_production_observation,
+    summarize_canonical_baserunning_production_monitoring,
+)
+
+
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(
+        bind=engine,
+        future=True,
+    )
+    return factory()
+
+
+def record(
+    game_pk=1,
+    game_date="2026-07-26",
+    observation_digest="a" * 64,
+):
+    return CanonicalBaserunningProductionMonitoringRecord(
+        game_pk=game_pk,
+        game_date=game_date,
+        canonical_run_id=f"canonical-{game_pk}",
+        observation_digest=observation_digest,
+        paired_context_digest="b" * 64,
+        calibrated_transform_digest="c" * 64,
+        simulation_count=250,
+        status="ready",
+        ready=True,
+        production_activation=True,
+        authoritative_source=(
+            CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        ),
+        payload={
+            "stolen_base_delta": 0.2,
+            "caught_stealing_delta": -0.1,
+        },
+    )
+
+
+def test_store_is_idempotent_by_observation_digest():
+    db = session()
+    first, first_created = (
+        store_canonical_baserunning_production_observation(
+            db,
+            record(),
+        )
+    )
+    second, second_created = (
+        store_canonical_baserunning_production_observation(
+            db,
+            record(),
+        )
+    )
+
+    assert first_created is True
+    assert second_created is False
+    assert first.id == second.id
+    assert len(
+        load_canonical_baserunning_production_observations(
+            db
+        )
+    ) == 1
+
+
+def test_summary_counts_unique_games():
+    db = session()
+
+    for game_pk in range(1, 4):
+        store_canonical_baserunning_production_observation(
+            db,
+            record(
+                game_pk=game_pk,
+                observation_digest=(
+                    f"{game_pk:064x}"
+                ),
+            ),
+        )
+
+    rows = (
+        load_canonical_baserunning_production_observations(
+            db
+        )
+    )
+    summary = (
+        summarize_canonical_baserunning_production_monitoring(
+            rows
+        )
+    )
+
+    assert summary["unique_game_count"] == 3
+    assert summary["ready_game_count"] == 3
+    assert summary["remaining_game_count"] == 97
+    assert summary["progress_rate"] == 0.03
+    assert summary["monitoring_complete"] is False
+    assert summary["transform_frozen"] is True
+    assert (
+        summary["parameter_reselection_permitted"]
+        is False
+    )
+
+
+def test_monitor_completes_at_100_unique_games():
+    db = session()
+
+    for game_pk in range(
+        1,
+        CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        + 1,
+    ):
+        store_canonical_baserunning_production_observation(
+            db,
+            record(
+                game_pk=game_pk,
+                observation_digest=(
+                    f"{game_pk:064x}"
+                ),
+            ),
+        )
+
+    summary = (
+        summarize_canonical_baserunning_production_monitoring(
+            load_canonical_baserunning_production_observations(
+                db
+            )
+        )
+    )
+
+    assert summary["ready_game_count"] == 100
+    assert summary["remaining_game_count"] == 0
+    assert summary["progress_rate"] == 1.0
+    assert summary["monitoring_complete"] is True
+
+
+def test_versions_are_explicit():
+    assert (
+        CANONICAL_BASERUNNING_PRODUCTION_MONITORING_VERSION
+        == "canonical_baserunning_production_monitoring_v1"
+    )
+    assert (
+        CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        == 100
+    )
+
+
+def eligibility(**overrides):
+    values = {
+        "game_date": "2026-07-26",
+        "game_status": "Scheduled",
+        "activation_requested": True,
+        "production_activation": True,
+        "selected_execution": "calibrated",
+        "observation_ready": True,
+        "input_parity_verified": True,
+        "seed_parity_verified": True,
+        "authoritative_source": (
+            CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY
+        ),
+    }
+    values.update(overrides)
+
+    return (
+        evaluate_canonical_production_monitoring_eligibility(
+            **values
+        )
+    )
+
+
+def test_ready_pregame_production_run_is_eligible():
+    result = eligibility()
+
+    assert result["eligible"] is True
+    assert result["failures"] == ()
+    assert (
+        result["monitoring_start_date"]
+        == CANONICAL_BASERUNNING_PRODUCTION_MONITORING_START_DATE
+    )
+
+
+def test_historical_game_is_not_eligible():
+    result = eligibility(game_date="2026-07-25")
+
+    assert result["eligible"] is False
+    assert (
+        "inside_monitoring_window"
+        in result["failures"]
+    )
+
+
+def test_final_and_live_games_are_not_eligible():
+    for status in (
+        "Game Over",
+        "Final",
+        "In Progress",
+        "Delayed",
+        "Postponed",
+    ):
+        result = eligibility(game_status=status)
+
+        assert result["eligible"] is False
+        assert "pregame_status" in result["failures"]
+
+
+def test_fallback_and_parity_failures_are_not_eligible():
+    fallback = eligibility(
+        production_activation=False,
+        selected_execution="legacy_fallback",
+        authoritative_source="legacy",
+    )
+    parity = eligibility(
+        input_parity_verified=False,
+        seed_parity_verified=False,
+    )
+
+    assert fallback["eligible"] is False
+    assert "production_activation" in fallback["failures"]
+    assert "calibrated_selected" in fallback["failures"]
+    assert "canonical_authority" in fallback["failures"]
+    assert parity["eligible"] is False
+    assert (
+        "input_parity_verified"
+        in parity["failures"]
+    )
+    assert "seed_parity_verified" in parity["failures"]
+
+
+def test_materializer_records_only_eligible_runs():
+    db = session()
+    eligible = eligibility()
+    skipped = eligibility(game_status="Game Over")
+
+    recorded = (
+        materialize_canonical_baserunning_production_monitoring(
+            db,
+            eligibility=eligible,
+            record=record(),
+        )
+    )
+    not_recorded = (
+        materialize_canonical_baserunning_production_monitoring(
+            db,
+            eligibility=skipped,
+        )
+    )
+
+    assert recorded["recorded"] is True
+    assert recorded["record_created"] is True
+    assert recorded["summary"]["unique_game_count"] == 1
+    assert not_recorded["recorded"] is False
+    assert not_recorded["record_created"] is False
+    assert (
+        not_recorded["summary"]["unique_game_count"]
+        == 1
+    )
+
+
+def test_materializer_is_idempotent():
+    db = session()
+    candidate = record()
+
+    first = (
+        materialize_canonical_baserunning_production_monitoring(
+            db,
+            eligibility=eligibility(),
+            record=candidate,
+        )
+    )
+    second = (
+        materialize_canonical_baserunning_production_monitoring(
+            db,
+            eligibility=eligibility(),
+            record=candidate,
+        )
+    )
+
+    assert first["record_created"] is True
+    assert second["recorded"] is True
+    assert second["record_created"] is False
+    assert second["summary"]["stored_observation_count"] == 1

--- a/tests/test_model_projection_canonical_production_execution.py
+++ b/tests/test_model_projection_canonical_production_execution.py
@@ -28,3 +28,32 @@ def test_initial_execution_does_not_replace_legacy():
     assert expected_contract[
         "authoritative_source"
     ] == "legacy"
+
+
+def test_baserunning_fail_open_constructor_matches_contract():
+    import inspect
+
+    from mlb_app.simulation.shadow import (
+        CanonicalShadowBaserunningEvidenceDiscovery,
+    )
+
+    parameters = inspect.signature(
+        CanonicalShadowBaserunningEvidenceDiscovery
+    ).parameters
+
+    assert "error_message" in parameters
+    assert "error_type" not in parameters
+
+    failure = (
+        CanonicalShadowBaserunningEvidenceDiscovery(
+            status="error",
+            error_message="production prior unavailable",
+        )
+    )
+
+    assert failure.status == "error"
+    assert (
+        failure.error_message
+        == "production prior unavailable"
+    )
+    assert failure.ready is False

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -367,6 +367,8 @@ def test_realism_payload_exposes_frontend_capability_aliases():
         realism["sacrifice_fly_scoring"]
         is True
     )
+    assert realism["stolen_bases"] is True
+    assert realism["stolen_base_model"] is True
     assert realism["steals_model_status"] == (
         "canonical_calibrated_active"
     )


### PR DESCRIPTION
## Summary

- persist an idempotent ledger for the 100-game calibrated baserunning production-monitoring window
- record only eligible pregame canonical production runs with verified input and seed parity
- retain the frozen calibrated transform and prohibit parameter reselection during the monitoring window
- expose progress, readiness, transform state, and recording eligibility through Model Projections diagnostics
- distinguish authoritative production execution from shadow execution in the frontend
- clarify global-profile fallback coverage labels and surface stolen bases as active
- repair the canonical baserunning evidence fail-open constructor path

## Monitoring behavior

Each eligible observation stores the game identity, canonical run ID, observation and paired-context digests, calibrated transform digest, simulation count, authority, and immutable payload. Duplicate observations are ignored, completed/live games are excluded, and the summary tracks unique ready games toward the 100-game target.

The selected `0.52` attempt multiplier and `+0.09` success adjustment remain frozen throughout this window. This PR collects evidence; it does not automatically retune or reselect parameters.

## Validation

- 1,127 canonical and Model Projection backend tests passed
- 43 canonical diagnostics and projections frontend tests passed
- frontend production build completed successfully
- Python compilation passed
- generated SQLite schema and monitoring index validated
- positive runtime probe persisted one eligible observation idempotently
- negative scheduled-game probe failed open without recording an ineligible observation
- `git diff --check` passed

Known warnings are pre-existing SQLAlchemy/datetime deprecations, existing duplicate style keys in `LandingV2Page.jsx`, and the existing frontend bundle-size advisory.