### PR TITLE
Persist Player Trends dataset and remove full event scans

### DIFF
--- a/frontend/src/pages/MyDashboardReportBuilderPage.jsx
+++ b/frontend/src/pages/MyDashboardReportBuilderPage.jsx
@@ -48,8 +48,21 @@ const FRANKLIN = '"Franklin Gothic Medium", "Franklin Gothic", "Arial Narrow", A
 const CENTURY = '"Century Gothic", CenturyGothic, AppleGothic, Arial, sans-serif'
 const EMPTY_TREND_CONFIG = { player_type: '', window_days: '', comparison_baseline: '', minimum_sample_size: '', trend_direction: 'all', selected_metrics: [] }
 const TREND_METRICS = {
-  hitter: [['batting_avg', 'Batting Average'], ['on_base_pct', 'OBP'], ['slugging_pct', 'SLG'], ['iso', 'ISO'], ['avg_exit_velocity', 'Average Exit Velocity'], ['hard_hit_pct', 'Hard-Hit Rate'], ['barrel_pct', 'Barrel Rate'], ['k_pct', 'Strikeout Rate'], ['bb_pct', 'Walk Rate'], ['whiff_pct', 'Whiff Rate']],
-  pitcher: [['k_pct', 'Strikeout Rate'], ['bb_pct', 'Walk Rate'], ['hard_hit_pct', 'Hard-Hit Rate Allowed'], ['avg_velocity', 'Average Pitch Velocity']],
+  hitter: [
+    ['batting_avg', 'Batting Average'], ['on_base_pct', 'OBP'], ['slugging_pct', 'SLG'],
+    ['ops', 'OPS'], ['iso', 'ISO'], ['avg_exit_velocity', 'Average Exit Velocity'],
+    ['max_exit_velocity', 'Maximum Exit Velocity'], ['avg_launch_angle', 'Average Launch Angle'],
+    ['hard_hit_pct', 'Hard-Hit Rate'], ['barrel_pct', 'Barrel Rate'],
+    ['k_pct', 'Strikeout Rate'], ['bb_pct', 'Walk Rate'],
+    ['whiff_pct', 'Whiff Rate'], ['contact_pct', 'Contact Rate'],
+  ],
+  pitcher: [
+    ['k_pct', 'Strikeout Rate'], ['bb_pct', 'Walk Rate'],
+    ['hard_hit_pct', 'Hard-Hit Rate Allowed'], ['avg_velocity', 'Average Pitch Velocity'],
+    ['avg_spin_rate', 'Average Spin Rate'], ['xwoba', 'xwOBA Allowed'],
+    ['xba', 'xBA Allowed'], ['avg_horiz_break', 'Average Horizontal Break'],
+    ['avg_vert_break', 'Average Vertical Break'],
+  ],
 }
 
 class DashboardWorkspaceErrorBoundary extends React.Component {

--- a/mlb_app/dashboard_object_models.py
+++ b/mlb_app/dashboard_object_models.py
@@ -152,3 +152,56 @@ class DashboardPlayerCurrent(Base):
         Index("ix_dashboard_current_hitter_xwoba", "player_type", "is_active", "xwoba"),
         Index("ix_dashboard_current_pitcher_score", "player_type", "is_active", "model_score"),
     )
+
+
+class PlayerTrendSnapshot(Base):
+    """Cached rolling-period comparison used by MyDashboard and AI analysis."""
+
+    __tablename__ = "player_trend_snapshots"
+
+    id: int = Column(Integer, primary_key=True, autoincrement=True)
+    as_of_date: date = Column(Date, nullable=False)
+    player_id: int = Column(Integer, nullable=False)
+    player_name: str = Column(String(255), nullable=False)
+    player_type: str = Column(String(32), nullable=False)
+    team: Optional[str] = Column(String(120), nullable=True)
+    window_days: int = Column(Integer, nullable=False)
+    comparison_baseline: str = Column(String(32), nullable=False)
+    metric: str = Column(String(64), nullable=False)
+    window_start: date = Column(Date, nullable=False)
+    window_end: date = Column(Date, nullable=False)
+    baseline_start: date = Column(Date, nullable=False)
+    baseline_end: date = Column(Date, nullable=False)
+    window_sample_size: int = Column(Integer, nullable=False, default=0)
+    baseline_sample_size: int = Column(Integer, nullable=False, default=0)
+    current_value: Optional[float] = Column(Float, nullable=True)
+    baseline_value: Optional[float] = Column(Float, nullable=True)
+    absolute_change: Optional[float] = Column(Float, nullable=True)
+    percentage_change: Optional[float] = Column(Float, nullable=True)
+    trend_direction: Optional[str] = Column(String(24), nullable=True)
+    favorable_direction: str = Column(String(12), nullable=False)
+    window_metrics_json = Column(JSON, nullable=False, default=dict)
+    baseline_metrics_json = Column(JSON, nullable=False, default=dict)
+    source: str = Column(String(120), nullable=False, default="statcast_events_sql_aggregate")
+    generated_at: datetime = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "as_of_date",
+            "player_id",
+            "player_type",
+            "window_days",
+            "comparison_baseline",
+            "metric",
+            name="uq_player_trend_snapshot_config_metric",
+        ),
+        Index(
+            "ix_player_trends_config",
+            "as_of_date",
+            "player_type",
+            "window_days",
+            "comparison_baseline",
+        ),
+        Index("ix_player_trends_player_date", "player_id", "as_of_date"),
+        Index("ix_player_trends_metric_direction", "metric", "trend_direction"),
+    )

