### PR TITLE
Audit expected hitter power evidence

### DIFF
--- a/mlb_app/simulation/shadow/hitter_power_incremental_validation.py
+++ b/mlb_app/simulation/shadow/hitter_power_incremental_validation.py
@@ -1,0 +1,449 @@
+"""Cross-season validation for shadow hitter expected-power evidence."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+
+MODEL_FEATURES = {
+    "intercept_only": (),
+    "actual_iso": ("pre_actual_iso",),
+    "expected_damage": ("pre_expected_damage_per_ab",),
+    "expected_damage_hard_hit": (
+        "pre_expected_damage_per_ab",
+        "pre_hard_hit_rate",
+    ),
+    "expected_damage_barrel": (
+        "pre_expected_damage_per_ab",
+        "pre_barrel_proxy_rate",
+    ),
+    "expected_damage_hard_hit_barrel": (
+        "pre_expected_damage_per_ab",
+        "pre_hard_hit_rate",
+        "pre_barrel_proxy_rate",
+    ),
+    "actual_expected": (
+        "pre_actual_iso",
+        "pre_expected_damage_per_ab",
+    ),
+    "actual_expected_hard_hit": (
+        "pre_actual_iso",
+        "pre_expected_damage_per_ab",
+        "pre_hard_hit_rate",
+    ),
+    "actual_expected_barrel": (
+        "pre_actual_iso",
+        "pre_expected_damage_per_ab",
+        "pre_barrel_proxy_rate",
+    ),
+    "actual_expected_hard_hit_barrel": (
+        "pre_actual_iso",
+        "pre_expected_damage_per_ab",
+        "pre_hard_hit_rate",
+        "pre_barrel_proxy_rate",
+    ),
+}
+
+
+def _number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _clean_samples(
+    samples: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    required = {
+        "season",
+        "holdout_ab",
+        "holdout_iso",
+        *{
+            feature
+            for features in MODEL_FEATURES.values()
+            for feature in features
+        },
+    }
+    cleaned = []
+    for sample in samples:
+        values = {key: _number(sample.get(key)) for key in required}
+        if any(value is None for value in values.values()):
+            continue
+        if values["holdout_ab"] <= 0:
+            continue
+        cleaned.append({
+            **dict(sample),
+            **values,
+            "season": int(values["season"]),
+        })
+    return cleaned
+
+
+def _solve(matrix: list[list[float]], vector: list[float]) -> list[float]:
+    size = len(vector)
+    augmented = [
+        list(matrix[row]) + [vector[row]]
+        for row in range(size)
+    ]
+    for pivot in range(size):
+        best = max(
+            range(pivot, size),
+            key=lambda row: abs(augmented[row][pivot]),
+        )
+        augmented[pivot], augmented[best] = (
+            augmented[best],
+            augmented[pivot],
+        )
+        divisor = augmented[pivot][pivot]
+        if abs(divisor) < 1e-12:
+            raise ValueError("singular weighted regression matrix")
+        augmented[pivot] = [
+            value / divisor for value in augmented[pivot]
+        ]
+        for row in range(size):
+            if row == pivot:
+                continue
+            factor = augmented[row][pivot]
+            augmented[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(
+                    augmented[row],
+                    augmented[pivot],
+                )
+            ]
+    return [augmented[row][-1] for row in range(size)]
+
+
+def _fit(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+) -> list[float]:
+    width = len(features) + 1
+    matrix = [[0.0] * width for _ in range(width)]
+    vector = [0.0] * width
+    for sample in samples:
+        weight = float(sample["holdout_ab"])
+        row = [1.0] + [float(sample[key]) for key in features]
+        target = float(sample["holdout_iso"])
+        for left in range(width):
+            vector[left] += weight * row[left] * target
+            for right in range(width):
+                matrix[left][right] += (
+                    weight * row[left] * row[right]
+                )
+    for index in range(1, width):
+        matrix[index][index] += 1e-9
+    return _solve(matrix, vector)
+
+
+def _score(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+    coefficients: Sequence[float],
+) -> dict[str, Any]:
+    total_weight = sum(float(row["holdout_ab"]) for row in samples)
+    squared_error = 0.0
+    absolute_error = 0.0
+    for sample in samples:
+        prediction = coefficients[0] + sum(
+            coefficient * float(sample[feature])
+            for coefficient, feature in zip(
+                coefficients[1:],
+                features,
+            )
+        )
+        prediction = max(0.0, min(1.0, prediction))
+        error = prediction - float(sample["holdout_iso"])
+        weight = float(sample["holdout_ab"])
+        squared_error += weight * error * error
+        absolute_error += weight * abs(error)
+    return {
+        "sample_count": len(samples),
+        "holdout_ab": int(total_weight),
+        "weighted_mean_squared_error": (
+            squared_error / total_weight if total_weight else None
+        ),
+        "weighted_mean_absolute_error": (
+            absolute_error / total_weight if total_weight else None
+        ),
+    }
+
+
+def _relative_improvement(candidate: float, reference: float) -> float:
+    return (reference - candidate) / reference if reference else 0.0
+
+
+def evaluate_hitter_power_incremental_models(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Compare expected-power feature sets on held-out seasons."""
+
+    cleaned = _clean_samples(samples)
+    seasons = sorted({row["season"] for row in cleaned})
+    blockers = []
+    if len(seasons) < 2:
+        blockers.append("insufficient_validation_seasons")
+    folds = []
+    aggregate: dict[str, dict[str, float]] = {
+        name: {
+            "weighted_squared_error": 0.0,
+            "weighted_absolute_error": 0.0,
+            "holdout_ab": 0.0,
+            "fold_count": 0.0,
+        }
+        for name in MODEL_FEATURES
+    }
+    for validation_season in seasons:
+        training = [
+            row for row in cleaned
+            if row["season"] != validation_season
+        ]
+        validation = [
+            row for row in cleaned
+            if row["season"] == validation_season
+        ]
+        if (
+            len(training) < minimum_fold_samples
+            or len(validation) < minimum_fold_samples
+        ):
+            blockers.append(
+                f"insufficient_fold_samples:{validation_season}"
+            )
+            continue
+        results = {}
+        for name, features in MODEL_FEATURES.items():
+            coefficients = _fit(training, features)
+            scores = _score(validation, features, coefficients)
+            results[name] = {
+                "features": list(features),
+                "coefficients": list(coefficients),
+                "validation_scores": scores,
+            }
+            accumulator = aggregate[name]
+            holdout_ab = float(scores["holdout_ab"])
+            accumulator["weighted_squared_error"] += (
+                scores["weighted_mean_squared_error"] * holdout_ab
+            )
+            accumulator["weighted_absolute_error"] += (
+                scores["weighted_mean_absolute_error"] * holdout_ab
+            )
+            accumulator["holdout_ab"] += holdout_ab
+            accumulator["fold_count"] += 1
+        ranked = sorted(
+            results,
+            key=lambda name: (
+                results[name]["validation_scores"][
+                    "weighted_mean_squared_error"
+                ],
+                len(MODEL_FEATURES[name]),
+                name,
+            ),
+        )
+        folds.append({
+            "validation_season": validation_season,
+            "training_seasons": [
+                season for season in seasons
+                if season != validation_season
+            ],
+            "training_sample_count": len(training),
+            "validation_sample_count": len(validation),
+            "best_model": ranked[0],
+            "models": results,
+        })
+
+    summary = {}
+    for name, accumulator in aggregate.items():
+        holdout_ab = accumulator["holdout_ab"]
+        if not holdout_ab:
+            continue
+        summary[name] = {
+            "fold_count": int(accumulator["fold_count"]),
+            "holdout_ab": int(holdout_ab),
+            "weighted_mean_squared_error": (
+                accumulator["weighted_squared_error"] / holdout_ab
+            ),
+            "weighted_mean_absolute_error": (
+                accumulator["weighted_absolute_error"] / holdout_ab
+            ),
+        }
+    ranked_models = sorted(
+        summary,
+        key=lambda name: (
+            summary[name]["weighted_mean_squared_error"],
+            len(MODEL_FEATURES[name]),
+            name,
+        ),
+    )
+    if summary:
+        actual_mse = summary["actual_iso"]["weighted_mean_squared_error"]
+        expected_mse = summary["expected_damage"][
+            "weighted_mean_squared_error"
+        ]
+        blend_mse = summary["actual_expected"][
+            "weighted_mean_squared_error"
+        ]
+        full_mse = summary["actual_expected_hard_hit_barrel"][
+            "weighted_mean_squared_error"
+        ]
+        comparisons = {
+            "expected_vs_actual_relative_mse_improvement":
+                _relative_improvement(expected_mse, actual_mse),
+            "blend_vs_best_univariate_relative_mse_improvement":
+                _relative_improvement(
+                    blend_mse,
+                    min(actual_mse, expected_mse),
+                ),
+            "full_vs_actual_expected_relative_mse_improvement":
+                _relative_improvement(full_mse, blend_mse),
+        }
+    else:
+        comparisons = {}
+    return {
+        "schema_version":
+            "shadow_hitter_power_incremental_validation_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "sample_count": len(cleaned),
+        "seasons": seasons,
+        "model_features": {
+            name: list(features)
+            for name, features in MODEL_FEATURES.items()
+        },
+        "cross_season_folds": folds,
+        "cross_season_summary": summary,
+        "ranked_models": ranked_models,
+        "comparisons": comparisons,
+        "blockers": blockers,
+    }
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("percentile requires at least one value")
+    position = (len(ordered) - 1) * probability
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return (
+        ordered[lower] * (1.0 - fraction)
+        + ordered[upper] * fraction
+    )
+
+
+def bootstrap_hitter_power_model_differences(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    iterations: int = 400,
+    seed: int = 20260729,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Bootstrap cross-season MSE differences by whole player clusters."""
+
+    cleaned = _clean_samples(samples)
+    grouped: dict[Any, list[dict[str, Any]]] = {}
+    for index, sample in enumerate(cleaned):
+        cluster = sample.get("player_id")
+        if cluster is None:
+            cluster = ("row", index)
+        grouped.setdefault(cluster, []).append(sample)
+    cluster_keys = sorted(grouped, key=str)
+    blockers = []
+    if len(cluster_keys) < 30:
+        blockers.append("insufficient_player_clusters")
+    if iterations < 100:
+        blockers.append("insufficient_bootstrap_iterations")
+    comparisons = {
+        "expected_damage_minus_actual_iso": (
+            "actual_iso",
+            "expected_damage",
+        ),
+        "hard_hit_increment_over_expected_damage": (
+            "expected_damage",
+            "expected_damage_hard_hit",
+        ),
+        "barrel_increment_over_expected_damage": (
+            "expected_damage",
+            "expected_damage_barrel",
+        ),
+        "full_increment_over_expected_damage": (
+            "expected_damage",
+            "expected_damage_hard_hit_barrel",
+        ),
+    }
+    draws = {name: [] for name in comparisons}
+    rng = random.Random(seed)
+    successful = 0
+    if not blockers:
+        for _ in range(iterations):
+            selected = [
+                cluster_keys[rng.randrange(len(cluster_keys))]
+                for _ in cluster_keys
+            ]
+            resampled = [
+                row
+                for cluster in selected
+                for row in grouped[cluster]
+            ]
+            result = evaluate_hitter_power_incremental_models(
+                resampled,
+                minimum_fold_samples=minimum_fold_samples,
+            )
+            if result["status"] != "ready":
+                continue
+            summary = result["cross_season_summary"]
+            for name, (reference, candidate) in comparisons.items():
+                reference_mse = summary[reference][
+                    "weighted_mean_squared_error"
+                ]
+                candidate_mse = summary[candidate][
+                    "weighted_mean_squared_error"
+                ]
+                draws[name].append(reference_mse - candidate_mse)
+            successful += 1
+    if successful < max(100, int(iterations * 0.90)):
+        blockers.append("insufficient_successful_bootstrap_draws")
+    intervals = {}
+    for name, values in draws.items():
+        if not values:
+            continue
+        intervals[name] = {
+            "mse_improvement_median": _percentile(values, 0.50),
+            "mse_improvement_ci_95": {
+                "lower": _percentile(values, 0.025),
+                "upper": _percentile(values, 0.975),
+            },
+            "probability_of_improvement": (
+                sum(value > 0 for value in values) / len(values)
+            ),
+        }
+    return {
+        "schema_version":
+            "shadow_hitter_power_clustered_bootstrap_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "cluster_key": "player_id",
+        "cluster_count": len(cluster_keys),
+        "requested_iterations": iterations,
+        "successful_iterations": successful,
+        "seed": seed,
+        "difference_definition":
+            "reference cross-season MSE minus candidate cross-season MSE",
+        "comparisons": intervals,
+        "blockers": blockers,
+    }

--- a/scripts/audit_shadow_hitter_power_incremental_value.py
+++ b/scripts/audit_shadow_hitter_power_incremental_value.py
@@ -1,0 +1,259 @@
+"""Run the cutoff-safe shadow hitter expected-power incremental audit."""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+import math
+import statistics
+
+from mlb_app.database import StatcastEvent
+from mlb_app.model_projection_routes import _session_factory
+from mlb_app.simulation.shadow.hitter_power_incremental_validation import (
+    bootstrap_hitter_power_model_differences,
+    evaluate_hitter_power_incremental_models,
+)
+
+
+AB_EVENTS = {
+    "field_out",
+    "force_out",
+    "grounded_into_double_play",
+    "field_error",
+    "fielders_choice",
+    "double_play",
+    "fielders_choice_out",
+    "triple_play",
+    "single",
+    "double",
+    "triple",
+    "home_run",
+    "strikeout",
+    "strikeout_double_play",
+}
+BBE_EVENTS = AB_EVENTS - {"strikeout", "strikeout_double_play"}
+HIT_EVENTS = {"single", "double", "triple", "home_run"}
+TOTAL_BASES = {"single": 1, "double": 2, "triple": 3, "home_run": 4}
+WINDOWS = (
+    (2024, dt.date(2024, 6, 1), dt.date(2024, 6, 30)),
+    (2024, dt.date(2024, 7, 1), dt.date(2024, 7, 31)),
+    (2024, dt.date(2024, 8, 1), dt.date(2024, 8, 31)),
+    (2025, dt.date(2025, 6, 1), dt.date(2025, 6, 30)),
+    (2025, dt.date(2025, 7, 1), dt.date(2025, 7, 31)),
+    (2025, dt.date(2025, 8, 1), dt.date(2025, 8, 31)),
+)
+SINGLE_WEIGHT = 0.90
+
+
+def _number(value):
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _barrel_proxy(exit_velocity, launch_angle):
+    if (
+        exit_velocity is None
+        or launch_angle is None
+        or exit_velocity < 98
+    ):
+        return 0
+    speed = min(exit_velocity, 116.0)
+    lower = max(8.0, 26.0 - (speed - 98.0))
+    upper = min(50.0, 30.0 + ((speed - 98.0) * 2.0))
+    return int(lower <= launch_angle <= upper)
+
+
+def _terminal_rows(rows):
+    deduped = {}
+    for row in rows:
+        (
+            row_id,
+            game_date,
+            game_pk,
+            at_bat,
+            pitch_number,
+            batter_id,
+            hand,
+            event,
+            exit_velocity,
+            launch_angle,
+            xba,
+            xwoba,
+        ) = row
+        if game_pk is not None and at_bat is not None:
+            key = (int(batter_id), hand, int(game_pk), int(at_bat))
+        else:
+            key = (int(batter_id), hand, "row", int(row_id))
+        deduped[key] = row
+    return list(deduped.values())
+
+
+def _sample(player_id, hand, season, cutoff, holdout_end, pre, holdout):
+    pre_ab = len(pre)
+    holdout_ab = len(holdout)
+    if pre_ab < 50:
+        return None, "insufficient_pre_ab"
+    if holdout_ab < 20:
+        return None, "insufficient_holdout_ab"
+    pre_bbe = [row for row in pre if row[7] in BBE_EVENTS]
+    covered = [
+        row
+        for row in pre_bbe
+        if _number(row[10]) is not None and _number(row[11]) is not None
+    ]
+    if len(covered) < 20:
+        return None, "insufficient_expected_bbe"
+    coverage = len(covered) / len(pre_bbe) if pre_bbe else 0.0
+    if coverage < 0.80:
+        return None, "insufficient_expected_coverage"
+    geometry = [
+        row
+        for row in pre_bbe
+        if _number(row[8]) is not None and _number(row[9]) is not None
+    ]
+    if len(geometry) < 20:
+        return None, "insufficient_contact_geometry"
+
+    pre_hits = sum(row[7] in HIT_EVENTS for row in pre)
+    pre_tb = sum(TOTAL_BASES.get(row[7], 0) for row in pre)
+    holdout_hits = sum(row[7] in HIT_EVENTS for row in holdout)
+    holdout_tb = sum(TOTAL_BASES.get(row[7], 0) for row in holdout)
+    damage = [
+        max(
+            _number(row[11]) - (SINGLE_WEIGHT * _number(row[10])),
+            0.0,
+        )
+        for row in covered
+    ]
+    expected_damage_per_ab = (
+        statistics.fmean(damage) * (len(pre_bbe) / pre_ab)
+    )
+    return {
+        "season": season,
+        "cutoff": cutoff.isoformat(),
+        "holdout_end": holdout_end.isoformat(),
+        "player_id": player_id,
+        "split": "vsR" if hand == "R" else "vsL",
+        "pre_ab": pre_ab,
+        "pre_bbe": len(pre_bbe),
+        "expected_bbe": len(covered),
+        "expected_coverage": coverage,
+        "pre_actual_iso": (pre_tb - pre_hits) / pre_ab,
+        "pre_expected_damage_per_ab": expected_damage_per_ab,
+        "pre_hard_hit_rate": statistics.fmean(
+            int(_number(row[8]) >= 95) for row in geometry
+        ),
+        "pre_barrel_proxy_rate": statistics.fmean(
+            _barrel_proxy(_number(row[8]), _number(row[9]))
+            for row in geometry
+        ),
+        "holdout_ab": holdout_ab,
+        "holdout_iso": (holdout_tb - holdout_hits) / holdout_ab,
+    }, None
+
+
+def main():
+    factory = _session_factory()
+    session = factory()
+    samples = []
+    window_coverage = []
+    for season, cutoff, holdout_end in WINDOWS:
+        raw = (
+            session.query(
+                StatcastEvent.id,
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+                StatcastEvent.events,
+                StatcastEvent.launch_speed,
+                StatcastEvent.launch_angle,
+                StatcastEvent.estimated_ba_using_speedangle,
+                StatcastEvent.estimated_woba_using_speedangle,
+            )
+            .filter(
+                StatcastEvent.game_date >= dt.date(season, 1, 1),
+                StatcastEvent.game_date <= holdout_end,
+                StatcastEvent.p_throws.in_(("R", "L")),
+                StatcastEvent.events.in_(tuple(AB_EVENTS)),
+            )
+            .order_by(
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.id,
+            )
+            .all()
+        )
+        grouped = collections.defaultdict(lambda: {"pre": [], "holdout": []})
+        for row in _terminal_rows(raw):
+            key = (int(row[5]), row[6])
+            target = "pre" if row[1] <= cutoff else "holdout"
+            grouped[key][target].append(row)
+        blocked = collections.Counter()
+        window_samples = []
+        for (player_id, hand), periods in grouped.items():
+            result, blocker = _sample(
+                player_id,
+                hand,
+                season,
+                cutoff,
+                holdout_end,
+                periods["pre"],
+                periods["holdout"],
+            )
+            if blocker:
+                blocked[blocker] += 1
+            else:
+                samples.append(result)
+                window_samples.append(result)
+        window_coverage.append({
+            "season": season,
+            "cutoff": cutoff.isoformat(),
+            "holdout_end": holdout_end.isoformat(),
+            "sample_count": len(window_samples),
+            "holdout_ab": sum(row["holdout_ab"] for row in window_samples),
+            "split_counts": dict(
+                collections.Counter(row["split"] for row in window_samples)
+            ),
+            "mean_expected_coverage": (
+                statistics.fmean(
+                    row["expected_coverage"] for row in window_samples
+                )
+                if window_samples
+                else None
+            ),
+            "blocked_counts": dict(blocked),
+        })
+    result = evaluate_hitter_power_incremental_models(samples)
+    result["clustered_bootstrap"] = (
+        bootstrap_hitter_power_model_differences(
+            samples,
+            iterations=400,
+        )
+    )
+    result["audit_method"] = {
+        "schema_version":
+            "cutoff_safe_hitter_power_incremental_audit_v1",
+        "single_weight": SINGLE_WEIGHT,
+        "expected_damage_definition":
+            "mean(max(xwoba - 0.90*xba, 0)) * BBE/AB",
+        "barrel_is_proxy": True,
+        "direct_xslg_used": False,
+    }
+    result["window_coverage"] = window_coverage
+    print(json.dumps(result, indent=2, sort_keys=True))
+    session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_power_incremental_validation.py
+++ b/tests/test_hitter_power_incremental_validation.py
@@ -1,0 +1,131 @@
+from mlb_app.simulation.shadow.hitter_power_incremental_validation import (
+    bootstrap_hitter_power_model_differences,
+    evaluate_hitter_power_incremental_models,
+)
+
+
+def samples():
+    rows = []
+    for season in (2024, 2025):
+        for index in range(80):
+            actual = 0.08 + ((index % 20) * 0.006)
+            expected = 0.03 + ((index % 17) * 0.004)
+            hard_hit = 0.25 + ((index % 10) * 0.025)
+            barrel = 0.03 + ((index % 8) * 0.012)
+            target = (
+                0.02
+                + (actual * 0.35)
+                + (expected * 1.20)
+                + (barrel * 0.08)
+                + ((season - 2024) * 0.002)
+            )
+            rows.append({
+                "player_id": index,
+                "season": season,
+                "holdout_ab": 20 + (index % 40),
+                "holdout_iso": target,
+                "pre_actual_iso": actual,
+                "pre_expected_damage_per_ab": expected,
+                "pre_hard_hit_rate": hard_hit,
+                "pre_barrel_proxy_rate": barrel,
+            })
+    return rows
+
+
+def test_cross_season_validation_finds_incremental_expected_signal():
+    result = evaluate_hitter_power_incremental_models(samples())
+
+    assert result["status"] == "ready"
+    assert result["seasons"] == [2024, 2025]
+    assert len(result["cross_season_folds"]) == 2
+    assert (
+        result["comparisons"][
+            "blend_vs_best_univariate_relative_mse_improvement"
+        ]
+        > 0
+    )
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False
+
+
+def test_model_contract_includes_double_counting_comparisons():
+    result = evaluate_hitter_power_incremental_models(samples())
+
+    assert "actual_expected" in result["cross_season_summary"]
+    assert "actual_expected_hard_hit" in result["cross_season_summary"]
+    assert "actual_expected_barrel" in result["cross_season_summary"]
+    assert "actual_expected_hard_hit_barrel" in (
+        result["cross_season_summary"]
+    )
+    assert "expected_damage_hard_hit" in result["cross_season_summary"]
+    assert "expected_damage_barrel" in result["cross_season_summary"]
+    assert "expected_damage_hard_hit_barrel" in (
+        result["cross_season_summary"]
+    )
+    assert "full_vs_actual_expected_relative_mse_improvement" in (
+        result["comparisons"]
+    )
+
+
+def test_blocks_when_cross_season_evidence_is_missing():
+    one_season = [
+        row for row in samples()
+        if row["season"] == 2024
+    ]
+    result = evaluate_hitter_power_incremental_models(one_season)
+
+    assert result["status"] == "blocked"
+    assert "insufficient_validation_seasons" in result["blockers"]
+    assert result["parameter_selected"] is False
+
+
+def test_excludes_incomplete_and_nonpositive_weight_rows():
+    payload = samples()
+    payload.extend([
+        {
+            **payload[0],
+            "pre_actual_iso": None,
+        },
+        {
+            **payload[1],
+            "holdout_ab": 0,
+        },
+    ])
+    result = evaluate_hitter_power_incremental_models(payload)
+
+    assert result["sample_count"] == len(samples())
+
+
+def test_player_clustered_bootstrap_is_deterministic_and_shadow_only():
+    first = bootstrap_hitter_power_model_differences(
+        samples(),
+        iterations=120,
+        seed=17,
+    )
+    second = bootstrap_hitter_power_model_differences(
+        samples(),
+        iterations=120,
+        seed=17,
+    )
+
+    assert first == second
+    assert first["status"] == "ready"
+    assert first["cluster_count"] == 80
+    assert first["successful_iterations"] == 120
+    assert first["parameter_selected"] is False
+    assert first["production_authority_changed"] is False
+    assert "expected_damage_minus_actual_iso" in first["comparisons"]
+
+
+def test_bootstrap_blocks_thin_cluster_evidence():
+    thin = [
+        {**row, "player_id": row["player_id"] % 10}
+        for row in samples()
+    ]
+    result = bootstrap_hitter_power_model_differences(
+        thin,
+        iterations=120,
+    )
+
+    assert result["status"] == "blocked"
+    assert "insufficient_player_clusters" in result["blockers"]


### PR DESCRIPTION
## Summary

- add a cutoff-safe, cross-season evaluator for expected hitter power evidence
- add a reproducible historical audit with player-clustered bootstrap uncertainty
- compare expected damage, actual ISO, hard-hit rate, and barrel-proxy evidence without conflating auxiliary signals with actual ISO
- keep the evaluation shadow-only with no production parameter or authority changes

## Findings

- expected damage improves future ISO MSE by 5.84% relative to actual ISO
- the clustered bootstrap supports that improvement with probability 1.0 and an entirely positive 95% interval
- hard-hit rate has a promising point estimate but its incremental interval crosses zero
- barrel proxy and the combined auxiliary model do not demonstrate reliable incremental value beyond expected damage
- the resulting policy is to retain expected damage alone and avoid independently adding hard-hit or barrel evidence

## Validation

- `1211 passed, 2 deselected` in the canonical and hitter-profile regression suite
- `17 passed` in the focused 6RQ suite
- Python compilation passed for the evaluator, audit script, and tests
- `git diff --check` and staged diff checks passed

## Impact

This adds evidence and reproducible tooling only. It does not select a new production parameter or change production simulation authority.