### PR TITLE
Fix settlement runner import path

### DIFF
--- a/docs/canonical_baserunning_production_monitoring.md
+++ b/docs/canonical_baserunning_production_monitoring.md
@@ -25,7 +25,7 @@ The service must share the production `DATABASE_URL`. Do not set
 `MLB_CANONICAL_SETTLEMENT_ALLOW_SQLITE` in production.
 
 The start command is
-`python scripts/run_canonical_baserunning_production_settlement.py`.
+`python -m scripts.run_canonical_baserunning_production_settlement`.
 
 The runner is idempotent. It processes only pending observations whose MLB
 schedule state is Final and stores at most one settlement per game.

--- a/railway.baserunning-settlement-cron.json
+++ b/railway.baserunning-settlement-cron.json
@@ -4,6 +4,6 @@
     "builder": "DOCKERFILE"
   },
   "deploy": {
-    "startCommand": "python scripts/run_canonical_baserunning_production_settlement.py"
+    "startCommand": "python -m scripts.run_canonical_baserunning_production_settlement"
   }
 }

--- a/tests/test_canonical_baserunning_production_settlement_deployment.py
+++ b/tests/test_canonical_baserunning_production_settlement_deployment.py
@@ -13,7 +13,7 @@ def test_settlement_cron_uses_dedicated_runner():
 
     assert payload["build"]["builder"] == "DOCKERFILE"
     assert payload["deploy"]["startCommand"] == (
-        "python scripts/run_canonical_baserunning_production_settlement.py"
+        "python -m scripts.run_canonical_baserunning_production_settlement"
     )
     assert RUNNER_PATH.is_file()
 


### PR DESCRIPTION
## Summary

- run the canonical baserunning settlement runner as a Python module
- preserve the repository root on `sys.path` so `mlb_app` imports resolve in Railway
- update the deployment contract and operations documentation to match the corrected command

## Root cause

The Railway cron successfully built and started its container, but direct script execution set the import path to `/app/scripts`. The runner then failed before accessing production data with:

```text
ModuleNotFoundError: No module named 'mlb_app'
```

Running the entry point with `python -m scripts.run_canonical_baserunning_production_settlement` preserves `/app` as the module root and makes the application package importable.

## Production impact

The failed execution occurred before database access, so no monitoring observation or settlement data was changed. After this PR is merged, Railway should redeploy the existing `baserunning settlement` cron with the corrected config-as-code command. Run the cron once manually after that deployment succeeds.

## Validation

- module resolution check passed for `scripts.run_canonical_baserunning_production_settlement`
- 30 settlement, ledger, runner, and deployment tests passed
- Python compilation passed
- Railway JSON validation passed
- `git diff --check` passed