### PR TITLE
Audit hitter hit-type allocation evidence

### DIFF
--- a/mlb_app/simulation/shadow/hitter_hit_type_allocation_validation.py
+++ b/mlb_app/simulation/shadow/hitter_hit_type_allocation_validation.py
@@ -1,0 +1,653 @@
+"""Cross-season validation for shadow hitter hit-type allocation evidence."""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Mapping, Sequence
+from typing import Any, Optional
+
+
+HIT_TYPES = ("single", "double", "triple", "home_run")
+MODEL_FEATURES = {
+    "league_prior": (),
+    "actual_allocation": (
+        "pre_double_share",
+        "pre_triple_share",
+        "pre_home_run_share",
+    ),
+    "expected_damage": (
+        "pre_expected_damage_per_bbe",
+    ),
+    "actual_expected": (
+        "pre_double_share",
+        "pre_triple_share",
+        "pre_home_run_share",
+        "pre_expected_damage_per_bbe",
+    ),
+    "actual_expected_geometry": (
+        "pre_double_share",
+        "pre_triple_share",
+        "pre_home_run_share",
+        "pre_expected_damage_per_bbe",
+        "pre_avg_exit_velocity",
+        "pre_avg_launch_angle",
+    ),
+}
+
+
+def _number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _clean_samples(
+    samples: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    required = {
+        "season",
+        "holdout_hits",
+        *{
+            f"holdout_{hit_type}_count"
+            for hit_type in HIT_TYPES
+        },
+        *{
+            feature
+            for features in MODEL_FEATURES.values()
+            for feature in features
+        },
+    }
+    cleaned = []
+    for sample in samples:
+        values = {
+            key: _number(sample.get(key))
+            for key in required
+        }
+        if any(value is None for value in values.values()):
+            continue
+        if values["holdout_hits"] <= 0:
+            continue
+        counts = [
+            values[f"holdout_{hit_type}_count"]
+            for hit_type in HIT_TYPES
+        ]
+        if any(count < 0 for count in counts):
+            continue
+        if abs(sum(counts) - values["holdout_hits"]) > 1e-6:
+            continue
+        cleaned.append({
+            **dict(sample),
+            **values,
+            "season": int(values["season"]),
+        })
+    return cleaned
+
+
+def _solve(
+    matrix: list[list[float]],
+    vector: list[float],
+) -> list[float]:
+    size = len(vector)
+    augmented = [
+        list(matrix[row]) + [vector[row]]
+        for row in range(size)
+    ]
+    for pivot in range(size):
+        best = max(
+            range(pivot, size),
+            key=lambda row: abs(augmented[row][pivot]),
+        )
+        augmented[pivot], augmented[best] = (
+            augmented[best],
+            augmented[pivot],
+        )
+        divisor = augmented[pivot][pivot]
+        if abs(divisor) < 1e-12:
+            raise ValueError(
+                "singular weighted regression matrix"
+            )
+        augmented[pivot] = [
+            value / divisor
+            for value in augmented[pivot]
+        ]
+        for row in range(size):
+            if row == pivot:
+                continue
+            factor = augmented[row][pivot]
+            augmented[row] = [
+                value - factor * pivot_value
+                for value, pivot_value in zip(
+                    augmented[row],
+                    augmented[pivot],
+                )
+            ]
+    return [
+        augmented[row][-1]
+        for row in range(size)
+    ]
+
+
+def _fit_outcome(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+    hit_type: str,
+) -> list[float]:
+    width = len(features) + 1
+    matrix = [
+        [0.0] * width
+        for _ in range(width)
+    ]
+    vector = [0.0] * width
+    count_key = f"holdout_{hit_type}_count"
+
+    for sample in samples:
+        weight = float(sample["holdout_hits"])
+        row = [1.0] + [
+            float(sample[feature])
+            for feature in features
+        ]
+        target = float(sample[count_key]) / weight
+        for left in range(width):
+            vector[left] += (
+                weight * row[left] * target
+            )
+            for right in range(width):
+                matrix[left][right] += (
+                    weight
+                    * row[left]
+                    * row[right]
+                )
+
+    for index in range(1, width):
+        matrix[index][index] += 1e-7
+    return _solve(matrix, vector)
+
+
+def _fit_model(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+) -> dict[str, list[float]]:
+    return {
+        hit_type: _fit_outcome(
+            samples,
+            features,
+            hit_type,
+        )
+        for hit_type in HIT_TYPES
+    }
+
+
+def _predict(
+    sample: Mapping[str, Any],
+    features: Sequence[str],
+    coefficients: Mapping[str, Sequence[float]],
+) -> dict[str, float]:
+    raw = {}
+    for hit_type in HIT_TYPES:
+        values = coefficients[hit_type]
+        prediction = values[0] + sum(
+            coefficient * float(sample[feature])
+            for coefficient, feature in zip(
+                values[1:],
+                features,
+            )
+        )
+        raw[hit_type] = max(prediction, 1e-9)
+
+    total = sum(raw.values())
+    return {
+        hit_type: raw[hit_type] / total
+        for hit_type in HIT_TYPES
+    }
+
+
+def _score(
+    samples: Sequence[Mapping[str, Any]],
+    features: Sequence[str],
+    coefficients: Mapping[str, Sequence[float]],
+) -> dict[str, Any]:
+    total_hits = 0.0
+    log_loss = 0.0
+    brier = 0.0
+    outcome_absolute_error = {
+        hit_type: 0.0
+        for hit_type in HIT_TYPES
+    }
+
+    for sample in samples:
+        weight = float(sample["holdout_hits"])
+        total_hits += weight
+        prediction = _predict(
+            sample,
+            features,
+            coefficients,
+        )
+
+        for hit_type in HIT_TYPES:
+            count = float(
+                sample[f"holdout_{hit_type}_count"]
+            )
+            observed_share = count / weight
+            predicted_share = prediction[hit_type]
+            log_loss -= count * math.log(
+                max(predicted_share, 1e-12)
+            )
+            brier += (
+                weight
+                * (
+                    predicted_share
+                    - observed_share
+                )
+                ** 2
+            )
+            outcome_absolute_error[hit_type] += (
+                weight
+                * abs(
+                    predicted_share
+                    - observed_share
+                )
+            )
+
+    return {
+        "sample_count": len(samples),
+        "holdout_hits": int(total_hits),
+        "weighted_multinomial_log_loss": (
+            log_loss / total_hits
+            if total_hits
+            else None
+        ),
+        "weighted_compositional_brier": (
+            brier / total_hits
+            if total_hits
+            else None
+        ),
+        "weighted_absolute_error_by_hit_type": {
+            hit_type: (
+                outcome_absolute_error[hit_type]
+                / total_hits
+                if total_hits
+                else None
+            )
+            for hit_type in HIT_TYPES
+        },
+    }
+
+
+def _relative_improvement(
+    candidate: float,
+    reference: float,
+) -> float:
+    if not reference:
+        return 0.0
+    return (reference - candidate) / reference
+
+
+def evaluate_hitter_hit_type_allocation_models(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Compare conditional hit-type allocation models."""
+
+    cleaned = _clean_samples(samples)
+    seasons = sorted({
+        row["season"]
+        for row in cleaned
+    })
+    blockers = []
+
+    if len(seasons) < 2:
+        blockers.append(
+            "insufficient_validation_seasons"
+        )
+
+    folds = []
+    aggregate = {
+        name: {
+            "weighted_log_loss": 0.0,
+            "weighted_brier": 0.0,
+            "holdout_hits": 0.0,
+            "fold_count": 0.0,
+        }
+        for name in MODEL_FEATURES
+    }
+
+    for validation_season in seasons:
+        training = [
+            row
+            for row in cleaned
+            if row["season"] != validation_season
+        ]
+        validation = [
+            row
+            for row in cleaned
+            if row["season"] == validation_season
+        ]
+
+        if (
+            len(training) < minimum_fold_samples
+            or len(validation) < minimum_fold_samples
+        ):
+            blockers.append(
+                "insufficient_fold_samples:"
+                f"{validation_season}"
+            )
+            continue
+
+        models = {}
+        for name, features in MODEL_FEATURES.items():
+            coefficients = _fit_model(
+                training,
+                features,
+            )
+            scores = _score(
+                validation,
+                features,
+                coefficients,
+            )
+            models[name] = {
+                "features": list(features),
+                "coefficients": coefficients,
+                "validation_scores": scores,
+            }
+
+            weight = float(scores["holdout_hits"])
+            accumulator = aggregate[name]
+            accumulator["weighted_log_loss"] += (
+                scores[
+                    "weighted_multinomial_log_loss"
+                ]
+                * weight
+            )
+            accumulator["weighted_brier"] += (
+                scores[
+                    "weighted_compositional_brier"
+                ]
+                * weight
+            )
+            accumulator["holdout_hits"] += weight
+            accumulator["fold_count"] += 1
+
+        ranked = sorted(
+            models,
+            key=lambda name: (
+                models[name]["validation_scores"][
+                    "weighted_multinomial_log_loss"
+                ],
+                len(MODEL_FEATURES[name]),
+                name,
+            ),
+        )
+        folds.append({
+            "validation_season": validation_season,
+            "training_seasons": [
+                season
+                for season in seasons
+                if season != validation_season
+            ],
+            "training_sample_count": len(training),
+            "validation_sample_count": len(validation),
+            "best_model": ranked[0],
+            "models": models,
+        })
+
+    summary = {}
+    for name, accumulator in aggregate.items():
+        weight = accumulator["holdout_hits"]
+        if not weight:
+            continue
+        summary[name] = {
+            "fold_count": int(
+                accumulator["fold_count"]
+            ),
+            "holdout_hits": int(weight),
+            "weighted_multinomial_log_loss": (
+                accumulator["weighted_log_loss"]
+                / weight
+            ),
+            "weighted_compositional_brier": (
+                accumulator["weighted_brier"]
+                / weight
+            ),
+        }
+
+    ranked_models = sorted(
+        summary,
+        key=lambda name: (
+            summary[name][
+                "weighted_multinomial_log_loss"
+            ],
+            len(MODEL_FEATURES[name]),
+            name,
+        ),
+    )
+
+    comparisons = {}
+    if summary:
+        metric = "weighted_multinomial_log_loss"
+        prior = summary["league_prior"][metric]
+        actual = summary["actual_allocation"][metric]
+        expected = summary["expected_damage"][metric]
+        combined = summary["actual_expected"][metric]
+        geometry = summary[
+            "actual_expected_geometry"
+        ][metric]
+
+        comparisons = {
+            "actual_vs_league_relative_log_loss_improvement":
+                _relative_improvement(actual, prior),
+            "expected_vs_league_relative_log_loss_improvement":
+                _relative_improvement(expected, prior),
+            "actual_expected_vs_actual_relative_log_loss_improvement":
+                _relative_improvement(combined, actual),
+            "geometry_increment_relative_log_loss_improvement":
+                _relative_improvement(
+                    geometry,
+                    combined,
+                ),
+        }
+
+    return {
+        "schema_version":
+            "shadow_hitter_hit_type_allocation_validation_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "allocation_condition": "conditional_on_hit",
+        "hit_types": list(HIT_TYPES),
+        "primary_metric":
+            "weighted_multinomial_log_loss",
+        "sample_count": len(cleaned),
+        "seasons": seasons,
+        "model_features": {
+            name: list(features)
+            for name, features in MODEL_FEATURES.items()
+        },
+        "cross_season_folds": folds,
+        "cross_season_summary": summary,
+        "ranked_models": ranked_models,
+        "comparisons": comparisons,
+        "blockers": blockers,
+        "known_limitations": [
+            "sprint_speed_not_stored",
+            "triple_allocation_lacks_direct_speed_evidence",
+        ],
+    }
+
+
+def _percentile(
+    values: Sequence[float],
+    probability: float,
+) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError(
+            "percentile requires at least one value"
+        )
+    position = (
+        (len(ordered) - 1)
+        * probability
+    )
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return (
+        ordered[lower] * (1.0 - fraction)
+        + ordered[upper] * fraction
+    )
+
+
+def bootstrap_hitter_hit_type_allocation_differences(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    iterations: int = 400,
+    seed: int = 20260731,
+    minimum_fold_samples: int = 50,
+) -> dict[str, Any]:
+    """Bootstrap allocation log-loss differences by player."""
+
+    cleaned = _clean_samples(samples)
+    grouped = {}
+    for index, sample in enumerate(cleaned):
+        cluster = sample.get("player_id")
+        if cluster is None:
+            cluster = ("row", index)
+        grouped.setdefault(cluster, []).append(sample)
+
+    cluster_keys = sorted(grouped, key=str)
+    blockers = []
+
+    if len(cluster_keys) < 30:
+        blockers.append(
+            "insufficient_player_clusters"
+        )
+    if iterations < 100:
+        blockers.append(
+            "insufficient_bootstrap_iterations"
+        )
+
+    comparisons = {
+        "actual_minus_league_prior": (
+            "league_prior",
+            "actual_allocation",
+        ),
+        "expected_minus_league_prior": (
+            "league_prior",
+            "expected_damage",
+        ),
+        "expected_increment_over_actual": (
+            "actual_allocation",
+            "actual_expected",
+        ),
+        "geometry_increment_over_actual_expected": (
+            "actual_expected",
+            "actual_expected_geometry",
+        ),
+    }
+    draws = {
+        name: []
+        for name in comparisons
+    }
+    successful = 0
+    rng = random.Random(seed)
+
+    if not blockers:
+        for _ in range(iterations):
+            selected = [
+                cluster_keys[
+                    rng.randrange(len(cluster_keys))
+                ]
+                for _ in cluster_keys
+            ]
+            resampled = [
+                row
+                for cluster in selected
+                for row in grouped[cluster]
+            ]
+            result = (
+                evaluate_hitter_hit_type_allocation_models(
+                    resampled,
+                    minimum_fold_samples=(
+                        minimum_fold_samples
+                    ),
+                )
+            )
+            if result["status"] != "ready":
+                continue
+
+            summary = result[
+                "cross_season_summary"
+            ]
+            metric = (
+                "weighted_multinomial_log_loss"
+            )
+            for (
+                name,
+                (reference, candidate),
+            ) in comparisons.items():
+                draws[name].append(
+                    summary[reference][metric]
+                    - summary[candidate][metric]
+                )
+            successful += 1
+
+    if successful < max(
+        100,
+        int(iterations * 0.90),
+    ):
+        blockers.append(
+            "insufficient_successful_bootstrap_draws"
+        )
+
+    intervals = {}
+    for name, values in draws.items():
+        if not values:
+            continue
+        intervals[name] = {
+            "log_loss_improvement_median":
+                _percentile(values, 0.50),
+            "log_loss_improvement_ci_95": {
+                "lower": _percentile(
+                    values,
+                    0.025,
+                ),
+                "upper": _percentile(
+                    values,
+                    0.975,
+                ),
+            },
+            "probability_of_improvement": (
+                sum(
+                    value > 0
+                    for value in values
+                )
+                / len(values)
+            ),
+        }
+
+    return {
+        "schema_version":
+            "shadow_hitter_hit_type_allocation_bootstrap_v1",
+        "status": "blocked" if blockers else "ready",
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "cluster_key": "player_id",
+        "cluster_count": len(cluster_keys),
+        "requested_iterations": iterations,
+        "successful_iterations": successful,
+        "seed": seed,
+        "difference_definition":
+            "reference cross-season log loss minus "
+            "candidate cross-season log loss",
+        "comparisons": intervals,
+        "blockers": blockers,
+    }

--- a/scripts/audit_shadow_hitter_hit_type_allocation.py
+++ b/scripts/audit_shadow_hitter_hit_type_allocation.py
@@ -1,0 +1,459 @@
+"""Run the cutoff-safe shadow hitter hit-type allocation audit."""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+import math
+import statistics
+
+from mlb_app.database import StatcastEvent
+from mlb_app.model_projection_routes import _session_factory
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_validation import (
+    bootstrap_hitter_hit_type_allocation_differences,
+    evaluate_hitter_hit_type_allocation_models,
+)
+
+
+AB_EVENTS = {
+    "field_out",
+    "force_out",
+    "grounded_into_double_play",
+    "field_error",
+    "fielders_choice",
+    "double_play",
+    "fielders_choice_out",
+    "triple_play",
+    "single",
+    "double",
+    "triple",
+    "home_run",
+    "strikeout",
+    "strikeout_double_play",
+}
+BBE_EVENTS = AB_EVENTS - {
+    "strikeout",
+    "strikeout_double_play",
+}
+HIT_EVENTS = {
+    "single",
+    "double",
+    "triple",
+    "home_run",
+}
+WINDOWS = (
+    (
+        2024,
+        dt.date(2024, 6, 1),
+        dt.date(2024, 6, 30),
+    ),
+    (
+        2024,
+        dt.date(2024, 7, 1),
+        dt.date(2024, 7, 31),
+    ),
+    (
+        2024,
+        dt.date(2024, 8, 1),
+        dt.date(2024, 8, 31),
+    ),
+    (
+        2025,
+        dt.date(2025, 6, 1),
+        dt.date(2025, 6, 30),
+    ),
+    (
+        2025,
+        dt.date(2025, 7, 1),
+        dt.date(2025, 7, 31),
+    ),
+    (
+        2025,
+        dt.date(2025, 8, 1),
+        dt.date(2025, 8, 31),
+    ),
+)
+SINGLE_WEIGHT = 0.90
+
+
+def _number(value):
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _terminal_rows(rows):
+    deduped = {}
+    for row in rows:
+        (
+            row_id,
+            _game_date,
+            game_pk,
+            at_bat,
+            _pitch_number,
+            batter_id,
+            hand,
+            _event,
+            _exit_velocity,
+            _launch_angle,
+            _xba,
+            _xwoba,
+        ) = row
+
+        if game_pk is not None and at_bat is not None:
+            key = (
+                int(batter_id),
+                hand,
+                int(game_pk),
+                int(at_bat),
+            )
+        else:
+            key = (
+                int(batter_id),
+                hand,
+                "row",
+                int(row_id),
+            )
+        deduped[key] = row
+    return list(deduped.values())
+
+
+def _hit_counts(rows):
+    counts = collections.Counter(
+        row[7]
+        for row in rows
+        if row[7] in HIT_EVENTS
+    )
+    return {
+        hit_type: counts.get(hit_type, 0)
+        for hit_type in HIT_EVENTS
+    }
+
+
+def _sample(
+    player_id,
+    hand,
+    season,
+    cutoff,
+    holdout_end,
+    pre,
+    holdout,
+):
+    pre_ab = len(pre)
+    holdout_ab = len(holdout)
+
+    if pre_ab < 50:
+        return None, "insufficient_pre_ab"
+    if holdout_ab < 20:
+        return None, "insufficient_holdout_ab"
+
+    pre_counts = _hit_counts(pre)
+    holdout_counts = _hit_counts(holdout)
+    pre_hits = sum(pre_counts.values())
+    holdout_hits = sum(holdout_counts.values())
+
+    if pre_hits < 15:
+        return None, "insufficient_pre_hits"
+    if holdout_hits < 8:
+        return None, "insufficient_holdout_hits"
+
+    pre_bbe = [
+        row
+        for row in pre
+        if row[7] in BBE_EVENTS
+    ]
+    expected_rows = [
+        row
+        for row in pre_bbe
+        if (
+            _number(row[10]) is not None
+            and _number(row[11]) is not None
+        )
+    ]
+    if len(expected_rows) < 20:
+        return None, "insufficient_expected_bbe"
+
+    expected_coverage = (
+        len(expected_rows) / len(pre_bbe)
+        if pre_bbe
+        else 0.0
+    )
+    if expected_coverage < 0.80:
+        return None, "insufficient_expected_coverage"
+
+    geometry_rows = [
+        row
+        for row in pre_bbe
+        if (
+            _number(row[8]) is not None
+            and _number(row[9]) is not None
+        )
+    ]
+    if len(geometry_rows) < 20:
+        return None, "insufficient_contact_geometry"
+
+    expected_damage = [
+        max(
+            _number(row[11])
+            - (
+                SINGLE_WEIGHT
+                * _number(row[10])
+            ),
+            0.0,
+        )
+        for row in expected_rows
+    ]
+
+    return {
+        "season": season,
+        "cutoff": cutoff.isoformat(),
+        "holdout_end": holdout_end.isoformat(),
+        "player_id": player_id,
+        "split": (
+            "vsR"
+            if hand == "R"
+            else "vsL"
+        ),
+        "pre_ab": pre_ab,
+        "pre_hits": pre_hits,
+        "pre_bbe": len(pre_bbe),
+        "expected_bbe": len(expected_rows),
+        "expected_coverage": expected_coverage,
+        "geometry_bbe": len(geometry_rows),
+        "pre_single_share":
+            pre_counts["single"] / pre_hits,
+        "pre_double_share":
+            pre_counts["double"] / pre_hits,
+        "pre_triple_share":
+            pre_counts["triple"] / pre_hits,
+        "pre_home_run_share":
+            pre_counts["home_run"] / pre_hits,
+        "pre_expected_damage_per_bbe":
+            statistics.fmean(expected_damage),
+        "pre_avg_exit_velocity":
+            statistics.fmean(
+                _number(row[8])
+                for row in geometry_rows
+            ),
+        "pre_avg_launch_angle":
+            statistics.fmean(
+                _number(row[9])
+                for row in geometry_rows
+            ),
+        "holdout_ab": holdout_ab,
+        "holdout_hits": holdout_hits,
+        "holdout_single_count":
+            holdout_counts["single"],
+        "holdout_double_count":
+            holdout_counts["double"],
+        "holdout_triple_count":
+            holdout_counts["triple"],
+        "holdout_home_run_count":
+            holdout_counts["home_run"],
+    }, None
+
+
+def build_samples(session):
+    samples = []
+    window_coverage = []
+
+    for season, cutoff, holdout_end in WINDOWS:
+        raw = (
+            session.query(
+                StatcastEvent.id,
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+                StatcastEvent.events,
+                StatcastEvent.launch_speed,
+                StatcastEvent.launch_angle,
+                StatcastEvent.estimated_ba_using_speedangle,
+                StatcastEvent.estimated_woba_using_speedangle,
+            )
+            .filter(
+                StatcastEvent.game_date
+                >= dt.date(season, 1, 1),
+                StatcastEvent.game_date
+                <= holdout_end,
+                StatcastEvent.p_throws.in_(
+                    ("R", "L")
+                ),
+                StatcastEvent.events.in_(
+                    tuple(AB_EVENTS)
+                ),
+            )
+            .order_by(
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.id,
+            )
+            .all()
+        )
+
+        grouped = collections.defaultdict(
+            lambda: {
+                "pre": [],
+                "holdout": [],
+            }
+        )
+        for row in _terminal_rows(raw):
+            key = (
+                int(row[5]),
+                row[6],
+            )
+            period = (
+                "pre"
+                if row[1] <= cutoff
+                else "holdout"
+            )
+            grouped[key][period].append(row)
+
+        blockers = collections.Counter()
+        window_samples = []
+
+        for (
+            player_id,
+            hand,
+        ), periods in grouped.items():
+            result, blocker = _sample(
+                player_id,
+                hand,
+                season,
+                cutoff,
+                holdout_end,
+                periods["pre"],
+                periods["holdout"],
+            )
+            if blocker:
+                blockers[blocker] += 1
+                continue
+            samples.append(result)
+            window_samples.append(result)
+
+        window_coverage.append({
+            "season": season,
+            "cutoff": cutoff.isoformat(),
+            "holdout_end":
+                holdout_end.isoformat(),
+            "sample_count":
+                len(window_samples),
+            "holdout_ab": sum(
+                row["holdout_ab"]
+                for row in window_samples
+            ),
+            "holdout_hits": sum(
+                row["holdout_hits"]
+                for row in window_samples
+            ),
+            "split_counts": dict(
+                collections.Counter(
+                    row["split"]
+                    for row in window_samples
+                )
+            ),
+            "mean_expected_coverage": (
+                statistics.fmean(
+                    row["expected_coverage"]
+                    for row in window_samples
+                )
+                if window_samples
+                else None
+            ),
+            "blocker_counts": dict(blockers),
+        })
+
+    return samples, window_coverage
+
+
+def main():
+    factory = _session_factory()
+    session = factory()
+    try:
+        samples, window_coverage = (
+            build_samples(session)
+        )
+    finally:
+        session.close()
+
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            samples
+        )
+    )
+    bootstrap = (
+        bootstrap_hitter_hit_type_allocation_differences(
+            samples
+        )
+    )
+
+    payload = {
+        **result,
+        "schema_version":
+            "historical_shadow_hitter_hit_type_allocation_audit_v1",
+        "window_coverage": window_coverage,
+        "holdout_ab": sum(
+            row["holdout_ab"]
+            for row in samples
+        ),
+        "holdout_hits": sum(
+            row["holdout_hits"]
+            for row in samples
+        ),
+        "sample_counts_by_season": dict(
+            collections.Counter(
+                row["season"]
+                for row in samples
+            )
+        ),
+        "sample_counts_by_split": dict(
+            collections.Counter(
+                row["split"]
+                for row in samples
+            )
+        ),
+        "allocation_policy": {
+            "condition": "conditional_on_hit",
+            "joint_outcomes": [
+                "single",
+                "double",
+                "triple",
+                "home_run",
+            ],
+            "primary_metric":
+                "weighted_multinomial_log_loss",
+        },
+        "speed_policy": {
+            "sprint_speed_included": False,
+            "reason":
+                "sprint speed is not stored in "
+                "StatcastEvent",
+            "triple_conclusion_restricted": True,
+        },
+        "production_impact": {
+            "parameter_selected": False,
+            "production_authority_changed": False,
+            "pa_outcome_model_modified": False,
+        },
+        "clustered_bootstrap": bootstrap,
+    }
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_hit_type_allocation_validation.py
+++ b/tests/test_hitter_hit_type_allocation_validation.py
@@ -1,0 +1,258 @@
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_validation import (
+    bootstrap_hitter_hit_type_allocation_differences,
+    evaluate_hitter_hit_type_allocation_models,
+)
+
+
+def samples():
+    rows = []
+    for season in (2024, 2025):
+        for index in range(80):
+            pre_double = 0.16 + ((index % 9) * 0.008)
+            pre_triple = 0.005 + ((index % 4) * 0.003)
+            pre_home_run = 0.08 + ((index % 11) * 0.008)
+            expected_damage = (
+                0.08
+                + ((index % 13) * 0.012)
+            )
+            exit_velocity = (
+                86.0
+                + ((index % 12) * 0.45)
+            )
+            launch_angle = (
+                7.0
+                + ((index % 15) * 0.7)
+            )
+
+            home_run_share = min(
+                0.34,
+                0.035
+                + (pre_home_run * 0.45)
+                + (expected_damage * 0.65),
+            )
+            double_share = min(
+                0.34,
+                0.08
+                + (pre_double * 0.60)
+                + (
+                    (exit_velocity - 86.0)
+                    * 0.004
+                ),
+            )
+            triple_share = min(
+                0.035,
+                0.006
+                + (pre_triple * 0.70),
+            )
+            single_share = (
+                1.0
+                - home_run_share
+                - double_share
+                - triple_share
+            )
+
+            holdout_hits = 40 + (index % 20)
+            double_count = round(
+                holdout_hits * double_share
+            )
+            triple_count = round(
+                holdout_hits * triple_share
+            )
+            home_run_count = round(
+                holdout_hits * home_run_share
+            )
+            single_count = (
+                holdout_hits
+                - double_count
+                - triple_count
+                - home_run_count
+            )
+
+            rows.append({
+                "player_id": index,
+                "season": season,
+                "holdout_hits": holdout_hits,
+                "holdout_single_count":
+                    single_count,
+                "holdout_double_count":
+                    double_count,
+                "holdout_triple_count":
+                    triple_count,
+                "holdout_home_run_count":
+                    home_run_count,
+                "pre_double_share": pre_double,
+                "pre_triple_share": pre_triple,
+                "pre_home_run_share":
+                    pre_home_run,
+                "pre_expected_damage_per_bbe":
+                    expected_damage,
+                "pre_avg_exit_velocity":
+                    exit_velocity,
+                "pre_avg_launch_angle":
+                    launch_angle,
+            })
+    return rows
+
+
+def test_cross_season_allocation_contract_is_ready():
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            samples()
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["seasons"] == [2024, 2025]
+    assert len(result["cross_season_folds"]) == 2
+    assert result["allocation_condition"] == (
+        "conditional_on_hit"
+    )
+    assert result["hit_types"] == [
+        "single",
+        "double",
+        "triple",
+        "home_run",
+    ]
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_joint_scoring_and_candidate_models_are_explicit():
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            samples()
+        )
+    )
+
+    assert result["primary_metric"] == (
+        "weighted_multinomial_log_loss"
+    )
+    assert {
+        "league_prior",
+        "actual_allocation",
+        "expected_damage",
+        "actual_expected",
+        "actual_expected_geometry",
+    } == set(result["cross_season_summary"])
+    assert (
+        "actual_expected_vs_actual_"
+        "relative_log_loss_improvement"
+        in result["comparisons"]
+    )
+
+
+def test_speed_limitation_is_not_hidden():
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            samples()
+        )
+    )
+
+    assert "sprint_speed_not_stored" in (
+        result["known_limitations"]
+    )
+    assert (
+        "triple_allocation_lacks_direct_speed_evidence"
+        in result["known_limitations"]
+    )
+
+
+def test_blocks_without_disjoint_validation_seasons():
+    one_season = [
+        row
+        for row in samples()
+        if row["season"] == 2024
+    ]
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            one_season
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "insufficient_validation_seasons" in (
+        result["blockers"]
+    )
+    assert result["parameter_selected"] is False
+
+
+def test_rejects_inconsistent_hit_counts():
+    payload = samples()
+    payload.extend([
+        {
+            **payload[0],
+            "holdout_hits": 0,
+        },
+        {
+            **payload[1],
+            "holdout_single_count": 999,
+        },
+        {
+            **payload[2],
+            "pre_avg_launch_angle": None,
+        },
+    ])
+
+    result = (
+        evaluate_hitter_hit_type_allocation_models(
+            payload
+        )
+    )
+
+    assert result["sample_count"] == len(
+        samples()
+    )
+
+
+def test_clustered_bootstrap_is_deterministic():
+    first = (
+        bootstrap_hitter_hit_type_allocation_differences(
+            samples(),
+            iterations=120,
+            seed=31,
+        )
+    )
+    second = (
+        bootstrap_hitter_hit_type_allocation_differences(
+            samples(),
+            iterations=120,
+            seed=31,
+        )
+    )
+
+    assert first == second
+    assert first["status"] == "ready"
+    assert first["cluster_count"] == 80
+    assert first["successful_iterations"] == 120
+    assert first["parameter_selected"] is False
+    assert (
+        first["production_authority_changed"]
+        is False
+    )
+    assert "expected_increment_over_actual" in (
+        first["comparisons"]
+    )
+
+
+def test_bootstrap_blocks_thin_player_clusters():
+    thin = [
+        {
+            **row,
+            "player_id": row["player_id"] % 10,
+        }
+        for row in samples()
+    ]
+    result = (
+        bootstrap_hitter_hit_type_allocation_differences(
+            thin,
+            iterations=120,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert "insufficient_player_clusters" in (
+        result["blockers"]
+    )


### PR DESCRIPTION
## Summary

- add a shadow-only compositional evaluator for conditional 1B/2B/3B/HR allocation
- use season-disjoint validation with weighted multinomial log loss as the primary metric
- compare league prior, actual allocation, expected damage, combined evidence, and contact-geometry additions
- add deterministic player-clustered bootstrap uncertainty
- add a reproducible six-window 2024–2025 historical audit
- preserve `parameter_selected=false` and `production_authority_changed=false`

## Historical evidence

The cutoff-safe audit produced 1,329 hitter/split/window samples, 74,329 holdout AB, and 19,828 holdout hits across six 2024–2025 windows.

- actual allocation beat the league prior with bootstrap probability 1.0 and a fully positive 95% interval
- expected damage also beat the league prior with bootstrap probability 1.0 and a fully positive interval
- expected damage alone had slightly lower pooled log loss than actual allocation
- adding expected damage to actual allocation improved the point estimate, but the bootstrap interval crossed zero (`p=0.905`), so incremental value was not proven
- adding exit velocity and launch angle was not reliable (`p=0.455`; interval crossed zero)
- sprint speed is not stored, so conclusions about triple allocation remain explicitly restricted

## Decision

This PR records evidence only. It does not select a production parameter, alter the PA outcome model, or change simulation authority. Actual allocation and expected damage are supported against the league prior, but neither the combined model nor the geometry increment is promoted.

## Validation

- historical audit completed successfully with 296 player clusters and 400 successful bootstrap iterations
- hitter-profile regression: `50 passed`
- focused allocation and power contracts: `13 passed`
- Python compilation passed
- staged diff and whitespace checks passed