--- a/mlb_app/dashboard_report_types.py
+++ b/mlb_app/dashboard_report_types.py
@@ -19,7 +19,7 @@ REPORT_TYPES: Dict[str, Dict[str, Any]] = {
     "model_projection_players": {"label": "Model Projection Players", "ui_object": "model_projection_players", "base_object": "model_projection_date_artifact", "population": {"row_type": "player"}, "relationships": ["model_projection_games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
     "model_tracker_snapshots": {"label": "Model Tracker", "ui_object": "model_tracker", "base_object": "model_tracker_snapshots", "population": {}, "relationships": ["games", "dashboard_player_current"], "queryable": True, "workbench_queryable": False},
     "competitive_batter_arsenal": {"label": "Batter vs Arsenal", "ui_object": "batter_arsenal", "base_object": "batter_pitch_type_matchups", "population": {}, "relationships": ["dashboard_players", "pitch_arsenal"], "queryable": True, "workbench_queryable": True},
-    "player_trends": {"label": "Player Trends", "ui_object": "player_trends", "base_object": "statcast_events", "population": {}, "relationships": ["dashboard_players", "batter_rolling", "pitcher_rolling"], "queryable": True, "workbench_queryable": False},
+    "player_trends": {"label": "Player Trends", "ui_object": "player_trends", "base_object": "player_trend_snapshots", "population": {"is_active": True, "player_type": "request_config"}, "relationships": ["dashboard_players", "statcast_events", "batter_id_rolling", "pitcher_id_rolling"], "queryable": True, "workbench_queryable": False},
 }
 
 
@@ -592,7 +592,7 @@ COMPETITIVE_ARSENAL_FIELDS.extend([
 ])
 
 PLAYER_TREND_FIELDS = [
-    _runtime_field(name, label, data_type, group, "statcast_events", description, freshness="requested_trend_window")
+    _runtime_field(name, label, data_type, group, "player_trend_snapshots", description, freshness="cached_trend_snapshot")
     for name, label, data_type, group, description in [
         ("rank", "Rank", "integer", "Identity", "Report-engine rank after the saved sort."),
         ("player_id", "MLB Player ID", "id", "Identity", "Canonical MLBAM player identifier."),
@@ -616,9 +616,124 @@ PLAYER_TREND_FIELDS = [
         ("trend_direction", "Trend Direction", "string", "Trend", "Deterministic improving, declining, or stable classification."),
         ("favorable_direction", "Favorable Direction", "string", "Trend", "Metric-aware higher- or lower-is-better rule."),
         ("freshness_date", "Freshness Date", "date", "Audit", "Requested as-of date for the calculation."),
-        ("source", "Source", "string", "Audit", "Authoritative rolling-page data source."),
+        ("dataset_generated_at", "Dataset Generated At", "datetime", "Audit", "Time the cached trend dataset was generated."),
+        ("source", "Source", "string", "Audit", "Cached trend dataset and authoritative rolling-page source."),
     ]
 ]
+
+PLAYER_TREND_ROLLING_FIELDS = {
+    "actual_pa": ("Plate Appearances", "integer"),
+    "actual_ab": ("At Bats", "integer"),
+    "event_count": ("Pitch Events", "integer"),
+    "batters_faced": ("Batters Faced", "integer"),
+    "pitch_count": ("Pitch Count", "integer"),
+    "batted_ball_count": ("Batted Balls", "integer"),
+    "hard_hit_count": ("Hard-Hit Balls", "integer"),
+    "barrel_count": ("Barrels", "integer"),
+    "hits": ("Hits", "integer"),
+    "doubles": ("Doubles", "integer"),
+    "triples": ("Triples", "integer"),
+    "walks": ("Walks", "integer"),
+    "strikeouts": ("Strikeouts", "integer"),
+    "home_runs": ("Home Runs", "integer"),
+    "total_bases": ("Total Bases", "integer"),
+    "swings": ("Swings", "integer"),
+    "whiffs": ("Whiffs", "integer"),
+    "batting_avg": ("Batting Average", "double"),
+    "on_base_pct": ("On-Base Percentage", "double"),
+    "slugging_pct": ("Slugging Percentage", "double"),
+    "ops": ("OPS", "double"),
+    "iso": ("ISO", "double"),
+    "avg_exit_velocity": ("Average Exit Velocity", "double"),
+    "max_exit_velocity": ("Maximum Exit Velocity", "double"),
+    "avg_launch_angle": ("Average Launch Angle", "double"),
+    "hard_hit_pct": ("Hard-Hit Rate", "double"),
+    "barrel_pct": ("Barrel Rate", "double"),
+    "k_pct": ("Strikeout Rate", "double"),
+    "bb_pct": ("Walk Rate", "double"),
+    "whiff_pct": ("Whiff Rate", "double"),
+    "contact_pct": ("Contact Rate", "double"),
+    "avg_velocity": ("Average Pitch Velocity", "double"),
+    "avg_spin_rate": ("Average Spin Rate", "double"),
+    "xwoba": ("xwOBA Allowed", "double"),
+    "xba": ("xBA Allowed", "double"),
+    "avg_horiz_break": ("Average Horizontal Break", "double"),
+    "avg_vert_break": ("Average Vertical Break", "double"),
+}
+for field_name, (label, data_type) in PLAYER_TREND_ROLLING_FIELDS.items():
+    PLAYER_TREND_FIELDS.extend([
+        _runtime_field(
+            f"window_{field_name}",
+            f"Window {label}",
+            data_type,
+            "Rolling Window",
+            "player_trend_snapshots",
+            f"{label} from the requested player-ID rolling window.",
+            freshness="cached_trend_snapshot",
+        ),
+        _runtime_field(
+            f"baseline_{field_name}",
+            f"Baseline {label}",
+            data_type,
+            "Rolling Baseline",
+            "player_trend_snapshots",
+            f"{label} from the authoritative comparison window.",
+            freshness="cached_trend_snapshot",
+        ),
+    ])
+
+PLAYER_TREND_CHANGE_FIELDS = {
+    "batting_avg": "Batting Average",
+    "on_base_pct": "On-Base Percentage",
+    "slugging_pct": "Slugging Percentage",
+    "ops": "OPS",
+    "iso": "ISO",
+    "avg_exit_velocity": "Average Exit Velocity",
+    "max_exit_velocity": "Maximum Exit Velocity",
+    "avg_launch_angle": "Average Launch Angle",
+    "hard_hit_pct": "Hard-Hit Rate",
+    "barrel_pct": "Barrel Rate",
+    "k_pct": "Strikeout Rate",
+    "bb_pct": "Walk Rate",
+    "whiff_pct": "Whiff Rate",
+    "contact_pct": "Contact Rate",
+    "avg_velocity": "Average Pitch Velocity",
+    "avg_spin_rate": "Average Spin Rate",
+    "xwoba": "xwOBA Allowed",
+    "xba": "xBA Allowed",
+    "avg_horiz_break": "Average Horizontal Break",
+    "avg_vert_break": "Average Vertical Break",
+}
+for metric_name, label in PLAYER_TREND_CHANGE_FIELDS.items():
+    PLAYER_TREND_FIELDS.extend([
+        _runtime_field(
+            f"{metric_name}_change",
+            f"{label} Change",
+            "double",
+            "Metric Changes",
+            "player_trend_snapshots",
+            f"Absolute change in {label.lower()} from baseline to window.",
+            freshness="cached_trend_snapshot",
+        ),
+        _runtime_field(
+            f"{metric_name}_change_pct",
+            f"{label} Change %",
+            "double",
+            "Metric Changes",
+            "player_trend_snapshots",
+            f"Percentage change in {label.lower()} from baseline to window.",
+            freshness="cached_trend_snapshot",
+        ),
+        _runtime_field(
+            f"{metric_name}_direction",
+            f"{label} Direction",
+            "string",
+            "Metric Changes",
+            "player_trend_snapshots",
+            f"Metric-aware improving, declining, or stable classification for {label.lower()}.",
+            freshness="cached_trend_snapshot",
+        ),
+    ])
 
 FIELD_CATALOG: Dict[str, List[Dict[str, Any]]] = {}
 for key, config in REPORT_TYPES.items():

--- a/mlb_app/player_trends.py
+++ b/mlb_app/player_trends.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 import datetime as dt
 import math
-from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional
 
-from .dashboard_object_models import DashboardPlayer
+from sqlalchemy import and_, case, func
+
+from .dashboard_object_models import DashboardPlayer, PlayerTrendSnapshot
 from .database import StatcastEvent
 from .dashboard_report_types import describe_report_type
-from .db_utils import _calculate_batter_stats, _events_to_pitcher_df
+from .db_utils import (
+    HBP_EVENTS,
+    HIT_EVENTS,
+    NON_AB_EVENTS,
+    STRIKEOUT_EVENTS,
+    SWING_DESCRIPTIONS,
+    TERMINAL_EVENTS,
+    TOTAL_BASES,
+    WALK_EVENTS,
+    WHIFF_DESCRIPTIONS,
+)
 from .my_dashboard_report_query import MAX_PAGE_SIZE, normalize_query
-from .statcast_utils import calculate_pitcher_aggregates
 
 
 METRICS: Dict[str, Dict[str, Dict[str, Any]]] = {
@@ -18,19 +28,58 @@ METRICS: Dict[str, Dict[str, Dict[str, Any]]] = {
         "batting_avg": {"label": "Batting Average", "favorable": "higher", "tolerance": .005},
         "on_base_pct": {"label": "On-Base Percentage", "favorable": "higher", "tolerance": .005},
         "slugging_pct": {"label": "Slugging Percentage", "favorable": "higher", "tolerance": .01},
+        "ops": {"label": "OPS", "favorable": "higher", "tolerance": .01},
         "iso": {"label": "ISO", "favorable": "higher", "tolerance": .01},
         "avg_exit_velocity": {"label": "Average Exit Velocity", "favorable": "higher", "tolerance": .5},
+        "max_exit_velocity": {"label": "Maximum Exit Velocity", "favorable": "higher", "tolerance": .5},
+        "avg_launch_angle": {"label": "Average Launch Angle", "favorable": "higher", "tolerance": .5},
         "hard_hit_pct": {"label": "Hard-Hit Rate", "favorable": "higher", "tolerance": .01},
         "barrel_pct": {"label": "Barrel Rate", "favorable": "higher", "tolerance": .01},
         "k_pct": {"label": "Strikeout Rate", "favorable": "lower", "tolerance": .01},
         "bb_pct": {"label": "Walk Rate", "favorable": "higher", "tolerance": .01},
         "whiff_pct": {"label": "Whiff Rate", "favorable": "lower", "tolerance": .01},
+        "contact_pct": {"label": "Contact Rate", "favorable": "higher", "tolerance": .01},
     },
     "pitcher": {
         "k_pct": {"label": "Strikeout Rate", "favorable": "higher", "tolerance": .01},
         "bb_pct": {"label": "Walk Rate", "favorable": "lower", "tolerance": .01},
         "hard_hit_pct": {"label": "Hard-Hit Rate Allowed", "favorable": "lower", "tolerance": .01},
         "avg_velocity": {"label": "Average Pitch Velocity", "favorable": "higher", "tolerance": .3},
+        "avg_spin_rate": {"label": "Average Spin Rate", "favorable": "higher", "tolerance": 25.0},
+        "xwoba": {"label": "xwOBA Allowed", "favorable": "lower", "tolerance": .01},
+        "xba": {"label": "xBA Allowed", "favorable": "lower", "tolerance": .01},
+        "avg_horiz_break": {"label": "Average Horizontal Break", "favorable": "higher", "tolerance": .25},
+        "avg_vert_break": {"label": "Average Vertical Break", "favorable": "higher", "tolerance": .25},
+    },
+}
+
+ROLLING_NUMERIC_FIELDS: Dict[str, Dict[str, str]] = {
+    "hitter": {
+        "actual_pa": "Plate Appearances",
+        "actual_ab": "At Bats",
+        "event_count": "Pitch Events",
+        "batted_ball_count": "Batted Balls",
+        "hard_hit_count": "Hard-Hit Balls",
+        "barrel_count": "Barrels",
+        "hits": "Hits",
+        "doubles": "Doubles",
+        "triples": "Triples",
+        "walks": "Walks",
+        "strikeouts": "Strikeouts",
+        "home_runs": "Home Runs",
+        "total_bases": "Total Bases",
+        **{key: value["label"] for key, value in METRICS["hitter"].items()},
+        "swings": "Swings",
+        "whiffs": "Whiffs",
+    },
+    "pitcher": {
+        "batters_faced": "Batters Faced",
+        "pitch_count": "Pitch Count",
+        "batted_ball_count": "Batted Balls Allowed",
+        "hard_hit_count": "Hard-Hit Balls Allowed",
+        "strikeouts": "Strikeouts",
+        "walks": "Walks",
+        **{key: value["label"] for key, value in METRICS["pitcher"].items()},
     },
 }
 
@@ -122,30 +171,281 @@ def _date_ranges(as_of_date: dt.date, config: Dict[str, Any]) -> Dict[str, dt.da
     }
 
 
-def _aggregate_period(session, player_type: str, start: dt.date, end: dt.date) -> Dict[int, Dict[str, Any]]:
-    """Batch the same calculators used by /batter/{id}/rolling and /pitcher/{id}/rolling."""
-    id_column = StatcastEvent.batter_id if player_type == "hitter" else StatcastEvent.pitcher_id
-    events = (
-        session.query(StatcastEvent)
-        .filter(StatcastEvent.game_date >= start, StatcastEvent.game_date <= end)
-        .order_by(id_column.asc(), StatcastEvent.game_date.asc())
+def _ratio(numerator: int, denominator: int, digits: int = 3) -> Optional[float]:
+    return round(numerator / denominator, digits) if denominator else None
+
+
+def _aggregate_hitter_period(
+    session,
+    start: dt.date,
+    end: dt.date,
+    player_ids: List[int],
+    metrics: List[str],
+) -> Dict[int, Dict[str, Any]]:
+    """Compute the batter rolling-page metrics in SQL instead of loading every pitch."""
+    terminal = (
+        session.query(
+            StatcastEvent.batter_id.label("player_id"),
+            StatcastEvent.game_pk.label("game_pk"),
+            StatcastEvent.at_bat_number.label("at_bat_number"),
+            func.max(case((StatcastEvent.events.in_(list(HIT_EVENTS)), 1), else_=0)).label("is_hit"),
+            func.max(case((StatcastEvent.events == "double", 1), else_=0)).label("is_double"),
+            func.max(case((StatcastEvent.events == "triple", 1), else_=0)).label("is_triple"),
+            func.max(case((StatcastEvent.events == "home_run", 1), else_=0)).label("is_home_run"),
+            func.max(case((StatcastEvent.events.in_(list(WALK_EVENTS)), 1), else_=0)).label("is_walk"),
+            func.max(case((StatcastEvent.events.in_(list(HBP_EVENTS)), 1), else_=0)).label("is_hbp"),
+            func.max(case((StatcastEvent.events.in_(list(STRIKEOUT_EVENTS)), 1), else_=0)).label("is_strikeout"),
+            func.max(case((StatcastEvent.events == "sac_fly", 1), else_=0)).label("is_sac_fly"),
+            func.max(case((StatcastEvent.events.notin_(list(NON_AB_EVENTS)), 1), else_=0)).label("is_ab"),
+            func.max(
+                case(
+                    *[(StatcastEvent.events == event, bases) for event, bases in TOTAL_BASES.items()],
+                    else_=0,
+                )
+            ).label("total_bases"),
+        )
+        .filter(
+            StatcastEvent.game_date >= start,
+            StatcastEvent.game_date <= end,
+            StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.batter_id.in_(player_ids),
+            StatcastEvent.events.in_(list(TERMINAL_EVENTS)),
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+        )
+        .group_by(StatcastEvent.batter_id, StatcastEvent.game_pk, StatcastEvent.at_bat_number)
+        .subquery()
+    )
+    counting_rows = (
+        session.query(
+            terminal.c.player_id,
+            func.count().label("pa"),
+            func.sum(terminal.c.is_ab).label("ab"),
+            func.sum(terminal.c.is_hit).label("hits"),
+            func.sum(terminal.c.is_double).label("doubles"),
+            func.sum(terminal.c.is_triple).label("triples"),
+            func.sum(terminal.c.is_home_run).label("home_runs"),
+            func.sum(terminal.c.is_walk).label("walks"),
+            func.sum(terminal.c.is_hbp).label("hbp"),
+            func.sum(terminal.c.is_strikeout).label("strikeouts"),
+            func.sum(terminal.c.is_sac_fly).label("sacrifice_flies"),
+            func.sum(terminal.c.total_bases).label("total_bases"),
+        )
+        .group_by(terminal.c.player_id)
         .all()
     )
-    grouped: Dict[int, List[StatcastEvent]] = defaultdict(list)
-    for event in events:
-        grouped[int(event.batter_id if player_type == "hitter" else event.pitcher_id)].append(event)
+
+    pitch_rows = []
+    if set(metrics).intersection({"avg_exit_velocity", "hard_hit_pct", "barrel_pct", "whiff_pct"}):
+        pitch = (
+            session.query(
+                StatcastEvent.batter_id.label("player_id"),
+                StatcastEvent.game_pk.label("game_pk"),
+                StatcastEvent.at_bat_number.label("at_bat_number"),
+                StatcastEvent.pitch_number.label("pitch_number"),
+                func.max(StatcastEvent.launch_speed).label("launch_speed"),
+                func.max(StatcastEvent.launch_angle).label("launch_angle"),
+                func.max(case((StatcastEvent.description.in_(list(SWING_DESCRIPTIONS)), 1), else_=0)).label("is_swing"),
+                func.max(case((StatcastEvent.description.in_(list(WHIFF_DESCRIPTIONS)), 1), else_=0)).label("is_whiff"),
+            )
+            .filter(
+                StatcastEvent.game_date >= start,
+                StatcastEvent.game_date <= end,
+                StatcastEvent.batter_id.isnot(None),
+                StatcastEvent.batter_id.in_(player_ids),
+                StatcastEvent.game_pk.isnot(None),
+                StatcastEvent.at_bat_number.isnot(None),
+                StatcastEvent.pitch_number.isnot(None),
+            )
+            .group_by(
+                StatcastEvent.batter_id,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+            )
+            .subquery()
+        )
+        pitch_rows = (
+            session.query(
+                pitch.c.player_id,
+                func.count().label("event_count"),
+                func.count(pitch.c.launch_speed).label("batted_balls"),
+                func.avg(pitch.c.launch_speed).label("avg_exit_velocity"),
+                func.max(pitch.c.launch_speed).label("max_exit_velocity"),
+                func.avg(pitch.c.launch_angle).label("avg_launch_angle"),
+                func.sum(case((pitch.c.launch_speed >= 95.0, 1), else_=0)).label("hard_hits"),
+                func.sum(
+                    case(
+                        (
+                            and_(
+                                pitch.c.launch_speed >= 98.0,
+                                pitch.c.launch_angle >= 8.0,
+                                pitch.c.launch_angle <= 50.0,
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ).label("barrels"),
+                func.sum(pitch.c.is_swing).label("swings"),
+                func.sum(pitch.c.is_whiff).label("whiffs"),
+            )
+            .group_by(pitch.c.player_id)
+            .all()
+        )
+    pitch_by_player = {int(row.player_id): row for row in pitch_rows}
+
     result: Dict[int, Dict[str, Any]] = {}
-    for player_id, player_events in grouped.items():
-        if player_type == "hitter":
-            stats = _calculate_batter_stats(player_events, raw_event_count=len(player_events))
-            stats["sample_size"] = int(stats.get("actual_pa") or 0)
-        else:
-            stats = calculate_pitcher_aggregates(_events_to_pitcher_df(player_events))
-            stats["sample_size"] = sum(1 for event in player_events if event.events)
-        stats["start_date"] = start.isoformat()
-        stats["end_date"] = end.isoformat()
-        result[player_id] = stats
+    for row in counting_rows:
+        player_id = int(row.player_id)
+        pa = int(row.pa or 0)
+        ab = int(row.ab or 0)
+        hits = int(row.hits or 0)
+        doubles = int(row.doubles or 0)
+        triples = int(row.triples or 0)
+        home_runs = int(row.home_runs or 0)
+        walks = int(row.walks or 0)
+        hbp = int(row.hbp or 0)
+        strikeouts = int(row.strikeouts or 0)
+        sacrifice_flies = int(row.sacrifice_flies or 0)
+        total_bases = int(row.total_bases or 0)
+        batting_avg = _ratio(hits, ab)
+        on_base_pct = _ratio(hits + walks + hbp, ab + walks + hbp + sacrifice_flies)
+        slugging_pct = _ratio(total_bases, ab)
+        pitch_row = pitch_by_player.get(player_id)
+        batted_balls = int(getattr(pitch_row, "batted_balls", 0) or 0)
+        hard_hits = int(getattr(pitch_row, "hard_hits", 0) or 0)
+        barrels = int(getattr(pitch_row, "barrels", 0) or 0)
+        swings = int(getattr(pitch_row, "swings", 0) or 0)
+        whiffs = int(getattr(pitch_row, "whiffs", 0) or 0)
+        avg_exit_velocity = getattr(pitch_row, "avg_exit_velocity", None)
+        max_exit_velocity = getattr(pitch_row, "max_exit_velocity", None)
+        avg_launch_angle = getattr(pitch_row, "avg_launch_angle", None)
+        result[player_id] = {
+            "sample_size": pa,
+            "actual_pa": pa,
+            "actual_ab": ab,
+            "event_count": int(getattr(pitch_row, "event_count", 0) or 0),
+            "batted_ball_count": batted_balls,
+            "hard_hit_count": hard_hits,
+            "barrel_count": barrels,
+            "hits": hits,
+            "doubles": doubles,
+            "triples": triples,
+            "walks": walks,
+            "strikeouts": strikeouts,
+            "home_runs": home_runs,
+            "total_bases": total_bases,
+            "batting_avg": batting_avg,
+            "on_base_pct": on_base_pct,
+            "slugging_pct": slugging_pct,
+            "ops": (
+                round(on_base_pct + slugging_pct, 3)
+                if on_base_pct is not None and slugging_pct is not None
+                else None
+            ),
+            "iso": (
+                round(slugging_pct - batting_avg, 3)
+                if slugging_pct is not None and batting_avg is not None
+                else None
+            ),
+            "avg_exit_velocity": round(float(avg_exit_velocity), 1) if avg_exit_velocity is not None else None,
+            "max_exit_velocity": round(float(max_exit_velocity), 1) if max_exit_velocity is not None else None,
+            "avg_launch_angle": round(float(avg_launch_angle), 1) if avg_launch_angle is not None else None,
+            "hard_hit_pct": _ratio(hard_hits, batted_balls),
+            "barrel_pct": _ratio(barrels, batted_balls),
+            "k_pct": _ratio(strikeouts, pa),
+            "bb_pct": _ratio(walks, pa),
+            "swings": swings,
+            "whiffs": whiffs,
+            "whiff_pct": _ratio(whiffs, swings),
+            "contact_pct": round(1 - (whiffs / swings), 3) if swings else None,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        }
     return result
+
+
+def _aggregate_pitcher_period(
+    session,
+    start: dt.date,
+    end: dt.date,
+    player_ids: List[int],
+) -> Dict[int, Dict[str, Any]]:
+    """Compute the pitcher rolling-page metrics in one grouped SQL query."""
+    rows = (
+        session.query(
+            StatcastEvent.pitcher_id.label("player_id"),
+            func.count(StatcastEvent.id).label("pitch_count"),
+            func.sum(
+                case(
+                    (
+                        and_(StatcastEvent.events.isnot(None), StatcastEvent.events != ""),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ).label("batters_faced"),
+            func.sum(case((StatcastEvent.events == "strikeout", 1), else_=0)).label("strikeouts"),
+            func.sum(case((StatcastEvent.events == "walk", 1), else_=0)).label("walks"),
+            func.count(StatcastEvent.launch_speed).label("batted_balls"),
+            func.sum(case((StatcastEvent.launch_speed >= 95.0, 1), else_=0)).label("hard_hits"),
+            func.avg(StatcastEvent.release_speed).label("avg_velocity"),
+            func.avg(StatcastEvent.release_spin_rate).label("avg_spin_rate"),
+            func.avg(StatcastEvent.estimated_woba_using_speedangle).label("xwoba"),
+            func.avg(StatcastEvent.estimated_ba_using_speedangle).label("xba"),
+            func.avg(StatcastEvent.pfx_x).label("avg_horiz_break"),
+            func.avg(StatcastEvent.pfx_z).label("avg_vert_break"),
+        )
+        .filter(
+            StatcastEvent.game_date >= start,
+            StatcastEvent.game_date <= end,
+            StatcastEvent.pitcher_id.isnot(None),
+            StatcastEvent.pitcher_id.in_(player_ids),
+        )
+        .group_by(StatcastEvent.pitcher_id)
+        .all()
+    )
+    result: Dict[int, Dict[str, Any]] = {}
+    for row in rows:
+        player_id = int(row.player_id)
+        batters_faced = int(row.batters_faced or 0)
+        batted_balls = int(row.batted_balls or 0)
+        result[player_id] = {
+            "sample_size": batters_faced,
+            "batters_faced": batters_faced,
+            "pitch_count": int(row.pitch_count or 0),
+            "batted_ball_count": batted_balls,
+            "hard_hit_count": int(row.hard_hits or 0),
+            "strikeouts": int(row.strikeouts or 0),
+            "walks": int(row.walks or 0),
+            "k_pct": _ratio(int(row.strikeouts or 0), batters_faced),
+            "bb_pct": _ratio(int(row.walks or 0), batters_faced),
+            "hard_hit_pct": _ratio(int(row.hard_hits or 0), batted_balls),
+            "avg_velocity": float(row.avg_velocity) if row.avg_velocity is not None else None,
+            "avg_spin_rate": float(row.avg_spin_rate) if row.avg_spin_rate is not None else None,
+            "xwoba": float(row.xwoba) if row.xwoba is not None else None,
+            "xba": float(row.xba) if row.xba is not None else None,
+            "avg_horiz_break": float(row.avg_horiz_break) if row.avg_horiz_break is not None else None,
+            "avg_vert_break": float(row.avg_vert_break) if row.avg_vert_break is not None else None,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        }
+    return result
+
+
+def _aggregate_period(
+    session,
+    player_type: str,
+    start: dt.date,
+    end: dt.date,
+    player_ids: List[int],
+    metrics: List[str],
+) -> Dict[int, Dict[str, Any]]:
+    """Batch the ID-page metric definitions without materializing the event warehouse."""
+    if player_type == "hitter":
+        return _aggregate_hitter_period(session, start, end, player_ids, metrics)
+    return _aggregate_pitcher_period(session, start, end, player_ids)
 
 
 def _classify(metric: str, player_type: str, change: float) -> str:
@@ -195,6 +495,185 @@ def _apply_filters(rows: Iterable[Dict[str, Any]], filters: Any) -> List[Dict[st
     ]
 
 
+def _snapshot_query(session, as_of_date: dt.date, config: Dict[str, Any]):
+    return session.query(PlayerTrendSnapshot).filter(
+        PlayerTrendSnapshot.as_of_date == as_of_date,
+        PlayerTrendSnapshot.player_type == config["player_type"],
+        PlayerTrendSnapshot.window_days == config["window_days"],
+        PlayerTrendSnapshot.comparison_baseline == config["comparison_baseline"],
+        PlayerTrendSnapshot.metric.in_(config["selected_metrics"]),
+    )
+
+
+def _cached_snapshots_are_fresh(
+    snapshots: List[PlayerTrendSnapshot],
+    *,
+    as_of_date: dt.date,
+    selected_metrics: List[str],
+) -> bool:
+    if {row.metric for row in snapshots} != set(selected_metrics):
+        return False
+    if as_of_date < dt.date.today():
+        return True
+    cutoff = dt.datetime.utcnow() - dt.timedelta(minutes=30)
+    return all(row.generated_at and row.generated_at >= cutoff for row in snapshots)
+
+
+def _materialize_trend_dataset(
+    session,
+    *,
+    as_of_date: dt.date,
+    config: Dict[str, Any],
+    ranges: Dict[str, dt.date],
+) -> List[PlayerTrendSnapshot]:
+    players_list = (
+        session.query(DashboardPlayer)
+        .filter(
+            DashboardPlayer.is_active.is_(True),
+            DashboardPlayer.player_type == config["player_type"],
+        )
+        .all()
+    )
+    players = {int(player.mlb_player_id): player for player in players_list}
+    player_ids = sorted(players)
+    if not player_ids:
+        return []
+
+    all_metrics = list(METRICS[config["player_type"]])
+    window = _aggregate_period(
+        session,
+        config["player_type"],
+        ranges["window_start"],
+        ranges["window_end"],
+        player_ids,
+        all_metrics,
+    )
+    baseline = _aggregate_period(
+        session,
+        config["player_type"],
+        ranges["baseline_start"],
+        ranges["baseline_end"],
+        player_ids,
+        all_metrics,
+    )
+    comparable_ids = sorted(set(window).intersection(baseline))
+    generated_at = dt.datetime.utcnow()
+    records: List[Dict[str, Any]] = []
+    for player_id in comparable_ids:
+        current = window[player_id]
+        comparison = baseline[player_id]
+        player = players[player_id]
+        window_metrics = {
+            key: current.get(key)
+            for key in ROLLING_NUMERIC_FIELDS[config["player_type"]]
+        }
+        baseline_metrics = {
+            key: comparison.get(key)
+            for key in ROLLING_NUMERIC_FIELDS[config["player_type"]]
+        }
+        for metric in config["selected_metrics"]:
+            current_value = current.get(metric)
+            baseline_value = comparison.get(metric)
+            change = (
+                float(current_value) - float(baseline_value)
+                if current_value is not None and baseline_value is not None
+                else None
+            )
+            records.append({
+                "as_of_date": as_of_date,
+                "player_id": player_id,
+                "player_name": player.full_name or str(player_id),
+                "player_type": config["player_type"],
+                "team": player.current_team_name,
+                "window_days": config["window_days"],
+                "comparison_baseline": config["comparison_baseline"],
+                "metric": metric,
+                "window_start": ranges["window_start"],
+                "window_end": ranges["window_end"],
+                "baseline_start": ranges["baseline_start"],
+                "baseline_end": ranges["baseline_end"],
+                "window_sample_size": int(current.get("sample_size") or 0),
+                "baseline_sample_size": int(comparison.get("sample_size") or 0),
+                "current_value": float(current_value) if current_value is not None else None,
+                "baseline_value": float(baseline_value) if baseline_value is not None else None,
+                "absolute_change": change,
+                "percentage_change": (
+                    change / abs(float(baseline_value))
+                    if change is not None and float(baseline_value) != 0
+                    else None
+                ),
+                "trend_direction": (
+                    _classify(metric, config["player_type"], change)
+                    if change is not None
+                    else None
+                ),
+                "favorable_direction": METRICS[config["player_type"]][metric]["favorable"],
+                "window_metrics_json": window_metrics,
+                "baseline_metrics_json": baseline_metrics,
+                "source": "statcast_events_sql_aggregate",
+                "generated_at": generated_at,
+            })
+
+    _snapshot_query(session, as_of_date, config).delete(synchronize_session=False)
+    if records:
+        session.bulk_insert_mappings(PlayerTrendSnapshot, records)
+    session.commit()
+    return _snapshot_query(session, as_of_date, config).all()
+
+
+def _snapshot_to_row(snapshot: PlayerTrendSnapshot) -> Dict[str, Any]:
+    window_metrics = dict(snapshot.window_metrics_json or {})
+    baseline_metrics = dict(snapshot.baseline_metrics_json or {})
+    row: Dict[str, Any] = {
+        "player_id": snapshot.player_id,
+        "player_name": snapshot.player_name,
+        "player_type": snapshot.player_type,
+        "team": snapshot.team,
+        "metric": snapshot.metric,
+        "metric_label": METRICS[snapshot.player_type][snapshot.metric]["label"],
+        "selected_window_days": snapshot.window_days,
+        "comparison_baseline": snapshot.comparison_baseline,
+        "window_start": snapshot.window_start.isoformat(),
+        "window_end": snapshot.window_end.isoformat(),
+        "baseline_start": snapshot.baseline_start.isoformat(),
+        "baseline_end": snapshot.baseline_end.isoformat(),
+        "window_sample_size": snapshot.window_sample_size,
+        "baseline_sample_size": snapshot.baseline_sample_size,
+        "current_value": snapshot.current_value,
+        "baseline_value": snapshot.baseline_value,
+        "absolute_change": snapshot.absolute_change,
+        "percentage_change": snapshot.percentage_change,
+        "trend_direction": snapshot.trend_direction,
+        "favorable_direction": snapshot.favorable_direction,
+        "freshness_date": snapshot.as_of_date.isoformat(),
+        "dataset_generated_at": snapshot.generated_at.isoformat(),
+        "source": snapshot.source,
+    }
+    for key in ROLLING_NUMERIC_FIELDS[snapshot.player_type]:
+        row[f"window_{key}"] = window_metrics.get(key)
+        row[f"baseline_{key}"] = baseline_metrics.get(key)
+    for metric in METRICS[snapshot.player_type]:
+        current = window_metrics.get(metric)
+        baseline = baseline_metrics.get(metric)
+        change = (
+            float(current) - float(baseline)
+            if current is not None and baseline is not None
+            else None
+        )
+        row[f"{metric}_change"] = change
+        row[f"{metric}_change_pct"] = (
+            change / abs(float(baseline))
+            if change is not None and float(baseline) != 0
+            else None
+        )
+        row[f"{metric}_direction"] = (
+            _classify(metric, snapshot.player_type, change)
+            if change is not None
+            else None
+        )
+    return row
+
+
 def query_player_trends(
     session,
     *,
@@ -210,57 +689,39 @@ def query_player_trends(
 ) -> Dict[str, Any]:
     config = _validated_config(trend_config)
     ranges = _date_ranges(as_of_date, config)
-    window = _aggregate_period(session, config["player_type"], ranges["window_start"], ranges["window_end"])
-    baseline = _aggregate_period(session, config["player_type"], ranges["baseline_start"], ranges["baseline_end"])
-    player_ids = sorted(set(window).intersection(baseline))
-    players = {}
-    if player_ids:
-        players = {
-            int(player.mlb_player_id): player
-            for player in session.query(DashboardPlayer).filter(DashboardPlayer.mlb_player_id.in_(player_ids)).all()
-        }
+    snapshots = _snapshot_query(session, as_of_date, config).all()
+    dataset_cache_hit = _cached_snapshots_are_fresh(
+        snapshots,
+        as_of_date=as_of_date,
+        selected_metrics=config["selected_metrics"],
+    )
+    if not dataset_cache_hit:
+        snapshots = _materialize_trend_dataset(
+            session,
+            as_of_date=as_of_date,
+            config=config,
+            ranges=ranges,
+        )
+
     rows: List[Dict[str, Any]] = []
     missing_metric_pairs = 0
-    for player_id in player_ids:
-        current = window[player_id]
-        comparison = baseline[player_id]
-        if current["sample_size"] < config["minimum_sample_size"] or comparison["sample_size"] < config["minimum_sample_size"]:
+    comparable_player_ids = set()
+    for snapshot in snapshots:
+        comparable_player_ids.add(snapshot.player_id)
+        if (
+            snapshot.window_sample_size < config["minimum_sample_size"]
+            or snapshot.baseline_sample_size < config["minimum_sample_size"]
+        ):
             continue
-        player = players.get(player_id)
-        for metric in config["selected_metrics"]:
-            current_value = current.get(metric)
-            baseline_value = comparison.get(metric)
-            if current_value is None or baseline_value is None:
-                missing_metric_pairs += 1
-                continue
-            change = float(current_value) - float(baseline_value)
-            direction = _classify(metric, config["player_type"], change)
-            if config["trend_direction"] != "all" and direction != config["trend_direction"]:
-                continue
-            rows.append({
-                "player_id": player_id,
-                "player_name": getattr(player, "full_name", None) or str(player_id),
-                "player_type": config["player_type"],
-                "team": getattr(player, "current_team_name", None),
-                "metric": metric,
-                "metric_label": METRICS[config["player_type"]][metric]["label"],
-                "selected_window_days": config["window_days"],
-                "comparison_baseline": config["comparison_baseline"],
-                "window_start": ranges["window_start"].isoformat(),
-                "window_end": ranges["window_end"].isoformat(),
-                "baseline_start": ranges["baseline_start"].isoformat(),
-                "baseline_end": ranges["baseline_end"].isoformat(),
-                "window_sample_size": current["sample_size"],
-                "baseline_sample_size": comparison["sample_size"],
-                "current_value": float(current_value),
-                "baseline_value": float(baseline_value),
-                "absolute_change": change,
-                "percentage_change": (change / abs(float(baseline_value))) if float(baseline_value) != 0 else None,
-                "trend_direction": direction,
-                "favorable_direction": METRICS[config["player_type"]][metric]["favorable"],
-                "freshness_date": as_of_date.isoformat(),
-                "source": "statcast_events",
-            })
+        if snapshot.current_value is None or snapshot.baseline_value is None:
+            missing_metric_pairs += 1
+            continue
+        if (
+            config["trend_direction"] != "all"
+            and snapshot.trend_direction != config["trend_direction"]
+        ):
+            continue
+        rows.append(_snapshot_to_row(snapshot))
     rows = _apply_filters(rows, filters)
     query = normalize_query(page_size, page_number, sort_by, sort_direction)
     rows.sort(
@@ -281,14 +742,18 @@ def query_player_trends(
         "trend_config": config,
         "supported_trend_configuration": supported_trend_configuration(),
         "provenance": {
-            "source": "statcast_events",
+            "source": "player_trend_snapshots",
+            "upstream_source": "statcast_events",
+            "calculation": "sql_aggregate_equivalent_to_player_id_rolling_pages",
             "requested_date": as_of_date.isoformat(),
             **{key: value.isoformat() for key, value in ranges.items()},
         },
         "data_quality": {
-            "players_with_both_periods": len(player_ids),
+            "players_with_both_periods": len(comparable_player_ids),
             "missing_metric_pairs": missing_metric_pairs,
             "minimum_sample_size": config["minimum_sample_size"],
+            "dataset_cache_hit": dataset_cache_hit,
+            "dataset_row_count": len(snapshots),
         },
         "page_info": {
             "page_number": query["page_number"],

--- a/tests/test_player_trends_and_saved_report_analysis.py
+++ b/tests/test_player_trends_and_saved_report_analysis.py
@@ -4,7 +4,8 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from mlb_app.dashboard_object_models import DashboardPlayer
+from mlb_app.dashboard_object_models import DashboardPlayer, PlayerTrendSnapshot
+from mlb_app.dashboard_report_types import describe_report_type
 from mlb_app.database import AppDashboardFolder, AppDashboardItem, Base, StatcastEvent
 from mlb_app.player_trends import query_player_trends, supported_trend_configuration
 from mlb_app.saved_report_analysis import (
@@ -75,7 +76,25 @@ def test_hitter_previous_window_uses_rolling_page_calculator_and_direction(sessi
     assert result["totalSize"] == 3
     assert {row["trend_direction"] for row in result["records"]} == {"improving"}
     assert all(row["window_sample_size"] == 2 for row in result["records"])
-    assert result["provenance"]["source"] == "statcast_events"
+    assert result["provenance"]["source"] == "player_trend_snapshots"
+    assert result["provenance"]["upstream_source"] == "statcast_events"
+    assert result["data_quality"]["dataset_cache_hit"] is False
+    assert session.query(PlayerTrendSnapshot).count() == 3
+
+    cached = query_player_trends(
+        session,
+        as_of_date=dt.date(2026, 7, 21),
+        trend_config={
+            "player_type": "hitter",
+            "window_days": 7,
+            "comparison_baseline": "previous_n_days",
+            "minimum_sample_size": 2,
+            "trend_direction": "all",
+            "selected_metrics": ["batting_avg", "avg_exit_velocity", "k_pct"],
+        },
+    )
+    assert cached["data_quality"]["dataset_cache_hit"] is True
+    assert cached["records"] == result["records"]
 
 
 def test_pitcher_higher_strikeout_rate_is_improving(session):
@@ -123,6 +142,27 @@ def test_unsupported_prior_equivalent_period_is_not_advertised(session):
                 "selected_metrics": ["batting_avg"],
             },
         )
+
+
+def test_player_trend_object_registers_cached_rolling_fields():
+    object_info = describe_report_type("player_trends")
+    field_names = {field["name"] for field in object_info["fields"]}
+
+    assert object_info["base_object"] == "player_trend_snapshots"
+    assert {
+        "window_batting_avg",
+        "baseline_batting_avg",
+        "batting_avg_change",
+        "window_avg_velocity",
+        "baseline_avg_velocity",
+        "avg_velocity_change",
+        "dataset_generated_at",
+    }.issubset(field_names)
+    assert all(
+        field["filterable"]
+        for field in object_info["fields"]
+        if field["name"] in {"window_batting_avg", "baseline_avg_velocity"}
+    )
 
 
 def test_saved_report_resolution_is_user_scoped_and_packet_preserves_rank(session):


### PR DESCRIPTION
## Production failure

The first Player Trends implementation loaded every `statcast_events` ORM row for both the selected window and baseline, grouped the rows in Python, and then built Pandas frames per player. In Railway, the 60-day hitter request ran for roughly 100–110 seconds and the Uvicorn process restarted before returning a response.

## Replacement architecture

- Adds the real `player_trend_snapshots` dataset, created through the existing `Base.metadata.create_all` object-model path.
- Keys cached rows by as-of date, active player, player type, N-day window, comparison baseline, and metric.
- Replaces full ORM event materialization with indexed SQL aggregation over `statcast_events`.
- Limits the population to canonical active `dashboard_players`.
- Reuses cached rows for 30 minutes on the current MLB date and indefinitely for historical dates.
- Keeps one execution path for MyDashboard, reopened saved reports, and AI Data Assistant analysis.

## Object Manager and fields

`player_trends` now registers with `player_trend_snapshots` as its base object and documents its relationships to `dashboard_players`, raw Statcast, and hitter/pitcher ID rolling authorities.

The registry exposes 158 unique filterable fields, including:

- player identity, date windows, samples, freshness, and dataset generation time;
- window and baseline hitter rolling values/counts;
- window and baseline pitcher rolling values/counts;
- per-metric absolute change, percentage change, and direction;
- generic selected-metric values used by the existing report UI.

The UI metric selector now includes the additional rolling metrics exposed by the hitter and pitcher ID pages.

## AI Data Assistant

No parallel AI implementation is introduced. Saved Player Trends reports execute through the same cached dataset query before the deterministic packet is built, so the AI path receives identical rows, filters, ranking, sample sizes, and provenance.

## Validation

- Python compilation passed for all changed backend modules and tests.
- Existing frontend report-builder suite: 12/12 passed.
- Registry contract check: 158 fields, 158 unique names, all filterable, required hitter/pitcher rolling fields present.
- Added regression coverage for dataset persistence, cache reuse, provenance, and Object Manager field registration.
- Full backend pytest requires the repository SQLAlchemy environment and should run in GitHub CI/Railway; this scratch environment does not include SQLAlchemy.
