### PR TITLE
Run paired hitter profile simulation shadow audit

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_paired_simulation_shadow_audit.py
+++ b/mlb_app/simulation/shadow/hitter_profile_paired_simulation_shadow_audit.py
@@ -1,0 +1,704 @@
+"""Paired full-game audit for hitter-profile simulation shadow."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_paired_simulation_shadow_audit_v1"
+)
+
+OUTCOME_KEYS = (
+    "away_win_probability",
+    "home_win_probability",
+    "tie_probability",
+    "extra_innings_probability",
+    "walk_off_probability",
+)
+
+RESERVED_EXECUTION_KEYS = {
+    "hitter_profile_shadow_enabled",
+    "hitter_profile_acceptance_gate",
+    "hitter_profile_candidate_results",
+}
+
+
+def _number(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return (
+        result
+        if math.isfinite(result)
+        else None
+    )
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return (
+        dict(value)
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _percentile(
+    values: list[float],
+    quantile: float,
+) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    if len(ordered) == 1:
+        return ordered[0]
+
+    position = (len(ordered) - 1) * quantile
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    fraction = position - lower
+
+    return (
+        ordered[lower]
+        + (
+            ordered[upper]
+            - ordered[lower]
+        )
+        * fraction
+    )
+
+
+def _distribution_mean(value: Any) -> float | None:
+    distribution = _mapping(value)
+    if not distribution:
+        return None
+
+    total = 0.0
+    probability_sum = 0.0
+
+    for raw_value, raw_probability in (
+        distribution.items()
+    ):
+        outcome = _number(raw_value)
+        probability = _number(raw_probability)
+        if outcome is None or probability is None:
+            return None
+        total += outcome * probability
+        probability_sum += probability
+
+    if abs(probability_sum - 1.0) > 0.00001:
+        return None
+
+    return total
+
+
+def _metric_means(
+    projections: Any,
+) -> dict[str, float]:
+    result: dict[str, float] = {}
+
+    if not isinstance(projections, list):
+        return result
+
+    for projection in projections:
+        row = _mapping(projection)
+        identity = str(
+            row.get("team_side")
+            or row.get("player_id")
+            or ""
+        )
+        team_side = str(
+            row.get("team_side") or ""
+        )
+        player_id = str(
+            row.get("player_id") or ""
+        )
+
+        if player_id:
+            identity = f"{team_side}:{player_id}"
+
+        for raw_metric in (
+            row.get("metrics") or []
+        ):
+            metric = _mapping(raw_metric)
+            name = str(metric.get("name") or "")
+            mean = _number(
+                _mapping(
+                    metric.get("summary")
+                ).get("mean")
+            )
+            if identity and name and mean is not None:
+                result[f"{identity}:{name}"] = mean
+
+    return result
+
+
+def _comparison_record(
+    *,
+    scope: str,
+    identity: str,
+    metric: str,
+    baseline: float,
+    candidate: float,
+) -> dict[str, Any]:
+    delta = candidate - baseline
+    return {
+        "scope": scope,
+        "identity": identity,
+        "metric": metric,
+        "baseline": baseline,
+        "candidate": candidate,
+        "signed_delta": delta,
+        "absolute_delta": abs(delta),
+    }
+
+
+def compare_hitter_profile_simulation_shadow_payloads(
+    *,
+    baseline_payload: Mapping[str, Any],
+    candidate_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compare paired canonical outputs without selecting thresholds."""
+
+    baseline = dict(baseline_payload)
+    candidate = dict(candidate_payload)
+
+    baseline_count = int(
+        baseline.get("simulation_count") or 0
+    )
+    candidate_count = int(
+        candidate.get("simulation_count") or 0
+    )
+
+    if (
+        baseline_count <= 0
+        or candidate_count <= 0
+        or baseline_count != candidate_count
+    ):
+        return {
+            "status": "blocked",
+            "comparison_count": 0,
+            "records": [],
+            "blockers": [
+                "paired_simulation_count_mismatch",
+            ],
+        }
+
+    records: list[dict[str, Any]] = []
+    baseline_outcomes = _mapping(
+        baseline.get("outcomes")
+    )
+    candidate_outcomes = _mapping(
+        candidate.get("outcomes")
+    )
+
+    for metric in OUTCOME_KEYS:
+        baseline_value = _number(
+            baseline_outcomes.get(metric)
+        )
+        candidate_value = _number(
+            candidate_outcomes.get(metric)
+        )
+        if (
+            baseline_value is not None
+            and candidate_value is not None
+        ):
+            records.append(
+                _comparison_record(
+                    scope="game",
+                    identity="game",
+                    metric=metric,
+                    baseline=baseline_value,
+                    candidate=candidate_value,
+                )
+            )
+
+    for metric in (
+        "away_run_distribution",
+        "home_run_distribution",
+        "total_run_distribution",
+    ):
+        baseline_value = _distribution_mean(
+            baseline_outcomes.get(metric)
+        )
+        candidate_value = _distribution_mean(
+            candidate_outcomes.get(metric)
+        )
+        if (
+            baseline_value is not None
+            and candidate_value is not None
+        ):
+            records.append(
+                _comparison_record(
+                    scope="game",
+                    identity="game",
+                    metric=f"{metric}_mean",
+                    baseline=baseline_value,
+                    candidate=candidate_value,
+                )
+            )
+
+    for group in (
+        "away_run_distribution",
+        "home_run_distribution",
+        "total_run_distribution",
+        "team_total_probabilities",
+        "total_probabilities",
+    ):
+        baseline_probabilities = _mapping(
+            baseline_outcomes.get(group)
+        )
+        candidate_probabilities = _mapping(
+            candidate_outcomes.get(group)
+        )
+
+        for metric in sorted(
+            set(baseline_probabilities)
+            & set(candidate_probabilities)
+        ):
+            baseline_value = _number(
+                baseline_probabilities[metric]
+            )
+            candidate_value = _number(
+                candidate_probabilities[metric]
+            )
+            if (
+                baseline_value is not None
+                and candidate_value is not None
+            ):
+                records.append(
+                    _comparison_record(
+                        scope="game_probability",
+                        identity=group,
+                        metric=str(metric),
+                        baseline=baseline_value,
+                        candidate=candidate_value,
+                    )
+                )
+
+    for group, scope in (
+        ("teams", "team"),
+        ("batters", "batter"),
+        ("pitchers", "pitcher"),
+    ):
+        baseline_metrics = _metric_means(
+            baseline.get(group)
+        )
+        candidate_metrics = _metric_means(
+            candidate.get(group)
+        )
+
+        for key in sorted(
+            set(baseline_metrics)
+            & set(candidate_metrics)
+        ):
+            identity, metric = key.rsplit(
+                ":",
+                1,
+            )
+            records.append(
+                _comparison_record(
+                    scope=scope,
+                    identity=identity,
+                    metric=metric,
+                    baseline=baseline_metrics[key],
+                    candidate=candidate_metrics[key],
+                )
+            )
+
+    absolute_deltas = [
+        float(record["absolute_delta"])
+        for record in records
+    ]
+    ordered_changes = sorted(
+        records,
+        key=lambda record: (
+            -record["absolute_delta"],
+            record["scope"],
+            record["identity"],
+            record["metric"],
+        ),
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if records
+            else "blocked"
+        ),
+        "simulation_count": baseline_count,
+        "comparison_count": len(records),
+        "records": records,
+        "largest_changes": ordered_changes[:25],
+        "absolute_delta_summary": {
+            "mean": (
+                sum(absolute_deltas)
+                / len(absolute_deltas)
+                if absolute_deltas
+                else 0.0
+            ),
+            "median": _percentile(
+                absolute_deltas,
+                0.50,
+            ),
+            "p95": _percentile(
+                absolute_deltas,
+                0.95,
+            ),
+            "maximum": (
+                max(absolute_deltas)
+                if absolute_deltas
+                else 0.0
+            ),
+        },
+        "blockers": (
+            []
+            if records
+            else [
+                "no_comparable_canonical_metrics",
+            ]
+        ),
+        "parameter_selected": False,
+        "production_authority_changed": False,
+    }
+
+
+def _execution_payload(
+    execution: Any,
+) -> dict[str, Any] | None:
+    material = getattr(
+        execution,
+        "material",
+        None,
+    )
+    payload = getattr(
+        material,
+        "canonical_payload",
+        None,
+    )
+    return (
+        dict(payload)
+        if isinstance(payload, Mapping)
+        else None
+    )
+
+
+def _execution_diagnostics(
+    execution: Any,
+) -> dict[str, Any]:
+    method = getattr(
+        execution,
+        "to_diagnostics",
+        None,
+    )
+    return (
+        dict(method())
+        if callable(method)
+        else {}
+    )
+
+
+def _materialization_summary(
+    materialization: Mapping[str, Any],
+) -> dict[str, Any]:
+    excluded = {
+        "candidate_results",
+        "records",
+    }
+    return {
+        key: value
+        for key, value in materialization.items()
+        if key not in excluded
+    }
+
+
+@dataclass(frozen=True)
+class HitterProfilePairedSimulationShadowAudit:
+    status: str
+    baseline_execution: Any = None
+    candidate_execution: Any = None
+    candidate_materialization: Mapping[
+        str,
+        Any,
+    ] | None = None
+    comparison: Mapping[str, Any] | None = None
+    blockers: tuple[str, ...] = ()
+    enabled: bool = False
+    audit_version: str = SCHEMA_VERSION
+
+    @property
+    def production_execution(self) -> Any:
+        return self.baseline_execution
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        baseline = _execution_diagnostics(
+            self.baseline_execution
+        )
+        candidate = _execution_diagnostics(
+            self.candidate_execution
+        )
+        materialization = dict(
+            self.candidate_materialization or {}
+        )
+        candidate_overlay = _mapping(
+            candidate.get(
+                "hitter_profile_simulation_shadow"
+            )
+        )
+
+        return {
+            "schema_version": self.audit_version,
+            "status": self.status,
+            "enabled": self.enabled,
+            "baseline_execution": baseline,
+            "candidate_execution": candidate,
+            "candidate_materialization": (
+                _materialization_summary(
+                    materialization
+                )
+            ),
+            "comparison": dict(
+                self.comparison or {}
+            ),
+            "blockers": list(self.blockers),
+            "safety_checks": {
+                "baseline_executed": (
+                    baseline.get("executed")
+                    is True
+                ),
+                "candidate_executed": (
+                    candidate.get("executed")
+                    is True
+                ),
+                "simulation_counts_match": (
+                    baseline.get("simulation_count")
+                    == candidate.get(
+                        "simulation_count"
+                    )
+                ),
+                "candidate_overlay_applied": (
+                    candidate_overlay.get(
+                        "overlay_applied"
+                    )
+                    is True
+                ),
+                "database_writes_absent": (
+                    materialization.get(
+                        "database_writes_performed"
+                    )
+                    is False
+                ),
+                "production_inputs_unchanged": (
+                    materialization.get(
+                        "production_inputs_unchanged"
+                    )
+                    is True
+                ),
+                "production_authority_unchanged": (
+                    baseline.get(
+                        "production_authority_changed"
+                    )
+                    is False
+                    and candidate.get(
+                        "production_authority_changed"
+                    )
+                    is False
+                    and materialization.get(
+                        "production_authority_changed"
+                    )
+                    is False
+                ),
+            },
+            "production_result": "baseline_execution",
+            "production_activation_allowed": False,
+            "parameter_selected": False,
+            "production_authority_changed": False,
+            "authoritative_source": "legacy",
+        }
+
+
+def run_paired_hitter_profile_simulation_shadow_audit(
+    *,
+    enabled: bool = False,
+    acceptance_gate: Mapping[str, Any] | None = None,
+    candidate_materialization: Mapping[
+        str,
+        Any,
+    ] | None = None,
+    execution_runner: Callable[..., Any] | None = None,
+    **production_inputs: Any,
+) -> HitterProfilePairedSimulationShadowAudit:
+    """Run baseline and candidate canonical shadows with paired inputs."""
+
+    if enabled is not True:
+        return HitterProfilePairedSimulationShadowAudit(
+            status="disabled",
+            enabled=False,
+        )
+
+    reserved = (
+        RESERVED_EXECUTION_KEYS
+        & set(production_inputs)
+    )
+    if reserved:
+        raise ValueError(
+            "paired audit owns hitter-profile "
+            "execution arguments"
+        )
+
+    materialization = dict(
+        candidate_materialization or {}
+    )
+    candidates = _mapping(
+        materialization.get(
+            "candidate_results"
+        )
+    )
+
+    if (
+        materialization.get("status") != "ready"
+        or materialization.get(
+            "materialized"
+        )
+        is not True
+        or not candidates
+        or materialization.get(
+            "database_writes_performed"
+        )
+        is not False
+        or materialization.get(
+            "production_inputs_unchanged"
+        )
+        is not True
+        or materialization.get(
+            "production_authority_changed"
+        )
+        is not False
+    ):
+        return HitterProfilePairedSimulationShadowAudit(
+            status="blocked",
+            candidate_materialization=(
+                materialization
+            ),
+            blockers=(
+                "candidate_materialization_not_ready",
+            ),
+            enabled=True,
+        )
+
+    if execution_runner is None:
+        from mlb_app.simulation.shadow.production_execution import (
+            run_canonical_production_shadow,
+        )
+
+        execution_runner = (
+            run_canonical_production_shadow
+        )
+
+    baseline = execution_runner(
+        **production_inputs,
+        hitter_profile_shadow_enabled=False,
+    )
+    candidate = execution_runner(
+        **production_inputs,
+        hitter_profile_shadow_enabled=True,
+        hitter_profile_acceptance_gate=(
+            acceptance_gate
+        ),
+        hitter_profile_candidate_results=(
+            candidates
+        ),
+    )
+
+    baseline_payload = _execution_payload(
+        baseline
+    )
+    candidate_payload = _execution_payload(
+        candidate
+    )
+
+    blockers = []
+    comparison = None
+    baseline_diagnostics = (
+        _execution_diagnostics(baseline)
+    )
+    candidate_diagnostics = (
+        _execution_diagnostics(candidate)
+    )
+    baseline_overlay = _mapping(
+        baseline_diagnostics.get(
+            "hitter_profile_simulation_shadow"
+        )
+    )
+    candidate_overlay = _mapping(
+        candidate_diagnostics.get(
+            "hitter_profile_simulation_shadow"
+        )
+    )
+
+    if baseline_payload is None:
+        blockers.append(
+            "baseline_execution_not_ready"
+        )
+    if candidate_payload is None:
+        blockers.append(
+            "candidate_execution_not_ready"
+        )
+    if baseline_overlay.get(
+        "overlay_applied"
+    ) is True:
+        blockers.append(
+            "baseline_overlay_unexpected"
+        )
+    if (
+        candidate_payload is not None
+        and candidate_overlay.get(
+            "overlay_applied"
+        )
+        is not True
+    ):
+        blockers.append(
+            "candidate_overlay_not_applied"
+        )
+    if (
+        baseline_diagnostics.get(
+            "simulation_count"
+        )
+        != candidate_diagnostics.get(
+            "simulation_count"
+        )
+    ):
+        blockers.append(
+            "paired_execution_count_mismatch"
+        )
+
+    if not blockers:
+        comparison = (
+            compare_hitter_profile_simulation_shadow_payloads(
+                baseline_payload=baseline_payload,
+                candidate_payload=candidate_payload,
+            )
+        )
+        if comparison.get("status") != "ready":
+            blockers.extend(
+                comparison.get("blockers") or ()
+            )
+
+    return HitterProfilePairedSimulationShadowAudit(
+        status=(
+            "observed"
+            if not blockers
+            else "blocked"
+        ),
+        baseline_execution=baseline,
+        candidate_execution=candidate,
+        candidate_materialization=materialization,
+        comparison=comparison,
+        blockers=tuple(sorted(set(blockers))),
+        enabled=True,
+    )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -35,6 +35,10 @@ from mlb_app.simulation.shadow import (
 )
 
 
