### PR TITLE
Harden cron matchup refresh retries

### DIFF
--- a/scripts/run_refresh_job.py
+++ b/scripts/run_refresh_job.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 import datetime as dt
 import json
 import os
+import socket
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -36,6 +38,15 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 REQUEST_TIMEOUT_SECONDS = int(os.environ.get("REFRESH_TIMEOUT_SECONDS", "60"))
+REQUEST_MAX_ATTEMPTS = max(
+    1,
+    int(os.environ.get("REFRESH_MAX_ATTEMPTS", "3")),
+)
+REQUEST_RETRY_BACKOFF_SECONDS = max(
+    0.0,
+    float(os.environ.get("REFRESH_RETRY_BACKOFF_SECONDS", "1")),
+)
+RETRYABLE_HTTP_STATUS_CODES = frozenset({502, 503, 504})
 RUN_FAST_MATCHUP_REFRESH = os.environ.get("RUN_FAST_MATCHUP_REFRESH", "1") == "1"
 WARM_SNAPSHOTS = os.environ.get("WARM_MATCHUP_SNAPSHOTS", "1") == "1"
 REFRESH_MATCHUPS_FIRST = os.environ.get("REFRESH_MATCHUPS_FIRST", "1") == "1"
@@ -57,16 +68,106 @@ def _log(message: str) -> None:
     print(f"[{timestamp}] {message}", flush=True)
 
 
-def _request_json(url: str, method: str = "GET") -> dict | list | str | None:
+def _is_retryable_request_error(exc: BaseException) -> bool:
+    if isinstance(exc, urllib.error.HTTPError):
+        return exc.code in RETRYABLE_HTTP_STATUS_CODES
+    return isinstance(
+        exc,
+        (
+            urllib.error.URLError,
+            TimeoutError,
+            socket.timeout,
+            ConnectionError,
+        ),
+    )
+
+
+def _request_json(
+    url: str,
+    method: str = "GET",
+    *,
+    label: str = "unknown",
+) -> dict | list | str | None:
     request = urllib.request.Request(url=url, method=method)
-    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
-        body = response.read().decode("utf-8", errors="replace")
-        if not body:
-            return None
+
+    for attempt in range(1, REQUEST_MAX_ATTEMPTS + 1):
+        started = time.monotonic()
         try:
-            return json.loads(body)
-        except json.JSONDecodeError:
-            return body
+            with urllib.request.urlopen(
+                request,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            ) as response:
+                body = response.read().decode(
+                    "utf-8",
+                    errors="replace",
+                )
+                if attempt > 1:
+                    _log(
+                        json.dumps(
+                            {
+                                "event": "refresh_request_recovered",
+                                "target": label,
+                                "url": url,
+                                "method": method,
+                                "attempt": attempt,
+                                "elapsed_seconds": round(
+                                    time.monotonic() - started,
+                                    3,
+                                ),
+                            },
+                            sort_keys=True,
+                        )
+                    )
+                if not body:
+                    return None
+                try:
+                    return json.loads(body)
+                except json.JSONDecodeError:
+                    return body
+        except Exception as exc:
+            elapsed = round(time.monotonic() - started, 3)
+            retryable = _is_retryable_request_error(exc)
+            exhausted = attempt >= REQUEST_MAX_ATTEMPTS
+            diagnostic = {
+                "event": "refresh_request_failed",
+                "target": label,
+                "url": url,
+                "method": method,
+                "attempt": attempt,
+                "max_attempts": REQUEST_MAX_ATTEMPTS,
+                "elapsed_seconds": elapsed,
+                "exception_type": type(exc).__name__,
+                "message": str(exc),
+                "retryable": retryable,
+                "retries_exhausted": exhausted,
+            }
+            if isinstance(exc, urllib.error.HTTPError):
+                diagnostic["http_status"] = exc.code
+            _log(json.dumps(diagnostic, sort_keys=True))
+
+            if not retryable or exhausted:
+                raise
+
+            backoff_seconds = (
+                REQUEST_RETRY_BACKOFF_SECONDS
+                * (2 ** (attempt - 1))
+            )
+            _log(
+                json.dumps(
+                    {
+                        "event": "refresh_request_retry_scheduled",
+                        "target": label,
+                        "url": url,
+                        "method": method,
+                        "next_attempt": attempt + 1,
+                        "backoff_seconds": backoff_seconds,
+                    },
+                    sort_keys=True,
+                )
+            )
+            time.sleep(backoff_seconds)
+
+    raise RuntimeError("request retry loop exited unexpectedly")
 
 
 def _has_pitcher(game: dict, side: str) -> bool:
@@ -97,7 +198,11 @@ def _refresh_matchups_for_date(label: str, base_url: str, target_date: dt.date) 
     query = urllib.parse.urlencode({"date": target_date.isoformat()})
     url = f"{base_url}/matchups?{query}"
     _log(f"[{label}] Refreshing live matchup payload for {target_date.isoformat()} via {url}")
