### PR TITLE
Operationalize projection warming

### DIFF
--- a/docs/model_projection_warming.md
+++ b/docs/model_projection_warming.md
@@ -1,0 +1,24 @@
+# Model Projection Game-Day Warming
+
+Model Projections serves precomputed artifacts and does not run heavyweight
+simulation work inside a user GET request.
+
+## Railway service
+
+Create a dedicated Railway cron service using
+`railway.game-day-warm-cron.json`. Configure its cron schedule as:
+
+`0 * * * *`
+
+The service calls the production web service and warms yesterday, today, and tomorrow. The 180-second per-request timeout covers the canonical production
+trial batch without reverting the public GET route to cold computation.
+
+The warmer must run after every deployment and hourly during game days.
+A successful model-projection snapshot reports `warmed: true` and a positive
+`games_cached` count when MLB games exist for the date.
+
+## Read behavior
+
+`GET /models/projections` remains read-only. When an artifact is unavailable,
+it returns `data_status: not_ready` and an explanatory message. The frontend
+must not persist that transient response in its 30-minute browser cache.

--- a/frontend/src/lib/modelProjectionsWarmingUiContract.test.mjs
+++ b/frontend/src/lib/modelProjectionsWarmingUiContract.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const source = fs.readFileSync(
+  new URL('../pages/ModelProjectionsPage.jsx', import.meta.url),
+  'utf8',
+)
+
+test('model projections bypass stale browser API cache', () => {
+  assert.match(
+    source,
+    /fetch\(url, \{ cache: 'no-store' \}\)/,
+  )
+})
+
+test('model projections distinguish unwarmed dates', () => {
+  assert.match(source, /data_status === 'not_ready'/)
+  assert.match(
+    source,
+    /payload\?\.message \|\| 'Model projections are being prepared for this date\.'/,
+  )
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1859,7 +1859,7 @@ export default function ModelProjectionsPage() {
 
       try {
         const url = `${API}/models/projections?date=${date}`
-        const res = await fetch(url)
+        const res = await fetch(url, { cache: 'no-store' })
         const contentType = res.headers.get('content-type') || ''
 
         if (!res.ok) {
@@ -1910,7 +1910,11 @@ export default function ModelProjectionsPage() {
       ) : null}
 
       {!loading && payload && !games.length ? (
-        <div style={s.card}>No games returned for this date.</div>
+        <div style={s.card}>
+          {payload?.data_status === 'not_ready'
+            ? (payload?.message || 'Model projections are being prepared for this date.')
+            : 'No games returned for this date.'}
+        </div>
       ) : null}
 
       {games.map(game => (

--- a/railway.game-day-warm-cron.json
+++ b/railway.game-day-warm-cron.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "startCommand": "python scripts/warm_game_day.py --base-url https://mlb-prediction-app-production-732c.up.railway.app --timeout 180"
+  }
+}

--- a/tests/test_game_day_warming_deployment.py
+++ b/tests/test_game_day_warming_deployment.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "railway.game-day-warm-cron.json"
+DOCS = ROOT / "docs" / "model_projection_warming.md"
+WARMER = ROOT / "scripts" / "warm_game_day.py"
+
+
+def test_game_day_warmer_has_dedicated_railway_contract():
+    payload = json.loads(
+        CONFIG.read_text(encoding="utf-8")
+    )
+    command = payload["deploy"]["startCommand"]
+
+    assert payload["build"]["builder"] == "DOCKERFILE"
+    assert "scripts/warm_game_day.py" in command
+    assert "--timeout 180" in command
+    assert (
+        "mlb-prediction-app-production-732c.up.railway.app"
+        in command
+    )
+    assert WARMER.is_file()
+
+
+def test_game_day_warming_operations_are_documented():
+    text = DOCS.read_text(encoding="utf-8")
+
+    assert "0 * * * *" in text
+    assert "yesterday, today, and tomorrow" in text
+    assert "data_status: not_ready" in text
+    assert "30-minute browser cache" in text


### PR DESCRIPTION
## Summary

- add a dedicated Railway game-day warming service configuration for the existing projection warmer
- warm yesterday, today, and tomorrow hourly with a 180-second per-request timeout
- bypass the frontend's 30-minute API cache when loading Model Projections
- distinguish an unwarmed date from a legitimately empty MLB schedule in the UI
- document the warming lifecycle, deployment requirement, and read-only route behavior

## Root cause

The Model Projections GET route intentionally serves precomputed artifacts and does not perform the expensive canonical simulation inline. After deployment, no scheduled service was warming those artifacts, so the route correctly returned `data_status: not_ready` with no games. The frontend then presented that transient state as “No games returned” and could retain the empty response in its browser cache.

A manual production snapshot warm confirmed the path itself was healthy: July 27 cached 12 games, and the subsequent GET returned `data_status: ready` with all 12 games.

## Production behavior

The public GET route remains read-only. A dedicated Railway cron invokes the existing `scripts/warm_game_day.py` process for yesterday, today, and tomorrow. The frontend uses `cache: no-store` for this workspace request and displays the backend's not-ready explanation when an artifact has not been warmed yet.

## Validation

- 1,154 canonical and Model Projections backend tests passed; 2 known unrelated baseline failures were deselected
- 25 frontend diagnostics and warming tests passed
- focused route, cache, probability, and deployment tests passed
- frontend production build passed
- Python compilation passed
- Railway JSON validation passed
- `git diff --check` passed

## Deployment requirement

After merge, create a dedicated Railway cron service from `railway.game-day-warm-cron.json`, configure the schedule as `0 * * * *`, deploy it, and run it once. Committing the configuration file does not create or schedule the Railway service automatically.