### PR TITLE
Run hitter profile shadow canary

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_canary_signal_adapter.py
+++ b/mlb_app/simulation/shadow/hitter_profile_canary_signal_adapter.py
@@ -1,0 +1,538 @@
+"""Cutoff-safe Statcast signal adapter for the hitter canary."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+import statistics
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+SIGNAL_ADAPTER_SCHEMA_VERSION = (
+    "hitter_profile_canary_signal_adapter_v1"
+)
+
+AB_EVENTS = {
+    "field_out",
+    "force_out",
+    "grounded_into_double_play",
+    "field_error",
+    "fielders_choice",
+    "double_play",
+    "fielders_choice_out",
+    "triple_play",
+    "single",
+    "double",
+    "triple",
+    "home_run",
+    "strikeout",
+    "strikeout_double_play",
+}
+BBE_EVENTS = AB_EVENTS - {
+    "strikeout",
+    "strikeout_double_play",
+}
+HIT_EVENTS = {
+    "single",
+    "double",
+    "triple",
+    "home_run",
+}
+SWING_DESCRIPTIONS = {
+    "swinging_strike",
+    "swinging_strike_blocked",
+    "missed_bunt",
+    "foul",
+    "foul_tip",
+    "foul_bunt",
+    "bunt_foul_tip",
+    "hit_into_play",
+}
+WHIFF_DESCRIPTIONS = {
+    "swinging_strike",
+    "swinging_strike_blocked",
+    "missed_bunt",
+}
+CALLED_BALL_DESCRIPTIONS = {
+    "ball",
+    "blocked_ball",
+    "pitchout",
+    "automatic_ball",
+}
+SINGLE_WEIGHT = 0.90
+
+
+def _value(
+    row: Any,
+    key: str,
+) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return (
+        result
+        if math.isfinite(result)
+        else None
+    )
+
+
+def _date(value: Any) -> dt.date | None:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(
+            str(value)
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _terminal_rows(
+    rows: Sequence[Any],
+) -> list[Any]:
+    deduped = {}
+
+    for index, row in enumerate(rows):
+        game_pk = _value(row, "game_pk")
+        at_bat = _value(
+            row,
+            "at_bat_number",
+        )
+        row_id = _value(row, "id")
+
+        if (
+            game_pk is not None
+            and at_bat is not None
+        ):
+            key = (
+                int(game_pk),
+                int(at_bat),
+            )
+        else:
+            key = (
+                "row",
+                int(row_id or index),
+            )
+
+        order = (
+            _number(
+                _value(row, "pitch_number")
+            )
+            or 0.0,
+            _number(row_id) or float(index),
+        )
+        previous = deduped.get(key)
+
+        if (
+            previous is None
+            or order > previous[0]
+        ):
+            deduped[key] = (
+                order,
+                row,
+            )
+
+    return [
+        value[1]
+        for value in deduped.values()
+    ]
+
+
+def build_hitter_profile_canary_signals(
+    rows: Sequence[Any],
+    *,
+    player_id: int,
+    season: int,
+    split: str,
+    as_of_date: Any,
+    minimum_pitches: int = 100,
+    minimum_swings: int = 50,
+    minimum_ab: int = 50,
+    minimum_expected_bbe: int = 20,
+    minimum_expected_coverage: float = 0.80,
+    minimum_hits: int = 15,
+) -> dict[str, Any]:
+    """Build pre-cutoff canary signals from pitch rows."""
+
+    cutoff = _date(as_of_date)
+    expected_hand = (
+        "R"
+        if split == "vsR"
+        else "L"
+        if split == "vsL"
+        else None
+    )
+
+    filtered = []
+    for row in rows:
+        row_date = _date(
+            _value(row, "game_date")
+        )
+        batter_id = _value(
+            row,
+            "batter_id",
+        )
+        hand = _value(row, "p_throws")
+
+        if cutoff is None or row_date is None:
+            continue
+        if row_date > cutoff:
+            continue
+        if row_date.year != int(season):
+            continue
+        if (
+            batter_id is None
+            or int(batter_id)
+            != int(player_id)
+        ):
+            continue
+        if (
+            expected_hand is not None
+            and hand != expected_hand
+        ):
+            continue
+        filtered.append(row)
+
+    descriptions = [
+        str(
+            _value(row, "description")
+            or ""
+        )
+        for row in filtered
+    ]
+    pitch_count = len(filtered)
+    swing_count = sum(
+        description
+        in SWING_DESCRIPTIONS
+        for description in descriptions
+    )
+    whiff_count = sum(
+        description
+        in WHIFF_DESCRIPTIONS
+        for description in descriptions
+    )
+    called_ball_count = sum(
+        description
+        in CALLED_BALL_DESCRIPTIONS
+        for description in descriptions
+    )
+
+    terminal = [
+        row
+        for row in _terminal_rows(filtered)
+        if _value(row, "events")
+        in AB_EVENTS
+    ]
+    ab_count = len(terminal)
+    bbe = [
+        row
+        for row in terminal
+        if _value(row, "events")
+        in BBE_EVENTS
+    ]
+    expected_rows = [
+        row
+        for row in bbe
+        if (
+            _number(
+                _value(
+                    row,
+                    "estimated_ba_using_speedangle",
+                )
+            )
+            is not None
+            and _number(
+                _value(
+                    row,
+                    "estimated_woba_using_speedangle",
+                )
+            )
+            is not None
+        )
+    ]
+    expected_coverage = (
+        len(expected_rows) / len(bbe)
+        if bbe
+        else 0.0
+    )
+
+    expected_damage = [
+        max(
+            _number(
+                _value(
+                    row,
+                    "estimated_woba_using_speedangle",
+                )
+            )
+            - SINGLE_WEIGHT
+            * _number(
+                _value(
+                    row,
+                    "estimated_ba_using_speedangle",
+                )
+            ),
+            0.0,
+        )
+        for row in expected_rows
+    ]
+    expected_damage_per_bbe = (
+        statistics.fmean(
+            expected_damage
+        )
+        if expected_damage
+        else None
+    )
+    expected_damage_per_ab = (
+        expected_damage_per_bbe
+        * len(bbe)
+        / ab_count
+        if (
+            expected_damage_per_bbe
+            is not None
+            and ab_count > 0
+        )
+        else None
+    )
+
+    hit_counts = Counter(
+        _value(row, "events")
+        for row in terminal
+        if _value(row, "events")
+        in HIT_EVENTS
+    )
+    hit_count = sum(
+        hit_counts.values()
+    )
+    actual_allocation = (
+        {
+            hit_type:
+                hit_counts[hit_type]
+                / hit_count
+            for hit_type in (
+                "single",
+                "double",
+                "triple",
+                "home_run",
+            )
+        }
+        if hit_count > 0
+        else None
+    )
+
+    blockers = []
+    if cutoff is None:
+        blockers.append(
+            "invalid_as_of_date"
+        )
+    if expected_hand is None:
+        blockers.append(
+            "invalid_split"
+        )
+    if pitch_count < minimum_pitches:
+        blockers.append(
+            "insufficient_pre_cutoff_pitches"
+        )
+    if swing_count < minimum_swings:
+        blockers.append(
+            "insufficient_pre_cutoff_swings"
+        )
+    if ab_count < minimum_ab:
+        blockers.append(
+            "insufficient_pre_cutoff_ab"
+        )
+    if (
+        len(expected_rows)
+        < minimum_expected_bbe
+    ):
+        blockers.append(
+            "insufficient_expected_bbe"
+        )
+    if (
+        expected_coverage
+        < minimum_expected_coverage
+    ):
+        blockers.append(
+            "insufficient_expected_coverage"
+        )
+    if hit_count < minimum_hits:
+        blockers.append(
+            "insufficient_pre_cutoff_hits"
+        )
+
+    signals = {
+        "called_ball_rate": (
+            called_ball_count
+            / pitch_count
+            if pitch_count
+            else None
+        ),
+        "whiff_rate": (
+            whiff_count
+            / swing_count
+            if swing_count
+            else None
+        ),
+        "expected_damage_per_ab":
+            expected_damage_per_ab,
+        "expected_damage_per_bbe":
+            expected_damage_per_bbe,
+        "actual_allocation":
+            actual_allocation,
+    }
+
+    return {
+        "schema_version":
+            SIGNAL_ADAPTER_SCHEMA_VERSION,
+        "status": (
+            "blocked"
+            if blockers
+            else "ready"
+        ),
+        "shadow_only": True,
+        "production_authority_changed":
+            False,
+        "cutoff_safe": True,
+        "player_id": int(player_id),
+        "season": int(season),
+        "split": split,
+        "as_of_date": (
+            cutoff.isoformat()
+            if cutoff
+            else None
+        ),
+        "signals": signals,
+        "coverage": {
+            "pitch_count": pitch_count,
+            "swing_count": swing_count,
+            "whiff_count": whiff_count,
+            "called_ball_count":
+                called_ball_count,
+            "ab_count": ab_count,
+            "bbe_count": len(bbe),
+            "expected_bbe_count":
+                len(expected_rows),
+            "expected_coverage":
+                expected_coverage,
+            "hit_count": hit_count,
+        },
+        "blockers": sorted(
+            set(blockers)
+        ),
+    }
+
+
+def load_hitter_profile_canary_signals(
+    session: Any,
+    *,
+    player_id: int,
+    season: int,
+    split: str,
+    as_of_date: Any,
+) -> dict[str, Any]:
+    """Load cutoff-safe Statcast rows and build signals."""
+
+    from mlb_app.database import (
+        StatcastEvent,
+    )
+
+    cutoff = _date(as_of_date)
+    if cutoff is None:
+        return (
+            build_hitter_profile_canary_signals(
+                [],
+                player_id=player_id,
+                season=season,
+                split=split,
+                as_of_date=as_of_date,
+            )
+        )
+
+    hand = (
+        "R"
+        if split == "vsR"
+        else "L"
+        if split == "vsL"
+        else ""
+    )
+
+    rows = (
+        session.query(
+            StatcastEvent.id,
+            StatcastEvent.game_date,
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+            StatcastEvent.batter_id,
+            StatcastEvent.p_throws,
+            StatcastEvent.description,
+            StatcastEvent.events,
+            StatcastEvent.estimated_ba_using_speedangle,
+            StatcastEvent.estimated_woba_using_speedangle,
+        )
+        .filter(
+            StatcastEvent.game_date
+            >= dt.date(int(season), 1, 1),
+            StatcastEvent.game_date
+            <= cutoff,
+            StatcastEvent.batter_id
+            == int(player_id),
+            StatcastEvent.p_throws == hand,
+        )
+        .order_by(
+            StatcastEvent.game_date,
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+            StatcastEvent.id,
+        )
+        .all()
+    )
+
+    fieldnames = (
+        "id",
+        "game_date",
+        "game_pk",
+        "at_bat_number",
+        "pitch_number",
+        "batter_id",
+        "p_throws",
+        "description",
+        "events",
+        "estimated_ba_using_speedangle",
+        "estimated_woba_using_speedangle",
+    )
+    mappings = [
+        dict(zip(fieldnames, row))
+        for row in rows
+    ]
+
+    result = (
+        build_hitter_profile_canary_signals(
+            mappings,
+            player_id=player_id,
+            season=season,
+            split=split,
+            as_of_date=cutoff,
+        )
+    )
+    result["storage_evidence"] = {
+        "raw_row_count": len(mappings),
+        "source":
+            "statcast_events",
+        "query_cutoff":
+            cutoff.isoformat(),
+    }
+    return result

--- a/mlb_app/simulation/shadow/hitter_profile_shadow_canary.py
+++ b/mlb_app/simulation/shadow/hitter_profile_shadow_canary.py
@@ -1,0 +1,480 @@
+"""Feature-flagged hitter-profile shadow canary."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+from mlb_app.simulation.shadow.hitter_hit_type_allocation_parameterization import (
+    resolve_hitter_hit_type_allocation,
+)
+from mlb_app.simulation.shadow.hitter_power_skill_parameterization import (
+    resolve_hitter_iso,
+)
+from mlb_app.simulation.shadow.hitter_profile_activation_readiness import (
+    synthesize_hitter_profile_activation_readiness,
+)
+from mlb_app.simulation.shadow.hitter_strikeout_skill_parameterization import (
+    resolve_hitter_strikeout_rate,
+)
+from mlb_app.simulation.shadow.hitter_walk_skill_parameterization import (
+    resolve_hitter_walk_rate,
+)
+
+
+CANARY_SCHEMA_VERSION = (
+    "hitter_profile_shadow_canary_v1"
+)
+HIT_OUTCOME_KEYS = (
+    "single",
+    "double",
+    "triple",
+    "hr",
+)
+
+
+def _nested(
+    profile: Mapping[str, Any],
+    section: str,
+    key: str,
+) -> Any:
+    return (
+        profile.get(section) or {}
+    ).get(key)
+
+
+def _disabled_result() -> dict[str, Any]:
+    return {
+        "schema_version":
+            CANARY_SCHEMA_VERSION,
+        "status": "disabled",
+        "executed": False,
+        "feature_flag_enabled": False,
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "production_inputs_unchanged": True,
+        "candidate_profile": None,
+        "candidate_probabilities": None,
+        "production_probabilities": None,
+        "probability_deltas": None,
+        "fallback_telemetry": None,
+        "blockers": [],
+    }
+
+
+def run_hitter_profile_shadow_canary(
+    *,
+    enabled: bool = False,
+    production_batter_profile: Mapping[
+        str,
+        Any,
+    ],
+    pitcher_profile: Mapping[
+        str,
+        Any,
+    ]
+    | None = None,
+    environment_profile: Mapping[
+        str,
+        Any,
+    ]
+    | None = None,
+    candidate_signals: Mapping[
+        str,
+        Any,
+    ]
+    | None = None,
+    readiness: Mapping[
+        str,
+        Any,
+    ]
+    | None = None,
+) -> dict[str, Any]:
+    """Run a paired PA comparison without changing authority."""
+
+    if enabled is not True:
+        return _disabled_result()
+
+    production_original = copy.deepcopy(
+        dict(production_batter_profile)
+    )
+    production_input = copy.deepcopy(
+        production_original
+    )
+    signal_payload = dict(
+        candidate_signals or {}
+    )
+    signal_envelope = isinstance(
+        signal_payload.get("signals"),
+        Mapping,
+    )
+    signals = (
+        dict(signal_payload["signals"])
+        if signal_envelope
+        else signal_payload
+    )
+    readiness_payload = dict(
+        readiness
+        or synthesize_hitter_profile_activation_readiness()
+    )
+
+    blockers = []
+    if signal_envelope:
+        if (
+            signal_payload.get("status")
+            != "ready"
+        ):
+            blockers.append(
+                "candidate_signals_not_ready"
+            )
+        if (
+            signal_payload.get("cutoff_safe")
+            is not True
+        ):
+            blockers.append(
+                "candidate_signals_not_cutoff_safe"
+            )
+
+    if (
+        readiness_payload.get("status")
+        != "ready_for_activation"
+        or readiness_payload.get(
+            "first_activation_ready"
+        )
+        is not True
+        or readiness_payload.get(
+            "parameter_selected"
+        )
+        is not True
+    ):
+        blockers.append(
+            "hitter_profile_activation_not_ready"
+        )
+
+    pitcher = dict(
+        pitcher_profile or {}
+    )
+    environment = dict(
+        environment_profile or {}
+    )
+    production_model = (
+        build_pa_outcome_probabilities(
+            production_input,
+            pitcher,
+            environment,
+        )
+    )
+    production_probabilities = dict(
+        production_model["probabilities"]
+    )
+    production_hit_mass = sum(
+        production_probabilities[key]
+        for key in HIT_OUTCOME_KEYS
+    )
+    production_hit_allocation = (
+        {
+            "single":
+                production_probabilities[
+                    "single"
+                ]
+                / production_hit_mass,
+            "double":
+                production_probabilities[
+                    "double"
+                ]
+                / production_hit_mass,
+            "triple":
+                production_probabilities[
+                    "triple"
+                ]
+                / production_hit_mass,
+            "home_run":
+                production_probabilities[
+                    "hr"
+                ]
+                / production_hit_mass,
+        }
+        if production_hit_mass > 0.0
+        else None
+    )
+
+    strikeout = resolve_hitter_strikeout_rate(
+        actual_k_rate=_nested(
+            production_input,
+            "contact_skill",
+            "k_rate",
+        ),
+        whiff_rate=signals.get(
+            "whiff_rate"
+        ),
+    )
+    walk = resolve_hitter_walk_rate(
+        called_ball_rate=signals.get(
+            "called_ball_rate"
+        ),
+        actual_walk_rate=_nested(
+            production_input,
+            "plate_discipline",
+            "bb_rate",
+        ),
+    )
+    power = resolve_hitter_iso(
+        expected_damage_per_ab=signals.get(
+            "expected_damage_per_ab"
+        ),
+        actual_iso=_nested(
+            production_input,
+            "power",
+            "iso",
+        ),
+    )
+    allocation = (
+        resolve_hitter_hit_type_allocation(
+            expected_damage_per_bbe=signals.get(
+                "expected_damage_per_bbe"
+            ),
+            conservative_triple_probability=(
+                signals.get(
+                    "conservative_triple_probability",
+                    (
+                        production_hit_allocation[
+                            "triple"
+                        ]
+                        if production_hit_allocation
+                        is not None
+                        else None
+                    ),
+                )
+            ),
+            actual_allocation=(
+                signals.get(
+                    "actual_allocation"
+                )
+                or production_hit_allocation
+            ),
+        )
+    )
+
+    parameter_results = {
+        "strikeout_skill": strikeout,
+        "walk_skill": walk,
+        "power_skill": power,
+        "hit_type_allocation": allocation,
+    }
+
+    for name, result in (
+        parameter_results.items()
+    ):
+        if result.get("status") != "ready":
+            blockers.append(
+                f"{name}_not_ready"
+            )
+
+    if blockers:
+        return {
+            "schema_version":
+                CANARY_SCHEMA_VERSION,
+            "status": "blocked",
+            "executed": False,
+            "feature_flag_enabled": True,
+            "shadow_only": True,
+            "parameter_selected": True,
+            "production_authority_changed":
+                False,
+            "production_inputs_unchanged":
+                (
+                    dict(production_batter_profile)
+                    == production_original
+                ),
+            "candidate_profile": None,
+            "candidate_probabilities": None,
+            "production_probabilities": None,
+            "probability_deltas": None,
+            "parameter_results":
+                parameter_results,
+            "fallback_telemetry": None,
+            "blockers": sorted(
+                set(blockers)
+            ),
+        }
+
+    candidate_profile = copy.deepcopy(
+        production_input
+    )
+    candidate_profile.setdefault(
+        "contact_skill",
+        {},
+    )["k_rate"] = strikeout[
+        "strikeout_rate"
+    ]
+    candidate_profile.setdefault(
+        "plate_discipline",
+        {},
+    )["bb_rate"] = walk[
+        "walk_rate"
+    ]
+    candidate_profile.setdefault(
+        "power",
+        {},
+    )["iso"] = power["iso"]
+    candidate_profile.setdefault(
+        "metadata",
+        {},
+    ).update({
+        "source_type":
+            "selected_hitter_profile_shadow_canary",
+        "canary_schema_version":
+            CANARY_SCHEMA_VERSION,
+        "shadow_only": True,
+        "feature_flag_enabled": True,
+        "production_authority_changed":
+            False,
+        "hit_skill_policy":
+            "retain_current_policy",
+    })
+
+    candidate_model = (
+        build_pa_outcome_probabilities(
+            candidate_profile,
+            pitcher,
+            environment,
+        )
+    )
+    candidate_probabilities = dict(
+        candidate_model["probabilities"]
+    )
+
+    candidate_hit_mass = sum(
+        candidate_probabilities[key]
+        for key in HIT_OUTCOME_KEYS
+    )
+    selected_allocation = allocation[
+        "allocation"
+    ]
+
+    candidate_probabilities.update({
+        "single":
+            candidate_hit_mass
+            * selected_allocation[
+                "single"
+            ],
+        "double":
+            candidate_hit_mass
+            * selected_allocation[
+                "double"
+            ],
+        "triple":
+            candidate_hit_mass
+            * selected_allocation[
+                "triple"
+            ],
+        "hr":
+            candidate_hit_mass
+            * selected_allocation[
+                "home_run"
+            ],
+    })
+
+    probability_keys = sorted(
+        set(production_probabilities)
+        | set(candidate_probabilities)
+    )
+    deltas = {
+        key: (
+            candidate_probabilities.get(
+                key,
+                0.0,
+            )
+            - production_probabilities.get(
+                key,
+                0.0,
+            )
+        )
+        for key in probability_keys
+    }
+
+    fallback_by_signal = {
+        name: {
+            "fallback_used":
+                result["fallback_used"],
+            "fallback_reason":
+                result["fallback_reason"],
+            "source":
+                result["source"],
+        }
+        for name, result
+        in parameter_results.items()
+    }
+    fallback_count = sum(
+        item["fallback_used"]
+        for item
+        in fallback_by_signal.values()
+    )
+
+    return {
+        "schema_version":
+            CANARY_SCHEMA_VERSION,
+        "status": "ready",
+        "executed": True,
+        "feature_flag_enabled": True,
+        "shadow_only": True,
+        "parameter_selected": True,
+        "production_authority_changed": False,
+        "production_inputs_unchanged": (
+            dict(production_batter_profile)
+            == production_original
+        ),
+        "production_model_version":
+            production_model[
+                "model_version"
+            ],
+        "candidate_model_version":
+            candidate_model[
+                "model_version"
+            ],
+        "production_profile":
+            production_input,
+        "candidate_profile":
+            candidate_profile,
+        "production_probabilities":
+            production_probabilities,
+        "candidate_probabilities":
+            candidate_probabilities,
+        "probability_deltas": deltas,
+        "maximum_absolute_probability_delta":
+            max(
+                abs(value)
+                for value in deltas.values()
+            ),
+        "candidate_probability_sum":
+            sum(
+                candidate_probabilities.values()
+            ),
+        "candidate_hit_probability":
+            candidate_hit_mass,
+        "selected_hit_type_allocation":
+            selected_allocation,
+        "parameter_results":
+            parameter_results,
+        "fallback_telemetry": {
+            "signal_count":
+                len(parameter_results),
+            "fallback_count":
+                fallback_count,
+            "fallback_rate":
+                fallback_count
+                / len(parameter_results),
+            "by_signal":
+                fallback_by_signal,
+        },
+        "readiness_status":
+            readiness_payload.get(
+                "status"
+            ),
+        "blockers": [],
+    }

