### PR TITLE
Combine shadow hitter profile evidence

### DIFF
--- a/mlb_app/simulation/pa_outcome_model.py
+++ b/mlb_app/simulation/pa_outcome_model.py
@@ -122,6 +122,7 @@ def build_pa_outcome_probabilities(
     batter_barrel = _nested(batter_profile, "power", "barrel_rate")
     batter_hard_hit = _nested(batter_profile, "power", "hard_hit_rate")
     batter_contact = _nested(batter_profile, "contact_skill", "contact_rate")
+    batter_hit_skill = _nested(batter_profile, "contact_skill", "hit_skill")
 
     pitcher_k = _nested(pitcher_profile, "bat_missing", "k_rate")
     pitcher_bb = _nested(pitcher_profile, "command_control", "bb_rate")
@@ -161,6 +162,7 @@ def build_pa_outcome_probabilities(
 
     hit_skill = _blend(
         [
+            batter_hit_skill,
             batter_contact,
             pitcher_xba_allowed,
             contact_quality,
@@ -244,6 +246,7 @@ def build_pa_outcome_probabilities(
         "barrel_rate": batter_barrel,
         "hard_hit_rate": batter_hard_hit,
         "contact_rate": batter_contact,
+        "hit_skill": batter_hit_skill,
     }
     pitcher_inputs = {
         "k_rate": pitcher_k,
@@ -289,6 +292,7 @@ def build_pa_outcome_probabilities(
             "batter_barrel_rate": batter_barrel,
             "batter_hard_hit_rate": batter_hard_hit,
             "batter_contact_rate": batter_contact,
+            "batter_hit_skill": batter_hit_skill,
             "pitcher_k_rate": pitcher_k,
             "pitcher_bb_rate": pitcher_bb,
             "pitcher_barrel_rate_allowed": pitcher_barrel_allowed,

--- a/mlb_app/simulation/shadow/combined_hitter_profile.py
+++ b/mlb_app/simulation/shadow/combined_hitter_profile.py
@@ -1,0 +1,274 @@
+"""Combine actual and expected hitter evidence for shadow PA comparisons."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping, Optional
+
+from mlb_app.simulation.shadow.player_profile_blend import (
+    build_shadow_candidate_batter_profile,
+)
+
+
+COMBINED_SHADOW_HITTER_PROFILE_VERSION = "combined_shadow_hitter_profile_v1"
+COMBINED_HIT_SKILL_POLICY_VERSION = "actual_ba_xba_equal_weight_v1"
+
+
+def _number(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_combined_shadow_hitter_profile(
+    *,
+    actual_blend: Mapping[str, Any],
+    expected_components: Mapping[str, Any],
+    expected_weight: float = 0.50,
+) -> dict[str, Any]:
+    """Build a shadow candidate without changing production authority."""
+
+    blockers = []
+    if actual_blend.get("status") != "ready":
+        blockers.append("actual_profile_blend_not_ready")
+    if expected_components.get("status") != "ready":
+        blockers.append("expected_components_not_ready")
+
+    identity_fields = ("player_id", "season", "split")
+    identity_mismatches = [
+        field
+        for field in identity_fields
+        if actual_blend.get(field) != expected_components.get(field)
+    ]
+    if identity_mismatches:
+        blockers.append("profile_evidence_identity_mismatch")
+
+    weight = _number(expected_weight)
+    if weight is None or not 0.0 <= weight <= 1.0:
+        blockers.append("invalid_expected_weight")
+
+    actual = dict(actual_blend.get("blended_actual_metrics") or {})
+    expected = dict(
+        expected_components.get("blended_expected_metrics") or {}
+    )
+    batting_avg = _number(actual.get("batting_avg"))
+    xba = _number(expected.get("xba"))
+    xwoba = _number(expected.get("xwoba"))
+    if batting_avg is None:
+        blockers.append("missing_blended_batting_average")
+    if xba is None:
+        blockers.append("missing_blended_xba")
+
+    base_candidate = build_shadow_candidate_batter_profile(actual_blend)
+    if base_candidate.get("status") != "ready":
+        blockers.append("actual_candidate_profile_not_ready")
+
+    blockers = list(dict.fromkeys(blockers))
+    if blockers:
+        return {
+            "schema_version": COMBINED_SHADOW_HITTER_PROFILE_VERSION,
+            "status": "blocked",
+            "shadow_only": True,
+            "production_authority_changed": False,
+            "player_id": actual_blend.get("player_id"),
+            "season": actual_blend.get("season"),
+            "split": actual_blend.get("split"),
+            "blockers": blockers,
+            "candidate_profile": None,
+        }
+
+    actual_weight = 1.0 - weight
+    hit_skill = (batting_avg * actual_weight) + (xba * weight)
+    profile = copy.deepcopy(base_candidate["profile"])
+    profile.setdefault("contact_skill", {})["contact_rate"] = None
+    profile["contact_skill"]["hit_skill"] = round(hit_skill, 6)
+    profile.setdefault("metadata", {}).update(
+        {
+            "source_type": "combined_shadow_hitter_profile_evidence",
+            "combined_profile_schema_version": (
+                COMBINED_SHADOW_HITTER_PROFILE_VERSION
+            ),
+            "hit_skill_policy_version": COMBINED_HIT_SKILL_POLICY_VERSION,
+            "actual_blend_schema_version": actual_blend.get(
+                "schema_version"
+            ),
+            "expected_components_schema_version": expected_components.get(
+                "schema_version"
+            ),
+            "expected_weight": weight,
+            "actual_weight": actual_weight,
+            "xwoba_applied": False,
+            "shadow_only": True,
+            "production_authority_changed": False,
+        }
+    )
+
+    return {
+        "schema_version": COMBINED_SHADOW_HITTER_PROFILE_VERSION,
+        "status": "ready",
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "player_id": actual_blend.get("player_id"),
+        "season": actual_blend.get("season"),
+        "split": actual_blend.get("split"),
+        "blockers": [],
+        "hit_skill_policy": {
+            "version": COMBINED_HIT_SKILL_POLICY_VERSION,
+            "actual_metric": "batting_avg",
+            "expected_metric": "xba",
+            "actual_weight": actual_weight,
+            "expected_weight": weight,
+            "actual_value": batting_avg,
+            "expected_value": xba,
+            "combined_value": round(hit_skill, 6),
+            "parameter_selected": False,
+        },
+        "expected_evidence": {
+            "xwoba": xwoba,
+            "xba": xba,
+            "xwoba_applied": False,
+            "xwoba_role": "evaluation_context_only",
+            "source_latest_date": expected_components.get(
+                "source_latest_date"
+            ),
+            "source_age_days": expected_components.get("source_age_days"),
+        },
+        "actual_warnings": list(actual_blend.get("warnings") or ()),
+        "expected_warnings": list(
+            expected_components.get("warnings") or ()
+        ),
+        "candidate_profile": profile,
+    }
+
+
+def load_combined_shadow_hitter_profile(
+    session: Any,
+    *,
+    player_id: int,
+    season: int,
+    split: str,
+    as_of_date: Any,
+    expected_weight: float = 0.50,
+    career_start_season: Optional[int] = None,
+) -> dict[str, Any]:
+    """Load player-ID evidence and build a cutoff-safe combined profile."""
+
+    from mlb_app.simulation.shadow.hitter_expected_components import (
+        load_shadow_hitter_expected_components,
+    )
+    from mlb_app.simulation.shadow.player_profile_blend import (
+        load_shadow_hitter_profile_blend,
+    )
+
+    actual_blend = load_shadow_hitter_profile_blend(
+        session,
+        player_id=player_id,
+        season=season,
+        split=split,
+        as_of_date=as_of_date,
+    )
+    expected_components = load_shadow_hitter_expected_components(
+        session,
+        player_id=player_id,
+        season=season,
+        split=split,
+        as_of_date=as_of_date,
+        career_start_season=career_start_season,
+    )
+    result = build_combined_shadow_hitter_profile(
+        actual_blend=actual_blend,
+        expected_components=expected_components,
+        expected_weight=expected_weight,
+    )
+    result["evidence_status"] = {
+        "actual": actual_blend.get("status"),
+        "expected": expected_components.get("status"),
+    }
+    result["evidence_blockers"] = {
+        "actual": list(actual_blend.get("blockers") or ()),
+        "expected": list(expected_components.get("blockers") or ()),
+    }
+    result["storage_evidence"] = {
+        "actual": dict(actual_blend.get("storage_evidence") or {}),
+        "expected": dict(
+            expected_components.get("storage_evidence") or {}
+        ),
+    }
+    return result
+
+
+def compare_combined_shadow_hitter_pa_outcomes(
+    *,
+    actual_blend: Mapping[str, Any],
+    expected_components: Mapping[str, Any],
+    production_batter_profile: Optional[Mapping[str, Any]],
+    pitcher_profile: Optional[Mapping[str, Any]],
+    environment_profile: Optional[Mapping[str, Any]],
+    expected_weight: float = 0.50,
+) -> dict[str, Any]:
+    """Compare combined shadow evidence with unchanged production inputs."""
+
+    from mlb_app.simulation.pa_outcome_model import (
+        build_pa_outcome_probabilities,
+    )
+
+    combined = build_combined_shadow_hitter_profile(
+        actual_blend=actual_blend,
+        expected_components=expected_components,
+        expected_weight=expected_weight,
+    )
+    if combined["status"] != "ready":
+        return {
+            "schema_version": "combined_shadow_hitter_pa_comparison_v1",
+            "status": "blocked",
+            "shadow_only": True,
+            "production_authority_changed": False,
+            "blockers": list(combined.get("blockers") or ()),
+        }
+
+    production_input = copy.deepcopy(
+        dict(production_batter_profile or {})
+    )
+    production = build_pa_outcome_probabilities(
+        production_input,
+        dict(pitcher_profile or {}),
+        dict(environment_profile or {}),
+    )
+    shadow = build_pa_outcome_probabilities(
+        combined["candidate_profile"],
+        dict(pitcher_profile or {}),
+        dict(environment_profile or {}),
+    )
+    production_probabilities = dict(production.get("probabilities") or {})
+    shadow_probabilities = dict(shadow.get("probabilities") or {})
+    keys = sorted(set(production_probabilities) | set(shadow_probabilities))
+    deltas = {
+        key: round(
+            float(shadow_probabilities.get(key) or 0.0)
+            - float(production_probabilities.get(key) or 0.0),
+            6,
+        )
+        for key in keys
+    }
+
+    return {
+        "schema_version": "combined_shadow_hitter_pa_comparison_v1",
+        "status": "ready",
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "production_model_version": production.get("model_version"),
+        "shadow_model_version": shadow.get("model_version"),
+        "production_probabilities": production_probabilities,
+        "shadow_probabilities": shadow_probabilities,
+        "probability_deltas": deltas,
+        "maximum_absolute_probability_delta": max(
+            (abs(value) for value in deltas.values()),
+            default=0.0,
+        ),
+        "combined_profile": combined,
+        "production_inputs_used": production.get("inputs_used"),
+        "shadow_inputs_used": shadow.get("inputs_used"),
+    }

--- a/tests/test_combined_shadow_hitter_profile.py
+++ b/tests/test_combined_shadow_hitter_profile.py
@@ -1,0 +1,229 @@
+import copy
+
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+from mlb_app.simulation.shadow.combined_hitter_profile import (
+    COMBINED_HIT_SKILL_POLICY_VERSION,
+    COMBINED_SHADOW_HITTER_PROFILE_VERSION,
+    build_combined_shadow_hitter_profile,
+    compare_combined_shadow_hitter_pa_outcomes,
+)
+
+
+def actual_blend():
+    return {
+        "schema_version": "shadow_player_profile_blend_v1",
+        "status": "ready",
+        "player_id": 7,
+        "season": 2026,
+        "split": "vsR",
+        "window_policy": "disjoint_current_prior_career",
+        "windows": {
+            "current_season": {"pa": 100},
+            "prior_season": {"pa": 200},
+            "career_pre_prior": {"pa": 400},
+        },
+        "blended_actual_metrics": {
+            "k_pct": 0.22,
+            "bb_pct": 0.09,
+            "batting_avg": 0.260,
+            "iso": 0.170,
+        },
+        "contact_quality_context": {},
+        "warnings": ["missing_batter_contact_aggregate"],
+    }
+
+
+def expected_components():
+    return {
+        "schema_version": "shadow_hitter_expected_components_v1",
+        "status": "ready",
+        "player_id": 7,
+        "season": 2026,
+        "split": "vsR",
+        "source_latest_date": "2026-07-26",
+        "source_age_days": 1,
+        "blended_expected_metrics": {
+            "xba": 0.280,
+            "xwoba": 0.360,
+        },
+        "warnings": [],
+    }
+
+
+def pitcher():
+    return {
+        "bat_missing": {"k_rate": 0.24},
+        "command_control": {"bb_rate": 0.08},
+        "contact_management": {
+            "barrel_rate_allowed": 0.08,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.250,
+        },
+    }
+
+
+def environment():
+    return {
+        "run_environment": {
+            "hr_boost_index": 1.0,
+            "hit_boost_index": 1.0,
+            "run_scoring_index": 1.0,
+        }
+    }
+
+
+def test_combines_actual_average_and_xba_without_applying_xwoba():
+    result = build_combined_shadow_hitter_profile(
+        actual_blend=actual_blend(),
+        expected_components=expected_components(),
+    )
+
+    assert result["schema_version"] == COMBINED_SHADOW_HITTER_PROFILE_VERSION
+    assert result["status"] == "ready"
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert result["hit_skill_policy"]["version"] == (
+        COMBINED_HIT_SKILL_POLICY_VERSION
+    )
+    assert result["hit_skill_policy"]["combined_value"] == 0.270
+    assert result["hit_skill_policy"]["parameter_selected"] is False
+    assert result["candidate_profile"]["contact_skill"]["hit_skill"] == 0.270
+    assert result["candidate_profile"]["contact_skill"]["contact_rate"] is None
+    assert result["expected_evidence"]["xwoba"] == 0.360
+    assert result["expected_evidence"]["xwoba_applied"] is False
+
+
+def test_blocks_unready_or_mismatched_evidence():
+    stale = expected_components()
+    stale["status"] = "blocked"
+    stale["blockers"] = ["stale_statcast_source"]
+    mismatched = expected_components()
+    mismatched["player_id"] = 99
+
+    stale_result = build_combined_shadow_hitter_profile(
+        actual_blend=actual_blend(),
+        expected_components=stale,
+    )
+    mismatch_result = build_combined_shadow_hitter_profile(
+        actual_blend=actual_blend(),
+        expected_components=mismatched,
+    )
+
+    assert stale_result["status"] == "blocked"
+    assert "expected_components_not_ready" in stale_result["blockers"]
+    assert mismatch_result["status"] == "blocked"
+    assert "profile_evidence_identity_mismatch" in mismatch_result["blockers"]
+
+
+def test_optional_hit_skill_is_backward_compatible_and_observable():
+    profile = {
+        "contact_skill": {"k_rate": 0.22, "contact_rate": None},
+        "plate_discipline": {"bb_rate": 0.09},
+        "power": {"iso": 0.170},
+    }
+    explicit_none = copy.deepcopy(profile)
+    explicit_none["contact_skill"]["hit_skill"] = None
+    candidate = copy.deepcopy(profile)
+    candidate["contact_skill"]["hit_skill"] = 0.270
+
+    baseline = build_pa_outcome_probabilities(
+        profile, pitcher(), environment()
+    )
+    unchanged = build_pa_outcome_probabilities(
+        explicit_none, pitcher(), environment()
+    )
+    adjusted = build_pa_outcome_probabilities(
+        candidate, pitcher(), environment()
+    )
+
+    assert baseline["probabilities"] == unchanged["probabilities"]
+    assert baseline["inputs_used"]["batter_hit_skill"] is None
+    assert adjusted["inputs_used"]["batter_hit_skill"] == 0.270
+    assert adjusted["probabilities"]["single"] != (
+        baseline["probabilities"]["single"]
+    )
+
+
+def test_paired_comparison_preserves_production_profile():
+    production_profile = {
+        "contact_skill": {"k_rate": 0.25, "contact_rate": 0.72},
+        "plate_discipline": {"bb_rate": 0.08},
+        "power": {
+            "iso": 0.150,
+            "barrel_rate": 0.07,
+            "hard_hit_rate": 0.36,
+        },
+    }
+    original = copy.deepcopy(production_profile)
+
+    result = compare_combined_shadow_hitter_pa_outcomes(
+        actual_blend=actual_blend(),
+        expected_components=expected_components(),
+        production_batter_profile=production_profile,
+        pitcher_profile=pitcher(),
+        environment_profile=environment(),
+    )
+
+    assert result["status"] == "ready"
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert production_profile == original
+    assert result["shadow_inputs_used"]["batter_hit_skill"] == 0.270
+    assert result["maximum_absolute_probability_delta"] > 0
+    assert abs(sum(result["production_probabilities"].values()) - 1.0) <= 0.0005
+    assert abs(sum(result["shadow_probabilities"].values()) - 1.0) <= 0.0005
+
+
+def test_player_id_loader_combines_matching_persisted_evidence(monkeypatch):
+    import mlb_app.simulation.shadow.hitter_expected_components as expected_mod
+    import mlb_app.simulation.shadow.player_profile_blend as actual_mod
+    from mlb_app.simulation.shadow.combined_hitter_profile import (
+        load_combined_shadow_hitter_profile,
+    )
+
+    calls = {}
+
+    def load_actual(session, **kwargs):
+        calls["actual"] = (session, kwargs)
+        result = actual_blend()
+        result["storage_evidence"] = {"player_split_row_count": 4}
+        return result
+
+    def load_expected(session, **kwargs):
+        calls["expected"] = (session, kwargs)
+        result = expected_components()
+        result["storage_evidence"] = {"raw_row_count": 700}
+        return result
+
+    monkeypatch.setattr(
+        actual_mod, "load_shadow_hitter_profile_blend", load_actual
+    )
+    monkeypatch.setattr(
+        expected_mod, "load_shadow_hitter_expected_components", load_expected
+    )
+    session = object()
+    result = load_combined_shadow_hitter_profile(
+        session,
+        player_id=7,
+        season=2026,
+        split="vsR",
+        as_of_date="2026-07-27",
+        career_start_season=2023,
+    )
+
+    assert result["status"] == "ready"
+    assert result["player_id"] == 7
+    assert result["evidence_status"] == {
+        "actual": "ready",
+        "expected": "ready",
+    }
+    assert result["storage_evidence"]["actual"] == {
+        "player_split_row_count": 4
+    }
+    assert result["storage_evidence"]["expected"] == {
+        "raw_row_count": 700
+    }
+    assert calls["actual"][1]["player_id"] == 7
+    assert calls["expected"][1]["career_start_season"] == 2023


### PR DESCRIPTION
## What changed

- Added an optional, backward-compatible `contact_skill.hit_skill` PA-model input.
- Added a combined shadow hitter profile keyed by player ID, season, handedness split, and as-of date.
- Combined blended actual batting average and blended xBA with an explicit 50/50 candidate policy.
- Retained xwOBA as evaluation context only; it does not alter PA probabilities.
- Added paired shadow-versus-baseline probability comparison, evidence provenance, freshness gating, identity checks, and storage evidence.

## Why

The actual-stat and expected-stat shadow evidence streams were previously separate. This PR combines them without changing production authority so their effect on PA outcomes can be measured safely before calibration or activation.

## Behavior and impact

- Shadow only: `production_authority_changed` remains `false`.
- Existing PA profiles behave identically when `hit_skill` is absent.
- Combined profiles block when actual or expected evidence is unavailable, incomplete, stale, or belongs to a different player/split.
- xBA affects the hitter hit-skill signal; xwOBA is not forced into an unsupported event-level mapping.

## Validation

- Broad regression: 1,187 passed, 2 known deselected, 127 warnings.
- Focused combined contract: 19 passed.
- Compilation and `git diff --check` passed.
- Persisted-data coverage audit: 15/25 candidates ready at the 2026-05-03 Statcast cutoff; 25/25 correctly blocked on 2026-07-27 because the source was stale.
- Paired real-data audit: maximum observed absolute PA probability delta was 0.0019; changes were isolated to singles and outs, with no production authority change.