### PR TITLE
Hotfix player trend schema startup crash

### DIFF
--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -608,7 +608,7 @@ PLAYER_TREND_FIELDS = [
         ("baseline_start", "Baseline Start", "date", "Window", "Inclusive comparison-period start date."),
         ("baseline_end", "Baseline End", "date", "Window", "Inclusive comparison-period end date."),
         ("window_sample_size", "Window Sample", "integer", "Sample", "Plate appearances for hitters or batters faced for pitchers."),
-        ("baseline_sample_size", "Baseline Sample", "integer", "Comparison plate appearances or batters faced."),
+        ("baseline_sample_size", "Baseline Sample", "integer", "Sample", "Comparison plate appearances or batters faced."),
         ("current_value", "Window Value", "double", "Trend", "Metric value in the selected window."),
         ("baseline_value", "Baseline Value", "double", "Trend", "Metric value in the comparison period."),
         ("absolute_change", "Absolute Change", "double", "Trend", "Window value minus baseline value."),


### PR DESCRIPTION
## Incident

The merged Player Trends schema added `baseline_sample_size` as a four-element tuple, while the `PLAYER_TREND_FIELDS` comprehension unpacks five values. This raises `ValueError: not enough values to unpack (expected 5, got 4)` during application import and prevents Uvicorn startup.

## Fix

Add the missing `"Sample"` field group to that tuple. No runtime behavior or unrelated files are changed.

## Validation

- Parsed every `PLAYER_TREND_FIELDS` metadata tuple and confirmed arity is exactly five.
- Executed `dashboard_report_types.py` via `importlib`; module import succeeds and creates all 23 player-trend fields.
- Fix is based on the current `main` branch after merge commit `cc08d08d6296cf748f2ac1687f7e7e3081256137`.
