### PR TITLE
Build shadow hitter expected components

### DIFF
--- a/mlb_app/simulation/shadow/hitter_expected_components.py
+++ b/mlb_app/simulation/shadow/hitter_expected_components.py
@@ -1,0 +1,372 @@
+"""Shadow-only hitter expected-component evidence from persisted Statcast."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import OrderedDict
+from typing import Any, Iterable, Mapping, Optional
+
+
+SHADOW_HITTER_EXPECTED_COMPONENTS_VERSION = (
+    "shadow_hitter_expected_components_v1"
+)
+
+WINDOW_PRIORS = OrderedDict(
+    (
+        ("current_season", 0.50),
+        ("prior_season", 0.30),
+        ("career_pre_prior", 0.20),
+    )
+)
+
+WOBA_DENOM_EVENTS = {
+    "field_out",
+    "strikeout",
+    "single",
+    "walk",
+    "double",
+    "home_run",
+    "force_out",
+    "grounded_into_double_play",
+    "hit_by_pitch",
+    "sac_fly",
+    "field_error",
+    "triple",
+    "fielders_choice",
+    "double_play",
+    "fielders_choice_out",
+    "strikeout_double_play",
+    "sac_fly_double_play",
+    "triple_play",
+}
+
+AB_EVENTS = {
+    "field_out",
+    "strikeout",
+    "single",
+    "double",
+    "home_run",
+    "force_out",
+    "grounded_into_double_play",
+    "field_error",
+    "triple",
+    "fielders_choice",
+    "double_play",
+    "fielders_choice_out",
+    "strikeout_double_play",
+    "triple_play",
+}
+
+STRIKEOUT_EVENTS = {"strikeout", "strikeout_double_play"}
+
+
+def _value(row: Any, field: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(field)
+    return getattr(row, field, None)
+
+
+def _float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        parsed = float(value)
+        return parsed if parsed == parsed else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _date(value: Any) -> Optional[dt.date]:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _terminal_rows(rows: Iterable[Any]) -> list[Any]:
+    """Return one final terminal row for each plate appearance."""
+
+    selected: dict[tuple[Any, ...], Any] = {}
+    for row in rows:
+        event = str(_value(row, "events") or "").strip().lower()
+        if event not in WOBA_DENOM_EVENTS:
+            continue
+        key = (
+            _value(row, "game_pk"),
+            _value(row, "at_bat_number"),
+        )
+        if key == (None, None):
+            key = ("row", _value(row, "id"))
+        current = selected.get(key)
+        order = (
+            _value(row, "pitch_number") or -1,
+            _value(row, "id") or -1,
+        )
+        current_order = (
+            _value(current, "pitch_number") or -1,
+            _value(current, "id") or -1,
+        ) if current is not None else (-2, -2)
+        if order >= current_order:
+            selected[key] = row
+    return list(selected.values())
+
+
+def _window_summary(
+    rows: list[Any],
+    *,
+    minimum_coverage: float,
+) -> dict[str, Any]:
+    woba_rows = [
+        row for row in rows
+        if str(_value(row, "events") or "").lower() in WOBA_DENOM_EVENTS
+    ]
+    xwoba_values = [
+        value
+        for value in (
+            _float(_value(row, "estimated_woba_using_speedangle"))
+            for row in woba_rows
+        )
+        if value is not None
+    ]
+
+    ab_rows = [
+        row for row in rows
+        if str(_value(row, "events") or "").lower() in AB_EVENTS
+    ]
+    contact_ab_rows = [
+        row for row in ab_rows
+        if str(_value(row, "events") or "").lower() not in STRIKEOUT_EVENTS
+    ]
+    xba_contact_values = [
+        value
+        for value in (
+            _float(_value(row, "estimated_ba_using_speedangle"))
+            for row in contact_ab_rows
+        )
+        if value is not None
+    ]
+
+    pa = len(woba_rows)
+    ab = len(ab_rows)
+    xwoba_coverage = len(xwoba_values) / pa if pa else 0.0
+    xba_contact_coverage = (
+        len(xba_contact_values) / len(contact_ab_rows)
+        if contact_ab_rows
+        else 0.0
+    )
+    xwoba = (
+        sum(xwoba_values) / len(xwoba_values)
+        if xwoba_values and xwoba_coverage >= minimum_coverage
+        else None
+    )
+    # Statcast expected BA is contact-only. Strikeout ABs contribute zero.
+    xba = (
+        sum(xba_contact_values) / ab
+        if ab and xba_contact_coverage >= minimum_coverage
+        else None
+    )
+    dates = [_date(_value(row, "game_date")) for row in rows]
+    dates = [value for value in dates if value is not None]
+
+    return {
+        "pa": pa,
+        "ab": ab,
+        "contact_ab": len(contact_ab_rows),
+        "xwoba_sample": len(xwoba_values),
+        "xba_contact_sample": len(xba_contact_values),
+        "xwoba_coverage": round(xwoba_coverage, 6),
+        "xba_contact_coverage": round(xba_contact_coverage, 6),
+        "xwoba": round(xwoba, 6) if xwoba is not None else None,
+        "xba": round(xba, 6) if xba is not None else None,
+        "start_date": min(dates).isoformat() if dates else None,
+        "end_date": max(dates).isoformat() if dates else None,
+    }
+
+
+def build_shadow_hitter_expected_components(
+    *,
+    player_id: int,
+    season: int,
+    split: str,
+    statcast_events: Iterable[Any],
+    as_of_date: dt.date,
+    source_latest_date: Optional[dt.date] = None,
+    minimum_current_pa: int = 25,
+    minimum_coverage: float = 0.80,
+    maximum_source_age_days: int = 14,
+) -> dict[str, Any]:
+    """Build disjoint, freshness-gated expected evidence without authority."""
+
+    required_throw = {"vsR": "R", "vsL": "L"}.get(split)
+    filtered = []
+    future_rows_excluded = 0
+    for row in statcast_events:
+        game_date = _date(_value(row, "game_date"))
+        if game_date is None:
+            continue
+        if game_date > as_of_date:
+            future_rows_excluded += 1
+            continue
+        if required_throw and _value(row, "p_throws") != required_throw:
+            continue
+        filtered.append(row)
+
+    terminals = _terminal_rows(filtered)
+    grouped = {
+        "current_season": [
+            row for row in terminals
+            if _date(_value(row, "game_date")).year == season
+        ],
+        "prior_season": [
+            row for row in terminals
+            if _date(_value(row, "game_date")).year == season - 1
+        ],
+        "career_pre_prior": [
+            row for row in terminals
+            if _date(_value(row, "game_date")).year < season - 1
+        ],
+    }
+    windows = {
+        name: _window_summary(rows, minimum_coverage=minimum_coverage)
+        for name, rows in grouped.items()
+    }
+
+    latest_dates = [
+        _date(_value(row, "game_date")) for row in terminals
+        if _date(_value(row, "game_date")) is not None
+    ]
+    player_latest_date = max(latest_dates) if latest_dates else None
+    latest_date = source_latest_date or player_latest_date
+    source_age_days = (
+        (as_of_date - latest_date).days if latest_date is not None else None
+    )
+
+    blockers = []
+    warnings = []
+    if windows["current_season"]["pa"] < minimum_current_pa:
+        blockers.append("insufficient_current_season_pa")
+    if windows["current_season"]["xwoba"] is None:
+        blockers.append("insufficient_current_xwoba_coverage")
+    if windows["current_season"]["xba"] is None:
+        blockers.append("insufficient_current_xba_coverage")
+    if source_age_days is None:
+        blockers.append("missing_statcast_source")
+    elif source_age_days > maximum_source_age_days:
+        blockers.append("stale_statcast_source")
+    if sum(window["xwoba"] is not None for window in windows.values()) < 2:
+        blockers.append("insufficient_xwoba_windows")
+    if sum(window["xba"] is not None for window in windows.values()) < 2:
+        blockers.append("insufficient_xba_windows")
+    if future_rows_excluded:
+        warnings.append("future_rows_excluded")
+
+    effective_weights = {}
+    for name, prior in WINDOW_PRIORS.items():
+        pa = windows[name]["pa"]
+        effective_weights[name] = prior * min(1.0, pa / 200.0)
+    total_weight = sum(effective_weights.values())
+    normalized_weights = {
+        name: (value / total_weight if total_weight else 0.0)
+        for name, value in effective_weights.items()
+    }
+    for name, weight in normalized_weights.items():
+        windows[name]["normalized_weight"] = round(weight, 6)
+
+    def blended(metric: str) -> Optional[float]:
+        available = [
+            (windows[name][metric], normalized_weights[name])
+            for name in WINDOW_PRIORS
+            if windows[name][metric] is not None
+        ]
+        denominator = sum(weight for _, weight in available)
+        if not denominator:
+            return None
+        return round(
+            sum(value * weight for value, weight in available) / denominator,
+            6,
+        )
+
+    return {
+        "schema_version": SHADOW_HITTER_EXPECTED_COMPONENTS_VERSION,
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "player_id": int(player_id),
+        "season": int(season),
+        "split": split,
+        "as_of_date": as_of_date.isoformat(),
+        "source_latest_date": (
+            latest_date.isoformat() if latest_date is not None else None
+        ),
+        "player_latest_date": (
+            player_latest_date.isoformat()
+            if player_latest_date is not None
+            else None
+        ),
+        "source_age_days": source_age_days,
+        "future_rows_excluded": future_rows_excluded,
+        "windows": windows,
+        "blended_expected_metrics": {
+            "xwoba": blended("xwoba"),
+            "xba": blended("xba"),
+        },
+        "blockers": blockers,
+        "warnings": warnings,
+        "expected_adjustment_applied": False,
+    }
+
+
+def load_shadow_hitter_expected_components(
+    session: Any,
+    *,
+    player_id: int,
+    season: int,
+    split: str,
+    as_of_date: dt.date,
+    career_start_season: Optional[int] = None,
+) -> dict[str, Any]:
+    """Load persisted Statcast rows with an explicit historical cutoff."""
+
+    from sqlalchemy import func
+
+    from mlb_app.database import StatcastEvent
+
+    start_season = career_start_season or max(2008, season - 10)
+    query = session.query(StatcastEvent).filter(
+        StatcastEvent.batter_id == int(player_id),
+        StatcastEvent.game_date >= dt.date(start_season, 1, 1),
+        StatcastEvent.game_date <= as_of_date,
+        StatcastEvent.events.isnot(None),
+    )
+    required_throw = {"vsR": "R", "vsL": "L"}.get(split)
+    if required_throw:
+        query = query.filter(StatcastEvent.p_throws == required_throw)
+    rows = query.order_by(
+        StatcastEvent.game_date,
+        StatcastEvent.game_pk,
+        StatcastEvent.at_bat_number,
+        StatcastEvent.pitch_number,
+        StatcastEvent.id,
+    ).all()
+    source_latest_date = (
+        session.query(func.max(StatcastEvent.game_date))
+        .filter(StatcastEvent.game_date <= as_of_date)
+        .scalar()
+    )
+    result = build_shadow_hitter_expected_components(
+        player_id=player_id,
+        season=season,
+        split=split,
+        statcast_events=rows,
+        as_of_date=as_of_date,
+        source_latest_date=source_latest_date,
+    )
+    result["storage_evidence"] = {
+        "raw_row_count": len(rows),
+        "career_start_season": start_season,
+    }
+    return result

--- a/tests/test_shadow_hitter_expected_components.py
+++ b/tests/test_shadow_hitter_expected_components.py
@@ -1,0 +1,171 @@
+import datetime as dt
+
+from mlb_app.simulation.shadow.hitter_expected_components import (
+    SHADOW_HITTER_EXPECTED_COMPONENTS_VERSION,
+    build_shadow_hitter_expected_components,
+)
+
+
+def event(
+    year,
+    pa,
+    outcome,
+    *,
+    pitch=1,
+    xwoba=None,
+    xba=None,
+    throws="R",
+    month=6,
+    day=1,
+):
+    return {
+        "id": year * 10000 + pa * 10 + pitch,
+        "game_date": dt.date(year, month, day),
+        "game_pk": year * 1000 + pa,
+        "at_bat_number": pa,
+        "pitch_number": pitch,
+        "events": outcome,
+        "p_throws": throws,
+        "estimated_woba_using_speedangle": xwoba,
+        "estimated_ba_using_speedangle": xba,
+    }
+
+
+def sample_rows(latest_day=25):
+    rows = []
+    for year in (2023, 2024, 2025, 2026):
+        for pa in range(1, 31):
+            outcome = "strikeout" if pa % 5 == 0 else "field_out"
+            rows.append(
+                event(
+                    year,
+                    pa,
+                    outcome,
+                    xwoba=0.0 if outcome == "strikeout" else 0.310,
+                    xba=None if outcome == "strikeout" else 0.250,
+                    month=7 if year == 2026 else 6,
+                    day=latest_day if year == 2026 else 1,
+                )
+            )
+    return rows
+
+
+def test_builds_disjoint_fresh_expected_windows_without_authority_change():
+    result = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=sample_rows(),
+        as_of_date=dt.date(2026, 7, 27),
+    )
+
+    assert result["schema_version"] == SHADOW_HITTER_EXPECTED_COMPONENTS_VERSION
+    assert result["status"] == "ready"
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert result["expected_adjustment_applied"] is False
+    assert result["windows"]["current_season"]["pa"] == 30
+    assert result["windows"]["prior_season"]["pa"] == 30
+    assert result["windows"]["career_pre_prior"]["pa"] == 60
+    assert result["blended_expected_metrics"]["xwoba"] is not None
+    assert result["blended_expected_metrics"]["xba"] is not None
+
+
+def test_xba_uses_all_at_bats_and_counts_strikeouts_as_zero():
+    result = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=sample_rows(),
+        as_of_date=dt.date(2026, 7, 27),
+    )
+
+    current = result["windows"]["current_season"]
+    assert current["ab"] == 30
+    assert current["contact_ab"] == 24
+    assert current["xba_contact_sample"] == 24
+    assert current["xba"] == 0.2
+
+
+def test_deduplicates_plate_appearances_and_excludes_future_and_wrong_split():
+    rows = sample_rows()
+    rows.extend(
+        [
+            event(2026, 1, "field_out", pitch=2, xwoba=0.4, xba=0.3, month=7, day=25),
+            event(2026, 99, "field_out", xwoba=0.9, xba=0.9, throws="L", month=7, day=25),
+            event(2026, 100, "field_out", xwoba=0.9, xba=0.9, month=7, day=28),
+        ]
+    )
+    result = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=rows,
+        as_of_date=dt.date(2026, 7, 27),
+    )
+
+    assert result["windows"]["current_season"]["pa"] == 30
+    assert result["future_rows_excluded"] == 1
+    assert "future_rows_excluded" in result["warnings"]
+
+
+def test_blocks_stale_or_incomplete_expected_evidence():
+    stale = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=sample_rows(latest_day=1),
+        as_of_date=dt.date(2026, 7, 27),
+    )
+    incomplete = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=[
+            event(2026, pa, "field_out", month=7, day=25)
+            for pa in range(1, 31)
+        ],
+        as_of_date=dt.date(2026, 7, 27),
+    )
+
+    assert stale["status"] == "blocked"
+    assert "stale_statcast_source" in stale["blockers"]
+    assert incomplete["status"] == "blocked"
+    assert "insufficient_xwoba_windows" in incomplete["blockers"]
+    assert "insufficient_xba_windows" in incomplete["blockers"]
+
+
+
+def test_requires_current_expected_coverage_even_when_history_is_usable():
+    rows = sample_rows()
+    for row in rows:
+        if row["game_date"].year == 2026:
+            row["estimated_woba_using_speedangle"] = None
+            row["estimated_ba_using_speedangle"] = None
+    result = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=rows,
+        as_of_date=dt.date(2026, 7, 27),
+    )
+
+    assert result["status"] == "blocked"
+    assert "insufficient_current_xwoba_coverage" in result["blockers"]
+    assert "insufficient_current_xba_coverage" in result["blockers"]
+
+
+def test_global_source_date_controls_freshness_not_player_split_recency():
+    result = build_shadow_hitter_expected_components(
+        player_id=7,
+        season=2026,
+        split="vsR",
+        statcast_events=sample_rows(latest_day=1),
+        as_of_date=dt.date(2026, 7, 27),
+        source_latest_date=dt.date(2026, 7, 26),
+    )
+
+    assert result["status"] == "ready"
+    assert result["source_age_days"] == 1
+    assert result["source_latest_date"] == "2026-07-26"
+    assert result["player_latest_date"] == "2026-07-01"


### PR DESCRIPTION
## What changed

- adds a shadow-only hitter expected-component builder over persisted Statcast terminal plate appearances
- deduplicates each plate appearance using game and at-bat identity, retaining the final terminal event
- computes disjoint current-season, prior-season, and pre-prior career expected windows
- computes xwOBA from eligible terminal PA expected values
- computes xBA using the full AB denominator, with strikeout ABs contributing zero and contact expected BA used only when available
- applies plate-appearance reliability and explicit recency priors when blending window evidence
- reports sample sizes, coverage, normalized weights, source dates, player dates, blockers, and warnings

## Evidence and safety gates

- requires at least 25 current-season PA
- requires at least 80% current-season xwOBA and contact-xBA coverage
- requires at least two usable historical windows for each expected metric
- uses the global latest persisted Statcast date for source freshness rather than a hitter's last same-handed matchup
- excludes future rows relative to the requested as-of date
- blocks evidence older than 14 days
- remains shadow-only and never changes production authority or applies an expected adjustment

## Real-data audit

The persisted source contains 2,066,295 Statcast rows from 2023-03-01 through 2026-05-03, including 465,228 expected-wOBA values and 315,164 expected-BA values.

Across 25 current hitter/split candidates:

- as of the source date, 15 were ready and 10 were blocked by insufficient current expected coverage
- as of 2026-07-27, all 25 were blocked by the global stale-source gate
- all production-date results consistently identified 2026-05-03 as the source date and 85 days as its age

## Validation

- `1182 passed, 2 deselected` across canonical, model-projection, lineup, matchup, sample-window, pitcher-blending, and shadow-profile suites
- `15 passed` in the focused expected-component and shadow-profile suites
- Python compilation passed
- `git diff --check` passed

The two deselected tests are established baseline exclusions unrelated to this change.