### PR TITLE
Audit hitter speed evidence availability

### DIFF
--- a/mlb_app/simulation/shadow/hitter_speed_evidence_availability.py
+++ b/mlb_app/simulation/shadow/hitter_speed_evidence_availability.py
@@ -1,0 +1,212 @@
+"""Readiness audit for cutoff-safe hitter speed evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "shadow_hitter_speed_evidence_availability_v1"
+)
+DIRECT_SPEED_FIELDS = frozenset({
+    "sprint_speed",
+    "competitive_runs",
+    "bolt_count",
+    "home_to_first",
+})
+REQUIRED_SNAPSHOT_FIELDS = frozenset({
+    "player_id",
+    "season",
+    "as_of_date",
+    "sprint_speed",
+    "competitive_runs",
+    "source_updated_at",
+    "source_version",
+})
+AUTHORITATIVE_SOURCE = {
+    "provider": "MLB Baseball Savant",
+    "dataset": "Statcast Sprint Speed Leaderboard",
+    "url":
+        "https://baseballsavant.mlb.com/"
+        "leaderboard/sprint_speed",
+    "metric_unit": "feet_per_second",
+    "qualification":
+        "minimum 10 competitive runs",
+}
+FORBIDDEN_PROXIES = (
+    "launch_speed",
+    "launch_angle",
+    "stolen_base_rate",
+    "triple_rate",
+)
+
+
+def evaluate_hitter_speed_evidence_availability(
+    *,
+    persisted_fields: Sequence[str],
+    source_capabilities: Mapping[str, Any],
+    baserunning_capabilities: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate whether speed evidence is ready for modeling."""
+
+    stored = {
+        str(field)
+        for field in persisted_fields
+    }
+    direct_stored = sorted(
+        stored & DIRECT_SPEED_FIELDS
+    )
+    missing_snapshot_fields = sorted(
+        REQUIRED_SNAPSHOT_FIELDS - stored
+    )
+
+    authoritative_source_confirmed = bool(
+        source_capabilities.get(
+            "authoritative_source_confirmed"
+        )
+    )
+    adapter_available = bool(
+        source_capabilities.get(
+            "adapter_available"
+        )
+    )
+    historical_snapshots_available = bool(
+        source_capabilities.get(
+            "historical_snapshots_available"
+        )
+    )
+    cutoff_query_supported = bool(
+        source_capabilities.get(
+            "cutoff_query_supported"
+        )
+    )
+    stable_player_identifier = bool(
+        source_capabilities.get(
+            "stable_player_identifier"
+        )
+    )
+    freshness_metadata_available = bool(
+        source_capabilities.get(
+            "freshness_metadata_available"
+        )
+    )
+
+    outcome_evidence_available = bool(
+        baserunning_capabilities.get(
+            "play_by_play_outcomes_available"
+        )
+    )
+    opportunity_denominators_available = bool(
+        baserunning_capabilities.get(
+            "opportunity_denominators_available"
+        )
+    )
+    direct_run_measurements_available = bool(
+        baserunning_capabilities.get(
+            "direct_run_measurements_available"
+        )
+    )
+
+    blockers = []
+    if not direct_stored:
+        blockers.append(
+            "direct_speed_fields_not_persisted"
+        )
+    if not authoritative_source_confirmed:
+        blockers.append(
+            "authoritative_source_not_confirmed"
+        )
+    if not adapter_available:
+        blockers.append(
+            "cutoff_safe_source_adapter_unavailable"
+        )
+    if not historical_snapshots_available:
+        blockers.append(
+            "historical_speed_snapshots_unavailable"
+        )
+    if not cutoff_query_supported:
+        blockers.append(
+            "historical_cutoff_query_unsupported"
+        )
+    if not stable_player_identifier:
+        blockers.append(
+            "stable_player_identifier_unverified"
+        )
+    if not freshness_metadata_available:
+        blockers.append(
+            "source_freshness_metadata_unavailable"
+        )
+
+    speed_signal_ready = not blockers
+    predictive_evaluation_allowed = (
+        speed_signal_ready
+        and outcome_evidence_available
+        and opportunity_denominators_available
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if speed_signal_ready
+            else "blocked"
+        ),
+        "shadow_only": True,
+        "audit_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "speed_signal_ready": speed_signal_ready,
+        "predictive_evaluation_allowed":
+            predictive_evaluation_allowed,
+        "persisted_field_count": len(stored),
+        "direct_speed_fields_present":
+            direct_stored,
+        "missing_snapshot_fields":
+            missing_snapshot_fields,
+        "authoritative_source":
+            dict(AUTHORITATIVE_SOURCE),
+        "source_capabilities": {
+            "authoritative_source_confirmed":
+                authoritative_source_confirmed,
+            "adapter_available":
+                adapter_available,
+            "historical_snapshots_available":
+                historical_snapshots_available,
+            "cutoff_query_supported":
+                cutoff_query_supported,
+            "stable_player_identifier":
+                stable_player_identifier,
+            "freshness_metadata_available":
+                freshness_metadata_available,
+        },
+        "baserunning_capabilities": {
+            "play_by_play_outcomes_available":
+                outcome_evidence_available,
+            "opportunity_denominators_available":
+                opportunity_denominators_available,
+            "direct_run_measurements_available":
+                direct_run_measurements_available,
+        },
+        "proxy_policy": {
+            "proxy_substitution_allowed": False,
+            "forbidden_speed_proxies":
+                list(FORBIDDEN_PROXIES),
+            "reason":
+                "outcomes and contact quality are not "
+                "direct measurements of runner speed",
+        },
+        "blockers": blockers,
+        "recommended_next_slice": (
+            None
+            if speed_signal_ready
+            else
+            "build_cutoff_safe_hitter_speed_source_adapter"
+        ),
+        "production_impact": {
+            "database_schema_changed": False,
+            "external_fetch_performed": False,
+            "production_model_modified": False,
+            "simulation_authority_changed": False,
+        },
+    }

