### PR TITLE
Rewire probable and lineup refresh into matchup snapshots

### DIFF
--- a/mlb_app/shared_payload_cache.py
+++ b/mlb_app/shared_payload_cache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import inspect
 import json
 import os
 import time
@@ -67,6 +68,33 @@ def _effective_ttl(key: str, ttl_seconds: int) -> int:
     return ttl_seconds
 
 
+def _explicit_matchup_snapshot_refresh(key: str) -> bool:
+    """Bypass the daily matchup cache only for the explicit snapshot endpoint.
+
+    The Railway refresh worker calls POST /matchups/snapshot/{date} after it has
+    refreshed probable-pitcher and lineup inputs. That endpoint historically
+    called the same cached generator used by the homepage, so a warm request
+    could simply re-store the old slate. Keep normal /matchups requests fast,
+    but treat the dedicated snapshot function as a force-refresh boundary.
+
+    This is intentionally narrow: only matchup date keys are eligible and only
+    while the call stack contains app.snapshot_matchups.
+    """
+    if not str(key).startswith("matchups:date:"):
+        return False
+
+    frame = inspect.currentframe()
+    try:
+        frame = frame.f_back if frame else None
+        while frame is not None:
+            if frame.f_code.co_name == "snapshot_matchups":
+                return True
+            frame = frame.f_back
+    finally:
+        del frame
+    return False
+
+
 def get_cache(key: str, ttl_seconds: int) -> Optional[Any]:
     ttl_seconds = _effective_ttl(key, ttl_seconds)
     with timing_span(
@@ -75,6 +103,22 @@ def get_cache(key: str, ttl_seconds: int) -> Optional[Any]:
         cache_status=None,
         extra={"cache_key_prefix": str(key).split(":", 1)[0], "ttl_seconds": ttl_seconds},
     ):
+        if _explicit_matchup_snapshot_refresh(key):
+            previous = _CACHE.pop(key, None)
+            record_cache_status("MISS")
+            record_span(
+                "shared_payload_cache.lookup",
+                category="cache",
+                cache_status="BYPASS",
+                payload_bytes=estimate_payload_bytes(previous[1]) if previous else None,
+                extra={
+                    "cache_key_prefix": str(key).split(":", 1)[0],
+                    "ttl_seconds": ttl_seconds,
+                    "refresh_boundary": "snapshot_matchups",
+                },
+            )
+            return None
+
         record = _CACHE.get(key)
         if not record:
             record_cache_status("MISS")

--- a/tests/test_matchup_snapshot_refresh_cache.py
+++ b/tests/test_matchup_snapshot_refresh_cache.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from mlb_app.shared_payload_cache import (
+    clear_shared_payload_cache,
+    get_cache,
+    make_cache_key,
+    set_cache,
+)
+
+
+def _snapshot_lookup(key: str):
+    # Keep this helper name aligned with the FastAPI endpoint function. The
+    # explicit refresh boundary is intentionally detected by function name so
+    # the normal homepage cache path remains unchanged.
+    def snapshot_matchups():
+        return get_cache(key, 300)
+
+    return snapshot_matchups()
+
+
+def setup_function() -> None:
+    clear_shared_payload_cache()
+
+
+def teardown_function() -> None:
+    clear_shared_payload_cache()
+
+
+def test_normal_matchup_lookup_remains_a_cache_hit() -> None:
+    key = make_cache_key("matchups", "date", "2026-07-31")
+    slate = [{"game_pk": 1, "home_pitcher_id": 101}]
+    set_cache(key, slate)
+
+    assert get_cache(key, 300) == slate
+
+
+def test_snapshot_lookup_bypasses_and_evicts_stale_matchup_slate() -> None:
+    key = make_cache_key("matchups", "date", "2026-07-31")
+    stale = [{"game_pk": 1, "home_pitcher_id": None}]
+    set_cache(key, stale)
+
+    assert _snapshot_lookup(key) is None
+    assert get_cache(key, 300) is None
+
+    refreshed = [{"game_pk": 1, "home_pitcher_id": 101}]
+    set_cache(key, refreshed)
+    assert get_cache(key, 300) == refreshed
+
+
+def test_snapshot_refresh_does_not_bypass_unrelated_cache_namespaces() -> None:
+    key = make_cache_key("model_projection", "date", "2026-07-31")
+    payload = {"games": [{"game_pk": 1}]}
+    set_cache(key, payload)
+
+    assert _snapshot_lookup(key) == payload
+    assert get_cache(key, 300) == payload
+
+
+def test_doubleheader_games_remain_separate_after_snapshot_replacement() -> None:
+    key = make_cache_key("matchups", "date", "2026-07-31")
+    stale = [
+        {"game_pk": 9001, "home_pitcher_id": 111},
+        {"game_pk": 9002, "home_pitcher_id": None},
+    ]
+    set_cache(key, stale)
+
+    assert _snapshot_lookup(key) is None
+
+    refreshed = [
+        {"game_pk": 9001, "home_pitcher_id": 111},
+        {"game_pk": 9002, "home_pitcher_id": 222},
+    ]
+    set_cache(key, refreshed)
+
+    cached = get_cache(key, 300)
+    assert [game["game_pk"] for game in cached] == [9001, 9002]
+    assert cached[0]["home_pitcher_id"] == 111
+    assert cached[1]["home_pitcher_id"] == 222


### PR DESCRIPTION
Closes #1316

## Root cause

The Railway refresh worker correctly calls `POST /matchups/snapshot/{date}` after refreshing probable-pitcher and lineup inputs. However, `snapshot_matchups()` calls `generate_matchups_for_date()`, and that generator first reads the same process-local `matchups:date:{date}` TTL cache used by the fast homepage.

When the cache is still warm, the explicit snapshot request receives the old slate and stores it again. Newly named/changed probable pitchers and official lineups therefore do not propagate until the generic matchup TTL expires.

## Fix

- Preserve the normal `/matchups` cache-hit path exactly.
- Treat only the explicit `snapshot_matchups` call boundary as a forced refresh for `matchups:date:*` keys.
- Evict the stale date-level generator entry before the snapshot builder runs.
- Leave unrelated cache namespaces untouched.
- Record the explicit bypass as `cache_status=BYPASS` with `refresh_boundary=snapshot_matchups` for diagnostics.

This keeps external schedule, lineup, pitcher, Statcast, and model work off ordinary homepage requests. The cron snapshot endpoint performs the rebuild and then stores the refreshed slate for immediate homepage cache hits.

## Doubleheaders

No team/date matching was introduced. Snapshot payloads continue carrying separate game objects keyed by their existing `game_pk`. Regression coverage verifies two games on the same date remain separate when only Game 2 receives a newly named pitcher.

## Files changed

- `mlb_app/shared_payload_cache.py`
  - adds the narrow explicit snapshot refresh boundary
  - preserves all normal cache behavior
- `tests/test_matchup_snapshot_refresh_cache.py`
  - normal matchup cache hit
  - stale TBA snapshot eviction and replacement
  - unrelated namespace preservation
  - doubleheader `game_pk` separation

## Validation

Repository diff is limited to 44 production lines and one focused test module. The runtime available for this session does not include a local GitHub checkout or GitHub CLI, so tests could not be executed locally; GitHub Actions should run the repository test suite on this draft PR.

## Safety

- No homepage route changes
- No cache TTL changes
- No synchronous external calls added to `/matchups`
- No response-contract changes
- No model, simulation, odds, dashboard, or Statcast formula changes
- Failed snapshot rebuild behavior remains unchanged: the endpoint returns an error and the app-level prior snapshot is not replaced