### PR TITLE
Audit canonical pitcher role and innings attribution

### DIFF
--- a/mlb_app/simulation/shadow/canonical_pitcher_role_and_innings_attribution_audit.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_role_and_innings_attribution_audit.py
@@ -1,0 +1,584 @@
+"""Audit canonical pitcher roles and projected innings attribution."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_role_and_innings_"
+    "attribution_audit_v1"
+)
+
+VALID_PLAN_TYPES = frozenset({
+    "traditional_starter",
+    "opener_bulk",
+    "tandem",
+    "bullpen_game",
+    "workload_capped_starter",
+    "unknown_fallback",
+})
+
+VALID_ROLES = frozenset({
+    "starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+    "reliever",
+    "unexpected_pitcher",
+})
+
+SUMMARY_FIELDS = (
+    "count",
+    "minimum",
+    "p10",
+    "median",
+    "mean",
+    "p90",
+    "p95",
+    "maximum",
+)
+
+
+def _value(
+    source: Any,
+    field_name: str,
+    default: Any = None,
+) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(field_name, default)
+
+    return getattr(source, field_name, default)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return (
+        value
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _identifier_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+
+    if isinstance(value, (str, bytes)):
+        values = (value,)
+    else:
+        try:
+            values = tuple(value)
+        except TypeError:
+            values = (value,)
+
+    result = []
+    seen = set()
+
+    for candidate in values:
+        normalized = _identifier(candidate)
+        if (
+            normalized is not None
+            and normalized not in seen
+        ):
+            result.append(normalized)
+            seen.add(normalized)
+
+    return tuple(result)
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    return None
+
+
+def _metric_summary(
+    projection: Mapping[str, Any],
+    metric_name: str,
+) -> Mapping[str, Any]:
+    metrics = projection.get("metrics") or ()
+
+    if isinstance(metrics, Mapping):
+        metric = metrics.get(metric_name)
+        if isinstance(metric, Mapping):
+            summary = metric.get("summary", metric)
+            return _mapping(summary)
+        return {}
+
+    for metric in metrics:
+        if not isinstance(metric, Mapping):
+            continue
+        if metric.get("name") != metric_name:
+            continue
+        return _mapping(metric.get("summary"))
+
+    return {}
+
+
+def _innings_summary(
+    outs_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    result = {}
+
+    for field_name in SUMMARY_FIELDS:
+        value = _number(
+            outs_summary.get(field_name)
+        )
+        result[field_name] = (
+            value / 3.0
+            if value is not None
+            else None
+        )
+
+    return result
+
+
+def _plan_contract(
+    plan: Any,
+    expected_team_side: str,
+) -> dict[str, Any]:
+    team_side = _value(
+        plan,
+        "team_side",
+        expected_team_side,
+    )
+    team_side = str(team_side or "").strip()
+
+    if team_side != expected_team_side:
+        raise ValueError(
+            "pitching plan team_side does not "
+            "match its audit side"
+        )
+
+    starter_id = _identifier(
+        _value(plan, "starter_id")
+    )
+    if starter_id is None:
+        raise ValueError(
+            "pitching plan requires starter_id"
+        )
+
+    bullpen_ids = _identifier_tuple(
+        _value(plan, "bullpen_pitcher_ids", ())
+    )
+    preferred_ids = _identifier_tuple(
+        _value(
+            plan,
+            "preferred_replacement_pitcher_ids",
+            (),
+        )
+    )
+    plan_type = str(
+        _value(
+            plan,
+            "plan_type",
+            "traditional_starter",
+        )
+        or "traditional_starter"
+    )
+
+    if plan_type not in VALID_PLAN_TYPES:
+        raise ValueError(
+            f"unsupported pitching plan type: "
+            f"{plan_type}"
+        )
+
+    if starter_id in bullpen_ids:
+        raise ValueError(
+            "starter cannot also be in bullpen"
+        )
+
+    if any(
+        pitcher_id not in bullpen_ids
+        for pitcher_id in preferred_ids
+    ):
+        raise ValueError(
+            "preferred replacement must be in bullpen"
+        )
+
+    return {
+        "team_side": team_side,
+        "starter_id": starter_id,
+        "bullpen_pitcher_ids": bullpen_ids,
+        "preferred_replacement_pitcher_ids": (
+            preferred_ids
+        ),
+        "plan_type": plan_type,
+    }
+
+
+def _starter_role(plan_type: str) -> str:
+    if plan_type in {
+        "opener_bulk",
+        "bullpen_game",
+    }:
+        return "opener"
+
+    if plan_type == "tandem":
+        return "tandem_primary"
+
+    return "starter"
+
+
+def _planned_roles(
+    plan: Mapping[str, Any],
+) -> dict[str, str]:
+    plan_type = str(plan["plan_type"])
+    preferred_ids = tuple(
+        plan[
+            "preferred_replacement_pitcher_ids"
+        ]
+    )
+
+    roles = {
+        str(plan["starter_id"]):
+            _starter_role(plan_type),
+    }
+
+    for pitcher_id in plan[
+        "bullpen_pitcher_ids"
+    ]:
+        roles[str(pitcher_id)] = "reliever"
+
+    if preferred_ids:
+        if plan_type == "opener_bulk":
+            roles[preferred_ids[0]] = (
+                "bulk_follower"
+            )
+        elif plan_type == "tandem":
+            roles[preferred_ids[0]] = (
+                "tandem_secondary"
+            )
+
+    return roles
+
+
+def _projection_pitchers(
+    projection_payload: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], ...]:
+    raw_pitchers = (
+        projection_payload.get("pitchers") or ()
+    )
+
+    if isinstance(raw_pitchers, Mapping):
+        raw_pitchers = raw_pitchers.values()
+
+    pitchers = []
+
+    for projection in raw_pitchers:
+        if not isinstance(projection, Mapping):
+            raise TypeError(
+                "pitcher projections must be mappings"
+            )
+        pitchers.append(projection)
+
+    return tuple(pitchers)
+
+
+def audit_canonical_pitcher_role_and_innings_attribution(
+    *,
+    projection_payload: Mapping[str, Any],
+    away_pitching_plan: Any,
+    home_pitching_plan: Any,
+    expected_roles_by_id: (
+        Mapping[str, str] | None
+    ) = None,
+) -> dict[str, Any]:
+    """
+    Compare canonical pitcher projections with canonical pitching plans.
+
+    This audit does not alter projection values, pitcher sequencing,
+    production inputs, database state, or production authority.
+    """
+
+    if not isinstance(
+        projection_payload,
+        Mapping,
+    ):
+        raise TypeError(
+            "projection_payload must be a mapping"
+        )
+
+    if (
+        expected_roles_by_id is not None
+        and not isinstance(
+            expected_roles_by_id,
+            Mapping,
+        )
+    ):
+        raise TypeError(
+            "expected_roles_by_id must be a mapping"
+        )
+
+    plans = {
+        "away": _plan_contract(
+            away_pitching_plan,
+            "away",
+        ),
+        "home": _plan_contract(
+            home_pitching_plan,
+            "home",
+        ),
+    }
+    roles_by_side = {
+        side: _planned_roles(plan)
+        for side, plan in plans.items()
+    }
+
+    expected_roles = {
+        str(player_id): str(role)
+        for player_id, role in (
+            expected_roles_by_id or {}
+        ).items()
+    }
+
+    invalid_expected_roles = sorted({
+        role
+        for role in expected_roles.values()
+        if role not in VALID_ROLES
+    })
+    if invalid_expected_roles:
+        raise ValueError(
+            "unsupported expected pitcher role: "
+            + ", ".join(invalid_expected_roles)
+        )
+
+    records = []
+    projected_keys = set()
+    anomalies = []
+
+    for projection in _projection_pitchers(
+        projection_payload
+    ):
+        player_id = _identifier(
+            projection.get("player_id")
+        )
+        team_side = str(
+            projection.get("team_side") or ""
+        ).strip()
+
+        if player_id is None:
+            raise ValueError(
+                "pitcher projection requires player_id"
+            )
+        if team_side not in plans:
+            raise ValueError(
+                "pitcher projection team_side must "
+                "be away or home"
+            )
+
+        key = (team_side, player_id)
+        if key in projected_keys:
+            raise ValueError(
+                "duplicate pitcher projection"
+            )
+        projected_keys.add(key)
+
+        planned_role = roles_by_side[
+            team_side
+        ].get(
+            player_id,
+            "unexpected_pitcher",
+        )
+        role_source = (
+            "canonical_pitching_plan"
+            if planned_role
+            != "unexpected_pitcher"
+            else "projection_only"
+        )
+        expected_role = expected_roles.get(
+            player_id
+        )
+
+        record_anomalies = []
+
+        if planned_role == "unexpected_pitcher":
+            record_anomalies.append(
+                "projected_pitcher_outside_plan"
+            )
+
+        if (
+            expected_role is not None
+            and expected_role != planned_role
+        ):
+            record_anomalies.append(
+                "expected_role_mismatch"
+            )
+
+        outs_summary = _metric_summary(
+            projection,
+            "outs_recorded",
+        )
+        if not outs_summary:
+            record_anomalies.append(
+                "outs_projection_unavailable"
+            )
+
+        anomalies.extend(record_anomalies)
+
+        records.append({
+            "player_id": player_id,
+            "team_side": team_side,
+            "plan_type":
+                plans[team_side]["plan_type"],
+            "role": planned_role,
+            "role_source": role_source,
+            "expected_role": expected_role,
+            "is_planned_starter": (
+                player_id
+                == plans[team_side]["starter_id"]
+            ),
+            "is_planned_bullpen_pitcher": (
+                player_id
+                in plans[team_side][
+                    "bullpen_pitcher_ids"
+                ]
+            ),
+            "is_preferred_replacement": (
+                player_id
+                in plans[team_side][
+                    "preferred_replacement_pitcher_ids"
+                ]
+            ),
+            "outs_recorded": {
+                field_name:
+                    _number(
+                        outs_summary.get(
+                            field_name
+                        )
+                    )
+                for field_name in SUMMARY_FIELDS
+            },
+            "innings_pitched": (
+                _innings_summary(outs_summary)
+            ),
+            "anomalies": sorted(
+                set(record_anomalies)
+            ),
+        })
+
+    for team_side, plan in plans.items():
+        starter_key = (
+            team_side,
+            str(plan["starter_id"]),
+        )
+        if starter_key not in projected_keys:
+            anomalies.append(
+                "planned_starter_not_projected"
+            )
+
+        for pitcher_id in plan[
+            "preferred_replacement_pitcher_ids"
+        ]:
+            if (
+                team_side,
+                str(pitcher_id),
+            ) not in projected_keys:
+                anomalies.append(
+                    "preferred_replacement_not_projected"
+                )
+
+    records.sort(
+        key=lambda record: (
+            record["team_side"],
+            record["role"],
+            record["player_id"],
+        )
+    )
+
+    anomaly_counts = dict(
+        sorted(Counter(anomalies).items())
+    )
+    projected_plan_count = sum(
+        record["role"] != "unexpected_pitcher"
+        for record in records
+    )
+    projected_pitcher_count = len(records)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "observed",
+        "audited": True,
+        "simulation_count":
+            projection_payload.get(
+                "simulation_count"
+            ),
+        "pitching_plans": {
+            side: {
+                "team_side": plan["team_side"],
+                "plan_type": plan["plan_type"],
+                "starter_id": plan["starter_id"],
+                "bullpen_pitcher_ids": list(
+                    plan["bullpen_pitcher_ids"]
+                ),
+                "preferred_replacement_pitcher_ids":
+                    list(
+                        plan[
+                            "preferred_replacement_pitcher_ids"
+                        ]
+                    ),
+            }
+            for side, plan in plans.items()
+        },
+        "projected_pitcher_count":
+            projected_pitcher_count,
+        "planned_projected_pitcher_count":
+            projected_plan_count,
+        "unexpected_projected_pitcher_count":
+            sum(
+                record["role"]
+                == "unexpected_pitcher"
+                for record in records
+            ),
+        "role_attribution_complete_rate": (
+            projected_plan_count
+            / projected_pitcher_count
+            if projected_pitcher_count
+            else 0.0
+        ),
+        "anomaly_counts": anomaly_counts,
+        "records": records,
+        "limitations": [
+            (
+                "aggregate_projection_payload_does_"
+                "not_expose_per_trial_pitcher_"
+                "appearance_sequence"
+            ),
+            (
+                "starter_versus_relief_innings_"
+                "cannot_be_proven_from_aggregate_"
+                "pitcher_metrics"
+            ),
+        ],
+        "safety_checks": {
+            "projection_values_unchanged": True,
+            "pitching_plans_unchanged": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "decision": {
+            "sequencing_activation_allowed": False,
+            "production_activation_allowed": False,
+            "recommended_next_slice": (
+                "audit_canonical_pitcher_"
+                "appearance_sequence"
+            ),
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/tests/test_canonical_pitcher_role_and_innings_attribution_audit.py
+++ b/tests/test_canonical_pitcher_role_and_innings_attribution_audit.py
@@ -1,0 +1,390 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.game.matchup_input import (
+    CanonicalPitchingPlan,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_role_and_innings_attribution_audit import (
+    audit_canonical_pitcher_role_and_innings_attribution,
+)
+
+
+def summary(
+    *,
+    mean,
+    p10=None,
+    p90=None,
+    maximum=None,
+):
+    return {
+        "count": 1000,
+        "minimum": 0.0,
+        "p10": p10,
+        "median": mean,
+        "mean": mean,
+        "p90": p90,
+        "p95": p90,
+        "maximum": maximum,
+    }
+
+
+def pitcher(
+    player_id,
+    team_side,
+    *,
+    mean_outs,
+):
+    return {
+        "player_id": player_id,
+        "team_side": team_side,
+        "metrics": [
+            {
+                "name": "outs_recorded",
+                "summary": summary(
+                    mean=mean_outs,
+                    p10=mean_outs - 3,
+                    p90=mean_outs + 3,
+                    maximum=mean_outs + 6,
+                ),
+            },
+        ],
+    }
+
+
+def traditional_plan(team_side):
+    return CanonicalPitchingPlan(
+        team_side=team_side,
+        starter_id=f"{team_side}_starter",
+        bullpen_pitcher_ids=(
+            f"{team_side}_reliever",
+        ),
+    )
+
+
+def opener_plan(team_side):
+    return CanonicalPitchingPlan(
+        team_side=team_side,
+        starter_id=f"{team_side}_opener",
+        bullpen_pitcher_ids=(
+            f"{team_side}_bulk",
+            f"{team_side}_reliever",
+        ),
+        plan_type="opener_bulk",
+        preferred_replacement_pitcher_ids=(
+            f"{team_side}_bulk",
+        ),
+    )
+
+
+def payload():
+    return {
+        "schema_version":
+            "canonical_projection_payload_v1",
+        "simulation_count": 1000,
+        "pitchers": [
+            pitcher(
+                "away_opener",
+                "away",
+                mean_outs=5.0,
+            ),
+            pitcher(
+                "away_bulk",
+                "away",
+                mean_outs=13.0,
+            ),
+            pitcher(
+                "away_reliever",
+                "away",
+                mean_outs=5.0,
+            ),
+            pitcher(
+                "home_starter",
+                "home",
+                mean_outs=17.0,
+            ),
+            pitcher(
+                "home_reliever",
+                "home",
+                mean_outs=7.0,
+            ),
+        ],
+    }
+
+
+def record(result, player_id):
+    return next(
+        value
+        for value in result["records"]
+        if value["player_id"] == player_id
+    )
+
+
+def test_attributes_opener_bulk_and_traditional_roles():
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    assert result["status"] == "observed"
+    assert result[
+        "role_attribution_complete_rate"
+    ] == 1.0
+    assert record(
+        result,
+        "away_opener",
+    )["role"] == "opener"
+    assert record(
+        result,
+        "away_bulk",
+    )["role"] == "bulk_follower"
+    assert record(
+        result,
+        "away_reliever",
+    )["role"] == "reliever"
+    assert record(
+        result,
+        "home_starter",
+    )["role"] == "starter"
+
+
+def test_converts_outs_distribution_to_innings():
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    bulk = record(result, "away_bulk")
+
+    assert bulk["outs_recorded"]["mean"] == 13.0
+    assert bulk["innings_pitched"]["mean"] == (
+        13.0 / 3.0
+    )
+    assert bulk["innings_pitched"]["p90"] == (
+        16.0 / 3.0
+    )
+
+
+def test_reports_pitcher_projected_outside_plan():
+    projection_payload = payload()
+    projection_payload["pitchers"].append(
+        pitcher(
+            "home_unplanned",
+            "home",
+            mean_outs=3.0,
+        )
+    )
+
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=projection_payload,
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    unexpected = record(
+        result,
+        "home_unplanned",
+    )
+
+    assert unexpected["role"] == (
+        "unexpected_pitcher"
+    )
+    assert (
+        "projected_pitcher_outside_plan"
+        in unexpected["anomalies"]
+    )
+    assert result["anomaly_counts"][
+        "projected_pitcher_outside_plan"
+    ] == 1
+
+
+def test_reports_missing_starter_and_bulk_follower():
+    projection_payload = payload()
+    projection_payload["pitchers"] = [
+        value
+        for value in projection_payload[
+            "pitchers"
+        ]
+        if value["player_id"] not in {
+            "away_opener",
+            "away_bulk",
+        }
+    ]
+
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=projection_payload,
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    assert result["anomaly_counts"][
+        "planned_starter_not_projected"
+    ] == 1
+    assert result["anomaly_counts"][
+        "preferred_replacement_not_projected"
+    ] == 1
+
+
+def test_reports_external_role_conflict():
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+            expected_roles_by_id={
+                "home_starter": "reliever",
+            },
+        )
+    )
+
+    starter = record(result, "home_starter")
+
+    assert starter["expected_role"] == (
+        "reliever"
+    )
+    assert "expected_role_mismatch" in (
+        starter["anomalies"]
+    )
+
+
+def test_attributes_tandem_roles():
+    tandem = replace(
+        opener_plan("away"),
+        plan_type="tandem",
+    )
+
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=tandem,
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    assert record(
+        result,
+        "away_opener",
+    )["role"] == "tandem_primary"
+    assert record(
+        result,
+        "away_bulk",
+    )["role"] == "tandem_secondary"
+
+
+def test_missing_outs_metric_is_diagnostic():
+    projection_payload = payload()
+    projection_payload["pitchers"][0][
+        "metrics"
+    ] = []
+
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=projection_payload,
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    opener = record(result, "away_opener")
+
+    assert "outs_projection_unavailable" in (
+        opener["anomalies"]
+    )
+    assert opener["innings_pitched"][
+        "mean"
+    ] is None
+
+
+def test_audit_is_non_authoritative_and_read_only():
+    result = (
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+    )
+
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert result["decision"][
+        "sequencing_activation_allowed"
+    ] is False
+
+
+def test_rejects_invalid_inputs():
+    with pytest.raises(
+        TypeError,
+        match="projection_payload",
+    ):
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=object(),
+            away_pitching_plan=opener_plan(
+                "away"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="team_side",
+    ):
+        audit_canonical_pitcher_role_and_innings_attribution(
+            projection_payload=payload(),
+            away_pitching_plan=traditional_plan(
+                "home"
+            ),
+            home_pitching_plan=traditional_plan(
+                "home"
+            ),
+        )


### PR DESCRIPTION
## Summary

- add a read-only audit that reconciles canonical pitcher projections with each team’s canonical pitching plan
- attribute traditional starters, openers, bulk followers, tandem pitchers, relievers, and unexpected pitchers with explicit role provenance
- convert projected outs summaries into innings summaries and report missing starters, missing preferred replacements, pitchers outside the plan, expected-role mismatches, and unavailable outs projections
- document that aggregate projection payloads cannot prove per-trial starter-versus-relief sequencing

## Safety

- no projection values or pitching plans are mutated
- no database writes
- no sequencing or production activation
- production authority remains unchanged

## Validation

- focused regression: 88 passed
- applicable pitcher-attribution regression: 227 passed
- compilation, diff, staged diff, and new-file whitespace checks passed
- ruff was not installed locally

## Known unrelated baseline failure

`tests/test_pitcher_handedness_resolution.py` was reproduced separately and excluded from the applicable regression because collection fails on the existing import `get_player_splits` from `mlb_app.player_splits`. None of the implicated files are modified by this PR.