### PR TITLE
Audit hitter walk skill evidence

### DIFF
--- a/mlb_app/simulation/shadow/hitter_walk_skill_validation.py
+++ b/mlb_app/simulation/shadow/hitter_walk_skill_validation.py
@@ -1,0 +1,325 @@
+"""Cross-season validation for shadow hitter walk-skill evidence."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+MODEL_FEATURES = {
+    "intercept_only": (),
+    "actual_bb_rate": ("pre_actual_bb_rate",),
+    "called_ball_rate": ("pre_called_ball_rate",),
+    "actual_called_ball": ("pre_actual_bb_rate", "pre_called_ball_rate"),
+    "actual_called_ball_take": (
+        "pre_actual_bb_rate",
+        "pre_called_ball_rate",
+        "pre_take_rate",
+    ),
+    "actual_called_ball_called_strike": (
+        "pre_actual_bb_rate",
+        "pre_called_ball_rate",
+        "pre_called_strike_rate",
+    ),
+    "full": (
+        "pre_actual_bb_rate",
+        "pre_called_ball_rate",
+        "pre_take_rate",
+        "pre_called_strike_rate",
+    ),
+}
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _clean(samples: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    required = {
+        "season",
+        "holdout_pa",
+        "holdout_bb_rate",
+        *{item for values in MODEL_FEATURES.values() for item in values},
+    }
+    cleaned = []
+    for source in samples:
+        values = {key: _number(source.get(key)) for key in required}
+        if any(value is None for value in values.values()):
+            continue
+        if values["holdout_pa"] <= 0:
+            continue
+        cleaned.append({**dict(source), **values, "season": int(values["season"])})
+    return cleaned
+
+
+def _solve(matrix: list[list[float]], vector: list[float]) -> list[float]:
+    size = len(vector)
+    augmented = [list(matrix[row]) + [vector[row]] for row in range(size)]
+    for pivot in range(size):
+        best = max(range(pivot, size), key=lambda row: abs(augmented[row][pivot]))
+        augmented[pivot], augmented[best] = augmented[best], augmented[pivot]
+        divisor = augmented[pivot][pivot]
+        if abs(divisor) < 1e-12:
+            raise ValueError("singular weighted regression matrix")
+        augmented[pivot] = [value / divisor for value in augmented[pivot]]
+        for row in range(size):
+            if row == pivot:
+                continue
+            factor = augmented[row][pivot]
+            augmented[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(augmented[row], augmented[pivot])
+            ]
+    return [augmented[row][-1] for row in range(size)]
+
+
+def _fit(samples: Sequence[Mapping[str, Any]], features: Sequence[str]) -> list[float]:
+    width = len(features) + 1
+    matrix = [[0.0] * width for _ in range(width)]
+    vector = [0.0] * width
+    for sample in samples:
+        weight = float(sample["holdout_pa"])
+        row = [1.0] + [float(sample[key]) for key in features]
+        target = float(sample["holdout_bb_rate"])
+        for left in range(width):
+            vector[left] += weight * row[left] * target
+            for right in range(width):
+                matrix[left][right] += weight * row[left] * row[right]
+    for index in range(1, width):
+        matrix[index][index] += 1e-9
+    return _solve(matrix, vector)
+
+
+def _score(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+    coefficients: Sequence[float],
+) -> dict[str, Any]:
+    weight_total = sum(float(row["holdout_pa"]) for row in samples)
+    squared = absolute = 0.0
+    for sample in samples:
+        prediction = coefficients[0] + sum(
+            coefficient * float(sample[feature])
+            for coefficient, feature in zip(coefficients[1:], features)
+        )
+        prediction = max(0.0, min(1.0, prediction))
+        error = prediction - float(sample["holdout_bb_rate"])
+        weight = float(sample["holdout_pa"])
+        squared += weight * error * error
+        absolute += weight * abs(error)
+    return {
+        "sample_count": len(samples),
+        "holdout_pa": int(weight_total),
+        "weighted_mean_squared_error": squared / weight_total,
+        "weighted_mean_absolute_error": absolute / weight_total,
+    }
+
+
+def evaluate_hitter_walk_skill_models(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Compare cutoff-safe walk feature sets on held-out seasons."""
+
+    cleaned = _clean(samples)
+    seasons = sorted({row["season"] for row in cleaned})
+    blockers = []
+    if len(seasons) < 2:
+        blockers.append("insufficient_validation_seasons")
+    aggregate = {
+        name: {"sse": 0.0, "sae": 0.0, "weight": 0.0, "folds": 0}
+        for name in MODEL_FEATURES
+    }
+    folds = []
+    for validation_season in seasons:
+        training = [row for row in cleaned if row["season"] != validation_season]
+        validation = [row for row in cleaned if row["season"] == validation_season]
+        if min(len(training), len(validation)) < minimum_fold_samples:
+            blockers.append(f"insufficient_fold_samples:{validation_season}")
+            continue
+        models = {}
+        for name, features in MODEL_FEATURES.items():
+            coefficients = _fit(training, features)
+            scores = _score(validation, features, coefficients)
+            models[name] = {
+                "features": list(features),
+                "coefficients": coefficients,
+                "validation_scores": scores,
+            }
+            weight = scores["holdout_pa"]
+            aggregate[name]["sse"] += scores["weighted_mean_squared_error"] * weight
+            aggregate[name]["sae"] += scores["weighted_mean_absolute_error"] * weight
+            aggregate[name]["weight"] += weight
+            aggregate[name]["folds"] += 1
+        folds.append({
+            "validation_season": validation_season,
+            "training_seasons": [item for item in seasons if item != validation_season],
+            "training_sample_count": len(training),
+            "validation_sample_count": len(validation),
+            "best_model": min(
+                models,
+                key=lambda name: (
+                    models[name]["validation_scores"]["weighted_mean_squared_error"],
+                    len(MODEL_FEATURES[name]),
+                    name,
+                ),
+            ),
+            "models": models,
+        })
+    summary = {
+        name: {
+            "fold_count": values["folds"],
+            "holdout_pa": int(values["weight"]),
+            "weighted_mean_squared_error": values["sse"] / values["weight"],
+            "weighted_mean_absolute_error": values["sae"] / values["weight"],
+        }
+        for name, values in aggregate.items()
+        if values["weight"]
+    }
+    ranked = sorted(
+        summary,
+        key=lambda name: (
+            summary[name]["weighted_mean_squared_error"],
+            len(MODEL_FEATURES[name]),
+            name,
+        ),
+    )
+    comparisons = {}
+    if summary:
+        mse = {
+            name: value["weighted_mean_squared_error"]
+            for name, value in summary.items()
+        }
+        best_single = min(mse["actual_bb_rate"], mse["called_ball_rate"])
+        comparisons = {
+            "called_ball_vs_actual_relative_mse_improvement":
+                (mse["actual_bb_rate"] - mse["called_ball_rate"]) / mse["actual_bb_rate"],
+            "blend_vs_best_univariate_relative_mse_improvement":
+                (best_single - mse["actual_called_ball"]) / best_single,
+            "take_increment_over_blend_relative_mse_improvement":
+                (mse["actual_called_ball"] - mse["actual_called_ball_take"])
+                / mse["actual_called_ball"],
+            "called_strike_increment_over_blend_relative_mse_improvement":
+                (mse["actual_called_ball"] - mse["actual_called_ball_called_strike"])
+                / mse["actual_called_ball"],
+            "full_increment_over_blend_relative_mse_improvement":
+                (mse["actual_called_ball"] - mse["full"]) / mse["actual_called_ball"],
+        }
+    return {
+        "schema_version": "shadow_hitter_walk_skill_validation_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "sample_count": len(cleaned),
+        "seasons": seasons,
+        "model_features": {key: list(value) for key, value in MODEL_FEATURES.items()},
+        "cross_season_folds": folds,
+        "cross_season_summary": summary,
+        "ranked_models": ranked,
+        "comparisons": comparisons,
+        "blockers": blockers,
+    }
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower, upper = math.floor(position), math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def bootstrap_hitter_walk_skill_differences(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    iterations: int = 400,
+    seed: int = 20260730,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Bootstrap cross-season MSE improvements by whole-player clusters."""
+
+    cleaned = _clean(samples)
+    grouped: dict[Any, list[dict[str, Any]]] = {}
+    for index, sample in enumerate(cleaned):
+        grouped.setdefault(sample.get("player_id", ("row", index)), []).append(sample)
+    keys = sorted(grouped, key=str)
+    blockers = []
+    if len(keys) < 30:
+        blockers.append("insufficient_player_clusters")
+    if iterations < 100:
+        blockers.append("insufficient_bootstrap_iterations")
+    pairs = {
+        "called_ball_minus_actual_bb": ("actual_bb_rate", "called_ball_rate"),
+        "blend_increment_over_best_univariate": (None, "actual_called_ball"),
+        "take_increment_over_blend": ("actual_called_ball", "actual_called_ball_take"),
+        "called_strike_increment_over_blend": (
+            "actual_called_ball",
+            "actual_called_ball_called_strike",
+        ),
+        "full_increment_over_blend": ("actual_called_ball", "full"),
+    }
+    draws = {name: [] for name in pairs}
+    successful = 0
+    rng = random.Random(seed)
+    if not blockers:
+        for _ in range(iterations):
+            selected = [keys[rng.randrange(len(keys))] for _ in keys]
+            resampled = [row for key in selected for row in grouped[key]]
+            result = evaluate_hitter_walk_skill_models(
+                resampled,
+                minimum_fold_samples=minimum_fold_samples,
+            )
+            if result["status"] != "ready":
+                continue
+            summary = result["cross_season_summary"]
+            for name, (reference, candidate) in pairs.items():
+                if reference is None:
+                    reference_mse = min(
+                        summary["actual_bb_rate"]["weighted_mean_squared_error"],
+                        summary["called_ball_rate"]["weighted_mean_squared_error"],
+                    )
+                else:
+                    reference_mse = summary[reference]["weighted_mean_squared_error"]
+                candidate_mse = summary[candidate]["weighted_mean_squared_error"]
+                draws[name].append(reference_mse - candidate_mse)
+            successful += 1
+    if successful < max(100, int(iterations * 0.9)):
+        blockers.append("insufficient_successful_bootstrap_draws")
+    comparisons = {}
+    if successful:
+        for name, values in draws.items():
+            comparisons[name] = {
+                "mse_improvement_median": _percentile(values, 0.5),
+                "mse_improvement_ci_95": {
+                    "lower": _percentile(values, 0.025),
+                    "upper": _percentile(values, 0.975),
+                },
+                "probability_of_improvement":
+                    sum(value > 0 for value in values) / len(values),
+            }
+    return {
+        "schema_version": "shadow_hitter_walk_skill_bootstrap_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "cluster_key": "player_id",
+        "cluster_count": len(keys),
+        "requested_iterations": iterations,
+        "successful_iterations": successful,
+        "difference_definition": "reference cross-season MSE minus candidate cross-season MSE",
+        "comparisons": comparisons,
+        "blockers": blockers,
+    }

--- a/scripts/audit_shadow_hitter_walk_skill.py
+++ b/scripts/audit_shadow_hitter_walk_skill.py
@@ -1,0 +1,162 @@
+"""Audit cutoff-safe hitter walk-skill evidence on historical holdouts."""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+
+from sqlalchemy import text
+
+from mlb_app.model_projection_routes import _session_factory
+from mlb_app.simulation.shadow.hitter_walk_skill_validation import (
+    bootstrap_hitter_walk_skill_differences,
+    evaluate_hitter_walk_skill_models,
+)
+
+
+VALID_PA = """
+events IS NOT NULL
+AND LOWER(TRIM(events)) NOT IN ('', 'nan', 'none', 'null', 'intent_walk')
+"""
+SWING = """
+description IN (
+    'swinging_strike', 'swinging_strike_blocked', 'missed_bunt',
+    'foul', 'foul_tip', 'foul_bunt', 'bunt_foul_tip', 'hit_into_play'
+)
+"""
+CALLED_BALL = """
+description IN ('ball', 'blocked_ball', 'pitchout', 'automatic_ball')
+"""
+WINDOWS = (
+    (2024, dt.date(2024, 6, 1), dt.date(2024, 6, 30)),
+    (2024, dt.date(2024, 7, 1), dt.date(2024, 7, 31)),
+    (2024, dt.date(2024, 8, 1), dt.date(2024, 8, 31)),
+    (2025, dt.date(2025, 6, 1), dt.date(2025, 6, 30)),
+    (2025, dt.date(2025, 7, 1), dt.date(2025, 7, 31)),
+    (2025, dt.date(2025, 8, 1), dt.date(2025, 8, 31)),
+)
+
+
+def _aggregate(session, start: dt.date, end: dt.date) -> dict:
+    query = text(
+        "SELECT batter_id,p_throws,COUNT(*) AS pitches, "
+        "SUM(CASE WHEN " + SWING + " THEN 1 ELSE 0 END) AS swings, "
+        "SUM(CASE WHEN " + CALLED_BALL + " THEN 1 ELSE 0 END) "
+        "AS called_balls, "
+        "SUM(CASE WHEN description='called_strike' "
+        "OR description='automatic_strike' THEN 1 ELSE 0 END) "
+        "AS called_strikes, "
+        "SUM(CASE WHEN " + VALID_PA + " THEN 1 ELSE 0 END) AS pa, "
+        "SUM(CASE WHEN events='walk' THEN 1 ELSE 0 END) AS walks "
+        "FROM statcast_events "
+        "WHERE game_date>=:start AND game_date<=:end "
+        "AND batter_id IS NOT NULL AND p_throws IN ('R','L') "
+        "GROUP BY batter_id,p_throws"
+    )
+    return {
+        (int(row["batter_id"]), str(row["p_throws"])): {
+            name: int(row[name] or 0)
+            for name in (
+                "pitches",
+                "swings",
+                "called_balls",
+                "called_strikes",
+                "pa",
+                "walks",
+            )
+        }
+        for row in session.execute(
+            query,
+            {"start": start, "end": end},
+        ).mappings()
+    }
+
+
+def build_samples(session) -> tuple[list[dict], list[dict]]:
+    samples = []
+    coverage = []
+    for season, cutoff, holdout_end in WINDOWS:
+        pre = _aggregate(session, dt.date(season, 1, 1), cutoff)
+        holdout = _aggregate(
+            session,
+            cutoff + dt.timedelta(days=1),
+            holdout_end,
+        )
+        blockers = collections.Counter()
+        window_samples = []
+        for (player_id, hand), actual in pre.items():
+            future = holdout.get((player_id, hand))
+            if actual["pa"] < 25:
+                blockers["insufficient_pre_pa"] += 1
+                continue
+            if actual["pitches"] < 100:
+                blockers["insufficient_pre_pitches"] += 1
+                continue
+            if future is None or future["pa"] < 20:
+                blockers["insufficient_holdout_pa"] += 1
+                continue
+            sample = {
+                "player_id": player_id,
+                "season": season,
+                "split": "vsR" if hand == "R" else "vsL",
+                "cutoff": cutoff.isoformat(),
+                "holdout_end": holdout_end.isoformat(),
+                "holdout_pa": future["pa"],
+                "holdout_bb_rate": future["walks"] / future["pa"],
+                "pre_actual_bb_rate": actual["walks"] / actual["pa"],
+                "pre_called_ball_rate":
+                    actual["called_balls"] / actual["pitches"],
+                "pre_take_rate": 1 - actual["swings"] / actual["pitches"],
+                "pre_called_strike_rate":
+                    actual["called_strikes"] / actual["pitches"],
+            }
+            samples.append(sample)
+            window_samples.append(sample)
+        coverage.append({
+            "season": season,
+            "cutoff": cutoff.isoformat(),
+            "holdout_end": holdout_end.isoformat(),
+            "sample_count": len(window_samples),
+            "holdout_pa": sum(row["holdout_pa"] for row in window_samples),
+            "blocker_counts": dict(blockers),
+        })
+    return samples, coverage
+
+
+def main() -> None:
+    factory = _session_factory()
+    session = factory()
+    try:
+        samples, coverage = build_samples(session)
+    finally:
+        session.close()
+    validation = evaluate_hitter_walk_skill_models(samples)
+    bootstrap = bootstrap_hitter_walk_skill_differences(samples)
+    print(json.dumps({
+        **validation,
+        "schema_version": "historical_shadow_hitter_walk_skill_audit_v1",
+        "window_coverage": coverage,
+        "holdout_pa": sum(row["holdout_pa"] for row in samples),
+        "sample_counts_by_season": dict(collections.Counter(
+            row["season"] for row in samples
+        )),
+        "sample_counts_by_split": dict(collections.Counter(
+            row["split"] for row in samples
+        )),
+        "target_policy": {
+            "target": "recorded non-intentional walk rate where distinguishable",
+            "intent_walk_rows_excluded": True,
+            "historical_limitation":
+                "intent_walk is distinguished only in available 2026 rows",
+        },
+        "zone_policy": {
+            "chase_rate_included": False,
+            "reason": "batter-specific strike-zone bounds are not stored",
+        },
+        "clustered_bootstrap": bootstrap,
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_walk_skill_validation.py
+++ b/tests/test_hitter_walk_skill_validation.py
@@ -1,0 +1,75 @@
+import copy
+
+from mlb_app.simulation.shadow.hitter_walk_skill_validation import (
+    bootstrap_hitter_walk_skill_differences,
+    evaluate_hitter_walk_skill_models,
+)
+
+
+def samples():
+    rows = []
+    for season, offset in ((2024, 0.0), (2025, 0.01)):
+        for player_id in range(1, 61):
+            actual = 0.12 + (player_id % 12) * 0.012 + offset
+            called_ball = 0.14 + (player_id % 10) * 0.014 + offset
+            future = 0.03 + 0.55 * actual + 0.35 * called_ball
+            rows.append({
+                "player_id": player_id,
+                "season": season,
+                "split": "vsR" if player_id % 2 else "vsL",
+                "holdout_pa": 40 + player_id,
+                "holdout_bb_rate": future,
+                "pre_actual_bb_rate": actual,
+                "pre_called_ball_rate": called_ball,
+                "pre_take_rate": 0.15 + (player_id % 4) * 0.002,
+                "pre_called_strike_rate": called_ball * 0.48,
+            })
+    return rows
+
+
+def test_cross_season_contract_is_shadow_only():
+    result = evaluate_hitter_walk_skill_models(samples())
+    assert result["status"] == "ready"
+    assert result["seasons"] == [2024, 2025]
+    assert result["sample_count"] == 120
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False
+    assert "actual_called_ball" in result["cross_season_summary"]
+    assert "contact_rate" not in str(result["model_features"])
+
+
+def test_blocks_without_two_seasons():
+    result = evaluate_hitter_walk_skill_models(
+        [row for row in samples() if row["season"] == 2024]
+    )
+    assert result["status"] == "blocked"
+    assert "insufficient_validation_seasons" in result["blockers"]
+
+
+def test_excludes_invalid_rows():
+    payload = samples()
+    invalid = copy.deepcopy(payload[0])
+    invalid["holdout_pa"] = 0
+    payload.append(invalid)
+    assert evaluate_hitter_walk_skill_models(payload)["sample_count"] == 120
+
+
+def test_clustered_bootstrap_contract():
+    result = bootstrap_hitter_walk_skill_differences(
+        samples(),
+        iterations=100,
+        seed=7,
+        minimum_fold_samples=30,
+    )
+    assert result["status"] == "ready"
+    assert result["cluster_count"] == 60
+    assert result["successful_iterations"] == 100
+    assert set(result["comparisons"]) == {
+        "called_ball_minus_actual_bb",
+        "blend_increment_over_best_univariate",
+        "take_increment_over_blend",
+        "called_strike_increment_over_blend",
+        "full_increment_over_blend",
+    }
+    assert result["parameter_selected"] is False
+    assert result["production_authority_changed"] is False


### PR DESCRIPTION
## Summary

- add a cutoff-safe historical evaluator for hitter walk-skill evidence
- compare actual walk rate with called-ball, take-rate, and called-strike signals across six 2024–2025 holdout windows
- add a reproducible audit script and contract tests
- keep the work shadow-only with no production parameter or authority changes

## Findings

Called-ball rate was the strongest supported standalone predictor of future walk rate. It improved MSE over actual walk rate by approximately 2.79%, with a clustered-bootstrap probability of improvement of 0.995 and a fully positive 95% interval.

Blending actual walk rate with called-ball rate did not produce reliable incremental value. Take rate, called-strike rate, and the full auxiliary model also had confidence intervals crossing zero, so they remain unselected.

The audit excludes recorded intentional walks where distinguishable. Historical rows have limited intentional-walk labeling, and chase rate is intentionally excluded because batter-specific strike-zone bounds are not stored.

## Validation

- canonical and hitter-profile regression: `1219 passed, 2 deselected`
- focused 6RS contract: `14 passed`
- Python compilation passed
- `git diff --check` passed