### PR TITLE
Model dynamic canonical starter exit policy

### DIFF
--- a/mlb_app/simulation/game/pitcher_hook_policy.py
+++ b/mlb_app/simulation/game/pitcher_hook_policy.py
@@ -27,12 +27,14 @@ class CanonicalStarterHookPolicy:
     consumes the replace decision and available reliever pool.
     """
 
-    minimum_batters_faced: int = 18
+    minimum_batters_faced: int = 3
     target_batters_faced: int = 24
     maximum_batters_faced: int = 27
     maximum_runs_during_stint: int = 5
     maximum_walks_allowed: int = 4
     maximum_home_runs_allowed: int = 3
+    maximum_hits_allowed: int = 9
+    maximum_traffic_allowed: int = 12
     late_inning_threshold: int = 7
     schema_version: str = (
         CANONICAL_STARTER_HOOK_POLICY_VERSION
@@ -46,6 +48,8 @@ class CanonicalStarterHookPolicy:
             self.maximum_runs_during_stint,
             self.maximum_walks_allowed,
             self.maximum_home_runs_allowed,
+            self.maximum_hits_allowed,
+            self.maximum_traffic_allowed,
             self.late_inning_threshold,
         )
 
@@ -148,6 +152,27 @@ class CanonicalStarterHookPolicy:
             return self._replace(
                 lifecycle.pitcher_id,
                 "home_run_threshold_reached",
+            )
+
+        if (
+            lifecycle.hits_allowed
+            >= self.maximum_hits_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "hits_threshold_reached",
+            )
+
+        traffic = (
+            lifecycle.hits_allowed
+            + lifecycle.walks_allowed
+            + lifecycle.hit_batters
+        )
+
+        if traffic >= self.maximum_traffic_allowed:
+            return self._replace(
+                lifecycle.pitcher_id,
+                "traffic_threshold_reached",
             )
 
         if (

--- a/tests/test_canonical_pitcher_hook_policy.py
+++ b/tests/test_canonical_pitcher_hook_policy.py
@@ -73,7 +73,7 @@ def test_holds_before_minimum_batters():
         .decide(
             context(
                 pitcher=lifecycle(
-                    batters_faced=17,
+                    batters_faced=2,
                     runs_scored_during_stint=8,
                 )
             )
@@ -87,6 +87,98 @@ def test_holds_before_minimum_batters():
         "minimum_batters_not_reached"
     )
 
+
+def test_poor_outing_can_exit_before_old_eighteen_batter_floor():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=6,
+                    runs_scored_during_stint=5,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "runs_threshold_reached"
+    )
+
+
+def test_hits_can_trigger_early_starter_exit():
+    policy = CanonicalStarterHookPolicy(
+        maximum_hits_allowed=6,
+    )
+
+    decision = policy.decide(
+        context(
+            pitcher=lifecycle(
+                batters_faced=12,
+                hits_allowed=6,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "hits_threshold_reached"
+    )
+
+
+def test_combined_traffic_can_trigger_starter_exit():
+    policy = CanonicalStarterHookPolicy(
+        maximum_hits_allowed=20,
+        maximum_walks_allowed=20,
+        maximum_traffic_allowed=8,
+    )
+
+    decision = policy.decide(
+        context(
+            pitcher=lifecycle(
+                batters_faced=12,
+                hits_allowed=5,
+                walks_allowed=2,
+                hit_batters=1,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "traffic_threshold_reached"
+    )
+
+
+def test_efficient_starter_can_continue_before_workload_target():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=20,
+                    hits_allowed=3,
+                    walks_allowed=1,
+                    runs_scored_during_stint=1,
+                ),
+                inning=5,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "starter_within_limits"
+    )
 
 def test_holds_when_no_reliever_is_available():
     decision = (
@@ -281,6 +373,16 @@ def test_inactive_starter_is_rejected():
                 )
             )
         )
+
+
+def test_baseline_starter_policy_uses_dynamic_decision_floor():
+    policy = build_baseline_starter_hook_policy()
+
+    assert policy.minimum_batters_faced == 3
+    assert policy.target_batters_faced == 24
+    assert policy.maximum_batters_faced == 27
+    assert policy.maximum_hits_allowed == 9
+    assert policy.maximum_traffic_allowed == 12
 
 
 def test_baseline_opener_policy_has_short_workload():

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1638,3 +1638,61 @@ def test_bulk_follower_exit_is_dynamic_with_bullpen_depth():
         audit["production_authority_changed"]
         is False
     )
+
+def test_starter_exit_is_dynamic_with_performance_and_workload():
+    result = run(
+        simulation_count=100,
+    )
+
+    diagnostics = result.to_diagnostics()
+    audit = diagnostics[
+        "pitcher_appearance_sequence_audit"
+    ]
+    roles = audit["role_summaries"]
+
+    starter_innings = roles[
+        "starter"
+    ]["innings_equivalent"]
+
+    starter_records = [
+        record
+        for record in audit["records"]
+        if record["planned_role"] == "starter"
+    ]
+
+    starter_batters_faced = [
+        record["batters_faced"]
+        for record in starter_records
+    ]
+
+    assert result.status == "executed"
+    assert audit["status"] == "observed"
+    assert audit["anomaly_counts"] == {}
+    assert (
+        audit["starter_relief_detected"]
+        is False
+    )
+
+    # Poor simulated starts are no longer forced
+    # through the old eighteen-batter floor.
+    assert min(starter_batters_faced) < 18
+    assert (
+        starter_innings["minimum"]
+        < starter_innings["median"]
+    )
+
+    # Efficient starts retain a meaningful deep
+    # workload tail instead of using a fixed IP.
+    assert starter_innings["p90"] >= 5.0
+    assert starter_innings["maximum"] >= 6.0
+
+    # Workload remains an emergent event-stream
+    # result and the audit stays non-authoritative.
+    assert (
+        audit["database_writes_performed"]
+        is False
+    )
+    assert (
+        audit["production_authority_changed"]
+        is False
+    )


### PR DESCRIPTION
## Summary

- replace the fixed 18-batter starter removal floor with a three-batter decision floor while retaining the 24-BF target and 27-BF maximum workload
- add starter hook triggers for hits allowed and combined traffic (H + BB + HBP), alongside the existing runs, walks, and home-run signals
- add unit and production regression coverage proving poor simulated starts can exit early while efficient starts retain a deep workload tail

## Why

The canonical starter hook previously held every starter through 18 batters regardless of simulated performance. That prevented severely poor outings from being removed dynamically and compressed the left side of the starter workload distribution.

## Production evidence

A deterministic 100-trial post-change probe produced 200 starter appearances. Performance exits before 18 BF increased from 0 to 26, with the earliest exit at 5 BF. Mean starter IP moved from 5.292 to 5.033 while median (5.667), p90 (6.333), p95 (6.667), and maximum (7.333) were unchanged. Hits and traffic triggers were both exercised. Pitcher sequencing anomalies remained empty, starter-relief detection remained false, and no database writes or production-authority changes occurred.

## Validation

- 179 tests passed across the explicit 12-file 6ST regression suite
- `py_compile` passed
- `git diff --check` passed
- staged isolation check passed; only the three intended 6ST files were committed
