### PR TITLE
Model dynamic canonical bulk follower exit policy

### DIFF
--- a/mlb_app/simulation/game/bulk_follower_hook_policy.py
+++ b/mlb_app/simulation/game/bulk_follower_hook_policy.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass
+
+from .pitcher_lifecycle import (
+    CanonicalPitchingDecisionContext,
+)
+from .reliever_hook_policy import (
+    CanonicalRelieverHookPolicy,
+)
+
+
+CANONICAL_BULK_FOLLOWER_HOOK_POLICY_VERSION = (
+    "canonical_bulk_follower_hook_policy_v1"
+)
+
+
+@dataclass(frozen=True)
+class CanonicalBulkFollowerHookPolicy(
+    CanonicalRelieverHookPolicy
+):
+    """
+    Dynamic canonical exit policy for an opener's bulk follower.
+
+    Workload thresholds are decision boundaries, not projected
+    innings. Simulated performance can trigger an earlier exit,
+    while an efficient appearance can continue deeper.
+    """
+
+    minimum_batters_faced: int = 3
+    target_batters_faced: int = 24
+    maximum_batters_faced: int = 30
+    maximum_runs_during_stint: int = 4
+    maximum_walks_allowed: int = 3
+    maximum_home_runs_allowed: int = 2
+    maximum_hits_allowed: int = 8
+    maximum_traffic_allowed: int = 10
+    schema_version: str = (
+        CANONICAL_BULK_FOLLOWER_HOOK_POLICY_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        thresholds = (
+            self.minimum_batters_faced,
+            self.target_batters_faced,
+            self.maximum_batters_faced,
+            self.maximum_runs_during_stint,
+            self.maximum_walks_allowed,
+            self.maximum_home_runs_allowed,
+            self.maximum_hits_allowed,
+            self.maximum_traffic_allowed,
+        )
+
+        if any(value < 0 for value in thresholds):
+            raise ValueError(
+                "bulk follower hook thresholds "
+                "cannot be negative"
+            )
+
+        if self.minimum_batters_faced < 3:
+            raise ValueError(
+                "minimum_batters_faced must be "
+                "at least three"
+            )
+
+        if not (
+            self.minimum_batters_faced
+            <= self.target_batters_faced
+            <= self.maximum_batters_faced
+        ):
+            raise ValueError(
+                "bulk follower batter thresholds "
+                "must be ordered"
+            )
+
+        if self.schema_version != (
+            CANONICAL_BULK_FOLLOWER_HOOK_POLICY_VERSION
+        ):
+            raise ValueError(
+                "unsupported bulk follower hook "
+                "policy version"
+            )
+
+    def decide(
+        self,
+        context: CanonicalPitchingDecisionContext,
+    ):
+        lifecycle = context.lifecycle
+
+        if not context.available_reliever_ids:
+            return self._hold(
+                lifecycle.pitcher_id,
+                "no_available_reliever",
+            )
+
+        if (
+            lifecycle.batters_faced
+            < self.minimum_batters_faced
+        ):
+            return self._hold(
+                lifecycle.pitcher_id,
+                "minimum_batters_not_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.maximum_batters_faced
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "maximum_batters_reached",
+            )
+
+        if (
+            lifecycle.runs_scored_during_stint
+            >= self.maximum_runs_during_stint
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "runs_threshold_reached",
+            )
+
+        if (
+            lifecycle.walks_allowed
+            >= self.maximum_walks_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "walks_threshold_reached",
+            )
+
+        if (
+            lifecycle.home_runs_allowed
+            >= self.maximum_home_runs_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "home_run_threshold_reached",
+            )
+
+        if (
+            lifecycle.hits_allowed
+            >= self.maximum_hits_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "hits_threshold_reached",
+            )
+
+        traffic = (
+            lifecycle.hits_allowed
+            + lifecycle.walks_allowed
+            + lifecycle.hit_batters
+        )
+
+        if traffic >= self.maximum_traffic_allowed:
+            return self._replace(
+                lifecycle.pitcher_id,
+                "traffic_threshold_reached",
+            )
+
+        if (
+            lifecycle.batters_faced
+            >= self.target_batters_faced
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "target_workload_reached",
+            )
+
+        return self._hold(
+            lifecycle.pitcher_id,
+            "bulk_follower_continues",
+        )
+
+
+def build_baseline_bulk_follower_hook_policy(
+) -> CanonicalBulkFollowerHookPolicy:
+    return CanonicalBulkFollowerHookPolicy()

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -10,6 +10,10 @@ from mlb_app.simulation.events import (
     PlayEvent,
 )
 
+from .bulk_follower_hook_policy import (
+    CanonicalBulkFollowerHookPolicy,
+    build_baseline_bulk_follower_hook_policy,
+)
 from .bullpen_selector import (
     CanonicalBullpenPitcher,
     CanonicalBullpenSelector,
@@ -68,6 +72,9 @@ class CanonicalPlateAppearanceResolverFactory:
     ] = None
     opener_hook_policy: Optional[
         CanonicalStarterHookPolicy
+    ] = None
+    bulk_follower_hook_policy: Optional[
+        CanonicalBulkFollowerHookPolicy
     ] = None
     bullpen_selector: Optional[
         CanonicalBullpenSelector
@@ -144,6 +151,10 @@ class CanonicalPlateAppearanceResolverFactory:
                 opener_hook_policy=(
                     self.opener_hook_policy
                     or build_baseline_opener_hook_policy()
+                ),
+                bulk_follower_hook_policy=(
+                    self.bulk_follower_hook_policy
+                    or build_baseline_bulk_follower_hook_policy()
                 ),
                 bullpen_selector=(
                     self.bullpen_selector

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -7,6 +7,10 @@ from typing import Dict, Optional, Tuple
 
 from mlb_app.simulation.events import GameState, PlayEvent
 
+from .bulk_follower_hook_policy import (
+    CanonicalBulkFollowerHookPolicy,
+    build_baseline_bulk_follower_hook_policy,
+)
 from .bullpen_selector import (
     CanonicalBullpenPitcher,
     CanonicalBullpenSelectionContext,
@@ -59,6 +63,9 @@ class CanonicalPitchingManager:
     home_bullpen: Tuple[CanonicalBullpenPitcher, ...]
     opener_hook_policy: Optional[
         CanonicalStarterHookPolicy
+    ] = None
+    bulk_follower_hook_policy: Optional[
+        CanonicalBulkFollowerHookPolicy
     ] = None
     reliever_hook_policy: CanonicalRelieverHookPolicy = (
         field(
@@ -125,6 +132,20 @@ class CanonicalPitchingManager:
             raise TypeError(
                 "opener_hook_policy must be a "
                 "CanonicalStarterHookPolicy or None"
+            )
+
+        if (
+            self.bulk_follower_hook_policy
+            is not None
+            and not isinstance(
+                self.bulk_follower_hook_policy,
+                CanonicalBulkFollowerHookPolicy,
+            )
+        ):
+            raise TypeError(
+                "bulk_follower_hook_policy must "
+                "be a CanonicalBulkFollowerHookPolicy "
+                "or None"
             )
 
         if not isinstance(
@@ -253,7 +274,32 @@ class CanonicalPitchingManager:
                 decision_context
             )
         else:
-            decision = self.reliever_hook_policy.decide(
+            pitching_plan = (
+                self.matchup_input.away_pitching_plan
+                if team_side == "away"
+                else
+                self.matchup_input.home_pitching_plan
+            )
+            hook_policy = self.reliever_hook_policy
+
+            preferred = (
+                pitching_plan.preferred_replacement_pitcher_ids
+            )
+
+            if (
+                pitching_plan.plan_type
+                == "opener_bulk"
+                and preferred
+                and lifecycle.pitcher_id
+                == str(preferred[0])
+                and self.bulk_follower_hook_policy
+                is not None
+            ):
+                hook_policy = (
+                    self.bulk_follower_hook_policy
+                )
+
+            decision = hook_policy.decide(
                 decision_context
             )
 

--- a/tests/test_canonical_bulk_follower_hook_policy.py
+++ b/tests/test_canonical_bulk_follower_hook_policy.py
@@ -1,0 +1,218 @@
+from dataclasses import replace
+
+from mlb_app.simulation.game.bulk_follower_hook_policy import (
+    CanonicalBulkFollowerHookPolicy,
+    build_baseline_bulk_follower_hook_policy,
+)
+from mlb_app.simulation.game.pitcher_lifecycle import (
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+)
+
+
+def context(**updates):
+    lifecycle = CanonicalPitcherLifecycleState(
+        team_side="away",
+        pitcher_id="bulk",
+        role=CanonicalPitcherRole.RELIEVER,
+        entered_inning=2,
+        entered_half="bottom",
+        batters_faced=12,
+        outs_recorded=9,
+    )
+
+    lifecycle = replace(
+        lifecycle,
+        **updates,
+    )
+
+    return CanonicalPitchingDecisionContext(
+        lifecycle=lifecycle,
+        inning=5,
+        half="bottom",
+        outs=0,
+        batting_team_score=2,
+        fielding_team_score=2,
+        runners_on_base=0,
+        upcoming_batter_id="batter_1",
+        available_reliever_ids=(
+            "reliever_1",
+            "reliever_2",
+        ),
+    )
+
+
+def test_clean_bulk_follower_can_continue():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+
+    decision = policy.decide(context())
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "bulk_follower_continues"
+    )
+
+
+def test_poor_run_outing_exits_early():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+
+    decision = policy.decide(
+        context(
+            batters_faced=10,
+            outs_recorded=6,
+            runs_scored_during_stint=4,
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "runs_threshold_reached"
+    )
+
+
+def test_walks_can_trigger_early_exit():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+
+    decision = policy.decide(
+        context(
+            batters_faced=9,
+            outs_recorded=5,
+            walks_allowed=3,
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "walks_threshold_reached"
+    )
+
+
+def test_hits_can_trigger_early_exit():
+    policy = CanonicalBulkFollowerHookPolicy(
+        maximum_hits_allowed=5,
+    )
+
+    decision = policy.decide(
+        context(
+            hits_allowed=5,
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "hits_threshold_reached"
+    )
+
+
+def test_combined_traffic_can_trigger_exit():
+    policy = CanonicalBulkFollowerHookPolicy(
+        maximum_hits_allowed=10,
+        maximum_walks_allowed=10,
+        maximum_traffic_allowed=6,
+    )
+
+    decision = policy.decide(
+        context(
+            hits_allowed=4,
+            walks_allowed=1,
+            hit_batters=1,
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "traffic_threshold_reached"
+    )
+
+
+def test_efficient_outing_reaches_workload_target():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+
+    before = policy.decide(
+        context(
+            batters_faced=23,
+            outs_recorded=18,
+        )
+    )
+    at_target = policy.decide(
+        context(
+            batters_faced=24,
+            outs_recorded=19,
+        )
+    )
+
+    assert before.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert at_target.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert at_target.reason == (
+        "target_workload_reached"
+    )
+
+
+def test_three_batter_floor_still_applies():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+
+    decision = policy.decide(
+        context(
+            batters_faced=2,
+            outs_recorded=0,
+            runs_scored_during_stint=4,
+            hits_allowed=2,
+            walks_allowed=2,
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "minimum_batters_not_reached"
+    )
+
+
+def test_no_available_reliever_fails_open():
+    policy = (
+        build_baseline_bulk_follower_hook_policy()
+    )
+    base = context(
+        runs_scored_during_stint=6,
+    )
+
+    decision = policy.decide(
+        replace(
+            base,
+            available_reliever_ids=(),
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "no_available_reliever"
+    )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1543,3 +1543,98 @@ def test_opener_bulk_sequence_is_observed_by_audit():
         "pitcher_appearance_sequence_audit"
         not in result.material.canonical_payload
     )
+
+def test_bulk_follower_exit_is_dynamic_with_bullpen_depth():
+    from dataclasses import replace
+
+    baseline_bullpens = bullpens()
+
+    expanded_bullpens = replace(
+        baseline_bullpens,
+        away=replace(
+            baseline_bullpens.away,
+            bullpen_pitcher_ids=(
+                "101",
+                "102",
+                "103",
+                "104",
+            ),
+            source_record_count=5,
+        ),
+        home=replace(
+            baseline_bullpens.home,
+            bullpen_pitcher_ids=(
+                "201",
+                "202",
+                "203",
+                "204",
+            ),
+            source_record_count=5,
+        ),
+    )
+
+    result = run(
+        simulation_count=25,
+        bullpens=expanded_bullpens,
+        away_pitching_plan_classification=(
+            opener_bulk_classification(
+                starter_id="100",
+                bulk_id="101",
+            )
+        ),
+    )
+
+    diagnostics = result.to_diagnostics()
+    audit = diagnostics[
+        "pitcher_appearance_sequence_audit"
+    ]
+    roles = audit["role_summaries"]
+
+    opener_innings = roles[
+        "opener"
+    ]["innings_equivalent"]
+    bulk_innings = roles[
+        "bulk_follower"
+    ]["innings_equivalent"]
+
+    assert result.status == "executed"
+    assert audit["status"] == "observed"
+    assert audit["anomaly_counts"] == {}
+    assert (
+        audit["starter_relief_detected"]
+        is False
+    )
+
+    # The opener remains shorter than its bulk
+    # follower without assigning final innings.
+    assert (
+        opener_innings["mean"]
+        < bulk_innings["mean"]
+    )
+
+    # Poor simulated outings can terminate well
+    # before the efficient-outing workload ceiling.
+    assert (
+        bulk_innings["minimum"]
+        < bulk_innings["median"]
+    )
+    assert bulk_innings["p10"] < 6.0
+
+    # Efficient bulk appearances can still go deep.
+    assert bulk_innings["maximum"] >= 6.0
+
+    # Replacement depth is actually exercised after
+    # the opener and planned bulk follower.
+    assert any(
+        len(trial["away_pitcher_ids"]) >= 3
+        for trial in audit["trials"]
+    )
+
+    assert (
+        audit["database_writes_performed"]
+        is False
+    )
+    assert (
+        audit["production_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## Summary

- add a dedicated canonical bulk-follower hook policy instead of treating the planned bulk follower as a generic reliever
- make bulk-follower exits respond deterministically to simulated runs, walks, home runs, hits, and cumulative traffic while preserving workload bounds
- route the preferred opener/bulk follower through that policy in the canonical pitching manager and PA resolver factory
- add unit coverage for performance-conditioned exits and production integration coverage with realistic bullpen replacement depth

## Why

The paired pitcher-sequencing audit showed that opener/bulk order was correct after 6SR, but the bulk follower workload remained suspiciously compressed: 6.0 IP minimum, 6.8 IP mean, and 8.33 IP maximum across 100 trials. Investigation showed the planned `bulk_follower` role existed in audit metadata, while runtime lifecycle treated the pitcher as a generic reliever. The initial production fixture also contained no pitcher behind the bulk follower, so no hook policy could actually replace him.

6SS preserves the safe no-replacement fallback, but gives the preferred bulk follower its own event-conditioned exit policy whenever bullpen depth exists.

## Evidence

A 100-trial production probe with replacement depth produced:

- bulk follower: 0.0 IP minimum, 2.33 p10, 5.0 median, 4.65 mean, 6.33 p90, 7.0 maximum
- 12 run-triggered exits
- 35 walk-triggered exits
- 6 home-run-triggered exits
- 6 hit-triggered exits
- 37 efficient outings reaching the workload target
- opener mean remained below bulk-follower mean
- no pitcher-sequencing anomalies or starter-relief leakage
- no database writes or production-authority changes

This makes innings an emergent distribution from simulated events rather than a fixed role-level projection.

## Validation

- 139 dependency-based regression tests passed
- focused production integration regression passed
- `py_compile` passed
- `git diff --check` passed
- new-file whitespace checks passed
- ruff was not installed in the local environment