### PR TITLE
Audit hitter strikeout skill evidence

### DIFF
--- a/mlb_app/simulation/shadow/hitter_strikeout_skill_validation.py
+++ b/mlb_app/simulation/shadow/hitter_strikeout_skill_validation.py
@@ -1,0 +1,322 @@
+"""Cross-season validation for shadow hitter strikeout-skill evidence."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+MODEL_FEATURES = {
+    "intercept_only": (),
+    "actual_k_rate": ("pre_actual_k_rate",),
+    "whiff_rate": ("pre_whiff_rate",),
+    "actual_whiff": ("pre_actual_k_rate", "pre_whiff_rate"),
+    "actual_whiff_called": (
+        "pre_actual_k_rate",
+        "pre_whiff_rate",
+        "pre_called_strike_rate",
+    ),
+    "actual_whiff_swinging": (
+        "pre_actual_k_rate",
+        "pre_whiff_rate",
+        "pre_swinging_strike_rate",
+    ),
+    "full": (
+        "pre_actual_k_rate",
+        "pre_whiff_rate",
+        "pre_called_strike_rate",
+        "pre_swinging_strike_rate",
+    ),
+}
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _clean(samples: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    required = {
+        "season",
+        "holdout_pa",
+        "holdout_k_rate",
+        *{item for values in MODEL_FEATURES.values() for item in values},
+    }
+    cleaned = []
+    for source in samples:
+        values = {key: _number(source.get(key)) for key in required}
+        if any(value is None for value in values.values()):
+            continue
+        if values["holdout_pa"] <= 0:
+            continue
+        cleaned.append({**dict(source), **values, "season": int(values["season"])})
+    return cleaned
+
+
+def _solve(matrix: list[list[float]], vector: list[float]) -> list[float]:
+    size = len(vector)
+    augmented = [list(matrix[row]) + [vector[row]] for row in range(size)]
+    for pivot in range(size):
+        best = max(range(pivot, size), key=lambda row: abs(augmented[row][pivot]))
+        augmented[pivot], augmented[best] = augmented[best], augmented[pivot]
+        divisor = augmented[pivot][pivot]
+        if abs(divisor) < 1e-12:
+            raise ValueError("singular weighted regression matrix")
+        augmented[pivot] = [value / divisor for value in augmented[pivot]]
+        for row in range(size):
+            if row == pivot:
+                continue
+            factor = augmented[row][pivot]
+            augmented[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(augmented[row], augmented[pivot])
+            ]
+    return [augmented[row][-1] for row in range(size)]
+
+
+def _fit(samples: Sequence[Mapping[str, Any]], features: Sequence[str]) -> list[float]:
+    width = len(features) + 1
+    matrix = [[0.0] * width for _ in range(width)]
+    vector = [0.0] * width
+    for sample in samples:
+        weight = float(sample["holdout_pa"])
+        row = [1.0] + [float(sample[key]) for key in features]
+        target = float(sample["holdout_k_rate"])
+        for left in range(width):
+            vector[left] += weight * row[left] * target
+            for right in range(width):
+                matrix[left][right] += weight * row[left] * row[right]
+    for index in range(1, width):
+        matrix[index][index] += 1e-9
+    return _solve(matrix, vector)
+
+
+def _score(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+    coefficients: Sequence[float],
+) -> dict[str, Any]:
+    weight_total = sum(float(row["holdout_pa"]) for row in samples)
+    squared = absolute = 0.0
+    for sample in samples:
+        prediction = coefficients[0] + sum(
+            coefficient * float(sample[feature])
+            for coefficient, feature in zip(coefficients[1:], features)
+        )
+        prediction = max(0.0, min(1.0, prediction))
+        error = prediction - float(sample["holdout_k_rate"])
+        weight = float(sample["holdout_pa"])
+        squared += weight * error * error
+        absolute += weight * abs(error)
+    return {
+        "sample_count": len(samples),
+        "holdout_pa": int(weight_total),
+        "weighted_mean_squared_error": squared / weight_total,
+        "weighted_mean_absolute_error": absolute / weight_total,
+    }
+
+
+def evaluate_hitter_strikeout_skill_models(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Compare cutoff-safe strikeout feature sets on held-out seasons."""
+
+    cleaned = _clean(samples)
+    seasons = sorted({row["season"] for row in cleaned})
+    blockers = []
+    if len(seasons) < 2:
+        blockers.append("insufficient_validation_seasons")
+    aggregate = {
+        name: {"sse": 0.0, "sae": 0.0, "weight": 0.0, "folds": 0}
+        for name in MODEL_FEATURES
+    }
+    folds = []
+    for validation_season in seasons:
+        training = [row for row in cleaned if row["season"] != validation_season]
+        validation = [row for row in cleaned if row["season"] == validation_season]
+        if min(len(training), len(validation)) < minimum_fold_samples:
+            blockers.append(f"insufficient_fold_samples:{validation_season}")
+            continue
+        models = {}
+        for name, features in MODEL_FEATURES.items():
+            coefficients = _fit(training, features)
+            scores = _score(validation, features, coefficients)
+            models[name] = {
+                "features": list(features),
+                "coefficients": coefficients,
+                "validation_scores": scores,
+            }
+            weight = scores["holdout_pa"]
+            aggregate[name]["sse"] += scores["weighted_mean_squared_error"] * weight
+            aggregate[name]["sae"] += scores["weighted_mean_absolute_error"] * weight
+            aggregate[name]["weight"] += weight
+            aggregate[name]["folds"] += 1
+        folds.append({
+            "validation_season": validation_season,
+            "training_seasons": [item for item in seasons if item != validation_season],
+            "training_sample_count": len(training),
+            "validation_sample_count": len(validation),
+            "best_model": min(
+                models,
+                key=lambda name: (
+                    models[name]["validation_scores"]["weighted_mean_squared_error"],
+                    len(MODEL_FEATURES[name]),
+                    name,
+                ),
+            ),
+            "models": models,
+        })
+    summary = {
+        name: {
+            "fold_count": values["folds"],
+            "holdout_pa": int(values["weight"]),
+            "weighted_mean_squared_error": values["sse"] / values["weight"],
+            "weighted_mean_absolute_error": values["sae"] / values["weight"],
+        }
+        for name, values in aggregate.items()
+        if values["weight"]
+    }
+    ranked = sorted(
+        summary,
+        key=lambda name: (
+            summary[name]["weighted_mean_squared_error"],
+            len(MODEL_FEATURES[name]),
+            name,
+        ),
+    )
+    comparisons = {}
+    if summary:
+        mse = {
+            name: value["weighted_mean_squared_error"]
+            for name, value in summary.items()
+        }
+        best_single = min(mse["actual_k_rate"], mse["whiff_rate"])
+        comparisons = {
+            "whiff_vs_actual_relative_mse_improvement":
+                (mse["actual_k_rate"] - mse["whiff_rate"]) / mse["actual_k_rate"],
+            "blend_vs_best_univariate_relative_mse_improvement":
+                (best_single - mse["actual_whiff"]) / best_single,
+            "called_increment_over_blend_relative_mse_improvement":
+                (mse["actual_whiff"] - mse["actual_whiff_called"])
+                / mse["actual_whiff"],
+            "swinging_increment_over_blend_relative_mse_improvement":
+                (mse["actual_whiff"] - mse["actual_whiff_swinging"])
+                / mse["actual_whiff"],
+            "full_increment_over_blend_relative_mse_improvement":
+                (mse["actual_whiff"] - mse["full"]) / mse["actual_whiff"],
+        }
+    return {
+        "schema_version": "shadow_hitter_strikeout_skill_validation_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "sample_count": len(cleaned),
+        "seasons": seasons,
+        "model_features": {key: list(value) for key, value in MODEL_FEATURES.items()},
+        "cross_season_folds": folds,
+        "cross_season_summary": summary,
+        "ranked_models": ranked,
+        "comparisons": comparisons,
+        "blockers": blockers,
+    }
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower, upper = math.floor(position), math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def bootstrap_hitter_strikeout_skill_differences(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    iterations: int = 400,
+    seed: int = 20260730,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Bootstrap cross-season MSE improvements by whole-player clusters."""
+
+    cleaned = _clean(samples)
+    grouped: dict[Any, list[dict[str, Any]]] = {}
+    for index, sample in enumerate(cleaned):
+        grouped.setdefault(sample.get("player_id", ("row", index)), []).append(sample)
+    keys = sorted(grouped, key=str)
+    blockers = []
+    if len(keys) < 30:
+        blockers.append("insufficient_player_clusters")
+    if iterations < 100:
+        blockers.append("insufficient_bootstrap_iterations")
+    pairs = {
+        "whiff_minus_actual_k": ("actual_k_rate", "whiff_rate"),
+        "blend_increment_over_best_univariate": (None, "actual_whiff"),
+        "called_increment_over_blend": ("actual_whiff", "actual_whiff_called"),
+        "swinging_increment_over_blend": ("actual_whiff", "actual_whiff_swinging"),
+        "full_increment_over_blend": ("actual_whiff", "full"),
+    }
+    draws = {name: [] for name in pairs}
+    successful = 0
+    rng = random.Random(seed)
+    if not blockers:
+        for _ in range(iterations):
+            selected = [keys[rng.randrange(len(keys))] for _ in keys]
+            resampled = [row for key in selected for row in grouped[key]]
+            result = evaluate_hitter_strikeout_skill_models(
+                resampled,
+                minimum_fold_samples=minimum_fold_samples,
+            )
+            if result["status"] != "ready":
+                continue
+            summary = result["cross_season_summary"]
+            for name, (reference, candidate) in pairs.items():
+                if reference is None:
+                    reference_mse = min(
+                        summary["actual_k_rate"]["weighted_mean_squared_error"],
+                        summary["whiff_rate"]["weighted_mean_squared_error"],
+                    )
+                else:
+                    reference_mse = summary[reference]["weighted_mean_squared_error"]
+                candidate_mse = summary[candidate]["weighted_mean_squared_error"]
+                draws[name].append(reference_mse - candidate_mse)
+            successful += 1
+    if successful < max(100, int(iterations * 0.9)):
+        blockers.append("insufficient_successful_bootstrap_draws")
+    comparisons = {}
+    if successful:
+        for name, values in draws.items():
+            comparisons[name] = {
+                "mse_improvement_median": _percentile(values, 0.5),
+                "mse_improvement_ci_95": {
+                    "lower": _percentile(values, 0.025),
+                    "upper": _percentile(values, 0.975),
+                },
+                "probability_of_improvement":
+                    sum(value > 0 for value in values) / len(values),
+            }
+    return {
+        "schema_version": "shadow_hitter_strikeout_skill_bootstrap_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "cluster_key": "player_id",
+        "cluster_count": len(keys),
+        "requested_iterations": iterations,
+        "successful_iterations": successful,
+        "difference_definition": "reference cross-season MSE minus candidate cross-season MSE",
+        "comparisons": comparisons,
+        "blockers": blockers,
+    }

--- a/scripts/audit_shadow_hitter_strikeout_skill.py
+++ b/scripts/audit_shadow_hitter_strikeout_skill.py
@@ -1,0 +1,168 @@
+"""Audit cutoff-safe hitter strikeout-skill evidence on historical holdouts."""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+
+from sqlalchemy import text
+
+from mlb_app.model_projection_routes import _session_factory
+from mlb_app.simulation.shadow.hitter_strikeout_skill_validation import (
+    bootstrap_hitter_strikeout_skill_differences,
+    evaluate_hitter_strikeout_skill_models,
+)
+
+
+VALID_EVENT = """
+events IS NOT NULL
+AND LOWER(TRIM(events)) NOT IN ('', 'nan', 'none', 'null')
+"""
+WHIFF = """
+description IN (
+    'swinging_strike',
+    'swinging_strike_blocked',
+    'missed_bunt'
+)
+"""
+SWING = """
+description IN (
+    'swinging_strike',
+    'swinging_strike_blocked',
+    'missed_bunt',
+    'foul',
+    'foul_tip',
+    'foul_bunt',
+    'bunt_foul_tip',
+    'hit_into_play'
+)
+"""
+STRIKEOUT = """
+events IN ('strikeout', 'strikeout_double_play')
+"""
+WINDOWS = (
+    (2024, dt.date(2024, 6, 1), dt.date(2024, 6, 30)),
+    (2024, dt.date(2024, 7, 1), dt.date(2024, 7, 31)),
+    (2024, dt.date(2024, 8, 1), dt.date(2024, 8, 31)),
+    (2025, dt.date(2025, 6, 1), dt.date(2025, 6, 30)),
+    (2025, dt.date(2025, 7, 1), dt.date(2025, 7, 31)),
+    (2025, dt.date(2025, 8, 1), dt.date(2025, 8, 31)),
+)
+
+
+def _aggregate(session, start: dt.date, end: dt.date) -> dict:
+    query = text(
+        "SELECT batter_id, p_throws, "
+        "COUNT(*) AS pitches, "
+        "SUM(CASE WHEN " + SWING + " THEN 1 ELSE 0 END) AS swings, "
+        "SUM(CASE WHEN " + WHIFF + " THEN 1 ELSE 0 END) AS whiffs, "
+        "SUM(CASE WHEN description='called_strike' THEN 1 ELSE 0 END) "
+        "AS called_strikes, "
+        "SUM(CASE WHEN " + VALID_EVENT + " THEN 1 ELSE 0 END) AS pa, "
+        "SUM(CASE WHEN " + STRIKEOUT + " THEN 1 ELSE 0 END) AS strikeouts "
+        "FROM statcast_events "
+        "WHERE game_date>=:start AND game_date<=:end "
+        "AND batter_id IS NOT NULL AND p_throws IN ('R','L') "
+        "GROUP BY batter_id,p_throws"
+    )
+    return {
+        (int(row["batter_id"]), str(row["p_throws"])): {
+            name: int(row[name] or 0)
+            for name in (
+                "pitches",
+                "swings",
+                "whiffs",
+                "called_strikes",
+                "pa",
+                "strikeouts",
+            )
+        }
+        for row in session.execute(
+            query,
+            {"start": start, "end": end},
+        ).mappings()
+    }
+
+
+def build_samples(session) -> tuple[list[dict], list[dict]]:
+    samples = []
+    windows = []
+    for season, cutoff, holdout_end in WINDOWS:
+        pre = _aggregate(session, dt.date(season, 1, 1), cutoff)
+        holdout = _aggregate(
+            session,
+            cutoff + dt.timedelta(days=1),
+            holdout_end,
+        )
+        blockers = collections.Counter()
+        window_samples = []
+        for (player_id, hand), actual in pre.items():
+            future = holdout.get((player_id, hand))
+            if actual["pa"] < 25:
+                blockers["insufficient_pre_pa"] += 1
+                continue
+            if actual["swings"] < 50:
+                blockers["insufficient_pre_swings"] += 1
+                continue
+            if future is None or future["pa"] < 20:
+                blockers["insufficient_holdout_pa"] += 1
+                continue
+            sample = {
+                "player_id": player_id,
+                "season": season,
+                "split": "vsR" if hand == "R" else "vsL",
+                "cutoff": cutoff.isoformat(),
+                "holdout_end": holdout_end.isoformat(),
+                "holdout_pa": future["pa"],
+                "holdout_k_rate": future["strikeouts"] / future["pa"],
+                "pre_actual_k_rate": actual["strikeouts"] / actual["pa"],
+                "pre_whiff_rate": actual["whiffs"] / actual["swings"],
+                "pre_called_strike_rate":
+                    actual["called_strikes"] / actual["pitches"],
+                "pre_swinging_strike_rate":
+                    actual["whiffs"] / actual["pitches"],
+            }
+            samples.append(sample)
+            window_samples.append(sample)
+        windows.append({
+            "season": season,
+            "cutoff": cutoff.isoformat(),
+            "holdout_end": holdout_end.isoformat(),
+            "sample_count": len(window_samples),
+            "holdout_pa": sum(row["holdout_pa"] for row in window_samples),
+            "blocker_counts": dict(blockers),
+        })
+    return samples, windows
+
+
+def main() -> None:
+    factory = _session_factory()
+    session = factory()
+    try:
+        samples, windows = build_samples(session)
+    finally:
+        session.close()
+    validation = evaluate_hitter_strikeout_skill_models(samples)
+    bootstrap = bootstrap_hitter_strikeout_skill_differences(samples)
+    print(json.dumps({
+        **validation,
+        "schema_version": "historical_shadow_hitter_strikeout_skill_audit_v1",
+        "window_coverage": windows,
+        "holdout_pa": sum(row["holdout_pa"] for row in samples),
+        "sample_counts_by_season": dict(collections.Counter(
+            row["season"] for row in samples
+        )),
+        "sample_counts_by_split": dict(collections.Counter(
+            row["split"] for row in samples
+        )),
+        "terminal_event_policy": {
+            "excluded_literal_values": ["", "nan", "none", "null"],
+            "plate_appearance_identity": ["game_pk", "at_bat_number"],
+        },
+        "clustered_bootstrap": bootstrap,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_strikeout_skill_validation.py
+++ b/tests/test_hitter_strikeout_skill_validation.py
@@ -1,0 +1,75 @@
+import copy
+
+from mlb_app.simulation.shadow.hitter_strikeout_skill_validation import (
+    bootstrap_hitter_strikeout_skill_differences,
+    evaluate_hitter_strikeout_skill_models,
+)
+
+
+def samples():
+    rows = []
+    for season, offset in ((2024, 0.0), (2025, 0.01)):
+        for player_id in range(1, 61):
+            actual = 0.12 + (player_id % 12) * 0.012 + offset
+            whiff = 0.14 + (player_id % 10) * 0.014 + offset
+            future = 0.03 + 0.55 * actual + 0.35 * whiff
+            rows.append({
+                "player_id": player_id,
+                "season": season,
+                "split": "vsR" if player_id % 2 else "vsL",
+                "holdout_pa": 40 + player_id,
+                "holdout_k_rate": future,
+                "pre_actual_k_rate": actual,
+                "pre_whiff_rate": whiff,
+                "pre_called_strike_rate": 0.15 + (player_id % 4) * 0.002,
+                "pre_swinging_strike_rate": whiff * 0.48,
+            })
+    return rows
+
+
+def test_cross_season_contract_is_shadow_only():
+    result = evaluate_hitter_strikeout_skill_models(samples())
+    assert result["status"] == "ready"
+    assert result["seasons"] == [2024, 2025]
+    assert result["sample_count"] == 120
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False
+    assert "actual_whiff" in result["cross_season_summary"]
+    assert "contact_rate" not in str(result["model_features"])
+
+
+def test_blocks_without_two_seasons():
+    result = evaluate_hitter_strikeout_skill_models(
+        [row for row in samples() if row["season"] == 2024]
+    )
+    assert result["status"] == "blocked"
+    assert "insufficient_validation_seasons" in result["blockers"]
+
+
+def test_excludes_invalid_rows():
+    payload = samples()
+    invalid = copy.deepcopy(payload[0])
+    invalid["holdout_pa"] = 0
+    payload.append(invalid)
+    assert evaluate_hitter_strikeout_skill_models(payload)["sample_count"] == 120
+
+
+def test_clustered_bootstrap_contract():
+    result = bootstrap_hitter_strikeout_skill_differences(
+        samples(),
+        iterations=100,
+        seed=7,
+        minimum_fold_samples=30,
+    )
+    assert result["status"] == "ready"
+    assert result["cluster_count"] == 60
+    assert result["successful_iterations"] == 100
+    assert set(result["comparisons"]) == {
+        "whiff_minus_actual_k",
+        "blend_increment_over_best_univariate",
+        "called_increment_over_blend",
+        "swinging_increment_over_blend",
+        "full_increment_over_blend",
+    }
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False


### PR DESCRIPTION
## Summary

- add a reusable cross-season evaluator for hitter strikeout-skill evidence
- add a player-clustered bootstrap for uncertainty-aware model comparisons
- add a reproducible six-window historical audit using cutoff-safe pitch and terminal-PA evidence
- normalize literal empty/`nan`/`none`/`null` event values so nonterminal pitches are not counted as plate appearances
- keep all results shadow-only with no production parameter or authority changes

## Findings

- actual strikeout rate is a stronger standalone predictor than whiff rate
- combining actual strikeout rate with whiff rate improves out-of-season MSE by 3.16% over the best standalone signal
- the blend improves in 99.75% of clustered bootstrap draws, with an entirely positive 95% interval
- called-strike rate does not add reliable value beyond the blend
- swinging-strike rate and the full auxiliary model have positive point estimates but bootstrap intervals cross zero
- contact rate is excluded because it is exactly redundant with whiff rate under the audited definitions

## Validation

- `1215 passed, 2 deselected` in the canonical and hitter-profile regression suite
- `21 passed` in the focused 6RR suite
- Python compilation passed for the evaluator, audit script, and tests
- `git diff --check` and staged diff checks passed

## Impact

This establishes actual strikeout rate plus whiff rate as the evidence-supported candidate for later calibration. It does not change the production hitter profile or simulation authority.