### PR TITLE
Expose canonical profile provenance

### DIFF
--- a/mlb_app/lineup_profile.py
+++ b/mlb_app/lineup_profile.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from .lineup_handedness import build_lineup_handedness_mix
+from .simulation.profile_provenance import (
+    build_canonical_profile_provenance,
+)
 from .statsapi_cache import fetch_json_with_cache, make_cache_key
 from sqlalchemy.orm import Session
 
@@ -336,6 +339,33 @@ def build_hitter_profile(
         "iso",
     ]
     has_usable_profile = any(simulation_inputs.get(key) is not None for key in usable_core_fields)
+    selected_split = (
+        split
+        if selected
+        else opposite_split
+        if opposite
+        else None
+    )
+    sample_window = (
+        f"{season}:{selected_split}"
+        if split_source
+        else "90d"
+        if agg_data
+        else "team_fallback"
+    )
+    profile_provenance = build_canonical_profile_provenance(
+        {
+            "profile_source": profile_source,
+            "profile_granularity": "individual_hitter",
+            "batter_id": player_id,
+            "requested_split": split,
+            "selected_split": selected_split,
+            "sample_window": sample_window,
+            "sample_size": split_data.get("pa"),
+        },
+        role="batter",
+        input_values=simulation_inputs,
+    )
 
     return {
         "batter_id": player_id,
@@ -349,6 +379,7 @@ def build_hitter_profile(
         "has_batter_aggregate": bool(agg_data),
         "used_opposite_split": bool(opposite and not selected),
         "has_usable_profile": has_usable_profile,
+        "profile_provenance": profile_provenance,
         "simulation_inputs": simulation_inputs,
     }
 
@@ -381,6 +412,48 @@ def _aggregate_hitter_profiles(
         iso = _compute_iso(batting_avg, slugging_pct, None)
 
     player_count_used = len(profiles)
+    source_distribution: Dict[str, int] = {}
+    for profile in profiles:
+        source = str(
+            profile.get("profile_source")
+            or "unavailable"
+        )
+        source_distribution[source] = (
+            source_distribution.get(source, 0) + 1
+        )
+    lineup_provenance = build_canonical_profile_provenance(
+        {
+            "source": "confirmed_lineup_player_splits",
+            "profile_granularity": "lineup_average",
+            "team_id": team_id,
+            "split": split,
+            "sample_window": str(season),
+            "sample_size": player_count_used,
+        },
+        role="lineup_offense",
+        input_values={
+            key: avg_key(key)
+            for key in (
+                "k_pct",
+                "bb_pct",
+                "batting_avg",
+                "on_base_pct",
+                "slugging_pct",
+                "iso",
+                "avg_exit_velocity",
+                "avg_launch_angle",
+                "hard_hit_pct",
+                "barrel_pct",
+            )
+        },
+        shared_profile_reused=True,
+    )
+    lineup_provenance["source_distribution"] = (
+        source_distribution
+    )
+    lineup_provenance["fallback_player_count"] = (
+        fallback_player_count
+    )
 
     return {
         "source": "confirmed_lineup_player_splits",
@@ -412,6 +485,7 @@ def _aggregate_hitter_profiles(
         "real_player_profile_count": player_count_used - fallback_player_count,
         "minimum_required_players": MIN_USABLE_HITTERS,
         "unavailable_reason": None,
+        "profile_provenance": lineup_provenance,
         "lineup": [
             {
                 "batter_id": profile.get("batter_id"),
@@ -423,6 +497,7 @@ def _aggregate_hitter_profiles(
                 "has_player_split": profile.get("has_player_split"),
                 "has_batter_aggregate": profile.get("has_batter_aggregate"),
                 "used_opposite_split": profile.get("used_opposite_split"),
+                "profile_provenance": profile.get("profile_provenance"),
                 "simulation_inputs": profile.get("simulation_inputs"),
             }
             for profile in profiles

--- a/mlb_app/matchup_workspace_builder.py
+++ b/mlb_app/matchup_workspace_builder.py
@@ -54,12 +54,29 @@ def build_lineup_pa_outcome_model(lineup, lineup_profile, opposing_pitcher_profi
             "player_name": player.get("name"),
             "probabilities": model.get("probabilities"),
             "summary": model.get("summary"),
+            "profile_provenance": (
+                model.get("profile_provenance")
+            ),
+            "profile_granularity": (
+                (lineup_profile or {}).get(
+                    "profile_granularity"
+                )
+                or "lineup_average"
+            ),
+            "shared_profile_reused": True,
         })
 
     return {
         "model_version": "lineup_pa_outcome_v1",
         "side": side_label,
         "player_count_used": len(player_models),
+        "profile_granularity": (
+            (lineup_profile or {}).get(
+                "profile_granularity"
+            )
+            or "lineup_average"
+        ),
+        "shared_profile_reused": True,
         "lineup_average_probabilities": _average_probability_dict(player_models),
         "lineup_average_summary": _average_summary_dict(player_models),
         "player_outcomes": player_models,

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -318,6 +318,9 @@ def _pitcher_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
             "pitcher_name": team.get("pitcher_name"),
             "pitch_arsenal_source": team.get("pitch_arsenal_source"),
             "profile_granularity": "probable_pitcher",
+            "sample_window": features.get("source_window"),
+            "sample_size": safe_float(features.get("pa")),
+            "sample_blend_policy": "selected_source_window",
             "rate_source_notes": rate_source_notes,
         },
         "bat_missing": {"k_rate": k_rate, "whiff_rate": None, "csw_rate": None},
@@ -349,6 +352,16 @@ def _offense_workspace_profile(team: Dict[str, Any]) -> Dict[str, Any]:
             "lineup_source": inputs.get("lineup_source"),
             "profile_granularity": inputs.get("profile_granularity") or "team_offense",
             "sample_blend": inputs.get("sample_blend"),
+            "sample_window": (
+                f"season={inputs.get('season')};"
+                f"split={inputs.get('split')}"
+                if inputs.get("season")
+                else None
+            ),
+            "sample_size": safe_float(inputs.get("pa")),
+            "sample_blend_policy": (
+                (inputs.get("sample_blend") or {}).get("type")
+            ),
             "rate_source_notes": {
                 "k_rate_source": k_rate_source,
                 "bb_rate_source": bb_rate_source,

--- a/mlb_app/simulation/game_engine_v2.py
+++ b/mlb_app/simulation/game_engine_v2.py
@@ -18,6 +18,10 @@ from mlb_app.environment_profile import compute_environment_profile
 from mlb_app.bullpen_profile import build_bullpen_profile
 from mlb_app.simulation.inning_simulator import simulate_half_innings
 from mlb_app.simulation.game_simulator import simulate_game, simulate_game_with_bullpen
+from mlb_app.simulation.profile_provenance import (
+    CANONICAL_PROFILE_PROVENANCE_VERSION,
+    build_canonical_profile_provenance,
+)
 
 
 ENGINE_VERSION = "game-engine-v2"
@@ -251,6 +255,42 @@ def _build_pa_model(
         "side": side,
         "lineup_average_probabilities": probabilities,
         "lineup_average_summary": summary,
+        "profile_provenance": {
+            "schema_version": CANONICAL_PROFILE_PROVENANCE_VERSION,
+            "batter": build_canonical_profile_provenance(
+                offense_profile,
+                role="batter",
+                input_values={
+                    "k_rate": off_k,
+                    "bb_rate": off_bb,
+                    "batting_avg": off_avg,
+                    "iso": off_iso,
+                    "slugging_pct": off_slg,
+                },
+                shared_profile_reused=True,
+            ),
+            "pitcher": build_canonical_profile_provenance(
+                opposing_pitcher_profile,
+                role=pitcher_role,
+                input_values={
+                    "k_rate": pit_k,
+                    "bb_rate": pit_bb,
+                    "xba_allowed": pit_xba,
+                    "xwoba_allowed": pit_xwoba,
+                    "hard_hit_rate_allowed": pit_hard_hit,
+                    "hr_rate": pit_hr,
+                },
+            ),
+            "environment": build_canonical_profile_provenance(
+                environment_profile,
+                role="environment",
+                input_values={
+                    "run_scoring_index": run_env,
+                    "hr_boost_index": hr_env,
+                    "hit_boost_index": hit_env,
+                },
+            ),
+        },
         "direct_inputs": {
             "offense": {
                 "k_rate": off_k,

--- a/mlb_app/simulation/pa_outcome_model.py
+++ b/mlb_app/simulation/pa_outcome_model.py
@@ -15,6 +15,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from .profile_provenance import (
+    CANONICAL_PROFILE_PROVENANCE_VERSION,
+    build_canonical_profile_provenance,
+)
+
 
 BASE_PA_OUTCOMES = {
     "k": 0.225,
@@ -232,10 +237,51 @@ def build_pa_outcome_probabilities(
         "contact_out_probability": probabilities["out"],
     }
 
+    batter_inputs = {
+        "k_rate": batter_k,
+        "bb_rate": batter_bb,
+        "iso": batter_iso,
+        "barrel_rate": batter_barrel,
+        "hard_hit_rate": batter_hard_hit,
+        "contact_rate": batter_contact,
+    }
+    pitcher_inputs = {
+        "k_rate": pitcher_k,
+        "bb_rate": pitcher_bb,
+        "barrel_rate_allowed": pitcher_barrel_allowed,
+        "hard_hit_rate_allowed": pitcher_hard_hit_allowed,
+        "xba_allowed": pitcher_xba_allowed,
+    }
+    environment_inputs = {
+        "hr_boost_index": hr_index,
+        "hit_boost_index": hit_index,
+        "run_scoring_index": run_index,
+    }
+
     return {
         "model_version": "pa_outcome_v1",
         "probabilities": probabilities,
         "summary": summary,
+        "profile_provenance": {
+            "schema_version": (
+                CANONICAL_PROFILE_PROVENANCE_VERSION
+            ),
+            "batter": build_canonical_profile_provenance(
+                batter_profile,
+                role="batter",
+                input_values=batter_inputs,
+            ),
+            "pitcher": build_canonical_profile_provenance(
+                pitcher_profile,
+                role="pitcher",
+                input_values=pitcher_inputs,
+            ),
+            "environment": build_canonical_profile_provenance(
+                environment_profile,
+                role="environment",
+                input_values=environment_inputs,
+            ),
+        },
         "inputs_used": {
             "batter_k_rate": batter_k,
             "batter_bb_rate": batter_bb,

--- a/mlb_app/simulation/profile_provenance.py
+++ b/mlb_app/simulation/profile_provenance.py
@@ -1,0 +1,121 @@
+"""Diagnostic-only provenance for profiles consumed by PA models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+
+CANONICAL_PROFILE_PROVENANCE_VERSION = (
+    "canonical_profile_provenance_v1"
+)
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def build_canonical_profile_provenance(
+    profile: Optional[Mapping[str, Any]],
+    *,
+    role: str,
+    input_values: Optional[Mapping[str, Any]] = None,
+    shared_profile_reused: bool = False,
+) -> Dict[str, Any]:
+    """Describe a profile without changing any modeled value."""
+
+    profile = dict(profile or {})
+    metadata = dict(profile.get("metadata") or {})
+    explicit = dict(profile.get("profile_provenance") or {})
+    inputs = dict(input_values or {})
+
+    source_type = _first(
+        explicit.get("source_type"),
+        profile.get("profile_source"),
+        profile.get("source"),
+        metadata.get("source_type"),
+        "unavailable",
+    )
+    granularity = _first(
+        explicit.get("profile_granularity"),
+        profile.get("profile_granularity"),
+        metadata.get("profile_granularity"),
+        "unknown",
+    )
+    fallback_used = explicit.get("fallback_used")
+    if fallback_used is None:
+        fallback_context = " ".join(
+            str(value).lower()
+            for value in (
+                source_type,
+                explicit.get("lineup_source"),
+                profile.get("lineup_source"),
+                metadata.get("lineup_source"),
+            )
+            if value is not None
+        )
+        fallback_used = (
+            "fallback" in fallback_context
+            or "prior" in fallback_context
+            or source_type == "unavailable"
+        )
+
+    return {
+        "schema_version": CANONICAL_PROFILE_PROVENANCE_VERSION,
+        "role": role,
+        "source_type": source_type,
+        "profile_granularity": granularity,
+        "player_id": _first(
+            explicit.get("player_id"),
+            profile.get("batter_id"),
+            profile.get("pitcher_id"),
+            profile.get("player_id"),
+            metadata.get("player_id"),
+            metadata.get("pitcher_id"),
+            metadata.get("batter_id"),
+        ),
+        "team_id": _first(
+            explicit.get("team_id"),
+            profile.get("team_id"),
+            metadata.get("team_id"),
+        ),
+        "requested_split": _first(
+            explicit.get("requested_split"),
+            profile.get("requested_split"),
+            profile.get("split"),
+        ),
+        "selected_split": _first(
+            explicit.get("selected_split"),
+            profile.get("selected_split"),
+        ),
+        "sample_window": _first(
+            explicit.get("sample_window"),
+            profile.get("sample_window"),
+            metadata.get("sample_window"),
+        ),
+        "sample_size": _first(
+            explicit.get("sample_size"),
+            profile.get("sample_size"),
+            metadata.get("sample_size"),
+        ),
+        "as_of_date": _first(
+            explicit.get("as_of_date"),
+            profile.get("as_of_date"),
+            metadata.get("as_of_date"),
+        ),
+        "sample_blend_policy": _first(
+            explicit.get("sample_blend_policy"),
+            profile.get("sample_blend_policy"),
+            metadata.get("sample_blend_policy"),
+        ),
+        "fallback_used": bool(fallback_used),
+        "shared_profile_reused": bool(shared_profile_reused),
+        "available_input_fields": sorted(
+            key for key, value in inputs.items() if value is not None
+        ),
+        "missing_input_fields": sorted(
+            key for key, value in inputs.items() if value is None
+        ),
+    }

--- a/tests/test_canonical_profile_provenance.py
+++ b/tests/test_canonical_profile_provenance.py
@@ -1,0 +1,244 @@
+from copy import deepcopy
+
+from mlb_app.matchup_workspace_builder import (
+    build_lineup_pa_outcome_model,
+)
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+from mlb_app.simulation.profile_provenance import (
+    CANONICAL_PROFILE_PROVENANCE_VERSION,
+    build_canonical_profile_provenance,
+)
+
+
+def batter_profile():
+    return {
+        "metadata": {
+            "source_type": "player_split",
+            "profile_granularity": "individual_hitter",
+            "sample_window": "2026:vsR",
+            "sample_size": 120,
+        },
+        "contact_skill": {
+            "k_rate": 0.20,
+            "contact_rate": 0.78,
+        },
+        "plate_discipline": {"bb_rate": 0.09},
+        "power": {
+            "iso": 0.19,
+            "barrel_rate": 0.10,
+            "hard_hit_rate": 0.42,
+        },
+    }
+
+
+def pitcher_profile():
+    return {
+        "metadata": {
+            "source_type": "pitcher_aggregate",
+            "profile_granularity": "individual_pitcher",
+            "sample_window": "90d",
+        },
+        "bat_missing": {"k_rate": 0.25},
+        "command_control": {"bb_rate": 0.07},
+        "contact_management": {
+            "barrel_rate_allowed": 0.08,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.245,
+        },
+    }
+
+
+def environment_profile():
+    return {
+        "metadata": {
+            "source_type": "game_environment",
+            "profile_granularity": "game",
+        },
+        "run_environment": {
+            "hr_boost_index": 1.02,
+            "hit_boost_index": 0.99,
+            "run_scoring_index": 1.01,
+        },
+    }
+
+
+def test_version_is_explicit():
+    assert CANONICAL_PROFILE_PROVENANCE_VERSION == (
+        "canonical_profile_provenance_v1"
+    )
+
+
+def test_normalizer_exposes_missing_metadata():
+    result = build_canonical_profile_provenance(
+        {"source": "team_splits"},
+        role="batter",
+        input_values={
+            "k_rate": 0.22,
+            "xwoba": None,
+        },
+    )
+
+    assert result["source_type"] == "team_splits"
+    assert result["sample_window"] is None
+    assert result["sample_size"] is None
+    assert result["available_input_fields"] == [
+        "k_rate"
+    ]
+    assert result["missing_input_fields"] == [
+        "xwoba"
+    ]
+
+
+def test_provenance_does_not_change_probabilities():
+    batter = batter_profile()
+    pitcher = pitcher_profile()
+    environment = environment_profile()
+
+    baseline = build_pa_outcome_probabilities(
+        deepcopy(batter),
+        deepcopy(pitcher),
+        deepcopy(environment),
+    )
+    enriched_batter = deepcopy(batter)
+    enriched_batter["profile_provenance"] = {
+        "source_type": "player_split",
+        "sample_window": "2026:vsR",
+        "sample_size": 120,
+    }
+    enriched = build_pa_outcome_probabilities(
+        enriched_batter,
+        deepcopy(pitcher),
+        deepcopy(environment),
+    )
+
+    assert enriched["probabilities"] == (
+        baseline["probabilities"]
+    )
+    provenance = enriched["profile_provenance"]
+    assert provenance["schema_version"] == (
+        CANONICAL_PROFILE_PROVENANCE_VERSION
+    )
+    assert provenance["batter"]["source_type"] == (
+        "player_split"
+    )
+    assert provenance["pitcher"]["sample_window"] == (
+        "90d"
+    )
+
+
+def test_lineup_rows_admit_shared_profile_reuse():
+    lineup_profile = batter_profile()
+    lineup_profile["profile_granularity"] = (
+        "lineup_average"
+    )
+
+    result = build_lineup_pa_outcome_model(
+        lineup=[
+            {"id": 1, "name": "One"},
+            {"id": 2, "name": "Two"},
+        ],
+        lineup_profile=lineup_profile,
+        opposing_pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        side_label="away_offense",
+    )
+
+    assert result["profile_granularity"] == (
+        "lineup_average"
+    )
+    assert result["shared_profile_reused"] is True
+    assert all(
+        row["shared_profile_reused"] is True
+        for row in result["player_outcomes"]
+    )
+    assert all(
+        row["profile_provenance"]["batter"][
+            "profile_granularity"
+        ]
+        == "lineup_average"
+        for row in result["player_outcomes"]
+    )
+
+
+def test_authoritative_engine_pa_wrapper_exposes_provenance():
+    from mlb_app.simulation.game_engine_v2 import _build_pa_model
+
+    result = _build_pa_model(
+        offense_profile={
+            "rates": {
+                "k_rate": 0.22,
+                "bb_rate": 0.09,
+                "batting_avg": 0.255,
+                "iso": 0.175,
+                "slugging_pct": 0.430,
+            },
+            "metadata": {
+                "source_type": "team_splits",
+                "profile_granularity": "team_offense",
+                "team_id": 140,
+                "lineup_source": (
+                    "team_splits_fallback_not_confirmed_lineup"
+                ),
+                "sample_window": "season=2026;split=vsR",
+                "sample_size": 925,
+                "sample_blend_policy": "team_split",
+            },
+        },
+        opposing_pitcher_profile={
+            "rates": {
+                "k_rate": 0.2133,
+                "bb_rate": 0.0872,
+                "xba_allowed": 0.250,
+                "xwoba_allowed": 0.320,
+                "hard_hit_rate_allowed": 0.38,
+                "hr_rate": 0.03,
+            },
+            "metadata": {
+                "source_type": (
+                    "model_projection_pitcher_features"
+                ),
+                "profile_granularity": "probable_pitcher",
+                "pitcher_id": 677958,
+                "sample_window": "season=2026",
+                "sample_size": 420,
+                "sample_blend_policy": "selected_source_window",
+            },
+        },
+        environment_profile={
+            "indices": {
+                "run_scoring_index": 1.01,
+                "hr_boost_index": 1.02,
+                "hit_boost_index": 1.00,
+            },
+            "metadata": {
+                "source_type": "matchup_detail_context",
+                "profile_granularity": "game_environment",
+            },
+        },
+        side="away_offense_vs_home_starter",
+    )
+
+    assert result["lineup_average_probabilities"]
+    provenance = result["profile_provenance"]
+    assert provenance["schema_version"] == (
+        CANONICAL_PROFILE_PROVENANCE_VERSION
+    )
+    assert provenance["batter"]["source_type"] == "team_splits"
+    assert (
+        provenance["batter"]["profile_granularity"]
+        == "team_offense"
+    )
+    assert provenance["batter"]["sample_size"] == 925
+    assert provenance["batter"]["shared_profile_reused"] is True
+    assert provenance["batter"]["fallback_used"] is True
+    assert provenance["pitcher"]["player_id"] == 677958
+    assert (
+        provenance["pitcher"]["sample_window"]
+        == "season=2026"
+    )
+    assert (
+        provenance["environment"]["source_type"]
+        == "matchup_detail_context"
+    )


### PR DESCRIPTION
## Summary

- Add a versioned canonical profile-provenance contract for batter, pitcher, bullpen, and environment inputs.
- Carry source type, granularity, sample window and size, fallback status, identifiers, and available/missing fields into PA models.
- Expose provenance from the authoritative `game-engine-v2` starter and bullpen PA wrappers.
- Preserve the existing simulation calculations and production probability authority.

## Why

Before replacing team-level inputs with blended player profiles, we need an auditable baseline showing exactly which profiles and samples currently feed each simulated plate appearance. The production smoke confirms that current offense inputs are team-split fallbacks, while starters use probable-pitcher feature profiles and bullpens use conservative priors.

## Validation

- 1,167 canonical/profile regression tests passed; 2 known baseline tests deselected.
- 22 focused provenance tests passed.
- Authoritative production-path smoke completed with `game-engine-v2`.
- All four starter/bullpen PA probability distributions remained normalized to `1.0`.
- Python compilation and `git diff --check` passed.