### PR TITLE
Fix matchup win probability extremes

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -108,6 +108,7 @@ from .draftkings_projection_routes import (
 from .daily_odds_routes import router as daily_odds_router
 from .simulation.inning_simulator import simulate_half_innings
 from .model_projection_routes import router as model_projection_router
+from .model_projection_probability import build_model_projection_probability
 from .ai_data_assistant_routes import router as ai_data_assistant_router
 from .news_routes import router as news_router
 from .starting_pitcher_arsenal_refresh import refresh_starting_pitcher_arsenal
@@ -1966,6 +1967,22 @@ def create_app():
                 away_bp=away_vs_home_bullpen_pa_outcome_model,
                 home_bp=home_vs_away_bullpen_pa_outcome_model,
             )
+
+            def projection_offense_inputs(profile: Dict[str, Any], lineup_source: Optional[str]) -> Dict[str, Any]:
+                contact = profile.get("contact_skill") or {}
+                discipline = profile.get("plate_discipline") or {}
+                power = profile.get("power") or {}
+                metadata = profile.get("metadata") or {}
+                return {
+                    "k_pct": contact.get("k_rate"),
+                    "bb_pct": discipline.get("bb_rate"),
+                    "iso": power.get("iso"),
+                    "lineup_source": lineup_source,
+                    "profile_granularity": metadata.get("profile_granularity"),
+                    "source": metadata.get("source_type"),
+                    "pa": metadata.get("sample_size"),
+                }
+
             shared_matchup_input = {
                 "game_pk": game_pk,
                 "game_date": game_date_iso,
@@ -1981,6 +1998,22 @@ def create_app():
 
                 "away_pitcher_name": away_pitcher.get("fullName"),
                 "home_pitcher_name": home_pitcher.get("fullName"),
+
+                # Keep Matchup Detail on the same probability inputs used by
+                # Model Projections instead of asking the shared simulator to
+                # operate on empty default profiles.
+                "away_pitcher_features": away_pitcher_detail.get("aggregate") or {},
+                "home_pitcher_features": home_pitcher_detail.get("aggregate") or {},
+                "away_pitcher_arsenal": away_pitcher_detail.get("arsenal") or [],
+                "home_pitcher_arsenal": home_pitcher_detail.get("arsenal") or [],
+                "away_offense_inputs": projection_offense_inputs(
+                    away_projected_lineup_offense_profile,
+                    away_lineup_source,
+                ),
+                "home_offense_inputs": projection_offense_inputs(
+                    home_projected_lineup_offense_profile,
+                    home_lineup_source,
+                ),
 
                 "venue": {"name": venue_name},
                 "weather": game.get("weather") or {},
@@ -2011,6 +2044,17 @@ def create_app():
                     },
                 }
 
