### PR TITLE
Slow MLB News Wire ticker

### DIFF
--- a/frontend/src/pages/NewsPage.css
+++ b/frontend/src/pages/NewsPage.css
@@ -4,7 +4,7 @@
 }
 
 .news-ticker-track {
-  animation: news-ticker-scroll 55s linear infinite;
+  animation: news-ticker-scroll 110s linear infinite;
   will-change: transform;
 }
 


### PR DESCRIPTION
## What changed
- Increased the News Wire ticker loop duration from 55 seconds to 110 seconds.
- Preserved the existing linear motion, hover/focus pause, and reduced-motion behavior.

## Why
The headlines were moving too quickly to read comfortably. Doubling the duration cuts the ticker speed in half without changing the component structure or news data flow.

## Validation
- Confirmed the change is isolated to `frontend/src/pages/NewsPage.css`.
- Confirmed accessibility behavior remains unchanged.