### PR TITLE
Define hitter profile simulation shadow acceptance gates

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_acceptance_gate.py
+++ b/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_acceptance_gate.py
@@ -1,0 +1,375 @@
+"""Evaluate live hitter-profile simulation-shadow evidence."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = (
+    "hitter_profile_simulation_shadow_acceptance_gate_v1"
+)
+
+MINIMUM_AUDITED_GAMES = 15
+MINIMUM_OBSERVED_GAMES = 10
+MINIMUM_OBSERVATION_RATE = 0.50
+MINIMUM_COMPARISON_COUNT = 2500
+MINIMUM_SIMULATION_COUNT = 1000
+MINIMUM_ARTIFACT_READY_RATE = 0.50
+MAXIMUM_SHARED_EXECUTION_ERROR_RATE = 0.10
+
+SCOPE_LIMITS = {
+    "game_probability": {
+        "p95": 0.03,
+        "maximum": 0.05,
+    },
+    "game": {
+        "p95": 0.25,
+        "maximum": 0.35,
+    },
+    "team": {
+        "p95": 0.30,
+        "maximum": 0.40,
+    },
+    "batter": {
+        "p95": 0.15,
+        "maximum": 1.25,
+    },
+    "pitcher": {
+        "p95": 0.15,
+        "maximum": 0.50,
+    },
+}
+
+METRIC_LIMITS = {
+    "home_win_probability": {
+        "p95": 0.03,
+        "maximum": 0.05,
+    },
+    "away_win_probability": {
+        "p95": 0.03,
+        "maximum": 0.05,
+    },
+    "total_run_distribution_mean": {
+        "p95": 0.30,
+        "maximum": 0.35,
+    },
+    "dfs_points": {
+        "p95": 0.75,
+        "maximum": 1.25,
+    },
+}
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return result if math.isfinite(result) else None
+
+
+def _at_least(
+    value: Any,
+    minimum: float,
+) -> bool:
+    number = _number(value)
+    return (
+        number is not None
+        and number >= minimum
+    )
+
+
+def _at_most(
+    value: Any,
+    maximum: float,
+) -> bool:
+    number = _number(value)
+    return (
+        number is not None
+        and number <= maximum
+    )
+
+
+def _records(
+    payload: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    value = payload.get("records")
+    if not isinstance(value, list):
+        return []
+
+    return [
+        record
+        for record in value
+        if isinstance(record, Mapping)
+    ]
+
+
+def evaluate_hitter_profile_simulation_shadow_acceptance(
+    audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Evaluate bounded live shadow evidence without activating production."""
+
+    payload = dict(audit or {})
+    records = _records(payload)
+    audited_game_count = _number(
+        payload.get("audited_game_count")
+    )
+    observed_game_count = _number(
+        payload.get("observed_game_count")
+    )
+
+    observed_record_count = sum(
+        1
+        for record in records
+        if record.get("status") == "observed"
+    )
+    artifact_ready_game_count = sum(
+        1
+        for record in records
+        if record.get("materialization_status")
+        == "ready"
+    )
+    shared_execution_error_game_count = sum(
+        1
+        for record in records
+        if (
+            (
+                record.get("baseline_execution")
+                or {}
+            ).get("status")
+            == "error"
+            and (
+                record.get("candidate_execution")
+                or {}
+            ).get("status")
+            == "error"
+        )
+    )
+
+    artifact_ready_rate = (
+        artifact_ready_game_count
+        / audited_game_count
+        if (
+            audited_game_count is not None
+            and audited_game_count > 0
+        )
+        else None
+    )
+    shared_execution_error_rate = (
+        shared_execution_error_game_count
+        / audited_game_count
+        if (
+            audited_game_count is not None
+            and audited_game_count > 0
+        )
+        else None
+    )
+
+    scope_evidence = (
+        payload.get("absolute_delta_by_scope")
+        or {}
+    )
+    metric_evidence = (
+        payload.get("absolute_delta_by_metric")
+        or {}
+    )
+    safety = payload.get("safety_checks") or {}
+
+    scope_checks = {
+        f"{scope}_{stat}_delta": _at_most(
+            (
+                scope_evidence.get(scope)
+                or {}
+            ).get(stat),
+            limit,
+        )
+        for scope, limits in SCOPE_LIMITS.items()
+        for stat, limit in limits.items()
+    }
+    metric_checks = {
+        f"{metric}_{stat}_delta": _at_most(
+            (
+                metric_evidence.get(metric)
+                or {}
+            ).get(stat),
+            limit,
+        )
+        for metric, limits in METRIC_LIMITS.items()
+        for stat, limit in limits.items()
+    }
+
+    checks = {
+        "audit_status_observed": (
+            payload.get("status") == "observed"
+        ),
+        "complete_game_records": (
+            audited_game_count is not None
+            and len(records)
+            == audited_game_count
+        ),
+        "observed_game_count_reconciles": (
+            observed_game_count is not None
+            and observed_record_count
+            == observed_game_count
+        ),
+        "minimum_audited_games": _at_least(
+            audited_game_count,
+            MINIMUM_AUDITED_GAMES,
+        ),
+        "minimum_observed_games": _at_least(
+            observed_game_count,
+            MINIMUM_OBSERVED_GAMES,
+        ),
+        "minimum_observation_rate": _at_least(
+            payload.get("observation_rate"),
+            MINIMUM_OBSERVATION_RATE,
+        ),
+        "minimum_comparison_count": _at_least(
+            payload.get("comparison_count"),
+            MINIMUM_COMPARISON_COUNT,
+        ),
+        "minimum_simulation_count": _at_least(
+            payload.get("simulation_count"),
+            MINIMUM_SIMULATION_COUNT,
+        ),
+        "minimum_artifact_ready_rate": _at_least(
+            artifact_ready_rate,
+            MINIMUM_ARTIFACT_READY_RATE,
+        ),
+        "maximum_shared_execution_error_rate":
+            _at_most(
+                shared_execution_error_rate,
+                MAXIMUM_SHARED_EXECUTION_ERROR_RATE,
+            ),
+        "production_inputs_unchanged": (
+            safety.get(
+                "all_production_inputs_unchanged"
+            )
+            is True
+        ),
+        "production_authority_unchanged": (
+            safety.get(
+                "all_production_authority_unchanged"
+            )
+            is True
+            and payload.get(
+                "production_authority_changed"
+            )
+            is False
+        ),
+        "simulation_counts_match": (
+            safety.get(
+                "all_simulation_counts_match"
+            )
+            is True
+        ),
+        "database_writes_absent": (
+            safety.get(
+                "database_writes_performed"
+            )
+            is False
+            and payload.get(
+                "database_writes_performed"
+            )
+            is False
+        ),
+        **scope_checks,
+        **metric_checks,
+    }
+
+    blockers = sorted(
+        name
+        for name, passed in checks.items()
+        if passed is not True
+    )
+    gate_passed = not blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "accepted_for_extended_shadow_evaluation"
+            if gate_passed
+            else "blocked"
+        ),
+        "gate_passed": gate_passed,
+        "checks": checks,
+        "blockers": blockers,
+        "thresholds": {
+            "minimum_audited_games":
+                MINIMUM_AUDITED_GAMES,
+            "minimum_observed_games":
+                MINIMUM_OBSERVED_GAMES,
+            "minimum_observation_rate":
+                MINIMUM_OBSERVATION_RATE,
+            "minimum_comparison_count":
+                MINIMUM_COMPARISON_COUNT,
+            "minimum_simulation_count":
+                MINIMUM_SIMULATION_COUNT,
+            "minimum_artifact_ready_rate":
+                MINIMUM_ARTIFACT_READY_RATE,
+            "maximum_shared_execution_error_rate":
+                MAXIMUM_SHARED_EXECUTION_ERROR_RATE,
+            "scope_limits": {
+                scope: dict(limits)
+                for scope, limits in (
+                    SCOPE_LIMITS.items()
+                )
+            },
+            "metric_limits": {
+                metric: dict(limits)
+                for metric, limits in (
+                    METRIC_LIMITS.items()
+                )
+            },
+        },
+        "observed": {
+            "audited_game_count":
+                payload.get("audited_game_count"),
+            "observed_game_count":
+                payload.get("observed_game_count"),
+            "observed_record_count":
+                observed_record_count,
+            "observation_rate":
+                payload.get("observation_rate"),
+            "comparison_count":
+                payload.get("comparison_count"),
+            "simulation_count":
+                payload.get("simulation_count"),
+            "artifact_ready_game_count":
+                artifact_ready_game_count,
+            "artifact_ready_rate":
+                artifact_ready_rate,
+            "shared_execution_error_game_count":
+                shared_execution_error_game_count,
+            "shared_execution_error_rate":
+                shared_execution_error_rate,
+            "absolute_delta_by_scope":
+                scope_evidence,
+            "absolute_delta_by_metric":
+                metric_evidence,
+        },
+        "evaluation_scope": {
+            "scope_specific_thresholds": True,
+            "feature_flag_required": True,
+            "simulation_shadow_required": True,
+            "production_fallback_required": True,
+            "production_enabled": False,
+        },
+        "decision": {
+            "extended_shadow_evaluation_allowed":
+                gate_passed,
+            "production_activation_allowed": False,
+            "recommended_next_slice": (
+                "run_extended_hitter_profile_simulation_shadow_evaluation"
+                if gate_passed
+                else "collect_additional_hitter_profile_simulation_shadow_evidence"
+            ),
+        },
+        "parameter_selected": False,
+        "production_authority_changed": False,
+    }