+from mlb_app.simulation.shadow.hitter_profile_paired_simulation_shadow_audit import (
+    run_paired_hitter_profile_simulation_shadow_audit,
+)
+
 PROVIDER = CanonicalProbabilityProviderIdentity(
     provider_name="model_projections_pa_outcome",
     provider_version="pa_outcome_v1",
@@ -1336,3 +1340,122 @@ def test_ineligible_hitter_candidate_fails_open():
         result.execution_inputs.provider_identity
         == PROVIDER.identity
     )
+
+def test_real_hitter_profile_shadow_pair_uses_same_trials():
+    candidate_materialization = {
+        "status": "ready",
+        "materialized": True,
+        "candidate_results": {
+            "a1": hitter_profile_candidate(),
+        },
+        "candidate_batter_count": 1,
+        "database_writes_performed": False,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+    }
+
+    paired = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            acceptance_gate=(
+                hitter_profile_gate()
+            ),
+            candidate_materialization=(
+                candidate_materialization
+            ),
+            execution_runner=(
+                run_canonical_production_shadow
+            ),
+            game_pk=123,
+            lineups=lineups(),
+            bullpens=bullpens(),
+            provider_discovery=(
+                provider_discovery()
+            ),
+            exact_artifact_discovery=(
+                exact_discovery()
+            ),
+            fallback_catalog_discovery=(
+                fallback_discovery()
+            ),
+            bootstrap_ready=True,
+            simulation_count=2,
+        )
+    )
+
+    assert paired.status == "observed"
+    assert paired.production_execution is (
+        paired.baseline_execution
+    )
+    assert (
+        paired.baseline_execution.status
+        == "executed"
+    )
+    assert (
+        paired.candidate_execution.status
+        == "executed"
+    )
+    assert (
+        paired.baseline_execution.simulation_count
+        == paired.candidate_execution.simulation_count
+        == 2
+    )
+
+    baseline_inputs = (
+        paired.baseline_execution.execution_inputs
+    )
+    candidate_inputs = (
+        paired.candidate_execution.execution_inputs
+    )
+
+    assert (
+        baseline_inputs.exact_artifact_digest
+        != candidate_inputs.exact_artifact_digest
+    )
+    assert (
+        baseline_inputs
+        .baserunning_evidence_catalog_digest
+        == candidate_inputs
+        .baserunning_evidence_catalog_digest
+    )
+    assert (
+        baseline_inputs.provider_identity
+        != candidate_inputs.provider_identity
+    )
+
+    diagnostics = paired.to_diagnostics()
+    overlay = diagnostics[
+        "candidate_execution"
+    ][
+        "hitter_profile_simulation_shadow"
+    ]
+
+    assert overlay["overlay_applied"] is True
+    assert overlay["overlaid_matchup_count"] == 1
+    assert diagnostics[
+        "safety_checks"
+    ]["simulation_counts_match"] is True
+    assert diagnostics[
+        "safety_checks"
+    ]["production_authority_unchanged"] is True
+    assert diagnostics[
+        "production_result"
+    ] == "baseline_execution"
+    assert diagnostics[
+        "production_activation_allowed"
+    ] is False
+
+    comparison = diagnostics["comparison"]
+    assert comparison["status"] == "ready"
+    assert comparison["simulation_count"] == 2
+    assert comparison["comparison_count"] > 0
+    assert {
+        record["scope"]
+        for record in comparison["records"]
+    } >= {
+        "game",
+        "game_probability",
+        "team",
+        "batter",
+        "pitcher",
+    }

