### PR TITLE
Materialize canonical pregame pitching plans

### DIFF
--- a/mlb_app/simulation/shadow/pregame_pitching_plan_materialization.py
+++ b/mlb_app/simulation/shadow/pregame_pitching_plan_materialization.py
@@ -1,0 +1,294 @@
+"""Materialize canonical pregame pitching plans safely."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Tuple
+
+from mlb_app.simulation.game.matchup_input import (
+    CanonicalPitchingPlan,
+)
+
+
+SUPPORTED_PLAN_TYPES = frozenset({
+    "traditional_starter",
+    "opener_bulk",
+    "tandem",
+    "bullpen_game",
+    "workload_capped_starter",
+    "unknown_fallback",
+})
+
+FOLLOWER_PLAN_TYPES = frozenset({
+    "opener_bulk",
+    "tandem",
+    "bullpen_game",
+})
+
+
+@dataclass(frozen=True)
+class CanonicalPregamePitchingPlanMaterialization:
+    """Read-only result of one team's plan materialization."""
+
+    status: str
+    pitching_plan: CanonicalPitchingPlan
+    requested_plan_type: str
+    fallback_used: bool
+    blockers: Tuple[str, ...] = ()
+    diagnostics: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+    database_writes_performed: bool = False
+    production_authority_changed: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+
+def _identifier(value: Any) -> str:
+    if value is None:
+        return ""
+
+    return str(value).strip()
+
+
+def _pitcher_ids(values: Any) -> Tuple[str, ...]:
+    if not isinstance(values, (list, tuple)):
+        return ()
+
+    result = []
+    seen = set()
+
+    for value in values:
+        pitcher_id = _identifier(value)
+
+        if not pitcher_id or pitcher_id in seen:
+            continue
+
+        seen.add(pitcher_id)
+        result.append(pitcher_id)
+
+    return tuple(result)
+
+
+def _requested_plan_type(
+    classification: Mapping[str, Any] | None,
+) -> str:
+    if not isinstance(classification, Mapping):
+        return "traditional_starter"
+
+    return (
+        _identifier(
+            classification.get("plan_type")
+        )
+        or "traditional_starter"
+    )
+
+
+def _preferred_replacements(
+    *,
+    classification: Mapping[str, Any],
+    starter_id: str,
+    bullpen_pitcher_ids: Tuple[str, ...],
+) -> tuple[Tuple[str, ...], int, int]:
+    planned_sequence = classification.get(
+        "planned_sequence"
+    )
+
+    if not isinstance(planned_sequence, (list, tuple)):
+        return (), 0, 0
+
+    bullpen_ids = set(bullpen_pitcher_ids)
+    preferred = []
+    seen = set()
+    invalid_record_count = 0
+    unavailable_pitcher_count = 0
+
+    for row in planned_sequence:
+        if not isinstance(row, Mapping):
+            invalid_record_count += 1
+            continue
+
+        pitcher_id = _identifier(
+            row.get("pitcher_id")
+        )
+
+        if not pitcher_id:
+            invalid_record_count += 1
+            continue
+
+        if (
+            pitcher_id == starter_id
+            or pitcher_id in seen
+        ):
+            continue
+
+        seen.add(pitcher_id)
+
+        if pitcher_id not in bullpen_ids:
+            unavailable_pitcher_count += 1
+            continue
+
+        preferred.append(pitcher_id)
+
+    return (
+        tuple(preferred),
+        invalid_record_count,
+        unavailable_pitcher_count,
+    )
+
+
+def materialize_canonical_pregame_pitching_plan(
+    *,
+    team_side: str,
+    starter_id: Any,
+    bullpen_pitcher_ids: Any,
+    classification: Mapping[str, Any] | None = None,
+) -> CanonicalPregamePitchingPlanMaterialization:
+    """
+    Convert classification evidence into one canonical plan.
+
+    Invalid, unsupported, or explicitly fallback classification
+    evidence safely produces a traditional-starter plan. Preferred
+    followers are retained only when they belong to the eligible
+    bullpen supplied to this boundary.
+    """
+
+    normalized_starter_id = _identifier(starter_id)
+
+    if not normalized_starter_id:
+        raise ValueError("starter_id is required")
+
+    normalized_bullpen_ids = _pitcher_ids(
+        bullpen_pitcher_ids
+    )
+    requested_plan_type = _requested_plan_type(
+        classification
+    )
+
+    blockers = []
+    fallback_used = False
+    fallback_reason = None
+    materialized_plan_type = requested_plan_type
+    preferred_replacements: Tuple[str, ...] = ()
+    invalid_sequence_record_count = 0
+    unavailable_planned_pitcher_count = 0
+
+    if not isinstance(classification, Mapping):
+        fallback_used = True
+        fallback_reason = (
+            "classification_unavailable"
+        )
+        blockers.append(fallback_reason)
+        materialized_plan_type = (
+            "traditional_starter"
+        )
+    elif requested_plan_type not in (
+        SUPPORTED_PLAN_TYPES
+    ):
+        fallback_used = True
+        fallback_reason = (
+            "unsupported_plan_type"
+        )
+        blockers.append(fallback_reason)
+        materialized_plan_type = (
+            "traditional_starter"
+        )
+    elif (
+        classification.get("fallback_used")
+        is True
+        or requested_plan_type
+        == "unknown_fallback"
+    ):
+        fallback_used = True
+        fallback_reason = (
+            "classification_fallback_used"
+        )
+        blockers.append(fallback_reason)
+        materialized_plan_type = (
+            "traditional_starter"
+        )
+    elif requested_plan_type in FOLLOWER_PLAN_TYPES:
+        (
+            preferred_replacements,
+            invalid_sequence_record_count,
+            unavailable_planned_pitcher_count,
+        ) = _preferred_replacements(
+            classification=classification,
+            starter_id=normalized_starter_id,
+            bullpen_pitcher_ids=(
+                normalized_bullpen_ids
+            ),
+        )
+
+        if invalid_sequence_record_count:
+            blockers.append(
+                "invalid_planned_sequence_record"
+            )
+
+        if unavailable_planned_pitcher_count:
+            blockers.append(
+                "planned_pitcher_not_in_bullpen"
+            )
+
+    pitching_plan = CanonicalPitchingPlan(
+        team_side=team_side,
+        starter_id=normalized_starter_id,
+        bullpen_pitcher_ids=(
+            normalized_bullpen_ids
+        ),
+        plan_type=materialized_plan_type,
+        preferred_replacement_pitcher_ids=(
+            preferred_replacements
+        ),
+    )
+
+    diagnostics = {
+        "schema_version": (
+            "canonical_pregame_pitching_plan_"
+            "materialization_v1"
+        ),
+        "status": "ready",
+        "requested_plan_type": (
+            requested_plan_type
+        ),
+        "materialized_plan_type": (
+            materialized_plan_type
+        ),
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "bullpen_pitcher_count": len(
+            normalized_bullpen_ids
+        ),
+        "preferred_replacement_count": len(
+            preferred_replacements
+        ),
+        "invalid_sequence_record_count": (
+            invalid_sequence_record_count
+        ),
+        "unavailable_planned_pitcher_count": (
+            unavailable_planned_pitcher_count
+        ),
+        "classification_available": isinstance(
+            classification,
+            Mapping,
+        ),
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+    return (
+        CanonicalPregamePitchingPlanMaterialization(
+            status="ready",
+            pitching_plan=pitching_plan,
+            requested_plan_type=(
+                requested_plan_type
+            ),
+            fallback_used=fallback_used,
+            blockers=tuple(
+                sorted(set(blockers))
+            ),
+            diagnostics=diagnostics,
+        )
+    )

--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -15,7 +15,6 @@ from mlb_app.simulation.game import (
     CanonicalBaserunningProbabilityTransform,
     CanonicalLineup,
     CanonicalMatchupInput,
-    CanonicalPitchingPlan,
     CanonicalProbabilityFallbackPolicy,
     CanonicalProbabilityFallbackTier,
     build_canonical_trial_factory_input,
@@ -23,6 +22,9 @@ from mlb_app.simulation.game import (
 
 from .bullpen_discovery import (
     CanonicalShadowBullpenDiscovery,
+)
+from .pregame_pitching_plan_materialization import (
+    materialize_canonical_pregame_pitching_plan,
 )
 from .execution_bundle import (
     CanonicalShadowExecutionMaterial,
@@ -206,76 +208,6 @@ class CanonicalProductionShadowExecution:
         return diagnostics
 
 
-def _canonical_pitching_plan_metadata(
-    *,
-    classification: Optional[
-        Mapping[str, Any]
-    ],
-    starter_id: str,
-    bullpen_pitcher_ids: Tuple[str, ...],
-) -> Tuple[str, Tuple[str, ...]]:
-    if not isinstance(classification, Mapping):
-        return "traditional_starter", ()
-
-    plan_type = str(
-        classification.get(
-            "plan_type",
-            "traditional_starter",
-        )
-    ).strip()
-
-    supported_plan_types = {
-        "traditional_starter",
-        "opener_bulk",
-        "tandem",
-        "bullpen_game",
-        "workload_capped_starter",
-        "unknown_fallback",
-    }
-
-    if plan_type not in supported_plan_types:
-        return "traditional_starter", ()
-
-    if classification.get("fallback_used") is True:
-        return "traditional_starter", ()
-
-    bullpen_ids = set(bullpen_pitcher_ids)
-    preferred = []
-    seen = set()
-
-    planned_sequence = classification.get(
-        "planned_sequence"
-    )
-
-    if isinstance(planned_sequence, (list, tuple)):
-        for row in planned_sequence:
-            if not isinstance(row, Mapping):
-                continue
-
-            pitcher_id = str(
-                row.get("pitcher_id") or ""
-            ).strip()
-
-            if (
-                not pitcher_id
-                or pitcher_id == starter_id
-                or pitcher_id not in bullpen_ids
-                or pitcher_id in seen
-            ):
-                continue
-
-            seen.add(pitcher_id)
-            preferred.append(pitcher_id)
-
-    if plan_type not in {
-        "opener_bulk",
-        "tandem",
-    }:
-        preferred = []
-
-    return plan_type, tuple(preferred)
-
-
 def _build_matchup_input(
     *,
     game_pk: int,
@@ -313,26 +245,25 @@ def _build_matchup_input(
         bullpens.home.bullpen_pitcher_ids
     )
 
-    (
-        away_plan_type,
-        away_preferred_replacements,
-    ) = _canonical_pitching_plan_metadata(
-        classification=(
-            away_pitching_plan_classification
-        ),
-        starter_id=away_starter,
-        bullpen_pitcher_ids=away_bullpen_ids,
+    away_plan_materialization = (
+        materialize_canonical_pregame_pitching_plan(
+            team_side="away",
+            starter_id=away_starter,
+            bullpen_pitcher_ids=away_bullpen_ids,
+            classification=(
+                away_pitching_plan_classification
+            ),
+        )
     )
-
-    (
-        home_plan_type,
-        home_preferred_replacements,
-    ) = _canonical_pitching_plan_metadata(
-        classification=(
-            home_pitching_plan_classification
-        ),
-        starter_id=home_starter,
-        bullpen_pitcher_ids=home_bullpen_ids,
+    home_plan_materialization = (
+        materialize_canonical_pregame_pitching_plan(
+            team_side="home",
+            starter_id=home_starter,
+            bullpen_pitcher_ids=home_bullpen_ids,
+            classification=(
+                home_pitching_plan_classification
+            ),
+        )
     )
 
     return CanonicalMatchupInput(
@@ -345,23 +276,11 @@ def _build_matchup_input(
             team_side="home",
             player_ids=lineups.home_player_ids,
         ),
-        away_pitching_plan=CanonicalPitchingPlan(
-            team_side="away",
-            starter_id=away_starter,
-            bullpen_pitcher_ids=away_bullpen_ids,
-            plan_type=away_plan_type,
-            preferred_replacement_pitcher_ids=(
-                away_preferred_replacements
-            ),
+        away_pitching_plan=(
+            away_plan_materialization.pitching_plan
         ),
-        home_pitching_plan=CanonicalPitchingPlan(
-            team_side="home",
-            starter_id=home_starter,
-            bullpen_pitcher_ids=home_bullpen_ids,
-            plan_type=home_plan_type,
-            preferred_replacement_pitcher_ids=(
-                home_preferred_replacements
-            ),
+        home_pitching_plan=(
+            home_plan_materialization.pitching_plan
         ),
         probability_provider=provider,
     )

--- a/tests/test_pregame_pitching_plan_materialization.py
+++ b/tests/test_pregame_pitching_plan_materialization.py
@@ -1,0 +1,396 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.pregame_pitching_plan_materialization import (
+    materialize_canonical_pregame_pitching_plan,
+)
+
+
+def classification(
+    *,
+    plan_type="opener_bulk",
+    starter_id="100",
+    follower_ids=("101",),
+):
+    roles = {
+        "opener_bulk": (
+            "opener",
+            "bulk_follower",
+        ),
+        "tandem": (
+            "tandem_primary",
+            "tandem_secondary",
+        ),
+        "bullpen_game": (
+            "opener",
+            "reliever",
+        ),
+    }
+    starter_role, follower_role = roles.get(
+        plan_type,
+        ("starter", "reliever"),
+    )
+
+    planned_sequence = [{
+        "order": 1,
+        "role": starter_role,
+        "pitcher_id": starter_id,
+    }]
+
+    planned_sequence.extend(
+        {
+            "order": index + 2,
+            "role": follower_role,
+            "pitcher_id": pitcher_id,
+        }
+        for index, pitcher_id in enumerate(
+            follower_ids
+        )
+    )
+
+    return {
+        "plan_type": plan_type,
+        "fallback_used": False,
+        "planned_sequence": planned_sequence,
+    }
+
+
+def materialize(
+    *,
+    team_side="away",
+    starter_id="100",
+    bullpen_pitcher_ids=(
+        "101",
+        "102",
+        "103",
+    ),
+    plan_classification=None,
+):
+    if plan_classification is None:
+        plan_classification = classification()
+
+    return (
+        materialize_canonical_pregame_pitching_plan(
+            team_side=team_side,
+            starter_id=starter_id,
+            bullpen_pitcher_ids=(
+                bullpen_pitcher_ids
+            ),
+            classification=(
+                plan_classification
+            ),
+        )
+    )
+
+
+def test_materializes_opener_bulk_sequence():
+    result = materialize()
+
+    assert result.status == "ready"
+    assert result.ready is True
+    assert result.fallback_used is False
+    assert result.blockers == ()
+    assert result.pitching_plan.plan_type == (
+        "opener_bulk"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("101",)
+    )
+
+
+def test_materializes_tandem_sequence():
+    result = materialize(
+        plan_classification=classification(
+            plan_type="tandem",
+        )
+    )
+
+    assert result.pitching_plan.plan_type == (
+        "tandem"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("101",)
+    )
+
+
+def test_materializes_bullpen_game_sequence():
+    result = materialize(
+        plan_classification=classification(
+            plan_type="bullpen_game",
+            follower_ids=("101", "102"),
+        )
+    )
+
+    assert result.pitching_plan.plan_type == (
+        "bullpen_game"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("101", "102")
+    )
+
+
+def test_traditional_plan_has_no_preferred_follower():
+    result = materialize(
+        plan_classification=classification(
+            plan_type="traditional_starter",
+            follower_ids=("101",),
+        )
+    )
+
+    assert result.pitching_plan.plan_type == (
+        "traditional_starter"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ()
+    )
+
+
+def test_workload_capped_plan_has_no_fixed_follower():
+    result = materialize(
+        plan_classification=classification(
+            plan_type=(
+                "workload_capped_starter"
+            ),
+            follower_ids=("101",),
+        )
+    )
+
+    assert result.pitching_plan.plan_type == (
+        "workload_capped_starter"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ()
+    )
+
+
+def test_missing_classification_falls_back_safely():
+    result = (
+        materialize_canonical_pregame_pitching_plan(
+            team_side="away",
+            starter_id="100",
+            bullpen_pitcher_ids=("101",),
+            classification=None,
+        )
+    )
+
+    assert result.fallback_used is True
+    assert result.pitching_plan.plan_type == (
+        "traditional_starter"
+    )
+    assert result.blockers == (
+        "classification_unavailable",
+    )
+
+
+def test_unknown_classification_falls_back_safely():
+    result = materialize(
+        plan_classification={
+            "plan_type": "unknown_fallback",
+            "fallback_used": True,
+            "planned_sequence": [],
+        }
+    )
+
+    assert result.fallback_used is True
+    assert result.pitching_plan.plan_type == (
+        "traditional_starter"
+    )
+    assert result.blockers == (
+        "classification_fallback_used",
+    )
+
+
+def test_unsupported_type_falls_back_safely():
+    result = materialize(
+        plan_classification={
+            "plan_type": "invented_plan",
+            "fallback_used": False,
+            "planned_sequence": [],
+        }
+    )
+
+    assert result.fallback_used is True
+    assert result.pitching_plan.plan_type == (
+        "traditional_starter"
+    )
+    assert result.blockers == (
+        "unsupported_plan_type",
+    )
+
+
+def test_unavailable_follower_is_not_materialized():
+    result = materialize(
+        plan_classification=classification(
+            follower_ids=("999",),
+        )
+    )
+
+    assert result.pitching_plan.plan_type == (
+        "opener_bulk"
+    )
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ()
+    )
+    assert result.blockers == (
+        "planned_pitcher_not_in_bullpen",
+    )
+    assert result.diagnostics[
+        "unavailable_planned_pitcher_count"
+    ] == 1
+
+
+def test_starter_is_not_repeated_as_follower():
+    result = materialize(
+        plan_classification=classification(
+            follower_ids=("100", "101"),
+        )
+    )
+
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("101",)
+    )
+
+
+def test_duplicate_followers_are_deduplicated():
+    result = materialize(
+        plan_classification=classification(
+            follower_ids=(
+                "101",
+                "101",
+                "102",
+            ),
+        )
+    )
+
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("101", "102")
+    )
+
+
+def test_invalid_sequence_records_are_diagnostic():
+    value = classification()
+    value["planned_sequence"].append(None)
+    value["planned_sequence"].append({
+        "order": 3,
+        "role": "reliever",
+        "pitcher_id": "",
+    })
+
+    result = materialize(
+        plan_classification=value
+    )
+
+    assert result.blockers == (
+        "invalid_planned_sequence_record",
+    )
+    assert result.diagnostics[
+        "invalid_sequence_record_count"
+    ] == 2
+
+
+def test_materialization_is_deterministic():
+    value = classification(
+        follower_ids=("102", "101"),
+    )
+
+    first = materialize(
+        plan_classification=deepcopy(value)
+    )
+    second = materialize(
+        plan_classification=deepcopy(value)
+    )
+
+    assert first == second
+    assert (
+        first.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("102", "101")
+    )
+
+
+def test_diagnostics_do_not_expose_pitcher_ids():
+    result = materialize()
+    diagnostics = str(result.diagnostics)
+
+    assert "100" not in diagnostics
+    assert "101" not in diagnostics
+    assert "102" not in diagnostics
+
+
+def test_is_read_only_and_non_authoritative():
+    result = materialize()
+
+    assert (
+        result.database_writes_performed
+        is False
+    )
+    assert (
+        result.production_authority_changed
+        is False
+    )
+    assert result.diagnostics[
+        "database_writes_performed"
+    ] is False
+    assert result.diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_requires_starter_identity():
+    with pytest.raises(
+        ValueError,
+        match="starter_id",
+    ):
+        materialize(
+            starter_id=None,
+        )
+
+
+def test_validates_team_side_through_contract():
+    with pytest.raises(
+        ValueError,
+        match="team_side",
+    ):
+        materialize(
+            team_side="neutral",
+        )
+
+
+def test_materializes_correct_home_team_side():
+    result = materialize(
+        team_side="home",
+        starter_id="200",
+        bullpen_pitcher_ids=(
+            "201",
+            "202",
+        ),
+        plan_classification=classification(
+            starter_id="200",
+            follower_ids=("201",),
+        ),
+    )
+
+    assert result.pitching_plan.team_side == "home"
+    assert result.pitching_plan.starter_id == "200"
+    assert (
+        result.pitching_plan
+        .preferred_replacement_pitcher_ids
+        == ("201",)
+    )


### PR DESCRIPTION
## Summary

- add a pure canonical pregame pitching-plan materializer
- materialize traditional starter, opener/bulk, tandem, bullpen-game, and workload-capped plan types into `CanonicalPitchingPlan`
- preserve ordered preferred followers only when they belong to the eligible bullpen
- safely fall back to a traditional-starter plan for missing, unsupported, or fallback classification evidence
- replace the private inline production metadata helper with direct away/home materialization

## Why

The preceding pitcher-role, appearance-sequence, and bullpen-eligibility slices established that the canonical manager follows a supplied plan correctly and that verified starters can be excluded from general relief pools. Production execution still assembled plan metadata internally, leaving no explicit, independently testable boundary between classification evidence and canonical matchup input.

This slice establishes that boundary while preserving existing production behavior.

## Safety

- no database writes
- no production-authority change
- no probability changes
- no pitcher-profile recalibration
- invalid or incomplete classification evidence falls back safely
- diagnostics do not expose pitcher identifiers

## Validation

- 205 complete pregame-plan regression tests passed
- Python compilation passed
- tracked and new-file whitespace checks passed
- legacy `_canonical_pitching_plan_metadata` helper removed
- only the three intended files were committed

Commit: `488eb58`