--- a/scripts/audit_shadow_hitter_profile_simulation_acceptance.py
+++ b/scripts/audit_shadow_hitter_profile_simulation_acceptance.py
@@ -1,0 +1,134 @@
+"""Evaluate live hitter-profile simulation-shadow acceptance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from mlb_app.database import (
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow.hitter_profile_canary_acceptance_gate import (
+    evaluate_hitter_profile_canary_acceptance,
+)
+from mlb_app.simulation.shadow.hitter_profile_live_simulation_shadow_window import (
+    run_hitter_profile_live_simulation_shadow_window,
+)
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_acceptance_gate import (
+    evaluate_hitter_profile_simulation_shadow_acceptance,
+)
+from scripts.audit_shadow_hitter_profile_canary import (
+    run_live_audit,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target-date",
+        required=True,
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+    )
+    parser.add_argument(
+        "--game-limit",
+        type=int,
+        default=15,
+    )
+    parser.add_argument(
+        "--simulation-count",
+        type=int,
+        default=1000,
+    )
+    parser.add_argument(
+        "--canary-limit",
+        type=int,
+        default=250,
+    )
+    args = parser.parse_args()
+
+    season = (
+        args.season
+        if args.season is not None
+        else int(args.target_date[:4])
+    )
+
+    canary_audit = run_live_audit(
+        season=season,
+        as_of_date=args.target_date,
+        limit=args.canary_limit,
+    )
+    canary_gate = (
+        evaluate_hitter_profile_canary_acceptance(
+            canary_audit
+        )
+    )
+
+    engine = get_engine(
+        os.getenv(
+            "DATABASE_URL",
+            "sqlite:///mlb.db",
+        )
+    )
+    create_tables(engine)
+    Session = get_session(engine)
+    session = Session()
+
+    try:
+        window = (
+            run_hitter_profile_live_simulation_shadow_window(
+                session,
+                enabled=True,
+                target_date=args.target_date,
+                acceptance_gate=canary_gate,
+                simulation_count=(
+                    args.simulation_count
+                ),
+                game_limit=args.game_limit,
+            )
+        )
+    finally:
+        session.close()
+
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            window
+        )
+    )
+    result["audit_provenance"] = {
+        "target_date": args.target_date,
+        "season": season,
+        "game_limit": args.game_limit,
+        "simulation_count":
+            args.simulation_count,
+        "canary_limit": args.canary_limit,
+        "canary_audit_status":
+            canary_audit.get("status"),
+        "canary_gate_status":
+            canary_gate.get("status"),
+        "canary_gate_passed":
+            canary_gate.get("gate_passed"),
+        "window_schema_version":
+            window.get("schema_version"),
+        "window_status":
+            window.get("status"),
+    }
+    result["database_writes_performed"] = False
+    result["production_authority_changed"] = False
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_profile_simulation_shadow_acceptance_gate.py
+++ b/tests/test_hitter_profile_simulation_shadow_acceptance_gate.py
@@ -1,0 +1,241 @@
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_acceptance_gate import (
+    evaluate_hitter_profile_simulation_shadow_acceptance,
+)
+
+
+def summary(
+    *,
+    p95,
+    maximum,
+):
+    return {
+        "count": 100,
+        "minimum": 0.0,
+        "mean": p95 / 2,
+        "median": p95 / 2,
+        "p95": p95,
+        "maximum": maximum,
+    }
+
+
+def audit_payload():
+    records = [
+        {
+            "game_pk": game_pk,
+            "status": "observed",
+            "materialization_status": "ready",
+            "baseline_execution": {
+                "status": "executed",
+            },
+            "candidate_execution": {
+                "status": "executed",
+            },
+        }
+        for game_pk in range(1, 11)
+    ]
+    records.extend({
+        "game_pk": game_pk,
+        "status": "blocked",
+        "materialization_status": "blocked",
+        "baseline_execution": {},
+        "candidate_execution": {},
+    } for game_pk in range(11, 16))
+
+    return {
+        "status": "observed",
+        "audited_game_count": 15,
+        "observed_game_count": 10,
+        "observation_rate": 10 / 15,
+        "comparison_count": 3000,
+        "simulation_count": 1000,
+        "records": records,
+        "absolute_delta_by_scope": {
+            "game_probability":
+                summary(p95=0.02, maximum=0.04),
+            "game":
+                summary(p95=0.20, maximum=0.30),
+            "team":
+                summary(p95=0.25, maximum=0.35),
+            "batter":
+                summary(p95=0.10, maximum=1.00),
+            "pitcher":
+                summary(p95=0.10, maximum=0.40),
+        },
+        "absolute_delta_by_metric": {
+            "home_win_probability":
+                summary(p95=0.02, maximum=0.04),
+            "away_win_probability":
+                summary(p95=0.02, maximum=0.04),
+            "total_run_distribution_mean":
+                summary(p95=0.25, maximum=0.30),
+            "dfs_points":
+                summary(p95=0.60, maximum=1.00),
+        },
+        "safety_checks": {
+            "all_production_authority_unchanged":
+                True,
+            "all_production_inputs_unchanged":
+                True,
+            "all_simulation_counts_match": True,
+            "database_writes_performed": False,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def test_accepts_scope_specific_shadow_evidence():
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            audit_payload()
+        )
+    )
+
+    assert result["gate_passed"] is True
+    assert (
+        result["status"]
+        == "accepted_for_extended_shadow_evaluation"
+    )
+    assert result["blockers"] == []
+    assert result["decision"][
+        "extended_shadow_evaluation_allowed"
+    ] is True
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert result["evaluation_scope"][
+        "scope_specific_thresholds"
+    ] is True
+
+
+def test_live_6sj_window_remains_coverage_blocked():
+    payload = audit_payload()
+    payload["observed_game_count"] = 5
+    payload["observation_rate"] = 5 / 15
+    payload["records"] = (
+        payload["records"][:5]
+        + [
+            {
+                "game_pk": game_pk,
+                "status": "blocked",
+                "materialization_status":
+                    "blocked",
+                "baseline_execution": {},
+                "candidate_execution": {},
+            }
+            for game_pk in range(6, 16)
+        ]
+    )
+
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert "minimum_observed_games" in (
+        result["blockers"]
+    )
+    assert "minimum_observation_rate" in (
+        result["blockers"]
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+
+
+def test_blocks_scope_specific_delta_breach():
+    payload = audit_payload()
+    payload["absolute_delta_by_scope"][
+        "game_probability"
+    ]["p95"] = 0.031
+    payload["absolute_delta_by_metric"][
+        "dfs_points"
+    ]["maximum"] = 1.26
+
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "game_probability_p95_delta"
+        in result["blockers"]
+    )
+    assert (
+        "dfs_points_maximum_delta"
+        in result["blockers"]
+    )
+
+
+def test_blocks_safety_and_shared_execution_failures():
+    payload = audit_payload()
+    payload["safety_checks"][
+        "all_production_inputs_unchanged"
+    ] = False
+
+    for index in (0, 1):
+        payload["records"][index][
+            "baseline_execution"
+        ]["status"] = "error"
+        payload["records"][index][
+            "candidate_execution"
+        ]["status"] = "error"
+
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert (
+        "production_inputs_unchanged"
+        in result["blockers"]
+    )
+    assert (
+        "maximum_shared_execution_error_rate"
+        in result["blockers"]
+    )
+
+
+def test_missing_evidence_fails_closed():
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            {}
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert result["blockers"]
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+def test_blocks_incomplete_or_unreconciled_records():
+    payload = audit_payload()
+    payload["records"].pop(0)
+
+    result = (
+        evaluate_hitter_profile_simulation_shadow_acceptance(
+            payload
+        )
+    )
+
+    assert result["gate_passed"] is False
+    assert "complete_game_records" in (
+        result["blockers"]
+    )
+    assert "observed_game_count_reconciles" in (
+        result["blockers"]
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False


### PR DESCRIPTION
## Summary

- define fail-closed, scope-specific acceptance gates for live hitter-profile simulation-shadow evidence
- evaluate population coverage, artifact readiness, shared execution failures, paired comparison volume, and simulation count
- gate game probabilities, run outcomes, team metrics, batter metrics, pitcher metrics, and DFS points on their own scales
- add a live acceptance audit CLI and focused positive, negative, safety, missing-evidence, and reconciliation tests

## Selected thresholds

- at least 15 audited games
- at least 10 observed games and a 50% observation rate
- at least 2,500 paired comparisons and 1,000 trials per game
- at least 50% artifact-ready games
- no more than a 10% shared baseline/candidate execution-error rate
- game-probability p95 no more than 3% and maximum no more than 5%
- total-run-mean p95 no more than 0.30 runs and maximum no more than 0.35
- DFS p95 no more than 0.75 points and maximum no more than 1.25
- scope-specific limits for game, team, batter, and pitcher comparisons

## Live decision

The deterministic 2025-09-28 window remains intentionally blocked:

- 15 audited games
- 5 observed games
- 33.3% observation rate
- 6 artifact-ready games (40%)
- 2,851 paired comparisons
- 1,000 trials per game
- 1 shared baseline/candidate canonical execution error (6.7%)

All effect-size and safety checks passed. The only blockers were:

- minimum observed games
- minimum observation rate
- minimum artifact-ready rate

Recommended next slice: collect additional hitter-profile simulation-shadow evidence.

## Safety

- production activation is always false
- extended shadow evaluation remains disallowed while the gate is blocked
- no database writes
- production inputs and authority remain unchanged
- missing or internally inconsistent evidence fails closed

## Validation

- 275 tests passed
- Python compilation passed
- tracked and new-file whitespace checks passed
- live acceptance audit completed successfully
- Ruff was not installed in the local environment