### PR TITLE
Enforce canonical bullpen eligibility

### DIFF
--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
+from .canonical_bullpen_eligibility import (
+    enforce_canonical_bullpen_eligibility,
+)
+
 
 CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION = (
     "canonical_shadow_bullpen_discovery_v1"
@@ -74,6 +78,7 @@ class CanonicalShadowBullpenSideDiscovery:
     team_id: Optional[str] = None
     starter_id: Optional[str] = None
     bullpen_pitcher_ids: Tuple[str, ...] = ()
+    eligibility: Optional[Dict[str, Any]] = None
     source_record_count: int = 0
     status: str = "unavailable"
     error_type: Optional[str] = None
@@ -114,6 +119,63 @@ class CanonicalShadowBullpenSideDiscovery:
                 self.bullpen_pitcher_ids
             ),
             "minimum_pitcher_count": 1,
+            "eligibility_status": (
+                self.eligibility.get("status")
+                if self.eligibility is not None
+                else None
+            ),
+            "eligibility_evidence_complete": (
+                self.eligibility.get(
+                    "eligibility_evidence_complete"
+                )
+                if self.eligibility is not None
+                else False
+            ),
+            "eligibility_evidence_coverage_rate": (
+                self.eligibility.get(
+                    "eligibility_evidence_coverage_rate"
+                )
+                if self.eligibility is not None
+                else 0.0
+            ),
+            "eligible_pitcher_count": (
+                self.eligibility.get(
+                    "eligible_pitcher_count"
+                )
+                if self.eligibility is not None
+                else len(self.bullpen_pitcher_ids)
+            ),
+            "excluded_pitcher_count": (
+                self.eligibility.get(
+                    "excluded_pitcher_count"
+                )
+                if self.eligibility is not None
+                else 0
+            ),
+            "unknown_role_count": (
+                self.eligibility.get(
+                    "unknown_role_count"
+                )
+                if self.eligibility is not None
+                else len(self.bullpen_pitcher_ids)
+            ),
+            "planned_override_count": (
+                self.eligibility.get(
+                    "planned_override_count"
+                )
+                if self.eligibility is not None
+                else 0
+            ),
+            "exclusion_reason_counts": (
+                dict(
+                    self.eligibility.get(
+                        "exclusion_reason_counts"
+                    )
+                    or {}
+                )
+                if self.eligibility is not None
+                else {}
+            ),
             "error_type": self.error_type,
             "error_message": self.error_message,
             "pitcher_identifiers_exposed": False,
