### PR TITLE
Reconcile dynamic canonical pitcher exit policies

### DIFF
--- a/mlb_app/simulation/game/pitcher_hook_policy.py
+++ b/mlb_app/simulation/game/pitcher_hook_policy.py
@@ -283,5 +283,10 @@ def build_baseline_opener_hook_policy(
         minimum_batters_faced=3,
         target_batters_faced=6,
         maximum_batters_faced=9,
+        maximum_runs_during_stint=3,
+        maximum_walks_allowed=2,
+        maximum_home_runs_allowed=2,
+        maximum_hits_allowed=4,
+        maximum_traffic_allowed=5,
         late_inning_threshold=3,
     )

--- a/mlb_app/simulation/game/reliever_hook_policy.py
+++ b/mlb_app/simulation/game/reliever_hook_policy.py
@@ -32,6 +32,8 @@ class CanonicalRelieverHookPolicy:
     maximum_runs_during_stint: int = 3
     maximum_walks_allowed: int = 2
     maximum_home_runs_allowed: int = 2
+    maximum_hits_allowed: int = 4
+    maximum_traffic_allowed: int = 5
     schema_version: str = (
         CANONICAL_RELIEVER_HOOK_POLICY_VERSION
     )
@@ -44,6 +46,8 @@ class CanonicalRelieverHookPolicy:
             self.maximum_runs_during_stint,
             self.maximum_walks_allowed,
             self.maximum_home_runs_allowed,
+            self.maximum_hits_allowed,
+            self.maximum_traffic_allowed,
         )
 
         if any(value < 0 for value in thresholds):
@@ -141,6 +145,27 @@ class CanonicalRelieverHookPolicy:
             return self._replace(
                 lifecycle.pitcher_id,
                 "home_run_threshold_reached",
+            )
+
+        if (
+            lifecycle.hits_allowed
+            >= self.maximum_hits_allowed
+        ):
+            return self._replace(
+                lifecycle.pitcher_id,
+                "hits_threshold_reached",
+            )
+
+        traffic = (
+            lifecycle.hits_allowed
+            + lifecycle.walks_allowed
+            + lifecycle.hit_batters
+        )
+
+        if traffic >= self.maximum_traffic_allowed:
+            return self._replace(
+                lifecycle.pitcher_id,
+                "traffic_threshold_reached",
             )
 
         if (

--- a/tests/test_canonical_pitcher_hook_policy.py
+++ b/tests/test_canonical_pitcher_hook_policy.py
@@ -432,6 +432,39 @@ def test_baseline_opener_policy_has_short_workload():
     assert policy.minimum_batters_faced == 3
     assert policy.target_batters_faced == 6
     assert policy.maximum_batters_faced == 9
+    assert policy.maximum_runs_during_stint == 3
+    assert policy.maximum_walks_allowed == 2
+    assert policy.maximum_home_runs_allowed == 2
+    assert policy.maximum_hits_allowed == 4
+    assert policy.maximum_traffic_allowed == 5
+
+
+def test_baseline_opener_uses_short_role_traffic_threshold():
+    from mlb_app.simulation.game.pitcher_hook_policy import (
+        build_baseline_opener_hook_policy,
+    )
+
+    decision = (
+        build_baseline_opener_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=5,
+                    hits_allowed=3,
+                    walks_allowed=1,
+                    hit_batters=1,
+                ),
+                inning=2,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "traffic_threshold_reached"
+    )
 
 
 def test_baseline_opener_replaces_at_nine_batters():

--- a/tests/test_canonical_reliever_hook_policy.py
+++ b/tests/test_canonical_reliever_hook_policy.py
@@ -51,6 +51,13 @@ def test_default_policy_has_stable_version():
     )
 
 
+def test_baseline_reliever_has_dynamic_performance_thresholds():
+    policy = build_baseline_reliever_hook_policy()
+
+    assert policy.maximum_hits_allowed == 4
+    assert policy.maximum_traffic_allowed == 5
+
+
 def test_thresholds_must_be_ordered():
     with pytest.raises(
         ValueError,
@@ -179,6 +186,51 @@ def test_replaces_at_performance_thresholds(
         CanonicalPitchingDecisionAction.REPLACE
     )
     assert decision.reason == reason
+
+
+def test_hits_can_trigger_early_reliever_exit():
+    decision = (
+        build_baseline_reliever_hook_policy()
+        .decide(
+            context(
+                pitcher=lifecycle(
+                    batters_faced=4,
+                    hits_allowed=4,
+                )
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "hits_threshold_reached"
+    )
+
+
+def test_combined_traffic_can_trigger_reliever_exit():
+    policy = CanonicalRelieverHookPolicy(
+        maximum_hits_allowed=10,
+        maximum_traffic_allowed=4,
+    )
+
+    decision = policy.decide(
+        context(
+            pitcher=lifecycle(
+                batters_faced=4,
+                hits_allowed=3,
+                walks_allowed=1,
+            )
+        )
+    )
+
+    assert decision.action is (
+        CanonicalPitchingDecisionAction.REPLACE
+    )
+    assert decision.reason == (
+        "traffic_threshold_reached"
+    )
 
 
 def test_replaces_at_target_workload():


### PR DESCRIPTION
## Summary
- reconcile performance-based exit signals across canonical pitcher roles
- give opener workloads role-scaled hit/traffic thresholds instead of inheriting starter-sized limits
- add hit and aggregate-traffic exit signals to the canonical reliever policy
- preserve role-specific workload targets and the opener's intentional short-role ceiling

## Why
The cross-role audit showed that generic relievers lacked hit/traffic exit signals, while openers inherited performance thresholds sized for starters. This made the dynamic exit framework inconsistent by role.

## Production evidence
A 100-trial post-change production audit exercised the new opener and reliever hit/traffic paths while preserving workload distributions and role ordering. Bulk followers remained longer than openers, starters remained longer than relievers, anomaly counts stayed empty, starter-relief detection stayed false, and no database writes or production-authority changes occurred.

## Validation
- 178 targeted regression tests passed
- `py_compile` passed
- `git diff --check` passed
- staged isolation passed; only the four intended 6SV files were committed
- ruff was not installed locally