### PR TITLE
Settle canonical production monitoring

### DIFF
--- a/docs/canonical_baserunning_production_monitoring.md
+++ b/docs/canonical_baserunning_production_monitoring.md
@@ -1,0 +1,37 @@
+# Canonical Baserunning Production Monitoring
+
+The calibrated canonical baserunning model is production authority while a
+frozen 100-game evidence window is collected.
+
+## Monitoring lifecycle
+
+1. Model Projections stores an immutable eligible pregame observation.
+2. A dedicated settlement cron checks pending observations.
+3. Only games MLB marks Final are sourced from the MLB schedule and play-by-play feed.
+4. Canonical parsing counts stolen bases and caught stealing.
+5. Exactly one immutable settlement is stored for each game.
+6. Diagnostics report pregame and settlement progress separately.
+7. Parameter review remains locked until 100 unique games are settled.
+
+Settlement does not rerun simulations, mutate pregame observations, change
+production authority, or automatically tune the calibrated transform.
+
+## Railway cron
+
+Create a dedicated Railway cron service with config file
+`railway.baserunning-settlement-cron.json` and schedule `0 * * * *`.
+
+The service must share the production `DATABASE_URL`. Do not set
+`MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE` in production.
+
+The start command is
+`python scripts/run_canonical_baserunning_production_settlement.py`.
+
+The runner is idempotent. It processes only pending observations whose MLB
+schedule state is Final and stores at most one settlement per game.
+
+## Review boundary
+
+The attempt multiplier and success-rate adjustment remain frozen throughout
+the monitoring window. Reaching 100 settled games permits human review; it
+does not automatically select or deploy new parameters.

--- a/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsUiContract.test.mjs
@@ -138,4 +138,9 @@ test('diagnostics distinguishes production monitoring', async () => {
     /Global Profile Fallback Rate/,
   )
   assert.match(source, /Parameter Reselection/)
+  assert.match(source, /Pregame Observation Progress/)
+  assert.match(source, /Settlement Progress/)
+  assert.match(source, /Settled Games/)
+  assert.match(source, /Stolen Base MAE/)
+  assert.match(source, /Caught Stealing MAE/)
 })

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -690,6 +690,9 @@ function buildProductionMonitoring(sharedSimulation) {
       .canonical_baserunning_production_monitoring
   )
   const summary = objectValue(report.summary)
+  const settlement = objectValue(
+    report.settlement
+  )
   const eligibility = objectValue(
     report.eligibility
   )
