### PR TITLE
Calibrate hitter strikeout skill parameterization

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
+++ b/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
@@ -63,11 +63,21 @@ DEFAULT_SIGNAL_EVIDENCE = {
             "bootstrap_interval_fully_positive":
                 True,
         },
-        "state": PARAMETERIZATION_PENDING,
-        "blockers": [
-            "production_coefficients_not_selected",
-            "coefficient_stability_not_validated",
-        ],
+        "state": ACTIVATION_ELIGIBLE,
+        "blockers": [],
+        "selected_parameterization": {
+            "schema_version":
+                "shadow_hitter_strikeout_skill_parameterization_v1",
+            "intercept":
+                0.04501320822630234,
+            "actual_k_coefficient":
+                0.4339959775511906,
+            "whiff_coefficient":
+                0.34344736989394414,
+            "outside_range_policy":
+                "fallback_to_actual_strikeout_rate",
+            "production_enabled": False,
+        },
         "excluded_features": [
             "called_strike_rate",
             "swinging_strike_rate_increment",

--- a/mlb_app/simulation/shadow/hitter_strikeout_skill_parameterization.py
+++ b/mlb_app/simulation/shadow/hitter_strikeout_skill_parameterization.py
@@ -1,0 +1,279 @@
+"""Selected shadow hitter strikeout-skill parameterization."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+INTERCEPT = 0.04501320822630234
+ACTUAL_K_COEFFICIENT = 0.4339959775511906
+WHIFF_COEFFICIENT = 0.34344736989394414
+
+MINIMUM_ACTUAL_K_RATE = (
+    0.013513513513513514
+)
+MAXIMUM_ACTUAL_K_RATE = (
+    0.4888888888888889
+)
+MINIMUM_WHIFF_RATE = (
+    0.02857142857142857
+)
+MAXIMUM_WHIFF_RATE = (
+    0.4946236559139785
+)
+
+FOLD_COEFFICIENTS = (
+    (
+        0.04058515695596576,
+        0.3922078243165415,
+        0.3973261085148262,
+    ),
+    (
+        0.05029054609184294,
+        0.4771567108488448,
+        0.284833397731686,
+    ),
+)
+
+BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT = (
+    0.9975
+)
+BOOTSTRAP_CI_95 = (
+    5.427378025309307e-05,
+    0.0002162508715375169,
+)
+
+
+def _rate(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(result)
+        or result < 0.0
+        or result > 1.0
+    ):
+        return None
+
+    return result
+
+
+def selected_hitter_strikeout_skill_parameterization(
+) -> dict[str, Any]:
+    """Return the frozen shadow-only strikeout mapping."""
+
+    return {
+        "schema_version":
+            "shadow_hitter_strikeout_skill_parameterization_v1",
+        "status": "selected",
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "selected_signals": [
+            "actual_strikeout_rate",
+            "whiff_rate",
+        ],
+        "source_denominators": {
+            "actual_strikeout_rate":
+                "plate_appearances",
+            "whiff_rate": "swings",
+        },
+        "target_denominator":
+            "plate_appearances",
+        "mapping": {
+            "formula":
+                "k_rate = intercept"
+                " + actual_k_coefficient * actual_k_rate"
+                " + whiff_coefficient * whiff_rate",
+            "intercept": INTERCEPT,
+            "actual_k_coefficient":
+                ACTUAL_K_COEFFICIENT,
+            "whiff_coefficient":
+                WHIFF_COEFFICIENT,
+            "output_clamp": {
+                "minimum": 0.0,
+                "maximum": 1.0,
+            },
+        },
+        "supported_input_ranges": {
+            "actual_k_rate": {
+                "minimum":
+                    MINIMUM_ACTUAL_K_RATE,
+                "maximum":
+                    MAXIMUM_ACTUAL_K_RATE,
+            },
+            "whiff_rate": {
+                "minimum":
+                    MINIMUM_WHIFF_RATE,
+                "maximum":
+                    MAXIMUM_WHIFF_RATE,
+            },
+            "outside_range_policy":
+                "fallback_to_actual_strikeout_rate",
+        },
+        "fallback": {
+            "signal":
+                "actual_strikeout_rate",
+            "used_when": [
+                "actual_k_rate_missing",
+                "actual_k_rate_invalid",
+                "actual_k_rate_outside_evidence_range",
+                "whiff_rate_missing",
+                "whiff_rate_invalid",
+                "whiff_rate_outside_evidence_range",
+            ],
+        },
+        "excluded_features": [
+            "whiff_rate_alone",
+            "called_strike_rate_increment",
+            "swinging_strike_rate_increment",
+            "full_auxiliary_model",
+            "contact_rate_redundant_with_whiff_rate",
+        ],
+        "selection_evidence": {
+            "sample_count": 2283,
+            "holdout_pa": 112835,
+            "seasons": [
+                2024,
+                2025,
+            ],
+            "blend_relative_mse_improvement":
+                0.031632504725093616,
+            "bootstrap_probability_of_improvement":
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+            "bootstrap_mse_improvement_ci_95": {
+                "lower": BOOTSTRAP_CI_95[0],
+                "upper": BOOTSTRAP_CI_95[1],
+            },
+            "fold_coefficients": [
+                list(coefficients)
+                for coefficients
+                in FOLD_COEFFICIENTS
+            ],
+            "coefficient_stability": {
+                "intercept_absolute_spread":
+                    0.00970538913587718,
+                "actual_k_relative_spread":
+                    0.19542754068324814,
+                "whiff_relative_spread":
+                    0.32981351063218545,
+                "all_non_intercept_signs_stable":
+                    True,
+            },
+            "prediction_stability": {
+                "median_spread":
+                    0.0034591149395032383,
+                "p95_spread":
+                    0.010033095014830904,
+                "maximum_spread":
+                    0.020210620182578576,
+            },
+            "selection_basis":
+                "stable_cross_season_predictions",
+        },
+        "activation": {
+            "activation_eligible": True,
+            "feature_flag_required": True,
+            "shadow_canary_required": True,
+            "production_enabled": False,
+        },
+    }
+
+
+def resolve_hitter_strikeout_rate(
+    *,
+    actual_k_rate: Any,
+    whiff_rate: Any,
+) -> dict[str, Any]:
+    """Resolve the selected mapping or actual-K fallback."""
+
+    actual_k = _rate(actual_k_rate)
+    whiff = _rate(whiff_rate)
+
+    fallback_reason = None
+
+    if actual_k is None:
+        fallback_reason = (
+            "actual_k_rate_missing"
+            if actual_k_rate is None
+            else "actual_k_rate_invalid"
+        )
+    elif not (
+        MINIMUM_ACTUAL_K_RATE
+        <= actual_k
+        <= MAXIMUM_ACTUAL_K_RATE
+    ):
+        fallback_reason = (
+            "actual_k_rate_outside_evidence_range"
+        )
+    elif whiff is None:
+        fallback_reason = (
+            "whiff_rate_missing"
+            if whiff_rate is None
+            else "whiff_rate_invalid"
+        )
+    elif not (
+        MINIMUM_WHIFF_RATE
+        <= whiff
+        <= MAXIMUM_WHIFF_RATE
+    ):
+        fallback_reason = (
+            "whiff_rate_outside_evidence_range"
+        )
+
+    if fallback_reason is not None:
+        if actual_k is None:
+            return {
+                "status": "blocked",
+                "strikeout_rate": None,
+                "source": None,
+                "fallback_used": False,
+                "fallback_reason":
+                    fallback_reason,
+                "blockers": [
+                    "actual_strikeout_rate_fallback_unavailable",
+                ],
+                "parameter_selected": True,
+                "production_authority_changed": False,
+            }
+
+        return {
+            "status": "ready",
+            "strikeout_rate": actual_k,
+            "source":
+                "actual_strikeout_rate",
+            "fallback_used": True,
+            "fallback_reason":
+                fallback_reason,
+            "blockers": [],
+            "parameter_selected": True,
+            "production_authority_changed": False,
+        }
+
+    mapped = (
+        INTERCEPT
+        + ACTUAL_K_COEFFICIENT * actual_k
+        + WHIFF_COEFFICIENT * whiff
+    )
+    mapped = max(
+        0.0,
+        min(1.0, mapped),
+    )
+
+    return {
+        "status": "ready",
+        "strikeout_rate": mapped,
+        "source":
+            "actual_strikeout_rate_plus_whiff_rate",
+        "fallback_used": False,
+        "fallback_reason": None,
+        "blockers": [],
+        "parameter_selected": True,
+        "production_authority_changed": False,
+    }

--- a/scripts/audit_shadow_hitter_strikeout_skill_parameterization.py
+++ b/scripts/audit_shadow_hitter_strikeout_skill_parameterization.py
@@ -1,0 +1,232 @@
+"""Audit the selected shadow hitter strikeout parameterization."""
+
+from __future__ import annotations
+
+import json
+import math
+
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.hitter_strikeout_skill_parameterization import (
+    ACTUAL_K_COEFFICIENT,
+    BOOTSTRAP_CI_95,
+    BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+    INTERCEPT,
+    MAXIMUM_ACTUAL_K_RATE,
+    MAXIMUM_WHIFF_RATE,
+    MINIMUM_ACTUAL_K_RATE,
+    MINIMUM_WHIFF_RATE,
+    WHIFF_COEFFICIENT,
+    selected_hitter_strikeout_skill_parameterization,
+)
+from mlb_app.simulation.shadow.hitter_strikeout_skill_validation import (
+    _clean,
+    _fit,
+    bootstrap_hitter_strikeout_skill_differences,
+    evaluate_hitter_strikeout_skill_models,
+)
+from scripts.audit_shadow_hitter_strikeout_skill import (
+    build_samples,
+)
+
+
+TOLERANCE = 1e-12
+
+
+def main() -> None:
+    factory = _session_factory()
+    session = factory()
+
+    try:
+        raw_samples, coverage = build_samples(
+            session
+        )
+    finally:
+        session.close()
+
+    samples = _clean(raw_samples)
+    validation = (
+        evaluate_hitter_strikeout_skill_models(
+            samples
+        )
+    )
+    bootstrap = (
+        bootstrap_hitter_strikeout_skill_differences(
+            samples
+        )
+    )
+
+    pooled = _fit(
+        samples,
+        (
+            "pre_actual_k_rate",
+            "pre_whiff_rate",
+        ),
+    )
+
+    actual_k_rates = sorted(
+        row["pre_actual_k_rate"]
+        for row in samples
+    )
+    whiff_rates = sorted(
+        row["pre_whiff_rate"]
+        for row in samples
+    )
+
+    blend_evidence = bootstrap[
+        "comparisons"
+    ][
+        "blend_increment_over_best_univariate"
+    ]
+
+    checks = {
+        "validation_ready":
+            validation["status"] == "ready",
+        "bootstrap_ready":
+            bootstrap["status"] == "ready",
+        "intercept_reproduced":
+            math.isclose(
+                pooled[0],
+                INTERCEPT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "actual_k_coefficient_reproduced":
+            math.isclose(
+                pooled[1],
+                ACTUAL_K_COEFFICIENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "whiff_coefficient_reproduced":
+            math.isclose(
+                pooled[2],
+                WHIFF_COEFFICIENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "minimum_actual_k_reproduced":
+            math.isclose(
+                actual_k_rates[0],
+                MINIMUM_ACTUAL_K_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "maximum_actual_k_reproduced":
+            math.isclose(
+                actual_k_rates[-1],
+                MAXIMUM_ACTUAL_K_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "minimum_whiff_reproduced":
+            math.isclose(
+                whiff_rates[0],
+                MINIMUM_WHIFF_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "maximum_whiff_reproduced":
+            math.isclose(
+                whiff_rates[-1],
+                MAXIMUM_WHIFF_RATE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_probability_reproduced":
+            math.isclose(
+                blend_evidence[
+                    "probability_of_improvement"
+                ],
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_lower_reproduced":
+            math.isclose(
+                blend_evidence[
+                    "mse_improvement_ci_95"
+                ]["lower"],
+                BOOTSTRAP_CI_95[0],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_upper_reproduced":
+            math.isclose(
+                blend_evidence[
+                    "mse_improvement_ci_95"
+                ]["upper"],
+                BOOTSTRAP_CI_95[1],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+    }
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if not passed
+    )
+
+    print(
+        json.dumps(
+            {
+                "schema_version":
+                    "shadow_hitter_strikeout_skill_parameterization_audit_v1",
+                "status":
+                    "ready"
+                    if not blockers
+                    else "blocked",
+                "shadow_only": True,
+                "parameter_selected":
+                    not blockers,
+                "production_authority_changed":
+                    False,
+                "selected_parameterization":
+                    selected_hitter_strikeout_skill_parameterization(),
+                "recomputed_mapping": {
+                    "intercept": pooled[0],
+                    "actual_k_coefficient":
+                        pooled[1],
+                    "whiff_coefficient":
+                        pooled[2],
+                    "minimum_actual_k_rate":
+                        actual_k_rates[0],
+                    "maximum_actual_k_rate":
+                        actual_k_rates[-1],
+                    "minimum_whiff_rate":
+                        whiff_rates[0],
+                    "maximum_whiff_rate":
+                        whiff_rates[-1],
+                },
+                "sample_count": len(samples),
+                "holdout_pa": sum(
+                    row["holdout_pa"]
+                    for row in samples
+                ),
+                "seasons":
+                    validation["seasons"],
+                "window_count":
+                    len(coverage),
+                "checks": checks,
+                "blockers": blockers,
+                "activation": {
+                    "activation_eligible":
+                        not blockers,
+                    "feature_flag_required":
+                        True,
+                    "shadow_canary_required":
+                        True,
+                    "production_enabled":
+                        False,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_profile_activation_readiness.py
+++ b/tests/test_hitter_profile_activation_readiness.py
@@ -22,14 +22,16 @@ def test_synthesizes_current_readiness():
     )
     assert (
         result["activation_eligible_signals"]
-        == ["walk_skill"]
+        == [
+            "strikeout_skill",
+            "walk_skill",
+        ]
     )
     assert set(
         result[
             "parameterization_pending_signals"
         ]
     ) == {
-        "strikeout_skill",
         "power_skill",
         "hit_type_allocation",
     }
@@ -81,7 +83,7 @@ def test_walk_policy_selects_called_ball_only():
     )
 
 
-def test_strikeout_blend_remains_pending():
+def test_strikeout_blend_is_activation_eligible():
     result = (
         synthesize_hitter_profile_activation_readiness()
     )
@@ -92,8 +94,16 @@ def test_strikeout_blend_remains_pending():
     assert strikeout["candidate"] == (
         "actual_strikeout_rate_plus_whiff_rate"
     )
-    assert strikeout["state"] == (
-        "signal_supported_parameterization_pending"
+    assert (
+        strikeout["state"]
+        == ACTIVATION_ELIGIBLE
+    )
+    assert strikeout["blockers"] == []
+    assert (
+        strikeout["selected_parameterization"][
+            "production_enabled"
+        ]
+        is False
     )
 
 

--- a/tests/test_hitter_strikeout_skill_parameterization.py
+++ b/tests/test_hitter_strikeout_skill_parameterization.py
@@ -1,0 +1,167 @@
+import math
+
+from mlb_app.simulation.shadow.hitter_strikeout_skill_parameterization import (
+    ACTUAL_K_COEFFICIENT,
+    INTERCEPT,
+    MAXIMUM_ACTUAL_K_RATE,
+    MAXIMUM_WHIFF_RATE,
+    MINIMUM_ACTUAL_K_RATE,
+    MINIMUM_WHIFF_RATE,
+    WHIFF_COEFFICIENT,
+    resolve_hitter_strikeout_rate,
+    selected_hitter_strikeout_skill_parameterization,
+)
+
+
+def test_selected_contract_is_shadow_only():
+    result = (
+        selected_hitter_strikeout_skill_parameterization()
+    )
+
+    assert result["status"] == "selected"
+    assert result["parameter_selected"] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+    assert result["selected_signals"] == [
+        "actual_strikeout_rate",
+        "whiff_rate",
+    ]
+    assert result["activation"] == {
+        "activation_eligible": True,
+        "feature_flag_required": True,
+        "shadow_canary_required": True,
+        "production_enabled": False,
+    }
+
+
+def test_mapping_uses_pooled_coefficients():
+    result = (
+        selected_hitter_strikeout_skill_parameterization()
+    )
+    mapping = result["mapping"]
+
+    assert mapping["intercept"] == INTERCEPT
+    assert (
+        mapping["actual_k_coefficient"]
+        == ACTUAL_K_COEFFICIENT
+    )
+    assert (
+        mapping["whiff_coefficient"]
+        == WHIFF_COEFFICIENT
+    )
+
+
+def test_resolves_blended_mapping_inside_range():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=0.22,
+        whiff_rate=0.25,
+    )
+    expected = (
+        INTERCEPT
+        + ACTUAL_K_COEFFICIENT * 0.22
+        + WHIFF_COEFFICIENT * 0.25
+    )
+
+    assert result["status"] == "ready"
+    assert result["source"] == (
+        "actual_strikeout_rate_plus_whiff_rate"
+    )
+    assert result["fallback_used"] is False
+    assert math.isclose(
+        result["strikeout_rate"],
+        expected,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+
+
+def test_supported_ranges_are_inclusive():
+    lower = resolve_hitter_strikeout_rate(
+        actual_k_rate=MINIMUM_ACTUAL_K_RATE,
+        whiff_rate=MINIMUM_WHIFF_RATE,
+    )
+    upper = resolve_hitter_strikeout_rate(
+        actual_k_rate=MAXIMUM_ACTUAL_K_RATE,
+        whiff_rate=MAXIMUM_WHIFF_RATE,
+    )
+
+    assert lower["fallback_used"] is False
+    assert upper["fallback_used"] is False
+
+
+def test_missing_whiff_uses_actual_k_fallback():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=0.24,
+        whiff_rate=None,
+    )
+
+    assert result["status"] == "ready"
+    assert result["strikeout_rate"] == 0.24
+    assert (
+        result["source"]
+        == "actual_strikeout_rate"
+    )
+    assert result["fallback_used"] is True
+    assert (
+        result["fallback_reason"]
+        == "whiff_rate_missing"
+    )
+
+
+def test_outside_whiff_range_uses_fallback():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=0.24,
+        whiff_rate=0.01,
+    )
+
+    assert result["strikeout_rate"] == 0.24
+    assert result["fallback_used"] is True
+    assert result["fallback_reason"] == (
+        "whiff_rate_outside_evidence_range"
+    )
+
+
+def test_outside_actual_k_range_uses_same_actual_fallback():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=0.50,
+        whiff_rate=0.25,
+    )
+
+    assert result["status"] == "ready"
+    assert result["strikeout_rate"] == 0.50
+    assert result["fallback_used"] is True
+    assert result["fallback_reason"] == (
+        "actual_k_rate_outside_evidence_range"
+    )
+
+
+def test_blocks_without_actual_k_fallback():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=None,
+        whiff_rate=0.25,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["strikeout_rate"] is None
+    assert result["source"] is None
+    assert result["blockers"] == [
+        "actual_strikeout_rate_fallback_unavailable",
+    ]
+
+
+def test_whiff_rate_is_not_used_alone():
+    result = resolve_hitter_strikeout_rate(
+        actual_k_rate=None,
+        whiff_rate=0.30,
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "whiff_rate_alone"
+        in selected_hitter_strikeout_skill_parameterization()[
+            "excluded_features"
+        ]
+    )


### PR DESCRIPTION
## Summary

- select a pooled actual-K-rate plus whiff-rate mapping for shadow hitter strikeout skill
- use `K% = 0.04501320822630234 + 0.4339959775511906 × actual_K_rate + 0.34344736989394414 × whiff_rate`
- constrain both inputs to their observed evidence ranges
- fall back to actual strikeout rate when whiff evidence is missing, invalid, or outside support
- mark strikeout skill activation-eligible while keeping production disabled
- add a live audit that reproduces the frozen mapping, input ranges, and bootstrap evidence

## Evidence

- 2,283 cutoff-safe samples across 2024–2025
- 112,835 held-out plate appearances
- blend improves cross-season MSE by 3.16% over the best univariate model
- clustered-bootstrap probability of improvement: 0.9975
- 95% improvement interval: `[0.00005427, 0.00021625]`
- both actual-K and whiff coefficients remain positive across folds
- prediction spread: 0.35 percentage-point median, 1.00-point p95, 2.02-point maximum
- whiff rate alone is not selected
- called-strike, swinging-strike, and full auxiliary increments remain excluded

## Safety

- shadow-only parameterization
- no simulation or production authority change
- no feature flag enabled
- shadow canary remains required
- actual strikeout rate remains the explicit fallback
- unrelated local audit/backtest/debug scripts are excluded

## Validation

- 130 hitter-profile tests passed
- focused parameterization/readiness contracts passed
- live reproducibility audit passed every check
- Python compilation passed
- diff and whitespace checks passed