### PR TITLE
Define hitter profile canary acceptance gates

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_canary_acceptance_gate.py
+++ b/mlb_app/simulation/shadow/hitter_profile_canary_acceptance_gate.py
@@ -1,0 +1,281 @@
+"""Acceptance gates for hitter-profile shadow canary evidence."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_canary_acceptance_gate_v1"
+)
+
+MINIMUM_AUDITED_PLAYER_SPLITS = 250
+MINIMUM_EXECUTED_PLAYER_SPLITS = 50
+MINIMUM_EXECUTION_RATE = 0.20
+MAXIMUM_FALLBACK_RATE = 0.05
+
+MAXIMUM_MEDIAN_PROBABILITY_DELTA = 0.05
+MAXIMUM_P95_PROBABILITY_DELTA = 0.08
+MAXIMUM_OBSERVED_PROBABILITY_DELTA = 0.10
+
+OUTCOME_P95_LIMITS = {
+    "bb": 0.05,
+    "hr": 0.03,
+    "k": 0.05,
+    "out": 0.08,
+}
+
+
+def _number(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return (
+        result
+        if math.isfinite(result)
+        else None
+    )
+
+
+def _at_least(
+    value: Any,
+    minimum: float,
+) -> bool:
+    parsed = _number(value)
+    return (
+        parsed is not None
+        and parsed >= minimum
+    )
+
+
+def _at_most(
+    value: Any,
+    maximum: float,
+) -> bool:
+    parsed = _number(value)
+    return (
+        parsed is not None
+        and parsed <= maximum
+    )
+
+
+def evaluate_hitter_profile_canary_acceptance(
+    audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate observed canary evidence without enabling production."""
+
+    payload = dict(audit)
+    safety = dict(
+        payload.get("safety_checks") or {}
+    )
+    fallback = dict(
+        payload.get("fallback_telemetry") or {}
+    )
+    maximum_delta = dict(
+        payload.get(
+            "maximum_absolute_probability_delta"
+        )
+        or {}
+    )
+    outcome_deltas = dict(
+        payload.get(
+            "absolute_probability_delta_by_outcome"
+        )
+        or {}
+    )
+    state_counts = dict(
+        payload.get("state_counts") or {}
+    )
+
+    outcome_checks = {
+        outcome: _at_most(
+            (
+                outcome_deltas.get(outcome)
+                or {}
+            ).get("p95"),
+            limit,
+        )
+        for outcome, limit in (
+            OUTCOME_P95_LIMITS.items()
+        )
+    }
+
+    checks = {
+        "audit_status_observed": (
+            payload.get("status")
+            == "observed"
+        ),
+        "minimum_audited_player_splits": (
+            _at_least(
+                payload.get(
+                    "audited_player_split_count"
+                ),
+                MINIMUM_AUDITED_PLAYER_SPLITS,
+            )
+        ),
+        "minimum_executed_player_splits": (
+            _at_least(
+                payload.get(
+                    "executed_player_split_count"
+                ),
+                MINIMUM_EXECUTED_PLAYER_SPLITS,
+            )
+        ),
+        "minimum_execution_rate": (
+            _at_least(
+                payload.get("execution_rate"),
+                MINIMUM_EXECUTION_RATE,
+            )
+        ),
+        "maximum_fallback_rate": (
+            _at_most(
+                fallback.get("fallback_rate"),
+                MAXIMUM_FALLBACK_RATE,
+            )
+        ),
+        "zero_audit_errors": (
+            int(
+                state_counts.get(
+                    "audit_error",
+                    0,
+                )
+                or 0
+            )
+            == 0
+        ),
+        "production_inputs_unchanged": (
+            safety.get(
+                "all_production_inputs_unchanged"
+            )
+            is True
+        ),
+        "production_authority_unchanged": (
+            safety.get(
+                "all_production_authority_unchanged"
+            )
+            is True
+            and payload.get(
+                "production_authority_changed"
+            )
+            is False
+        ),
+        "candidate_probabilities_normalized": (
+            safety.get(
+                "all_candidate_probabilities_normalized"
+            )
+            is True
+        ),
+        "database_writes_absent": (
+            safety.get(
+                "database_writes_performed"
+            )
+            is False
+        ),
+        "maximum_median_probability_delta": (
+            _at_most(
+                maximum_delta.get("median"),
+                MAXIMUM_MEDIAN_PROBABILITY_DELTA,
+            )
+        ),
+        "maximum_p95_probability_delta": (
+            _at_most(
+                maximum_delta.get("p95"),
+                MAXIMUM_P95_PROBABILITY_DELTA,
+            )
+        ),
+        "maximum_observed_probability_delta": (
+            _at_most(
+                maximum_delta.get("maximum"),
+                MAXIMUM_OBSERVED_PROBABILITY_DELTA,
+            )
+        ),
+        **{
+            f"{outcome}_p95_probability_delta":
+                passed
+            for outcome, passed in (
+                outcome_checks.items()
+            )
+        },
+    }
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if passed is not True
+    )
+    gate_passed = not blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "accepted_for_feature_flag_integration"
+            if gate_passed
+            else "blocked"
+        ),
+        "gate_passed": gate_passed,
+        "checks": checks,
+        "blockers": blockers,
+        "thresholds": {
+            "minimum_audited_player_splits":
+                MINIMUM_AUDITED_PLAYER_SPLITS,
+            "minimum_executed_player_splits":
+                MINIMUM_EXECUTED_PLAYER_SPLITS,
+            "minimum_execution_rate":
+                MINIMUM_EXECUTION_RATE,
+            "maximum_fallback_rate":
+                MAXIMUM_FALLBACK_RATE,
+            "maximum_median_probability_delta":
+                MAXIMUM_MEDIAN_PROBABILITY_DELTA,
+            "maximum_p95_probability_delta":
+                MAXIMUM_P95_PROBABILITY_DELTA,
+            "maximum_observed_probability_delta":
+                MAXIMUM_OBSERVED_PROBABILITY_DELTA,
+            "outcome_p95_limits":
+                dict(OUTCOME_P95_LIMITS),
+        },
+        "observed": {
+            "audited_player_split_count":
+                payload.get(
+                    "audited_player_split_count"
+                ),
+            "executed_player_split_count":
+                payload.get(
+                    "executed_player_split_count"
+                ),
+            "execution_rate":
+                payload.get("execution_rate"),
+            "fallback_rate":
+                fallback.get("fallback_rate"),
+            "maximum_absolute_probability_delta":
+                maximum_delta,
+            "outcome_p95_deltas": {
+                outcome: (
+                    outcome_deltas.get(outcome)
+                    or {}
+                ).get("p95")
+                for outcome in OUTCOME_P95_LIMITS
+            },
+        },
+        "activation_scope": {
+            "eligible_player_splits_only": True,
+            "production_fallback_required": True,
+            "feature_flag_required": True,
+            "simulation_shadow_required": True,
+            "production_enabled": False,
+        },
+        "decision": {
+            "feature_flag_integration_allowed":
+                gate_passed,
+            "production_activation_allowed":
+                False,
+            "recommended_next_slice": (
+                "integrate_hitter_profiles_into_simulation_shadow"
+                if gate_passed
+                else "collect_additional_hitter_profile_canary_evidence"
+            ),
+        },
+        "parameter_selected": False,
+        "production_authority_changed": False,
+    }