--- a/tests/test_hitter_profile_paired_simulation_shadow_audit.py
+++ b/tests/test_hitter_profile_paired_simulation_shadow_audit.py
@@ -1,0 +1,407 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.simulation.shadow.hitter_profile_paired_simulation_shadow_audit import (
+    compare_hitter_profile_simulation_shadow_payloads,
+    run_paired_hitter_profile_simulation_shadow_audit,
+)
+
+
+def summary(mean):
+    return {
+        "count": 10,
+        "mean": mean,
+        "median": mean,
+        "p10": mean,
+        "p25": mean,
+        "p75": mean,
+        "p90": mean,
+        "minimum": mean,
+        "maximum": mean,
+    }
+
+
+def metric(name, mean):
+    return {
+        "name": name,
+        "summary": summary(mean),
+    }
+
+
+def payload(*, adjustment=0.0):
+    return {
+        "simulation_count": 10,
+        "teams": [
+            {
+                "team_side": "away",
+                "metrics": [
+                    metric(
+                        "runs",
+                        4.0 + adjustment,
+                    ),
+                ],
+            },
+            {
+                "team_side": "home",
+                "metrics": [
+                    metric(
+                        "runs",
+                        5.0 - adjustment,
+                    ),
+                ],
+            },
+        ],
+        "batters": [
+            {
+                "player_id": "10",
+                "team_side": "away",
+                "metrics": [
+                    metric(
+                        "dfs_points",
+                        8.0 + adjustment,
+                    ),
+                    metric(
+                        "walks",
+                        0.5 + adjustment,
+                    ),
+                ],
+            },
+        ],
+        "pitchers": [
+            {
+                "player_id": "100",
+                "team_side": "home",
+                "metrics": [
+                    metric(
+                        "strikeouts",
+                        6.0 - adjustment,
+                    ),
+                ],
+            },
+        ],
+        "outcomes": {
+            "simulation_count": 10,
+            "away_win_probability":
+                0.40 + adjustment,
+            "home_win_probability":
+                0.60 - adjustment,
+            "tie_probability": 0.0,
+            "extra_innings_probability": 0.10,
+            "walk_off_probability": 0.05,
+            "away_run_distribution": {
+                "3": 0.5,
+                "5": 0.5,
+            },
+            "home_run_distribution": {
+                "4": 0.5,
+                "6": 0.5,
+            },
+            "total_run_distribution": {
+                "7": 0.5,
+                "11": 0.5,
+            },
+            "team_total_probabilities": {
+                "away_4_plus":
+                    0.50 + adjustment,
+                "home_5_plus":
+                    0.50 - adjustment,
+            },
+            "total_probabilities": {
+                "total_8_plus":
+                    0.60 + adjustment,
+            },
+        },
+    }
+
+
+def materialization():
+    return {
+        "status": "ready",
+        "materialized": True,
+        "candidate_results": {
+            "10": {
+                "status": "ready",
+            },
+        },
+        "candidate_batter_count": 1,
+        "database_writes_performed": False,
+        "production_inputs_unchanged": True,
+        "production_authority_changed": False,
+    }
+
+
+class Execution:
+    def __init__(
+        self,
+        payload_value,
+        *,
+        overlay=None,
+    ):
+        self.material = SimpleNamespace(
+            canonical_payload=payload_value,
+        )
+        self.overlay = overlay
+
+    def to_diagnostics(self):
+        result = {
+            "status": "executed",
+            "executed": True,
+            "simulation_count": 10,
+            "production_authority_changed": False,
+        }
+        if self.overlay is not None:
+            result[
+                "hitter_profile_simulation_shadow"
+            ] = self.overlay
+        return result
+
+
+def test_comparator_reports_game_team_and_player_deltas():
+    result = (
+        compare_hitter_profile_simulation_shadow_payloads(
+            baseline_payload=payload(),
+            candidate_payload=payload(
+                adjustment=0.02,
+            ),
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["simulation_count"] == 10
+    assert result["comparison_count"] == len(
+        result["records"]
+    )
+    assert result["comparison_count"] == 22
+    assert result[
+        "absolute_delta_summary"
+    ]["maximum"] == pytest.approx(0.02)
+    assert {
+        record["scope"]
+        for record in result["records"]
+    } == {
+        "game",
+        "game_probability",
+        "team",
+        "batter",
+        "pitcher",
+    }
+    assert any(
+        record["identity"]
+        == "total_probabilities"
+        and record["metric"]
+        == "total_8_plus"
+        for record in result["records"]
+    )
+
+
+def test_comparator_rejects_simulation_count_mismatch():
+    candidate = payload()
+    candidate["simulation_count"] = 11
+
+    result = (
+        compare_hitter_profile_simulation_shadow_payloads(
+            baseline_payload=payload(),
+            candidate_payload=candidate,
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert result["blockers"] == [
+        "paired_simulation_count_mismatch",
+    ]
+
+
+def test_disabled_pair_does_not_execute():
+    calls = []
+
+    result = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            execution_runner=lambda **kwargs: (
+                calls.append(kwargs)
+            ),
+        )
+    )
+
+    assert result.status == "disabled"
+    assert calls == []
+
+
+def test_blocked_materialization_does_not_execute():
+    calls = []
+
+    result = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            candidate_materialization={
+                "status": "fallback",
+            },
+            execution_runner=lambda **kwargs: (
+                calls.append(kwargs)
+            ),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+
+
+def test_pair_uses_identical_inputs_and_candidate_only_overlay():
+    calls = []
+
+    def runner(**kwargs):
+        calls.append(kwargs)
+        enabled = kwargs[
+            "hitter_profile_shadow_enabled"
+        ]
+        return Execution(
+            payload(
+                adjustment=(
+                    0.02 if enabled else 0.0
+                )
+            ),
+            overlay=(
+                {
+                    "overlay_applied": True,
+                }
+                if enabled
+                else None
+            ),
+        )
+
+    result = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            acceptance_gate={
+                "gate_passed": True,
+            },
+            candidate_materialization=(
+                materialization()
+            ),
+            execution_runner=runner,
+            game_pk=123,
+            simulation_count=10,
+            bootstrap_ready=True,
+        )
+    )
+
+    assert result.status == "observed"
+    assert len(calls) == 2
+    assert calls[0]["game_pk"] == 123
+    assert calls[1]["game_pk"] == 123
+    assert calls[0]["simulation_count"] == 10
+    assert calls[1]["simulation_count"] == 10
+    assert (
+        calls[0]["hitter_profile_shadow_enabled"]
+        is False
+    )
+    assert (
+        calls[1]["hitter_profile_shadow_enabled"]
+        is True
+    )
+    assert (
+        calls[1][
+            "hitter_profile_candidate_results"
+        ]
+        == materialization()[
+            "candidate_results"
+        ]
+    )
+    assert (
+        result.production_execution
+        is result.baseline_execution
+    )
+
+    diagnostics = result.to_diagnostics()
+    assert (
+        diagnostics["safety_checks"][
+            "candidate_overlay_applied"
+        ]
+        is True
+    )
+    assert (
+        diagnostics[
+            "production_activation_allowed"
+        ]
+        is False
+    )
+    assert (
+        diagnostics[
+            "production_authority_changed"
+        ]
+        is False
+    )
+
+
+def test_candidate_execution_failure_blocks_observation():
+    calls = []
+
+    def runner(**kwargs):
+        calls.append(kwargs)
+        if kwargs[
+            "hitter_profile_shadow_enabled"
+        ]:
+            return Execution(None)
+        return Execution(payload())
+
+    result = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            acceptance_gate={
+                "gate_passed": True,
+            },
+            candidate_materialization=(
+                materialization()
+            ),
+            execution_runner=runner,
+            game_pk=123,
+            simulation_count=10,
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.blockers == (
+        "candidate_execution_not_ready",
+    )
+
+
+def test_reserved_overlay_arguments_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match="owns hitter-profile",
+    ):
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            candidate_materialization=(
+                materialization()
+            ),
+            execution_runner=lambda **kwargs: None,
+            hitter_profile_shadow_enabled=True,
+        )
+
+def test_candidate_overlay_must_actually_apply():
+    def runner(**kwargs):
+        return Execution(
+            payload(),
+            overlay=None,
+        )
+
+    result = (
+        run_paired_hitter_profile_simulation_shadow_audit(
+            enabled=True,
+            acceptance_gate={
+                "gate_passed": True,
+            },
+            candidate_materialization=(
+                materialization()
+            ),
+            execution_runner=runner,
+            game_pk=123,
+            simulation_count=10,
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.blockers == (
+        "candidate_overlay_not_applied",
+    )


### PR DESCRIPTION
## Summary

- Add a paired canonical baseline/candidate simulation-shadow runner using identical production inputs and trial counts.
- Apply the hitter-profile overlay only to the candidate execution using request-scoped 6SH materialization results.
- Compare game outcomes, run distributions, betting thresholds, and team, batter, pitcher, and DFS metric means.
- Emit deterministic delta summaries while preserving the baseline execution as the production result.
- Add unit coverage plus a real canonical paired-execution integration test.

## Safety

- Disabled by default.
- Baseline remains the production result.
- Candidate observation requires proof that its hitter-profile overlay was applied.
- No model-projection activation or persistence wiring.
- No database writes.
- Production authority remains unchanged.

## Validation

- 296 tests passed.
- Python compilation passed.
- Tracked diff and new-file whitespace checks passed.
- Ruff was unavailable in the local environment.