### PR TITLE
Select hitter hit-type allocation parameterization

### DIFF
--- a/mlb_app/simulation/shadow/hitter_hit_type_allocation_parameterization.py
+++ b/mlb_app/simulation/shadow/hitter_hit_type_allocation_parameterization.py
@@ -1,0 +1,322 @@
+"""Selected shadow hitter hit-type allocation parameterization."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+
+HIT_TYPES = (
+    "single",
+    "double",
+    "triple",
+    "home_run",
+)
+SELECTED_NON_TRIPLE_TYPES = (
+    "single",
+    "double",
+    "home_run",
+)
+
+EXPECTED_DAMAGE_COEFFICIENTS = {
+    "single": (
+        0.7528494269872082,
+        -1.417128517190727,
+    ),
+    "double": (
+        0.18342632599531214,
+        0.16515326588651238,
+    ),
+    "home_run": (
+        0.045412442752847434,
+        1.2559422367292983,
+    ),
+}
+
+MINIMUM_EXPECTED_DAMAGE_PER_BBE = (
+    0.010037499999999991
+)
+MAXIMUM_EXPECTED_DAMAGE_PER_BBE = (
+    0.2687966791454845
+)
+
+EXPECTED_BOOTSTRAP_PROBABILITY = 1.0
+EXPECTED_BOOTSTRAP_CI_95 = (
+    0.006337619580733706,
+    0.013231422817683957,
+)
+
+
+def _rate(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(result)
+        or result < 0.0
+        or result > 1.0
+    ):
+        return None
+
+    return result
+
+
+def _allocation(
+    value: Any,
+) -> dict[str, float] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    parsed = {
+        hit_type: _rate(
+            value.get(hit_type)
+        )
+        for hit_type in HIT_TYPES
+    }
+
+    if any(
+        item is None
+        for item in parsed.values()
+    ):
+        return None
+
+    total = sum(parsed.values())
+    if total <= 0.0:
+        return None
+
+    return {
+        hit_type:
+            parsed[hit_type] / total
+        for hit_type in HIT_TYPES
+    }
+
+
+def selected_hitter_hit_type_allocation_parameterization(
+) -> dict[str, Any]:
+    """Return the frozen conditional allocation contract."""
+
+    return {
+        "schema_version":
+            "shadow_hitter_hit_type_allocation_parameterization_v1",
+        "status": "selected",
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "allocation_condition":
+            "conditional_on_hit",
+        "selected_model":
+            "expected_damage",
+        "selected_signal":
+            "expected_damage_per_bbe",
+        "selected_outcomes": [
+            "single",
+            "double",
+            "home_run",
+        ],
+        "mapping": {
+            hit_type: {
+                "intercept":
+                    coefficients[0],
+                "expected_damage_coefficient":
+                    coefficients[1],
+            }
+            for hit_type, coefficients
+            in EXPECTED_DAMAGE_COEFFICIENTS.items()
+        },
+        "normalization_policy":
+            "normalize_selected_non_triples_to_remaining_mass",
+        "triple_policy": {
+            "selected_model_controls_triples":
+                False,
+            "policy":
+                "retain_current_conservative_triple_probability",
+            "reason":
+                "direct_speed_evidence_unavailable",
+        },
+        "supported_input_range": {
+            "minimum_expected_damage_per_bbe":
+                MINIMUM_EXPECTED_DAMAGE_PER_BBE,
+            "maximum_expected_damage_per_bbe":
+                MAXIMUM_EXPECTED_DAMAGE_PER_BBE,
+            "outside_range_policy":
+                "fallback_to_actual_allocation",
+        },
+        "fallback": {
+            "signal": "actual_allocation",
+            "used_when": [
+                "expected_damage_missing",
+                "expected_damage_invalid",
+                "expected_damage_outside_evidence_range",
+                "conservative_triple_probability_missing",
+                "conservative_triple_probability_invalid",
+            ],
+        },
+        "excluded_models": [
+            "actual_expected_blend",
+            "actual_expected_geometry",
+            "speed_based_triple_adjustment",
+        ],
+        "selection_evidence": {
+            "sample_count": 1329,
+            "holdout_hits": 19828,
+            "seasons": [
+                2024,
+                2025,
+            ],
+            "expected_relative_log_loss_improvement_over_actual":
+                0.0013222043312561623,
+            "expected_vs_league_bootstrap_probability":
+                EXPECTED_BOOTSTRAP_PROBABILITY,
+            "expected_vs_league_bootstrap_ci_95": {
+                "lower":
+                    EXPECTED_BOOTSTRAP_CI_95[0],
+                "upper":
+                    EXPECTED_BOOTSTRAP_CI_95[1],
+            },
+            "blend_increment_probability":
+                0.905,
+            "blend_increment_ci_crosses_zero":
+                True,
+            "prediction_stability": {
+                "metric":
+                    "total_variation_distance",
+                "median":
+                    0.00765036580673064,
+                "p95":
+                    0.01716114609187617,
+                "maximum":
+                    0.04109522139859782,
+            },
+        },
+        "activation": {
+            "activation_eligible": True,
+            "feature_flag_required": True,
+            "shadow_canary_required": True,
+            "production_enabled": False,
+        },
+    }
+
+
+def resolve_hitter_hit_type_allocation(
+    *,
+    expected_damage_per_bbe: Any,
+    conservative_triple_probability: Any,
+    actual_allocation: Any,
+) -> dict[str, Any]:
+    """Resolve selected non-triples or actual fallback."""
+
+    expected_damage = _rate(
+        expected_damage_per_bbe
+    )
+    triple_probability = _rate(
+        conservative_triple_probability
+    )
+    actual = _allocation(
+        actual_allocation
+    )
+
+    fallback_reason = None
+
+    if expected_damage is None:
+        fallback_reason = (
+            "expected_damage_missing"
+            if expected_damage_per_bbe is None
+            else "expected_damage_invalid"
+        )
+    elif not (
+        MINIMUM_EXPECTED_DAMAGE_PER_BBE
+        <= expected_damage
+        <= MAXIMUM_EXPECTED_DAMAGE_PER_BBE
+    ):
+        fallback_reason = (
+            "expected_damage_outside_evidence_range"
+        )
+    elif triple_probability is None:
+        fallback_reason = (
+            "conservative_triple_probability_missing"
+            if conservative_triple_probability
+            is None
+            else
+            "conservative_triple_probability_invalid"
+        )
+    elif triple_probability >= 1.0:
+        fallback_reason = (
+            "conservative_triple_probability_invalid"
+        )
+
+    if fallback_reason is not None:
+        if actual is None:
+            return {
+                "status": "blocked",
+                "allocation": None,
+                "source": None,
+                "fallback_used": False,
+                "fallback_reason":
+                    fallback_reason,
+                "blockers": [
+                    "actual_allocation_fallback_unavailable",
+                ],
+                "parameter_selected": True,
+                "production_authority_changed": False,
+            }
+
+        return {
+            "status": "ready",
+            "allocation": actual,
+            "source": "actual_allocation",
+            "fallback_used": True,
+            "fallback_reason":
+                fallback_reason,
+            "blockers": [],
+            "parameter_selected": True,
+            "production_authority_changed": False,
+        }
+
+    raw = {
+        hit_type: max(
+            coefficients[0]
+            + coefficients[1]
+            * expected_damage,
+            1e-12,
+        )
+        for hit_type, coefficients
+        in EXPECTED_DAMAGE_COEFFICIENTS.items()
+    }
+    raw_total = sum(raw.values())
+    remaining_mass = (
+        1.0 - triple_probability
+    )
+
+    allocation = {
+        hit_type:
+            remaining_mass
+            * raw[hit_type]
+            / raw_total
+        for hit_type
+        in SELECTED_NON_TRIPLE_TYPES
+    }
+    allocation["triple"] = (
+        triple_probability
+    )
+    allocation = {
+        hit_type: allocation[hit_type]
+        for hit_type in HIT_TYPES
+    }
+
+    return {
+        "status": "ready",
+        "allocation": allocation,
+        "source":
+            "expected_damage_with_conservative_triple",
+        "fallback_used": False,
+        "fallback_reason": None,
+        "blockers": [],
+        "parameter_selected": True,
+        "production_authority_changed": False,
+    }

--- a/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
+++ b/mlb_app/simulation/shadow/hitter_profile_activation_readiness.py
@@ -186,12 +186,24 @@ DEFAULT_SIGNAL_EVIDENCE = {
             "blend_increment_probability": 0.905,
             "geometry_increment_probability": 0.455,
         },
-        "state": PARAMETERIZATION_PENDING,
-        "blockers": [
-            "production_model_choice_not_selected",
-            "allocation_shrinkage_not_selected",
-            "triple_policy_restricted_without_speed",
-        ],
+        "state": ACTIVATION_ELIGIBLE,
+        "blockers": [],
+        "selected_parameterization": {
+            "schema_version":
+                "shadow_hitter_hit_type_allocation_parameterization_v1",
+            "selected_model":
+                "expected_damage",
+            "selected_outcomes": [
+                "single",
+                "double",
+                "home_run",
+            ],
+            "triple_policy":
+                "retain_current_conservative_triple_probability",
+            "outside_range_policy":
+                "fallback_to_actual_allocation",
+            "production_enabled": False,
+        },
         "excluded_features": [
             "actual_expected_blend_increment",
             "contact_geometry_increment",
@@ -373,8 +385,11 @@ def synthesize_hitter_profile_activation_readiness(
             context_only_signals,
         "activation_blockers":
             activation_blockers,
-        "recommended_next_slice":
-            RECOMMENDED_NEXT_SLICE,
+        "recommended_next_slice": (
+            "run_hitter_profile_shadow_canary"
+            if first_activation_ready
+            else RECOMMENDED_NEXT_SLICE
+        ),
         "first_activation_scope": {
             "include_only_after_selection": [
                 "strikeout_skill",
@@ -408,7 +423,8 @@ def synthesize_hitter_profile_activation_readiness(
             "production_enabled":
                 False,
         },
-        "parameter_selected": False,
+        "parameter_selected":
+            first_activation_ready,
         "production_authority_changed": False,
         "shadow_only": True,
     }

--- a/scripts/audit_shadow_hitter_hit_type_allocation_parameterization.py
+++ b/scripts/audit_shadow_hitter_hit_type_allocation_parameterization.py
@@ -1,0 +1,213 @@
+"""Audit the selected shadow hitter hit-type allocation."""
+
+from __future__ import annotations
+
+import json
+import math
+
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_parameterization import (
+    EXPECTED_BOOTSTRAP_CI_95,
+    EXPECTED_BOOTSTRAP_PROBABILITY,
+    EXPECTED_DAMAGE_COEFFICIENTS,
+    MAXIMUM_EXPECTED_DAMAGE_PER_BBE,
+    MINIMUM_EXPECTED_DAMAGE_PER_BBE,
+    selected_hitter_hit_type_allocation_parameterization,
+)
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_validation import (
+    MODEL_FEATURES,
+    _clean_samples,
+    _fit_model,
+    bootstrap_hitter_hit_type_allocation_differences,
+    evaluate_hitter_hit_type_allocation_models,
+)
+from scripts.audit_shadow_hitter_hit_type_allocation import (
+    build_samples,
+)
+
+
+TOLERANCE = 1e-12
+
+
+def main() -> None:
+    factory = _session_factory()
+    session = factory()
+
+    try:
+        raw_samples, coverage = build_samples(
+            session
+        )
+    finally:
+        session.close()
+
+    samples = _clean_samples(raw_samples)
+    validation = (
+        evaluate_hitter_hit_type_allocation_models(
+            samples
+        )
+    )
+    bootstrap = (
+        bootstrap_hitter_hit_type_allocation_differences(
+            samples
+        )
+    )
+
+    pooled = _fit_model(
+        samples,
+        MODEL_FEATURES["expected_damage"],
+    )
+    expected_damage_values = sorted(
+        row["pre_expected_damage_per_bbe"]
+        for row in samples
+    )
+    expected_evidence = bootstrap[
+        "comparisons"
+    ]["expected_minus_league_prior"]
+
+    checks = {
+        "validation_ready":
+            validation["status"] == "ready",
+        "bootstrap_ready":
+            bootstrap["status"] == "ready",
+        "minimum_input_reproduced":
+            math.isclose(
+                expected_damage_values[0],
+                MINIMUM_EXPECTED_DAMAGE_PER_BBE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "maximum_input_reproduced":
+            math.isclose(
+                expected_damage_values[-1],
+                MAXIMUM_EXPECTED_DAMAGE_PER_BBE,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_probability_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "probability_of_improvement"
+                ],
+                EXPECTED_BOOTSTRAP_PROBABILITY,
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_lower_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "log_loss_improvement_ci_95"
+                ]["lower"],
+                EXPECTED_BOOTSTRAP_CI_95[0],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+        "bootstrap_upper_reproduced":
+            math.isclose(
+                expected_evidence[
+                    "log_loss_improvement_ci_95"
+                ]["upper"],
+                EXPECTED_BOOTSTRAP_CI_95[1],
+                rel_tol=0.0,
+                abs_tol=TOLERANCE,
+            ),
+    }
+
+    for hit_type, selected in (
+        EXPECTED_DAMAGE_COEFFICIENTS.items()
+    ):
+        recomputed = pooled[hit_type]
+        checks[
+            f"{hit_type}_intercept_reproduced"
+        ] = math.isclose(
+            recomputed[0],
+            selected[0],
+            rel_tol=0.0,
+            abs_tol=TOLERANCE,
+        )
+        checks[
+            f"{hit_type}_coefficient_reproduced"
+        ] = math.isclose(
+            recomputed[1],
+            selected[1],
+            rel_tol=0.0,
+            abs_tol=TOLERANCE,
+        )
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if not passed
+    )
+
+    print(
+        json.dumps(
+            {
+                "schema_version":
+                    "shadow_hitter_hit_type_allocation_parameterization_audit_v1",
+                "status":
+                    "ready"
+                    if not blockers
+                    else "blocked",
+                "shadow_only": True,
+                "parameter_selected":
+                    not blockers,
+                "production_authority_changed":
+                    False,
+                "selected_parameterization":
+                    selected_hitter_hit_type_allocation_parameterization(),
+                "recomputed_mapping": {
+                    hit_type: {
+                        "intercept":
+                            coefficients[0],
+                        "expected_damage_coefficient":
+                            coefficients[1],
+                    }
+                    for hit_type, coefficients
+                    in pooled.items()
+                    if hit_type
+                    in EXPECTED_DAMAGE_COEFFICIENTS
+                },
+                "supported_input_range": {
+                    "minimum_expected_damage_per_bbe":
+                        expected_damage_values[0],
+                    "maximum_expected_damage_per_bbe":
+                        expected_damage_values[-1],
+                },
+                "sample_count": len(samples),
+                "holdout_hits": sum(
+                    row["holdout_hits"]
+                    for row in samples
+                ),
+                "seasons":
+                    validation["seasons"],
+                "window_count":
+                    len(coverage),
+                "checks": checks,
+                "blockers": blockers,
+                "triple_policy": {
+                    "selected_model_controls_triples":
+                        False,
+                    "policy":
+                        "retain_current_conservative_triple_probability",
+                },
+                "activation": {
+                    "activation_eligible":
+                        not blockers,
+                    "feature_flag_required":
+                        True,
+                    "shadow_canary_required":
+                        True,
+                    "production_enabled":
+                        False,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_hit_type_allocation_parameterization.py
+++ b/tests/test_hitter_hit_type_allocation_parameterization.py
@@ -1,0 +1,186 @@
+import math
+
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_parameterization import (
+    HIT_TYPES,
+    MAXIMUM_EXPECTED_DAMAGE_PER_BBE,
+    MINIMUM_EXPECTED_DAMAGE_PER_BBE,
+    resolve_hitter_hit_type_allocation,
+    selected_hitter_hit_type_allocation_parameterization,
+)
+
+
+ACTUAL = {
+    "single": 0.68,
+    "double": 0.19,
+    "triple": 0.03,
+    "home_run": 0.10,
+}
+
+
+def test_selected_contract_is_shadow_only():
+    result = (
+        selected_hitter_hit_type_allocation_parameterization()
+    )
+
+    assert result["status"] == "selected"
+    assert result["parameter_selected"] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["shadow_only"] is True
+    assert (
+        result["selected_model"]
+        == "expected_damage"
+    )
+    assert result["activation"] == {
+        "activation_eligible": True,
+        "feature_flag_required": True,
+        "shadow_canary_required": True,
+        "production_enabled": False,
+    }
+
+
+def test_selected_model_does_not_control_triples():
+    result = (
+        selected_hitter_hit_type_allocation_parameterization()
+    )
+
+    assert result["triple_policy"][
+        "selected_model_controls_triples"
+    ] is False
+    assert (
+        "speed_based_triple_adjustment"
+        in result["excluded_models"]
+    )
+
+
+def test_resolves_normalized_allocation():
+    result = (
+        resolve_hitter_hit_type_allocation(
+            expected_damage_per_bbe=0.10,
+            conservative_triple_probability=0.02,
+            actual_allocation=ACTUAL,
+        )
+    )
+    allocation = result["allocation"]
+
+    assert result["status"] == "ready"
+    assert result["fallback_used"] is False
+    assert result["source"] == (
+        "expected_damage_with_conservative_triple"
+    )
+    assert set(allocation) == set(HIT_TYPES)
+    assert math.isclose(
+        sum(allocation.values()),
+        1.0,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert allocation["triple"] == 0.02
+
+
+def test_damage_increases_home_run_share():
+    lower = resolve_hitter_hit_type_allocation(
+        expected_damage_per_bbe=0.05,
+        conservative_triple_probability=0.02,
+        actual_allocation=ACTUAL,
+    )
+    upper = resolve_hitter_hit_type_allocation(
+        expected_damage_per_bbe=0.20,
+        conservative_triple_probability=0.02,
+        actual_allocation=ACTUAL,
+    )
+
+    assert (
+        upper["allocation"]["home_run"]
+        > lower["allocation"]["home_run"]
+    )
+    assert (
+        upper["allocation"]["single"]
+        < lower["allocation"]["single"]
+    )
+
+
+def test_supported_range_is_inclusive():
+    lower = resolve_hitter_hit_type_allocation(
+        expected_damage_per_bbe=(
+            MINIMUM_EXPECTED_DAMAGE_PER_BBE
+        ),
+        conservative_triple_probability=0.02,
+        actual_allocation=ACTUAL,
+    )
+    upper = resolve_hitter_hit_type_allocation(
+        expected_damage_per_bbe=(
+            MAXIMUM_EXPECTED_DAMAGE_PER_BBE
+        ),
+        conservative_triple_probability=0.02,
+        actual_allocation=ACTUAL,
+    )
+
+    assert lower["fallback_used"] is False
+    assert upper["fallback_used"] is False
+
+
+def test_missing_damage_uses_actual_fallback():
+    result = (
+        resolve_hitter_hit_type_allocation(
+            expected_damage_per_bbe=None,
+            conservative_triple_probability=0.02,
+            actual_allocation=ACTUAL,
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["allocation"] == ACTUAL
+    assert result["source"] == "actual_allocation"
+    assert result["fallback_used"] is True
+    assert (
+        result["fallback_reason"]
+        == "expected_damage_missing"
+    )
+
+
+def test_missing_triple_policy_uses_actual_fallback():
+    result = (
+        resolve_hitter_hit_type_allocation(
+            expected_damage_per_bbe=0.10,
+            conservative_triple_probability=None,
+            actual_allocation=ACTUAL,
+        )
+    )
+
+    assert result["fallback_used"] is True
+    assert result["allocation"] == ACTUAL
+    assert result["fallback_reason"] == (
+        "conservative_triple_probability_missing"
+    )
+
+
+def test_blocks_without_valid_actual_fallback():
+    result = (
+        resolve_hitter_hit_type_allocation(
+            expected_damage_per_bbe=None,
+            conservative_triple_probability=None,
+            actual_allocation=None,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["allocation"] is None
+    assert result["blockers"] == [
+        "actual_allocation_fallback_unavailable",
+    ]
+
+
+def test_blend_and_geometry_are_not_selected():
+    result = (
+        selected_hitter_hit_type_allocation_parameterization()
+    )
+
+    assert "actual_expected_blend" in (
+        result["excluded_models"]
+    )
+    assert "actual_expected_geometry" in (
+        result["excluded_models"]
+    )

--- a/tests/test_hitter_profile_activation_readiness.py
+++ b/tests/test_hitter_profile_activation_readiness.py
@@ -14,27 +14,27 @@ def test_synthesizes_current_readiness():
 
     assert (
         result["status"]
-        == "not_ready_for_activation"
+        == "ready_for_activation"
     )
     assert (
         result["first_activation_ready"]
-        is False
+        is True
     )
     assert (
         result["activation_eligible_signals"]
         == [
+            "hit_type_allocation",
             "power_skill",
             "strikeout_skill",
             "walk_skill",
         ]
     )
-    assert set(
+    assert (
         result[
             "parameterization_pending_signals"
         ]
-    ) == {
-        "hit_type_allocation",
-    }
+        == []
+    )
 
 
 def test_walk_policy_selects_called_ball_only():
@@ -132,6 +132,37 @@ def test_expected_damage_power_is_activation_eligible():
     )
     assert "barrel_proxy_increment" in (
         power["excluded_features"]
+    )
+
+
+def test_hit_type_allocation_is_activation_eligible():
+    result = (
+        synthesize_hitter_profile_activation_readiness()
+    )
+    allocation = result["signals"][
+        "hit_type_allocation"
+    ]
+
+    assert (
+        allocation["state"]
+        == ACTIVATION_ELIGIBLE
+    )
+    assert allocation["blockers"] == []
+    assert (
+        allocation["selected_parameterization"][
+            "selected_model"
+        ]
+        == "expected_damage"
+    )
+    assert (
+        allocation["selected_parameterization"][
+            "production_enabled"
+        ]
+        is False
+    )
+    assert (
+        result["recommended_next_slice"]
+        == "run_hitter_profile_shadow_canary"
     )
 
 
@@ -235,7 +266,7 @@ def test_no_authority_or_selection():
         synthesize_hitter_profile_activation_readiness()
     )
 
-    assert result["parameter_selected"] is False
+    assert result["parameter_selected"] is True
     assert (
         result["production_authority_changed"]
         is False
@@ -281,8 +312,13 @@ def test_audit_script_reports_same_contract():
     assert payload == expected
     assert (
         payload["status"]
-        == "not_ready_for_activation"
+        == "ready_for_activation"
     )
+    assert (
+        payload["recommended_next_slice"]
+        == "run_hitter_profile_shadow_canary"
+    )
+    assert payload["parameter_selected"] is True
     assert (
         payload["walk_policy"][
             "supported_signal"


### PR DESCRIPTION
## Summary

- select expected damage as the single shadow hit-type allocation model
- freeze pooled mappings for single, double, and home-run relative shares
- preserve the current conservative triple probability because direct speed evidence remains unavailable
- normalize selected non-triple shares into the probability mass remaining after the retained triple probability
- fall back to actual allocation when expected damage or the conservative triple policy is unavailable
- move hit-type allocation to activation-eligible
- transition overall hitter-profile readiness to `ready_for_activation`
- recommend `run_hitter_profile_shadow_canary` as the next slice

## Evidence

- 1,329 cutoff-safe samples across 2024–2025
- 19,828 held-out hits
- expected-damage cross-season log loss: 0.969252
- actual-allocation cross-season log loss: 0.970535
- expected damage improves over actual allocation by 0.13%
- expected damage beats the league prior with bootstrap probability 1.0 and fully positive interval
- allocation prediction stability: 0.77% median, 1.72% p95, 4.11% maximum total-variation distance
- the actual/expected blend is excluded because its bootstrap interval crosses zero
- geometry and speed-based triple adjustments remain excluded

## Readiness milestone

Activation-eligible signals:
- strikeout skill
- walk skill
- power skill
- hit-type allocation

Still excluded or retained:
- current hit-skill policy remains unchanged because blend weights were unstable
- speed/triple enhancement remains evidence-blocked
- xwOBA remains evaluation context only

All supported parameterizations are now selected. This does **not** activate production authority; it permits the next feature-flagged shadow-canary slice.

## Safety

- shadow-only parameterization
- production authority unchanged
- no feature flag enabled
- no production model wiring changed
- current triple policy retained
- explicit actual-allocation fallback
- unrelated local audit/backtest/debug scripts excluded

## Validation

- 148 hitter-profile tests passed
- live allocation reproducibility audit passed every check
- readiness reports no pending parameterizations
- Python compilation passed
- diff and whitespace checks passed