### PR TITLE
Calibrate hitter walk skill parameterization

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
+++ b/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
@@ -93,12 +93,23 @@ DEFAULT_SIGNAL_EVIDENCE = {
             "production_denominator":
                 "plate_appearances",
         },
-        "state": PARAMETERIZATION_PENDING,
-        "blockers": [
-            "per_pitch_to_per_pa_mapping_not_selected",
-            "production_coefficients_not_selected",
-            "coefficient_stability_not_validated",
-        ],
+        "state": ACTIVATION_ELIGIBLE,
+        "blockers": [],
+        "selected_parameterization": {
+            "schema_version":
+                "shadow_hitter_walk_skill_parameterization_v1",
+            "intercept":
+                -0.12043625608007737,
+            "slope":
+                0.5605462949774747,
+            "minimum_called_ball_rate":
+                0.2383177570093458,
+            "maximum_called_ball_rate":
+                0.5,
+            "outside_range_policy":
+                "fallback_to_actual_walk_rate",
+            "production_enabled": False,
+        },
         "fallback": "actual_walk_rate",
         "excluded_features": [
             "actual_walk_rate_blend_increment",
@@ -368,7 +379,13 @@ def synthesize_hitter_profile_activation_readiness(
                 "production_fallback",
             "blend_supported": False,
             "per_pitch_to_per_pa_mapping_required":
+                False,
+            "parameterization_selected":
                 True,
+            "activation_eligible":
+                True,
+            "production_enabled":
+                False,
         },
         "parameter_selected": False,
         "production_authority_changed": False,

--- a/mlb_app/simulation/shadow/hitter_walk_skill_parameterization.py
+++ b/mlb_app/simulation/shadow/hitter_walk_skill_parameterization.py
@@ -1,0 +1,227 @@
+"""Selected shadow hitter walk-skill parameterization."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+INTERCEPT = -0.12043625608007737
+SLOPE = 0.5605462949774747
+
+MINIMUM_CALLED_BALL_RATE = (
+    0.2383177570093458
+)
+MAXIMUM_CALLED_BALL_RATE = 0.5
+
+FOLD_COEFFICIENTS = (
+    (
+        -0.1316003330531189,
+        0.5914475805750489,
+    ),
+    (
+        -0.10621455198132441,
+        0.5205614482626899,
+    ),
+)
+
+RELATIVE_SLOPE_SPREAD = (
+    0.12749200856120468
+)
+MAXIMUM_PREDICTION_SPREAD = (
+    0.01005728508438497
+)
+
+BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT = 0.995
+BOOTSTRAP_CI_95 = (
+    9.329340466915365e-06,
+    9.386277643518045e-05,
+)
+
+
+def _rate(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(result)
+        or result < 0.0
+        or result > 1.0
+    ):
+        return None
+
+    return result
+
+
+def selected_hitter_walk_skill_parameterization(
+) -> dict[str, Any]:
+    """Return the frozen shadow-only walk mapping."""
+
+    return {
+        "schema_version":
+            "shadow_hitter_walk_skill_parameterization_v1",
+        "status": "selected",
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "selected_signal": "called_ball_rate",
+        "source_denominator": "pitches",
+        "target_denominator": "plate_appearances",
+        "mapping": {
+            "formula":
+                "bb_rate = intercept + slope * called_ball_rate",
+            "intercept": INTERCEPT,
+            "slope": SLOPE,
+            "output_clamp": {
+                "minimum": 0.0,
+                "maximum": 1.0,
+            },
+        },
+        "supported_input_range": {
+            "minimum_called_ball_rate":
+                MINIMUM_CALLED_BALL_RATE,
+            "maximum_called_ball_rate":
+                MAXIMUM_CALLED_BALL_RATE,
+            "outside_range_policy":
+                "fallback_to_actual_walk_rate",
+        },
+        "fallback": {
+            "signal": "actual_walk_rate",
+            "used_when": [
+                "called_ball_rate_missing",
+                "called_ball_rate_invalid",
+                "called_ball_rate_outside_evidence_range",
+            ],
+        },
+        "excluded_features": [
+            "actual_walk_rate_blend",
+            "take_rate",
+            "called_strike_rate",
+            "full_auxiliary_model",
+            "chase_rate",
+        ],
+        "selection_evidence": {
+            "sample_count": 2289,
+            "holdout_pa": 113016,
+            "seasons": [
+                2024,
+                2025,
+            ],
+            "relative_mse_improvement_over_actual_bb":
+                0.027927450312243456,
+            "bootstrap_probability_of_improvement":
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+            "bootstrap_mse_improvement_ci_95": {
+                "lower": BOOTSTRAP_CI_95[0],
+                "upper": BOOTSTRAP_CI_95[1],
+            },
+            "fold_coefficients": [
+                list(coefficients)
+                for coefficients in FOLD_COEFFICIENTS
+            ],
+            "relative_slope_spread":
+                RELATIVE_SLOPE_SPREAD,
+            "maximum_prediction_spread":
+                MAXIMUM_PREDICTION_SPREAD,
+            "selection_gates": {
+                "validation_ready": True,
+                "bootstrap_ready": True,
+                "bootstrap_probability_at_least_0_95":
+                    True,
+                "bootstrap_interval_fully_positive":
+                    True,
+                "all_fold_slopes_positive": True,
+                "relative_slope_spread_at_most_0_20":
+                    True,
+                "maximum_prediction_spread_at_most_0_02":
+                    True,
+            },
+        },
+        "activation": {
+            "activation_eligible": True,
+            "feature_flag_required": True,
+            "shadow_canary_required": True,
+            "production_enabled": False,
+        },
+    }
+
+
+def resolve_hitter_walk_rate(
+    *,
+    called_ball_rate: Any,
+    actual_walk_rate: Any,
+) -> dict[str, Any]:
+    """Resolve the selected mapping or its explicit fallback."""
+
+    called_ball = _rate(called_ball_rate)
+    actual_walk = _rate(actual_walk_rate)
+
+    fallback_reason = None
+
+    if called_ball is None:
+        fallback_reason = (
+            "called_ball_rate_missing"
+            if called_ball_rate is None
+            else "called_ball_rate_invalid"
+        )
+    elif not (
+        MINIMUM_CALLED_BALL_RATE
+        <= called_ball
+        <= MAXIMUM_CALLED_BALL_RATE
+    ):
+        fallback_reason = (
+            "called_ball_rate_outside_evidence_range"
+        )
+
+    if fallback_reason is not None:
+        if actual_walk is None:
+            return {
+                "status": "blocked",
+                "walk_rate": None,
+                "source": None,
+                "fallback_used": False,
+                "fallback_reason":
+                    fallback_reason,
+                "blockers": [
+                    "actual_walk_rate_fallback_unavailable",
+                ],
+                "parameter_selected": True,
+                "production_authority_changed": False,
+            }
+
+        return {
+            "status": "ready",
+            "walk_rate": actual_walk,
+            "source": "actual_walk_rate",
+            "fallback_used": True,
+            "fallback_reason":
+                fallback_reason,
+            "blockers": [],
+            "parameter_selected": True,
+            "production_authority_changed": False,
+        }
+
+    mapped = (
+        INTERCEPT
+        + SLOPE * called_ball
+    )
+    mapped = max(
+        0.0,
+        min(1.0, mapped),
+    )
+
+    return {
+        "status": "ready",
+        "walk_rate": mapped,
+        "source": "called_ball_rate",
+        "fallback_used": False,
+        "fallback_reason": None,
+        "blockers": [],
+        "parameter_selected": True,
+        "production_authority_changed": False,
+    }

--- a/scripts/audit_shadow_hitter_walk_skill_parameterization.py
+++ b/scripts/audit_shadow_hitter_walk_skill_parameterization.py
@@ -1,0 +1,191 @@
+"""Audit the selected shadow hitter walk parameterization."""
+
+from __future__ import annotations
+
+import json
+import math
+
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.hitter_walk_skill_parameterization import (
+    BOOTSTRAP_CI_95,
+    BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+    INTERCEPT,
+    MAXIMUM_CALLED_BALL_RATE,
+    MINIMUM_CALLED_BALL_RATE,
+    SLOPE,
+    selected_hitter_walk_skill_parameterization,
+)
+from mlb_app.simulation.shadow.hitter_walk_skill_validation import (
+    _clean,
+    _fit,
+    bootstrap_hitter_walk_skill_differences,
+    evaluate_hitter_walk_skill_models,
+)
+from scripts.audit_shadow_hitter_walk_skill import (
+    build_samples,
+)
+
+
+TOLERANCE = 1e-12
+
+
+def main() -> None:
+    factory = _session_factory()
+    session = factory()
+
+    try:
+        raw_samples, coverage = build_samples(
+            session
+        )
+    finally:
+        session.close()
+
+    samples = _clean(raw_samples)
+    validation = (
+        evaluate_hitter_walk_skill_models(
+            samples
+        )
+    )
+    bootstrap = (
+        bootstrap_hitter_walk_skill_differences(
+            samples
+        )
+    )
+
+    pooled = _fit(
+        samples,
+        ("pre_called_ball_rate",),
+    )
+    called_ball_rates = sorted(
+        row["pre_called_ball_rate"]
+        for row in samples
+    )
+
+    called_ball_evidence = bootstrap[
+        "comparisons"
+    ]["called_ball_minus_actual_bb"]
+
+    checks = {
+        "validation_ready":
+            validation["status"] == "ready",
+        "bootstrap_ready":
+            bootstrap["status"] == "ready",
+        "intercept_reproduced":
+            math.isclose(
+                pooled[0],
+                INTERCEPT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "slope_reproduced":
+            math.isclose(
+                pooled[1],
+                SLOPE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "minimum_input_reproduced":
+            math.isclose(
+                called_ball_rates[0],
+                MINIMUM_CALLED_BALL_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "maximum_input_reproduced":
+            math.isclose(
+                called_ball_rates[-1],
+                MAXIMUM_CALLED_BALL_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_probability_reproduced":
+            math.isclose(
+                called_ball_evidence[
+                    "probability_of_improvement"
+                ],
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_lower_reproduced":
+            math.isclose(
+                called_ball_evidence[
+                    "mse_improvement_ci_95"
+                ]["lower"],
+                BOOTSTRAP_CI_95[0],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_upper_reproduced":
+            math.isclose(
+                called_ball_evidence[
+                    "mse_improvement_ci_95"
+                ]["upper"],
+                BOOTSTRAP_CI_95[1],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+    }
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if not passed
+    )
+
+    print(
+        json.dumps(
+            {
+                "schema_version":
+                    "shadow_hitter_walk_skill_parameterization_audit_v1",
+                "status":
+                    "ready"
+                    if not blockers
+                    else "blocked",
+                "shadow_only": True,
+                "parameter_selected":
+                    not blockers,
+                "production_authority_changed":
+                    False,
+                "selected_parameterization":
+                    selected_hitter_walk_skill_parameterization(),
+                "recomputed_mapping": {
+                    "intercept": pooled[0],
+                    "slope": pooled[1],
+                    "minimum_called_ball_rate":
+                        called_ball_rates[0],
+                    "maximum_called_ball_rate":
+                        called_ball_rates[-1],
+                },
+                "sample_count": len(samples),
+                "holdout_pa": sum(
+                    row["holdout_pa"]
+                    for row in samples
+                ),
+                "seasons":
+                    validation["seasons"],
+                "window_count":
+                    len(coverage),
+                "checks": checks,
+                "blockers": blockers,
+                "activation": {
+                    "activation_eligible":
+                        not blockers,
+                    "feature_flag_required":
+                        True,
+                    "shadow_canary_required":
+                        True,
+                    "production_enabled":
+                        False,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_profile_activation_readiness.py
+++ b/tests/test_hitter_profile_activation_readiness.py
@@ -22,7 +22,7 @@ def test_synthesizes_current_readiness():
     )
     assert (
         result["activation_eligible_signals"]
-        == []
+        == ["walk_skill"]
     )
     assert set(
         result[
@@ -30,7 +30,6 @@ def test_synthesizes_current_readiness():
         ]
     ) == {
         "strikeout_skill",
-        "walk_skill",
         "power_skill",
         "hit_type_allocation",
     }
@@ -61,7 +60,24 @@ def test_walk_policy_selects_called_ball_only():
         result["walk_policy"][
             "per_pitch_to_per_pa_mapping_required"
         ]
+        is False
+    )
+    assert (
+        result["walk_policy"][
+            "parameterization_selected"
+        ]
         is True
+    )
+    assert (
+        walk["state"]
+        == ACTIVATION_ELIGIBLE
+    )
+    assert walk["blockers"] == []
+    assert (
+        walk["selected_parameterization"][
+            "production_enabled"
+        ]
+        is False
     )
 
 

--- a/tests/test_hitter_walk_skill_parameterization.py
+++ b/tests/test_hitter_walk_skill_parameterization.py
@@ -1,0 +1,159 @@
+import math
+
+from mlb_app.simulation.shadow.hitter_walk_skill_parameterization import (
+    INTERCEPT,
+    MAXIMUM_CALLED_BALL_RATE,
+    MINIMUM_CALLED_BALL_RATE,
+    SLOPE,
+    resolve_hitter_walk_rate,
+    selected_hitter_walk_skill_parameterization,
+)
+
+
+def test_selected_contract_is_shadow_only():
+    result = (
+        selected_hitter_walk_skill_parameterization()
+    )
+
+    assert result["status"] == "selected"
+    assert result["parameter_selected"] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+    assert (
+        result["selected_signal"]
+        == "called_ball_rate"
+    )
+    assert result["activation"] == {
+        "activation_eligible": True,
+        "feature_flag_required": True,
+        "shadow_canary_required": True,
+        "production_enabled": False,
+    }
+
+
+def test_selected_mapping_uses_pooled_coefficients():
+    result = (
+        selected_hitter_walk_skill_parameterization()
+    )
+
+    assert result["mapping"]["intercept"] == INTERCEPT
+    assert result["mapping"]["slope"] == SLOPE
+    assert (
+        result["supported_input_range"][
+            "minimum_called_ball_rate"
+        ]
+        == MINIMUM_CALLED_BALL_RATE
+    )
+    assert (
+        result["supported_input_range"][
+            "maximum_called_ball_rate"
+        ]
+        == MAXIMUM_CALLED_BALL_RATE
+    )
+
+
+def test_resolves_called_ball_mapping_inside_range():
+    result = resolve_hitter_walk_rate(
+        called_ball_rate=0.30,
+        actual_walk_rate=0.09,
+    )
+
+    assert result["status"] == "ready"
+    assert result["source"] == "called_ball_rate"
+    assert result["fallback_used"] is False
+    assert result["fallback_reason"] is None
+    assert math.isclose(
+        result["walk_rate"],
+        INTERCEPT + SLOPE * 0.30,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+
+
+def test_supported_range_is_inclusive():
+    lower = resolve_hitter_walk_rate(
+        called_ball_rate=MINIMUM_CALLED_BALL_RATE,
+        actual_walk_rate=0.09,
+    )
+    upper = resolve_hitter_walk_rate(
+        called_ball_rate=MAXIMUM_CALLED_BALL_RATE,
+        actual_walk_rate=0.09,
+    )
+
+    assert lower["source"] == "called_ball_rate"
+    assert upper["source"] == "called_ball_rate"
+
+
+def test_outside_range_uses_actual_walk_fallback():
+    result = resolve_hitter_walk_rate(
+        called_ball_rate=0.20,
+        actual_walk_rate=0.087,
+    )
+
+    assert result["status"] == "ready"
+    assert result["walk_rate"] == 0.087
+    assert result["source"] == "actual_walk_rate"
+    assert result["fallback_used"] is True
+    assert (
+        result["fallback_reason"]
+        == "called_ball_rate_outside_evidence_range"
+    )
+
+
+def test_missing_or_invalid_called_ball_uses_fallback():
+    missing = resolve_hitter_walk_rate(
+        called_ball_rate=None,
+        actual_walk_rate=0.08,
+    )
+    invalid = resolve_hitter_walk_rate(
+        called_ball_rate=float("nan"),
+        actual_walk_rate=0.08,
+    )
+
+    assert (
+        missing["fallback_reason"]
+        == "called_ball_rate_missing"
+    )
+    assert (
+        invalid["fallback_reason"]
+        == "called_ball_rate_invalid"
+    )
+    assert missing["walk_rate"] == 0.08
+    assert invalid["walk_rate"] == 0.08
+
+
+def test_blocks_when_mapping_and_fallback_are_unusable():
+    result = resolve_hitter_walk_rate(
+        called_ball_rate=0.10,
+        actual_walk_rate=None,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["walk_rate"] is None
+    assert result["source"] is None
+    assert result["blockers"] == [
+        "actual_walk_rate_fallback_unavailable",
+    ]
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_actual_walk_rate_is_not_blended():
+    result = resolve_hitter_walk_rate(
+        called_ball_rate=0.35,
+        actual_walk_rate=0.01,
+    )
+
+    expected = INTERCEPT + SLOPE * 0.35
+    assert math.isclose(
+        result["walk_rate"],
+        expected,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert result["walk_rate"] != 0.01


### PR DESCRIPTION
## Summary

- select a pooled called-ball-rate mapping for shadow hitter walk skill
- convert the per-pitch signal to projected per-PA walk rate using:
  `BB% = -0.12043625608007737 + 0.5605462949774747 × called_ball_rate`
- restrict the mapping to the observed called-ball-rate range `[0.2383177570093458, 0.5]`
- fall back to actual walk rate when called-ball evidence is missing, invalid, or outside that range
- mark walk skill activation-eligible in the readiness matrix while keeping production disabled
- add a live reproducibility audit for the frozen coefficients, evidence range, and bootstrap results

## Evidence

- 2,289 cutoff-safe samples across 2024–2025
- 113,016 held-out plate appearances
- called-ball rate improves cross-season MSE over actual BB rate by 2.79%
- clustered-bootstrap probability of improvement: 0.995
- 95% improvement interval is fully positive
- fold slopes: 0.59145 and 0.52056
- relative slope spread: 12.75%
- maximum prediction spread across the supported range: 1.01 percentage points
- adding actual walk rate as a blend was not selected

## Safety

- shadow-only parameterization
- no simulation or production authority change
- no feature flag enabled
- shadow canary remains required before activation
- actual walk rate remains the explicit fallback
- unrelated local audit/backtest/debug scripts are excluded

## Validation

- 121 hitter-profile tests passed
- focused parameterization/readiness contracts passed
- live reproducibility audit passed every gate
- Python compilation passed
- diff and whitespace checks passed