### PR TITLE
Validate shadow hitter weight stability

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_weight_stability.py
+++ b/mlb_app/simulation/shadow/hitter_profile_weight_stability.py
@@ -1,0 +1,154 @@
+"""Shadow-only stability gate for hitter profile weight calibration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+
+DEFAULT_STABILITY_POLICY = {
+    "minimum_windows": 4,
+    "minimum_seasons": 2,
+    "minimum_samples_per_window": 200,
+    "minimum_total_holdout_ab": 50_000,
+    "maximum_global_weight_spread": 0.15,
+    "maximum_split_weight_spread": 0.20,
+}
+
+
+def _number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _candidate_weight(candidate: Any) -> Optional[float]:
+    if not isinstance(candidate, Mapping):
+        return None
+    return _number(candidate.get("expected_weight"))
+
+
+def _range(values: Sequence[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "weights": [],
+            "minimum": None,
+            "maximum": None,
+            "spread": None,
+        }
+    minimum = min(values)
+    maximum = max(values)
+    return {
+        "weights": list(values),
+        "minimum": minimum,
+        "maximum": maximum,
+        "spread": maximum - minimum,
+    }
+
+
+def validate_shadow_hitter_weight_stability(
+    audit: Mapping[str, Any],
+    *,
+    policy: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Evaluate temporal and handedness stability without selecting a parameter."""
+
+    applied_policy = dict(DEFAULT_STABILITY_POLICY)
+    applied_policy.update(dict(policy or {}))
+    windows = [
+        row for row in (audit.get("windows") or ())
+        if isinstance(row, Mapping)
+    ]
+    seasons = sorted({
+        int(row["season"])
+        for row in windows
+        if row.get("season") is not None
+    })
+    global_weights = [
+        weight
+        for row in windows
+        if (weight := _candidate_weight(row.get("best_candidate"))) is not None
+    ]
+    split_weights: dict[str, list[float]] = {"vsR": [], "vsL": []}
+    for row in windows:
+        split_results = row.get("split_results") or {}
+        for split in split_weights:
+            split_row = split_results.get(split) or {}
+            weight = _candidate_weight(split_row.get("best_candidate"))
+            if weight is not None:
+                split_weights[split].append(weight)
+
+    global_range = _range(global_weights)
+    split_ranges = {
+        split: _range(weights)
+        for split, weights in split_weights.items()
+    }
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    if len(windows) < int(applied_policy["minimum_windows"]):
+        blockers.append("insufficient_stability_windows")
+    if len(seasons) < int(applied_policy["minimum_seasons"]):
+        blockers.append("insufficient_stability_seasons")
+    if any(
+        int(row.get("sample_count") or 0)
+        < int(applied_policy["minimum_samples_per_window"])
+        for row in windows
+    ):
+        blockers.append("insufficient_window_samples")
+    if int(audit.get("holdout_ab") or 0) < int(
+        applied_policy["minimum_total_holdout_ab"]
+    ):
+        blockers.append("insufficient_total_holdout_ab")
+    if len(global_weights) != len(windows):
+        blockers.append("missing_window_weight_candidates")
+    elif (
+        global_range["spread"]
+        > float(applied_policy["maximum_global_weight_spread"])
+    ):
+        blockers.append("unstable_global_expected_weight")
+
+    for split, split_range in split_ranges.items():
+        if len(split_range["weights"]) != len(windows):
+            blockers.append(f"missing_{split}_weight_candidates")
+        elif (
+            split_range["spread"]
+            > float(applied_policy["maximum_split_weight_spread"])
+        ):
+            blockers.append(f"unstable_{split}_expected_weight")
+
+    pooled_candidate = audit.get("pooled_candidate")
+    pooled_weight = _candidate_weight(pooled_candidate)
+    if pooled_weight is None:
+        blockers.append("missing_pooled_candidate")
+    elif pooled_weight != 0.50:
+        warnings.append("pooled_candidate_differs_from_current_policy")
+
+    return {
+        "schema_version": "shadow_hitter_weight_stability_gate_v1",
+        "status": "blocked" if blockers else "ready_for_selection_review",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "candidate_expected_weight": pooled_weight,
+        "candidate_actual_weight": (
+            None if pooled_weight is None else 1.0 - pooled_weight
+        ),
+        "window_count": len(windows),
+        "seasons": seasons,
+        "sample_count": int(audit.get("sample_count") or 0),
+        "holdout_ab": int(audit.get("holdout_ab") or 0),
+        "global_weight_range": global_range,
+        "split_weight_ranges": split_ranges,
+        "policy": applied_policy,
+        "blockers": blockers,
+        "warnings": warnings,
+        "decision": (
+            "retain_current_policy"
+            if blockers
+            else "eligible_for_separate_selection_pr"
+        ),
+    }

