### PR TITLE
Audit hitter speed snapshot acquisition

### DIFF
--- a/mlb_app/simulation/shadow/hitter_speed_snapshot_acquisition_validation.py
+++ b/mlb_app/simulation/shadow/hitter_speed_snapshot_acquisition_validation.py
@@ -1,0 +1,342 @@
+"""Validate hitter speed snapshot acquisition evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+REQUIRED_CSV_FIELDS = {
+    "player_id",
+    "competitive_runs",
+    "sprint_speed",
+}
+
+RECOMMENDED_NEXT_SLICE = (
+    "begin_prospective_hitter_speed_snapshot_collection"
+)
+
+
+def evaluate_hitter_speed_snapshot_acquisition_contract(
+    observations: Iterable[dict[str, Any]],
+    *,
+    historical_as_of_query_supported: bool,
+) -> dict[str, Any]:
+    """Evaluate observed Savant acquisition capabilities."""
+
+    rows = sorted(
+        (
+            dict(observation)
+            for observation in observations
+        ),
+        key=lambda row: row.get(
+            "season_requested",
+            -1,
+        ),
+    )
+
+    blockers = []
+    seasons = [
+        row.get("season_requested")
+        for row in rows
+    ]
+
+    if not rows:
+        blockers.append(
+            "acquisition_observations_missing"
+        )
+
+    if any(
+        not isinstance(season, int)
+        or season < 2015
+        for season in seasons
+    ):
+        blockers.append(
+            "invalid_observation_season"
+        )
+
+    if len(set(seasons)) != len(seasons):
+        blockers.append(
+            "duplicate_observation_season"
+        )
+
+    response_contract_ready = bool(rows)
+
+    required_field_failures = {}
+    invalid_response_seasons = []
+    replay_failures = []
+    identity_failures = []
+    qualification_failures = []
+    measurement_failures = []
+    embedded_season_fields = []
+    embedded_freshness_fields = []
+
+    semantic_hashes = []
+
+    for row in rows:
+        season = row.get("season_requested")
+        fields = {
+            str(field).strip().lower()
+            for field in (
+                row.get("fieldnames")
+                or []
+            )
+        }
+        missing_fields = sorted(
+            REQUIRED_CSV_FIELDS - fields
+        )
+
+        if missing_fields:
+            required_field_failures[
+                str(season)
+            ] = missing_fields
+            response_contract_ready = False
+
+        if (
+            row.get("http_status") != 200
+            or not str(
+                row.get("content_type") or ""
+            ).lower().startswith("text/csv")
+        ):
+            invalid_response_seasons.append(
+                season
+            )
+            response_contract_ready = False
+
+        if not (
+            row.get("raw_replay_identical")
+            and row.get(
+                "semantic_replay_identical"
+            )
+        ):
+            replay_failures.append(season)
+            response_contract_ready = False
+
+        if (
+            row.get(
+                "invalid_player_id_count",
+                0,
+            )
+            != 0
+            or row.get(
+                "duplicate_player_id_count",
+                0,
+            )
+            != 0
+            or row.get(
+                "unique_player_count",
+                0,
+            )
+            != row.get("row_count", 0)
+        ):
+            identity_failures.append(season)
+            response_contract_ready = False
+
+        if (
+            row.get(
+                "underqualified_row_count",
+                0,
+            )
+            != 0
+        ):
+            qualification_failures.append(
+                season
+            )
+            response_contract_ready = False
+
+        if (
+            row.get(
+                "invalid_sprint_speed_count",
+                0,
+            )
+            != 0
+        ):
+            measurement_failures.append(
+                season
+            )
+            response_contract_ready = False
+
+        if row.get("season_field_present"):
+            embedded_season_fields.append(
+                season
+            )
+
+        if row.get(
+            "freshness_field_present"
+        ):
+            embedded_freshness_fields.append(
+                season
+            )
+
+        semantic_hash = row.get(
+            "semantic_sha256"
+        )
+        if semantic_hash:
+            semantic_hashes.append(
+                semantic_hash
+            )
+        else:
+            response_contract_ready = False
+
+    cross_season_distinct = (
+        len(semantic_hashes) == len(rows)
+        and len(set(semantic_hashes))
+        == len(semantic_hashes)
+    )
+
+    if rows and not cross_season_distinct:
+        blockers.append(
+            "cross_season_responses_not_distinct"
+        )
+        response_contract_ready = False
+
+    if required_field_failures:
+        blockers.append(
+            "required_csv_fields_missing"
+        )
+
+    if invalid_response_seasons:
+        blockers.append(
+            "invalid_csv_response_contract"
+        )
+
+    if replay_failures:
+        blockers.append(
+            "response_replay_not_deterministic"
+        )
+
+    if identity_failures:
+        blockers.append(
+            "player_identity_contract_failed"
+        )
+
+    if qualification_failures:
+        blockers.append(
+            "qualification_contract_failed"
+        )
+
+    if measurement_failures:
+        blockers.append(
+            "speed_measurement_contract_failed"
+        )
+
+    season_metadata_external_required = (
+        bool(rows)
+        and not embedded_season_fields
+    )
+    freshness_metadata_external_required = (
+        bool(rows)
+        and not embedded_freshness_fields
+    )
+
+    acquisition_supported = (
+        response_contract_ready
+        and cross_season_distinct
+    )
+    prospective_collection_allowed = (
+        acquisition_supported
+        and season_metadata_external_required
+        and freshness_metadata_external_required
+    )
+
+    retrospective_predictive_evaluation_allowed = (
+        acquisition_supported
+        and historical_as_of_query_supported
+        and not freshness_metadata_external_required
+    )
+
+    temporal_blockers = []
+
+    if not historical_as_of_query_supported:
+        temporal_blockers.append(
+            "historical_as_of_query_unsupported"
+        )
+
+    if freshness_metadata_external_required:
+        temporal_blockers.append(
+            "source_freshness_metadata_not_embedded"
+        )
+
+    if not retrospective_predictive_evaluation_allowed:
+        temporal_blockers.append(
+            "historical_capture_precedes_outcomes_unverified"
+        )
+
+    overall_blockers = sorted(
+        set(blockers + temporal_blockers)
+    )
+
+    return {
+        "status": (
+            "ready"
+            if acquisition_supported
+            else "blocked"
+        ),
+        "acquisition_supported":
+            acquisition_supported,
+        "response_contract_ready":
+            response_contract_ready,
+        "csv_download_supported":
+            acquisition_supported,
+        "season_query_supported":
+            acquisition_supported,
+        "historical_as_of_query_supported":
+            historical_as_of_query_supported,
+        "cross_season_responses_distinct":
+            cross_season_distinct,
+        "observed_seasons": seasons,
+        "observation_count": len(rows),
+        "required_csv_fields": sorted(
+            REQUIRED_CSV_FIELDS
+        ),
+        "required_field_failures":
+            required_field_failures,
+        "invalid_response_seasons":
+            invalid_response_seasons,
+        "replay_failure_seasons":
+            replay_failures,
+        "identity_failure_seasons":
+            identity_failures,
+        "qualification_failure_seasons":
+            qualification_failures,
+        "measurement_failure_seasons":
+            measurement_failures,
+        "season_metadata_external_required":
+            season_metadata_external_required,
+        "freshness_metadata_external_required":
+            freshness_metadata_external_required,
+        "prospective_collection_allowed":
+            prospective_collection_allowed,
+        "retrospective_predictive_evaluation_allowed":
+            retrospective_predictive_evaluation_allowed,
+        "retrospective_temporal_blockers":
+            sorted(set(temporal_blockers)),
+        "blockers": overall_blockers,
+        "recommended_next_slice": (
+            RECOMMENDED_NEXT_SLICE
+            if prospective_collection_allowed
+            else (
+                "repair_hitter_speed_acquisition_contract"
+            )
+        ),
+        "decision": {
+            "source_endpoint_confirmed":
+                acquisition_supported,
+            "begin_prospective_collection":
+                prospective_collection_allowed,
+            "run_retrospective_speed_audit":
+                retrospective_predictive_evaluation_allowed,
+            "proxy_substitution_allowed": False,
+            "parameter_selection_allowed": False,
+        },
+        "production_impact": {
+            "external_fetch_performed": False,
+            "database_schema_changed": False,
+            "database_writes_performed": False,
+            "production_model_modified": False,
+            "simulation_authority_changed": False,
+            "production_authority_changed": False,
+        },
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "shadow_only": True,
+    }

--- a/scripts/audit_shadow_hitter_speed_snapshot_acquisition.py
+++ b/scripts/audit_shadow_hitter_speed_snapshot_acquisition.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Audit the official hitter speed snapshot acquisition contract."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Iterable
+
+from mlb_app.simulation.shadow.hitter_speed_snapshot_acquisition_validation import (
+    evaluate_hitter_speed_snapshot_acquisition_contract,
+)
+
+
+BASE_URL = (
+    "https://baseballsavant.mlb.com/"
+    "leaderboard/sprint_speed"
+)
+DEFAULT_SEASONS = (2024, 2025, 2026)
+
+
+def build_acquisition_url(
+    season: int,
+    *,
+    minimum_competitive_runs: int = 10,
+) -> str:
+    query = urllib.parse.urlencode({
+        "year": season,
+        "position": "",
+        "team": "",
+        "min": minimum_competitive_runs,
+        "csv": "true",
+    })
+    return f"{BASE_URL}?{query}"
+
+
+def fetch_response(
+    url: str,
+    *,
+    timeout: float,
+) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": (
+                "mlb-prediction-app/"
+                "hitter-speed-acquisition-audit"
+            ),
+            "Accept": "text/csv",
+        },
+        method="GET",
+    )
+
+    with urllib.request.urlopen(
+        request,
+        timeout=timeout,
+    ) as response:
+        body = response.read()
+        headers = {
+            key.lower(): value
+            for key, value
+            in response.headers.items()
+        }
+        return {
+            "http_status": response.status,
+            "headers": headers,
+            "body": body,
+            "final_url": response.geturl(),
+        }
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _normalize_response(
+    response: dict[str, Any],
+    *,
+    season: int,
+) -> dict[str, Any]:
+    body = response.get("body")
+
+    if not isinstance(body, bytes):
+        raise TypeError(
+            "acquisition response body must be bytes"
+        )
+
+    text = body.decode(
+        "utf-8-sig"
+    )
+    reader = csv.DictReader(
+        io.StringIO(text)
+    )
+    rows = list(reader)
+    fieldnames = list(
+        reader.fieldnames or []
+    )
+
+    normalized = []
+    invalid_player_ids = 0
+    duplicate_player_ids = 0
+    underqualified_rows = 0
+    invalid_sprint_speeds = 0
+    player_ids = set()
+
+    for row in rows:
+        try:
+            player_id = int(
+                row["player_id"]
+            )
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+        ):
+            invalid_player_ids += 1
+            continue
+
+        if player_id in player_ids:
+            duplicate_player_ids += 1
+        player_ids.add(player_id)
+
+        try:
+            competitive_runs = int(
+                row["competitive_runs"]
+            )
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+        ):
+            competitive_runs = None
+
+        try:
+            sprint_speed = float(
+                row["sprint_speed"]
+            )
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+        ):
+            sprint_speed = None
+
+        if (
+            competitive_runs is None
+            or competitive_runs < 10
+        ):
+            underqualified_rows += 1
+
+        if (
+            sprint_speed is None
+            or not 15.0 <= sprint_speed <= 40.0
+        ):
+            invalid_sprint_speeds += 1
+
+        normalized.append({
+            "player_id": player_id,
+            "competitive_runs":
+                competitive_runs,
+            "sprint_speed": sprint_speed,
+            "team_id": row.get("team_id"),
+            "position": row.get("position"),
+        })
+
+    normalized.sort(
+        key=lambda row: row["player_id"]
+    )
+    headers = {
+        str(key).lower(): value
+        for key, value in (
+            response.get("headers") or {}
+        ).items()
+    }
+
+    return {
+        "season_requested": season,
+        "http_status":
+            response.get("http_status"),
+        "content_type":
+            headers.get("content-type"),
+        "content_disposition":
+            headers.get(
+                "content-disposition"
+            ),
+        "final_url":
+            response.get("final_url"),
+        "fieldnames": fieldnames,
+        "row_count": len(rows),
+        "unique_player_count":
+            len(player_ids),
+        "invalid_player_id_count":
+            invalid_player_ids,
+        "duplicate_player_id_count":
+            duplicate_player_ids,
+        "underqualified_row_count":
+            underqualified_rows,
+        "invalid_sprint_speed_count":
+            invalid_sprint_speeds,
+        "raw_byte_count": len(body),
+        "raw_sha256": hashlib.sha256(
+            body
+        ).hexdigest(),
+        "semantic_sha256": hashlib.sha256(
+            _canonical_json(
+                normalized
+            ).encode("utf-8")
+        ).hexdigest(),
+        "season_field_present": any(
+            str(field).strip().lower()
+            in {"season", "year", "timeframe"}
+            for field in fieldnames
+        ),
+        "freshness_field_present": any(
+            str(field).strip().lower()
+            in {
+                "as_of_date",
+                "source_updated_at",
+                "updated_at",
+                "timestamp",
+            }
+            for field in fieldnames
+        ),
+    }
+
+
+def observe_season(
+    season: int,
+    *,
+    fetcher: Callable[..., dict[str, Any]],
+    timeout: float,
+) -> dict[str, Any]:
+    url = build_acquisition_url(season)
+
+    first_response = fetcher(
+        url,
+        timeout=timeout,
+    )
+    second_response = fetcher(
+        url,
+        timeout=timeout,
+    )
+
+    first = _normalize_response(
+        first_response,
+        season=season,
+    )
+    second = _normalize_response(
+        second_response,
+        season=season,
+    )
+
+    first["raw_replay_identical"] = (
+        first["raw_sha256"]
+        == second["raw_sha256"]
+    )
+    first["semantic_replay_identical"] = (
+        first["semantic_sha256"]
+        == second["semantic_sha256"]
+    )
+    first["repeat_raw_sha256"] = (
+        second["raw_sha256"]
+    )
+    first["repeat_semantic_sha256"] = (
+        second["semantic_sha256"]
+    )
+    return first
+
+
+def run_acquisition_audit(
+    seasons: Iterable[int] = DEFAULT_SEASONS,
+    *,
+    fetcher: Callable[..., dict[str, Any]] = (
+        fetch_response
+    ),
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    ordered_seasons = sorted(
+        set(seasons)
+    )
+    observations = [
+        observe_season(
+            season,
+            fetcher=fetcher,
+            timeout=timeout,
+        )
+        for season in ordered_seasons
+    ]
+
+    evaluation = (
+        evaluate_hitter_speed_snapshot_acquisition_contract(
+            observations,
+            historical_as_of_query_supported=False,
+        )
+    )
+
+    return {
+        "status": evaluation["status"],
+        "observations": observations,
+        "evaluation": evaluation,
+        "external_fetch_performed": True,
+        "database_writes_performed": False,
+        "artifact_file_write_performed": False,
+        "production_model_modified": False,
+        "simulation_authority_changed": False,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "shadow_only": True,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+    )
+    parser.add_argument(
+        "--season",
+        action="append",
+        dest="seasons",
+        type=int,
+    )
+    parser.add_argument(
+        "--timeout",
+        default=30.0,
+        type=float,
+    )
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    seasons = (
+        tuple(args.seasons)
+        if args.seasons
+        else DEFAULT_SEASONS
+    )
+
+    try:
+        result = run_acquisition_audit(
+            seasons,
+            timeout=args.timeout,
+        )
+    except Exception as exc:
+        result = {
+            "status": "error",
+            "error_type": type(exc).__name__,
+            "error": str(exc),
+            "external_fetch_performed": True,
+            "database_writes_performed": False,
+            "artifact_file_write_performed": False,
+            "production_authority_changed": False,
+            "shadow_only": True,
+        }
+        print(
+            json.dumps(
+                result,
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 2
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return (
+        0
+        if result["status"] == "ready"
+        else 2
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_audit_shadow_hitter_speed_snapshot_acquisition.py
+++ b/tests/test_audit_shadow_hitter_speed_snapshot_acquisition.py
@@ -1,0 +1,238 @@
+import importlib.util
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "scripts"
+    / "audit_shadow_hitter_speed_snapshot_acquisition.py"
+)
+
+SPEC = importlib.util.spec_from_file_location(
+    "hitter_speed_acquisition_audit",
+    SCRIPT,
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def csv_bytes(season):
+    speeds = {
+        2024: (29.6, 30.5),
+        2025: (30.3, 30.2),
+        2026: (29.8, 30.3),
+    }
+    first, second = speeds[season]
+    text = (
+        '"last_name, first_name",player_id,'
+        'team_id,team,position,age,'
+        'competitive_runs,bolts,hp_to_1b,'
+        'sprint_speed\n'
+        f'"Turner, Trea",607208,143,PHI,SS,'
+        f'31,200,10,4.1,{first}\n'
+        f'"Witt, Bobby",677951,118,KC,SS,'
+        f'25,220,20,4.0,{second}\n'
+    )
+    return text.encode("utf-8")
+
+
+def season_from_url(url):
+    query = parse_qs(
+        urlparse(url).query
+    )
+    return int(query["year"][0])
+
+
+def response(url, body):
+    return {
+        "http_status": 200,
+        "headers": {
+            "content-type":
+                "text/csv; charset=utf-8",
+            "content-disposition":
+                "attachment;filename=sprint_speed.csv",
+        },
+        "body": body,
+        "final_url": url,
+    }
+
+
+def deterministic_fetcher(url, *, timeout):
+    del timeout
+    season = season_from_url(url)
+    return response(
+        url,
+        csv_bytes(season),
+    )
+
+
+def test_builds_exact_year_csv_url():
+    url = MODULE.build_acquisition_url(2025)
+    query = parse_qs(
+        urlparse(url).query,
+        keep_blank_values=True,
+    )
+
+    assert query["year"] == ["2025"]
+    assert query["min"] == ["10"]
+    assert query["csv"] == ["true"]
+    assert "start_year" not in query
+    assert "end_year" not in query
+
+
+def test_observes_deterministic_response():
+    result = MODULE.observe_season(
+        2025,
+        fetcher=deterministic_fetcher,
+        timeout=1.0,
+    )
+
+    assert result["row_count"] == 2
+    assert result["unique_player_count"] == 2
+    assert (
+        result["raw_replay_identical"]
+        is True
+    )
+    assert (
+        result["semantic_replay_identical"]
+        is True
+    )
+    assert (
+        result["duplicate_player_id_count"]
+        == 0
+    )
+    assert (
+        result["underqualified_row_count"]
+        == 0
+    )
+
+
+def test_audit_confirms_prospective_path():
+    result = MODULE.run_acquisition_audit(
+        (2026, 2024, 2025),
+        fetcher=deterministic_fetcher,
+        timeout=1.0,
+    )
+
+    assert result["status"] == "ready"
+    assert [
+        row["season_requested"]
+        for row in result["observations"]
+    ] == [2024, 2025, 2026]
+
+    evaluation = result["evaluation"]
+    assert (
+        evaluation["acquisition_supported"]
+        is True
+    )
+    assert (
+        evaluation[
+            "prospective_collection_allowed"
+        ]
+        is True
+    )
+    assert (
+        evaluation[
+            "retrospective_predictive_"
+            "evaluation_allowed"
+        ]
+        is False
+    )
+
+
+def test_changed_repeat_blocks_replay():
+    calls = {}
+
+    def changing_fetcher(url, *, timeout):
+        del timeout
+        season = season_from_url(url)
+        calls[season] = calls.get(season, 0) + 1
+        body = csv_bytes(season)
+
+        if (
+            season == 2025
+            and calls[season] == 2
+        ):
+            body = body.replace(
+                b"30.3",
+                b"30.4",
+                1,
+            )
+
+        return response(url, body)
+
+    result = MODULE.run_acquisition_audit(
+        (2024, 2025, 2026),
+        fetcher=changing_fetcher,
+        timeout=1.0,
+    )
+
+    assert result["status"] == "blocked"
+    assert 2025 in (
+        result["evaluation"][
+            "replay_failure_seasons"
+        ]
+    )
+
+
+def test_rejects_duplicate_identity():
+    duplicate = (
+        '"last_name, first_name",player_id,'
+        'competitive_runs,sprint_speed\n'
+        '"Witt, Bobby",677951,200,30.2\n'
+        '"Witt, Bobby",677951,210,30.3\n'
+    ).encode("utf-8")
+
+    def duplicate_fetcher(url, *, timeout):
+        del timeout
+        return response(url, duplicate)
+
+    result = MODULE.run_acquisition_audit(
+        (2025,),
+        fetcher=duplicate_fetcher,
+        timeout=1.0,
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "player_identity_contract_failed"
+        in result["evaluation"]["blockers"]
+    )
+
+
+def test_audit_reports_only_external_read():
+    result = MODULE.run_acquisition_audit(
+        (2024, 2025, 2026),
+        fetcher=deterministic_fetcher,
+        timeout=1.0,
+    )
+
+    assert (
+        result["external_fetch_performed"]
+        is True
+    )
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert (
+        result["artifact_file_write_performed"]
+        is False
+    )
+    assert (
+        result["production_model_modified"]
+        is False
+    )
+    assert (
+        result["simulation_authority_changed"]
+        is False
+    )
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True

--- a/tests/test_hitter_speed_snapshot_acquisition_validation.py
+++ b/tests/test_hitter_speed_snapshot_acquisition_validation.py
@@ -1,0 +1,261 @@
+from copy import deepcopy
+
+from mlb_app.simulation.shadow.hitter_speed_snapshot_acquisition_validation import (
+    evaluate_hitter_speed_snapshot_acquisition_contract,
+)
+
+
+FIELDS = [
+    "last_name, first_name",
+    "player_id",
+    "team_id",
+    "team",
+    "position",
+    "age",
+    "competitive_runs",
+    "bolts",
+    "hp_to_1b",
+    "sprint_speed",
+]
+
+
+def observation(
+    season,
+    semantic_sha256,
+):
+    return {
+        "season_requested": season,
+        "http_status": 200,
+        "content_type":
+            "text/csv; charset=utf-8",
+        "fieldnames": list(FIELDS),
+        "row_count": 500,
+        "unique_player_count": 500,
+        "invalid_player_id_count": 0,
+        "duplicate_player_id_count": 0,
+        "underqualified_row_count": 0,
+        "invalid_sprint_speed_count": 0,
+        "raw_replay_identical": True,
+        "semantic_replay_identical": True,
+        "semantic_sha256":
+            semantic_sha256,
+        "season_field_present": False,
+        "freshness_field_present": False,
+    }
+
+
+def evidence():
+    return [
+        observation(2024, "a" * 64),
+        observation(2025, "b" * 64),
+        observation(2026, "c" * 64),
+    ]
+
+
+def evaluate(rows=None, **overrides):
+    values = {
+        "historical_as_of_query_supported":
+            False,
+    }
+    values.update(overrides)
+    return (
+        evaluate_hitter_speed_snapshot_acquisition_contract(
+            evidence() if rows is None else rows,
+            **values,
+        )
+    )
+
+
+def test_confirms_acquisition_contract():
+    result = evaluate()
+
+    assert result["status"] == "ready"
+    assert (
+        result["acquisition_supported"]
+        is True
+    )
+    assert (
+        result["response_contract_ready"]
+        is True
+    )
+    assert (
+        result[
+            "cross_season_responses_distinct"
+        ]
+        is True
+    )
+    assert result["observed_seasons"] == [
+        2024,
+        2025,
+        2026,
+    ]
+
+
+def test_allows_prospective_collection():
+    result = evaluate()
+
+    assert (
+        result[
+            "prospective_collection_allowed"
+        ]
+        is True
+    )
+    assert (
+        result["decision"][
+            "begin_prospective_collection"
+        ]
+        is True
+    )
+    assert result["recommended_next_slice"] == (
+        "begin_prospective_hitter_speed_"
+        "snapshot_collection"
+    )
+
+
+def test_blocks_retrospective_evaluation():
+    result = evaluate()
+
+    assert (
+        result[
+            "retrospective_predictive_"
+            "evaluation_allowed"
+        ]
+        is False
+    )
+    assert (
+        "historical_as_of_query_unsupported"
+        in result[
+            "retrospective_temporal_blockers"
+        ]
+    )
+    assert (
+        "historical_capture_precedes_"
+        "outcomes_unverified"
+        in result[
+            "retrospective_temporal_blockers"
+        ]
+    )
+    assert (
+        result["decision"][
+            "run_retrospective_speed_audit"
+        ]
+        is False
+    )
+
+
+def test_requires_external_capture_metadata():
+    result = evaluate()
+
+    assert (
+        result[
+            "season_metadata_external_required"
+        ]
+        is True
+    )
+    assert (
+        result[
+            "freshness_metadata_external_required"
+        ]
+        is True
+    )
+
+
+def test_missing_required_field_blocks():
+    rows = evidence()
+    rows[0]["fieldnames"].remove(
+        "sprint_speed"
+    )
+
+    result = evaluate(rows)
+
+    assert result["status"] == "blocked"
+    assert (
+        result["acquisition_supported"]
+        is False
+    )
+    assert "required_csv_fields_missing" in (
+        result["blockers"]
+    )
+
+
+def test_duplicate_identity_blocks():
+    rows = evidence()
+    rows[1][
+        "duplicate_player_id_count"
+    ] = 1
+
+    result = evaluate(rows)
+
+    assert result["status"] == "blocked"
+    assert (
+        "player_identity_contract_failed"
+        in result["blockers"]
+    )
+
+
+def test_non_deterministic_replay_blocks():
+    rows = evidence()
+    rows[2]["raw_replay_identical"] = False
+
+    result = evaluate(rows)
+
+    assert result["status"] == "blocked"
+    assert (
+        "response_replay_not_deterministic"
+        in result["blockers"]
+    )
+
+
+def test_cross_season_collision_blocks():
+    rows = evidence()
+    rows[2]["semantic_sha256"] = (
+        rows[1]["semantic_sha256"]
+    )
+
+    result = evaluate(rows)
+
+    assert result["status"] == "blocked"
+    assert (
+        "cross_season_responses_not_distinct"
+        in result["blockers"]
+    )
+
+
+def test_input_order_does_not_change_result():
+    rows = evidence()
+
+    first = evaluate(rows)
+    second = evaluate(
+        list(reversed(deepcopy(rows)))
+    )
+
+    assert first == second
+
+
+def test_no_production_authority():
+    result = evaluate()
+
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+
+    impact = result["production_impact"]
+    assert (
+        impact["external_fetch_performed"]
+        is False
+    )
+    assert (
+        impact["database_writes_performed"]
+        is False
+    )
+    assert (
+        impact["production_model_modified"]
+        is False
+    )
+    assert (
+        impact["simulation_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## What changed

- Adds a deterministic decision gate for the official Baseball Savant Sprint Speed CSV acquisition contract.
- Validates required fields, season-specific response identity, replay determinism, player identity uniqueness, qualification thresholds, and measurement ranges.
- Adds an explicit live audit script using the confirmed `year=<season>&min=10&csv=true` request shape.
- Fetches each requested season twice and compares both raw-response and normalized semantic SHA-256 identities.
- Keeps automated tests offline through injected fetchers covering deterministic, changing, duplicate-identity, and production-isolation cases.

## Evidence

The live audit observed reproducible and distinct official responses for 2024, 2025, and 2026:

- 2024: 566 unique qualified players
- 2025: 579 unique qualified players
- 2026: 513 unique qualified players
- Raw and semantic replay were identical for every season.
- No duplicate player IDs, under-qualified rows, or invalid Sprint Speed measurements were observed.

The source does not embed season or freshness metadata and does not support historical as-of queries. Therefore, prospective collection is allowed, while retrospective predictive evaluation remains blocked because capture-before-outcome timing cannot be verified.

## Decision

- Source endpoint confirmed: **yes**
- Begin prospective snapshot collection: **yes**
- Run retrospective speed audit: **no**
- Proxy substitution: **not allowed**
- Parameter selection: **not allowed**

## Production impact

- Live audit performs explicit read-only external requests.
- No response or artifact is persisted by the audit.
- No database schema or database writes change.
- No production model or simulation authority changes.
- Production authority remains unchanged.

## Validation

- Complete hitter regression: **103 passed**.
- Python compilation passed.
- New-file and staged whitespace checks passed.
- Staged path isolation passed.
- Commit: `82f9424`.