@@ -732,8 +735,49 @@ function buildProductionMonitoring(sharedSimulation) {
     transformDigests: arrayValue(
       summary.transform_digests
     ).map(String),
+    settledGameCount: finiteNumber(
+      settlement.settled_game_count
+    ),
+    settlementTargetGameCount: finiteNumber(
+      settlement.target_game_count
+    ),
+    settlementRemainingGameCount: finiteNumber(
+      settlement.remaining_game_count
+    ),
+    settlementProgressRate: finiteNumber(
+      settlement.progress_rate
+    ),
+    settlementComplete:
+      settlement.settlement_complete === true,
+    projectedStolenBases: finiteNumber(
+      settlement.projected_stolen_bases
+    ),
+    observedStolenBases: finiteNumber(
+      settlement.observed_stolen_bases
+    ),
+    stolenBaseBias: finiteNumber(
+      settlement.stolen_base_bias
+    ),
+    stolenBaseMae: finiteNumber(
+      settlement.stolen_base_mae
+    ),
+    projectedCaughtStealing: finiteNumber(
+      settlement.projected_caught_stealing
+    ),
+    observedCaughtStealing: finiteNumber(
+      settlement.observed_caught_stealing
+    ),
+    caughtStealingBias: finiteNumber(
+      settlement.caught_stealing_bias
+    ),
+    caughtStealingMae: finiteNumber(
+      settlement.caught_stealing_mae
+    ),
+    attemptMae: finiteNumber(
+      settlement.attempt_mae
+    ),
     parameterReselectionPermitted:
-      summary.parameter_reselection_permitted === true,
+      settlement.parameter_reselection_permitted === true,
   }
 }
 

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -642,6 +642,23 @@ test('exposes canonical production monitoring progress', () => {
       transform_digests: ['transform-1'],
       parameter_reselection_permitted: false,
     },
+    settlement: {
+      settled_game_count: 1,
+      target_game_count: 100,
+      remaining_game_count: 99,
+      progress_rate: 0.01,
+      settlement_complete: false,
+      projected_stolen_bases: 1.4,
+      observed_stolen_bases: 2,
+      stolen_base_bias: -0.6,
+      stolen_base_mae: 0.6,
+      projected_caught_stealing: 0.3,
+      observed_caught_stealing: 1,
+      caught_stealing_bias: -0.7,
+      caught_stealing_mae: 0.7,
+      attempt_mae: 1.3,
+      parameter_reselection_permitted: false,
+    },
   }
 
   const view = (
@@ -668,6 +685,28 @@ test('exposes canonical production monitoring progress', () => {
   assert.equal(
     view.productionMonitoring.transformFrozen,
     true,
+  )
+  assert.equal(
+    view.productionMonitoring.settledGameCount,
+    1,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .settlementRemainingGameCount,
+    99,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .settlementProgressRate,
+    0.01,
+  )
+  assert.equal(
+    view.productionMonitoring.stolenBaseBias,
+    -0.6,
+  )
+  assert.equal(
+    view.productionMonitoring.attemptMae,
+    1.3,
   )
   assert.equal(
     view.productionMonitoring

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1520,34 +1520,44 @@ function DiagnosticsTab({ game }) {
             title="Production Baserunning Monitoring"
             subtitle="Frozen 100-game evidence window"
             tag={
-              monitoring.monitoringComplete
+              monitoring.settlementComplete
                 ? 'Review ready'
                 : 'Collecting'
             }
             tagTone={
-              monitoring.monitoringComplete
+              monitoring.settlementComplete
                 ? 'success'
                 : 'diagnostic'
             }
           >
             <StatRow
-              k="Progress"
+              k="Pregame Observation Progress"
               v={monitoring.progressRate}
               format="pct"
             />
             <StatRow
-              k="Ready Games"
+              k="Pregame Observations"
               v={monitoring.readyGameCount}
               format="num"
             />
             <StatRow
-              k="Target Games"
-              v={monitoring.targetGameCount}
+              k="Settlement Progress"
+              v={monitoring.settlementProgressRate}
+              format="pct"
+            />
+            <StatRow
+              k="Settled Games"
+              v={monitoring.settledGameCount}
               format="num"
             />
             <StatRow
-              k="Games Remaining"
-              v={monitoring.remainingGameCount}
+              k="Target Settled Games"
+              v={monitoring.settlementTargetGameCount}
+              format="num"
+            />
+            <StatRow
+              k="Settlements Remaining"
+              v={monitoring.settlementRemainingGameCount}
               format="num"
             />
             <StatRow
@@ -1555,6 +1565,55 @@ function DiagnosticsTab({ game }) {
               v={monitoring.recorded ? 'Yes' : 'No'}
               format="text"
             />
+            {monitoring.settledGameCount > 0 ? (
+              <>
+                <StatRow
+                  k="Projected Stolen Bases"
+                  v={monitoring.projectedStolenBases}
+                  format="num"
+                />
+                <StatRow
+                  k="Observed Stolen Bases"
+                  v={monitoring.observedStolenBases}
+                  format="num"
+                />
+                <StatRow
+                  k="Stolen Base Bias"
+                  v={monitoring.stolenBaseBias}
+                  format="num"
+                />
+                <StatRow
+                  k="Stolen Base MAE"
+                  v={monitoring.stolenBaseMae}
+                  format="num"
+                />
+                <StatRow
+                  k="Projected Caught Stealing"
+                  v={monitoring.projectedCaughtStealing}
+                  format="num"
+                />
+                <StatRow
+                  k="Observed Caught Stealing"
+                  v={monitoring.observedCaughtStealing}
+                  format="num"
+                />
+                <StatRow
+                  k="Caught Stealing Bias"
+                  v={monitoring.caughtStealingBias}
+                  format="num"
+                />
+                <StatRow
+                  k="Caught Stealing MAE"
+                  v={monitoring.caughtStealingMae}
+                  format="num"
+                />
+                <StatRow
+                  k="Attempt MAE"
+                  v={monitoring.attemptMae}
+                  format="num"
+                />
+              </>
+            ) : null}
             <StatRow
               k="Transform Frozen"
               v={

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -459,6 +459,85 @@ class CanonicalBaserunningProductionObservation(Base):
     )
 
 
+class CanonicalBaserunningProductionSettlement(Base):
+    """Immutable postgame settlement for one production observation."""
+
+    __tablename__ = (
+        "canonical_baserunning_production_settlements"
+    )
+
+    id: int = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+    )
+    monitoring_observation_digest: str = Column(
+        String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    settlement_digest: str = Column(
+        String(64),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    game_pk: int = Column(
+        Integer,
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    game_date: date = Column(
+        Date,
+        nullable=False,
+        index=True,
+    )
+    canonical_run_id: str = Column(
+        String(128),
+        nullable=False,
+    )
+    observed_source_version: str = Column(
+        String(96),
+        nullable=False,
+    )
+    observed_source_digest: str = Column(
+        String(64),
+        nullable=False,
+    )
+    observed_stolen_bases: int = Column(
+        Integer,
+        nullable=False,
+    )
+    observed_caught_stealing: int = Column(
+        Integer,
+        nullable=False,
+    )
+    comparison_json = Column(
+        JSON,
+        nullable=False,
+    )
+    payload_json = Column(
+        JSON,
+        nullable=False,
+    )
+    created_at: datetime = Column(
+        DateTime,
+        default=datetime.utcnow,
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_canonical_baserunning_settlement_game",
+            "game_date",
+            "game_pk",
+        ),
+    )
+
+
+
 class AppGlobalSetting(Base):
     __tablename__ = "app_global_settings"
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -41,7 +41,9 @@ from mlb_app.simulation.shadow import (
     discover_confirmed_catcher_assignments,
     execute_live_baserunning_shadow_pair,
     load_baserunning_production_prior,
+    load_canonical_baserunning_production_settlements,
     run_canonical_production_shadow,
+    summarize_canonical_baserunning_production_settlements,
 )
 
 
@@ -1334,6 +1336,16 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                     record=monitoring_record,
                 )
             )
+            settlement_summary = (
+                summarize_canonical_baserunning_production_settlements(
+                    load_canonical_baserunning_production_settlements(
+                        session
+                    )
+                )
+            )
+            production_monitoring[
+                "settlement"
+            ] = settlement_summary
             workspace[
                 "canonicalBaserunningProductionMonitoring"
             ] = production_monitoring

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -664,3 +664,14 @@ from .production_monitoring_ledger import (
     store_canonical_baserunning_production_observation,
     summarize_canonical_baserunning_production_monitoring,
 )
+
+from .production_monitoring_settlement import (
+    CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION,
+    CanonicalBaserunningProductionSettlementRecord,
+    build_canonical_baserunning_production_settlement,
+    load_canonical_baserunning_production_settlements,
+    load_pending_canonical_baserunning_production_observations,
+    materialize_canonical_baserunning_production_settlements,
+    store_canonical_baserunning_production_settlement,
+    summarize_canonical_baserunning_production_settlements,
+)

--- a/mlb_app/simulation/shadow/production_monitoring_settlement.py
+++ b/mlb_app/simulation/shadow/production_monitoring_settlement.py
@@ -1,0 +1,902 @@
+"""Settle canonical production baserunning observations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from mlb_app.database import (
+    CanonicalBaserunningProductionObservation,
+    CanonicalBaserunningProductionSettlement,
+)
+
+from .mlb_play_by_play_baserunning_source import (
+    CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    CanonicalMlbPlayByPlayBaserunningSnapshot,
+)
+from .production_monitoring_ledger import (
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+)
+
+
+CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION = (
+    "canonical_baserunning_production_settlement_v1"
+)
+
+_FINAL_STATUSES = {
+    "final",
+    "game over",
+    "completed",
+}
+
+
+def _sha256(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _finite_nonnegative(
+    value: Any,
+    field_name: str,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < 0.0
+    ):
+        raise ValueError(
+            f"{field_name} must be nonnegative and finite"
+        )
+    return float(value)
+
+
+def _digest(value: Any, field_name: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in value
+        )
+    ):
+        raise ValueError(
+            f"{field_name} must be a SHA-256 digest"
+        )
+    return value
+
+
+def _mapping(
+    value: Any,
+    field_name: str,
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(
+            f"{field_name} must be a mapping"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProductionSettlementRecord:
+    monitoring_observation_digest: str
+    game_pk: int
+    game_date: str
+    canonical_run_id: str
+    projected_stolen_bases: float
+    projected_caught_stealing: float
+    observed_stolen_bases: int
+    observed_caught_stealing: int
+    observed_source_version: str
+    observed_source_digest: str
+    payload: Mapping[str, Any]
+    schema_version: str = (
+        CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        _digest(
+            self.monitoring_observation_digest,
+            "monitoring_observation_digest",
+        )
+        _digest(
+            self.observed_source_digest,
+            "observed_source_digest",
+        )
+
+        if (
+            not isinstance(self.game_pk, int)
+            or isinstance(self.game_pk, bool)
+            or self.game_pk <= 0
+        ):
+            raise ValueError(
+                "game_pk must be a positive integer"
+            )
+
+        parsed_date = date.fromisoformat(
+            self.game_date
+        )
+        if parsed_date.isoformat() != self.game_date:
+            raise ValueError(
+                "game_date must use ISO format"
+            )
+
+        if (
+            not isinstance(self.canonical_run_id, str)
+            or not self.canonical_run_id
+        ):
+            raise ValueError(
+                "canonical_run_id must be non-empty"
+            )
+
+        _finite_nonnegative(
+            self.projected_stolen_bases,
+            "projected_stolen_bases",
+        )
+        _finite_nonnegative(
+            self.projected_caught_stealing,
+            "projected_caught_stealing",
+        )
+
+        for field_name in (
+            "observed_stolen_bases",
+            "observed_caught_stealing",
+        ):
+            value = getattr(self, field_name)
+            if (
+                not isinstance(value, int)
+                or isinstance(value, bool)
+                or value < 0
+            ):
+                raise ValueError(
+                    f"{field_name} must be a "
+                    "nonnegative integer"
+                )
+
+        if (
+            not isinstance(
+                self.observed_source_version,
+                str,
+            )
+            or not self.observed_source_version
+        ):
+            raise ValueError(
+                "observed_source_version must be non-empty"
+            )
+
+        _mapping(self.payload, "payload")
+
+        if self.schema_version != (
+            CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION
+        ):
+            raise ValueError(
+                "unsupported production settlement version"
+            )
+
+    @property
+    def projected_attempts(self) -> float:
+        return round(
+            self.projected_stolen_bases
+            + self.projected_caught_stealing,
+            6,
+        )
+
+    @property
+    def observed_attempts(self) -> int:
+        return (
+            self.observed_stolen_bases
+            + self.observed_caught_stealing
+        )
+
+    @property
+    def projected_success_rate(self) -> Optional[float]:
+        if self.projected_attempts == 0.0:
+            return None
+        return round(
+            self.projected_stolen_bases
+            / self.projected_attempts,
+            6,
+        )
+
+    @property
+    def observed_success_rate(self) -> Optional[float]:
+        if self.observed_attempts == 0:
+            return None
+        return round(
+            self.observed_stolen_bases
+            / self.observed_attempts,
+            6,
+        )
+
+    @property
+    def comparison(self) -> Dict[str, Any]:
+        projected_success = self.projected_success_rate
+        observed_success = self.observed_success_rate
+
+        return {
+            "projected_stolen_bases": round(
+                self.projected_stolen_bases,
+                6,
+            ),
+            "observed_stolen_bases": (
+                self.observed_stolen_bases
+            ),
+            "stolen_base_error": round(
+                self.projected_stolen_bases
+                - self.observed_stolen_bases,
+                6,
+            ),
+            "stolen_base_absolute_error": round(
+                abs(
+                    self.projected_stolen_bases
+                    - self.observed_stolen_bases
+                ),
+                6,
+            ),
+            "projected_caught_stealing": round(
+                self.projected_caught_stealing,
+                6,
+            ),
+            "observed_caught_stealing": (
+                self.observed_caught_stealing
+            ),
+            "caught_stealing_error": round(
+                self.projected_caught_stealing
+                - self.observed_caught_stealing,
+                6,
+            ),
+            "caught_stealing_absolute_error": round(
+                abs(
+                    self.projected_caught_stealing
+                    - self.observed_caught_stealing
+                ),
+                6,
+            ),
+            "projected_attempts": (
+                self.projected_attempts
+            ),
+            "observed_attempts": self.observed_attempts,
+            "attempt_error": round(
+                self.projected_attempts
+                - self.observed_attempts,
+                6,
+            ),
+            "attempt_absolute_error": round(
+                abs(
+                    self.projected_attempts
+                    - self.observed_attempts
+                ),
+                6,
+            ),
+            "projected_success_rate": projected_success,
+            "observed_success_rate": observed_success,
+            "success_rate_absolute_error": (
+                None
+                if (
+                    projected_success is None
+                    or observed_success is None
+                )
+                else round(
+                    abs(
+                        projected_success
+                        - observed_success
+                    ),
+                    6,
+                )
+            ),
+        }
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "monitoring_observation_digest": (
+                self.monitoring_observation_digest
+            ),
+            "game_pk": self.game_pk,
+            "game_date": self.game_date,
+            "canonical_run_id": self.canonical_run_id,
+            "observed_source_version": (
+                self.observed_source_version
+            ),
+            "observed_source_digest": (
+                self.observed_source_digest
+            ),
+            "comparison": self.comparison,
+            "payload": dict(self.payload),
+            "parameter_reselection_permitted": False,
+            "production_authority_changed": False,
+        }
+
+    @property
+    def digest(self) -> str:
+        return _sha256(self.to_payload())
+
+
+def _calibrated_validation(
+    observation: CanonicalBaserunningProductionObservation,
+) -> Mapping[str, Any]:
+    root = _mapping(
+        observation.payload_json,
+        "monitoring payload",
+    )
+    payload = _mapping(
+        root.get("payload"),
+        "monitoring payload.payload",
+    )
+    source_observation = _mapping(
+        payload.get("observation"),
+        "monitoring observation",
+    )
+    return _mapping(
+        source_observation.get(
+            "calibrated_validation"
+        ),
+        "calibrated validation",
+    )
+
+
+def build_canonical_baserunning_production_settlement(
+    *,
+    observation: CanonicalBaserunningProductionObservation,
+    observed_game: CanonicalMlbPlayByPlayBaserunningGame,
+    observed_source_digest: str,
+    final_status: str,
+) -> CanonicalBaserunningProductionSettlementRecord:
+    if not isinstance(
+        observation,
+        CanonicalBaserunningProductionObservation,
+    ):
+        raise TypeError(
+            "observation must be a canonical "
+            "production monitoring observation"
+        )
+    if not isinstance(
+        observed_game,
+        CanonicalMlbPlayByPlayBaserunningGame,
+    ):
+        raise TypeError(
+            "observed_game must be canonical MLB "
+            "play-by-play baserunning evidence"
+        )
+
+    if str(final_status).strip().lower() not in (
+        _FINAL_STATUSES
+    ):
+        raise ValueError(
+            "settlement requires a final game status"
+        )
+
+    if observation.game_pk != observed_game.game_pk:
+        raise ValueError(
+            "observed game_pk must match monitoring "
+            "observation"
+        )
+    if (
+        observation.game_date.isoformat()
+        != observed_game.game_date
+    ):
+        raise ValueError(
+            "observed game_date must match monitoring "
+            "observation"
+        )
+
+    validation = _calibrated_validation(
+        observation
+    )
+
+    return CanonicalBaserunningProductionSettlementRecord(
+        monitoring_observation_digest=(
+            observation.observation_digest
+        ),
+        game_pk=observation.game_pk,
+        game_date=observation.game_date.isoformat(),
+        canonical_run_id=observation.canonical_run_id,
+        projected_stolen_bases=(
+            _finite_nonnegative(
+                validation.get(
+                    "stolen_base_mean_total"
+                ),
+                "stolen_base_mean_total",
+            )
+        ),
+        projected_caught_stealing=(
+            _finite_nonnegative(
+                validation.get(
+                    "caught_stealing_mean_total"
+                ),
+                "caught_stealing_mean_total",
+            )
+        ),
+        observed_stolen_bases=(
+            observed_game.stolen_bases
+        ),
+        observed_caught_stealing=(
+            observed_game.caught_stealing
+        ),
+        observed_source_version=(
+            CANONICAL_MLB_PLAY_BY_PLAY_BASERUNNING_SOURCE_VERSION
+        ),
+        observed_source_digest=(
+            _digest(
+                observed_source_digest,
+                "observed_source_digest",
+            )
+        ),
+        payload={
+            "final_status": final_status,
+            "monitoring_schema_version": (
+                observation.payload_json.get(
+                    "schema_version"
+                )
+            ),
+            "calibrated_transform_digest": (
+                observation.calibrated_transform_digest
+            ),
+        },
+    )
+
+
+def store_canonical_baserunning_production_settlement(
+    session: Session,
+    record: CanonicalBaserunningProductionSettlementRecord,
+) -> Tuple[
+    CanonicalBaserunningProductionSettlement,
+    bool,
+]:
+    if not isinstance(
+        record,
+        CanonicalBaserunningProductionSettlementRecord,
+    ):
+        raise TypeError(
+            "record must be a canonical production "
+            "settlement"
+        )
+
+    existing = (
+        session.query(
+            CanonicalBaserunningProductionSettlement
+        )
+        .filter(
+            CanonicalBaserunningProductionSettlement
+            .monitoring_observation_digest
+            == record.monitoring_observation_digest
+        )
+        .one_or_none()
+    )
+    if existing is not None:
+        if existing.settlement_digest != record.digest:
+            raise ValueError(
+                "monitoring observation already has a "
+                "different settlement"
+            )
+        return existing, False
+
+    existing_game = (
+        session.query(
+            CanonicalBaserunningProductionSettlement
+        )
+        .filter(
+            CanonicalBaserunningProductionSettlement
+            .game_pk
+            == record.game_pk
+        )
+        .one_or_none()
+    )
+    if existing_game is not None:
+        if (
+            existing_game.monitoring_observation_digest
+            != record.monitoring_observation_digest
+        ):
+            raise ValueError(
+                "game already has a settlement from a "
+                "different monitoring observation"
+            )
+        if existing_game.settlement_digest != record.digest:
+            raise ValueError(
+                "game already has a different settlement"
+            )
+        return existing_game, False
+
+    row = CanonicalBaserunningProductionSettlement(
+        monitoring_observation_digest=(
+            record.monitoring_observation_digest
+        ),
+        settlement_digest=record.digest,
+        game_pk=record.game_pk,
+        game_date=date.fromisoformat(
+            record.game_date
+        ),
+        canonical_run_id=record.canonical_run_id,
+        observed_source_version=(
+            record.observed_source_version
+        ),
+        observed_source_digest=(
+            record.observed_source_digest
+        ),
+        observed_stolen_bases=(
+            record.observed_stolen_bases
+        ),
+        observed_caught_stealing=(
+            record.observed_caught_stealing
+        ),
+        comparison_json=record.comparison,
+        payload_json=record.to_payload(),
+    )
+
+    try:
+        with session.begin_nested():
+            session.add(row)
+            session.flush()
+    except IntegrityError:
+        existing = (
+            session.query(
+                CanonicalBaserunningProductionSettlement
+            )
+            .filter(
+                CanonicalBaserunningProductionSettlement
+                .monitoring_observation_digest
+                == record.monitoring_observation_digest
+            )
+            .one_or_none()
+        )
+        if existing is None:
+            raise
+        if existing.settlement_digest != record.digest:
+            raise ValueError(
+                "monitoring observation already has a "
+                "different settlement"
+            )
+        return existing, False
+
+    return row, True
+
+
+def load_canonical_baserunning_production_settlements(
+    session: Session,
+) -> Tuple[
+    CanonicalBaserunningProductionSettlement,
+    ...,
+]:
+    return tuple(
+        session.query(
+            CanonicalBaserunningProductionSettlement
+        )
+        .order_by(
+            CanonicalBaserunningProductionSettlement
+            .game_date,
+            CanonicalBaserunningProductionSettlement
+            .game_pk,
+        )
+        .all()
+    )
+
+
+def summarize_canonical_baserunning_production_settlements(
+    rows: Tuple[
+        CanonicalBaserunningProductionSettlement,
+        ...,
+    ],
+) -> Dict[str, Any]:
+    if not isinstance(rows, tuple):
+        raise TypeError(
+            "settlement rows must be a tuple"
+        )
+
+    settled_count = len(rows)
+    projected_sb = sum(
+        float(
+            row.comparison_json[
+                "projected_stolen_bases"
+            ]
+        )
+        for row in rows
+    )
+    observed_sb = sum(
+        row.observed_stolen_bases
+        for row in rows
+    )
+    projected_cs = sum(
+        float(
+            row.comparison_json[
+                "projected_caught_stealing"
+            ]
+        )
+        for row in rows
+    )
+    observed_cs = sum(
+        row.observed_caught_stealing
+        for row in rows
+    )
+
+    def mean(key: str) -> float:
+        if not rows:
+            return 0.0
+        return round(
+            sum(
+                float(row.comparison_json[key])
+                for row in rows
+            )
+            / len(rows),
+            6,
+        )
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION
+        ),
+        "settled_game_count": settled_count,
+        "target_game_count": (
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "remaining_game_count": max(
+            0,
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+            - settled_count,
+        ),
+        "progress_rate": round(
+            min(
+                settled_count
+                / CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+                1.0,
+            ),
+            6,
+        ),
+        "settlement_complete": (
+            settled_count
+            >= CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "projected_stolen_bases": round(
+            projected_sb,
+            6,
+        ),
+        "observed_stolen_bases": observed_sb,
+        "stolen_base_bias": round(
+            projected_sb - observed_sb,
+            6,
+        ),
+        "stolen_base_mae": mean(
+            "stolen_base_absolute_error"
+        ),
+        "projected_caught_stealing": round(
+            projected_cs,
+            6,
+        ),
+        "observed_caught_stealing": observed_cs,
+        "caught_stealing_bias": round(
+            projected_cs - observed_cs,
+            6,
+        ),
+        "caught_stealing_mae": mean(
+            "caught_stealing_absolute_error"
+        ),
+        "attempt_mae": mean(
+            "attempt_absolute_error"
+        ),
+        "parameter_reselection_permitted": (
+            settled_count
+            >= CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        "production_authority_changed": False,
+    }
+
+
+def _canonical_observations_by_game(
+    session: Session,
+) -> Dict[
+    int,
+    CanonicalBaserunningProductionObservation,
+]:
+    """
+    Select the latest eligible stored observation for each game.
+
+    Multiple pregame refreshes may create distinct observation digests.
+    Settlement uses exactly one observation per game: the latest persisted
+    eligible snapshot, with primary-key order as a deterministic tie-break.
+    """
+
+    rows = tuple(
+        session.query(
+            CanonicalBaserunningProductionObservation
+        )
+        .filter(
+            CanonicalBaserunningProductionObservation
+            .ready
+            .is_(True)
+        )
+        .filter(
+            CanonicalBaserunningProductionObservation
+            .production_activation
+            .is_(True)
+        )
+        .order_by(
+            CanonicalBaserunningProductionObservation
+            .game_date,
+            CanonicalBaserunningProductionObservation
+            .game_pk,
+            CanonicalBaserunningProductionObservation
+            .created_at,
+            CanonicalBaserunningProductionObservation
+            .id,
+        )
+        .all()
+    )
+
+    selected = {}
+    for row in rows:
+        selected[row.game_pk] = row
+
+    return selected
+
+
+def materialize_canonical_baserunning_production_settlements(
+    session: Session,
+    *,
+    observed: CanonicalMlbPlayByPlayBaserunningSnapshot,
+) -> Dict[str, Any]:
+    """
+    Settle canonical monitoring games covered by one completed-game snapshot.
+
+    The caller owns network access and transaction commit. Games absent from
+    the completed-game snapshot remain pending. Extraneous completed games
+    are reported but never persisted.
+    """
+
+    if not isinstance(
+        observed,
+        CanonicalMlbPlayByPlayBaserunningSnapshot,
+    ):
+        raise TypeError(
+            "observed must be a canonical MLB "
+            "play-by-play baserunning snapshot"
+        )
+
+    observations = _canonical_observations_by_game(
+        session
+    )
+    existing_rows = (
+        load_canonical_baserunning_production_settlements(
+            session
+        )
+    )
+    settled_game_ids = {
+        row.game_pk
+        for row in existing_rows
+    }
+
+    created_game_ids = []
+    reused_game_ids = []
+    unmatched_observed_game_ids = []
+
+    for observed_game in observed.games:
+        monitoring = observations.get(
+            observed_game.game_pk
+        )
+        if monitoring is None:
+            unmatched_observed_game_ids.append(
+                observed_game.game_pk
+            )
+            continue
+
+        settlement = (
+            build_canonical_baserunning_production_settlement(
+                observation=monitoring,
+                observed_game=observed_game,
+                observed_source_digest=observed.digest,
+                final_status="Final",
+            )
+        )
+        _, created = (
+            store_canonical_baserunning_production_settlement(
+                session,
+                settlement,
+            )
+        )
+
+        if created:
+            created_game_ids.append(
+                observed_game.game_pk
+            )
+        else:
+            reused_game_ids.append(
+                observed_game.game_pk
+            )
+
+    rows = (
+        load_canonical_baserunning_production_settlements(
+            session
+        )
+    )
+    summary = (
+        summarize_canonical_baserunning_production_settlements(
+            rows
+        )
+    )
+    final_settled_game_ids = {
+        row.game_pk
+        for row in rows
+    }
+    pending_game_ids = tuple(
+        sorted(
+            set(observations)
+            - final_settled_game_ids
+        )
+    )
+
+    return {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION
+        ),
+        "observed_source_version": (
+            observed.source_version
+        ),
+        "observed_source_digest": observed.digest,
+        "observed_game_count": observed.game_count,
+        "eligible_monitoring_game_count": len(
+            observations
+        ),
+        "previously_settled_game_count": len(
+            settled_game_ids
+        ),
+        "created_game_ids": tuple(
+            sorted(created_game_ids)
+        ),
+        "reused_game_ids": tuple(
+            sorted(reused_game_ids)
+        ),
+        "unmatched_observed_game_ids": tuple(
+            sorted(unmatched_observed_game_ids)
+        ),
+        "pending_game_ids": pending_game_ids,
+        "summary": summary,
+        "parameter_reselection_permitted": (
+            summary[
+                "parameter_reselection_permitted"
+            ]
+        ),
+        "production_authority_changed": False,
+    }
+
+
+def load_pending_canonical_baserunning_production_observations(
+    session: Session,
+) -> Tuple[
+    CanonicalBaserunningProductionObservation,
+    ...,
+]:
+    """Return one canonical unsettled observation per game."""
+
+    selected = _canonical_observations_by_game(
+        session
+    )
+    settled_game_ids = {
+        row.game_pk
+        for row in (
+            load_canonical_baserunning_production_settlements(
+                session
+            )
+        )
+    }
+
+    return tuple(
+        selected[game_pk]
+        for game_pk in sorted(
+            set(selected) - settled_game_ids,
+            key=lambda value: (
+                selected[value].game_date,
+                value,
+            ),
+        )
+    )

--- a/railway.baserunning-settlement-cron.json
+++ b/railway.baserunning-settlement-cron.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "startCommand": "python scripts/run_canonical_baserunning_production_settlement.py"
+  }
+}

--- a/scripts/run_canonical_baserunning_production_settlement.py
+++ b/scripts/run_canonical_baserunning_production_settlement.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Settle completed canonical baserunning production observations."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from copy import deepcopy
+from typing import Any, Callable, Dict, Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from mlb_app.database import (
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow import (
+    load_canonical_baserunning_production_settlements,
+    load_pending_canonical_baserunning_production_observations,
+    materialize_canonical_baserunning_production_settlements,
+    source_mlb_play_by_play_baserunning_window,
+    summarize_canonical_baserunning_production_settlements,
+)
+
+
+SCHEDULE_URL = (
+    "https://statsapi.mlb.com/api/v1/schedule"
+)
+GAME_FEED_URL = (
+    "https://statsapi.mlb.com/api/v1.1/game/"
+    "{game_pk}/feed/live"
+)
+USER_AGENT = (
+    "mlb-prediction-app/"
+    "canonical-baserunning-settlement-v1"
+)
+MAX_ATTEMPTS = 4
+TIMEOUT_SECONDS = 30
+
+
+def fetch_json(
+    url: str,
+    *,
+    max_attempts: int = MAX_ATTEMPTS,
+    timeout_seconds: int = TIMEOUT_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Mapping[str, Any]:
+    """Fetch one JSON payload with bounded exponential retry."""
+
+    if max_attempts <= 0:
+        raise ValueError(
+            "max_attempts must be positive"
+        )
+    if timeout_seconds <= 0:
+        raise ValueError(
+            "timeout_seconds must be positive"
+        )
+
+    last_error = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            request = Request(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": USER_AGENT,
+                },
+            )
+            with urlopen(
+                request,
+                timeout=timeout_seconds,
+            ) as response:
+                payload = json.load(response)
+
+            if not isinstance(payload, Mapping):
+                raise TypeError(
+                    "MLB response must be a mapping"
+                )
+            return payload
+        except (
+            HTTPError,
+            URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+        ) as exc:
+            last_error = exc
+
+            if attempt == max_attempts:
+                break
+
+            delay = 2 ** (attempt - 1)
+            print(
+                (
+                    "canonical_settlement_source_retry "
+                    f"attempt={attempt} "
+                    f"delay_seconds={delay} "
+                    f"error={type(exc).__name__}"
+                ),
+                file=sys.stderr,
+            )
+            sleep(delay)
+
+    raise RuntimeError(
+        "canonical settlement source unavailable"
+    ) from last_error
+
+
+def _schedule_url(
+    start_date: str,
+    end_date: str,
+) -> str:
+    return (
+        SCHEDULE_URL
+        + "?"
+        + urlencode(
+            {
+                "sportId": 1,
+                "startDate": start_date,
+                "endDate": end_date,
+            }
+        )
+    )
+
+
+def filter_schedule_to_pending_final_games(
+    schedule: Mapping[str, Any],
+    *,
+    pending_game_ids: set[int],
+) -> Dict[str, Any]:
+    """Keep only final games represented by pending observations."""
+
+    if not isinstance(schedule, Mapping):
+        raise TypeError(
+            "schedule must be a mapping"
+        )
+
+    filtered_dates = []
+
+    for raw_date in schedule.get("dates") or []:
+        if not isinstance(raw_date, Mapping):
+            raise TypeError(
+                "schedule date rows must be mappings"
+            )
+
+        games = []
+        for raw_game in raw_date.get("games") or []:
+            if not isinstance(raw_game, Mapping):
+                raise TypeError(
+                    "schedule games must be mappings"
+                )
+
+            try:
+                game_pk = int(
+                    raw_game.get("gamePk")
+                )
+            except (TypeError, ValueError):
+                continue
+
+            status = raw_game.get("status") or {}
+            abstract_state = str(
+                status.get(
+                    "abstractGameState",
+                    "",
+                )
+            ).strip()
+
+            if (
+                game_pk in pending_game_ids
+                and abstract_state == "Final"
+            ):
+                games.append(
+                    deepcopy(dict(raw_game))
+                )
+
+        if games:
+            date_row = deepcopy(dict(raw_date))
+            date_row["games"] = games
+            filtered_dates.append(date_row)
+
+    return {"dates": filtered_dates}
+
+
+def final_game_ids(
+    schedule: Mapping[str, Any],
+) -> tuple[int, ...]:
+    return tuple(
+        sorted(
+            int(game["gamePk"])
+            for date_row in (
+                schedule.get("dates") or []
+            )
+            for game in (
+                date_row.get("games") or []
+            )
+        )
+    )
+
+
+def run_canonical_baserunning_production_settlement(
+    session,
+    *,
+    fetcher: Callable[
+        [str],
+        Mapping[str, Any],
+    ] = fetch_json,
+) -> Dict[str, Any]:
+    """Fetch and settle all currently final pending games."""
+
+    pending = (
+        load_pending_canonical_baserunning_production_observations(
+            session
+        )
+    )
+
+    if not pending:
+        rows = (
+            load_canonical_baserunning_production_settlements(
+                session
+            )
+        )
+        return {
+            "status": "complete",
+            "pending_observation_count": 0,
+            "final_game_count": 0,
+            "created_game_ids": (),
+            "reused_game_ids": (),
+            "pending_game_ids": (),
+            "summary": (
+                summarize_canonical_baserunning_production_settlements(
+                    rows
+                )
+            ),
+        }
+
+    start_date = min(
+        row.game_date.isoformat()
+        for row in pending
+    )
+    end_date = max(
+        row.game_date.isoformat()
+        for row in pending
+    )
+    pending_game_ids = {
+        row.game_pk
+        for row in pending
+    }
+
+    schedule = fetcher(
+        _schedule_url(
+            start_date,
+            end_date,
+        )
+    )
+    filtered_schedule = (
+        filter_schedule_to_pending_final_games(
+            schedule,
+            pending_game_ids=pending_game_ids,
+        )
+    )
+    game_ids = final_game_ids(
+        filtered_schedule
+    )
+
+    if not game_ids:
+        rows = (
+            load_canonical_baserunning_production_settlements(
+                session
+            )
+        )
+        return {
+            "status": "waiting_for_final_games",
+            "window_start": start_date,
+            "window_end": end_date,
+            "pending_observation_count": len(
+                pending
+            ),
+            "final_game_count": 0,
+            "created_game_ids": (),
+            "reused_game_ids": (),
+            "pending_game_ids": tuple(
+                sorted(pending_game_ids)
+            ),
+            "summary": (
+                summarize_canonical_baserunning_production_settlements(
+                    rows
+                )
+            ),
+        }
+
+    game_feeds = {
+        game_pk: fetcher(
+            GAME_FEED_URL.format(
+                game_pk=game_pk
+            )
+        )
+        for game_pk in game_ids
+    }
+
+    observed = (
+        source_mlb_play_by_play_baserunning_window(
+            schedule=filtered_schedule,
+            game_feeds=game_feeds,
+            window_start=start_date,
+            window_end=end_date,
+        )
+    )
+    result = (
+        materialize_canonical_baserunning_production_settlements(
+            session,
+            observed=observed,
+        )
+    )
+    result["status"] = "settled"
+    result["window_start"] = start_date
+    result["window_end"] = end_date
+    result["pending_observation_count"] = len(
+        pending
+    )
+    result["final_game_count"] = len(
+        game_ids
+    )
+
+    return result
+
+
+def _database_url() -> str:
+    value = os.getenv("DATABASE_URL", "").strip()
+
+    if not value:
+        raise RuntimeError(
+            "DATABASE_URL is required for canonical "
+            "production settlement"
+        )
+
+    if (
+        value.startswith("sqlite")
+        and os.getenv(
+            "MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE",
+            "",
+        ).strip()
+        != "1"
+    ):
+        raise RuntimeError(
+            "canonical production settlement refuses "
+            "SQLite unless "
+            "MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE=1"
+        )
+
+    return value
+
+
+def main() -> int:
+    engine = get_engine(_database_url())
+    create_tables(engine)
+    session_factory = get_session(engine)
+
+    with session_factory() as session:
+        result = (
+            run_canonical_baserunning_production_settlement(
+                session
+            )
+        )
+        session.commit()
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+            default=str,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_canonical_baserunning_production_settlement.py
+++ b/tests/test_canonical_baserunning_production_settlement.py
@@ -1,0 +1,478 @@
+import hashlib
+from datetime import date
+
+import pytest
+
+from mlb_app.database import (
+    CanonicalBaserunningProductionObservation,
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow import (
+    CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION,
+    CanonicalMlbPlayByPlayBaserunningGame,
+    build_canonical_baserunning_production_settlement,
+    load_canonical_baserunning_production_settlements,
+    materialize_canonical_baserunning_production_settlements,
+    store_canonical_baserunning_production_settlement,
+    summarize_canonical_baserunning_production_settlements,
+    source_mlb_play_by_play_baserunning_window,
+)
+
+
+DIGEST = hashlib.sha256(b"monitoring").hexdigest()
+SOURCE_DIGEST = hashlib.sha256(b"source").hexdigest()
+
+
+def observation(
+    *,
+    game_pk=1,
+    game_date="2026-07-26",
+):
+    return CanonicalBaserunningProductionObservation(
+        game_pk=game_pk,
+        game_date=date.fromisoformat(game_date),
+        canonical_run_id="canonical-run",
+        observation_digest=DIGEST,
+        paired_context_digest=hashlib.sha256(
+            b"context"
+        ).hexdigest(),
+        calibrated_transform_digest=hashlib.sha256(
+            b"transform"
+        ).hexdigest(),
+        simulation_count=250,
+        status="ready",
+        ready=True,
+        production_activation=True,
+        authoritative_source=(
+            "canonical_event_driven_calibrated_baserunning"
+        ),
+        payload_json={
+            "schema_version": (
+                "canonical_baserunning_"
+                "production_monitoring_v1"
+            ),
+            "payload": {
+                "observation": {
+                    "calibrated_validation": {
+                        "stolen_base_mean_total": 1.4,
+                        "caught_stealing_mean_total": 0.3,
+                    },
+                },
+            },
+        },
+    )
+
+
+def observed(
+    *,
+    game_pk=1,
+    game_date="2026-07-26",
+    stolen_bases=2,
+    caught_stealing=1,
+):
+    return CanonicalMlbPlayByPlayBaserunningGame(
+        game_pk=game_pk,
+        game_date=game_date,
+        stolen_bases=stolen_bases,
+        caught_stealing=caught_stealing,
+    )
+
+
+def record(**overrides):
+    values = {
+        "observation": observation(),
+        "observed_game": observed(),
+        "observed_source_digest": SOURCE_DIGEST,
+        "final_status": "Final",
+    }
+    values.update(overrides)
+    return build_canonical_baserunning_production_settlement(
+        **values
+    )
+
+
+def session():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    return get_session(engine)()
+
+
+def test_builds_exact_per_game_comparison():
+    result = record()
+
+    assert result.projected_attempts == 1.7
+    assert result.observed_attempts == 3
+    assert result.comparison[
+        "stolen_base_error"
+    ] == -0.6
+    assert result.comparison[
+        "caught_stealing_error"
+    ] == -0.7
+    assert result.comparison[
+        "attempt_absolute_error"
+    ] == 1.3
+    assert result.observed_success_rate == 0.666667
+    assert len(result.digest) == 64
+
+
+def test_zero_activity_game_is_valid_truth():
+    result = record(
+        observed_game=observed(
+            stolen_bases=0,
+            caught_stealing=0,
+        )
+    )
+
+    assert result.observed_attempts == 0
+    assert result.observed_success_rate is None
+
+
+def test_identity_and_final_status_are_required():
+    with pytest.raises(
+        ValueError,
+        match="final game status",
+    ):
+        record(final_status="Scheduled")
+
+    with pytest.raises(
+        ValueError,
+        match="game_pk",
+    ):
+        record(
+            observed_game=observed(game_pk=2)
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="game_date",
+    ):
+        record(
+            observed_game=observed(
+                game_date="2026-07-27"
+            )
+        )
+
+
+def test_store_is_idempotent():
+    db = session()
+    value = record()
+
+    first, first_created = (
+        store_canonical_baserunning_production_settlement(
+            db,
+            value,
+        )
+    )
+    second, second_created = (
+        store_canonical_baserunning_production_settlement(
+            db,
+            value,
+        )
+    )
+
+    assert first.id == second.id
+    assert first_created is True
+    assert second_created is False
+    assert len(
+        load_canonical_baserunning_production_settlements(
+            db
+        )
+    ) == 1
+
+
+def test_conflicting_settlement_is_rejected():
+    db = session()
+    value = record()
+    store_canonical_baserunning_production_settlement(
+        db,
+        value,
+    )
+
+    changed = record(
+        observed_game=observed(stolen_bases=3)
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="different settlement",
+    ):
+        store_canonical_baserunning_production_settlement(
+            db,
+            changed,
+        )
+
+
+def test_summary_tracks_settled_games_and_errors():
+    db = session()
+    value = record()
+    store_canonical_baserunning_production_settlement(
+        db,
+        value,
+    )
+    rows = (
+        load_canonical_baserunning_production_settlements(
+            db
+        )
+    )
+    summary = (
+        summarize_canonical_baserunning_production_settlements(
+            rows
+        )
+    )
+
+    assert summary["settled_game_count"] == 1
+    assert summary["remaining_game_count"] == 99
+    assert summary["progress_rate"] == 0.01
+    assert summary["stolen_base_bias"] == -0.6
+    assert summary["stolen_base_mae"] == 0.6
+    assert (
+        summary["parameter_reselection_permitted"]
+        is False
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_BASERUNNING_PRODUCTION_SETTLEMENT_VERSION
+        == "canonical_baserunning_production_settlement_v1"
+    )
+
+
+
+def completed_snapshot(
+    *,
+    game_pk=1,
+    game_date="2026-07-26",
+    stolen_bases=2,
+    caught_stealing=1,
+):
+    runners = []
+
+    for index in range(stolen_bases):
+        runners.append(
+            {
+                "details": {
+                    "runner": {
+                        "id": 100 + index,
+                    },
+                    "eventType": "stolen_base_2b",
+                }
+            }
+        )
+
+    for index in range(caught_stealing):
+        runners.append(
+            {
+                "details": {
+                    "runner": {
+                        "id": 200 + index,
+                    },
+                    "eventType": "caught_stealing_2b",
+                }
+            }
+        )
+
+    return source_mlb_play_by_play_baserunning_window(
+        schedule={
+            "dates": [
+                {
+                    "date": game_date,
+                    "games": [
+                        {
+                            "gamePk": game_pk,
+                            "officialDate": game_date,
+                            "status": {
+                                "abstractGameState": "Final",
+                            },
+                        },
+                    ],
+                },
+            ],
+        },
+        game_feeds={
+            game_pk: {
+                "liveData": {
+                    "plays": {
+                        "allPlays": [
+                            {
+                                "about": {
+                                    "atBatIndex": 1,
+                                },
+                                "result": {
+                                    "eventType": "",
+                                },
+                                "runners": runners,
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        window_start=game_date,
+        window_end=game_date,
+    )
+
+
+def persist_observation(
+    db,
+    value=None,
+):
+    value = value or observation()
+    db.add(value)
+    db.flush()
+    return value
+
+
+def test_batch_settles_matching_completed_game():
+    db = session()
+    persist_observation(db)
+
+    result = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=completed_snapshot(),
+        )
+    )
+
+    assert result["created_game_ids"] == (1,)
+    assert result["reused_game_ids"] == ()
+    assert result["pending_game_ids"] == ()
+    assert result["summary"][
+        "settled_game_count"
+    ] == 1
+
+
+def test_batch_is_idempotent():
+    db = session()
+    persist_observation(db)
+    snapshot = completed_snapshot()
+
+    first = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=snapshot,
+        )
+    )
+    second = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=snapshot,
+        )
+    )
+
+    assert first["created_game_ids"] == (1,)
+    assert second["created_game_ids"] == ()
+    assert second["reused_game_ids"] == (1,)
+    assert second["summary"][
+        "settled_game_count"
+    ] == 1
+
+
+def test_batch_leaves_unobserved_monitoring_game_pending():
+    db = session()
+    pending = observation(
+        game_pk=2,
+        game_date="2026-07-27",
+    )
+    pending.observation_digest = hashlib.sha256(
+        b"pending"
+    ).hexdigest()
+
+    persist_observation(db, observation())
+    persist_observation(db, pending)
+
+    result = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=completed_snapshot(),
+        )
+    )
+
+    assert result["created_game_ids"] == (1,)
+    assert result["pending_game_ids"] == (2,)
+
+
+def test_batch_reports_extraneous_completed_game():
+    db = session()
+    persist_observation(db)
+
+    result = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=completed_snapshot(
+                game_pk=9,
+            ),
+        )
+    )
+
+    assert result["created_game_ids"] == ()
+    assert result[
+        "unmatched_observed_game_ids"
+    ] == (9,)
+    assert result["pending_game_ids"] == (1,)
+
+
+def test_latest_monitoring_observation_wins_per_game():
+    db = session()
+    first = observation()
+    second = observation()
+    second.observation_digest = hashlib.sha256(
+        b"second"
+    ).hexdigest()
+    second.canonical_run_id = "canonical-run-2"
+
+    persist_observation(db, first)
+    persist_observation(db, second)
+
+    result = (
+        materialize_canonical_baserunning_production_settlements(
+            db,
+            observed=completed_snapshot(),
+        )
+    )
+    rows = (
+        load_canonical_baserunning_production_settlements(
+            db
+        )
+    )
+
+    assert result["created_game_ids"] == (1,)
+    assert len(rows) == 1
+    assert rows[0].canonical_run_id == (
+        "canonical-run-2"
+    )
+
+
+def test_game_can_only_be_settled_once():
+    db = session()
+    first = observation()
+    persist_observation(db, first)
+
+    first_record = record(
+        observation=first,
+    )
+    store_canonical_baserunning_production_settlement(
+        db,
+        first_record,
+    )
+
+    second = observation()
+    second.observation_digest = hashlib.sha256(
+        b"second-game-observation"
+    ).hexdigest()
+    second.canonical_run_id = "canonical-run-2"
+
+    conflicting = record(
+        observation=second,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="different monitoring observation",
+    ):
+        store_canonical_baserunning_production_settlement(
+            db,
+            conflicting,
+        )

--- a/tests/test_canonical_baserunning_production_settlement_deployment.py
+++ b/tests/test_canonical_baserunning_production_settlement_deployment.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / "railway.baserunning-settlement-cron.json"
+DOCS_PATH = ROOT / "docs" / "canonical_baserunning_production_monitoring.md"
+RUNNER_PATH = ROOT / "scripts" / "run_canonical_baserunning_production_settlement.py"
+
+
+def test_settlement_cron_uses_dedicated_runner():
+    payload = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    assert payload["build"]["builder"] == "DOCKERFILE"
+    assert payload["deploy"]["startCommand"] == (
+        "python scripts/run_canonical_baserunning_production_settlement.py"
+    )
+    assert RUNNER_PATH.is_file()
+
+
+def test_settlement_operations_are_documented():
+    text = DOCS_PATH.read_text(encoding="utf-8")
+
+    assert "0 * * * *" in text
+    assert "DATABASE_URL" in text
+    assert "MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE" in text
+    assert "100 settled games" in text
+    assert "does not automatically" in text

--- a/tests/test_run_canonical_baserunning_production_settlement.py
+++ b/tests/test_run_canonical_baserunning_production_settlement.py
@@ -1,0 +1,250 @@
+import hashlib
+from datetime import date
+
+from mlb_app.database import (
+    CanonicalBaserunningProductionObservation,
+    create_tables,
+    get_engine,
+    get_session,
+)
+from scripts.run_canonical_baserunning_production_settlement import (
+    GAME_FEED_URL,
+    filter_schedule_to_pending_final_games,
+    run_canonical_baserunning_production_settlement,
+)
+
+
+def session():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    return get_session(engine)()
+
+
+def observation(
+    *,
+    game_pk=1,
+    game_date="2026-07-26",
+):
+    digest = hashlib.sha256(
+        f"observation-{game_pk}".encode()
+    ).hexdigest()
+
+    return CanonicalBaserunningProductionObservation(
+        game_pk=game_pk,
+        game_date=date.fromisoformat(game_date),
+        canonical_run_id=f"run-{game_pk}",
+        observation_digest=digest,
+        paired_context_digest=hashlib.sha256(
+            f"context-{game_pk}".encode()
+        ).hexdigest(),
+        calibrated_transform_digest=hashlib.sha256(
+            b"transform"
+        ).hexdigest(),
+        simulation_count=250,
+        status="ready",
+        ready=True,
+        production_activation=True,
+        authoritative_source=(
+            "canonical_event_driven_calibrated_baserunning"
+        ),
+        payload_json={
+            "schema_version": (
+                "canonical_baserunning_"
+                "production_monitoring_v1"
+            ),
+            "payload": {
+                "observation": {
+                    "calibrated_validation": {
+                        "stolen_base_mean_total": 1.2,
+                        "caught_stealing_mean_total": 0.2,
+                    },
+                },
+            },
+        },
+    )
+
+
+def schedule(
+    *,
+    game_pk=1,
+    state="Final",
+):
+    return {
+        "dates": [
+            {
+                "date": "2026-07-26",
+                "games": [
+                    {
+                        "gamePk": game_pk,
+                        "officialDate": "2026-07-26",
+                        "status": {
+                            "abstractGameState": state,
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def feed():
+    return {
+        "liveData": {
+            "plays": {
+                "allPlays": [
+                    {
+                        "about": {
+                            "atBatIndex": 1,
+                        },
+                        "result": {
+                            "eventType": "",
+                        },
+                        "runners": [
+                            {
+                                "details": {
+                                    "runner": {
+                                        "id": 10,
+                                    },
+                                    "eventType": (
+                                        "stolen_base_2b"
+                                    ),
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    }
+
+
+def test_filter_keeps_only_pending_final_games():
+    value = {
+        "dates": [
+            {
+                "date": "2026-07-26",
+                "games": [
+                    schedule(
+                        game_pk=1
+                    )["dates"][0]["games"][0],
+                    schedule(
+                        game_pk=2,
+                        state="Live",
+                    )["dates"][0]["games"][0],
+                    schedule(
+                        game_pk=3,
+                    )["dates"][0]["games"][0],
+                ],
+            },
+        ],
+    }
+
+    result = (
+        filter_schedule_to_pending_final_games(
+            value,
+            pending_game_ids={1, 2},
+        )
+    )
+
+    assert [
+        game["gamePk"]
+        for game in result["dates"][0]["games"]
+    ] == [1]
+
+
+def test_runner_settles_final_pending_game():
+    db = session()
+    db.add(observation())
+    db.flush()
+    urls = []
+
+    def fetcher(url):
+        urls.append(url)
+        if "schedule" in url:
+            return schedule()
+        return feed()
+
+    result = (
+        run_canonical_baserunning_production_settlement(
+            db,
+            fetcher=fetcher,
+        )
+    )
+
+    assert result["status"] == "settled"
+    assert result["created_game_ids"] == (1,)
+    assert result["pending_game_ids"] == ()
+    assert len(urls) == 2
+    assert urls[1] == GAME_FEED_URL.format(
+        game_pk=1
+    )
+
+
+def test_runner_leaves_nonfinal_game_pending():
+    db = session()
+    db.add(observation())
+    db.flush()
+
+    result = (
+        run_canonical_baserunning_production_settlement(
+            db,
+            fetcher=lambda url: schedule(
+                state="Live"
+            ),
+        )
+    )
+
+    assert (
+        result["status"]
+        == "waiting_for_final_games"
+    )
+    assert result["pending_game_ids"] == (1,)
+    assert result["summary"][
+        "settled_game_count"
+    ] == 0
+
+
+def test_runner_without_pending_work_is_noop():
+    db = session()
+    calls = []
+
+    result = (
+        run_canonical_baserunning_production_settlement(
+            db,
+            fetcher=lambda url: calls.append(url),
+        )
+    )
+
+    assert result["status"] == "complete"
+    assert calls == []
+    assert result["pending_observation_count"] == 0
+
+
+def test_runner_is_idempotent():
+    db = session()
+    db.add(observation())
+    db.flush()
+
+    def fetcher(url):
+        if "schedule" in url:
+            return schedule()
+        return feed()
+
+    first = (
+        run_canonical_baserunning_production_settlement(
+            db,
+            fetcher=fetcher,
+        )
+    )
+    second = (
+        run_canonical_baserunning_production_settlement(
+            db,
+            fetcher=fetcher,
+        )
+    )
+
+    assert first["created_game_ids"] == (1,)
+    assert second["status"] == "complete"
+    assert second["summary"][
+        "settled_game_count"
+    ] == 1


### PR DESCRIPTION
## Summary

- settle immutable canonical baserunning pregame observations against final MLB play-by-play outcomes
- persist one digest-verified stolen-base/caught-stealing settlement per game
- aggregate projected-versus-observed bias and error across the frozen 100-game window
- keep parameter reselection locked until 100 unique games have settled
- surface observation and settlement progress separately in Model Projections diagnostics
- add an idempotent production settlement runner and dedicated Railway cron contract
- document the production monitoring lifecycle and operational requirements

## Production behavior

The settlement runner checks only pending monitoring observations, verifies that MLB marks each game Final, parses the canonical MLB play-by-play source, and stores at most one immutable settlement per game. It does not rerun simulations, mutate pregame observations, change production authority, or automatically tune parameters.

The selected attempt multiplier and success-rate adjustment remain frozen throughout the 100-game monitoring window. Completion permits human review only.

## Deployment

Create a dedicated Railway cron service using `railway.baserunning-settlement-cron.json`, share the production `DATABASE_URL`, and schedule it hourly with `0 * * * *`. Do not set `MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE` in production.

## Validation

- 1,152 canonical/model-projection backend tests passed; 2 known unrelated baseline failures explicitly deselected
- 43 canonical diagnostics/projections frontend tests passed
- frontend production build passed
- settlement and deployment guard tests passed
- owned Python modules compiled successfully
- production monitoring and settlement schemas validated with required columns and unique indexes
- real MLB-feed smoke settled game `822706` idempotently and preserved zero stolen-base activity
- `git diff --check` passed

## Notes

The existing unrelated untracked analysis scripts are intentionally excluded from this pull request.