--- a/scripts/audit_shadow_hitter_profile_canary_acceptance.py
+++ b/scripts/audit_shadow_hitter_profile_canary_acceptance.py
@@ -1,0 +1,67 @@
+"""Run hitter-profile canary evidence through acceptance gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from mlb_app.simulation.shadow.hitter_profile_canary_acceptance_gate import (
+    evaluate_hitter_profile_canary_acceptance,
+)
+from scripts.audit_shadow_hitter_profile_canary import (
+    run_live_audit,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--season",
+        type=int,
+    )
+    parser.add_argument(
+        "--as-of-date",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=250,
+    )
+    args = parser.parse_args()
+
+    audit = run_live_audit(
+        season=args.season,
+        as_of_date=args.as_of_date,
+        limit=args.limit,
+    )
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            audit
+        )
+    )
+    result["audit_provenance"] = {
+        "schema_version":
+            audit.get("schema_version"),
+        "season":
+            audit.get("season"),
+        "as_of_date":
+            audit.get("as_of_date"),
+        "audit_limit":
+            audit.get("audit_limit"),
+        "candidate_population_count":
+            audit.get(
+                "candidate_population_count"
+            ),
+    }
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_profile_canary_acceptance_gate.py
+++ b/tests/test_hitter_profile_canary_acceptance_gate.py
@@ -1,0 +1,172 @@
+from mlb_app.simulation.shadow.hitter_profile_canary_acceptance_gate import (
+    evaluate_hitter_profile_canary_acceptance,
+)
+
+
+def audit_payload():
+    return {
+        "status": "observed",
+        "audited_player_split_count": 250,
+        "executed_player_split_count": 61,
+        "execution_rate": 0.244,
+        "state_counts": {
+            "executed": 61,
+            "signal_evidence_blocked": 177,
+            "production_profile_blocked": 12,
+        },
+        "fallback_telemetry": {
+            "fallback_rate": 0.0,
+        },
+        "maximum_absolute_probability_delta": {
+            "median": 0.0334,
+            "p95": 0.0761,
+            "maximum": 0.0918,
+        },
+        "absolute_probability_delta_by_outcome": {
+            "bb": {"p95": 0.0418},
+            "hr": {"p95": 0.0215},
+            "k": {"p95": 0.0439},
+            "out": {"p95": 0.0761},
+        },
+        "safety_checks": {
+            "all_production_inputs_unchanged":
+                True,
+            "all_production_authority_unchanged":
+                True,
+            "all_candidate_probabilities_normalized":
+                True,
+            "database_writes_performed": False,
+        },
+        "production_authority_changed": False,
+    }
+
+
+def test_accepts_observed_top_250_evidence():
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            audit_payload()
+        )
+    )
+
+    assert result["gate_passed"] is True
+    assert (
+        result["status"]
+        == "accepted_for_feature_flag_integration"
+    )
+    assert result["blockers"] == []
+    assert result["decision"][
+        "feature_flag_integration_allowed"
+    ] is True
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert result["activation_scope"][
+        "eligible_player_splits_only"
+    ] is True
+    assert result["activation_scope"][
+        "production_fallback_required"
+    ] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_blocks_insufficient_evidence():
+    payload = audit_payload()
+    payload["audited_player_split_count"] = 100
+    payload["executed_player_split_count"] = 31
+
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "minimum_audited_player_splits"
+        in result["blockers"]
+    )
+    assert (
+        "minimum_executed_player_splits"
+        in result["blockers"]
+    )
+
+
+def test_blocks_probability_delta_breach():
+    payload = audit_payload()
+    payload[
+        "maximum_absolute_probability_delta"
+    ]["p95"] = 0.081
+
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "maximum_p95_probability_delta"
+        in result["blockers"]
+    )
+
+
+def test_blocks_outcome_specific_breach():
+    payload = audit_payload()
+    payload[
+        "absolute_probability_delta_by_outcome"
+    ]["hr"]["p95"] = 0.031
+
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "hr_p95_probability_delta"
+        in result["blockers"]
+    )
+
+
+def test_blocks_safety_or_fallback_failure():
+    payload = audit_payload()
+    payload["fallback_telemetry"][
+        "fallback_rate"
+    ] = 0.051
+    payload["safety_checks"][
+        "all_production_inputs_unchanged"
+    ] = False
+
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "maximum_fallback_rate"
+        in result["blockers"]
+    )
+    assert (
+        "production_inputs_unchanged"
+        in result["blockers"]
+    )
+
+
+def test_missing_metrics_fail_closed():
+    result = (
+        evaluate_hitter_profile_canary_acceptance(
+            {}
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert result["blockers"]
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False


### PR DESCRIPTION
## Summary

- define fail-closed acceptance gates for hitter-profile shadow-canary evidence
- require minimum audited and executed player-split cohorts, execution coverage, bounded fallback behavior, and zero audit errors
- enforce production-input immutability, probability normalization, no database writes, and unchanged production authority
- bound overall and outcome-specific PA probability shifts
- add a live audit entry point and focused gate tests

## Observed evidence

The current top-250 player-split cohort passes all gates:

- 250 audited and 61 executed player-splits
- 24.4% execution rate
- zero fallbacks across eligible signal applications
- median / p95 / maximum absolute probability deltas of 0.0334 / 0.0761 / 0.0918
- BB / HR / K / out p95 deltas of 0.0418 / 0.02147 / 0.0439 / 0.0761
- every normalization, immutability, authority, and write-safety check passed

A top-100 negative control fails closed on both minimum audited and minimum executed evidence requirements.

## Scope

Passing this gate permits only eligible-player-split feature-flag integration into simulation shadow with production fallback. It does not enable production activation or change production authority.

## Validation

- 174 hitter tests passed
- live top-250 acceptance audit passed
- live top-100 negative control blocked as expected
- Python compilation passed
- diff and new-file whitespace checks passed

## Follow-up

Integrate eligible hitter profiles into the simulation shadow path behind a disabled-by-default feature flag, retaining production fallback for all ineligible or incomplete player-splits.