--- a/tests/test_hitter_profile_weight_stability.py
+++ b/tests/test_hitter_profile_weight_stability.py
@@ -1,0 +1,103 @@
+from mlb_app.simulation.shadow.hitter_profile_weight_stability import (
+    validate_shadow_hitter_weight_stability,
+)
+
+
+def candidate(expected_weight):
+    return {
+        "actual_weight": 1.0 - expected_weight,
+        "expected_weight": expected_weight,
+        "scores": {"log_loss": 0.57},
+    }
+
+
+def audit(global_weights, vsr_weights=None, vsl_weights=None):
+    vsr_weights = vsr_weights or global_weights
+    vsl_weights = vsl_weights or global_weights
+    windows = []
+    for index, weight in enumerate(global_weights):
+        windows.append({
+            "season": 2024 + (index % 2),
+            "sample_count": 250,
+            "best_candidate": candidate(weight),
+            "split_results": {
+                "vsR": {"best_candidate": candidate(vsr_weights[index])},
+                "vsL": {"best_candidate": candidate(vsl_weights[index])},
+            },
+        })
+    return {
+        "sample_count": len(windows) * 250,
+        "holdout_ab": 60_000,
+        "pooled_candidate": candidate(0.35),
+        "windows": windows,
+    }
+
+
+def test_blocks_observed_global_and_split_instability():
+    result = validate_shadow_hitter_weight_stability(
+        audit(
+            [0.40, 0.40, 0.50, 0.15, 0.20, 0.40],
+            [0.55, 0.35, 0.30, 0.10, 0.15, 0.40],
+            [0.00, 0.60, 0.90, 0.25, 0.35, 0.35],
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["decision"] == "retain_current_policy"
+    assert result["candidate_expected_weight"] == 0.35
+    assert result["global_weight_range"]["spread"] == 0.35
+    assert set(result["blockers"]) == {
+        "unstable_global_expected_weight",
+        "unstable_vsR_expected_weight",
+        "unstable_vsL_expected_weight",
+    }
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False
+
+
+def test_stable_evidence_is_only_ready_for_separate_selection_review():
+    result = validate_shadow_hitter_weight_stability(
+        audit(
+            [0.35, 0.40, 0.35, 0.40],
+            [0.30, 0.35, 0.30, 0.35],
+            [0.40, 0.45, 0.40, 0.45],
+        )
+    )
+
+    assert result["status"] == "ready_for_selection_review"
+    assert result["decision"] == "eligible_for_separate_selection_pr"
+    assert result["blockers"] == []
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False
+
+
+def test_blocks_missing_or_thin_evidence():
+    payload = audit([0.35, 0.40])
+    payload["holdout_ab"] = 10_000
+    payload["windows"][0]["sample_count"] = 50
+    del payload["windows"][1]["split_results"]["vsL"]["best_candidate"]
+
+    result = validate_shadow_hitter_weight_stability(payload)
+
+    assert result["status"] == "blocked"
+    assert {
+        "insufficient_stability_windows",
+        "insufficient_window_samples",
+        "insufficient_total_holdout_ab",
+        "missing_vsL_weight_candidates",
+    }.issubset(result["blockers"])
+
+
+def test_custom_policy_is_applied_without_mutating_defaults():
+    payload = audit([0.20, 0.40, 0.20, 0.40])
+    result = validate_shadow_hitter_weight_stability(
+        payload,
+        policy={
+            "maximum_global_weight_spread": 0.25,
+            "maximum_split_weight_spread": 0.25,
+        },
+    )
+    default_result = validate_shadow_hitter_weight_stability(payload)
+
+    assert result["status"] == "ready_for_selection_review"
+    assert default_result["status"] == "blocked"


### PR DESCRIPTION
## Summary
- add a shadow-only stability gate for calibrated hitter profile weights
- require sufficient windows, seasons, per-window samples, and total holdout at-bats
- measure global and pitcher-hand-specific expected-weight ranges
- retain the current policy when temporal or handedness estimates are unstable

## Evidence
The six-window historical audit covered 1,816 samples and 84,883 holdout at-bats. Although the pooled candidate was 35% expected / 65% actual, the global expected-weight range was 15%–50% (35-point spread). The vsR spread was 45 points and the vsL spread was 90 points. The new gate therefore records the candidate but blocks parameter selection and preserves production authority.

## Validation
- 1,205 regression tests passed; 2 deliberately deselected
- 29 focused shadow hitter tests passed
- Python compilation passed
- `git diff --check` passed

## Production impact
None. This PR is shadow-only: `parameter_selected` and `production_authority_changed` remain false, and the current 50/50 policy is retained.