--- a/scripts/audit_shadow_hitter_profile_canary.py
+++ b/scripts/audit_shadow_hitter_profile_canary.py
@@ -1,0 +1,539 @@
+"""Run the read-only hitter-profile shadow canary audit."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import copy
+import datetime as dt
+import json
+import math
+from typing import Any, Iterable, Mapping
+
+from sqlalchemy import func
+
+from mlb_app.database import StatcastEvent
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.combined_hitter_profile import (
+    load_combined_shadow_hitter_profile,
+)
+from mlb_app.simulation.shadow.hitter_profile_activation_readiness import (
+    synthesize_hitter_profile_activation_readiness,
+)
+from mlb_app.simulation.shadow.hitter_profile_canary_signal_adapter import (
+    load_hitter_profile_canary_signals,
+)
+from mlb_app.simulation.shadow.hitter_profile_shadow_canary import (
+    run_hitter_profile_shadow_canary,
+)
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_shadow_canary_audit_v1"
+)
+OUTCOME_KEYS = (
+    "bb",
+    "double",
+    "hbp",
+    "hr",
+    "k",
+    "out",
+    "reached_on_error",
+    "single",
+    "triple",
+)
+
+
+def _date(value: Any) -> dt.date | None:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    try:
+        return dt.date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def percentile(
+    values: Iterable[float],
+    quantile: float,
+) -> float | None:
+    ordered = sorted(
+        float(value)
+        for value in values
+        if math.isfinite(float(value))
+    )
+    if not ordered:
+        return None
+    if len(ordered) == 1:
+        return ordered[0]
+
+    position = (
+        max(0.0, min(1.0, float(quantile)))
+        * (len(ordered) - 1)
+    )
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return ordered[lower]
+
+    fraction = position - lower
+    return (
+        ordered[lower]
+        + (
+            ordered[upper]
+            - ordered[lower]
+        )
+        * fraction
+    )
+
+
+def summarize_canary_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    season: int,
+    as_of_date: Any,
+    candidate_count: int,
+    limit: int | None,
+) -> dict[str, Any]:
+    rows = [
+        dict(record)
+        for record in records
+    ]
+    executed = [
+        row
+        for row in rows
+        if row.get("executed") is True
+    ]
+
+    state_counts = collections.Counter(
+        str(row.get("state") or "unknown")
+        for row in rows
+    )
+    blocker_counts = collections.Counter()
+    fallback_counts = collections.Counter()
+    maximum_deltas = []
+    probability_sums = []
+    absolute_outcome_deltas = {
+        key: []
+        for key in OUTCOME_KEYS
+    }
+
+    for row in rows:
+        blocker_counts.update(
+            row.get("blockers") or ()
+        )
+        canary = dict(
+            row.get("canary") or {}
+        )
+        telemetry = dict(
+            canary.get("fallback_telemetry")
+            or {}
+        )
+        for signal, payload in (
+            telemetry.get("by_signal") or {}
+        ).items():
+            if payload.get("fallback_used") is True:
+                fallback_counts[str(signal)] += 1
+
+        maximum_delta = canary.get(
+            "maximum_absolute_probability_delta"
+        )
+        if maximum_delta is not None:
+            maximum_deltas.append(
+                float(maximum_delta)
+            )
+
+        probability_sum = canary.get(
+            "candidate_probability_sum"
+        )
+        if probability_sum is not None:
+            probability_sums.append(
+                float(probability_sum)
+            )
+
+        for key, value in (
+            canary.get("probability_deltas")
+            or {}
+        ).items():
+            if (
+                key in absolute_outcome_deltas
+                and value is not None
+            ):
+                absolute_outcome_deltas[key].append(
+                    abs(float(value))
+                )
+
+    execution_count = len(executed)
+    fallback_total = sum(
+        fallback_counts.values()
+    )
+    possible_signal_count = (
+        execution_count * 4
+    )
+
+    production_inputs_unchanged = all(
+        (
+            row.get("canary") or {}
+        ).get("production_inputs_unchanged")
+        is True
+        for row in executed
+    )
+    production_authority_unchanged = all(
+        (
+            row.get("canary") or {}
+        ).get("production_authority_changed")
+        is False
+        for row in executed
+    )
+    probabilities_normalized = all(
+        0.999 <= value <= 1.001
+        for value in probability_sums
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "observed",
+        "season": int(season),
+        "as_of_date": str(as_of_date),
+        "candidate_population_count":
+            int(candidate_count),
+        "audit_limit": limit,
+        "audited_player_split_count":
+            len(rows),
+        "executed_player_split_count":
+            execution_count,
+        "execution_rate": (
+            execution_count / len(rows)
+            if rows
+            else 0.0
+        ),
+        "state_counts": dict(
+            sorted(state_counts.items())
+        ),
+        "blocker_counts": dict(
+            sorted(blocker_counts.items())
+        ),
+        "fallback_telemetry": {
+            "fallback_counts_by_signal": dict(
+                sorted(fallback_counts.items())
+            ),
+            "fallback_count": fallback_total,
+            "possible_signal_count":
+                possible_signal_count,
+            "fallback_rate": (
+                fallback_total
+                / possible_signal_count
+                if possible_signal_count
+                else 0.0
+            ),
+        },
+        "maximum_absolute_probability_delta": {
+            "median": percentile(
+                maximum_deltas,
+                0.50,
+            ),
+            "p95": percentile(
+                maximum_deltas,
+                0.95,
+            ),
+            "maximum": (
+                max(maximum_deltas)
+                if maximum_deltas
+                else None
+            ),
+        },
+        "absolute_probability_delta_by_outcome": {
+            key: {
+                "median": percentile(
+                    values,
+                    0.50,
+                ),
+                "p95": percentile(
+                    values,
+                    0.95,
+                ),
+                "maximum": (
+                    max(values)
+                    if values
+                    else None
+                ),
+            }
+            for key, values in (
+                absolute_outcome_deltas.items()
+            )
+        },
+        "safety_checks": {
+            "all_production_inputs_unchanged":
+                production_inputs_unchanged,
+            "all_production_authority_unchanged":
+                production_authority_unchanged,
+            "all_candidate_probabilities_normalized":
+                probabilities_normalized,
+            "database_writes_performed": False,
+        },
+        "decision": {
+            "production_activation_allowed": False,
+            "parameter_selected": False,
+            "promotion_thresholds_selected": False,
+            "recommended_next_slice":
+                "define_hitter_profile_canary_acceptance_gates",
+        },
+        "production_authority_changed": False,
+        "records": rows,
+    }
+
+
+def run_live_audit(
+    *,
+    season: int | None = None,
+    as_of_date: Any = None,
+    limit: int | None = 100,
+) -> dict[str, Any]:
+    factory = _session_factory()
+    session = factory()
+
+    try:
+        source_maximum = (
+            session.query(
+                func.max(StatcastEvent.game_date)
+            )
+            .scalar()
+        )
+        cutoff = (
+            _date(as_of_date)
+            or source_maximum
+        )
+        if cutoff is None:
+            return summarize_canary_records(
+                [],
+                season=(
+                    int(season)
+                    if season is not None
+                    else dt.date.today().year
+                ),
+                as_of_date=None,
+                candidate_count=0,
+                limit=limit,
+            )
+
+        target_season = int(
+            season or cutoff.year
+        )
+        query = (
+            session.query(
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+                func.count(
+                    StatcastEvent.id
+                ).label("row_count"),
+            )
+            .filter(
+                StatcastEvent.game_date
+                >= dt.date(target_season, 1, 1),
+                StatcastEvent.game_date <= cutoff,
+                StatcastEvent.p_throws.in_(
+                    ("R", "L")
+                ),
+            )
+            .group_by(
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+            )
+            .order_by(
+                func.count(
+                    StatcastEvent.id
+                ).desc(),
+                StatcastEvent.batter_id,
+                StatcastEvent.p_throws,
+            )
+        )
+        candidates = query.all()
+        candidate_count = len(candidates)
+        if limit is not None:
+            candidates = candidates[
+                : max(0, int(limit))
+            ]
+
+        readiness = (
+            synthesize_hitter_profile_activation_readiness()
+        )
+        records = []
+
+        for player_id, hand, row_count in candidates:
+            split = (
+                "vsR"
+                if hand == "R"
+                else "vsL"
+            )
+            record = {
+                "player_id": int(player_id),
+                "split": split,
+                "raw_row_count":
+                    int(row_count),
+                "state": "not_evaluated",
+                "executed": False,
+                "blockers": [],
+            }
+
+            try:
+                signals = (
+                    load_hitter_profile_canary_signals(
+                        session,
+                        player_id=int(player_id),
+                        season=target_season,
+                        split=split,
+                        as_of_date=cutoff,
+                    )
+                )
+                record["signal_status"] = (
+                    signals.get("status")
+                )
+                record["signal_coverage"] = dict(
+                    signals.get("coverage") or {}
+                )
+
+                if signals.get("status") != "ready":
+                    record["state"] = (
+                        "signal_evidence_blocked"
+                    )
+                    record["blockers"] = list(
+                        signals.get("blockers")
+                        or ()
+                    )
+                    records.append(record)
+                    continue
+
+                combined = (
+                    load_combined_shadow_hitter_profile(
+                        session,
+                        player_id=int(player_id),
+                        season=target_season,
+                        split=split,
+                        as_of_date=cutoff,
+                    )
+                )
+                record["combined_status"] = (
+                    combined.get("status")
+                )
+
+                if combined.get("status") != "ready":
+                    record["state"] = (
+                        "production_profile_blocked"
+                    )
+                    record["blockers"] = sorted(
+                        {
+                            blocker
+                            for blockers in (
+                                combined.get(
+                                    "evidence_blockers"
+                                )
+                                or {}
+                            ).values()
+                            for blocker in (
+                                blockers or ()
+                            )
+                        }
+                    )
+                    records.append(record)
+                    continue
+
+                production_profile = copy.deepcopy(
+                    dict(
+                        combined.get(
+                            "candidate_profile"
+                        )
+                        or {}
+                    )
+                )
+                production_original = copy.deepcopy(
+                    production_profile
+                )
+
+                canary = (
+                    run_hitter_profile_shadow_canary(
+                        enabled=True,
+                        production_batter_profile=(
+                            production_profile
+                        ),
+                        candidate_signals=signals,
+                        readiness=readiness,
+                    )
+                )
+                record["canary"] = canary
+                record["executed"] = (
+                    canary.get("executed")
+                    is True
+                )
+                record["state"] = (
+                    "executed"
+                    if canary.get("status")
+                    == "ready"
+                    else "canary_blocked"
+                )
+                record["blockers"] = list(
+                    canary.get("blockers")
+                    or ()
+                )
+                record[
+                    "production_profile_unchanged"
+                ] = (
+                    production_profile
+                    == production_original
+                )
+            except Exception as exc:
+                record["state"] = "audit_error"
+                record["blockers"] = [
+                    "audit_exception",
+                ]
+                record["error_type"] = (
+                    type(exc).__name__
+                )
+
+            records.append(record)
+
+        return summarize_canary_records(
+            records,
+            season=target_season,
+            as_of_date=cutoff.isoformat(),
+            candidate_count=candidate_count,
+            limit=limit,
+        )
+    finally:
+        session.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--season",
+        type=int,
+    )
+    parser.add_argument(
+        "--as-of-date",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+    )
+    args = parser.parse_args()
+
+    print(
+        json.dumps(
+            run_live_audit(
+                season=args.season,
+                as_of_date=args.as_of_date,
+                limit=args.limit,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_audit_shadow_hitter_profile_canary.py
+++ b/tests/test_audit_shadow_hitter_profile_canary.py
@@ -1,0 +1,143 @@
+from scripts.audit_shadow_hitter_profile_canary import (
+    percentile,
+    summarize_canary_records,
+)
+
+
+def canary(
+    maximum_delta,
+    *,
+    fallback=False,
+    normalized=True,
+):
+    return {
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+        "candidate_probability_sum": (
+            1.0 if normalized else 1.1
+        ),
+        "maximum_absolute_probability_delta":
+            maximum_delta,
+        "probability_deltas": {
+            "bb": -0.01,
+            "k": 0.02,
+        },
+        "fallback_telemetry": {
+            "by_signal": {
+                "walk_skill": {
+                    "fallback_used": fallback,
+                },
+                "strikeout_skill": {
+                    "fallback_used": False,
+                },
+                "power_skill": {
+                    "fallback_used": False,
+                },
+                "hit_type_allocation": {
+                    "fallback_used": False,
+                },
+            },
+        },
+    }
+
+
+def test_percentile_interpolates():
+    result = percentile(
+        [0.01, 0.03],
+        0.50,
+    )
+
+    assert result is not None
+    assert abs(result - 0.02) < 1e-15
+    assert percentile([], 0.95) is None
+
+
+def test_summarizes_population_canary():
+    records = [
+        {
+            "state": "executed",
+            "executed": True,
+            "blockers": [],
+            "canary": canary(0.04),
+        },
+        {
+            "state": "executed",
+            "executed": True,
+            "blockers": [],
+            "canary": canary(
+                0.02,
+                fallback=True,
+            ),
+        },
+        {
+            "state": "signal_evidence_blocked",
+            "executed": False,
+            "blockers": [
+                "insufficient_expected_coverage",
+            ],
+        },
+    ]
+
+    result = summarize_canary_records(
+        records,
+        season=2026,
+        as_of_date="2026-05-03",
+        candidate_count=10,
+        limit=3,
+    )
+
+    assert result["status"] == "observed"
+    assert (
+        result["executed_player_split_count"]
+        == 2
+    )
+    assert result["state_counts"] == {
+        "executed": 2,
+        "signal_evidence_blocked": 1,
+    }
+    assert result["blocker_counts"] == {
+        "insufficient_expected_coverage": 1,
+    }
+    assert result[
+        "fallback_telemetry"
+    ]["fallback_count"] == 1
+    assert result[
+        "maximum_absolute_probability_delta"
+    ]["median"] == 0.03
+    assert result["safety_checks"][
+        "all_production_inputs_unchanged"
+    ] is True
+    assert result["safety_checks"][
+        "all_candidate_probabilities_normalized"
+    ] is True
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_detects_probability_normalization_failure():
+    result = summarize_canary_records(
+        [
+            {
+                "state": "executed",
+                "executed": True,
+                "blockers": [],
+                "canary": canary(
+                    0.04,
+                    normalized=False,
+                ),
+            },
+        ],
+        season=2026,
+        as_of_date="2026-05-03",
+        candidate_count=1,
+        limit=1,
+    )
+
+    assert result["safety_checks"][
+        "all_candidate_probabilities_normalized"
+    ] is False

--- a/tests/test_hitter_profile_canary_signal_adapter.py
+++ b/tests/test_hitter_profile_canary_signal_adapter.py
@@ -1,0 +1,237 @@
+import datetime as dt
+
+from mlb_app.simulation.shadow.hitter_profile_canary_signal_adapter import (
+    build_hitter_profile_canary_signals,
+)
+
+
+def rows():
+    result = []
+    row_id = 0
+
+    for at_bat in range(1, 61):
+        event = (
+            "single"
+            if at_bat <= 12
+            else "double"
+            if at_bat <= 18
+            else "triple"
+            if at_bat == 19
+            else "home_run"
+            if at_bat <= 23
+            else "strikeout"
+            if at_bat <= 33
+            else "field_out"
+        )
+
+        for pitch_number in (1, 2):
+            row_id += 1
+            terminal = (
+                pitch_number == 2
+            )
+            description = (
+                "ball"
+                if pitch_number == 1
+                else "hit_into_play"
+                if event
+                not in {
+                    "strikeout",
+                }
+                else "swinging_strike"
+            )
+            result.append({
+                "id": row_id,
+                "game_date":
+                    dt.date(2026, 7, 1),
+                "game_pk": 1,
+                "at_bat_number":
+                    at_bat,
+                "pitch_number":
+                    pitch_number,
+                "batter_id": 7,
+                "p_throws": "R",
+                "description":
+                    description,
+                "events":
+                    event
+                    if terminal
+                    else None,
+                "estimated_ba_using_speedangle":
+                    (
+                        0.30
+                        if terminal
+                        and event
+                        != "strikeout"
+                        else None
+                    ),
+                "estimated_woba_using_speedangle":
+                    (
+                        0.42
+                        if terminal
+                        and event
+                        != "strikeout"
+                        else None
+                    ),
+            })
+
+    return result
+
+
+def test_builds_cutoff_safe_signals():
+    result = (
+        build_hitter_profile_canary_signals(
+            rows(),
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["cutoff_safe"] is True
+    assert (
+        result[
+            "production_authority_changed"
+        ]
+        is False
+    )
+    assert result["coverage"][
+        "pitch_count"
+    ] == 120
+    assert result["coverage"][
+        "ab_count"
+    ] == 60
+    assert result["signals"][
+        "called_ball_rate"
+    ] == 0.5
+    assert result["signals"][
+        "whiff_rate"
+    ] > 0
+
+
+def test_expected_damage_definitions():
+    result = (
+        build_hitter_profile_canary_signals(
+            rows(),
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+    signals = result["signals"]
+
+    assert signals[
+        "expected_damage_per_bbe"
+    ] > 0
+    assert signals[
+        "expected_damage_per_ab"
+    ] > 0
+    assert (
+        signals[
+            "expected_damage_per_ab"
+        ]
+        < signals[
+            "expected_damage_per_bbe"
+        ]
+    )
+
+
+def test_builds_actual_hit_allocation():
+    result = (
+        build_hitter_profile_canary_signals(
+            rows(),
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+    allocation = result[
+        "signals"
+    ]["actual_allocation"]
+
+    assert allocation == {
+        "single": 12 / 23,
+        "double": 6 / 23,
+        "triple": 1 / 23,
+        "home_run": 4 / 23,
+    }
+    assert sum(allocation.values()) == 1.0
+
+
+def test_excludes_post_cutoff_rows():
+    payload = rows()
+    future = dict(payload[-1])
+    future["id"] = 999
+    future["game_date"] = (
+        dt.date(2026, 8, 1)
+    )
+    payload.append(future)
+
+    result = (
+        build_hitter_profile_canary_signals(
+            payload,
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+
+    assert result["coverage"][
+        "pitch_count"
+    ] == 120
+
+
+def test_blocks_insufficient_samples():
+    result = (
+        build_hitter_profile_canary_signals(
+            rows()[:20],
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "insufficient_pre_cutoff_pitches"
+        in result["blockers"]
+    )
+    assert (
+        "insufficient_pre_cutoff_ab"
+        in result["blockers"]
+    )
+
+
+def test_filters_player_and_split():
+    payload = rows()
+    wrong_player = dict(payload[0])
+    wrong_player["id"] = 1001
+    wrong_player["batter_id"] = 99
+    wrong_hand = dict(payload[0])
+    wrong_hand["id"] = 1002
+    wrong_hand["p_throws"] = "L"
+    payload.extend(
+        [
+            wrong_player,
+            wrong_hand,
+        ]
+    )
+
+    result = (
+        build_hitter_profile_canary_signals(
+            payload,
+            player_id=7,
+            season=2026,
+            split="vsR",
+            as_of_date="2026-07-31",
+        )
+    )
+
+    assert result["coverage"][
+        "pitch_count"
+    ] == 120

--- a/tests/test_hitter_profile_shadow_canary.py
+++ b/tests/test_hitter_profile_shadow_canary.py
@@ -1,0 +1,414 @@
+import copy
+import math
+
+from mlb_app.simulation.shadow.hitter_profile_shadow_canary import (
+    run_hitter_profile_shadow_canary,
+)
+
+
+def production_profile():
+    return {
+        "contact_skill": {
+            "k_rate": 0.22,
+            "contact_rate": 0.74,
+            "hit_skill": 0.27,
+        },
+        "plate_discipline": {
+            "bb_rate": 0.09,
+        },
+        "power": {
+            "iso": 0.17,
+            "barrel_rate": 0.08,
+            "hard_hit_rate": 0.39,
+        },
+        "metadata": {
+            "source_type": "production_test",
+        },
+    }
+
+
+def signals():
+    return {
+        "whiff_rate": 0.25,
+        "called_ball_rate": 0.32,
+        "expected_damage_per_ab": 0.08,
+        "expected_damage_per_bbe": 0.10,
+        "conservative_triple_probability":
+            0.02,
+        "actual_allocation": {
+            "single": 0.68,
+            "double": 0.19,
+            "triple": 0.03,
+            "home_run": 0.10,
+        },
+    }
+
+
+def pitcher_profile():
+    return {
+        "bat_missing": {
+            "k_rate": 0.24,
+        },
+        "command_control": {
+            "bb_rate": 0.08,
+        },
+        "contact_management": {
+            "barrel_rate_allowed": 0.08,
+            "hard_hit_rate_allowed": 0.38,
+            "xba_allowed": 0.25,
+        },
+    }
+
+
+def environment_profile():
+    return {
+        "run_environment": {
+            "hr_boost_index": 1.0,
+            "hit_boost_index": 1.0,
+            "run_scoring_index": 1.0,
+        },
+    }
+
+
+def test_disabled_by_default():
+    result = run_hitter_profile_shadow_canary(
+        production_batter_profile=(
+            production_profile()
+        ),
+        candidate_signals=signals(),
+    )
+
+    assert result["status"] == "disabled"
+    assert result["executed"] is False
+    assert (
+        result["feature_flag_enabled"]
+        is False
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_enabled_canary_preserves_production_input():
+    production = production_profile()
+    original = copy.deepcopy(production)
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=production,
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=signals(),
+    )
+
+    assert result["status"] == "ready"
+    assert result["executed"] is True
+    assert production == original
+    assert (
+        result["production_inputs_unchanged"]
+        is True
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_applies_selected_k_bb_and_iso():
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=signals(),
+    )
+    candidate = result["candidate_profile"]
+
+    assert (
+        candidate["contact_skill"]["k_rate"]
+        != 0.22
+    )
+    assert (
+        candidate["plate_discipline"]["bb_rate"]
+        != 0.09
+    )
+    assert candidate["power"]["iso"] != 0.17
+    assert (
+        candidate["contact_skill"]["hit_skill"]
+        == 0.27
+    )
+
+
+def test_reallocates_hit_mass_and_retains_triple_policy():
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=signals(),
+    )
+    probabilities = result[
+        "candidate_probabilities"
+    ]
+    hit_mass = sum(
+        probabilities[key]
+        for key in (
+            "single",
+            "double",
+            "triple",
+            "hr",
+        )
+    )
+
+    assert math.isclose(
+        hit_mass,
+        result["candidate_hit_probability"],
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert math.isclose(
+        probabilities["triple"],
+        hit_mass * 0.02,
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+    assert math.isclose(
+        result["candidate_probability_sum"],
+        sum(probabilities.values()),
+        rel_tol=0.0,
+        abs_tol=1e-15,
+    )
+
+
+def test_reports_paired_probability_deltas():
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=signals(),
+    )
+
+    assert set(
+        result["production_probabilities"]
+    ) == set(
+        result["candidate_probabilities"]
+    )
+    assert (
+        result[
+            "maximum_absolute_probability_delta"
+        ]
+        > 0
+    )
+    assert (
+        result["candidate_probability_sum"]
+        > 0.999
+    )
+    assert (
+        result["candidate_probability_sum"]
+        < 1.001
+    )
+
+
+def test_derives_current_triple_policy_from_production():
+    derived_signals = signals()
+    derived_signals.pop(
+        "conservative_triple_probability"
+    )
+    derived_signals.pop(
+        "actual_allocation"
+    )
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=derived_signals,
+    )
+
+    production = result[
+        "production_probabilities"
+    ]
+    production_hit_mass = sum(
+        production[key]
+        for key in (
+            "single",
+            "double",
+            "triple",
+            "hr",
+        )
+    )
+    expected_triple_share = (
+        production["triple"]
+        / production_hit_mass
+    )
+
+    assert result["status"] == "ready"
+    assert result[
+        "selected_hit_type_allocation"
+    ]["triple"] == expected_triple_share
+    assert (
+        result["parameter_results"][
+            "hit_type_allocation"
+        ]["fallback_used"]
+        is False
+    )
+
+
+def test_reports_signal_fallbacks():
+    fallback_signals = signals()
+    fallback_signals["whiff_rate"] = None
+    fallback_signals[
+        "called_ball_rate"
+    ] = None
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=fallback_signals,
+    )
+
+    telemetry = result[
+        "fallback_telemetry"
+    ]
+    assert telemetry["fallback_count"] == 2
+    assert telemetry["fallback_rate"] == 0.5
+    assert telemetry["by_signal"][
+        "strikeout_skill"
+    ]["fallback_used"] is True
+    assert telemetry["by_signal"][
+        "walk_skill"
+    ]["fallback_used"] is True
+
+
+def test_blocks_when_fallback_is_unavailable():
+    production = production_profile()
+    production["contact_skill"][
+        "k_rate"
+    ] = None
+    blocked_signals = signals()
+    blocked_signals["whiff_rate"] = None
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=production,
+        candidate_signals=blocked_signals,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["executed"] is False
+    assert (
+        "strikeout_skill_not_ready"
+        in result["blockers"]
+    )
+
+
+def test_blocks_when_readiness_is_not_ready():
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        candidate_signals=signals(),
+        readiness={
+            "status":
+                "not_ready_for_activation",
+            "first_activation_ready": False,
+            "parameter_selected": False,
+        },
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "hitter_profile_activation_not_ready"
+        in result["blockers"]
+    )
+
+def test_accepts_ready_signal_adapter_envelope():
+    envelope = {
+        "status": "ready",
+        "cutoff_safe": True,
+        "blockers": [],
+        "signals": signals(),
+        "coverage": {
+            "pitch_count": 120,
+            "swing_count": 60,
+            "ab_count": 60,
+            "bbe_count": 40,
+            "expected_bbe_count": 40,
+            "expected_coverage": 1.0,
+            "hit_count": 23,
+        },
+        "shadow_only": True,
+        "production_authority_changed": False,
+    }
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        pitcher_profile=pitcher_profile(),
+        environment_profile=environment_profile(),
+        candidate_signals=envelope,
+    )
+
+    assert result["status"] == "ready"
+    assert result["executed"] is True
+    assert (
+        result["fallback_telemetry"][
+            "fallback_count"
+        ]
+        == 0
+    )
+    assert (
+        result[
+            "maximum_absolute_probability_delta"
+        ]
+        > 0
+    )
+
+
+def test_blocks_non_ready_signal_adapter_envelope():
+    envelope = {
+        "status": "blocked",
+        "cutoff_safe": True,
+        "blockers": [
+            "insufficient_expected_coverage",
+        ],
+        "signals": signals(),
+        "shadow_only": True,
+        "production_authority_changed": False,
+    }
+
+    result = run_hitter_profile_shadow_canary(
+        enabled=True,
+        production_batter_profile=(
+            production_profile()
+        ),
+        candidate_signals=envelope,
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "candidate_signals_not_ready"
+        in result["blockers"]
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## Summary

- add a cutoff-safe Statcast signal adapter for the selected hitter walk, strikeout, power, and hit-type parameterizations
- add an explicitly enabled, shadow-only paired PA canary that preserves production inputs and authority
- add a read-only population audit with coverage, fallback, probability-delta, normalization, and safety telemetry
- preserve the current hit-skill policy and conservative triple allocation policy

## Why

All four supported hitter-profile parameterizations are selected, but production activation requires an observed canary. This slice establishes that canary and measures its behavior without changing simulation authority.

The live audit of the top 100 current-season player/splits observed 31 eligible executions, zero fallbacks across 124 eligible signal applications, normalized candidate probabilities, immutable production inputs, and no production authority change. It also observed material coverage limits and a p95 maximum absolute outcome-probability delta of 0.07765, so this PR does not enable production activation or select promotion thresholds.

## Validation

- 168 hitter tests passed
- Python compilation passed
- diff and new-file whitespace checks passed
- live single-player canary: four selected signals applied, zero fallbacks, probability sum 1.0, maximum absolute delta 0.0397
- live population audit: 31/100 executed, zero eligible-signal fallbacks, safety checks passed

## Follow-up

Define hitter-profile canary acceptance gates using the observed coverage and probability-delta distributions before any production activation.