### PR TITLE
Synthesize hitter profile activation readiness

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
+++ b/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
@@ -1,0 +1,376 @@
+"""Synthesize hitter-profile activation readiness."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+ACTIVATION_ELIGIBLE = "activation_eligible"
+PARAMETERIZATION_PENDING = (
+    "signal_supported_parameterization_pending"
+)
+EVIDENCE_BLOCKED = "evidence_blocked"
+CONTEXT_ONLY = "evaluation_context_only"
+
+RECOMMENDED_NEXT_SLICE = (
+    "select_hitter_profile_candidate_parameterizations"
+)
+
+
+DEFAULT_SIGNAL_EVIDENCE = {
+    "hit_skill": {
+        "production_input":
+            "contact_skill.hit_skill",
+        "candidate":
+            "actual_batting_average_plus_xba",
+        "evidence_source_prs": [
+            1300,
+            1305,
+        ],
+        "evidence": {
+            "pooled_expected_weight": 0.35,
+            "current_expected_weight": 0.50,
+            "global_expected_weight_spread":
+                0.35,
+            "vsR_expected_weight_spread": 0.45,
+            "vsL_expected_weight_spread": 0.90,
+            "holdout_ab": 84883,
+        },
+        "state": EVIDENCE_BLOCKED,
+        "blockers": [
+            "unstable_global_expected_weight",
+            "unstable_vsR_expected_weight",
+            "unstable_vsL_expected_weight",
+            "production_weight_not_selected",
+        ],
+        "excluded_features": [
+            "xwoba_as_direct_hit_probability",
+        ],
+    },
+    "strikeout_skill": {
+        "production_input":
+            "contact_skill.k_rate",
+        "candidate":
+            "actual_strikeout_rate_plus_whiff_rate",
+        "evidence_source_prs": [
+            1307,
+        ],
+        "evidence": {
+            "relative_mse_improvement": 0.0316,
+            "bootstrap_probability_of_improvement":
+                0.9975,
+            "bootstrap_interval_fully_positive":
+                True,
+        },
+        "state": PARAMETERIZATION_PENDING,
+        "blockers": [
+            "production_coefficients_not_selected",
+            "coefficient_stability_not_validated",
+        ],
+        "excluded_features": [
+            "called_strike_rate",
+            "swinging_strike_rate_increment",
+            "full_auxiliary_model",
+            "contact_rate_redundant_with_whiff_rate",
+        ],
+    },
+    "walk_skill": {
+        "production_input":
+            "plate_discipline.bb_rate",
+        "candidate": "called_ball_rate",
+        "evidence_source_prs": [
+            1308,
+        ],
+        "evidence": {
+            "relative_mse_improvement_over_actual_bb":
+                0.0279,
+            "bootstrap_probability_of_improvement":
+                0.995,
+            "bootstrap_interval_fully_positive":
+                True,
+            "source_denominator": "pitches",
+            "production_denominator":
+                "plate_appearances",
+        },
+        "state": PARAMETERIZATION_PENDING,
+        "blockers": [
+            "per_pitch_to_per_pa_mapping_not_selected",
+            "production_coefficients_not_selected",
+            "coefficient_stability_not_validated",
+        ],
+        "fallback": "actual_walk_rate",
+        "excluded_features": [
+            "actual_walk_rate_blend_increment",
+            "take_rate",
+            "called_strike_rate",
+            "full_auxiliary_model",
+            "chase_rate_unavailable",
+        ],
+    },
+    "power_skill": {
+        "production_input": "power.iso",
+        "candidate": "expected_damage",
+        "evidence_source_prs": [
+            1306,
+        ],
+        "evidence": {
+            "relative_mse_improvement_over_actual_iso":
+                0.0584,
+            "bootstrap_probability_of_improvement":
+                1.0,
+            "bootstrap_interval_fully_positive":
+                True,
+        },
+        "state": PARAMETERIZATION_PENDING,
+        "blockers": [
+            "production_coefficients_not_selected",
+            "coefficient_stability_not_validated",
+            "expected_damage_to_iso_mapping_not_selected",
+        ],
+        "excluded_features": [
+            "hard_hit_increment",
+            "barrel_proxy_increment",
+            "full_auxiliary_model",
+        ],
+    },
+    "hit_type_allocation": {
+        "production_input":
+            "single_double_triple_hr_allocation",
+        "candidate":
+            "single_supported_model_only",
+        "supported_models": [
+            "actual_allocation",
+            "expected_damage",
+        ],
+        "evidence_source_prs": [
+            1310,
+        ],
+        "evidence": {
+            "actual_vs_league_bootstrap_probability":
+                1.0,
+            "expected_vs_league_bootstrap_probability":
+                1.0,
+            "blend_increment_probability": 0.905,
+            "geometry_increment_probability": 0.455,
+        },
+        "state": PARAMETERIZATION_PENDING,
+        "blockers": [
+            "production_model_choice_not_selected",
+            "allocation_shrinkage_not_selected",
+            "triple_policy_restricted_without_speed",
+        ],
+        "excluded_features": [
+            "actual_expected_blend_increment",
+            "contact_geometry_increment",
+        ],
+    },
+    "speed_and_triples": {
+        "production_input": "triple_probability",
+        "candidate":
+            "prospective_sprint_speed_evidence",
+        "evidence_source_prs": [
+            1311,
+            1312,
+            1313,
+            1314,
+        ],
+        "evidence": {
+            "source_endpoint_confirmed": True,
+            "prospective_collection_allowed": True,
+            "historical_as_of_query_supported":
+                False,
+            "retrospective_evaluation_allowed":
+                False,
+        },
+        "state": EVIDENCE_BLOCKED,
+        "blockers": [
+            "historical_as_of_query_unsupported",
+            "historical_capture_precedes_outcomes_unverified",
+            "prospective_outcomes_not_yet_observed",
+        ],
+        "fallback":
+            "retain_conservative_triple_policy",
+        "excluded_features": [
+            "launch_angle_as_speed_proxy",
+            "exit_velocity_as_speed_proxy",
+            "stolen_base_rate_as_speed_proxy",
+            "triple_rate_as_speed_proxy",
+        ],
+    },
+    "xwoba_context": {
+        "production_input": None,
+        "candidate": "xwoba",
+        "evidence_source_prs": [
+            1296,
+        ],
+        "state": CONTEXT_ONLY,
+        "blockers": [
+            "direct_pa_outcome_mapping_not_selected",
+        ],
+        "excluded_features": [],
+    },
+}
+
+
+def synthesize_hitter_profile_activation_readiness(
+    signal_evidence: Mapping[
+        str,
+        Mapping[str, Any],
+    ]
+    | None = None,
+) -> dict[str, Any]:
+    """Build one deterministic activation decision matrix."""
+
+    signals = deepcopy(
+        dict(
+            signal_evidence
+            or DEFAULT_SIGNAL_EVIDENCE
+        )
+    )
+    allowed_states = {
+        ACTIVATION_ELIGIBLE,
+        PARAMETERIZATION_PENDING,
+        EVIDENCE_BLOCKED,
+        CONTEXT_ONLY,
+    }
+    contract_blockers = []
+
+    for name, signal in sorted(
+        signals.items()
+    ):
+        state = signal.get("state")
+        if state not in allowed_states:
+            contract_blockers.append(
+                f"invalid_signal_state:{name}"
+            )
+
+        if not signal.get("candidate"):
+            contract_blockers.append(
+                f"missing_candidate:{name}"
+            )
+
+        if (
+            state
+            in {
+                PARAMETERIZATION_PENDING,
+                EVIDENCE_BLOCKED,
+            }
+            and not signal.get("blockers")
+        ):
+            contract_blockers.append(
+                f"missing_signal_blockers:{name}"
+            )
+
+    state_counts = {
+        state: sum(
+            signal.get("state") == state
+            for signal in signals.values()
+        )
+        for state in sorted(allowed_states)
+    }
+    activation_eligible_signals = sorted(
+        name
+        for name, signal in signals.items()
+        if signal.get("state")
+        == ACTIVATION_ELIGIBLE
+    )
+    pending_signals = sorted(
+        name
+        for name, signal in signals.items()
+        if signal.get("state")
+        == PARAMETERIZATION_PENDING
+    )
+    blocked_signals = sorted(
+        name
+        for name, signal in signals.items()
+        if signal.get("state")
+        == EVIDENCE_BLOCKED
+    )
+    context_only_signals = sorted(
+        name
+        for name, signal in signals.items()
+        if signal.get("state")
+        == CONTEXT_ONLY
+    )
+
+    first_activation_ready = (
+        not contract_blockers
+        and bool(activation_eligible_signals)
+        and not pending_signals
+    )
+
+    activation_blockers = list(
+        contract_blockers
+    )
+    if pending_signals:
+        activation_blockers.append(
+            "supported_signals_require_parameter_selection"
+        )
+    if not activation_eligible_signals:
+        activation_blockers.append(
+            "no_new_signal_is_activation_eligible"
+        )
+
+    activation_blockers = sorted(
+        set(activation_blockers)
+    )
+
+    return {
+        "schema_version":
+            "hitter_profile_activation_readiness_v1",
+        "status": (
+            "ready_for_activation"
+            if first_activation_ready
+            else "not_ready_for_activation"
+        ),
+        "first_activation_ready":
+            first_activation_ready,
+        "signals": {
+            name: signals[name]
+            for name in sorted(signals)
+        },
+        "state_counts": state_counts,
+        "activation_eligible_signals":
+            activation_eligible_signals,
+        "parameterization_pending_signals":
+            pending_signals,
+        "evidence_blocked_signals":
+            blocked_signals,
+        "context_only_signals":
+            context_only_signals,
+        "activation_blockers":
+            activation_blockers,
+        "recommended_next_slice":
+            RECOMMENDED_NEXT_SLICE,
+        "first_activation_scope": {
+            "include_only_after_selection": [
+                "strikeout_skill",
+                "walk_skill",
+                "power_skill",
+                "hit_type_allocation",
+            ],
+            "retain_current_policy": [
+                "hit_skill",
+            ],
+            "exclude": [
+                "speed_and_triples",
+                "xwoba_context",
+            ],
+            "fallback_required": True,
+            "feature_flag_required": True,
+            "shadow_canary_required": True,
+        },
+        "walk_policy": {
+            "supported_signal":
+                "called_ball_rate",
+            "actual_walk_rate_role":
+                "production_fallback",
+            "blend_supported": False,
+            "per_pitch_to_per_pa_mapping_required":
+                True,
+        },
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "shadow_only": True,
+    }

--- a/scripts/audit_shadow_hitter_profile_activation_readiness.py
+++ b/scripts/audit_shadow_hitter_profile_activation_readiness.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Report synthesized hitter-profile activation readiness."""
+
+from __future__ import annotations
+
+import json
+
+from mlb_app.simulation.shadow.hitter_profile_activation_readiness import (
+    synthesize_hitter_profile_activation_readiness,
+)
+
+
+def main() -> int:
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    print(
+        json.dumps(
+            result,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hitter_profile_activation_readiness.py
+++ b/tests/test_hitter_profile_activation_readiness.py
@@ -1,0 +1,258 @@
+from copy import deepcopy
+
+from mlb_app.simulation.shadow.hitter_profile_activation_readiness import (
+    ACTIVATION_ELIGIBLE,
+    DEFAULT_SIGNAL_EVIDENCE,
+    synthesize_hitter_profile_activation_readiness,
+)
+
+
+def test_synthesizes_current_readiness():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+
+    assert (
+        result["status"]
+        == "not_ready_for_activation"
+    )
+    assert (
+        result["first_activation_ready"]
+        is False
+    )
+    assert (
+        result["activation_eligible_signals"]
+        == []
+    )
+    assert set(
+        result[
+            "parameterization_pending_signals"
+        ]
+    ) == {
+        "strikeout_skill",
+        "walk_skill",
+        "power_skill",
+        "hit_type_allocation",
+    }
+
+
+def test_walk_policy_selects_called_ball_only():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    walk = result["signals"]["walk_skill"]
+
+    assert walk["candidate"] == "called_ball_rate"
+    assert (
+        walk["fallback"]
+        == "actual_walk_rate"
+    )
+    assert (
+        "actual_walk_rate_blend_increment"
+        in walk["excluded_features"]
+    )
+    assert (
+        result["walk_policy"][
+            "blend_supported"
+        ]
+        is False
+    )
+    assert (
+        result["walk_policy"][
+            "per_pitch_to_per_pa_mapping_required"
+        ]
+        is True
+    )
+
+
+def test_strikeout_blend_remains_pending():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    strikeout = result["signals"][
+        "strikeout_skill"
+    ]
+
+    assert strikeout["candidate"] == (
+        "actual_strikeout_rate_plus_whiff_rate"
+    )
+    assert strikeout["state"] == (
+        "signal_supported_parameterization_pending"
+    )
+
+
+def test_expected_damage_is_power_candidate():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    power = result["signals"]["power_skill"]
+
+    assert power["candidate"] == (
+        "expected_damage"
+    )
+    assert "hard_hit_increment" in (
+        power["excluded_features"]
+    )
+    assert "barrel_proxy_increment" in (
+        power["excluded_features"]
+    )
+
+
+def test_unstable_hit_skill_retains_policy():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    hit_skill = result["signals"]["hit_skill"]
+
+    assert hit_skill["state"] == (
+        "evidence_blocked"
+    )
+    assert (
+        hit_skill["evidence"][
+            "global_expected_weight_spread"
+        ]
+        == 0.35
+    )
+    assert "hit_skill" in (
+        result["first_activation_scope"][
+            "retain_current_policy"
+        ]
+    )
+
+
+def test_speed_does_not_block_other_selection():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+
+    assert "speed_and_triples" in (
+        result["evidence_blocked_signals"]
+    )
+    assert "speed_and_triples" in (
+        result["first_activation_scope"][
+            "exclude"
+        ]
+    )
+    assert (
+        result["signals"][
+            "speed_and_triples"
+        ]["fallback"]
+        == "retain_conservative_triple_policy"
+    )
+
+
+def test_contract_rejects_invalid_state():
+    signals = deepcopy(
+        DEFAULT_SIGNAL_EVIDENCE
+    )
+    signals["walk_skill"]["state"] = (
+        "invented_state"
+    )
+
+    result = (
+        synthesize_hitter_profile_activation_readiness(
+            signals
+        )
+    )
+
+    assert (
+        "invalid_signal_state:walk_skill"
+        in result["activation_blockers"]
+    )
+    assert (
+        result["first_activation_ready"]
+        is False
+    )
+
+
+def test_eligible_matrix_can_reach_ready():
+    signals = deepcopy(
+        DEFAULT_SIGNAL_EVIDENCE
+    )
+
+    for signal in signals.values():
+        if signal["state"] == (
+            "signal_supported_parameterization_pending"
+        ):
+            signal["state"] = ACTIVATION_ELIGIBLE
+            signal["blockers"] = []
+
+    result = (
+        synthesize_hitter_profile_activation_readiness(
+            signals
+        )
+    )
+
+    assert (
+        result["status"]
+        == "ready_for_activation"
+    )
+    assert (
+        result["first_activation_ready"]
+        is True
+    )
+
+
+def test_no_authority_or_selection():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+
+    assert result["parameter_selected"] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+    assert result["first_activation_scope"][
+        "feature_flag_required"
+    ] is True
+    assert result["first_activation_scope"][
+        "shadow_canary_required"
+    ] is True
+
+def test_audit_script_reports_same_contract():
+    import json
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    script = (
+        root
+        / "scripts"
+        / "audit_shadow_hitter_profile_activation_readiness.py"
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+        ],
+        cwd=root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    payload = json.loads(completed.stdout)
+    expected = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+
+    assert payload == expected
+    assert (
+        payload["status"]
+        == "not_ready_for_activation"
+    )
+    assert (
+        payload["walk_policy"][
+            "supported_signal"
+        ]
+        == "called_ball_rate"
+    )
+    assert (
+        payload["production_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## What changed

- Adds one deterministic readiness matrix synthesizing the merged hitter-profile evidence into activation states.
- Classifies each signal as `activation_eligible`, `signal_supported_parameterization_pending`, `evidence_blocked`, or `evaluation_context_only`.
- Records the supported candidate, production input, evidence provenance, blockers, excluded features, and fallback policy for each domain.
- Adds a reproducible audit CLI and end-to-end contract test.

## Readiness decision

No new signal is activation-eligible yet. Four signals have reliable evidence but still require explicit production parameterization:

- Strikeout: actual K% plus whiff rate
- Walk: called-ball rate alone
- Power: expected damage alone
- Hit-type allocation: select one supported allocation model

Two areas remain evidence-blocked:

- Hit-skill blend: pooled evidence exists, but temporal and handedness weight estimates are unstable, so the current 50/50 policy is retained.
- Speed/triples: prospective collection is allowed, but historical as-of evidence is unavailable.

xwOBA remains evaluation context only.

## Walk policy

Called-ball rate is the supported walk-skill signal. Actual walk rate remains the production fallback; its blend with called-ball rate was not reliably incremental. Because called-ball rate is per pitch and production `bb_rate` is per plate appearance, a calibrated mapping and stable coefficients must be selected before activation.

## First activation scope

- Include K, BB, power, and hit allocation only after parameter selection.
- Retain the current hit-skill policy.
- Exclude speed/triples and direct xwOBA application.
- Require deterministic fallback, a feature flag, and a shadow canary before authority changes.

## Production impact

- No parameter is selected.
- No production profile or PA-model behavior changes.
- No simulation authority changes.
- The synthesis remains shadow-only.

## Validation

- Complete hitter regression: **113 passed**.
- Python compilation passed.
- New-file and staged whitespace checks passed.
- Staged path isolation passed.
- Commit: `9ae4cba`.