### PR TITLE
Collect additional hitter profile simulation shadow evidence

### DIFF
--- a/mlb_app/simulation/shadow/hitter_profile_live_simulation_shadow_window.py
+++ b/mlb_app/simulation/shadow/hitter_profile_live_simulation_shadow_window.py
@@ -537,6 +537,7 @@ def run_hitter_profile_live_simulation_shadow_window(
     candidate_materializer: Any = None,
     paired_audit_runner: Any = None,
     pitcher_hand_loader: Any = None,
+    observation_observer: Any = None,
 ) -> dict[str, Any]:
     """Run a bounded read-only paired audit over projection games."""
 
@@ -547,6 +548,13 @@ def run_hitter_profile_live_simulation_shadow_window(
     if game_limit <= 0:
         raise ValueError(
             "game_limit must be positive"
+        )
+    if (
+        observation_observer is not None
+        and not callable(observation_observer)
+    ):
+        raise TypeError(
+            "observation_observer must be callable"
         )
 
     if enabled is not True:
@@ -886,6 +894,12 @@ def run_hitter_profile_live_simulation_shadow_window(
                 "production_authority_changed":
                     False,
             })
+
+    if observation_observer is not None:
+        for observation in observations:
+            observation_observer(
+                dict(observation)
+            )
 
     result = (
         aggregate_hitter_profile_live_simulation_shadow_window(

--- a/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_evidence_collection.py
+++ b/mlb_app/simulation/shadow/hitter_profile_simulation_shadow_evidence_collection.py
@@ -1,0 +1,361 @@
+"""Collect cutoff-safe hitter-profile simulation-shadow evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+COLLECTION_SCHEMA_VERSION = (
+    "hitter_profile_simulation_shadow_evidence_collection_v1"
+)
+
+
+def _target_dates(
+    values: Sequence[Any],
+) -> tuple[str, ...]:
+    dates = sorted({
+        str(value).strip()
+        for value in values
+        if str(value).strip()
+    })
+
+    if not dates:
+        raise ValueError(
+            "target_dates must contain at least one date"
+        )
+
+    return tuple(dates)
+
+
+def _game_key(
+    observation: Mapping[str, Any],
+) -> str | None:
+    game_pk = observation.get("game_pk")
+
+    if (
+        game_pk is None
+        or isinstance(game_pk, bool)
+    ):
+        return None
+
+    return str(game_pk)
+
+
+def collect_hitter_profile_simulation_shadow_evidence(
+    session: Any,
+    *,
+    enabled: bool = False,
+    target_dates: Sequence[Any],
+    acceptance_gates_by_date: Mapping[
+        str,
+        Mapping[str, Any],
+    ],
+    simulation_count: int = 1000,
+    game_limit: int = 5,
+    window_runner: Any = None,
+    window_aggregator: Any = None,
+    acceptance_evaluator: Any = None,
+) -> dict[str, Any]:
+    """Pool raw paired observations across deterministic dates."""
+
+    dates = _target_dates(target_dates)
+
+    if simulation_count <= 0:
+        raise ValueError(
+            "simulation_count must be positive"
+        )
+    if game_limit <= 0:
+        raise ValueError(
+            "game_limit must be positive"
+        )
+
+    if enabled is not True:
+        return {
+            "schema_version":
+                COLLECTION_SCHEMA_VERSION,
+            "status": "disabled",
+            "target_dates": list(dates),
+            "requested_date_count": len(dates),
+            "requested_game_count":
+                len(dates) * int(game_limit),
+            "audited_game_count": 0,
+            "observed_game_count": 0,
+            "observation_rate": 0.0,
+            "simulation_count":
+                int(simulation_count),
+            "records": [],
+            "windows": [],
+            "simulation_acceptance": None,
+            "decision": {
+                "extended_shadow_evaluation_allowed":
+                    False,
+                "production_activation_allowed":
+                    False,
+                "recommended_next_slice":
+                    "collect_additional_hitter_profile_"
+                    "simulation_shadow_evidence",
+            },
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+    if window_runner is None:
+        from mlb_app.simulation.shadow.hitter_profile_live_simulation_shadow_window import (
+            run_hitter_profile_live_simulation_shadow_window,
+        )
+
+        window_runner = (
+            run_hitter_profile_live_simulation_shadow_window
+        )
+
+    if window_aggregator is None:
+        from mlb_app.simulation.shadow.hitter_profile_live_simulation_shadow_window import (
+            aggregate_hitter_profile_live_simulation_shadow_window,
+        )
+
+        window_aggregator = (
+            aggregate_hitter_profile_live_simulation_shadow_window
+        )
+
+    if acceptance_evaluator is None:
+        from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_acceptance_gate import (
+            evaluate_hitter_profile_simulation_shadow_acceptance,
+        )
+
+        acceptance_evaluator = (
+            evaluate_hitter_profile_simulation_shadow_acceptance
+        )
+
+    observations_by_game: dict[
+        str,
+        dict[str, Any],
+    ] = {}
+    windows: list[dict[str, Any]] = []
+
+    for date_index, target_date in enumerate(dates):
+        captured: list[dict[str, Any]] = []
+
+        def observe(
+            observation: Mapping[str, Any],
+        ) -> None:
+            record = dict(observation)
+            record["evidence_target_date"] = (
+                target_date
+            )
+            captured.append(record)
+
+        try:
+            window = dict(
+                window_runner(
+                    session,
+                    enabled=True,
+                    target_date=target_date,
+                    acceptance_gate=dict(
+                        acceptance_gates_by_date.get(
+                            target_date,
+                            {},
+                        )
+                    ),
+                    simulation_count=int(
+                        simulation_count
+                    ),
+                    game_limit=int(game_limit),
+                    observation_observer=observe,
+                )
+            )
+        except Exception as exc:
+            window = {
+                "status": "blocked",
+                "audited_game_count": 0,
+                "observed_game_count": 0,
+                "blocker_counts": {
+                    "evidence_window_error": 1,
+                },
+                "error_type":
+                    type(exc).__name__,
+                "error_message": str(exc),
+                "database_writes_performed":
+                    False,
+                "production_authority_changed":
+                    False,
+            }
+
+        if not captured:
+            blocker_counts = dict(
+                window.get("blocker_counts")
+                or {}
+            )
+            blockers = sorted(
+                str(blocker)
+                for blocker, count in (
+                    blocker_counts.items()
+                )
+                if count
+            )
+            captured.append({
+                "game_pk": -(date_index + 1),
+                "game_date": target_date,
+                "evidence_target_date":
+                    target_date,
+                "status": "blocked",
+                "blockers": (
+                    blockers
+                    or [
+                        "live_window_no_game_observations"
+                    ]
+                ),
+                "candidate_materialization": {
+                    "status": "blocked",
+                    "candidate_count": 0,
+                    "state_counts": {},
+                    "blocker_counts":
+                        blocker_counts,
+                    "blockers": blockers,
+                    "records": [],
+                },
+                "database_writes_performed":
+                    False,
+                "production_authority_changed":
+                    False,
+            })
+
+        duplicate_game_count = 0
+
+        for observation in captured:
+            key = _game_key(observation)
+
+            if key is None:
+                continue
+            if key in observations_by_game:
+                duplicate_game_count += 1
+                continue
+
+            observations_by_game[key] = (
+                observation
+            )
+
+        windows.append({
+            "target_date": target_date,
+            "status": window.get("status"),
+            "audited_game_count":
+                window.get(
+                    "audited_game_count"
+                ),
+            "observed_game_count":
+                window.get(
+                    "observed_game_count"
+                ),
+            "captured_observation_count":
+                len(captured),
+            "duplicate_game_count":
+                duplicate_game_count,
+            "blocker_counts": dict(
+                window.get("blocker_counts")
+                or {}
+            ),
+            "source": dict(
+                window.get("source") or {}
+            ),
+            "database_writes_performed":
+                False,
+            "production_authority_changed":
+                False,
+        })
+
+    observations = sorted(
+        observations_by_game.values(),
+        key=lambda value: (
+            str(
+                value.get(
+                    "evidence_target_date"
+                )
+                or ""
+            ),
+            str(value.get("game_pk") or ""),
+        ),
+    )
+
+    combined = dict(
+        window_aggregator(
+            observations=observations,
+            target_date=(
+                dates[0]
+                if len(dates) == 1
+                else f"{dates[0]}..{dates[-1]}"
+            ),
+            requested_game_count=(
+                len(dates) * int(game_limit)
+            ),
+            simulation_count=int(
+                simulation_count
+            ),
+        )
+    )
+
+    combined["schema_version"] = (
+        COLLECTION_SCHEMA_VERSION
+    )
+    combined["target_dates"] = list(dates)
+    combined["requested_date_count"] = len(
+        dates
+    )
+    combined["captured_observation_count"] = (
+        sum(
+            window[
+                "captured_observation_count"
+            ]
+            for window in windows
+        )
+    )
+    combined["deduplicated_game_count"] = len(
+        observations
+    )
+    combined["duplicate_game_count"] = sum(
+        window["duplicate_game_count"]
+        for window in windows
+    )
+    combined["windows"] = windows
+    combined[
+        "database_writes_performed"
+    ] = False
+    combined[
+        "production_authority_changed"
+    ] = False
+
+    simulation_acceptance = dict(
+        acceptance_evaluator(combined)
+    )
+    combined["simulation_acceptance"] = (
+        simulation_acceptance
+    )
+    combined["decision"] = {
+        "extended_shadow_evaluation_allowed":
+            (
+                simulation_acceptance.get(
+                    "decision"
+                )
+                or {}
+            ).get(
+                "extended_shadow_evaluation_allowed"
+            )
+            is True,
+        "production_activation_allowed": False,
+        "recommended_next_slice": (
+            simulation_acceptance.get(
+                "decision"
+            )
+            or {}
+        ).get(
+            "recommended_next_slice",
+            "collect_additional_hitter_profile_"
+            "simulation_shadow_evidence",
+        ),
+    }
+    combined[
+        "database_writes_performed"
+    ] = False
+    combined[
+        "production_authority_changed"
+    ] = False
+
+    return combined

--- a/scripts/audit_hitter_profile_simulation_shadow_evidence_collection.py
+++ b/scripts/audit_hitter_profile_simulation_shadow_evidence_collection.py
@@ -1,0 +1,133 @@
+"""Collect multi-date hitter-profile simulation-shadow evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from mlb_app.database import (
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow.hitter_profile_canary_acceptance_gate import (
+    evaluate_hitter_profile_canary_acceptance,
+)
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_evidence_collection import (
+    collect_hitter_profile_simulation_shadow_evidence,
+)
+from scripts.audit_shadow_hitter_profile_canary import (
+    run_live_audit,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target-date",
+        action="append",
+        required=True,
+        dest="target_dates",
+    )
+    parser.add_argument(
+        "--game-limit",
+        type=int,
+        default=5,
+    )
+    parser.add_argument(
+        "--simulation-count",
+        type=int,
+        default=1000,
+    )
+    parser.add_argument(
+        "--canary-limit",
+        type=int,
+        default=250,
+    )
+    args = parser.parse_args()
+
+    target_dates = sorted(
+        set(args.target_dates)
+    )
+    gates_by_date = {}
+    canary_provenance = {}
+
+    for target_date in target_dates:
+        season = int(target_date[:4])
+        audit = run_live_audit(
+            season=season,
+            as_of_date=target_date,
+            limit=args.canary_limit,
+        )
+        gate = (
+            evaluate_hitter_profile_canary_acceptance(
+                audit
+            )
+        )
+        gates_by_date[target_date] = gate
+        canary_provenance[target_date] = {
+            "season": audit.get("season"),
+            "as_of_date":
+                audit.get("as_of_date"),
+            "audit_limit":
+                audit.get("audit_limit"),
+            "audit_status":
+                audit.get("status"),
+            "gate_status":
+                gate.get("status"),
+            "gate_passed":
+                gate.get("gate_passed"),
+            "gate_blockers":
+                gate.get("blockers"),
+        }
+
+    engine = get_engine(
+        os.getenv(
+            "DATABASE_URL",
+            "sqlite:///mlb.db",
+        )
+    )
+    create_tables(engine)
+    Session = get_session(engine)
+    session = Session()
+
+    try:
+        result = (
+            collect_hitter_profile_simulation_shadow_evidence(
+                session,
+                enabled=True,
+                target_dates=target_dates,
+                acceptance_gates_by_date=(
+                    gates_by_date
+                ),
+                simulation_count=(
+                    args.simulation_count
+                ),
+                game_limit=args.game_limit,
+            )
+        )
+    finally:
+        session.close()
+
+    result["canary_provenance_by_date"] = (
+        canary_provenance
+    )
+    result[
+        "database_writes_performed"
+    ] = False
+    result[
+        "production_authority_changed"
+    ] = False
+
+    print(
+        json.dumps(
+            result,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hitter_profile_live_simulation_shadow_window.py
+++ b/tests/test_hitter_profile_live_simulation_shadow_window.py
@@ -531,3 +531,73 @@ def test_preserves_paired_execution_errors():
         "error_type": "ValueError",
         "error_message": "candidate failed",
     }
+
+def test_live_runner_emits_raw_observations():
+    emitted = []
+
+    def payload_builder(
+        session,
+        target_date,
+        *,
+        canonical_shadow_context_observer,
+    ):
+        canonical_shadow_context_observer(
+            context(10)
+        )
+        return {
+            "games": [{"game_pk": 10}],
+        }
+
+    def materializer(*args, **kwargs):
+        return {
+            "status": "ready",
+            "materialized": True,
+            "candidate_results": {
+                "1": {"status": "ready"},
+            },
+            "database_writes_performed": False,
+            "production_inputs_unchanged": True,
+            "production_authority_changed": False,
+        }
+
+    class Paired:
+        def to_diagnostics(self):
+            return observation(
+                game_pk=10,
+                delta=0.01,
+            )
+
+    run_hitter_profile_live_simulation_shadow_window(
+        object(),
+        enabled=True,
+        target_date="2026-05-03",
+        acceptance_gate=accepted_gate(),
+        game_limit=1,
+        projection_payload_builder=payload_builder,
+        candidate_materializer=materializer,
+        paired_audit_runner=(
+            lambda **kwargs: Paired()
+        ),
+        observation_observer=emitted.append,
+    )
+
+    assert len(emitted) == 1
+    assert emitted[0]["game_pk"] == 10
+    assert emitted[0]["comparison"][
+        "records"
+    ][0]["absolute_delta"] == 0.01
+
+
+def test_live_runner_validates_observer():
+    import pytest
+
+    with pytest.raises(
+        TypeError,
+        match="observation_observer",
+    ):
+        run_hitter_profile_live_simulation_shadow_window(
+            object(),
+            target_date="2026-05-03",
+            acceptance_gate=accepted_gate(),
+            observation_observer=object(),
+        )

--- a/tests/test_hitter_profile_simulation_shadow_evidence_collection.py
+++ b/tests/test_hitter_profile_simulation_shadow_evidence_collection.py
@@ -1,0 +1,326 @@
+from mlb_app.simulation.shadow.hitter_profile_simulation_shadow_evidence_collection import (
+    collect_hitter_profile_simulation_shadow_evidence,
+)
+
+
+def accepted_gate():
+    return {
+        "gate_passed": True,
+        "decision": {
+            "feature_flag_integration_allowed":
+                True,
+            "production_activation_allowed":
+                False,
+        },
+        "production_authority_changed": False,
+    }
+
+
+def observation(game_pk, delta):
+    return {
+        "game_pk": game_pk,
+        "status": "observed",
+        "blockers": [],
+        "comparison": {
+            "comparison_count": 1,
+            "absolute_delta_summary": {
+                "maximum": abs(delta),
+            },
+            "records": [
+                {
+                    "scope":
+                        "game_probability",
+                    "metric":
+                        "home_win_probability",
+                    "delta": delta,
+                    "absolute_delta":
+                        abs(delta),
+                },
+            ],
+        },
+        "candidate_materialization": {
+            "status": "ready",
+            "candidate_count": 1,
+        },
+        "safety_checks": {
+            "production_authority_unchanged":
+                True,
+            "production_inputs_unchanged":
+                True,
+            "simulation_counts_match": True,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def test_collects_dates_and_deduplicates_games():
+    calls = []
+
+    def window_runner(
+        session,
+        *,
+        target_date,
+        observation_observer,
+        **kwargs,
+    ):
+        calls.append((target_date, kwargs))
+        observation_observer(
+            observation(
+                10,
+                0.01
+                if target_date == "2026-05-01"
+                else 0.02,
+            )
+        )
+        observation_observer(
+            observation(
+                20
+                if target_date == "2026-05-01"
+                else 30,
+                0.03,
+            )
+        )
+        return {
+            "status": "observed",
+            "audited_game_count": 2,
+            "observed_game_count": 2,
+            "blocker_counts": {},
+            "source": {},
+        }
+
+    evaluated = {}
+
+    def evaluator(payload):
+        evaluated.update(payload)
+        return {
+            "status": "blocked",
+            "gate_passed": False,
+            "decision": {
+                "extended_shadow_evaluation_allowed":
+                    False,
+                "production_activation_allowed":
+                    False,
+                "recommended_next_slice":
+                    "collect_additional_hitter_profile_"
+                    "simulation_shadow_evidence",
+            },
+        }
+
+    result = (
+        collect_hitter_profile_simulation_shadow_evidence(
+            object(),
+            enabled=True,
+            target_dates=[
+                "2026-05-02",
+                "2026-05-01",
+                "2026-05-02",
+            ],
+            acceptance_gates_by_date={
+                "2026-05-01": accepted_gate(),
+                "2026-05-02": accepted_gate(),
+            },
+            simulation_count=1000,
+            game_limit=2,
+            window_runner=window_runner,
+            acceptance_evaluator=evaluator,
+        )
+    )
+
+    assert [
+        call[0] for call in calls
+    ] == [
+        "2026-05-01",
+        "2026-05-02",
+    ]
+    assert result["target_dates"] == [
+        "2026-05-01",
+        "2026-05-02",
+    ]
+    assert result[
+        "captured_observation_count"
+    ] == 4
+    assert result[
+        "deduplicated_game_count"
+    ] == 3
+    assert result["duplicate_game_count"] == 1
+    assert result["audited_game_count"] == 3
+    assert result["comparison_count"] == 3
+    assert evaluated["audited_game_count"] == 3
+    assert (
+        evaluated[
+            "database_writes_performed"
+        ]
+        is False
+    )
+    assert (
+        evaluated[
+            "production_authority_changed"
+        ]
+        is False
+    )
+    assert result["absolute_delta_by_scope"][
+        "game_probability"
+    ]["maximum"] == 0.03
+
+
+def test_uses_cutoff_safe_gate_for_each_date():
+    observed_gates = {}
+
+    def window_runner(
+        session,
+        *,
+        target_date,
+        acceptance_gate,
+        observation_observer,
+        **kwargs,
+    ):
+        observed_gates[target_date] = (
+            acceptance_gate["identity"]
+        )
+        observation_observer(
+            observation(
+                int(target_date[-2:]),
+                0.01,
+            )
+        )
+        return {
+            "status": "observed",
+            "audited_game_count": 1,
+            "observed_game_count": 1,
+        }
+
+    collect_hitter_profile_simulation_shadow_evidence(
+        object(),
+        enabled=True,
+        target_dates=[
+            "2026-05-01",
+            "2026-05-02",
+        ],
+        acceptance_gates_by_date={
+            "2026-05-01": {
+                **accepted_gate(),
+                "identity": "gate-one",
+            },
+            "2026-05-02": {
+                **accepted_gate(),
+                "identity": "gate-two",
+            },
+        },
+        window_runner=window_runner,
+        acceptance_evaluator=lambda payload: {
+            "decision": {},
+        },
+    )
+
+    assert observed_gates == {
+        "2026-05-01": "gate-one",
+        "2026-05-02": "gate-two",
+    }
+
+
+def test_isolates_failed_date():
+    def window_runner(
+        session,
+        *,
+        target_date,
+        observation_observer,
+        **kwargs,
+    ):
+        if target_date == "2026-05-01":
+            raise RuntimeError(
+                "projection unavailable"
+            )
+
+        observation_observer(
+            observation(2, 0.01)
+        )
+        return {
+            "status": "observed",
+            "audited_game_count": 1,
+            "observed_game_count": 1,
+        }
+
+    result = (
+        collect_hitter_profile_simulation_shadow_evidence(
+            object(),
+            enabled=True,
+            target_dates=[
+                "2026-05-01",
+                "2026-05-02",
+            ],
+            acceptance_gates_by_date={
+                "2026-05-01": accepted_gate(),
+                "2026-05-02": accepted_gate(),
+            },
+            window_runner=window_runner,
+            acceptance_evaluator=lambda payload: {
+                "decision": {},
+            },
+        )
+    )
+
+    assert result["audited_game_count"] == 2
+    assert result["observed_game_count"] == 1
+    assert result["blocker_counts"] == {
+        "evidence_window_error": 1,
+    }
+    assert result["windows"][0][
+        "status"
+    ] == "blocked"
+
+
+def test_disabled_by_default():
+    called = False
+
+    def runner(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    result = (
+        collect_hitter_profile_simulation_shadow_evidence(
+            object(),
+            target_dates=[
+                "2026-05-01",
+            ],
+            acceptance_gates_by_date={},
+            window_runner=runner,
+        )
+    )
+
+    assert result["status"] == "disabled"
+    assert called is False
+    assert result["database_writes_performed"] is False
+    assert result["production_authority_changed"] is False
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+
+
+def test_validates_bounds_and_dates():
+    import pytest
+
+    with pytest.raises(
+        ValueError,
+        match="target_dates",
+    ):
+        collect_hitter_profile_simulation_shadow_evidence(
+            object(),
+            enabled=True,
+            target_dates=[],
+            acceptance_gates_by_date={},
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="simulation_count",
+    ):
+        collect_hitter_profile_simulation_shadow_evidence(
+            object(),
+            enabled=True,
+            target_dates=[
+                "2026-05-01",
+            ],
+            acceptance_gates_by_date={},
+            simulation_count=0,
+        )


### PR DESCRIPTION
## Summary

- add an optional raw-observation hook to the live hitter-profile simulation-shadow window
- collect cutoff-safe evidence across deterministically ordered target dates
- use a date-specific canary acceptance gate for every historical window
- deduplicate games by `game_pk` and aggregate raw comparison records once across the combined sample
- preserve per-date provenance, blockers, execution diagnostics, and production-safety invariants
- add a multi-date audit CLI and focused regression coverage

## Why

The single-window audit had enough comparisons but insufficient observed-game and artifact-readiness coverage. This slice gathers a broader valid evidence sample without averaging percentile summaries, weakening the acceptance gates, writing to the database, or changing production authority.

## Live evidence

Three cutoff-safe windows (2025-09-26 through 2025-09-28), 1,000 paired trials per game:

- 45 audited games
- 23 observed games
- 51.1% observation rate
- 13,239 raw comparisons
- 57.8% artifact-ready rate
- 6.7% shared execution-error rate
- all sample-size, readiness, and safety checks passed
- production activation remains blocked on genuine effect-size limits
- no database writes or production-authority changes

The evidence indicates the next slice should calibrate or constrain hitter-profile overlay influence rather than relax thresholds or collect more of the same evidence.

## Validation

- 255 relevant regression tests passed
- Python compilation passed
- CLI help contract passed
- tracked and new-file whitespace checks passed
- staged path isolation passed
- Ruff was unavailable in the local environment