@@ -190,6 +252,10 @@ def _discover_side(
     starter_id: Any,
     season: int,
     roster_fetcher: Callable[..., Sequence[Mapping[str, Any]]],
+    eligibility_evidence_by_pitcher_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    planned_pitcher_ids: Any = (),
 ) -> CanonicalShadowBullpenSideDiscovery:
     normalized_team = _normalize_identifier(
         team_id
@@ -253,15 +319,35 @@ def _discover_side(
         records,
         starter_id=normalized_starter,
     )
+    eligibility = (
+        enforce_canonical_bullpen_eligibility(
+            candidate_pitcher_ids=pitcher_ids,
+            starter_id=normalized_starter,
+            evidence_by_pitcher_id=(
+                eligibility_evidence_by_pitcher_id
+            ),
+            planned_pitcher_ids=(
+                planned_pitcher_ids
+            ),
+        )
+    )
+    eligible_pitcher_ids = tuple(
+        eligibility[
+            "eligible_bullpen_pitcher_ids"
+        ]
+    )
 
     return CanonicalShadowBullpenSideDiscovery(
         team_id=normalized_team,
         starter_id=normalized_starter,
-        bullpen_pitcher_ids=pitcher_ids,
+        bullpen_pitcher_ids=(
+            eligible_pitcher_ids
+        ),
+        eligibility=eligibility,
         source_record_count=len(records),
         status=(
             "ready"
-            if pitcher_ids
+            if eligible_pitcher_ids
             else "unavailable"
         ),
     )
@@ -279,6 +365,14 @@ def discover_canonical_shadow_bullpens(
     roster_fetcher: Optional[
         Callable[..., Sequence[Mapping[str, Any]]]
     ] = None,
+    away_eligibility_evidence_by_pitcher_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    home_eligibility_evidence_by_pitcher_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    away_planned_pitcher_ids: Any = (),
+    home_planned_pitcher_ids: Any = (),
 ) -> CanonicalShadowBullpenDiscovery:
     """
     Discover active-roster bullpen IDs without activating canonical execution.
@@ -301,6 +395,12 @@ def discover_canonical_shadow_bullpens(
             starter_id=away_starter_id,
             season=season,
             roster_fetcher=roster_fetcher,
+            eligibility_evidence_by_pitcher_id=(
+                away_eligibility_evidence_by_pitcher_id
+            ),
+            planned_pitcher_ids=(
+                away_planned_pitcher_ids
+            ),
         ),
         home=_discover_side(
             team_id=home_team_id,
@@ -308,5 +408,11 @@ def discover_canonical_shadow_bullpens(
             starter_id=home_starter_id,
             season=season,
             roster_fetcher=roster_fetcher,
+            eligibility_evidence_by_pitcher_id=(
+                home_eligibility_evidence_by_pitcher_id
+            ),
+            planned_pitcher_ids=(
+                home_planned_pitcher_ids
+            ),
         ),
     )

--- a/mlb_app/simulation/shadow/canonical_bullpen_eligibility.py
+++ b/mlb_app/simulation/shadow/canonical_bullpen_eligibility.py
@@ -1,0 +1,400 @@
+"""Deterministically enforce canonical bullpen eligibility evidence."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "canonical_bullpen_eligibility_v1"
+)
+
+VALID_EVIDENCE_STATUSES = frozenset({
+    "eligible",
+    "ineligible",
+    "unknown",
+})
+
+VALID_PITCHER_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+    "reliever",
+    "long_reliever",
+    "middle_reliever",
+    "setup",
+    "closer",
+    "unknown",
+})
+
+
+def _identifier(value: Any) -> str | None:
+    if value in (None, "") or isinstance(
+        value,
+        bool,
+    ):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        return text or None
+
+    return str(parsed) if parsed > 0 else None
+
+
+def _identifiers(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+
+    if isinstance(value, (str, bytes)):
+        values = (value,)
+    elif isinstance(value, Sequence):
+        values = tuple(value)
+    else:
+        try:
+            values = tuple(value)
+        except TypeError:
+            values = (value,)
+
+    result = []
+    seen = set()
+
+    for candidate in values:
+        identifier = _identifier(candidate)
+        if (
+            identifier is not None
+            and identifier not in seen
+        ):
+            result.append(identifier)
+            seen.add(identifier)
+
+    return tuple(result)
+
+
+def _evidence_index(
+    evidence_by_pitcher_id: (
+        Mapping[Any, Any] | None
+    ),
+) -> dict[str, Any]:
+    if evidence_by_pitcher_id is None:
+        return {}
+
+    if not isinstance(
+        evidence_by_pitcher_id,
+        Mapping,
+    ):
+        raise TypeError(
+            "evidence_by_pitcher_id must be "
+            "a mapping or None"
+        )
+
+    result = {}
+
+    for raw_identifier, evidence in (
+        evidence_by_pitcher_id.items()
+    ):
+        identifier = _identifier(
+            raw_identifier
+        )
+        if identifier is not None:
+            result[identifier] = evidence
+
+    return result
+
+
+def _evidence_record(
+    value: Any,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {
+            "valid": False,
+            "status": "unknown",
+            "role": "unknown",
+            "source": None,
+            "reason":
+                "invalid_eligibility_evidence",
+        }
+
+    status = str(
+        value.get("status") or "unknown"
+    ).strip().lower()
+    role = str(
+        value.get("role") or "unknown"
+    ).strip().lower()
+    source = (
+        str(value.get("source")).strip()
+        if value.get("source") not in {
+            None,
+            "",
+        }
+        else None
+    )
+    reason = (
+        str(value.get("reason")).strip()
+        if value.get("reason") not in {
+            None,
+            "",
+        }
+        else None
+    )
+
+    valid = (
+        status in VALID_EVIDENCE_STATUSES
+        and role in VALID_PITCHER_ROLES
+        and source is not None
+    )
+
+    if not valid:
+        return {
+            "valid": False,
+            "status": "unknown",
+            "role": (
+                role
+                if role in VALID_PITCHER_ROLES
+                else "unknown"
+            ),
+            "source": source,
+            "reason":
+                "invalid_eligibility_evidence",
+        }
+
+    return {
+        "valid": True,
+        "status": status,
+        "role": role,
+        "source": source,
+        "reason": reason,
+    }
+
+
+def enforce_canonical_bullpen_eligibility(
+    *,
+    candidate_pitcher_ids: Any,
+    starter_id: Any,
+    evidence_by_pitcher_id: (
+        Mapping[Any, Any] | None
+    ) = None,
+    planned_pitcher_ids: Any = (),
+) -> dict[str, Any]:
+    """
+    Filter a bullpen pool using explicit evidence only.
+
+    Unknown or unavailable evidence fails open and retains the pitcher.
+    Explicitly planned opener, bulk, or tandem pitchers are retained even
+    when general role evidence classifies them as starters.
+    """
+
+    candidates = _identifiers(
+        candidate_pitcher_ids
+    )
+    normalized_starter = _identifier(
+        starter_id
+    )
+    planned = set(
+        _identifiers(planned_pitcher_ids)
+    )
+    evidence_index = _evidence_index(
+        evidence_by_pitcher_id
+    )
+
+    eligible = []
+    excluded = []
+    records = []
+    reason_counts = Counter()
+    evidence_pitcher_count = 0
+    valid_evidence_count = 0
+    unknown_role_count = 0
+    planned_override_count = 0
+
+    for pitcher_id in candidates:
+        evidence_present = (
+            pitcher_id in evidence_index
+        )
+        evidence = _evidence_record(
+            evidence_index.get(pitcher_id)
+        )
+
+        if evidence_present:
+            evidence_pitcher_count += 1
+        if evidence["valid"]:
+            valid_evidence_count += 1
+        if evidence["role"] == "unknown":
+            unknown_role_count += 1
+
+        retained = True
+        decision_reason = (
+            "eligibility_evidence_unavailable"
+        )
+
+        if (
+            normalized_starter is not None
+            and pitcher_id == normalized_starter
+        ):
+            retained = False
+            decision_reason = (
+                "scheduled_starter_excluded"
+            )
+        elif pitcher_id in planned:
+            retained = True
+            decision_reason = (
+                "explicit_pitching_plan_override"
+            )
+            planned_override_count += 1
+        elif (
+            evidence["valid"]
+            and evidence["status"]
+            == "ineligible"
+        ):
+            retained = False
+            decision_reason = (
+                evidence["reason"]
+                or (
+                    f"{evidence['role']}_"
+                    "ineligible"
+                )
+            )
+        elif (
+            evidence["valid"]
+            and evidence["status"]
+            == "eligible"
+        ):
+            retained = True
+            decision_reason = (
+                "explicitly_eligible"
+            )
+        elif evidence_present:
+            retained = True
+            decision_reason = (
+                evidence["reason"]
+                or "unknown_eligibility_retained"
+            )
+
+        reason_counts[decision_reason] += 1
+
+        if retained:
+            eligible.append(pitcher_id)
+        else:
+            excluded.append(pitcher_id)
+
+        records.append({
+            "pitcher_id": pitcher_id,
+            "retained": retained,
+            "decision_reason":
+                decision_reason,
+            "planned_pitcher": (
+                pitcher_id in planned
+            ),
+            "evidence_present":
+                evidence_present,
+            "evidence_valid":
+                evidence["valid"],
+            "evidence_status":
+                evidence["status"],
+            "pitcher_role":
+                evidence["role"],
+            "evidence_source":
+                evidence["source"],
+        })
+
+    candidate_count = len(candidates)
+    evidence_complete = (
+        candidate_count > 0
+        and all(
+            record["evidence_valid"]
+            or record["planned_pitcher"]
+            or (
+                normalized_starter is not None
+                and record["pitcher_id"]
+                == normalized_starter
+            )
+            for record in records
+        )
+    )
+    evidence_coverage_rate = (
+        valid_evidence_count
+        / candidate_count
+        if candidate_count
+        else 0.0
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "enforced"
+            if valid_evidence_count > 0
+            else "fallback"
+        ),
+        "candidate_pitcher_ids": list(
+            candidates
+        ),
+        "eligible_bullpen_pitcher_ids":
+            eligible,
+        "excluded_pitcher_ids": excluded,
+        "candidate_pitcher_count":
+            candidate_count,
+        "eligible_pitcher_count":
+            len(eligible),
+        "excluded_pitcher_count":
+            len(excluded),
+        "evidence_pitcher_count":
+            evidence_pitcher_count,
+        "valid_evidence_count":
+            valid_evidence_count,
+        "unknown_role_count":
+            unknown_role_count,
+        "planned_override_count":
+            planned_override_count,
+        "eligibility_evidence_complete":
+            evidence_complete,
+        "eligibility_evidence_coverage_rate":
+            evidence_coverage_rate,
+        "exclusion_reason_counts": dict(
+            sorted(
+                (
+                    reason,
+                    count,
+                )
+                for reason, count
+                in reason_counts.items()
+                if any(
+                    (
+                        not record["retained"]
+                        and record[
+                            "decision_reason"
+                        ] == reason
+                    )
+                    for record in records
+                )
+            )
+        ),
+        "decision_reason_counts": dict(
+            sorted(reason_counts.items())
+        ),
+        "records": records,
+        "safety_checks": {
+            "unknown_evidence_fails_open": True,
+            "explicit_plans_take_precedence":
+                True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "decision": {
+            "bullpen_filter_applied": (
+                bool(excluded)
+            ),
+            "production_activation_allowed":
+                False,
+            "recommended_next_slice": (
+                "materialize_pregame_pitching_plans"
+            ),
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/tests/test_canonical_bullpen_eligibility.py
+++ b/tests/test_canonical_bullpen_eligibility.py
@@ -1,0 +1,266 @@
+import pytest
+
+from mlb_app.simulation.shadow.canonical_bullpen_eligibility import (
+    enforce_canonical_bullpen_eligibility,
+)
+
+
+def evidence(
+    *,
+    status,
+    role,
+    reason=None,
+):
+    return {
+        "status": status,
+        "role": role,
+        "source": "pregame_role_evidence_v1",
+        "reason": reason,
+    }
+
+
+def enforce(**overrides):
+    kwargs = {
+        "candidate_pitcher_ids": (
+            "100",
+            "101",
+            "102",
+            "103",
+        ),
+        "starter_id": "100",
+        "evidence_by_pitcher_id": {
+            "101": evidence(
+                status="ineligible",
+                role="probable_starter",
+                reason=(
+                    "probable_starter_not_in_plan"
+                ),
+            ),
+            "102": evidence(
+                status="eligible",
+                role="reliever",
+            ),
+            "103": evidence(
+                status="eligible",
+                role="long_reliever",
+            ),
+        },
+    }
+    kwargs.update(overrides)
+
+    return (
+        enforce_canonical_bullpen_eligibility(
+            **kwargs
+        )
+    )
+
+
+def record(result, pitcher_id):
+    return next(
+        value
+        for value in result["records"]
+        if value["pitcher_id"] == pitcher_id
+    )
+
+
+def test_excludes_scheduled_and_probable_starters():
+    result = enforce()
+
+    assert result["status"] == "enforced"
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == [
+        "102",
+        "103",
+    ]
+    assert result["excluded_pitcher_ids"] == [
+        "100",
+        "101",
+    ]
+    assert result["exclusion_reason_counts"] == {
+        "probable_starter_not_in_plan": 1,
+        "scheduled_starter_excluded": 1,
+    }
+
+
+def test_retains_explicitly_eligible_relievers():
+    result = enforce()
+
+    reliever = record(result, "102")
+
+    assert reliever["retained"] is True
+    assert reliever["pitcher_role"] == (
+        "reliever"
+    )
+    assert reliever["decision_reason"] == (
+        "explicitly_eligible"
+    )
+
+
+def test_unknown_evidence_fails_open():
+    result = enforce(
+        candidate_pitcher_ids=(
+            "101",
+            "102",
+        ),
+        starter_id="100",
+        evidence_by_pitcher_id=None,
+    )
+
+    assert result["status"] == "fallback"
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == [
+        "101",
+        "102",
+    ]
+    assert result["excluded_pitcher_ids"] == []
+    assert result[
+        "eligibility_evidence_complete"
+    ] is False
+    assert result[
+        "eligibility_evidence_coverage_rate"
+    ] == 0.0
+
+
+def test_planned_bulk_pitcher_overrides_exclusion():
+    result = enforce(
+        planned_pitcher_ids=("101",),
+    )
+
+    bulk = record(result, "101")
+
+    assert bulk["retained"] is True
+    assert bulk["planned_pitcher"] is True
+    assert bulk["decision_reason"] == (
+        "explicit_pitching_plan_override"
+    )
+    assert result["planned_override_count"] == 1
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == [
+        "101",
+        "102",
+        "103",
+    ]
+
+
+def test_planned_tandem_pitcher_is_retained():
+    result = enforce(
+        candidate_pitcher_ids=("101",),
+        starter_id="100",
+        planned_pitcher_ids=("101",),
+        evidence_by_pitcher_id={
+            "101": evidence(
+                status="ineligible",
+                role="probable_starter",
+            ),
+        },
+    )
+
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == ["101"]
+    assert result["planned_override_count"] == 1
+
+
+def test_invalid_evidence_fails_open():
+    result = enforce(
+        candidate_pitcher_ids=("101",),
+        starter_id="100",
+        evidence_by_pitcher_id={
+            "101": {
+                "status": "blocked",
+                "role": "mystery",
+            },
+        },
+    )
+
+    pitcher = record(result, "101")
+
+    assert pitcher["retained"] is True
+    assert pitcher["evidence_valid"] is False
+    assert pitcher["decision_reason"] == (
+        "invalid_eligibility_evidence"
+    )
+
+
+def test_normalizes_and_deduplicates_ids():
+    result = enforce(
+        candidate_pitcher_ids=(
+            101,
+            "101",
+            None,
+            102,
+            "102",
+        ),
+        starter_id=100,
+        evidence_by_pitcher_id=None,
+    )
+
+    assert result["candidate_pitcher_ids"] == [
+        "101",
+        "102",
+    ]
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == [
+        "101",
+        "102",
+    ]
+
+
+def test_evidence_completeness_reconciles():
+    result = enforce(
+        candidate_pitcher_ids=(
+            "101",
+            "102",
+        ),
+        starter_id="100",
+        evidence_by_pitcher_id={
+            "101": evidence(
+                status="ineligible",
+                role="probable_starter",
+            ),
+            "102": evidence(
+                status="eligible",
+                role="reliever",
+            ),
+        },
+    )
+
+    assert result[
+        "eligibility_evidence_complete"
+    ] is True
+    assert result[
+        "eligibility_evidence_coverage_rate"
+    ] == 1.0
+
+
+def test_is_read_only_and_non_authoritative():
+    result = enforce()
+
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert result["safety_checks"][
+        "unknown_evidence_fails_open"
+    ] is True
+
+
+def test_rejects_invalid_evidence_container():
+    with pytest.raises(
+        TypeError,
+        match="evidence_by_pitcher_id",
+    ):
+        enforce(
+            evidence_by_pitcher_id=object(),
+        )

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -181,3 +181,144 @@ def test_roster_failure_fails_open():
         "RuntimeError"
     )
     assert result.readiness_matchup_fields() == {}
+
+def role_evidence(
+    status,
+    role,
+    reason=None,
+):
+    return {
+        "status": status,
+        "role": role,
+        "source": "pregame_role_evidence_v1",
+        "reason": reason,
+    }
+
+
+def test_verified_probable_starter_is_excluded():
+    result = discovery(
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "ineligible",
+                "probable_starter",
+                "probable_starter_not_in_plan",
+            ),
+            "102": role_evidence(
+                "eligible",
+                "reliever",
+            ),
+        },
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "102",
+    )
+
+    diagnostics = (
+        result.away.to_diagnostics()
+    )
+
+    assert diagnostics[
+        "eligibility_status"
+    ] == "enforced"
+    assert diagnostics[
+        "eligibility_evidence_complete"
+    ] is True
+    assert diagnostics[
+        "excluded_pitcher_count"
+    ] == 1
+    assert diagnostics[
+        "exclusion_reason_counts"
+    ] == {
+        "probable_starter_not_in_plan": 1,
+    }
+
+
+def test_missing_evidence_preserves_existing_pool():
+    result = discovery()
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+        "102",
+    )
+
+    diagnostics = (
+        result.away.to_diagnostics()
+    )
+
+    assert diagnostics[
+        "eligibility_status"
+    ] == "fallback"
+    assert diagnostics[
+        "eligibility_evidence_complete"
+    ] is False
+    assert diagnostics[
+        "eligibility_evidence_coverage_rate"
+    ] == 0.0
+    assert diagnostics[
+        "excluded_pitcher_count"
+    ] == 0
+
+
+def test_planned_bulk_pitcher_overrides_exclusion():
+    result = discovery(
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "ineligible",
+                "probable_starter",
+            ),
+            "102": role_evidence(
+                "eligible",
+                "reliever",
+            ),
+        },
+        away_planned_pitcher_ids=(
+            "101",
+        ),
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+        "102",
+    )
+    assert result.away.to_diagnostics()[
+        "planned_override_count"
+    ] == 1
+
+
+def test_invalid_evidence_retains_candidate():
+    result = discovery(
+        away_eligibility_evidence_by_pitcher_id={
+            "101": {
+                "status": "blocked",
+                "role": "mystery",
+            },
+        },
+    )
+
+    assert "101" in (
+        result.away.bullpen_pitcher_ids
+    )
+    assert result.away.to_diagnostics()[
+        "excluded_pitcher_count"
+    ] == 0
+
+
+def test_eligibility_diagnostics_do_not_expose_ids():
+    diagnostics = discovery(
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "ineligible",
+                "probable_starter",
+            ),
+        },
+    ).to_diagnostics()
+
+    assert (
+        "eligible_bullpen_pitcher_ids"
+        not in diagnostics["away"]
+    )
+    assert (
+        "excluded_pitcher_ids"
+        not in diagnostics["away"]
+    )


### PR DESCRIPTION
## Summary

- add a canonical bullpen eligibility contract that excludes verified scheduled or probable starters from general relief pools
- preserve explicitly planned opener, bulk-follower, and tandem pitchers through a pitching-plan override
- fail open when role evidence is absent, unknown, or invalid so incomplete evidence cannot silently empty a bullpen
- integrate eligibility diagnostics into canonical bullpen discovery without exposing pitcher identifiers

## Why

Pitcher appearance-sequence audits showed that the canonical pitching manager follows its supplied plan correctly, including opener/bulk ordering. The remaining risk was upstream bullpen construction: active-roster pitchers could enter the general relief pool without verified role eligibility, allowing starting pitchers to receive relief innings.

This slice adds a read-only, non-authoritative eligibility boundary at bullpen discovery while preserving existing behavior when evidence is unavailable.

## Safety

- no database writes
- no production authority change
- production activation remains disabled
- missing or invalid evidence fails open
- explicit pitching-plan assignments override general exclusions

## Validation

- 133 targeted regression tests passed
- Python compilation passed
- working-tree and staged diff checks passed
- only the four intended files were committed

Commit: `4fb89ea`