--- a/scripts/audit_shadow_hitter_speed_evidence_availability.py
+++ b/scripts/audit_shadow_hitter_speed_evidence_availability.py
@@ -1,0 +1,188 @@
+"""Audit cutoff-safe hitter speed evidence availability."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mlb_app.database import StatcastEvent
+from mlb_app.simulation.shadow.hitter_speed_evidence_availability import (
+    evaluate_hitter_speed_evidence_availability,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BASERUNNING_SETTLEMENT = (
+    ROOT
+    / "scripts"
+    / "run_canonical_baserunning_production_settlement.py"
+)
+DATABASE_SOURCE = ROOT / "mlb_app" / "database.py"
+SPEED_ADAPTER_CANDIDATES = (
+    ROOT
+    / "mlb_app"
+    / "hitter_speed_source.py",
+    ROOT
+    / "mlb_app"
+    / "sprint_speed_source.py",
+    ROOT
+    / "mlb_app"
+    / "simulation"
+    / "shadow"
+    / "hitter_speed_source.py",
+)
+SPEED_SNAPSHOT_CANDIDATES = (
+    ROOT
+    / "data"
+    / "sprint_speed",
+    ROOT
+    / "data"
+    / "hitter_speed",
+    ROOT
+    / "fixtures"
+    / "sprint_speed",
+)
+
+
+def _contains(path: Path, tokens) -> bool:
+    if not path.is_file():
+        return False
+    text = path.read_text(
+        encoding="utf-8",
+        errors="ignore",
+    )
+    return all(
+        token in text
+        for token in tokens
+    )
+
+
+def build_audit():
+    persisted_fields = {
+        column.name
+        for column in StatcastEvent.__table__.columns
+    }
+
+    adapter_paths = [
+        str(path.relative_to(ROOT))
+        for path in SPEED_ADAPTER_CANDIDATES
+        if path.is_file()
+    ]
+    snapshot_paths = [
+        str(path.relative_to(ROOT))
+        for path in SPEED_SNAPSHOT_CANDIDATES
+        if path.exists()
+    ]
+
+    play_by_play_available = _contains(
+        BASERUNNING_SETTLEMENT,
+        (
+            "statsapi.mlb.com",
+            "feed/live",
+            "baserunning",
+        ),
+    )
+    opportunity_denominators_available = (
+        _contains(
+            BASERUNNING_SETTLEMENT,
+            (
+                "stolen_base",
+                "caught_stealing",
+                "eligible",
+            ),
+        )
+    )
+
+    result = (
+        evaluate_hitter_speed_evidence_availability(
+            persisted_fields=persisted_fields,
+            source_capabilities={
+                "authoritative_source_confirmed":
+                    True,
+                "adapter_available":
+                    bool(adapter_paths),
+                "historical_snapshots_available":
+                    bool(snapshot_paths),
+                "cutoff_query_supported":
+                    False,
+                "stable_player_identifier":
+                    False,
+                "freshness_metadata_available":
+                    False,
+            },
+            baserunning_capabilities={
+                "play_by_play_outcomes_available":
+                    play_by_play_available,
+                "opportunity_denominators_available":
+                    opportunity_denominators_available,
+                "direct_run_measurements_available":
+                    False,
+            },
+        )
+    )
+
+    return {
+        **result,
+        "schema_version":
+            "historical_shadow_hitter_speed_evidence_availability_audit_v1",
+        "repository_evidence": {
+            "statcast_table":
+                StatcastEvent.__tablename__,
+            "statcast_persisted_fields":
+                sorted(persisted_fields),
+            "statcast_speed_fields_present":
+                result[
+                    "direct_speed_fields_present"
+                ],
+            "speed_adapter_paths":
+                adapter_paths,
+            "speed_snapshot_paths":
+                snapshot_paths,
+            "baserunning_settlement_path": (
+                str(
+                    BASERUNNING_SETTLEMENT.relative_to(
+                        ROOT
+                    )
+                )
+                if BASERUNNING_SETTLEMENT.is_file()
+                else None
+            ),
+            "database_source_path": (
+                str(
+                    DATABASE_SOURCE.relative_to(
+                        ROOT
+                    )
+                )
+                if DATABASE_SOURCE.is_file()
+                else None
+            ),
+        },
+        "decision": {
+            "current_speed_signal_usable":
+                result["speed_signal_ready"],
+            "predictive_speed_audit_allowed":
+                result[
+                    "predictive_evaluation_allowed"
+                ],
+            "proxy_substitution_allowed":
+                False,
+            "source_acquisition_required":
+                not result["speed_signal_ready"],
+            "recommended_next_slice":
+                result["recommended_next_slice"],
+        },
+    }
+
+
+def main():
+    print(
+        json.dumps(
+            build_audit(),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_speed_evidence_availability.py
+++ b/tests/test_hitter_speed_evidence_availability.py
@@ -1,0 +1,225 @@
+from mlb_app.simulation.shadow.hitter_speed_evidence_availability import (
+    REQUIRED_SNAPSHOT_FIELDS,
+    evaluate_hitter_speed_evidence_availability,
+)
+from scripts.audit_shadow_hitter_speed_evidence_availability import (
+    build_audit,
+)
+
+
+def evaluate(
+    *,
+    persisted_fields=(),
+    source=None,
+    baserunning=None,
+):
+    return evaluate_hitter_speed_evidence_availability(
+        persisted_fields=persisted_fields,
+        source_capabilities=source or {},
+        baserunning_capabilities=baserunning or {},
+    )
+
+
+def ready_source():
+    return {
+        "authoritative_source_confirmed": True,
+        "adapter_available": True,
+        "historical_snapshots_available": True,
+        "cutoff_query_supported": True,
+        "stable_player_identifier": True,
+        "freshness_metadata_available": True,
+    }
+
+
+def ready_baserunning():
+    return {
+        "play_by_play_outcomes_available": True,
+        "opportunity_denominators_available": True,
+        "direct_run_measurements_available": True,
+    }
+
+
+def test_current_repository_contract_is_blocked():
+    result = evaluate(
+        persisted_fields={
+            "player_id",
+            "season",
+            "launch_speed",
+            "launch_angle",
+        },
+        source={
+            "authoritative_source_confirmed": True,
+        },
+        baserunning={
+            "play_by_play_outcomes_available": True,
+        },
+    )
+
+    assert result["status"] == "blocked"
+    assert result["speed_signal_ready"] is False
+    assert (
+        result["predictive_evaluation_allowed"]
+        is False
+    )
+    assert "direct_speed_fields_not_persisted" in (
+        result["blockers"]
+    )
+    assert (
+        "cutoff_safe_source_adapter_unavailable"
+        in result["blockers"]
+    )
+    assert (
+        "historical_speed_snapshots_unavailable"
+        in result["blockers"]
+    )
+
+
+def test_contact_and_outcome_metrics_are_not_speed_proxies():
+    result = evaluate()
+
+    assert (
+        result["proxy_policy"][
+            "proxy_substitution_allowed"
+        ]
+        is False
+    )
+    assert {
+        "launch_speed",
+        "launch_angle",
+        "stolen_base_rate",
+        "triple_rate",
+    } == set(
+        result["proxy_policy"][
+            "forbidden_speed_proxies"
+        ]
+    )
+
+
+def test_authoritative_source_contract_is_explicit():
+    result = evaluate()
+
+    assert (
+        result["authoritative_source"]["provider"]
+        == "MLB Baseball Savant"
+    )
+    assert (
+        result["authoritative_source"][
+            "metric_unit"
+        ]
+        == "feet_per_second"
+    )
+    assert "10 competitive runs" in (
+        result["authoritative_source"][
+            "qualification"
+        ]
+    )
+
+
+def test_complete_cutoff_safe_contract_can_be_ready():
+    result = evaluate(
+        persisted_fields=REQUIRED_SNAPSHOT_FIELDS,
+        source=ready_source(),
+        baserunning=ready_baserunning(),
+    )
+
+    assert result["status"] == "ready"
+    assert result["speed_signal_ready"] is True
+    assert (
+        result["predictive_evaluation_allowed"]
+        is True
+    )
+    assert result["blockers"] == []
+    assert result["recommended_next_slice"] is None
+
+
+def test_outcomes_without_opportunities_do_not_allow_evaluation():
+    baserunning = ready_baserunning()
+    baserunning[
+        "opportunity_denominators_available"
+    ] = False
+
+    result = evaluate(
+        persisted_fields=REQUIRED_SNAPSHOT_FIELDS,
+        source=ready_source(),
+        baserunning=baserunning,
+    )
+
+    assert result["speed_signal_ready"] is True
+    assert (
+        result["predictive_evaluation_allowed"]
+        is False
+    )
+
+
+def test_audit_remains_shadow_only():
+    result = evaluate()
+
+    assert result["shadow_only"] is True
+    assert result["audit_only"] is True
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert (
+        result["production_impact"][
+            "external_fetch_performed"
+        ]
+        is False
+    )
+    assert (
+        result["production_impact"][
+            "database_schema_changed"
+        ]
+        is False
+    )
+
+def test_repository_audit_proves_current_source_gap():
+    result = build_audit()
+
+    assert result["status"] == "blocked"
+    assert (
+        result["decision"][
+            "current_speed_signal_usable"
+        ]
+        is False
+    )
+    assert (
+        result["decision"][
+            "source_acquisition_required"
+        ]
+        is True
+    )
+    assert result["repository_evidence"][
+        "statcast_speed_fields_present"
+    ] == []
+    assert result["repository_evidence"][
+        "speed_adapter_paths"
+    ] == []
+    assert result["repository_evidence"][
+        "speed_snapshot_paths"
+    ] == []
+
+
+def test_repository_audit_does_not_authorize_proxy_or_production():
+    result = build_audit()
+
+    assert (
+        result["decision"][
+            "proxy_substitution_allowed"
+        ]
+        is False
+    )
+    assert (
+        result["predictive_evaluation_allowed"]
+        is False
+    )
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert (
+        result["recommended_next_slice"]
+        == "build_cutoff_safe_hitter_speed_source_adapter"
+    )


### PR DESCRIPTION
## Summary

- add a shadow-only readiness contract for cutoff-safe hitter speed evidence
- inspect the actual `StatcastEvent` schema and repository source surfaces
- identify the official MLB Baseball Savant Sprint Speed leaderboard as the authoritative candidate source
- prohibit launch angle, exit velocity, stolen-base rate, and triple rate from silently substituting for direct speed measurements
- preserve `parameter_selected=false` and `production_authority_changed=false`

## Findings

The current repository cannot support a defensible predictive speed audit yet:

- no direct sprint-speed, competitive-run, Bolt, or home-to-first fields are persisted
- no cutoff-safe Sprint Speed adapter exists
- no historical speed snapshots exist
- historical cutoff queries, stable source-to-player identity, and source freshness metadata are unverified
- play-by-play baserunning outcomes exist, but opportunity denominators and direct run measurements are unavailable

The official Savant leaderboard defines Sprint Speed in feet per second and requires at least 10 competitive runs for qualification. That source is authoritative, but source availability alone is insufficient for historical modeling without dated snapshots and cutoff-safe retrieval.

## Decision

Speed modeling remains blocked. This PR performs no external fetch, database migration, proxy substitution, parameter selection, PA-model modification, or production-authority change.

Recommended next slice: `build_cutoff_safe_hitter_speed_source_adapter`.

## Validation

- hitter-profile regression: `58 passed`
- focused speed and hit-type contracts: `15 passed`
- repository audit completed successfully and reported the expected blockers
- Python compilation passed
- staged diff and whitespace checks passed
