### PR TITLE
Materialize cutoff-safe hitter speed snapshots

### DIFF
--- a/mlb_app/simulation/shadow/hitter_speed_snapshot_artifact.py
+++ b/mlb_app/simulation/shadow/hitter_speed_snapshot_artifact.py
@@ -1,0 +1,385 @@
+"""Immutable cutoff-safe hitter speed snapshot artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from mlb_app.simulation.shadow.hitter_speed_source_adapter import (
+    parse_savant_sprint_speed_csv,
+)
+
+
+ARTIFACT_CONTRACT_VERSION = (
+    "hitter_speed_snapshot_artifact_v1"
+)
+ARTIFACT_TYPE = "hitter_speed_snapshot"
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _sha256_payload(value: Any) -> str:
+    return hashlib.sha256(
+        _canonical_json(value).encode("utf-8")
+    ).hexdigest()
+
+
+def build_hitter_speed_snapshot_artifact(
+    csv_text: str,
+    *,
+    season: int,
+    as_of_date,
+    source_updated_at,
+    source_url: str = (
+        "https://baseballsavant.mlb.com/"
+        "leaderboard/sprint_speed"
+    ),
+    source_version: str = (
+        "savant_sprint_speed_csv_v1"
+    ),
+    minimum_competitive_runs: int = 10,
+) -> dict[str, Any]:
+    """Build a deterministic artifact without persistence."""
+
+    adapter_result = parse_savant_sprint_speed_csv(
+        csv_text,
+        season=season,
+        as_of_date=as_of_date,
+        source_updated_at=source_updated_at,
+        source_url=source_url,
+        source_version=source_version,
+        minimum_competitive_runs=(
+            minimum_competitive_runs
+        ),
+    )
+
+    records = list(
+        adapter_result.get("records") or []
+    )
+    blockers = sorted(
+        set(adapter_result.get("blockers") or [])
+    )
+
+    artifact = {
+        "artifact_contract_version":
+            ARTIFACT_CONTRACT_VERSION,
+        "artifact_type": ARTIFACT_TYPE,
+        "status": adapter_result.get("status"),
+        "season": adapter_result.get("season"),
+        "as_of_date":
+            adapter_result.get("as_of_date"),
+        "source_updated_at":
+            adapter_result.get(
+                "source_updated_at"
+            ),
+        "source_provider":
+            adapter_result.get(
+                "source_provider"
+            ),
+        "source_dataset":
+            adapter_result.get(
+                "source_dataset"
+            ),
+        "source_url":
+            adapter_result.get("source_url"),
+        "source_version":
+            adapter_result.get(
+                "source_version"
+            ),
+        "raw_source_sha256":
+            adapter_result.get(
+                "raw_source_sha256"
+            ),
+        "normalized_snapshot_sha256":
+            adapter_result.get(
+                "snapshot_sha256"
+            ),
+        "adapter_contract_version":
+            adapter_result.get(
+                "adapter_contract_version"
+            ),
+        "adapter_result_sha256":
+            _sha256_payload(adapter_result),
+        "minimum_competitive_runs": (
+            adapter_result.get(
+                "minimum_competitive_runs"
+            )
+        ),
+        "record_count": len(records),
+        "rejected_row_count":
+            adapter_result.get(
+                "rejected_row_count",
+                0,
+            ),
+        "records": records,
+        "rejected_rows": list(
+            adapter_result.get(
+                "rejected_rows"
+            )
+            or []
+        ),
+        "missing_required_headers": list(
+            adapter_result.get(
+                "missing_required_headers"
+            )
+            or []
+        ),
+        "blockers": blockers,
+        "artifact_ready": (
+            adapter_result.get("status")
+            == "ready"
+            and not blockers
+            and bool(records)
+        ),
+        "external_fetch_performed": False,
+        "database_writes_performed": False,
+        "production_model_modified": False,
+        "simulation_authority_changed": False,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "shadow_only": True,
+    }
+
+    digest_payload = dict(artifact)
+    artifact["artifact_sha256"] = (
+        _sha256_payload(digest_payload)
+    )
+    return artifact
+
+
+def serialize_hitter_speed_snapshot_artifact(
+    artifact: dict[str, Any],
+) -> str:
+    """Serialize an artifact deterministically."""
+
+    return (
+        json.dumps(
+            artifact,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+
+def validate_hitter_speed_snapshot_artifact(
+    artifact: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate identity, readiness, and isolation."""
+
+    supplied_digest = artifact.get(
+        "artifact_sha256"
+    )
+    digest_payload = dict(artifact)
+    digest_payload.pop(
+        "artifact_sha256",
+        None,
+    )
+    expected_digest = _sha256_payload(
+        digest_payload
+    )
+
+    blockers = []
+
+    if (
+        artifact.get(
+            "artifact_contract_version"
+        )
+        != ARTIFACT_CONTRACT_VERSION
+    ):
+        blockers.append(
+            "artifact_contract_version_mismatch"
+        )
+
+    if artifact.get("artifact_type") != ARTIFACT_TYPE:
+        blockers.append(
+            "artifact_type_mismatch"
+        )
+
+    if supplied_digest != expected_digest:
+        blockers.append(
+            "artifact_sha256_mismatch"
+        )
+
+    if not artifact.get("artifact_ready"):
+        blockers.append(
+            "artifact_not_ready"
+        )
+
+    if artifact.get("status") != "ready":
+        blockers.append(
+            "adapter_result_not_ready"
+        )
+
+    if artifact.get("blockers"):
+        blockers.append(
+            "adapter_blockers_present"
+        )
+
+    if not artifact.get("records"):
+        blockers.append(
+            "artifact_records_missing"
+        )
+
+    prohibited_truthy_flags = [
+        "external_fetch_performed",
+        "database_writes_performed",
+        "production_model_modified",
+        "simulation_authority_changed",
+        "parameter_selected",
+        "production_authority_changed",
+    ]
+
+    if any(
+        artifact.get(field) is not False
+        for field in prohibited_truthy_flags
+    ):
+        blockers.append(
+            "production_isolation_violation"
+        )
+
+    if artifact.get("shadow_only") is not True:
+        blockers.append(
+            "shadow_only_flag_missing"
+        )
+
+    blockers = sorted(set(blockers))
+
+    return {
+        "status": (
+            "ready"
+            if not blockers
+            else "blocked"
+        ),
+        "artifact_valid": not blockers,
+        "artifact_sha256":
+            supplied_digest,
+        "expected_artifact_sha256":
+            expected_digest,
+        "record_count": len(
+            artifact.get("records") or []
+        ),
+        "blockers": blockers,
+        "external_fetch_performed": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def materialize_hitter_speed_snapshot_artifact(
+    artifact: dict[str, Any],
+    output_path,
+    *,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Atomically persist one validated artifact."""
+
+    validation = (
+        validate_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+    destination = Path(output_path)
+
+    if destination.exists() and not overwrite:
+        return {
+            "status": "blocked",
+            "artifact_file_write_performed":
+                False,
+            "output_path": str(destination),
+            "artifact_sha256":
+                artifact.get(
+                    "artifact_sha256"
+                ),
+            "blockers": [
+                "output_path_exists",
+            ],
+            "external_fetch_performed": False,
+            "database_writes_performed": False,
+            "production_authority_changed":
+                False,
+        }
+
+    if not validation["artifact_valid"]:
+        return {
+            "status": "blocked",
+            "artifact_file_write_performed":
+                False,
+            "output_path": str(destination),
+            "artifact_sha256":
+                artifact.get(
+                    "artifact_sha256"
+                ),
+            "blockers": validation["blockers"],
+            "external_fetch_performed": False,
+            "database_writes_performed": False,
+            "production_authority_changed":
+                False,
+        }
+
+    destination.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    serialized = (
+        serialize_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary_path = Path(handle.name)
+
+        os.replace(
+            temporary_path,
+            destination,
+        )
+        temporary_path = None
+    finally:
+        if (
+            temporary_path is not None
+            and temporary_path.exists()
+        ):
+            temporary_path.unlink()
+
+    return {
+        "status": "written",
+        "artifact_file_write_performed": True,
+        "output_path": str(destination),
+        "artifact_sha256":
+            artifact["artifact_sha256"],
+        "serialized_sha256": hashlib.sha256(
+            serialized.encode("utf-8")
+        ).hexdigest(),
+        "record_count":
+            artifact["record_count"],
+        "external_fetch_performed": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/scripts/materialize_shadow_hitter_speed_snapshot.py
+++ b/scripts/materialize_shadow_hitter_speed_snapshot.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Materialize an offline hitter speed snapshot artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from mlb_app.simulation.shadow.hitter_speed_snapshot_artifact import (
+    build_hitter_speed_snapshot_artifact,
+    materialize_hitter_speed_snapshot_artifact,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize an explicitly supplied "
+            "Baseball Savant Sprint Speed CSV "
+            "as a deterministic shadow artifact."
+        )
+    )
+    parser.add_argument(
+        "--input-csv",
+        required=True,
+        type=Path,
+    )
+    parser.add_argument(
+        "--output-json",
+        required=True,
+        type=Path,
+    )
+    parser.add_argument(
+        "--season",
+        required=True,
+        type=int,
+    )
+    parser.add_argument(
+        "--as-of-date",
+        required=True,
+    )
+    parser.add_argument(
+        "--source-updated-at",
+        required=True,
+    )
+    parser.add_argument(
+        "--source-url",
+        default=(
+            "https://baseballsavant.mlb.com/"
+            "leaderboard/sprint_speed"
+        ),
+    )
+    parser.add_argument(
+        "--source-version",
+        default="savant_sprint_speed_csv_v1",
+    )
+    parser.add_argument(
+        "--minimum-competitive-runs",
+        default=10,
+        type=int,
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+    )
+    return parser
+
+
+def _summary(
+    *,
+    status: str,
+    input_path: Path,
+    output_path: Path,
+    artifact=None,
+    materialization=None,
+    blockers=None,
+) -> dict:
+    artifact = artifact or {}
+    materialization = materialization or {}
+
+    return {
+        "status": status,
+        "input_path": str(input_path),
+        "output_path": str(output_path),
+        "artifact_contract_version":
+            artifact.get(
+                "artifact_contract_version"
+            ),
+        "artifact_sha256":
+            artifact.get("artifact_sha256"),
+        "raw_source_sha256":
+            artifact.get(
+                "raw_source_sha256"
+            ),
+        "record_count":
+            artifact.get("record_count", 0),
+        "artifact_ready":
+            artifact.get(
+                "artifact_ready",
+                False,
+            ),
+        "artifact_file_write_performed": (
+            materialization.get(
+                "artifact_file_write_performed",
+                False,
+            )
+        ),
+        "serialized_sha256":
+            materialization.get(
+                "serialized_sha256"
+            ),
+        "blockers": sorted(
+            set(
+                blockers
+                or materialization.get(
+                    "blockers"
+                )
+                or artifact.get("blockers")
+                or []
+            )
+        ),
+        "external_fetch_performed": False,
+        "database_writes_performed": False,
+        "production_model_modified": False,
+        "simulation_authority_changed": False,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "shadow_only": True,
+    }
+
+
+def main(
+    argv: Sequence[str] | None = None,
+) -> int:
+    args = _parser().parse_args(argv)
+
+    input_path = args.input_csv
+    output_path = args.output_json
+
+    try:
+        same_path = (
+            input_path.resolve()
+            == output_path.resolve()
+        )
+    except OSError:
+        same_path = False
+
+    if same_path:
+        payload = _summary(
+            status="blocked",
+            input_path=input_path,
+            output_path=output_path,
+            blockers=[
+                "input_and_output_paths_match",
+            ],
+        )
+        print(
+            json.dumps(
+                payload,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    try:
+        csv_text = input_path.read_text(
+            encoding="utf-8"
+        )
+    except OSError as exc:
+        payload = _summary(
+            status="blocked",
+            input_path=input_path,
+            output_path=output_path,
+            blockers=[
+                "input_csv_unreadable",
+                type(exc).__name__,
+            ],
+        )
+        print(
+            json.dumps(
+                payload,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    artifact = (
+        build_hitter_speed_snapshot_artifact(
+            csv_text,
+            season=args.season,
+            as_of_date=args.as_of_date,
+            source_updated_at=(
+                args.source_updated_at
+            ),
+            source_url=args.source_url,
+            source_version=args.source_version,
+            minimum_competitive_runs=(
+                args.minimum_competitive_runs
+            ),
+        )
+    )
+
+    materialization = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact,
+            output_path,
+            overwrite=args.overwrite,
+        )
+    )
+
+    success = (
+        materialization.get("status")
+        == "written"
+    )
+    payload = _summary(
+        status=(
+            "written"
+            if success
+            else "blocked"
+        ),
+        input_path=input_path,
+        output_path=output_path,
+        artifact=artifact,
+        materialization=materialization,
+    )
+    print(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if success else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hitter_speed_snapshot_artifact.py
+++ b/tests/test_hitter_speed_snapshot_artifact.py
@@ -1,0 +1,221 @@
+import json
+
+from mlb_app.simulation.shadow.hitter_speed_snapshot_artifact import (
+    build_hitter_speed_snapshot_artifact,
+    materialize_hitter_speed_snapshot_artifact,
+    serialize_hitter_speed_snapshot_artifact,
+    validate_hitter_speed_snapshot_artifact,
+)
+
+
+CSV = """last_name,first_name,player_id,competitive_runs,sprint_speed,season
+Witt,Bobby,677951,182,30.4,2025
+Turner,Trea,607208,165,29.5,2025
+"""
+
+
+def build(text=CSV, **overrides):
+    values = {
+        "season": 2025,
+        "as_of_date": "2025-07-31",
+        "source_updated_at":
+            "2025-07-31T23:59:00+00:00",
+    }
+    values.update(overrides)
+    return build_hitter_speed_snapshot_artifact(
+        text,
+        **values,
+    )
+
+
+def test_builds_deterministic_artifact():
+    first = build()
+    second = build()
+
+    assert first == second
+    assert first["status"] == "ready"
+    assert first["artifact_ready"] is True
+    assert first["record_count"] == 2
+    assert [
+        row["player_id"]
+        for row in first["records"]
+    ] == [607208, 677951]
+    assert len(first["artifact_sha256"]) == 64
+    assert len(
+        first["adapter_result_sha256"]
+    ) == 64
+
+
+def test_serialization_is_deterministic():
+    artifact = build()
+
+    first = (
+        serialize_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+    second = (
+        serialize_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+
+    assert first == second
+    assert first.endswith("\n")
+    assert json.loads(first) == artifact
+
+
+def test_validates_artifact_identity():
+    artifact = build()
+    result = (
+        validate_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["artifact_valid"] is True
+    assert result["blockers"] == []
+
+
+def test_tampering_invalidates_artifact():
+    artifact = build()
+    artifact["records"][0][
+        "sprint_speed"
+    ] = 15.0
+
+    result = (
+        validate_hitter_speed_snapshot_artifact(
+            artifact
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["artifact_valid"] is False
+    assert "artifact_sha256_mismatch" in (
+        result["blockers"]
+    )
+
+
+def test_blocked_adapter_cannot_be_materialized(
+    tmp_path,
+):
+    artifact = build(
+        "player_id,competitive_runs\n"
+        "677951,182\n"
+    )
+    output_path = (
+        tmp_path / "blocked.json"
+    )
+
+    result = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact,
+            output_path,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        result["artifact_file_write_performed"]
+        is False
+    )
+    assert not output_path.exists()
+
+
+def test_materializes_atomically_and_replays(
+    tmp_path,
+):
+    artifact = build()
+    output_path = (
+        tmp_path
+        / "snapshots"
+        / "hitter-speed-2025-07-31.json"
+    )
+
+    result = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact,
+            output_path,
+        )
+    )
+
+    assert result["status"] == "written"
+    assert (
+        result["artifact_file_write_performed"]
+        is True
+    )
+    assert output_path.exists()
+
+    loaded = json.loads(
+        output_path.read_text(
+            encoding="utf-8"
+        )
+    )
+    assert loaded == artifact
+    assert (
+        validate_hitter_speed_snapshot_artifact(
+            loaded
+        )["artifact_valid"]
+        is True
+    )
+
+    temporary_files = list(
+        output_path.parent.glob("*.tmp")
+    )
+    assert temporary_files == []
+
+
+def test_repeated_materialization_is_identical(
+    tmp_path,
+):
+    artifact = build()
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+
+    first = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact,
+            first_path,
+        )
+    )
+    second = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact,
+            second_path,
+        )
+    )
+
+    assert first["serialized_sha256"] == (
+        second["serialized_sha256"]
+    )
+    assert first_path.read_bytes() == (
+        second_path.read_bytes()
+    )
+
+
+def test_artifact_has_no_production_authority():
+    artifact = build()
+
+    assert (
+        artifact["external_fetch_performed"]
+        is False
+    )
+    assert (
+        artifact["database_writes_performed"]
+        is False
+    )
+    assert (
+        artifact["production_model_modified"]
+        is False
+    )
+    assert (
+        artifact["simulation_authority_changed"]
+        is False
+    )
+    assert artifact["parameter_selected"] is False
+    assert (
+        artifact["production_authority_changed"]
+        is False
+    )
+    assert artifact["shadow_only"] is True

--- a/tests/test_materialize_shadow_hitter_speed_snapshot.py
+++ b/tests/test_materialize_shadow_hitter_speed_snapshot.py
@@ -1,0 +1,263 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from mlb_app.simulation.shadow.hitter_speed_snapshot_artifact import (
+    build_hitter_speed_snapshot_artifact,
+    materialize_hitter_speed_snapshot_artifact,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "materialize_shadow_hitter_speed_snapshot.py"
+)
+CSV = """player_id,competitive_runs,sprint_speed,season
+677951,182,30.4,2025
+607208,165,29.5,2025
+"""
+
+
+def command(input_path, output_path, *extra):
+    return [
+        sys.executable,
+        str(SCRIPT),
+        "--input-csv",
+        str(input_path),
+        "--output-json",
+        str(output_path),
+        "--season",
+        "2025",
+        "--as-of-date",
+        "2025-07-31",
+        "--source-updated-at",
+        "2025-07-31T23:59:00+00:00",
+        *extra,
+    ]
+
+
+def run_cli(input_path, output_path, *extra):
+    return subprocess.run(
+        command(
+            input_path,
+            output_path,
+            *extra,
+        ),
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def artifact():
+    return build_hitter_speed_snapshot_artifact(
+        CSV,
+        season=2025,
+        as_of_date="2025-07-31",
+        source_updated_at=(
+            "2025-07-31T23:59:00+00:00"
+        ),
+    )
+
+
+def test_cli_materializes_supplied_csv(tmp_path):
+    input_path = tmp_path / "speed.csv"
+    output_path = tmp_path / "speed.json"
+    input_path.write_text(
+        CSV,
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        input_path,
+        output_path,
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "written"
+    assert payload["record_count"] == 2
+    assert (
+        payload["artifact_file_write_performed"]
+        is True
+    )
+    assert output_path.exists()
+
+    written = json.loads(
+        output_path.read_text(
+            encoding="utf-8"
+        )
+    )
+    assert written["artifact_ready"] is True
+    assert written["record_count"] == 2
+
+
+def test_cli_refuses_existing_output(tmp_path):
+    input_path = tmp_path / "speed.csv"
+    output_path = tmp_path / "speed.json"
+    input_path.write_text(
+        CSV,
+        encoding="utf-8",
+    )
+    output_path.write_text(
+        '{"preserve": true}\n',
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        input_path,
+        output_path,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert "output_path_exists" in (
+        payload["blockers"]
+    )
+    assert json.loads(
+        output_path.read_text(
+            encoding="utf-8"
+        )
+    ) == {"preserve": True}
+
+
+def test_cli_overwrite_is_explicit(tmp_path):
+    input_path = tmp_path / "speed.csv"
+    output_path = tmp_path / "speed.json"
+    input_path.write_text(
+        CSV,
+        encoding="utf-8",
+    )
+    output_path.write_text(
+        '{"old": true}\n',
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        input_path,
+        output_path,
+        "--overwrite",
+    )
+
+    assert result.returncode == 0
+    assert json.loads(
+        output_path.read_text(
+            encoding="utf-8"
+        )
+    )["artifact_ready"] is True
+
+
+def test_cli_rejects_same_input_and_output(
+    tmp_path,
+):
+    path = tmp_path / "speed.csv"
+    path.write_text(
+        CSV,
+        encoding="utf-8",
+    )
+    original = path.read_bytes()
+
+    result = run_cli(path, path)
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert "input_and_output_paths_match" in (
+        payload["blockers"]
+    )
+    assert path.read_bytes() == original
+
+
+def test_cli_rejects_blocked_adapter_result(
+    tmp_path,
+):
+    input_path = tmp_path / "speed.csv"
+    output_path = tmp_path / "speed.json"
+    input_path.write_text(
+        "player_id,competitive_runs\n"
+        "677951,182\n",
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        input_path,
+        output_path,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked"
+    assert (
+        payload["artifact_file_write_performed"]
+        is False
+    )
+    assert not output_path.exists()
+
+
+def test_materializer_refuses_existing_path(
+    tmp_path,
+):
+    output_path = tmp_path / "speed.json"
+    output_path.write_text(
+        "preserve\n",
+        encoding="utf-8",
+    )
+
+    result = (
+        materialize_hitter_speed_snapshot_artifact(
+            artifact(),
+            output_path,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["blockers"] == [
+        "output_path_exists",
+    ]
+    assert output_path.read_text(
+        encoding="utf-8"
+    ) == "preserve\n"
+
+
+def test_cli_reports_production_isolation(
+    tmp_path,
+):
+    input_path = tmp_path / "speed.csv"
+    output_path = tmp_path / "speed.json"
+    input_path.write_text(
+        CSV,
+        encoding="utf-8",
+    )
+
+    result = run_cli(
+        input_path,
+        output_path,
+    )
+    payload = json.loads(result.stdout)
+
+    assert (
+        payload["external_fetch_performed"]
+        is False
+    )
+    assert (
+        payload["database_writes_performed"]
+        is False
+    )
+    assert (
+        payload["production_model_modified"]
+        is False
+    )
+    assert (
+        payload["simulation_authority_changed"]
+        is False
+    )
+    assert payload["parameter_selected"] is False
+    assert (
+        payload["production_authority_changed"]
+        is False
+    )
+    assert payload["shadow_only"] is True


### PR DESCRIPTION
## What changed

- Adds a deterministic hitter-speed snapshot artifact contract around the cutoff-safe Savant CSV adapter.
- Canonically serializes artifacts and records artifact, adapter-result, normalized-snapshot, and raw-source SHA-256 identities.
- Validates artifact integrity, readiness, records, blockers, and production-isolation flags before persistence.
- Adds atomic local artifact materialization with temporary-file cleanup and explicit overwrite protection.
- Adds an offline CLI that reads only an explicitly supplied local CSV and writes only the requested JSON artifact path.
- Rejects unreadable inputs, matching input/output paths, blocked adapter results, and existing outputs unless `--overwrite` is explicitly supplied.

## Why

The source adapter established a cutoff-safe normalization boundary, but predictive work still needed a reproducible immutable snapshot artifact. This slice makes supplied speed evidence replayable and tamper-evident without introducing live fetching, database persistence, or production authority.

## Production impact

- No external fetch is performed.
- No database schema or database writes are introduced.
- No production model or simulation authority changes.
- No parameter is selected.
- All artifacts remain shadow-only.

## Validation

- Complete hitter regression: **87 passed**.
- Python compilation passed.
- New-file and staged whitespace checks passed.
- Staged path isolation passed.
- Commit: `23dca97`.