### PR TITLE
Materialize hitter profile shadow candidates

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_candidate_materialization.py
+++ b/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_candidate_materialization.py
@@ -1,0 +1,494 @@
+"""Request-scoped hitter-profile shadow candidate materialization."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_simulation_shadow_candidate_materialization_v1"
+)
+
+
+def _accepted_gate(
+    gate: Mapping[str, Any] | None,
+) -> bool:
+    payload = dict(gate or {})
+    decision = dict(
+        payload.get("decision") or {}
+    )
+    activation_scope = dict(
+        payload.get("activation_scope") or {}
+    )
+
+    return (
+        payload.get("status")
+        == "accepted_for_feature_flag_integration"
+        and payload.get("gate_passed") is True
+        and decision.get(
+            "feature_flag_integration_allowed"
+        )
+        is True
+        and decision.get(
+            "production_activation_allowed"
+        )
+        is False
+        and activation_scope.get(
+            "production_enabled"
+        )
+        is False
+        and payload.get(
+            "production_authority_changed"
+        )
+        is False
+    )
+
+
+def _base_result(
+    *,
+    status: str,
+    enabled: bool,
+    blockers: list[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "enabled": enabled,
+        "materialized": False,
+        "candidate_results": {},
+        "candidate_batter_count": 0,
+        "requested_batter_count": 0,
+        "blocked_batter_count": 0,
+        "state_counts": {},
+        "blocker_counts": {},
+        "records": [],
+        "blockers": sorted(set(blockers)),
+        "database_writes_performed": False,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+    }
+
+
+def _identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+    result = str(value).strip()
+    return result or None
+
+
+def _pitcher_split(value: Any) -> str | None:
+    hand = str(value or "").strip().upper()
+    if hand == "R":
+        return "vsR"
+    if hand == "L":
+        return "vsL"
+    return None
+
+
+def _increment(
+    values: dict[str, int],
+    key: str,
+) -> None:
+    values[key] = values.get(key, 0) + 1
+
+
+def materialize_hitter_profile_simulation_shadow_candidates(
+    session: Any,
+    *,
+    enabled: bool = False,
+    acceptance_gate: Mapping[str, Any] | None = None,
+    lineups: Any,
+    exact_artifact_discovery: Any,
+    pitcher_hands_by_id: Mapping[str, Any] | None = None,
+    pitcher_profiles_by_id: Mapping[
+        str,
+        Mapping[str, Any],
+    ] | None = None,
+    environment_profile: Mapping[
+        str,
+        Any,
+    ] | None = None,
+    season: int,
+    as_of_date: Any,
+    readiness: Mapping[str, Any] | None = None,
+    combined_profile_loader: Callable[..., Mapping[str, Any]]
+    | None = None,
+    signal_loader: Callable[..., Mapping[str, Any]]
+    | None = None,
+    canary_runner: Callable[..., Mapping[str, Any]]
+    | None = None,
+) -> dict[str, Any]:
+    """Build eligible canary results once, outside simulation execution."""
+
+    if enabled is not True:
+        return _base_result(
+            status="disabled",
+            enabled=False,
+            blockers=[],
+        )
+
+    if not _accepted_gate(acceptance_gate):
+        return _base_result(
+            status="blocked",
+            enabled=True,
+            blockers=[
+                "canary_acceptance_gate_not_passed",
+            ],
+        )
+
+    if getattr(lineups, "ready", False) is not True:
+        return _base_result(
+            status="blocked",
+            enabled=True,
+            blockers=[
+                "canonical_lineups_not_ready",
+            ],
+        )
+
+    artifact = getattr(
+        exact_artifact_discovery,
+        "artifact",
+        None,
+    )
+    if artifact is None:
+        return _base_result(
+            status="blocked",
+            enabled=True,
+            blockers=[
+                "canonical_exact_artifact_not_ready",
+            ],
+        )
+
+    if environment_profile is None:
+        return _base_result(
+            status="blocked",
+            enabled=True,
+            blockers=[
+                "environment_profile_unavailable",
+            ],
+        )
+
+    if combined_profile_loader is None:
+        from mlb_app.simulation.shadow.combined_hitter_profile import (
+            load_combined_shadow_hitter_profile,
+        )
+
+        combined_profile_loader = (
+            load_combined_shadow_hitter_profile
+        )
+
+    if signal_loader is None:
+        from mlb_app.simulation.shadow.hitter_profile_canary_signal_adapter import (
+            load_hitter_profile_canary_signals,
+        )
+
+        signal_loader = (
+            load_hitter_profile_canary_signals
+        )
+
+    if canary_runner is None:
+        from mlb_app.simulation.shadow.hitter_profile_shadow_canary import (
+            run_hitter_profile_shadow_canary,
+        )
+
+        canary_runner = (
+            run_hitter_profile_shadow_canary
+        )
+
+    lineup_ids = {
+        str(value)
+        for value in (
+            tuple(lineups.away_player_ids)
+            + tuple(lineups.home_player_ids)
+        )
+    }
+    pitcher_hands = {
+        str(key): value
+        for key, value in (
+            pitcher_hands_by_id or {}
+        ).items()
+    }
+    pitcher_profiles = {
+        str(key): copy.deepcopy(dict(value))
+        for key, value in (
+            pitcher_profiles_by_id or {}
+        ).items()
+    }
+    environment = copy.deepcopy(
+        dict(environment_profile or {})
+    )
+
+    batter_matchups: dict[
+        str,
+        tuple[str, str],
+    ] = {}
+    matchup_blockers: dict[str, str] = {}
+    ambiguous_batters: set[str] = set()
+
+    for artifact_record in artifact.records:
+        batter_id = _identifier(
+            artifact_record.batter_id
+        )
+        pitcher_id = _identifier(
+            artifact_record.pitcher_id
+        )
+
+        if (
+            batter_id is None
+            or pitcher_id is None
+            or batter_id not in lineup_ids
+        ):
+            continue
+
+        split = _pitcher_split(
+            pitcher_hands.get(pitcher_id)
+        )
+        if split is None:
+            matchup_blockers[batter_id] = (
+                "opposing_pitcher_hand_unavailable"
+            )
+            continue
+
+        if pitcher_id not in pitcher_profiles:
+            matchup_blockers[batter_id] = (
+                "opposing_pitcher_profile_unavailable"
+            )
+            continue
+
+        matchup = (pitcher_id, split)
+        existing = batter_matchups.get(batter_id)
+        if (
+            existing is not None
+            and existing != matchup
+        ):
+            ambiguous_batters.add(batter_id)
+            continue
+
+        batter_matchups[batter_id] = matchup
+
+    for batter_id in ambiguous_batters:
+        batter_matchups.pop(batter_id, None)
+
+    records: list[dict[str, Any]] = []
+    candidate_results: dict[
+        str,
+        Mapping[str, Any],
+    ] = {}
+    state_counts: dict[str, int] = {}
+    blocker_counts: dict[str, int] = {}
+
+    unresolved_batters = sorted(
+        lineup_ids - set(batter_matchups)
+    )
+    for batter_id in unresolved_batters:
+        blocker = (
+            "ambiguous_opposing_pitcher_matchup"
+            if batter_id in ambiguous_batters
+            else matchup_blockers.get(
+                batter_id,
+                "canonical_matchup_record_unavailable",
+            )
+        )
+        records.append({
+            "batter_id": batter_id,
+            "split": None,
+            "state": "matchup_blocked",
+            "executed": False,
+            "blockers": [blocker],
+        })
+        _increment(
+            state_counts,
+            "matchup_blocked",
+        )
+        _increment(blocker_counts, blocker)
+
+    for batter_id in sorted(batter_matchups):
+        pitcher_id, split = (
+            batter_matchups[batter_id]
+        )
+        record: dict[str, Any] = {
+            "batter_id": batter_id,
+            "pitcher_id": pitcher_id,
+            "split": split,
+            "state": "not_evaluated",
+            "executed": False,
+            "blockers": [],
+        }
+
+        try:
+            signals = dict(
+                signal_loader(
+                    session,
+                    player_id=int(batter_id),
+                    season=int(season),
+                    split=split,
+                    as_of_date=as_of_date,
+                )
+            )
+            record["signal_status"] = (
+                signals.get("status")
+            )
+            record["signal_coverage"] = dict(
+                signals.get("coverage") or {}
+            )
+
+            if signals.get("status") != "ready":
+                record["state"] = (
+                    "signal_evidence_blocked"
+                )
+                record["blockers"] = list(
+                    signals.get("blockers") or ()
+                )
+            else:
+                combined = dict(
+                    combined_profile_loader(
+                        session,
+                        player_id=int(batter_id),
+                        season=int(season),
+                        split=split,
+                        as_of_date=as_of_date,
+                    )
+                )
+                record["combined_status"] = (
+                    combined.get("status")
+                )
+
+                if combined.get("status") != "ready":
+                    record["state"] = (
+                        "production_profile_blocked"
+                    )
+                    record["blockers"] = sorted({
+                        blocker
+                        for blockers in (
+                            combined.get(
+                                "evidence_blockers"
+                            )
+                            or {}
+                        ).values()
+                        for blocker in (
+                            blockers or ()
+                        )
+                    })
+                else:
+                    production_profile = copy.deepcopy(
+                        dict(
+                            combined.get(
+                                "candidate_profile"
+                            )
+                            or {}
+                        )
+                    )
+                    production_original = copy.deepcopy(
+                        production_profile
+                    )
+                    canary = dict(
+                        canary_runner(
+                            enabled=True,
+                            production_batter_profile=(
+                                production_profile
+                            ),
+                            pitcher_profile=copy.deepcopy(
+                                pitcher_profiles.get(
+                                    pitcher_id,
+                                    {},
+                                )
+                            ),
+                            environment_profile=(
+                                copy.deepcopy(
+                                    environment
+                                )
+                            ),
+                            candidate_signals=signals,
+                            readiness=readiness,
+                        )
+                    )
+
+                    record["executed"] = (
+                        canary.get("executed")
+                        is True
+                    )
+                    record[
+                        "production_profile_unchanged"
+                    ] = (
+                        production_profile
+                        == production_original
+                    )
+
+                    if (
+                        canary.get("status") == "ready"
+                        and canary.get("executed")
+                        is True
+                    ):
+                        record["state"] = "materialized"
+                        candidate_results[
+                            batter_id
+                        ] = canary
+                    else:
+                        record["state"] = (
+                            "canary_blocked"
+                        )
+                        record["blockers"] = list(
+                            canary.get("blockers")
+                            or ()
+                        )
+        except Exception as exc:
+            record["state"] = "materialization_error"
+            record["blockers"] = [
+                "materialization_exception",
+            ]
+            record["error_type"] = (
+                type(exc).__name__
+            )
+
+        _increment(
+            state_counts,
+            record["state"],
+        )
+        for blocker in record["blockers"]:
+            _increment(
+                blocker_counts,
+                str(blocker),
+            )
+        records.append(record)
+
+    candidate_count = len(candidate_results)
+    requested_count = len(lineup_ids)
+    blocked_count = (
+        requested_count - candidate_count
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if candidate_count > 0
+            else "fallback"
+        ),
+        "enabled": True,
+        "materialized": candidate_count > 0,
+        "candidate_results":
+            candidate_results,
+        "candidate_batter_count":
+            candidate_count,
+        "requested_batter_count":
+            requested_count,
+        "blocked_batter_count":
+            blocked_count,
+        "state_counts":
+            dict(sorted(state_counts.items())),
+        "blocker_counts":
+            dict(sorted(blocker_counts.items())),
+        "records": records,
+        "blockers": (
+            []
+            if candidate_count > 0
+            else [
+                "no_eligible_hitter_profile_candidates",
+            ]
+        ),
+        "database_writes_performed": False,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+    }

--- a/tests/test_hitter_profile_simulation_shadow_candidate_materialization.py
+++ b/tests/test_hitter_profile_simulation_shadow_candidate_materialization.py
@@ -1,0 +1,399 @@
+from types import SimpleNamespace
+
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_candidate_materialization import (
+    materialize_hitter_profile_simulation_shadow_candidates,
+)
+
+
+def gate():
+    return {
+        "status":
+            "accepted_for_feature_flag_integration",
+        "gate_passed": True,
+        "decision": {
+            "feature_flag_integration_allowed":
+                True,
+            "production_activation_allowed":
+                False,
+        },
+        "activation_scope": {
+            "production_enabled": False,
+        },
+        "production_authority_changed": False,
+    }
+
+
+def lineups():
+    return SimpleNamespace(
+        ready=True,
+        away_player_ids=("10",),
+        home_player_ids=("20",),
+    )
+
+
+def artifact():
+    return SimpleNamespace(
+        records=(
+            SimpleNamespace(
+                batter_id="10",
+                pitcher_id="200",
+            ),
+            SimpleNamespace(
+                batter_id="20",
+                pitcher_id="100",
+            ),
+        )
+    )
+
+
+def discovery():
+    return SimpleNamespace(
+        artifact=artifact(),
+    )
+
+
+def signals(
+    session,
+    *,
+    player_id,
+    season,
+    split,
+    as_of_date,
+):
+    return {
+        "status": "ready",
+        "cutoff_safe": True,
+        "coverage": {
+            "pitch_count": 100,
+        },
+        "signals": {
+            "called_ball_rate": 0.30,
+        },
+        "blockers": [],
+    }
+
+
+def combined(
+    session,
+    *,
+    player_id,
+    season,
+    split,
+    as_of_date,
+):
+    return {
+        "status": "ready",
+        "candidate_profile": {
+            "contact_skill": {
+                "hit_skill": 0.25,
+                "k_rate": 0.22,
+            },
+            "plate_discipline": {
+                "bb_rate": 0.08,
+            },
+            "power": {
+                "iso": 0.17,
+            },
+        },
+        "evidence_blockers": {
+            "actual": [],
+            "expected": [],
+        },
+    }
+
+
+def canary(
+    *,
+    enabled,
+    production_batter_profile,
+    pitcher_profile,
+    environment_profile,
+    candidate_signals,
+    readiness,
+):
+    return {
+        "status": "ready",
+        "executed": True,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+        "fallback_telemetry": {
+            "fallback_count": 0,
+        },
+        "probability_deltas": {
+            "bb": 0.01,
+            "double": 0.0,
+            "hbp": 0.0,
+            "hr": 0.0,
+            "k": -0.01,
+            "out": 0.0,
+            "reached_on_error": 0.0,
+            "single": 0.0,
+            "triple": 0.0,
+        },
+        "blockers": [],
+    }
+
+
+def materialize(**overrides):
+    values = {
+        "enabled": True,
+        "acceptance_gate": gate(),
+        "lineups": lineups(),
+        "exact_artifact_discovery":
+            discovery(),
+        "pitcher_hands_by_id": {
+            "100": "R",
+            "200": "L",
+        },
+        "pitcher_profiles_by_id": {
+            "100": {
+                "strikeout_rate": 0.24,
+            },
+            "200": {
+                "strikeout_rate": 0.21,
+            },
+        },
+        "environment_profile": {
+            "park_run_factor": 1.02,
+        },
+        "season": 2026,
+        "as_of_date": "2026-05-03",
+        "readiness": {
+            "status": "ready_for_activation",
+        },
+        "combined_profile_loader": combined,
+        "signal_loader": signals,
+        "canary_runner": canary,
+    }
+    values.update(overrides)
+    return (
+        materialize_hitter_profile_simulation_shadow_candidates(
+            object(),
+            **values,
+        )
+    )
+
+
+def test_disabled_by_default_without_loading_evidence():
+    result = (
+        materialize_hitter_profile_simulation_shadow_candidates(
+            object(),
+            lineups=lineups(),
+            exact_artifact_discovery=discovery(),
+            season=2026,
+            as_of_date="2026-05-03",
+        )
+    )
+
+    assert result["status"] == "disabled"
+    assert result["materialized"] is False
+    assert result["candidate_results"] == {}
+
+
+def test_rejects_unaccepted_gate():
+    blocked = gate()
+    blocked["gate_passed"] = False
+
+    result = materialize(
+        acceptance_gate=blocked,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["blockers"] == [
+        "canary_acceptance_gate_not_passed",
+    ]
+
+
+def test_materializes_lineup_candidates_by_batter_id():
+    result = materialize()
+
+    assert result["status"] == "ready"
+    assert result["materialized"] is True
+    assert result["candidate_batter_count"] == 2
+    assert result["requested_batter_count"] == 2
+    assert sorted(
+        result["candidate_results"]
+    ) == ["10", "20"]
+    assert result["state_counts"] == {
+        "materialized": 2,
+    }
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_uses_opposing_pitcher_hand_for_split():
+    observed = {}
+
+    def capture(
+        session,
+        *,
+        player_id,
+        season,
+        split,
+        as_of_date,
+    ):
+        observed[player_id] = split
+        return signals(
+            session,
+            player_id=player_id,
+            season=season,
+            split=split,
+            as_of_date=as_of_date,
+        )
+
+    result = materialize(
+        signal_loader=capture,
+    )
+
+    assert result["status"] == "ready"
+    assert observed == {
+        10: "vsL",
+        20: "vsR",
+    }
+
+
+def test_missing_pitcher_hand_fails_open_per_batter():
+    result = materialize(
+        pitcher_hands_by_id={
+            "100": "R",
+        },
+    )
+
+    assert result["status"] == "ready"
+    assert result["candidate_batter_count"] == 1
+    assert result["blocked_batter_count"] == 1
+    assert result["state_counts"] == {
+        "matchup_blocked": 1,
+        "materialized": 1,
+    }
+    assert result["blocker_counts"] == {
+        "opposing_pitcher_hand_unavailable": 1,
+    }
+
+
+def test_signal_evidence_failure_isolated_to_batter():
+    def partial(
+        session,
+        *,
+        player_id,
+        season,
+        split,
+        as_of_date,
+    ):
+        if player_id == 10:
+            return {
+                "status": "blocked",
+                "blockers": [
+                    "insufficient_pre_cutoff_ab",
+                ],
+            }
+        return signals(
+            session,
+            player_id=player_id,
+            season=season,
+            split=split,
+            as_of_date=as_of_date,
+        )
+
+    result = materialize(
+        signal_loader=partial,
+    )
+
+    assert result["status"] == "ready"
+    assert sorted(
+        result["candidate_results"]
+    ) == ["20"]
+    assert result["state_counts"] == {
+        "materialized": 1,
+        "signal_evidence_blocked": 1,
+    }
+    assert result["blocker_counts"] == {
+        "insufficient_pre_cutoff_ab": 1,
+    }
+
+
+def test_all_blocked_returns_fallback():
+    result = materialize(
+        pitcher_hands_by_id={},
+    )
+
+    assert result["status"] == "fallback"
+    assert result["materialized"] is False
+    assert result["candidate_results"] == {}
+    assert result["blockers"] == [
+        "no_eligible_hitter_profile_candidates",
+    ]
+
+def test_passes_matching_pitcher_and_environment_context():
+    observed = {}
+
+    def capture(
+        *,
+        enabled,
+        production_batter_profile,
+        pitcher_profile,
+        environment_profile,
+        candidate_signals,
+        readiness,
+    ):
+        observed[
+            pitcher_profile["strikeout_rate"]
+        ] = environment_profile[
+            "park_run_factor"
+        ]
+        return canary(
+            enabled=enabled,
+            production_batter_profile=(
+                production_batter_profile
+            ),
+            pitcher_profile=pitcher_profile,
+            environment_profile=environment_profile,
+            candidate_signals=candidate_signals,
+            readiness=readiness,
+        )
+
+    result = materialize(
+        canary_runner=capture,
+    )
+
+    assert result["status"] == "ready"
+    assert observed == {
+        0.21: 1.02,
+        0.24: 1.02,
+    }
+
+def test_missing_pitcher_profile_fails_open_per_batter():
+    result = materialize(
+        pitcher_profiles_by_id={
+            "100": {
+                "strikeout_rate": 0.24,
+            },
+        },
+    )
+
+    assert result["status"] == "ready"
+    assert sorted(
+        result["candidate_results"]
+    ) == ["20"]
+    assert result["blocker_counts"] == {
+        "opposing_pitcher_profile_unavailable": 1,
+    }
+
+
+def test_missing_environment_blocks_materialization():
+    result = materialize(
+        environment_profile=None,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["materialized"] is False
+    assert result["candidate_results"] == {}
+    assert result["blockers"] == [
+        "environment_profile_unavailable",
+    ]


### PR DESCRIPTION
## Summary

- add a request-scoped materializer for hitter-profile simulation-shadow candidates
- key eligible canary results by canonical batter ID for direct use by the existing 6SG overlay
- resolve each batter against the opposing starter's handedness, pitcher profile, and shared environment context
- isolate missing or invalid evidence per batter while preserving eligible lineup candidates
- require the previously accepted canary gate as an immutable injected input

## Safety

- disabled by default
- does not modify the live model-projection caller
- does not rerun the population acceptance audit per request
- does not perform database writes
- leaves production inputs and authority unchanged
- blocks missing lineups, exact artifacts, environment context, pitcher handedness, and pitcher profiles
- catches per-batter materialization failures without blocking other eligible hitters
- unrelated local scripts are excluded

## Validation

- 234 hitter and canonical shadow regression tests passed
- Python compilation passed
- tracked and new-file whitespace checks passed
- Ruff was not installed, so no Ruff execution was available
