### PR TITLE
Audit paired canonical pitcher sequencing

### DIFF
--- a/mlb_app/simulation/shadow/pitcher_sequencing_paired_shadow_audit.py
+++ b/mlb_app/simulation/shadow/pitcher_sequencing_paired_shadow_audit.py
@@ -1,0 +1,572 @@
+"""Paired audit for canonical pitcher sequencing plans."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from mlb_app.simulation.shadow.hitter_profile_paired_simulation_shadow_audit import (
+    compare_hitter_profile_simulation_shadow_payloads,
+)
+
+
+SCHEMA_VERSION = (
+    "pitcher_sequencing_paired_shadow_audit_v1"
+)
+
+STABLE_INPUT_DIAGNOSTIC_KEYS = (
+    "provider_identity",
+    "exact_artifact_digest",
+    "fallback_catalog_digest",
+    "baserunning_evidence_catalog_digest",
+    "canonical_model_version",
+)
+
+SEQUENCE_BLOCKER_NAMES = frozenset({
+    "planned_starter_not_first",
+    "planned_starter_used_in_relief",
+    "preferred_follower_skipped",
+    "pitcher_reentry",
+    "pitcher_outside_plan",
+})
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return (
+        dict(value)
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _execution_payload(
+    execution: Any,
+) -> dict[str, Any] | None:
+    material = getattr(
+        execution,
+        "material",
+        None,
+    )
+    payload = getattr(
+        material,
+        "canonical_payload",
+        None,
+    )
+
+    return (
+        dict(payload)
+        if isinstance(payload, Mapping)
+        else None
+    )
+
+
+def _execution_diagnostics(
+    execution: Any,
+) -> dict[str, Any]:
+    method = getattr(
+        execution,
+        "to_diagnostics",
+        None,
+    )
+
+    return (
+        dict(method())
+        if callable(method)
+        else {}
+    )
+
+
+def _sequence_audit(
+    diagnostics: Mapping[str, Any],
+) -> dict[str, Any]:
+    return _mapping(
+        diagnostics.get(
+            "pitcher_appearance_sequence_audit"
+        )
+    )
+
+
+def _role_mean_innings(
+    sequence_audit: Mapping[str, Any],
+    role: str,
+) -> float | None:
+    role_summaries = _mapping(
+        sequence_audit.get("role_summaries")
+    )
+    role_summary = _mapping(
+        role_summaries.get(role)
+    )
+    innings_summary = _mapping(
+        role_summary.get("innings_equivalent")
+    )
+
+    try:
+        value = float(
+            innings_summary.get("mean")
+        )
+    except (TypeError, ValueError):
+        return None
+
+    return value
+
+
+def _opener_bulk_workload_inverted(
+    sequence_audit: Mapping[str, Any],
+) -> bool:
+    """
+    Detect role inversion without selecting a fixed threshold.
+
+    An opener must have a shorter average workload than its bulk
+    follower. This relational invariant avoids hard-coding an innings
+    limit while still detecting traditional-starter treatment of an
+    opener.
+    """
+
+    opener_mean = _role_mean_innings(
+        sequence_audit,
+        "opener",
+    )
+    bulk_mean = _role_mean_innings(
+        sequence_audit,
+        "bulk_follower",
+    )
+
+    return (
+        opener_mean is not None
+        and bulk_mean is not None
+        and opener_mean >= bulk_mean
+    )
+
+
+def _sequence_blockers(
+    sequence_audit: Mapping[str, Any],
+) -> tuple[str, ...]:
+    anomaly_counts = _mapping(
+        sequence_audit.get("anomaly_counts")
+    )
+    blockers = set()
+
+    for raw_name, raw_count in (
+        anomaly_counts.items()
+    ):
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+
+        if count <= 0:
+            continue
+
+        name = str(raw_name)
+        normalized_name = name.rsplit(
+            ":",
+            1,
+        )[-1]
+
+        if normalized_name in (
+            SEQUENCE_BLOCKER_NAMES
+        ):
+            blockers.add(normalized_name)
+
+    if (
+        sequence_audit.get(
+            "starter_relief_detected"
+        )
+        is True
+    ):
+        blockers.add(
+            "planned_starter_used_in_relief"
+        )
+
+    if _opener_bulk_workload_inverted(
+        sequence_audit
+    ):
+        blockers.add(
+            "opener_bulk_workload_order_invalid"
+        )
+
+    return tuple(sorted(blockers))
+
+
+def _stable_inputs_match(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> bool:
+    return all(
+        baseline.get(key) == candidate.get(key)
+        for key in STABLE_INPUT_DIAGNOSTIC_KEYS
+    )
+
+
+def _sequence_summary(
+    sequence_audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    role_summaries = _mapping(
+        sequence_audit.get("role_summaries")
+    )
+
+    return {
+        "status": sequence_audit.get("status"),
+        "audited": sequence_audit.get(
+            "audited"
+        ),
+        "trial_count": sequence_audit.get(
+            "trial_count"
+        ),
+        "appearance_count":
+            sequence_audit.get(
+                "appearance_count"
+            ),
+        "affected_trial_count":
+            sequence_audit.get(
+                "affected_trial_count"
+            ),
+        "affected_trial_rate":
+            sequence_audit.get(
+                "affected_trial_rate"
+            ),
+        "starter_relief_appearance_count":
+            sequence_audit.get(
+                "starter_relief_appearance_count"
+            ),
+        "starter_relief_detected":
+            sequence_audit.get(
+                "starter_relief_detected"
+            ),
+        "anomaly_counts": _mapping(
+            sequence_audit.get("anomaly_counts")
+        ),
+        "role_summaries": {
+            role: {
+                "appearance_count":
+                    _mapping(summary).get(
+                        "appearance_count"
+                    ),
+                "appearance_rate":
+                    _mapping(summary).get(
+                        "appearance_rate"
+                    ),
+                "team_trial_appearance_count":
+                    _mapping(summary).get(
+                        "team_trial_appearance_count"
+                    ),
+                "outs_recorded":
+                    _mapping(summary).get(
+                        "outs_recorded"
+                    ),
+                "innings_equivalent":
+                    _mapping(summary).get(
+                        "innings_equivalent"
+                    ),
+            }
+            for role, summary
+            in sorted(role_summaries.items())
+        },
+    }
+
+
+@dataclass(frozen=True)
+class PitcherSequencingPairedShadowAudit:
+    """Read-only paired sequencing audit result."""
+
+    status: str
+    baseline_execution: Any = None
+    candidate_execution: Any = None
+    comparison: Mapping[str, Any] | None = None
+    blockers: tuple[str, ...] = ()
+    enabled: bool = False
+    audit_version: str = SCHEMA_VERSION
+
+    @property
+    def production_execution(self) -> Any:
+        return self.baseline_execution
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        baseline_diagnostics = (
+            _execution_diagnostics(
+                self.baseline_execution
+            )
+        )
+        candidate_diagnostics = (
+            _execution_diagnostics(
+                self.candidate_execution
+            )
+        )
+        baseline_sequence = _sequence_audit(
+            baseline_diagnostics
+        )
+        candidate_sequence = _sequence_audit(
+            candidate_diagnostics
+        )
+        comparison = _mapping(self.comparison)
+
+        return {
+            "schema_version": self.audit_version,
+            "status": self.status,
+            "enabled": self.enabled,
+            "blockers": list(self.blockers),
+            "baseline_execution": {
+                "status":
+                    baseline_diagnostics.get(
+                        "status"
+                    ),
+                "executed":
+                    baseline_diagnostics.get(
+                        "executed"
+                    ),
+                "simulation_count":
+                    baseline_diagnostics.get(
+                        "simulation_count"
+                    ),
+            },
+            "candidate_execution": {
+                "status":
+                    candidate_diagnostics.get(
+                        "status"
+                    ),
+                "executed":
+                    candidate_diagnostics.get(
+                        "executed"
+                    ),
+                "simulation_count":
+                    candidate_diagnostics.get(
+                        "simulation_count"
+                    ),
+            },
+            "baseline_sequence": (
+                _sequence_summary(
+                    baseline_sequence
+                )
+            ),
+            "candidate_sequence": (
+                _sequence_summary(
+                    candidate_sequence
+                )
+            ),
+            "comparison": {
+                key: value
+                for key, value
+                in comparison.items()
+                if key != "records"
+            },
+            "safety_checks": {
+                "production_inputs_unchanged": (
+                    _stable_inputs_match(
+                        baseline_diagnostics,
+                        candidate_diagnostics,
+                    )
+                    if (
+                        baseline_diagnostics
+                        and candidate_diagnostics
+                    )
+                    else False
+                ),
+                "simulation_counts_match": (
+                    baseline_diagnostics.get(
+                        "simulation_count"
+                    )
+                    == candidate_diagnostics.get(
+                        "simulation_count"
+                    )
+                ),
+                "database_writes_performed":
+                    False,
+                "production_authority_changed":
+                    False,
+            },
+            "decision": {
+                "pitcher_sequence_activation_allowed":
+                    False,
+                "production_activation_allowed":
+                    False,
+                "recommended_next_slice": (
+                    "correct_canonical_opener_bulk_"
+                    "workload_policy"
+                    if (
+                        "opener_bulk_workload_"
+                        "order_invalid"
+                        in self.blockers
+                    )
+                    else (
+                        "audit_pitcher_profile_skill_"
+                        "and_role_calibration"
+                        if self.status == "observed"
+                        else
+                        "run_paired_pitcher_"
+                        "sequencing_shadow_audit"
+                    )
+                ),
+            },
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+
+def run_paired_pitcher_sequencing_shadow_audit(
+    *,
+    enabled: bool = False,
+    away_pitching_plan_classification: (
+        Mapping[str, Any] | None
+    ) = None,
+    home_pitching_plan_classification: (
+        Mapping[str, Any] | None
+    ) = None,
+    execution_runner: Callable[..., Any] | None = None,
+    **production_inputs: Any,
+) -> PitcherSequencingPairedShadowAudit:
+    """
+    Run baseline and candidate plans with identical inputs.
+
+    The baseline omits classification evidence and therefore uses the
+    safe traditional-starter materialization. The candidate receives
+    the supplied classifications. Neither result becomes authoritative.
+    """
+
+    if enabled is not True:
+        return PitcherSequencingPairedShadowAudit(
+            status="disabled",
+            enabled=False,
+        )
+
+    if (
+        not isinstance(
+            away_pitching_plan_classification,
+            Mapping,
+        )
+        and not isinstance(
+            home_pitching_plan_classification,
+            Mapping,
+        )
+    ):
+        return PitcherSequencingPairedShadowAudit(
+            status="blocked",
+            blockers=(
+                "candidate_plan_classification_unavailable",
+            ),
+            enabled=True,
+        )
+
+    if execution_runner is None:
+        from mlb_app.simulation.shadow.production_execution import (
+            run_canonical_production_shadow,
+        )
+
+        execution_runner = (
+            run_canonical_production_shadow
+        )
+
+    baseline = execution_runner(
+        **production_inputs,
+        away_pitching_plan_classification=None,
+        home_pitching_plan_classification=None,
+    )
+    candidate = execution_runner(
+        **production_inputs,
+        away_pitching_plan_classification=(
+            away_pitching_plan_classification
+        ),
+        home_pitching_plan_classification=(
+            home_pitching_plan_classification
+        ),
+    )
+
+    baseline_payload = _execution_payload(
+        baseline
+    )
+    candidate_payload = _execution_payload(
+        candidate
+    )
+    baseline_diagnostics = (
+        _execution_diagnostics(baseline)
+    )
+    candidate_diagnostics = (
+        _execution_diagnostics(candidate)
+    )
+    baseline_sequence = _sequence_audit(
+        baseline_diagnostics
+    )
+    candidate_sequence = _sequence_audit(
+        candidate_diagnostics
+    )
+
+    blockers = []
+    comparison = None
+
+    if baseline_payload is None:
+        blockers.append(
+            "baseline_execution_not_ready"
+        )
+
+    if candidate_payload is None:
+        blockers.append(
+            "candidate_execution_not_ready"
+        )
+
+    if (
+        baseline_diagnostics.get(
+            "simulation_count"
+        )
+        != candidate_diagnostics.get(
+            "simulation_count"
+        )
+    ):
+        blockers.append(
+            "paired_execution_count_mismatch"
+        )
+
+    if not _stable_inputs_match(
+        baseline_diagnostics,
+        candidate_diagnostics,
+    ):
+        blockers.append(
+            "production_inputs_changed"
+        )
+
+    if (
+        baseline_sequence.get("status")
+        != "observed"
+    ):
+        blockers.append(
+            "baseline_sequence_audit_not_observed"
+        )
+
+    if (
+        candidate_sequence.get("status")
+        != "observed"
+    ):
+        blockers.append(
+            "candidate_sequence_audit_not_observed"
+        )
+    else:
+        blockers.extend(
+            _sequence_blockers(
+                candidate_sequence
+            )
+        )
+
+    if not blockers:
+        comparison = (
+            compare_hitter_profile_simulation_shadow_payloads(
+                baseline_payload=baseline_payload,
+                candidate_payload=candidate_payload,
+            )
+        )
+
+        if comparison.get("status") != "ready":
+            blockers.extend(
+                comparison.get("blockers") or ()
+            )
+
+    return PitcherSequencingPairedShadowAudit(
+        status=(
+            "observed"
+            if not blockers
+            else "blocked"
+        ),
+        baseline_execution=baseline,
+        candidate_execution=candidate,
+        comparison=comparison,
+        blockers=tuple(sorted(set(blockers))),
+        enabled=True,
+    )

--- a/tests/test_pitcher_sequencing_paired_shadow_audit.py
+++ b/tests/test_pitcher_sequencing_paired_shadow_audit.py
@@ -1,0 +1,537 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.simulation.shadow.pitcher_sequencing_paired_shadow_audit import (
+    run_paired_pitcher_sequencing_shadow_audit,
+)
+
+
+STABLE_DIAGNOSTICS = {
+    "provider_identity": "provider:v1",
+    "exact_artifact_digest": "exact",
+    "fallback_catalog_digest": "fallback",
+    "baserunning_evidence_catalog_digest": (
+        "baserunning"
+    ),
+    "canonical_model_version": "model-v1",
+}
+
+
+def classification(
+    *,
+    plan_type="opener_bulk",
+):
+    return {
+        "plan_type": plan_type,
+        "fallback_used": False,
+        "planned_sequence": [
+            {
+                "order": 1,
+                "role": "opener",
+                "pitcher_id": "100",
+            },
+            {
+                "order": 2,
+                "role": "bulk_follower",
+                "pitcher_id": "101",
+            },
+        ],
+    }
+
+
+def payload(
+    *,
+    simulation_count=25,
+    home_win_probability=0.5,
+):
+    return {
+        "simulation_count": simulation_count,
+        "outcomes": {
+            "away_win_probability": (
+                1.0 - home_win_probability
+            ),
+            "home_win_probability":
+                home_win_probability,
+            "tie_probability": 0.0,
+            "extra_innings_probability": 0.0,
+            "walk_off_probability": 0.0,
+            "away_run_distribution": {
+                "4": 1.0,
+            },
+            "home_run_distribution": {
+                "4": 1.0,
+            },
+            "total_run_distribution": {
+                "8": 1.0,
+            },
+        },
+        "teams": [],
+        "batters": [],
+        "pitchers": [],
+    }
+
+
+def sequence_audit(
+    *,
+    status="observed",
+    anomaly_counts=None,
+    starter_relief_detected=False,
+):
+    return {
+        "status": status,
+        "audited": status == "observed",
+        "trial_count": 25,
+        "appearance_count": 100,
+        "affected_trial_count": (
+            1 if anomaly_counts else 0
+        ),
+        "affected_trial_rate": (
+            0.04 if anomaly_counts else 0.0
+        ),
+        "starter_relief_appearance_count": (
+            1 if starter_relief_detected else 0
+        ),
+        "starter_relief_detected": (
+            starter_relief_detected
+        ),
+        "anomaly_counts": (
+            anomaly_counts or {}
+        ),
+        "role_summaries": {
+            "starter": {
+                "appearance_count": 50,
+                "team_trial_appearance_count": 50,
+                "appearance_rate": 1.0,
+                "outs_recorded": {
+                    "mean": 15.0,
+                },
+                "innings_equivalent": {
+                    "mean": 5.0,
+                },
+            },
+        },
+    }
+
+
+class Execution:
+    def __init__(
+        self,
+        *,
+        canonical_payload=None,
+        diagnostics=None,
+    ):
+        self.material = (
+            SimpleNamespace(
+                canonical_payload=canonical_payload
+            )
+            if canonical_payload is not None
+            else None
+        )
+        self._diagnostics = diagnostics or {}
+
+    def to_diagnostics(self):
+        return dict(self._diagnostics)
+
+
+def execution(
+    *,
+    simulation_count=25,
+    sequence=None,
+    canonical_payload=None,
+    diagnostics_overrides=None,
+):
+    diagnostics = {
+        "status": "executed",
+        "executed": True,
+        "simulation_count": simulation_count,
+        "pitcher_appearance_sequence_audit": (
+            sequence or sequence_audit()
+        ),
+        **STABLE_DIAGNOSTICS,
+    }
+    diagnostics.update(
+        diagnostics_overrides or {}
+    )
+
+    return Execution(
+        canonical_payload=(
+            canonical_payload
+            if canonical_payload is not None
+            else payload(
+                simulation_count=simulation_count
+            )
+        ),
+        diagnostics=diagnostics,
+    )
+
+
+def paired_runner(
+    baseline=None,
+    candidate=None,
+):
+    calls = []
+    results = iter((
+        baseline or execution(),
+        candidate or execution(
+            canonical_payload=payload(
+                home_win_probability=0.52,
+            )
+        ),
+    ))
+
+    def runner(**kwargs):
+        calls.append(kwargs)
+        return next(results)
+
+    return runner, calls
+
+
+def run(
+    *,
+    runner=None,
+    **kwargs,
+):
+    if runner is None:
+        runner, _ = paired_runner()
+
+    return (
+        run_paired_pitcher_sequencing_shadow_audit(
+            enabled=True,
+            away_pitching_plan_classification=(
+                classification()
+            ),
+            execution_runner=runner,
+            bootstrap_ready=True,
+            **kwargs,
+        )
+    )
+
+
+def test_runs_paired_baseline_and_candidate():
+    runner, calls = paired_runner()
+
+    result = run(runner=runner)
+
+    assert result.status == "observed"
+    assert result.blockers == ()
+    assert len(calls) == 2
+    assert calls[0][
+        "away_pitching_plan_classification"
+    ] is None
+    assert calls[0][
+        "home_pitching_plan_classification"
+    ] is None
+    assert calls[1][
+        "away_pitching_plan_classification"
+    ]["plan_type"] == "opener_bulk"
+    assert result.comparison["status"] == "ready"
+
+
+def test_disabled_does_not_execute():
+    called = False
+
+    def runner(**kwargs):
+        nonlocal called
+        called = True
+        return execution()
+
+    result = (
+        run_paired_pitcher_sequencing_shadow_audit(
+            enabled=False,
+            execution_runner=runner,
+        )
+    )
+
+    assert result.status == "disabled"
+    assert result.enabled is False
+    assert called is False
+
+
+def test_requires_candidate_classification():
+    result = (
+        run_paired_pitcher_sequencing_shadow_audit(
+            enabled=True,
+            execution_runner=lambda **kwargs: (
+                execution()
+            ),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert result.blockers == (
+        "candidate_plan_classification_unavailable",
+    )
+
+
+def test_routes_both_candidate_classifications():
+    runner, calls = paired_runner()
+    away = classification(
+        plan_type="opener_bulk",
+    )
+    home = classification(
+        plan_type="tandem",
+    )
+
+    result = (
+        run_paired_pitcher_sequencing_shadow_audit(
+            enabled=True,
+            away_pitching_plan_classification=away,
+            home_pitching_plan_classification=home,
+            execution_runner=runner,
+            bootstrap_ready=True,
+        )
+    )
+
+    assert result.status == "observed"
+    assert calls[0][
+        "away_pitching_plan_classification"
+    ] is None
+    assert calls[0][
+        "home_pitching_plan_classification"
+    ] is None
+    assert calls[1][
+        "away_pitching_plan_classification"
+    ] is away
+    assert calls[1][
+        "home_pitching_plan_classification"
+    ] is home
+
+
+@pytest.mark.parametrize(
+    "anomaly_name",
+    [
+        "planned_starter_not_first",
+        "planned_starter_used_in_relief",
+        "pitcher_reentry",
+        "pitcher_outside_plan",
+        "away:preferred_follower_skipped",
+    ],
+)
+def test_blocks_candidate_sequence_anomalies(
+    anomaly_name,
+):
+    runner, _ = paired_runner(
+        candidate=execution(
+            sequence=sequence_audit(
+                anomaly_counts={
+                    anomaly_name: 1,
+                },
+                starter_relief_detected=(
+                    anomaly_name
+                    == "planned_starter_used_in_relief"
+                ),
+            )
+        )
+    )
+
+    result = run(runner=runner)
+
+    expected = anomaly_name.rsplit(
+        ":",
+        1,
+    )[-1]
+    assert result.status == "blocked"
+    assert expected in result.blockers
+
+
+def test_blocks_unobserved_candidate_audit():
+    runner, _ = paired_runner(
+        candidate=execution(
+            sequence=sequence_audit(
+                status="blocked",
+            )
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "blocked"
+    assert (
+        "candidate_sequence_audit_not_observed"
+        in result.blockers
+    )
+
+
+def test_blocks_execution_count_mismatch():
+    runner, _ = paired_runner(
+        candidate=execution(
+            simulation_count=24,
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "blocked"
+    assert (
+        "paired_execution_count_mismatch"
+        in result.blockers
+    )
+
+
+def test_blocks_stable_input_changes():
+    runner, _ = paired_runner(
+        candidate=execution(
+            diagnostics_overrides={
+                "provider_identity":
+                    "different-provider",
+            }
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "blocked"
+    assert (
+        "production_inputs_changed"
+        in result.blockers
+    )
+
+
+def test_blocks_failed_candidate_execution():
+    runner, _ = paired_runner(
+        candidate=Execution(
+            canonical_payload=None,
+            diagnostics={
+                "status": "error",
+                "executed": False,
+                "simulation_count": 0,
+                **STABLE_DIAGNOSTICS,
+            },
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "blocked"
+    assert (
+        "candidate_execution_not_ready"
+        in result.blockers
+    )
+
+
+def test_diagnostics_are_read_only():
+    result = run()
+    diagnostics = result.to_diagnostics()
+
+    assert diagnostics["status"] == "observed"
+    assert diagnostics[
+        "database_writes_performed"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["decision"][
+        "pitcher_sequence_activation_allowed"
+    ] is False
+    assert diagnostics["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert "records" not in (
+        diagnostics["comparison"]
+    )
+
+
+def test_diagnostics_include_workload_summary():
+    result = run()
+    diagnostics = result.to_diagnostics()
+
+    starter = diagnostics[
+        "candidate_sequence"
+    ]["role_summaries"]["starter"]
+
+    assert starter["appearance_count"] == 50
+    assert starter["outs_recorded"][
+        "mean"
+    ] == 15.0
+    assert starter["innings_equivalent"][
+        "mean"
+    ] == 5.0
+
+
+def test_blocks_inverted_opener_bulk_workloads():
+    candidate_sequence = sequence_audit()
+    candidate_sequence["role_summaries"] = {
+        "opener": {
+            "appearance_count": 25,
+            "team_trial_appearance_count": 25,
+            "appearance_rate": 0.5,
+            "outs_recorded": {
+                "mean": 16.5,
+            },
+            "innings_equivalent": {
+                "mean": 5.5,
+            },
+        },
+        "bulk_follower": {
+            "appearance_count": 25,
+            "team_trial_appearance_count": 25,
+            "appearance_rate": 0.5,
+            "outs_recorded": {
+                "mean": 10.0,
+            },
+            "innings_equivalent": {
+                "mean": 3.3333333333333335,
+            },
+        },
+    }
+    runner, _ = paired_runner(
+        candidate=execution(
+            sequence=candidate_sequence,
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "blocked"
+    assert (
+        "opener_bulk_workload_order_invalid"
+        in result.blockers
+    )
+    assert result.to_diagnostics()["decision"][
+        "recommended_next_slice"
+    ] == (
+        "correct_canonical_opener_bulk_"
+        "workload_policy"
+    )
+
+
+def test_accepts_shorter_opener_than_bulk_follower():
+    candidate_sequence = sequence_audit()
+    candidate_sequence["role_summaries"] = {
+        "opener": {
+            "appearance_count": 25,
+            "team_trial_appearance_count": 25,
+            "appearance_rate": 0.5,
+            "outs_recorded": {
+                "mean": 4.0,
+            },
+            "innings_equivalent": {
+                "mean": 1.3333333333333333,
+            },
+        },
+        "bulk_follower": {
+            "appearance_count": 25,
+            "team_trial_appearance_count": 25,
+            "appearance_rate": 0.5,
+            "outs_recorded": {
+                "mean": 14.0,
+            },
+            "innings_equivalent": {
+                "mean": 4.666666666666667,
+            },
+        },
+    }
+    runner, _ = paired_runner(
+        candidate=execution(
+            sequence=candidate_sequence,
+        )
+    )
+
+    result = run(runner=runner)
+
+    assert result.status == "observed"
+    assert (
+        "opener_bulk_workload_order_invalid"
+        not in result.blockers
+    )


### PR DESCRIPTION
## Summary

- add a read-only paired pitcher-sequencing shadow audit
- run baseline traditional/fallback plans and candidate materialized plans with identical non-plan inputs and simulation counts
- reuse the canonical payload comparator for game, probability, team, batter, pitcher, and DFS deltas
- reconcile embedded pitcher appearance-sequence diagnostics and stable execution provenance
- block starter misuse, reentry, outside-plan appearances, skipped preferred followers, execution mismatches, and input drift
- detect opener/bulk workload inversion using a relational invariant rather than a fixed innings threshold

## Evidence

A representative 25-trial production-fixture audit showed:

- baseline and candidate executions both completed with 25 trials
- zero sequence anomalies
- zero starter relief appearances
- opener and bulk follower appeared in the intended order
- 408 canonical metrics reconciled with zero output delta in the fixture
- production inputs and simulation counts matched
- no database writes or production-authority changes

However, the candidate workload relationship was invalid:

- opener mean workload: **5.5867 innings**
- bulk-follower mean workload: **3.2933 innings**

The audit therefore correctly returns `blocked` with `opener_bulk_workload_order_invalid`. This shows that ordering is correct while the pitching manager still treats the opener like a traditional starter for workload purposes.

## Decision

- pitcher sequencing activation remains disallowed
- production activation remains disallowed
- recommended next slice: `correct_canonical_opener_bulk_workload_policy`

## Validation

- 220 complete paired-sequencing regression tests passed
- representative real production paired probe passed and reproduced the blocker
- Python compilation passed
- tracked and new-file whitespace checks passed
- only the two intended files were committed

Commit: `abbdda7`