### PR TITLE
Integrate hitter profiles into simulation shadow

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_overlay.py
+++ b/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_overlay.py
@@ -1,0 +1,462 @@
+"""Immutable hitter-profile overlay for canonical simulation shadow."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import hashlib
+import json
+import math
+from typing import Any, Mapping
+
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityProviderIdentity,
+)
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_simulation_shadow_overlay_v1"
+)
+PROVIDER_NAME = (
+    "hitter_profile_simulation_shadow"
+)
+PROVIDER_VERSION = "v1"
+
+DELTA_KEYS = {
+    CanonicalPlateAppearanceOutcome.OUT: (
+        "out",
+        "reached_on_error",
+    ),
+    CanonicalPlateAppearanceOutcome.SINGLE: (
+        "single",
+    ),
+    CanonicalPlateAppearanceOutcome.DOUBLE: (
+        "double",
+    ),
+    CanonicalPlateAppearanceOutcome.TRIPLE: (
+        "triple",
+    ),
+    CanonicalPlateAppearanceOutcome.HOME_RUN: (
+        "hr",
+    ),
+    CanonicalPlateAppearanceOutcome.WALK: (
+        "bb",
+    ),
+    CanonicalPlateAppearanceOutcome.HIT_BY_PITCH: (
+        "hbp",
+    ),
+    CanonicalPlateAppearanceOutcome.STRIKEOUT: (
+        "k",
+    ),
+}
+
+
+def _number(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return (
+        result
+        if math.isfinite(result)
+        else None
+    )
+
+
+def _accepted_gate(
+    gate: Mapping[str, Any] | None,
+) -> bool:
+    payload = dict(gate or {})
+    decision = dict(
+        payload.get("decision") or {}
+    )
+    return (
+        payload.get("gate_passed") is True
+        and payload.get("status")
+        == "accepted_for_feature_flag_integration"
+        and decision.get(
+            "feature_flag_integration_allowed"
+        )
+        is True
+        and decision.get(
+            "production_activation_allowed"
+        )
+        is False
+        and payload.get(
+            "production_authority_changed"
+        )
+        is False
+    )
+
+
+def _candidate_deltas(
+    value: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    payload = dict(value or {})
+    telemetry = dict(
+        payload.get("fallback_telemetry") or {}
+    )
+
+    if (
+        payload.get("status") != "ready"
+        or payload.get("executed") is not True
+        or payload.get(
+            "production_authority_changed"
+        )
+        is not False
+        or payload.get(
+            "production_inputs_unchanged"
+        )
+        is not True
+        or telemetry.get("fallback_count") != 0
+    ):
+        return None
+
+    deltas = payload.get(
+        "probability_deltas"
+    )
+    if not isinstance(deltas, Mapping):
+        return None
+
+    required = {
+        key
+        for keys in DELTA_KEYS.values()
+        for key in keys
+    }
+    if not required.issubset(deltas):
+        return None
+
+    if any(
+        _number(deltas.get(key)) is None
+        for key in required
+    ):
+        return None
+
+    return deltas
+
+
+def _overlay_probabilities(
+    record: CanonicalProbabilityArtifactRecord,
+    deltas: Mapping[str, Any],
+) -> tuple[CanonicalOutcomeProbability, ...]:
+    adjusted = {}
+
+    for point in record.probabilities:
+        delta = sum(
+            float(deltas[key])
+            for key in DELTA_KEYS[
+                point.outcome
+            ]
+        )
+        adjusted[point.outcome] = max(
+            0.0,
+            point.probability + delta,
+        )
+
+    total = sum(adjusted.values())
+    if total <= 0.0:
+        raise ValueError(
+            "candidate overlay has no probability mass"
+        )
+
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=(
+                adjusted[outcome] / total
+            ),
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def _artifact_id(
+    *,
+    matchup_input: CanonicalMatchupInput,
+    exact_artifact: CanonicalProbabilityArtifact,
+    fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    eligible_batters: tuple[str, ...],
+) -> str:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "game_pk": matchup_input.game_pk,
+        "base_provider": (
+            matchup_input
+            .probability_provider
+            .identity
+        ),
+        "exact_artifact_digest":
+            exact_artifact.digest,
+        "fallback_catalog_digest":
+            fallback_catalog.digest,
+        "eligible_batters":
+            list(eligible_batters),
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    return digest
+
+
+def _unchanged_result(
+    *,
+    status: str,
+    enabled: bool,
+    blocker: str | None,
+    matchup_input: CanonicalMatchupInput,
+    exact_artifact: CanonicalProbabilityArtifact,
+    fallback_catalog: CanonicalProbabilityFallbackCatalog,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "enabled": enabled,
+        "overlay_applied": False,
+        "eligible_batter_count": 0,
+        "overlaid_matchup_count": 0,
+        "preserved_matchup_count":
+            len(exact_artifact.records),
+        "blockers": (
+            [blocker]
+            if blocker is not None
+            else []
+        ),
+        "matchup_input": matchup_input,
+        "exact_artifact": exact_artifact,
+        "fallback_catalog": fallback_catalog,
+        "base_provider_identity": (
+            matchup_input
+            .probability_provider
+            .identity
+        ),
+        "shadow_provider_identity": None,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+    }
+
+
+def build_hitter_profile_simulation_shadow_overlay(
+    *,
+    enabled: bool = False,
+    acceptance_gate: Mapping[
+        str,
+        Any,
+    ] | None = None,
+    matchup_input: CanonicalMatchupInput,
+    exact_artifact: CanonicalProbabilityArtifact,
+    fallback_catalog: CanonicalProbabilityFallbackCatalog,
+    candidate_results: Mapping[
+        str,
+        Mapping[str, Any],
+    ] | None = None,
+) -> dict[str, Any]:
+    """Copy canonical inputs and overlay eligible exact matchup rows."""
+
+    if enabled is not True:
+        return _unchanged_result(
+            status="disabled",
+            enabled=False,
+            blocker=None,
+            matchup_input=matchup_input,
+            exact_artifact=exact_artifact,
+            fallback_catalog=fallback_catalog,
+        )
+
+    if not _accepted_gate(
+        acceptance_gate
+    ):
+        return _unchanged_result(
+            status="blocked",
+            enabled=True,
+            blocker="canary_acceptance_gate_not_passed",
+            matchup_input=matchup_input,
+            exact_artifact=exact_artifact,
+            fallback_catalog=fallback_catalog,
+        )
+
+    base_provider = (
+        matchup_input.probability_provider
+    )
+    if (
+        exact_artifact.provider != base_provider
+        or fallback_catalog.provider
+        != base_provider
+    ):
+        return _unchanged_result(
+            status="fallback",
+            enabled=True,
+            blocker="canonical_provider_identity_mismatch",
+            matchup_input=matchup_input,
+            exact_artifact=exact_artifact,
+            fallback_catalog=fallback_catalog,
+        )
+
+    candidates = {
+        str(key): dict(value)
+        for key, value in (
+            candidate_results or {}
+        ).items()
+    }
+    eligible = {
+        batter_id: deltas
+        for batter_id, candidate in (
+            candidates.items()
+        )
+        if (
+            deltas := _candidate_deltas(
+                candidate
+            )
+        )
+        is not None
+    }
+
+    if not eligible:
+        return _unchanged_result(
+            status="fallback",
+            enabled=True,
+            blocker="no_eligible_hitter_profile_candidates",
+            matchup_input=matchup_input,
+            exact_artifact=exact_artifact,
+            fallback_catalog=fallback_catalog,
+        )
+
+    try:
+        eligible_batters = tuple(
+            sorted(eligible)
+        )
+        shadow_provider = (
+            CanonicalProbabilityProviderIdentity(
+                provider_name=PROVIDER_NAME,
+                provider_version=PROVIDER_VERSION,
+                artifact_id=_artifact_id(
+                    matchup_input=matchup_input,
+                    exact_artifact=exact_artifact,
+                    fallback_catalog=fallback_catalog,
+                    eligible_batters=eligible_batters,
+                ),
+            )
+        )
+
+        overlaid_records = []
+        overlaid_count = 0
+
+        for record in exact_artifact.records:
+            deltas = eligible.get(
+                record.batter_id
+            )
+            if deltas is None:
+                probabilities = (
+                    record.probabilities
+                )
+            else:
+                probabilities = (
+                    _overlay_probabilities(
+                        record,
+                        deltas,
+                    )
+                )
+                overlaid_count += 1
+
+            overlaid_records.append(
+                CanonicalProbabilityArtifactRecord(
+                    batter_id=record.batter_id,
+                    pitcher_id=record.pitcher_id,
+                    probabilities=probabilities,
+                )
+            )
+
+        if overlaid_count == 0:
+            return _unchanged_result(
+                status="fallback",
+                enabled=True,
+                blocker=(
+                    "eligible_candidates_absent_"
+                    "from_exact_artifact"
+                ),
+                matchup_input=matchup_input,
+                exact_artifact=exact_artifact,
+                fallback_catalog=fallback_catalog,
+            )
+
+        shadow_matchup = replace(
+            matchup_input,
+            probability_provider=shadow_provider,
+        )
+        shadow_artifact = (
+            CanonicalProbabilityArtifact(
+                provider=shadow_provider,
+                records=tuple(
+                    overlaid_records
+                ),
+            )
+        )
+        shadow_fallback = (
+            CanonicalProbabilityFallbackCatalog(
+                provider=shadow_provider,
+                records=tuple(
+                    CanonicalProbabilityFallbackRecord(
+                        tier=record.tier,
+                        identity=record.identity,
+                        probabilities=(
+                            record.probabilities
+                        ),
+                    )
+                    for record in (
+                        fallback_catalog.records
+                    )
+                ),
+            )
+        )
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "ready",
+            "enabled": True,
+            "overlay_applied": True,
+            "eligible_batter_count":
+                len(eligible_batters),
+            "overlaid_matchup_count":
+                overlaid_count,
+            "preserved_matchup_count": (
+                len(exact_artifact.records)
+                - overlaid_count
+            ),
+            "blockers": [],
+            "matchup_input": shadow_matchup,
+            "exact_artifact": shadow_artifact,
+            "fallback_catalog": shadow_fallback,
+            "base_provider_identity":
+                base_provider.identity,
+            "shadow_provider_identity":
+                shadow_provider.identity,
+            "base_exact_artifact_digest":
+                exact_artifact.digest,
+            "shadow_exact_artifact_digest":
+                shadow_artifact.digest,
+            "base_fallback_catalog_digest":
+                fallback_catalog.digest,
+            "shadow_fallback_catalog_digest":
+                shadow_fallback.digest,
+            "production_inputs_unchanged": True,
+            "production_authority_changed": False,
+        }
+    except Exception:
+        return _unchanged_result(
+            status="fallback",
+            enabled=True,
+            blocker="hitter_profile_overlay_error",
+            matchup_input=matchup_input,
+            exact_artifact=exact_artifact,
+            fallback_catalog=fallback_catalog,
+        )

--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -46,6 +46,11 @@ from .probability_provider_discovery import (
 )
 
 
+from .hitter_profile_simulation_shadow_overlay import (
+    build_hitter_profile_simulation_shadow_overlay,
+)
+
+
 CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION = (
     "canonical_production_shadow_execution_v1"
 )
@@ -65,6 +70,9 @@ class CanonicalProductionShadowExecution:
     simulation_count: int = 0
     error_type: Optional[str] = None
     error_message: Optional[str] = None
+    hitter_profile_overlay: Optional[
+        Mapping[str, Any]
+    ] = None
     execution_version: str = (
         CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION
     )
@@ -102,6 +110,19 @@ class CanonicalProductionShadowExecution:
                 "CanonicalShadowExecutionInputs or None"
             )
 
+        if (
+            self.hitter_profile_overlay
+            is not None
+            and not isinstance(
+                self.hitter_profile_overlay,
+                Mapping,
+            )
+        ):
+            raise TypeError(
+                "hitter_profile_overlay must be "
+                "a mapping or None"
+            )
+
     @property
     def executed(self) -> bool:
         return self.material is not None
@@ -118,7 +139,7 @@ class CanonicalProductionShadowExecution:
             or {}
         )
 
-        return {
+        diagnostics = {
             "schema_version": self.execution_version,
             "status": self.status,
             "executed": self.executed,
@@ -161,6 +182,15 @@ class CanonicalProductionShadowExecution:
             "production_authority_changed": False,
             "authoritative_source": "legacy",
         }
+
+        if self.hitter_profile_overlay is not None:
+            diagnostics[
+                "hitter_profile_simulation_shadow"
+            ] = dict(
+                self.hitter_profile_overlay
+            )
+
+        return diagnostics
 
 
 def _canonical_pitching_plan_metadata(
@@ -354,6 +384,16 @@ def run_canonical_production_shadow(
     home_pitching_plan_classification: Optional[
         Mapping[str, Any]
     ] = None,
+    hitter_profile_shadow_enabled: bool = False,
+    hitter_profile_acceptance_gate: Optional[
+        Mapping[str, Any]
+    ] = None,
+    hitter_profile_candidate_results: Optional[
+        Mapping[
+            str,
+            Mapping[str, Any],
+        ]
+    ] = None,
 ) -> CanonicalProductionShadowExecution:
     """
     Execute a small canonical batch when every production input is ready.
