### PR TITLE
Build cutoff-safe hitter speed source adapter

### DIFF
--- a/mlb_app/simulation/shadow/hitter_speed_source_adapter.py
+++ b/mlb_app/simulation/shadow/hitter_speed_source_adapter.py
@@ -1,0 +1,546 @@
+"""Cutoff-safe adapter for supplied Savant Sprint Speed CSV snapshots."""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import hashlib
+import io
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "shadow_hitter_speed_source_adapter_v1"
+)
+SOURCE_PROVIDER = "MLB Baseball Savant"
+SOURCE_DATASET = "Statcast Sprint Speed Leaderboard"
+DEFAULT_SOURCE_URL = (
+    "https://baseballsavant.mlb.com/"
+    "leaderboard/sprint_speed"
+)
+MINIMUM_COMPETITIVE_RUNS = 10
+
+REQUIRED_ALIASES = {
+    "player_id": (
+        "player_id",
+        "playerid",
+        "mlb_id",
+        "mlbam_id",
+    ),
+    "competitive_runs": (
+        "competitive_runs",
+        "competitive run",
+        "competitive_runs_count",
+        "runs",
+    ),
+    "sprint_speed": (
+        "sprint_speed",
+        "sprint speed",
+        "sprint_speed_ft_sec",
+    ),
+}
+OPTIONAL_ALIASES = {
+    "last_name": (
+        "last_name",
+        "last name",
+    ),
+    "first_name": (
+        "first_name",
+        "first name",
+    ),
+    "team_id": (
+        "team_id",
+        "teamid",
+    ),
+    "team": (
+        "team",
+        "team_name",
+    ),
+    "position": (
+        "position",
+        "position_name",
+        "pos",
+    ),
+    "bolt_count": (
+        "bolts",
+        "bolt_count",
+        "bolt count",
+    ),
+    "home_to_first": (
+        "hp_to_1b",
+        "home_to_first",
+        "home to first",
+    ),
+    "row_season": (
+        "season",
+        "year",
+    ),
+}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_payload(value: Any) -> str:
+    return _sha256_bytes(
+        _canonical_json(value).encode("utf-8")
+    )
+
+
+def _normalized_header(value: Any) -> str:
+    return " ".join(
+        str(value or "")
+        .strip()
+        .lower()
+        .replace("-", " ")
+        .replace("_", " ")
+        .split()
+    )
+
+
+def _header_lookup(
+    fieldnames: list[str],
+) -> dict[str, str]:
+    return {
+        _normalized_header(field): field
+        for field in fieldnames
+        if field is not None
+    }
+
+
+def _resolve_header(
+    lookup: Mapping[str, str],
+    aliases,
+):
+    for alias in aliases:
+        resolved = lookup.get(
+            _normalized_header(alias)
+        )
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _integer(value: Any):
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        number = float(
+            text.replace(",", "")
+        )
+    except ValueError:
+        return None
+    if not math.isfinite(number):
+        return None
+    integer = int(number)
+    return integer if number == integer else None
+
+
+def _number(value: Any):
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        number = float(
+            text.replace(",", "")
+        )
+    except ValueError:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _date(value: Any):
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(
+            str(value).strip()[:10]
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _timestamp(value: Any):
+    if isinstance(value, dt.datetime):
+        parsed = value
+    else:
+        text = str(value or "").strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = dt.datetime.fromisoformat(
+                text
+            )
+        except (TypeError, ValueError):
+            return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
+
+
+def parse_savant_sprint_speed_csv(
+    csv_text: str,
+    *,
+    season: int,
+    as_of_date,
+    source_updated_at,
+    source_url: str = DEFAULT_SOURCE_URL,
+    source_version: str = "savant_sprint_speed_csv_v1",
+    minimum_competitive_runs: int = (
+        MINIMUM_COMPETITIVE_RUNS
+    ),
+) -> dict[str, Any]:
+    """Normalize a supplied immutable Savant CSV snapshot."""
+
+    raw_bytes = csv_text.encode("utf-8")
+    raw_sha256 = _sha256_bytes(raw_bytes)
+    parsed_as_of = _date(as_of_date)
+    parsed_updated_at = _timestamp(
+        source_updated_at
+    )
+    blockers = []
+
+    if not isinstance(season, int) or season < 2015:
+        blockers.append("invalid_season")
+    if parsed_as_of is None:
+        blockers.append("invalid_as_of_date")
+    if parsed_updated_at is None:
+        blockers.append(
+            "invalid_source_updated_at"
+        )
+    if (
+        parsed_as_of is not None
+        and parsed_updated_at is not None
+        and parsed_updated_at.date()
+        != parsed_as_of
+    ):
+        blockers.append(
+            "snapshot_date_does_not_match_capture_date"
+        )
+    if minimum_competitive_runs < 1:
+        blockers.append(
+            "invalid_minimum_competitive_runs"
+        )
+    if not str(source_version).strip():
+        blockers.append("missing_source_version")
+    if not str(source_url).strip():
+        blockers.append("missing_source_url")
+
+    reader = csv.DictReader(
+        io.StringIO(csv_text)
+    )
+    fieldnames = list(
+        reader.fieldnames or []
+    )
+    lookup = _header_lookup(fieldnames)
+    resolved = {}
+    missing_headers = []
+
+    for field, aliases in REQUIRED_ALIASES.items():
+        header = _resolve_header(
+            lookup,
+            aliases,
+        )
+        resolved[field] = header
+        if header is None:
+            missing_headers.append(field)
+
+    for field, aliases in OPTIONAL_ALIASES.items():
+        resolved[field] = _resolve_header(
+            lookup,
+            aliases,
+        )
+
+    if missing_headers:
+        blockers.append(
+            "missing_required_csv_headers"
+        )
+
+    records = []
+    rejected_rows = []
+    seen_player_ids = set()
+
+    if not missing_headers:
+        for row_number, row in enumerate(
+            reader,
+            start=2,
+        ):
+            player_id = _integer(
+                row.get(resolved["player_id"])
+            )
+            competitive_runs = _integer(
+                row.get(
+                    resolved["competitive_runs"]
+                )
+            )
+            sprint_speed = _number(
+                row.get(
+                    resolved["sprint_speed"]
+                )
+            )
+            row_season = (
+                _integer(
+                    row.get(
+                        resolved["row_season"]
+                    )
+                )
+                if resolved["row_season"]
+                else None
+            )
+
+            reasons = []
+            if player_id is None or player_id <= 0:
+                reasons.append(
+                    "invalid_player_id"
+                )
+            if (
+                competitive_runs is None
+                or competitive_runs < 0
+            ):
+                reasons.append(
+                    "invalid_competitive_runs"
+                )
+            elif (
+                competitive_runs
+                < minimum_competitive_runs
+            ):
+                reasons.append(
+                    "insufficient_competitive_runs"
+                )
+            if (
+                sprint_speed is None
+                or not 15.0 <= sprint_speed <= 40.0
+            ):
+                reasons.append(
+                    "invalid_sprint_speed"
+                )
+            if (
+                row_season is not None
+                and row_season != season
+            ):
+                reasons.append(
+                    "row_season_mismatch"
+                )
+            if player_id in seen_player_ids:
+                reasons.append(
+                    "duplicate_player_id"
+                )
+
+            if reasons:
+                rejected_rows.append({
+                    "row_number": row_number,
+                    "player_id": player_id,
+                    "reasons": sorted(
+                        set(reasons)
+                    ),
+                })
+                continue
+
+            seen_player_ids.add(player_id)
+            record = {
+                "player_id": player_id,
+                "season": season,
+                "as_of_date":
+                    (
+                        parsed_as_of.isoformat()
+                        if parsed_as_of is not None
+                        else None
+                    ),
+                "sprint_speed": sprint_speed,
+                "competitive_runs":
+                    competitive_runs,
+                "bolt_count": (
+                    _integer(
+                        row.get(
+                            resolved["bolt_count"]
+                        )
+                    )
+                    if resolved["bolt_count"]
+                    else None
+                ),
+                "home_to_first": (
+                    _number(
+                        row.get(
+                            resolved["home_to_first"]
+                        )
+                    )
+                    if resolved["home_to_first"]
+                    else None
+                ),
+                "first_name": (
+                    str(
+                        row.get(
+                            resolved["first_name"]
+                        )
+                        or ""
+                    ).strip()
+                    if resolved["first_name"]
+                    else None
+                ),
+                "last_name": (
+                    str(
+                        row.get(
+                            resolved["last_name"]
+                        )
+                        or ""
+                    ).strip()
+                    if resolved["last_name"]
+                    else None
+                ),
+                "team_id": (
+                    _integer(
+                        row.get(
+                            resolved["team_id"]
+                        )
+                    )
+                    if resolved["team_id"]
+                    else None
+                ),
+                "team": (
+                    str(
+                        row.get(
+                            resolved["team"]
+                        )
+                        or ""
+                    ).strip()
+                    if resolved["team"]
+                    else None
+                ),
+                "position": (
+                    str(
+                        row.get(
+                            resolved["position"]
+                        )
+                        or ""
+                    ).strip()
+                    if resolved["position"]
+                    else None
+                ),
+                "source_updated_at":
+                    (
+                        parsed_updated_at.isoformat()
+                        if parsed_updated_at is not None
+                        else None
+                    ),
+                "source_version":
+                    str(source_version).strip(),
+                "source_provider":
+                    SOURCE_PROVIDER,
+                "source_dataset":
+                    SOURCE_DATASET,
+                "source_url":
+                    str(source_url).strip(),
+                "raw_source_sha256":
+                    raw_sha256,
+            }
+            record["record_sha256"] = (
+                _sha256_payload(record)
+            )
+            records.append(record)
+
+    records.sort(
+        key=lambda record: record["player_id"]
+    )
+    rejected_rows.sort(
+        key=lambda row: (
+            row["row_number"],
+            row["player_id"] or -1,
+        )
+    )
+
+    if rejected_rows:
+        blockers.append(
+            "csv_rows_rejected"
+        )
+    if not records:
+        blockers.append(
+            "no_eligible_speed_records"
+        )
+
+    snapshot_identity = {
+        "season": season,
+        "as_of_date": (
+            parsed_as_of.isoformat()
+            if parsed_as_of is not None
+            else None
+        ),
+        "source_updated_at": (
+            parsed_updated_at.isoformat()
+            if parsed_updated_at is not None
+            else None
+        ),
+        "source_version":
+            str(source_version).strip(),
+        "raw_source_sha256": raw_sha256,
+        "player_ids": [
+            record["player_id"]
+            for record in records
+        ],
+    }
+    snapshot_sha256 = _sha256_payload(
+        snapshot_identity
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if not blockers
+            else "blocked"
+        ),
+        "shadow_only": True,
+        "source_adapter_only": True,
+        "external_fetch_performed": False,
+        "database_writes_performed": False,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "season": season,
+        "as_of_date": (
+            parsed_as_of.isoformat()
+            if parsed_as_of is not None
+            else None
+        ),
+        "source_updated_at": (
+            parsed_updated_at.isoformat()
+            if parsed_updated_at is not None
+            else None
+        ),
+        "source_version":
+            str(source_version).strip(),
+        "source_provider": SOURCE_PROVIDER,
+        "source_dataset": SOURCE_DATASET,
+        "source_url": str(source_url).strip(),
+        "raw_source_byte_length":
+            len(raw_bytes),
+        "raw_source_sha256": raw_sha256,
+        "snapshot_sha256": snapshot_sha256,
+        "minimum_competitive_runs":
+            minimum_competitive_runs,
+        "csv_headers": fieldnames,
+        "resolved_headers": resolved,
+        "missing_required_headers":
+            missing_headers,
+        "record_count": len(records),
+        "rejected_row_count":
+            len(rejected_rows),
+        "records": records,
+        "rejected_rows": rejected_rows,
+        "blockers": sorted(set(blockers)),
+    }

