### PR TITLE
Calibrate hitter power skill parameterization

### DIFF
--- a/mlb_app/simulation/shadow/hitter_power_skill_parameterization.py
+++ b/mlb_app/simulation/shadow/hitter_power_skill_parameterization.py
@@ -1,0 +1,237 @@
+"""Selected shadow hitter power-skill parameterization."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+INTERCEPT = 0.08025334564396619
+EXPECTED_DAMAGE_COEFFICIENT = (
+    1.5145365016897803
+)
+
+MINIMUM_EXPECTED_DAMAGE_PER_AB = (
+    0.005903692307692304
+)
+MAXIMUM_EXPECTED_DAMAGE_PER_AB = (
+    0.1880161714254247
+)
+
+FOLD_COEFFICIENTS = (
+    (
+        0.08328975015864178,
+        1.462696501756593,
+    ),
+    (
+        0.07641492450475228,
+        1.5771476716029722,
+    ),
+)
+
+BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT = 1.0
+BOOTSTRAP_CI_95 = (
+    0.00030631363360671446,
+    0.0007716463476866683,
+)
+
+
+def _rate(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(result)
+        or result < 0.0
+        or result > 1.0
+    ):
+        return None
+
+    return result
+
+
+def selected_hitter_power_skill_parameterization(
+) -> dict[str, Any]:
+    """Return the frozen shadow-only power mapping."""
+
+    return {
+        "schema_version":
+            "shadow_hitter_power_skill_parameterization_v1",
+        "status": "selected",
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "selected_signal":
+            "expected_damage_per_ab",
+        "source_denominator":
+            "at_bats",
+        "target":
+            "isolated_power",
+        "target_denominator":
+            "at_bats",
+        "mapping": {
+            "formula":
+                "iso = intercept"
+                " + expected_damage_coefficient"
+                " * expected_damage_per_ab",
+            "intercept": INTERCEPT,
+            "expected_damage_coefficient":
+                EXPECTED_DAMAGE_COEFFICIENT,
+            "output_clamp": {
+                "minimum": 0.0,
+                "maximum": 1.0,
+            },
+        },
+        "supported_input_range": {
+            "minimum_expected_damage_per_ab":
+                MINIMUM_EXPECTED_DAMAGE_PER_AB,
+            "maximum_expected_damage_per_ab":
+                MAXIMUM_EXPECTED_DAMAGE_PER_AB,
+            "outside_range_policy":
+                "fallback_to_actual_iso",
+        },
+        "fallback": {
+            "signal": "actual_iso",
+            "used_when": [
+                "expected_damage_missing",
+                "expected_damage_invalid",
+                "expected_damage_outside_evidence_range",
+            ],
+        },
+        "excluded_features": [
+            "actual_iso_blend",
+            "hard_hit_rate_increment",
+            "barrel_proxy_increment",
+            "full_auxiliary_model",
+        ],
+        "selection_evidence": {
+            "sample_count": 1867,
+            "holdout_ab": 89625,
+            "seasons": [
+                2024,
+                2025,
+            ],
+            "relative_mse_improvement_over_actual_iso":
+                0.058420323214843806,
+            "actual_iso_blend_relative_improvement":
+                -0.0036500125063122315,
+            "bootstrap_probability_of_improvement":
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+            "bootstrap_mse_improvement_ci_95": {
+                "lower": BOOTSTRAP_CI_95[0],
+                "upper": BOOTSTRAP_CI_95[1],
+            },
+            "fold_coefficients": [
+                list(coefficients)
+                for coefficients
+                in FOLD_COEFFICIENTS
+            ],
+            "coefficient_stability": {
+                "intercept_absolute_spread":
+                    0.006874825653889499,
+                "relative_slope_spread":
+                    0.07530068208719427,
+                "all_fold_slopes_positive":
+                    True,
+            },
+            "prediction_stability": {
+                "median_spread":
+                    0.002043936385427353,
+                "p95_spread":
+                    0.005938486968585549,
+                "maximum_spread":
+                    0.014643845115787757,
+            },
+        },
+        "activation": {
+            "activation_eligible": True,
+            "feature_flag_required": True,
+            "shadow_canary_required": True,
+            "production_enabled": False,
+        },
+    }
+
+
+def resolve_hitter_iso(
+    *,
+    expected_damage_per_ab: Any,
+    actual_iso: Any,
+) -> dict[str, Any]:
+    """Resolve selected expected damage or actual-ISO fallback."""
+
+    expected_damage = _rate(
+        expected_damage_per_ab
+    )
+    actual = _rate(actual_iso)
+
+    fallback_reason = None
+
+    if expected_damage is None:
+        fallback_reason = (
+            "expected_damage_missing"
+            if expected_damage_per_ab is None
+            else "expected_damage_invalid"
+        )
+    elif not (
+        MINIMUM_EXPECTED_DAMAGE_PER_AB
+        <= expected_damage
+        <= MAXIMUM_EXPECTED_DAMAGE_PER_AB
+    ):
+        fallback_reason = (
+            "expected_damage_outside_evidence_range"
+        )
+
+    if fallback_reason is not None:
+        if actual is None:
+            return {
+                "status": "blocked",
+                "iso": None,
+                "source": None,
+                "fallback_used": False,
+                "fallback_reason":
+                    fallback_reason,
+                "blockers": [
+                    "actual_iso_fallback_unavailable",
+                ],
+                "parameter_selected": True,
+                "production_authority_changed": False,
+            }
+
+        return {
+            "status": "ready",
+            "iso": actual,
+            "source": "actual_iso",
+            "fallback_used": True,
+            "fallback_reason":
+                fallback_reason,
+            "blockers": [],
+            "parameter_selected": True,
+            "production_authority_changed": False,
+        }
+
+    mapped = (
+        INTERCEPT
+        + EXPECTED_DAMAGE_COEFFICIENT
+        * expected_damage
+    )
+    mapped = max(
+        0.0,
+        min(1.0, mapped),
+    )
+
+    return {
+        "status": "ready",
+        "iso": mapped,
+        "source":
+            "expected_damage_per_ab",
+        "fallback_used": False,
+        "fallback_reason": None,
+        "blockers": [],
+        "parameter_selected": True,
+        "production_authority_changed": False,
+    }

--- a/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
+++ b/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
@@ -143,12 +143,23 @@ DEFAULT_SIGNAL_EVIDENCE = {
             "bootstrap_interval_fully_positive":
                 True,
         },
-        "state": PARAMETERIZATION_PENDING,
-        "blockers": [
-            "production_coefficients_not_selected",
-            "coefficient_stability_not_validated",
-            "expected_damage_to_iso_mapping_not_selected",
-        ],
+        "state": ACTIVATION_ELIGIBLE,
+        "blockers": [],
+        "selected_parameterization": {
+            "schema_version":
+                "shadow_hitter_power_skill_parameterization_v1",
+            "intercept":
+                0.08025334564396619,
+            "expected_damage_coefficient":
+                1.5145365016897803,
+            "minimum_expected_damage_per_ab":
+                0.005903692307692304,
+            "maximum_expected_damage_per_ab":
+                0.1880161714254247,
+            "outside_range_policy":
+                "fallback_to_actual_iso",
+            "production_enabled": False,
+        },
         "excluded_features": [
             "hard_hit_increment",
             "barrel_proxy_increment",

--- a/scripts/audit_shadow_hitter_power_skill_parameterization.py
+++ b/scripts/audit_shadow_hitter_power_skill_parameterization.py
@@ -1,0 +1,233 @@
+"""Audit the selected shadow hitter power parameterization."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import math
+from pathlib import Path
+
+from mlb_app.simulation.shadow.hitter_power_incremental_validation import (
+    _clean_samples,
+    _fit,
+)
+from mlb_app.simulation.shadow.hitter_power_skill_parameterization import (
+    BOOTSTRAP_CI_95,
+    BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+    EXPECTED_DAMAGE_COEFFICIENT,
+    INTERCEPT,
+    MAXIMUM_EXPECTED_DAMAGE_PER_AB,
+    MINIMUM_EXPECTED_DAMAGE_PER_AB,
+    selected_hitter_power_skill_parameterization,
+)
+
+
+TOLERANCE = 1e-12
+
+
+def _run_source_audit() -> tuple[
+    dict,
+    list[dict],
+]:
+    source_path = (
+        Path(__file__).resolve().parent
+        / "audit_shadow_hitter_power_incremental_value.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "power_incremental_audit",
+        source_path,
+    )
+    audit = importlib.util.module_from_spec(
+        spec
+    )
+    spec.loader.exec_module(audit)
+
+    captured_samples = []
+    original_evaluate = (
+        audit.evaluate_hitter_power_incremental_models
+    )
+
+    def capture_evaluation(
+        samples,
+        *args,
+        **kwargs,
+    ):
+        captured_samples.extend(
+            dict(row)
+            for row in samples
+        )
+        return original_evaluate(
+            samples,
+            *args,
+            **kwargs,
+        )
+
+    audit.evaluate_hitter_power_incremental_models = (
+        capture_evaluation
+    )
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        audit.main()
+
+    return (
+        json.loads(stdout.getvalue()),
+        captured_samples,
+    )
+
+
+def main() -> None:
+    source_audit, raw_samples = (
+        _run_source_audit()
+    )
+    samples = _clean_samples(raw_samples)
+
+    pooled = _fit(
+        samples,
+        (
+            "pre_expected_damage_per_ab",
+        ),
+    )
+    expected_damage_values = sorted(
+        row["pre_expected_damage_per_ab"]
+        for row in samples
+    )
+
+    bootstrap = source_audit[
+        "clustered_bootstrap"
+    ]
+    expected_evidence = bootstrap[
+        "comparisons"
+    ][
+        "expected_damage_minus_actual_iso"
+    ]
+
+    checks = {
+        "validation_ready":
+            source_audit["status"] == "ready",
+        "bootstrap_ready":
+            bootstrap["status"] == "ready",
+        "intercept_reproduced":
+            math.isclose(
+                pooled[0],
+                INTERCEPT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "expected_damage_coefficient_reproduced":
+            math.isclose(
+                pooled[1],
+                EXPECTED_DAMAGE_COEFFICIENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "minimum_input_reproduced":
+            math.isclose(
+                expected_damage_values[0],
+                MINIMUM_EXPECTED_DAMAGE_PER_AB,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "maximum_input_reproduced":
+            math.isclose(
+                expected_damage_values[-1],
+                MAXIMUM_EXPECTED_DAMAGE_PER_AB,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_probability_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "probability_of_improvement"
+                ],
+                BOOTSTRAP_PROBABILITY_OF_IMPROVEMENT,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_lower_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "mse_improvement_ci_95"
+                ]["lower"],
+                BOOTSTRAP_CI_95[0],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_upper_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "mse_improvement_ci_95"
+                ]["upper"],
+                BOOTSTRAP_CI_95[1],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+    }
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if not passed
+    )
+
+    print(
+        json.dumps(
+            {
+                "schema_version":
+                    "shadow_hitter_power_skill_parameterization_audit_v1",
+                "status":
+                    "ready"
+                    if not blockers
+                    else "blocked",
+                "shadow_only": True,
+                "parameter_selected":
+                    not blockers,
+                "production_authority_changed":
+                    False,
+                "selected_parameterization":
+                    selected_hitter_power_skill_parameterization(),
+                "recomputed_mapping": {
+                    "intercept": pooled[0],
+                    "expected_damage_coefficient":
+                        pooled[1],
+                    "minimum_expected_damage_per_ab":
+                        expected_damage_values[0],
+                    "maximum_expected_damage_per_ab":
+                        expected_damage_values[-1],
+                },
+                "sample_count": len(samples),
+                "holdout_ab": sum(
+                    row["holdout_ab"]
+                    for row in samples
+                ),
+                "seasons":
+                    source_audit["seasons"],
+                "window_count":
+                    len(
+                        source_audit[
+                            "window_coverage"
+                        ]
+                    ),
+                "checks": checks,
+                "blockers": blockers,
+                "activation": {
+                    "activation_eligible":
+                        not blockers,
+                    "feature_flag_required":
+                        True,
+                    "shadow_canary_required":
+                        True,
+                    "production_enabled":
+                        False,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_power_skill_parameterization.py
+++ b/tests/test_hitter_power_skill_parameterization.py
@@ -1,0 +1,161 @@
+import math
+
+from mlb_app.simulation.shadow.hitter_power_skill_parameterization import (
+    EXPECTED_DAMAGE_COEFFICIENT,
+    INTERCEPT,
+    MAXIMUM_EXPECTED_DAMAGE_PER_AB,
+    MINIMUM_EXPECTED_DAMAGE_PER_AB,
+    resolve_hitter_iso,
+    selected_hitter_power_skill_parameterization,
+)
+
+
+def test_selected_contract_is_shadow_only():
+    result = (
+        selected_hitter_power_skill_parameterization()
+    )
+
+    assert result["status"] == "selected"
+    assert result["parameter_selected"] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+    assert (
+        result["selected_signal"]
+        == "expected_damage_per_ab"
+    )
+    assert result["activation"] == {
+        "activation_eligible": True,
+        "feature_flag_required": True,
+        "shadow_canary_required": True,
+        "production_enabled": False,
+    }
+
+
+def test_mapping_uses_pooled_coefficients():
+    result = (
+        selected_hitter_power_skill_parameterization()
+    )
+
+    assert result["mapping"]["intercept"] == INTERCEPT
+    assert (
+        result["mapping"][
+            "expected_damage_coefficient"
+        ]
+        == EXPECTED_DAMAGE_COEFFICIENT
+    )
+
+
+def test_resolves_expected_damage_inside_range():
+    result = resolve_hitter_iso(
+        expected_damage_per_ab=0.08,
+        actual_iso=0.17,
+    )
+    expected = (
+        INTERCEPT
+        + EXPECTED_DAMAGE_COEFFICIENT
+        * 0.08
+    )
+
+    assert result["status"] == "ready"
+    assert (
+        result["source"]
+        == "expected_damage_per_ab"
+    )
+    assert result["fallback_used"] is False
+    assert math.isclose(
+        result["iso"],
+        expected,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+
+
+def test_supported_range_is_inclusive():
+    lower = resolve_hitter_iso(
+        expected_damage_per_ab=(
+            MINIMUM_EXPECTED_DAMAGE_PER_AB
+        ),
+        actual_iso=0.15,
+    )
+    upper = resolve_hitter_iso(
+        expected_damage_per_ab=(
+            MAXIMUM_EXPECTED_DAMAGE_PER_AB
+        ),
+        actual_iso=0.15,
+    )
+
+    assert lower["fallback_used"] is False
+    assert upper["fallback_used"] is False
+
+
+def test_missing_expected_damage_uses_fallback():
+    result = resolve_hitter_iso(
+        expected_damage_per_ab=None,
+        actual_iso=0.175,
+    )
+
+    assert result["status"] == "ready"
+    assert result["iso"] == 0.175
+    assert result["source"] == "actual_iso"
+    assert result["fallback_used"] is True
+    assert (
+        result["fallback_reason"]
+        == "expected_damage_missing"
+    )
+
+
+def test_outside_range_uses_actual_iso_fallback():
+    result = resolve_hitter_iso(
+        expected_damage_per_ab=0.20,
+        actual_iso=0.18,
+    )
+
+    assert result["iso"] == 0.18
+    assert result["source"] == "actual_iso"
+    assert result["fallback_used"] is True
+    assert result["fallback_reason"] == (
+        "expected_damage_outside_evidence_range"
+    )
+
+
+def test_blocks_without_actual_iso_fallback():
+    result = resolve_hitter_iso(
+        expected_damage_per_ab=None,
+        actual_iso=None,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["iso"] is None
+    assert result["source"] is None
+    assert result["blockers"] == [
+        "actual_iso_fallback_unavailable",
+    ]
+
+
+def test_actual_iso_is_not_blended():
+    result = resolve_hitter_iso(
+        expected_damage_per_ab=0.10,
+        actual_iso=0.01,
+    )
+    expected = (
+        INTERCEPT
+        + EXPECTED_DAMAGE_COEFFICIENT
+        * 0.10
+    )
+
+    assert math.isclose(
+        result["iso"],
+        expected,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert result["iso"] != 0.01
+    assert (
+        "actual_iso_blend"
+        in selected_hitter_power_skill_parameterization()[
+            "excluded_features"
+        ]
+    )

--- a/tests/test_hitter_profile_activation_readiness.py
+++ b/tests/test_hitter_profile_activation_readiness.py
@@ -23,6 +23,7 @@ def test_synthesizes_current_readiness():
     assert (
         result["activation_eligible_signals"]
         == [
+            "power_skill",
             "strikeout_skill",
             "walk_skill",
         ]
@@ -32,7 +33,6 @@ def test_synthesizes_current_readiness():
             "parameterization_pending_signals"
         ]
     ) == {
-        "power_skill",
         "hit_type_allocation",
     }
 
@@ -107,7 +107,7 @@ def test_strikeout_blend_is_activation_eligible():
     )
 
 
-def test_expected_damage_is_power_candidate():
+def test_expected_damage_power_is_activation_eligible():
     result = (
         synthesize_hitter_profile_activation_readiness()
     )
@@ -115,6 +115,17 @@ def test_expected_damage_is_power_candidate():
 
     assert power["candidate"] == (
         "expected_damage"
+    )
+    assert (
+        power["state"]
+        == ACTIVATION_ELIGIBLE
+    )
+    assert power["blockers"] == []
+    assert (
+        power["selected_parameterization"][
+            "production_enabled"
+        ]
+        is False
     )
     assert "hard_hit_increment" in (
         power["excluded_features"]


### PR DESCRIPTION
## Summary

- select a pooled expected-damage-per-AB mapping for shadow hitter power skill
- use `ISO = 0.08025334564396619 + 1.5145365016897803 × expected_damage_per_AB`
- constrain expected damage to its observed evidence range
- fall back to actual ISO when expected damage is missing, invalid, or outside support
- mark power skill activation-eligible while keeping production disabled
- add a live audit that reproduces the frozen mapping, support range, and bootstrap evidence

## Evidence

- 1,867 cutoff-safe samples across 2024–2025
- 89,625 held-out at-bats
- expected damage improves cross-season MSE over actual ISO by 5.84%
- clustered-bootstrap probability of improvement: 1.0
- 95% improvement interval: `[0.00030631, 0.00077165]`
- fold slopes: 1.46270 and 1.57715
- relative slope spread: 7.53%
- prediction spread: 0.20 percentage-point median, 0.59-point p95, 1.46-point maximum
- blending actual ISO is not selected because it worsens MSE by 0.37%
- hard-hit, barrel-proxy, and full auxiliary increments remain excluded

## Safety

- shadow-only parameterization
- no simulation or production authority change
- no feature flag enabled
- shadow canary remains required
- actual ISO remains the explicit fallback
- unrelated local audit/backtest/debug scripts are excluded

## Validation

- 138 hitter-profile tests passed
- focused parameterization/readiness contracts passed
- live reproducibility audit passed every check
- Python compilation passed
- diff and whitespace checks passed