@@ -393,6 +433,8 @@ def run_canonical_production_shadow(
             status="blocked",
         )
 
+    hitter_profile_overlay_diagnostics = None
+
     try:
         normalized_simulation_count = int(
             simulation_count
@@ -415,6 +457,43 @@ def run_canonical_production_shadow(
                 home_pitching_plan_classification
             ),
         )
+
+        if hitter_profile_shadow_enabled is True:
+            overlay = (
+                build_hitter_profile_simulation_shadow_overlay(
+                    enabled=True,
+                    acceptance_gate=(
+                        hitter_profile_acceptance_gate
+                    ),
+                    matchup_input=matchup_input,
+                    exact_artifact=exact_artifact,
+                    fallback_catalog=fallback_catalog,
+                    candidate_results=(
+                        hitter_profile_candidate_results
+                    ),
+                )
+            )
+            hitter_profile_overlay_diagnostics = {
+                key: value
+                for key, value in overlay.items()
+                if key
+                not in {
+                    "matchup_input",
+                    "exact_artifact",
+                    "fallback_catalog",
+                }
+            }
+
+            if overlay.get("overlay_applied") is True:
+                matchup_input = overlay[
+                    "matchup_input"
+                ]
+                exact_artifact = overlay[
+                    "exact_artifact"
+                ]
+                fallback_catalog = overlay[
+                    "fallback_catalog"
+                ]
 
         fallback_policy = (
             CanonicalProbabilityFallbackPolicy(
@@ -489,6 +568,9 @@ def run_canonical_production_shadow(
             simulation_count=(
                 normalized_simulation_count
             ),
+            hitter_profile_overlay=(
+                hitter_profile_overlay_diagnostics
+            ),
         )
     except Exception as exc:
         return CanonicalProductionShadowExecution(
@@ -496,4 +578,7 @@ def run_canonical_production_shadow(
             simulation_count=0,
             error_type=exc.__class__.__name__,
             error_message=str(exc),
+            hitter_profile_overlay=(
+                hitter_profile_overlay_diagnostics
+            ),
         )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1196,3 +1196,143 @@ def test_authority_adapter_rejects_invalid_activation():
             legacy_result={},
             activation=object(),
         )
+
+def hitter_profile_gate(passed=True):
+    return {
+        "status": (
+            "accepted_for_feature_flag_integration"
+            if passed
+            else "blocked"
+        ),
+        "gate_passed": passed,
+        "decision": {
+            "feature_flag_integration_allowed":
+                passed,
+            "production_activation_allowed":
+                False,
+        },
+        "production_authority_changed": False,
+    }
+
+
+def hitter_profile_candidate():
+    return {
+        "status": "ready",
+        "executed": True,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+        "fallback_telemetry": {
+            "fallback_count": 0,
+        },
+        "probability_deltas": {
+            "out": 0.02,
+            "reached_on_error": 0.0,
+            "single": 0.0,
+            "double": 0.0,
+            "triple": 0.0,
+            "hr": 0.0,
+            "bb": 0.0,
+            "hbp": 0.0,
+            "k": -0.02,
+        },
+    }
+
+
+def test_hitter_profile_shadow_is_disabled_by_default():
+    result = run()
+    diagnostics = result.to_diagnostics()
+
+    assert result.status == "executed"
+    assert (
+        "hitter_profile_simulation_shadow"
+        not in diagnostics
+    )
+    assert (
+        result.execution_inputs.provider_identity
+        == PROVIDER.identity
+    )
+
+
+def test_explicit_hitter_profile_shadow_uses_overlay():
+    result = run(
+        hitter_profile_shadow_enabled=True,
+        hitter_profile_acceptance_gate=(
+            hitter_profile_gate()
+        ),
+        hitter_profile_candidate_results={
+            "a1": hitter_profile_candidate(),
+        },
+    )
+    diagnostics = result.to_diagnostics()
+    overlay = diagnostics[
+        "hitter_profile_simulation_shadow"
+    ]
+
+    assert result.status == "executed"
+    assert overlay["status"] == "ready"
+    assert overlay["overlay_applied"] is True
+    assert overlay["overlaid_matchup_count"] == 1
+    assert (
+        result.execution_inputs.provider_identity
+        == overlay["shadow_provider_identity"]
+    )
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+
+
+def test_blocked_hitter_gate_fails_open_to_base_shadow():
+    result = run(
+        hitter_profile_shadow_enabled=True,
+        hitter_profile_acceptance_gate=(
+            hitter_profile_gate(False)
+        ),
+        hitter_profile_candidate_results={
+            "a1": hitter_profile_candidate(),
+        },
+    )
+    diagnostics = result.to_diagnostics()
+    overlay = diagnostics[
+        "hitter_profile_simulation_shadow"
+    ]
+
+    assert result.status == "executed"
+    assert overlay["status"] == "blocked"
+    assert overlay["overlay_applied"] is False
+    assert (
+        result.execution_inputs.provider_identity
+        == PROVIDER.identity
+    )
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+
+
+def test_ineligible_hitter_candidate_fails_open():
+    candidate = hitter_profile_candidate()
+    candidate["fallback_telemetry"] = {
+        "fallback_count": 1,
+    }
+
+    result = run(
+        hitter_profile_shadow_enabled=True,
+        hitter_profile_acceptance_gate=(
+            hitter_profile_gate()
+        ),
+        hitter_profile_candidate_results={
+            "a1": candidate,
+        },
+    )
+    overlay = result.to_diagnostics()[
+        "hitter_profile_simulation_shadow"
+    ]
+
+    assert result.status == "executed"
+    assert overlay["status"] == "fallback"
+    assert overlay["overlay_applied"] is False
+    assert (
+        result.execution_inputs.provider_identity
+        == PROVIDER.identity
+    )

--- a/tests/test_hitter_profile_simulation_shadow_overlay.py
+++ b/tests/test_hitter_profile_simulation_shadow_overlay.py
@@ -1,0 +1,364 @@
+from mlb_app.simulation.game import (
+    CANONICAL_PA_OUTCOME_ORDER,
+    CanonicalGameConfig,
+    CanonicalLineup,
+    CanonicalMatchupInput,
+    CanonicalOutcomeProbability,
+    CanonicalPitchingPlan,
+    CanonicalPlateAppearanceOutcome,
+    CanonicalProbabilityArtifact,
+    CanonicalProbabilityArtifactRecord,
+    CanonicalProbabilityFallbackCatalog,
+    CanonicalProbabilityFallbackRecord,
+    CanonicalProbabilityFallbackTier,
+    CanonicalProbabilityProviderIdentity,
+)
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_overlay import (
+    build_hitter_profile_simulation_shadow_overlay,
+)
+
+
+def provider():
+    return CanonicalProbabilityProviderIdentity(
+        provider_name="base-provider",
+        provider_version="v1",
+        artifact_id="base-artifact",
+    )
+
+
+def probabilities(k_rate=0.20):
+    remaining = 1.0 - k_rate
+    values = {
+        CanonicalPlateAppearanceOutcome.OUT:
+            remaining * 0.60,
+        CanonicalPlateAppearanceOutcome.SINGLE:
+            remaining * 0.15,
+        CanonicalPlateAppearanceOutcome.DOUBLE:
+            remaining * 0.06,
+        CanonicalPlateAppearanceOutcome.TRIPLE:
+            remaining * 0.01,
+        CanonicalPlateAppearanceOutcome.HOME_RUN:
+            remaining * 0.05,
+        CanonicalPlateAppearanceOutcome.WALK:
+            remaining * 0.08,
+        CanonicalPlateAppearanceOutcome.HIT_BY_PITCH:
+            remaining * 0.05,
+        CanonicalPlateAppearanceOutcome.STRIKEOUT:
+            k_rate,
+    }
+    return tuple(
+        CanonicalOutcomeProbability(
+            outcome=outcome,
+            probability=values[outcome],
+        )
+        for outcome in CANONICAL_PA_OUTCOME_ORDER
+    )
+
+
+def inputs():
+    identity = provider()
+    matchup = CanonicalMatchupInput(
+        game_pk=1,
+        away_lineup=CanonicalLineup(
+            team_side="away",
+            player_ids=tuple(
+                str(value)
+                for value in range(1, 10)
+            ),
+        ),
+        home_lineup=CanonicalLineup(
+            team_side="home",
+            player_ids=tuple(
+                str(value)
+                for value in range(11, 20)
+            ),
+        ),
+        away_pitching_plan=CanonicalPitchingPlan(
+            team_side="away",
+            starter_id="100",
+            bullpen_pitcher_ids=("101",),
+        ),
+        home_pitching_plan=CanonicalPitchingPlan(
+            team_side="home",
+            starter_id="200",
+            bullpen_pitcher_ids=("201",),
+        ),
+        probability_provider=identity,
+    )
+    artifact = CanonicalProbabilityArtifact(
+        provider=identity,
+        records=(
+            CanonicalProbabilityArtifactRecord(
+                batter_id="1",
+                pitcher_id="200",
+                probabilities=probabilities(),
+            ),
+            CanonicalProbabilityArtifactRecord(
+                batter_id="2",
+                pitcher_id="200",
+                probabilities=probabilities(0.25),
+            ),
+        ),
+    )
+    catalog = CanonicalProbabilityFallbackCatalog(
+        provider=identity,
+        records=(
+            CanonicalProbabilityFallbackRecord(
+                tier=CanonicalProbabilityFallbackTier.GLOBAL,
+                identity=None,
+                probabilities=probabilities(),
+            ),
+        ),
+    )
+    return matchup, artifact, catalog
+
+
+def gate(passed=True):
+    return {
+        "status": (
+            "accepted_for_feature_flag_integration"
+            if passed
+            else "blocked"
+        ),
+        "gate_passed": passed,
+        "decision": {
+            "feature_flag_integration_allowed":
+                passed,
+            "production_activation_allowed":
+                False,
+        },
+        "production_authority_changed": False,
+    }
+
+
+def candidate():
+    return {
+        "status": "ready",
+        "executed": True,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+        "fallback_telemetry": {
+            "fallback_count": 0,
+        },
+        "probability_deltas": {
+            "out": 0.02,
+            "reached_on_error": 0.0,
+            "single": 0.0,
+            "double": 0.0,
+            "triple": 0.0,
+            "hr": 0.0,
+            "bb": 0.0,
+            "hbp": 0.0,
+            "k": -0.02,
+        },
+    }
+
+
+def test_disabled_returns_original_inputs():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    assert result["status"] == "disabled"
+    assert result["overlay_applied"] is False
+    assert result["matchup_input"] is matchup
+    assert result["exact_artifact"] is artifact
+    assert result["fallback_catalog"] is catalog
+
+
+def test_blocked_gate_fails_closed():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(False),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["overlay_applied"] is False
+    assert (
+        "canary_acceptance_gate_not_passed"
+        in result["blockers"]
+    )
+
+
+def test_overlays_only_eligible_exact_rows():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["overlay_applied"] is True
+    assert result["overlaid_matchup_count"] == 1
+    assert result["preserved_matchup_count"] == 1
+
+    shadow_artifact = result["exact_artifact"]
+    eligible = shadow_artifact.record_for(
+        batter_id="1",
+        pitcher_id="200",
+    )
+    preserved = shadow_artifact.record_for(
+        batter_id="2",
+        pitcher_id="200",
+    )
+
+    original_eligible = artifact.record_for(
+        batter_id="1",
+        pitcher_id="200",
+    )
+    original_preserved = artifact.record_for(
+        batter_id="2",
+        pitcher_id="200",
+    )
+
+    assert (
+        eligible.probabilities
+        != original_eligible.probabilities
+    )
+    assert (
+        preserved.probabilities
+        == original_preserved.probabilities
+    )
+    assert (
+        artifact.record_for(
+            batter_id="1",
+            pitcher_id="200",
+        )
+        == original_eligible
+    )
+
+
+def test_rebinds_all_canonical_provider_identities():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    shadow_provider = result[
+        "matchup_input"
+    ].probability_provider
+
+    assert shadow_provider != provider()
+    assert (
+        result["exact_artifact"].provider
+        == shadow_provider
+    )
+    assert (
+        result["fallback_catalog"].provider
+        == shadow_provider
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_preserves_fallback_probability_values():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    assert (
+        result["fallback_catalog"]
+        .records[0]
+        .probabilities
+        == catalog.records[0].probabilities
+    )
+
+
+def test_ineligible_candidate_uses_original_inputs():
+    matchup, artifact, catalog = inputs()
+    blocked = candidate()
+    blocked["fallback_telemetry"] = {
+        "fallback_count": 1,
+    }
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": blocked,
+            },
+        )
+    )
+
+    assert result["status"] == "fallback"
+    assert result["overlay_applied"] is False
+    assert result["exact_artifact"] is artifact
+
+
+def test_output_is_factory_compatible():
+    matchup, artifact, catalog = inputs()
+
+    result = (
+        build_hitter_profile_simulation_shadow_overlay(
+            enabled=True,
+            acceptance_gate=gate(),
+            matchup_input=matchup,
+            exact_artifact=artifact,
+            fallback_catalog=catalog,
+            candidate_results={
+                "1": candidate(),
+            },
+        )
+    )
+
+    assert (
+        result["matchup_input"]
+        .probability_provider
+        == result["exact_artifact"].provider
+        == result["fallback_catalog"].provider
+    )


### PR DESCRIPTION
## Summary

- add a deterministic hitter-profile probability overlay for canonical simulation shadow execution
- gate the overlay behind explicit enablement and an accepted hitter-profile canary decision
- apply eligible precomputed candidate probability deltas to immutable exact-matchup artifacts before trial execution
- preserve canonical provider identity alignment across matchup inputs, exact artifacts, and fallback catalogs
- add fail-open diagnostics for blocked gates and ineligible candidates

## Safety

- disabled by default
- production activation remains prohibited
- production inputs and authority remain unchanged
- no database work is introduced into the plate-appearance loop
- blocked or invalid overlay inputs execute the existing canonical shadow path unchanged
- unrelated local scripts are excluded

## Validation

- 259 integration and hitter regression tests passed
- 4 explicit default/overlay/fail-open contract tests passed
- Python compilation passed
- tracked and new-file whitespace checks passed
- Ruff was not installed, so no Ruff execution was available
