### PR TITLE
Correct canonical starter workload ceiling

### DIFF
--- a/mlb_app/simulation/game/pitcher_hook_policy.py
+++ b/mlb_app/simulation/game/pitcher_hook_policy.py
@@ -29,7 +29,7 @@ class CanonicalStarterHookPolicy:
 
     minimum_batters_faced: int = 3
     target_batters_faced: int = 24
-    maximum_batters_faced: int = 27
+    maximum_batters_faced: int | None = None
     maximum_runs_during_stint: int = 5
     maximum_walks_allowed: int = 4
     maximum_home_runs_allowed: int = 3
@@ -44,7 +44,6 @@ class CanonicalStarterHookPolicy:
         thresholds = (
             self.minimum_batters_faced,
             self.target_batters_faced,
-            self.maximum_batters_faced,
             self.maximum_runs_during_stint,
             self.maximum_walks_allowed,
             self.maximum_home_runs_allowed,
@@ -53,7 +52,13 @@ class CanonicalStarterHookPolicy:
             self.late_inning_threshold,
         )
 
-        if any(value < 0 for value in thresholds):
+        if (
+            any(value < 0 for value in thresholds)
+            or (
+                self.maximum_batters_faced is not None
+                and self.maximum_batters_faced < 0
+            )
+        ):
             raise ValueError(
                 "starter hook thresholds cannot be negative"
             )
@@ -63,10 +68,15 @@ class CanonicalStarterHookPolicy:
                 "minimum_batters_faced must be at least three"
             )
 
-        if not (
+        if (
             self.minimum_batters_faced
-            <= self.target_batters_faced
-            <= self.maximum_batters_faced
+            > self.target_batters_faced
+            or (
+                self.maximum_batters_faced
+                is not None
+                and self.target_batters_faced
+                > self.maximum_batters_faced
+            )
         ):
             raise ValueError(
                 "starter batter thresholds must be ordered"
@@ -119,7 +129,8 @@ class CanonicalStarterHookPolicy:
             )
 
         if (
-            lifecycle.batters_faced
+            self.maximum_batters_faced is not None
+            and lifecycle.batters_faced
             >= self.maximum_batters_faced
         ):
             return self._replace(

--- a/tests/test_canonical_pitcher_hook_policy.py
+++ b/tests/test_canonical_pitcher_hook_policy.py
@@ -67,6 +67,17 @@ def test_policy_thresholds_must_be_ordered():
         )
 
 
+def test_optional_maximum_must_not_precede_target():
+    with pytest.raises(
+        ValueError,
+        match="must be ordered",
+    ):
+        CanonicalStarterHookPolicy(
+            target_batters_faced=24,
+            maximum_batters_faced=20,
+        )
+
+
 def test_holds_before_minimum_batters():
     decision = (
         build_baseline_starter_hook_policy()
@@ -201,14 +212,15 @@ def test_holds_when_no_reliever_is_available():
     )
 
 
-def test_replaces_at_maximum_batters():
-    decision = (
-        build_baseline_starter_hook_policy()
-        .decide(
-            context(
-                pitcher=lifecycle(
-                    batters_faced=27,
-                )
+def test_optional_maximum_batters_is_enforced_when_configured():
+    policy = CanonicalStarterHookPolicy(
+        maximum_batters_faced=27,
+    )
+
+    decision = policy.decide(
+        context(
+            pitcher=lifecycle(
+                batters_faced=27,
             )
         )
     )
@@ -218,6 +230,31 @@ def test_replaces_at_maximum_batters():
     )
     assert decision.reason == (
         "maximum_batters_reached"
+    )
+
+
+def test_baseline_starter_can_exceed_twenty_seven_batters():
+    decision = (
+        build_baseline_starter_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=28,
+                    hits_allowed=4,
+                    walks_allowed=2,
+                    runs_scored_during_stint=2,
+                ),
+                batting_score=0,
+                fielding_score=5,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.HOLD
+    )
+    assert decision.reason == (
+        "starter_within_limits"
     )
 
 
@@ -380,7 +417,7 @@ def test_baseline_starter_policy_uses_dynamic_decision_floor():
 
     assert policy.minimum_batters_faced == 3
     assert policy.target_batters_faced == 24
-    assert policy.maximum_batters_faced == 27
+    assert policy.maximum_batters_faced is None
     assert policy.maximum_hits_allowed == 9
     assert policy.maximum_traffic_allowed == 12
 

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1676,6 +1676,11 @@ def test_starter_exit_is_dynamic_with_performance_and_workload():
     # Poor simulated starts are no longer forced
     # through the old eighteen-batter floor.
     assert min(starter_batters_faced) < 18
+
+    # Efficient starters are not forcibly removed
+    # merely because they faced batter number 27.
+    assert max(starter_batters_faced) > 27
+
     assert (
         starter_innings["minimum"]
         < starter_innings["median"]


### PR DESCRIPTION
## Summary

- remove the ordinary starter's hard 27-batter workload ceiling by making `maximum_batters_faced` optional and unset for the baseline starter policy
- preserve the explicit 9-BF maximum for the opener specialization
- retain the existing dynamic performance, late-game, and leverage-based starter exit decisions
- add unit and production regression coverage proving an ordinary starter may face more than 27 batters

## Root cause

`27` was being treated as a maximum number of batters faced even though it corresponds conceptually to regulation defensive outs, not a realistic batter-facing ceiling. In a deterministic 100-trial baseline, 11 starters were forcibly removed at exactly 27 BF with only 17–18 outs recorded. Starter BF never exceeded 27.

Game completion remains owned by canonical game state; this change does not introduce a 27-out pitcher hook.

## Production evidence

After removing the ordinary-starter BF ceiling, 7 of 200 starter appearances naturally exceeded 27 BF, reaching 28. `maximum_batters_reached` ordinary-starter exits fell from 11 to 0. Those 11 exits redistributed naturally to +10 `late_game_target_reached` decisions and +1 `traffic_threshold_reached` decision.

Dynamic early exits were preserved at 26. Starter mean IP changed only from 5.0333 to 5.0433 (+0.01), while minimum, p10, median, p90, p95, and maximum were unchanged. Sequencing anomalies remained empty, starter-relief detection remained false, and no database writes or production-authority changes occurred.

## Validation

- 181 tests passed across the explicit 12-file 6SU regression suite
- `py_compile` passed
- `git diff --check` passed
- staged isolation check passed; only the three intended 6SU files were committed
