### PR TITLE
Fail open settlement diagnostics

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -47,6 +47,49 @@ from mlb_app.simulation.shadow import (
 )
 
 
+def _load_production_settlement_diagnostics(
+    session: Session,
+) -> Dict[str, Any]:
+    # Optional settlement storage must never suppress projection games.
+
+    try:
+        with session.begin_nested():
+            rows = (
+                load_canonical_baserunning_production_settlements(
+                    session
+                )
+            )
+        summary = (
+            summarize_canonical_baserunning_production_settlements(
+                rows
+            )
+        )
+        summary.update(
+            {
+                "status": "ready",
+                "storage_available": True,
+                "error_type": None,
+                "error_message": None,
+            }
+        )
+        return summary
+    except Exception as exc:
+        summary = (
+            summarize_canonical_baserunning_production_settlements(
+                ()
+            )
+        )
+        summary.update(
+            {
+                "status": "unavailable",
+                "storage_available": False,
+                "error_type": exc.__class__.__name__,
+                "error_message": str(exc),
+            }
+        )
+        return summary
+
+
 def _build_game_state_realism_diagnostics() -> dict:
     """Layer 6OF guarded diagnostic payload.
 
@@ -1337,10 +1380,8 @@ def build_model_projection_payload(session: Session, target_date: str) -> Dict[s
                 )
             )
             settlement_summary = (
-                summarize_canonical_baserunning_production_settlements(
-                    load_canonical_baserunning_production_settlements(
-                        session
-                    )
+                _load_production_settlement_diagnostics(
+                    session
                 )
             )
             production_monitoring[

--- a/tests/test_model_projection_settlement_fail_open.py
+++ b/tests/test_model_projection_settlement_fail_open.py
@@ -1,0 +1,66 @@
+from contextlib import contextmanager
+
+from mlb_app import model_projections
+
+
+class Session:
+    @contextmanager
+    def begin_nested(self):
+        yield
+
+
+def test_settlement_diagnostics_are_ready_when_storage_loads(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        model_projections,
+        "load_canonical_baserunning_production_settlements",
+        lambda session: (),
+    )
+
+    result = (
+        model_projections
+        ._load_production_settlement_diagnostics(
+            Session()
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["storage_available"] is True
+    assert result["settled_game_count"] == 0
+    assert result["error_type"] is None
+
+
+def test_settlement_storage_failure_is_diagnostic_only(
+    monkeypatch,
+):
+    def unavailable(session):
+        raise RuntimeError(
+            "settlement table is unavailable"
+        )
+
+    monkeypatch.setattr(
+        model_projections,
+        "load_canonical_baserunning_production_settlements",
+        unavailable,
+    )
+
+    result = (
+        model_projections
+        ._load_production_settlement_diagnostics(
+            Session()
+         )
+    )
+
+    assert result["status"] == "unavailable"
+    assert result["storage_available"] is False
+    assert result["settled_game_count"] == 0
+    assert result["remaining_game_count"] == 100
+    assert result["error_type"] == "RuntimeError"
+    assert result["error_message"] == (
+        "settlement table is unavailable"
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## Summary

- prevent optional canonical settlement diagnostics from suppressing Model Projections games
- isolate settlement reads inside a nested transaction/savepoint
- return an explicit `unavailable` diagnostic when settlement storage cannot be queried
- preserve the canonical simulation, player projections, production authority, and game payload
- add regression coverage for both available and unavailable settlement storage

## Root cause

PR #1290 added an unconditional settlement-table query inside the per-game projection assembly block. When the deployed database could not query `canonical_baserunning_production_settlements`, the exception reached the outer per-game handler. Every matchup was moved into the payload error list, leaving `games` empty and causing the frontend to display “No games returned for this date.”

Settlement reporting is optional diagnostic material and must not control whether authoritative projections are returned.

## Production behavior

A settlement query failure now yields:

- `status: unavailable`
- `storage_available: false`
- structured error type and message
- zeroed settlement progress without changing production authority

The affected game remains in the response.

## Validation

- 1,154 canonical/model-projection tests passed; 2 known unrelated baseline failures explicitly deselected
- focused settlement and production tests passed
- Python compilation passed
- `git diff --check` passed
- forced-outage real-matchup smoke returned one game, zero payload errors, and an unavailable settlement diagnostic

Forced-outage smoke result:

- game PK `822868`
- `payload_game_count: 1`
- `payload_error_count: 0`
- `game_preserved: true`
- `settlement_storage_available: false`

## Scope

Only `mlb_app/model_projections.py` and the new fail-open regression test are included. Existing unrelated untracked analysis scripts remain excluded.