--- a/tests/test_hitter_speed_source_adapter.py
+++ b/tests/test_hitter_speed_source_adapter.py
@@ -1,0 +1,178 @@
+from mlb_app.simulation.shadow.hitter_speed_source_adapter import (
+    parse_savant_sprint_speed_csv,
+)
+
+
+CSV = """last_name,first_name,player_id,team_id,position_name,competitive_runs,bolts,hp_to_1b,sprint_speed,season
+Witt,Bobby,677951,118,SS,182,44,4.12,30.4,2025
+Turner,Trea,607208,143,SS,165,31,4.19,29.5,2025
+"""
+
+
+def parse(text=CSV, **overrides):
+    values = {
+        "season": 2025,
+"as_of_date": "2025-07-31",
+"source_updated_at":
+"2025-07-31T23:59:00+00:00",
+    }
+    values.update(overrides)
+    return parse_savant_sprint_speed_csv(
+        text,
+        **values,
+    )
+
+
+def test_parses_cutoff_safe_snapshot():
+    result = parse()
+
+    assert result["status"] == "ready"
+    assert result["record_count"] == 2
+    assert result["rejected_row_count"] == 0
+    assert [
+        row["player_id"]
+        for row in result["records"]
+    ] == [607208, 677951]
+    assert result["records"][1][
+"sprint_speed"
+    ] == 30.4
+    assert result["records"][1][
+"competitive_runs"
+    ] == 182
+    assert result["records"][1][
+"bolt_count"
+    ] == 44
+    assert result["records"][1][
+"home_to_first"
+    ] == 4.12
+
+
+def test_snapshot_is_deterministic_and_hashed():
+    first = parse()
+    second = parse()
+
+    assert first == second
+    assert len(first["raw_source_sha256"]) == 64
+    assert len(first["snapshot_sha256"]) == 64
+    assert all(
+        len(row["record_sha256"]) == 64
+        for row in first["records"]
+    )
+
+
+def test_header_aliases_are_supported():
+    text = """Last Name,First Name,mlbam_id,Competitive Run,Sprint Speed
+Witt,Bobby,677951,182,30.4
+"""
+    result = parse(text)
+
+    assert result["status"] == "ready"
+    assert result["record_count"] == 1
+    assert result["records"][0][
+"player_id"
+    ] == 677951
+
+
+def test_missing_required_headers_blocks():
+    result = parse(
+        "player_id,competitive_runs\n"
+        "677951,182\n"
+    )
+
+    assert result["status"] == "blocked"
+    assert "sprint_speed" in (
+        result["missing_required_headers"]
+    )
+    assert (
+        "missing_required_csv_headers"
+        in result["blockers"]
+    )
+
+
+def test_rejects_invalid_and_unqualified_rows():
+    text = """player_id,competitive_runs,sprint_speed
+677951,9,30.4
+607208,100,50.0
+bad,100,29.0
+"""
+    result = parse(text)
+
+    assert result["status"] == "blocked"
+    assert result["record_count"] == 0
+    assert result["rejected_row_count"] == 3
+    assert "csv_rows_rejected" in (
+        result["blockers"]
+    )
+    assert "no_eligible_speed_records" in (
+        result["blockers"]
+    )
+
+
+def test_duplicate_player_identity_blocks_snapshot():
+    text = """player_id,competitive_runs,sprint_speed
+677951,100,30.4
+677951,101,30.5
+"""
+    result = parse(text)
+
+    assert result["status"] == "blocked"
+    assert result["record_count"] == 1
+    assert (
+        result["rejected_rows"][0]["reasons"]
+        == ["duplicate_player_id"]
+    )
+
+
+def test_row_season_must_match_snapshot_season():
+    text = """player_id,competitive_runs,sprint_speed,year
+677951,100,30.4,2024
+"""
+    result = parse(text)
+
+    assert result["status"] == "blocked"
+    assert "row_season_mismatch" in (
+        result["rejected_rows"][0]["reasons"]
+    )
+
+
+def test_snapshot_date_must_match_capture_date():
+    result = parse(
+        source_updated_at=
+            "2025-08-01T00:01:00+00:00"
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "snapshot_date_does_not_match_capture_date"
+        in result["blockers"]
+    )
+
+
+def test_naive_capture_timestamp_is_rejected():
+    result = parse(
+        source_updated_at="2025-07-31T23:59:00"
+    )
+
+    assert result["status"] == "blocked"
+    assert "invalid_source_updated_at" in (
+        result["blockers"]
+    )
+
+
+def test_adapter_has_no_fetch_write_or_authority():
+    result = parse()
+
+    assert (
+        result["external_fetch_performed"]
+        is False
+    )
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True


### PR DESCRIPTION
## What changed

- Adds a deterministic parser for explicitly supplied Baseball Savant Sprint Speed CSV snapshots.
- Normalizes player identity, season, cutoff date, source freshness, qualification volume, sprint speed, and optional leaderboard fields.
- Records raw-source, normalized-record, and snapshot SHA-256 provenance.
- Rejects missing headers, invalid identifiers or measurements, under-qualified rows, duplicate players, season mismatches, naive timestamps, and capture-date mismatches.
- Adds focused contract coverage for aliases, deterministic hashing, validation failures, provenance, and production isolation.

## Why

The preceding hitter-speed availability audit found that direct speed evidence was not yet usable because the repository lacked a cutoff-safe, reproducible source adapter. This slice establishes that offline ingestion boundary without selecting a parameter or granting production authority.

## Production impact

- No external fetch is performed.
- No database schema or persistence behavior changes.
- No simulation or production model authority changes.
- `parameter_selected` and `production_authority_changed` remain false.

## Validation

- Complete hitter-profile regression: **72 passed**.
- Python compilation passed.
- Staged diff and new-file whitespace checks passed.
- Commit: `aaa0fae`.