-    result = _request_json(url, method="GET")
+    result = _request_json(
+        url,
+        method="GET",
+        label=label,
+    )
     if isinstance(result, list):
         pitcher_counts = {
             "home": sum(
@@ -134,7 +239,11 @@ def _refresh_matchups_for_date(label: str, base_url: str, target_date: dt.date) 
 def _warm_snapshot_for_date(label: str, base_url: str, target_date: dt.date) -> None:
     url = f"{base_url}/matchups/snapshot/{target_date.isoformat()}"
     _log(f"[{label}] Warming matchup snapshot for {target_date.isoformat()} via {url}")
-    result = _request_json(url, method="POST")
+    result = _request_json(
+        url,
+        method="POST",
+        label=label,
+    )
     _log(f"[{label}] Snapshot response for {target_date.isoformat()}: {result}")
 
 
@@ -151,7 +260,11 @@ def _clear_ai_data_assistant_cache(label: str, base_url: str) -> None:
     url = f"{base_url}/ai-data-assistant/cache/clear"
     try:
         _log(f"[{label}] Clearing AI Data Assistant cache via {url}")
-        result = _request_json(url, method="POST")
+        result = _request_json(
+            url,
+            method="POST",
+            label=label,
+        )
         _log(f"[{label}] AI Data Assistant cache clear response: {result}")
     except Exception as exc:
         _log(f"[{label}] AI Data Assistant cache clear failed but refresh will continue: {exc}")
@@ -294,7 +407,19 @@ def _load_targets() -> list[tuple[str, str]]:
     return targets
 
 
+def _check_readiness(label: str, base_url: str) -> None:
+    url = f"{base_url}/health"
+    _log(f"[{label}] Checking target readiness via {url}")
+    result = _request_json(
+        url,
+        method="GET",
+        label=label,
+    )
+    _log(f"[{label}] Readiness response: {result}")
+
+
 def _run_target(label: str, base_url: str) -> None:
+    _check_readiness(label, base_url)
     today = dt.date.today()
     tomorrow = today + dt.timedelta(days=1)
 
@@ -357,7 +482,10 @@ def main() -> int:
         f"run_hitter_statcast_backfill={int(RUN_HITTER_STATCAST_BACKFILL)}, "
         f"run_hitting_matchups_refresh={int(RUN_HITTING_MATCHUPS_REFRESH)}, "
         f"run_canonical_dashboard_refresh={int(RUN_CANONICAL_DASHBOARD_REFRESH)}, "
-        f"clear_ai_cache_after_refresh={int(CLEAR_AI_CACHE_AFTER_REFRESH)}"
+        f"clear_ai_cache_after_refresh={int(CLEAR_AI_CACHE_AFTER_REFRESH)}, "
+        f"request_timeout_seconds={REQUEST_TIMEOUT_SECONDS}, "
+        f"request_max_attempts={REQUEST_MAX_ATTEMPTS}, "
+        f"request_retry_backoff_seconds={REQUEST_RETRY_BACKOFF_SECONDS}"
     )
 
     try:

--- a/tests/test_refresh_job_retries.py
+++ b/tests/test_refresh_job_retries.py
@@ -1,0 +1,281 @@
+import io
+import socket
+import urllib.error
+
+import pytest
+
+from scripts import run_refresh_job
+
+
+class FakeResponse:
+    def __init__(self, body=b"{}"):
+        self.body = body
+        self.status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+def configure_retries(monkeypatch, *, attempts=3, backoff=1.0):
+    monkeypatch.setattr(
+        run_refresh_job,
+        "REQUEST_MAX_ATTEMPTS",
+        attempts,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "REQUEST_RETRY_BACKOFF_SECONDS",
+        backoff,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "REQUEST_TIMEOUT_SECONDS",
+        60,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_log",
+        lambda _message: None,
+    )
+
+
+def test_request_retries_timeout_then_recovers(monkeypatch):
+    configure_retries(monkeypatch)
+    calls = []
+    sleeps = []
+
+    def urlopen(_request, *, timeout):
+        calls.append(timeout)
+        if len(calls) == 1:
+            raise socket.timeout("read operation timed out")
+        return FakeResponse(b'{"status": "ok"}')
+
+    monkeypatch.setattr(
+        run_refresh_job.urllib.request,
+        "urlopen",
+        urlopen,
+    )
+    monkeypatch.setattr(
+        run_refresh_job.time,
+        "sleep",
+        sleeps.append,
+    )
+
+    result = run_refresh_job._request_json(
+        "https://example.test/matchups",
+        label="production",
+    )
+
+    assert result == {"status": "ok"}
+    assert calls == [60, 60]
+    assert sleeps == [1.0]
+
+
+def test_request_retries_http_503_then_recovers(monkeypatch):
+    configure_retries(monkeypatch)
+    calls = []
+    sleeps = []
+
+    def urlopen(request, *, timeout):
+        calls.append((request.full_url, timeout))
+        if len(calls) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(b"temporarily unavailable"),
+            )
+        return FakeResponse(b"[]")
+
+    monkeypatch.setattr(
+        run_refresh_job.urllib.request,
+        "urlopen",
+        urlopen,
+    )
+    monkeypatch.setattr(
+        run_refresh_job.time,
+        "sleep",
+        sleeps.append,
+    )
+
+    assert run_refresh_job._request_json(
+        "https://example.test/matchups",
+        label="production",
+    ) == []
+    assert len(calls) == 2
+    assert sleeps == [1.0]
+
+
+def test_request_does_not_retry_nontransient_http_error(monkeypatch):
+    configure_retries(monkeypatch)
+    calls = []
+    sleeps = []
+
+    def urlopen(request, *, timeout):
+        calls.append((request.full_url, timeout))
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "Internal Server Error",
+            {},
+            io.BytesIO(b"persistent failure"),
+        )
+
+    monkeypatch.setattr(
+        run_refresh_job.urllib.request,
+        "urlopen",
+        urlopen,
+    )
+    monkeypatch.setattr(
+        run_refresh_job.time,
+        "sleep",
+        sleeps.append,
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        run_refresh_job._request_json(
+            "https://example.test/matchups",
+            label="production",
+        )
+
+    assert raised.value.code == 500
+    assert len(calls) == 1
+    assert sleeps == []
+
+
+def test_request_raises_after_transient_retries_exhausted(
+    monkeypatch,
+):
+    configure_retries(monkeypatch, attempts=3, backoff=0.5)
+    calls = []
+    sleeps = []
+
+    def urlopen(_request, *, timeout):
+        calls.append(timeout)
+        raise TimeoutError("read operation timed out")
+
+    monkeypatch.setattr(
+        run_refresh_job.urllib.request,
+        "urlopen",
+        urlopen,
+    )
+    monkeypatch.setattr(
+        run_refresh_job.time,
+        "sleep",
+        sleeps.append,
+    )
+
+    with pytest.raises(TimeoutError):
+        run_refresh_job._request_json(
+            "https://example.test/matchups",
+            label="production",
+        )
+
+    assert calls == [60, 60, 60]
+    assert sleeps == [0.5, 1.0]
+
+
+def test_target_checks_readiness_before_expensive_refresh(
+    monkeypatch,
+):
+    calls = []
+    monkeypatch.setattr(
+        run_refresh_job,
+        "REFRESH_MATCHUPS_FIRST",
+        True,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "WARM_SNAPSHOTS",
+        False,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "CLEAR_AI_CACHE_AFTER_REFRESH",
+        False,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_check_readiness",
+        lambda label, base_url: calls.append(
+            ("readiness", label, base_url)
+        ),
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_refresh_matchups_for_date",
+        lambda label, base_url, target_date: calls.append(
+            ("matchups", label, base_url, target_date)
+        ),
+    )
+
+    run_refresh_job._run_target(
+        "production",
+        "https://example.test",
+    )
+
+    assert calls[0] == (
+        "readiness",
+        "production",
+        "https://example.test",
+    )
+    assert [row[0] for row in calls] == [
+        "readiness",
+        "matchups",
+        "matchups",
+    ]
+
+
+def test_target_isolation_is_preserved_after_exhausted_failure(
+    monkeypatch,
+):
+    calls = []
+    monkeypatch.setattr(
+        run_refresh_job,
+        "RUN_FAST_MATCHUP_REFRESH",
+        True,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_run_hitting_matchups_refresh",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_load_targets",
+        lambda: [
+            ("production", "https://production.test"),
+            ("sandbox", "https://sandbox.test"),
+        ],
+    )
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_log",
+        lambda _message: None,
+    )
+
+    def run_target(label, _base_url):
+        calls.append(label)
+        if label == "production":
+            raise TimeoutError("read operation timed out")
+
+    monkeypatch.setattr(
+        run_refresh_job,
+        "_run_target",
+        run_target,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="One or more refresh targets failed",
+    ):
+        run_refresh_job._run_fast_matchup_refresh()
+
+    assert calls == ["production", "sandbox"]


### PR DESCRIPTION
## Summary

- add bounded retries for transient timeouts, connection failures, and HTTP 502/503/504 responses
- use short exponential backoff and a lightweight `/health` readiness request before expensive matchup refreshes
- preserve production/sandbox target isolation and fail the cron only after retries are exhausted
- emit structured request diagnostics with target, URL, method, attempt, elapsed time, exception type, retryability, and exhaustion state
- keep AI Data Assistant cache clearing best-effort and unchanged in authority

## Root cause

The Railway refresh job issued each request once. A production `/matchups` request reached the exact 60-second read timeout, propagated into the target failure collector, and caused the cron to exit nonzero even though the preceding hitting-matchup ETL and the sandbox target succeeded.

## Production impact

This hardens the existing cron transport behavior without changing simulation logic, hitter-profile evidence, endpoint authority, or model parameters. Persistent and non-transient failures remain visible and still fail the job.

## Validation

- `9 passed` across retry, dashboard refresh schedule, and game-day warming tests
- `python -m py_compile scripts/run_refresh_job.py tests/test_refresh_job_retries.py`
- staged and unstaged diff checks passed
- broader local pytest attempts were stopped because the VS Code terminal process repeatedly terminated; CI should provide independent broader validation