+            model_projection_probability = build_model_projection_probability(
+                game_pk=game_pk,
+                date=game_date_iso[:10] if game_date_iso else None,
+                shared_simulation=shared_game_simulation,
+                matchup={
+                    "home_win_prob": home_win_prob,
+                    "away_win_prob": away_win_prob,
+                    "model_version": "legacy_matchup_win_probability_v1",
+                },
+            )
+
             return {
                 "game_pk": game_pk,
                 "game_date": game_date_iso,
@@ -2018,8 +2062,17 @@ def create_app():
                 "status": (game.get("status") or {}).get("detailedState"),
                 "weather": _extract_weather(game),
                 "park_factor": get_park_factor(venue_name),
-                "home_win_prob": home_win_prob,
-                "away_win_prob": away_win_prob,
+                "home_win_prob": model_projection_probability.get("home_win_prob"),
+                "away_win_prob": model_projection_probability.get("away_win_prob"),
+                "home_win_probability": model_projection_probability.get("home_win_probability"),
+                "away_win_probability": model_projection_probability.get("away_win_probability"),
+                "model_projection_probability": model_projection_probability,
+                "probability": model_projection_probability,
+                "probability_source": model_projection_probability.get("source"),
+                "probability_source_path": model_projection_probability.get("source_path"),
+                "probability_is_fallback": model_projection_probability.get("is_fallback"),
+                "legacy_home_win_prob": home_win_prob,
+                "legacy_away_win_prob": away_win_prob,
                 "homePitcherProfile": home_pitcher_profile,
                 "awayPitcherProfile": away_pitcher_profile,
                 "homeProjectedLineupOffenseProfile": home_projected_lineup_offense_profile,

--- a/mlb_app/model_projection_probability.py
+++ b/mlb_app/model_projection_probability.py
@@ -79,8 +79,12 @@ def build_model_projection_probability(
             "is_fallback": False,
         }
 
-    canonical_home = _safe_float(matchup.get("home_win_prob") or matchup.get("home_win_probability"))
-    canonical_away = _safe_float(matchup.get("away_win_prob") or matchup.get("away_win_probability"))
+    canonical_home = _safe_float(matchup.get("home_win_prob"))
+    if canonical_home is None:
+        canonical_home = _safe_float(matchup.get("home_win_probability"))
+    canonical_away = _safe_float(matchup.get("away_win_prob"))
+    if canonical_away is None:
+        canonical_away = _safe_float(matchup.get("away_win_probability"))
     missing_reason = "sharedSimulation derived outputs missing"
     if source_path and (home_prob is None or away_prob is None):
         missing_reason = "sharedSimulation derived outputs missing home/away win probability"

--- a/mlb_app/scoring.py
+++ b/mlb_app/scoring.py
@@ -137,6 +137,21 @@ def _normalize(value: Optional[float], baseline: float) -> float:
     return value - baseline
 
 
+def _normalize_rate(value: Optional[float]) -> Optional[float]:
+    """Normalize rate fields that may be stored as either 0-1 or 0-100.
+
+    Historical warehouse rows contain both representations. Feeding a value
+    such as ``24.7`` into a model whose baseline is ``0.225`` overwhelms the
+    logit and produces a false 0%/100% result.
+    """
+    if value is None:
+        return None
+    number = float(value)
+    if abs(number) > 1.0:
+        number /= 100.0
+    return max(0.0, min(1.0, number))
+
+
 def _logistic(x: float) -> float:
     if x > 20:
         return 1.0
@@ -151,6 +166,8 @@ def _pitcher_advantage(agg) -> float:
     score = 0.0
     for field, weight in PITCHER_WEIGHTS.items():
         val = getattr(agg, field, None)
+        if field in {"k_pct", "bb_pct", "hard_hit_pct"}:
+            val = _normalize_rate(val)
         baseline = PITCHER_BASELINE.get(field, 0.0)
         score += weight * _normalize(val, baseline)
     return score
@@ -162,6 +179,8 @@ def _batter_advantage(agg) -> float:
     score = 0.0
     for field, weight in BATTER_WEIGHTS.items():
         val = getattr(agg, field, None)
+        if field in {"hard_hit_pct", "barrel_pct", "k_pct", "bb_pct"}:
+            val = _normalize_rate(val)
         baseline = BATTER_BASELINE.get(field, 0.0)
         score += weight * _normalize(val, baseline)
     return score
@@ -173,14 +192,16 @@ def _arsenal_vs_batter(arsenal: List, batter_split) -> float:
 
     batter_obp = None
     if batter_split:
-        batter_obp = getattr(batter_split, "on_base_pct", None)
+        batter_obp = _normalize_rate(getattr(batter_split, "on_base_pct", None))
 
     score = 0.0
     for pitch in arsenal:
-        usage = pitch.usage_pct or 0.0
+        usage = _normalize_rate(pitch.usage_pct) or 0.0
         pitch_score = 0.0
         for field, weight in ARSENAL_WEIGHTS.items():
             val = getattr(pitch, field, None)
+            if field in {"whiff_pct", "strikeout_pct"}:
+                val = _normalize_rate(val)
             baseline = ARSENAL_BASELINE.get(field, 0.0)
             pitch_score += weight * _normalize(val, baseline)
         score += usage * pitch_score

--- a/tests/test_model_projection_probability.py
+++ b/tests/test_model_projection_probability.py
@@ -71,6 +71,23 @@ def test_build_probability_contract_marks_canonical_fallback_explicitly() -> Non
     assert probability["away_win_prob"] == 0.49
 
 
+def test_build_probability_contract_preserves_zero_fallback_value() -> None:
+    probability = build_model_projection_probability(
+        game_pk=123,
+        date="2026-07-09",
+        shared_simulation={"derived_outputs": {}},
+        matchup={
+            "home_win_prob": 0.0,
+            "home_win_probability": 0.55,
+            "away_win_prob": 1.0,
+            "away_win_probability": 0.45,
+        },
+    )
+
+    assert probability["home_win_prob"] == 0.0
+    assert probability["away_win_prob"] == 1.0
+
+
 def test_projection_route_contract_repoints_legacy_aliases_from_model_projection() -> None:
     payload = {
         "date": "2026-07-09",

--- a/tests/test_scoring_rate_normalization.py
+++ b/tests/test_scoring_rate_normalization.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.scoring import _arsenal_vs_batter, _batter_advantage, _pitcher_advantage
+
+
+def _row(**values):
+    return SimpleNamespace(**values)
+
+
+def test_pitcher_advantage_accepts_fractional_or_whole_percent_rates() -> None:
+    fractional = _row(
+        k_pct=0.247,
+        bb_pct=0.081,
+        hard_hit_pct=0.386,
+        xwoba=0.318,
+        avg_velocity=94.2,
+    )
+    whole_percent = _row(
+        k_pct=24.7,
+        bb_pct=8.1,
+        hard_hit_pct=38.6,
+        xwoba=0.318,
+        avg_velocity=94.2,
+    )
+
+    assert _pitcher_advantage(whole_percent) == pytest.approx(
+        _pitcher_advantage(fractional)
+    )
+
+
+def test_batter_advantage_accepts_fractional_or_whole_percent_rates() -> None:
+    fractional = _row(
+        avg_exit_velocity=90.1,
+        hard_hit_pct=0.421,
+        barrel_pct=0.093,
+        k_pct=0.201,
+        bb_pct=0.088,
+        batting_avg=0.265,
+    )
+    whole_percent = _row(
+        avg_exit_velocity=90.1,
+        hard_hit_pct=42.1,
+        barrel_pct=9.3,
+        k_pct=20.1,
+        bb_pct=8.8,
+        batting_avg=0.265,
+    )
+
+    assert _batter_advantage(whole_percent) == pytest.approx(
+        _batter_advantage(fractional)
+    )
+
+
+def test_arsenal_score_accepts_fractional_or_whole_percent_rates() -> None:
+    fractional = [
+        _row(
+            usage_pct=0.42,
+            whiff_pct=0.285,
+            strikeout_pct=0.248,
+            rv_per_100=-0.4,
+            xwoba=0.301,
+        )
+    ]
+    whole_percent = [
+        _row(
+            usage_pct=42.0,
+            whiff_pct=28.5,
+            strikeout_pct=24.8,
+            rv_per_100=-0.4,
+            xwoba=0.301,
+        )
+    ]
+
+    assert _arsenal_vs_batter(
+        whole_percent, _row(on_base_pct=32.6)
+    ) == pytest.approx(
+        _arsenal_vs_batter(fractional, _row(on_base_pct=0.326))
+    )


### PR DESCRIPTION
## What changed

- makes Matchup Detail publish the normalized Model Projections probability contract instead of the legacy pitcher-only probability
- supplies the shared simulation with real pitcher, arsenal, and projected-lineup inputs
- preserves legacy probabilities only as diagnostic fallback fields
- normalizes warehouse rate values stored as either 0–1 or 0–100 before legacy scoring
- preserves legitimate zero-valued fallback aliases instead of replacing them via truthiness

## Root cause

`GET /matchup/{game_pk}` still exposed `compute_win_probability(...)` directly. Historical rate columns can contain either fractional or whole-percent values; whole-percent values overwhelmed the legacy logit and saturated it to 0/1, which the frontend correctly rendered as 0%/100%. The newer Model Projections probability contract already existed but was not wired into Matchup Detail.

## Impact

The matchup page now uses the same displayed/default probability source as Model Projections and avoids false 0%/100% outcomes caused by mixed rate units. Existing consumers keep the legacy alias names, while diagnostic legacy values remain available separately.

## Validation

- 18 rate/probability/artifact tests passed
- 21 matchup-analysis and shared-simulation tests passed
- Python compile check passed for all modified backend modules
- `git diff --check` passed

One unrelated pre-existing test (`tests/test_matchup_profile_contract.py`) still cannot collect because `analysis_pipeline.py` imports a nonexistent `get_player_splits`; this PR does not touch that path.