### PR TITLE
Surface canonical pitcher roles in projections

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -79,6 +79,15 @@ test('projections tab renders requested batter metrics', async () => {
   }
 })
 
+test('projections tab renders canonical pitcher role', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /key: 'pitcherRoleLabel', label: 'Role'/,
+  )
+})
+
 test('projections tab renders pitcher workload distribution', async () => {
   const source = await pageSource()
 

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -91,6 +91,22 @@ function teamSide(row) {
   return value || '—'
 }
 
+function pitcherRoleLabel(value) {
+  const role = String(value || '').trim()
+
+  const labels = {
+    starter: 'Starter',
+    opener: 'Opener',
+    bulk_follower: 'Bulk Follower',
+    reliever: 'Reliever',
+    tandem_primary: 'Tandem Primary',
+    tandem_secondary: 'Tandem Secondary',
+    unexpected_pitcher: 'Unexpected',
+  }
+
+  return labels[role] || '—'
+}
+
 function dfsValue(row, key) {
   const direct = number(row?.[key])
 
@@ -171,6 +187,10 @@ function pitcherRow(row) {
     mlbPlayerId: row?.mlb_player_id ?? null,
     name: playerName(row),
     side: teamSide(row),
+    pitcherRole: row?.pitcher_role ?? null,
+    pitcherRoleLabel: pitcherRoleLabel(
+      row?.pitcher_role,
+    ),
     battersFaced: metricValue(
       row,
       'batters_faced',

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -60,6 +60,7 @@ function payload() {
               player_id: 'p-1',
               player_type: 'pitcher',
               team_side: 'home',
+              pitcher_role: 'starter',
               metrics: {
                 batters_faced: metric(24),
                 outs_recorded: metric(
@@ -139,6 +140,11 @@ test('derives pitcher innings from canonical outs recorded', () => {
   const pitcher = view.pitchers[0]
 
   assert.equal(pitcher.name, 'p-1')
+  assert.equal(pitcher.pitcherRole, 'starter')
+  assert.equal(
+    pitcher.pitcherRoleLabel,
+    'Starter',
+  )
   assert.equal(pitcher.inningsPitched, 6)
   assert.equal(pitcher.inningsPitchedP10, 4)
   assert.equal(
@@ -151,6 +157,60 @@ test('derives pitcher innings from canonical outs recorded', () => {
   assert.equal(pitcher.dfsFloor, 8)
   assert.equal(pitcher.dfsMedian, 17)
   assert.equal(pitcher.dfsCeiling, 27)
+})
+
+
+test('does not infer missing pitcher role from workload', () => {
+  const source = payload()
+  const pitcher = (
+    source
+      .diagnostics
+      .canonical_shadow
+      .player_projections
+      .players[1]
+  )
+
+  delete pitcher.pitcher_role
+
+  pitcher.metrics.outs_recorded.mean = 24
+  pitcher.metrics.batters_faced.mean = 35
+
+  const view = (
+    buildCanonicalProjectionsViewModel(source)
+  )
+
+  assert.equal(
+    view.pitchers[0].pitcherRole,
+    null,
+  )
+  assert.equal(
+    view.pitchers[0].pitcherRoleLabel,
+    '—',
+  )
+})
+
+
+test('formats canonical bulk follower role', () => {
+  const source = payload()
+  source
+    .diagnostics
+    .canonical_shadow
+    .player_projections
+    .players[1]
+    .pitcher_role = 'bulk_follower'
+
+  const view = (
+    buildCanonicalProjectionsViewModel(source)
+  )
+
+  assert.equal(
+    view.pitchers[0].pitcherRole,
+    'bulk_follower',
+  )
+  assert.equal(
+    view.pitchers[0].pitcherRoleLabel,
+    'Bulk Follower',
+  )
 })
 
 

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -887,6 +887,7 @@ const BATTER_PROJECTION_COLUMNS = [
 const PITCHER_PROJECTION_COLUMNS = [
   { key: 'name', label: 'Pitcher', format: 'text', align: 'left' },
   { key: 'side', label: 'Side', format: 'text', align: 'left' },
+  { key: 'pitcherRoleLabel', label: 'Role', format: 'text', align: 'left' },
   { key: 'battersFaced', label: 'BF' },
   { key: 'inningsPitched', label: 'IP' },
   { key: 'inningsPitchedP10', label: 'IP P10' },

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -774,6 +774,10 @@ def _attach_production_shadow_comparison(
             material
             .canonical_shadow_execution_inputs
         ),
+        pitcher_appearance_sequence_audit=(
+            material
+            .pitcher_appearance_sequence_audit
+        ),
     )
 
 

--- a/mlb_app/simulation/projections/pitcher_role_enrichment.py
+++ b/mlb_app/simulation/projections/pitcher_role_enrichment.py
@@ -1,0 +1,156 @@
+"""Attach canonical pitching-role evidence to projection rows."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+CANONICAL_PITCHER_PROJECTION_ROLE_ENRICHMENT_VERSION = (
+    "canonical_pitcher_projection_role_enrichment_v1"
+)
+
+
+def enrich_canonical_pitcher_projection_roles(
+    *,
+    payload: Mapping[str, Any],
+    appearance_audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Attach observed canonical planned-role evidence to pitcher rows.
+
+    Roles come only from the same-run canonical appearance audit.
+    Missing or conflicting evidence remains explicit and is never
+    inferred from workload, row order, or player identity.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping")
+
+    if not isinstance(appearance_audit, Mapping):
+        raise TypeError(
+            "appearance_audit must be a mapping"
+        )
+
+    result = deepcopy(dict(payload))
+    players = result.get("players")
+
+    if not isinstance(players, list):
+        raise TypeError(
+            "projection players must be a list"
+        )
+
+    records = appearance_audit.get("records")
+
+    if not isinstance(records, (list, tuple)):
+        raise TypeError(
+            "appearance audit records must be a list or tuple"
+        )
+
+    evidence = defaultdict(set)
+    invalid_record_count = 0
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            invalid_record_count += 1
+            continue
+
+        team_side = str(
+            record.get("team_side") or ""
+        ).strip()
+        pitcher_id = str(
+            record.get("pitcher_id") or ""
+        ).strip()
+        planned_role = str(
+            record.get("planned_role") or ""
+        ).strip()
+
+        if (
+            team_side not in {"away", "home"}
+            or not pitcher_id
+            or not planned_role
+        ):
+            invalid_record_count += 1
+            continue
+
+        evidence[
+            (team_side, pitcher_id)
+        ].add(planned_role)
+
+    resolved_count = 0
+    missing_count = 0
+    conflicting_count = 0
+    conflicting_pitcher_ids = []
+
+    for row in players:
+        if not isinstance(row, dict):
+            raise TypeError(
+                "projection player rows must be dictionaries"
+            )
+
+        if row.get("player_type") != "pitcher":
+            continue
+
+        team_side = str(
+            row.get("team_side") or ""
+        ).strip()
+        pitcher_id = str(
+            row.get("player_id") or ""
+        ).strip()
+
+        roles = evidence.get(
+            (team_side, pitcher_id),
+            set(),
+        )
+
+        if len(roles) == 1:
+            row["pitcher_role"] = next(iter(roles))
+            row[
+                "pitcher_role_resolution_status"
+            ] = "resolved"
+            resolved_count += 1
+        elif len(roles) > 1:
+            row["pitcher_role"] = None
+            row[
+                "pitcher_role_resolution_status"
+            ] = "conflicting"
+            conflicting_count += 1
+            conflicting_pitcher_ids.append(
+                pitcher_id
+            )
+        else:
+            row["pitcher_role"] = None
+            row[
+                "pitcher_role_resolution_status"
+            ] = "missing"
+            missing_count += 1
+
+    result[
+        "pitcher_role_enrichment_applied"
+    ] = True
+    result["pitcher_role_enrichment"] = {
+        "schema_version": (
+            CANONICAL_PITCHER_PROJECTION_ROLE_ENRICHMENT_VERSION
+        ),
+        "status": "observed",
+        "source": (
+            "canonical_pitcher_appearance_sequence_audit"
+        ),
+        "resolved_pitcher_count": resolved_count,
+        "missing_pitcher_count": missing_count,
+        "conflicting_pitcher_count": (
+            conflicting_count
+        ),
+        "invalid_record_count": (
+            invalid_record_count
+        ),
+        "conflicting_pitcher_ids": sorted(
+            set(conflicting_pitcher_ids)
+        ),
+        "inference_used": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+    return result

--- a/mlb_app/simulation/shadow/integration.py
+++ b/mlb_app/simulation/shadow/integration.py
@@ -11,6 +11,9 @@ from mlb_app.simulation.game.probability_diagnostics import (
 from mlb_app.simulation.projections import (
     canonical_player_projection_rows,
 )
+from mlb_app.simulation.projections.pitcher_role_enrichment import (
+    enrich_canonical_pitcher_projection_roles,
+)
 from .input_assembly import (
     CanonicalShadowExecutionInputs,
 )
@@ -37,6 +40,9 @@ def attach_canonical_shadow(
     ] = None,
     canonical_shadow_execution_inputs: Optional[
         CanonicalShadowExecutionInputs
+    ] = None,
+    pitcher_appearance_sequence_audit: Optional[
+        Dict[str, Any]
     ] = None,
 ) -> Dict[str, Any]:
     """Attach shadow diagnostics without mutating legacy data."""
@@ -105,15 +111,13 @@ def attach_canonical_shadow(
 
     if enabled and canonical_payload is not None:
         try:
-            shadow_payload[
-                "player_projections"
-            ] = canonical_player_projection_rows(
-                canonical_payload
+            projection_rows = (
+                canonical_player_projection_rows(
+                    canonical_payload
+                )
             )
         except Exception as exc:
-            shadow_payload[
-                "player_projections"
-            ] = {
+            projection_rows = {
                 "schema_version": (
                     "canonical_player_projection_rows_v1"
                 ),
@@ -127,6 +131,46 @@ def attach_canonical_shadow(
                 "authoritative": False,
                 "authoritative_source": "legacy",
             }
+        else:
+            if (
+                pitcher_appearance_sequence_audit
+                is not None
+            ):
+                try:
+                    projection_rows = (
+                        enrich_canonical_pitcher_projection_roles(
+                            payload=projection_rows,
+                            appearance_audit=(
+                                pitcher_appearance_sequence_audit
+                            ),
+                        )
+                    )
+                except Exception as exc:
+                    projection_rows[
+                        "pitcher_role_enrichment_applied"
+                    ] = False
+                    projection_rows[
+                        "pitcher_role_enrichment"
+                    ] = {
+                        "schema_version": (
+                            "canonical_pitcher_projection_"
+                            "role_enrichment_v1"
+                        ),
+                        "status": "error",
+                        "error_type": (
+                            exc.__class__.__name__
+                        ),
+                        "error_message": str(exc),
+                        "inference_used": False,
+                        "database_writes_performed":
+                            False,
+                        "production_authority_changed":
+                            False,
+                    }
+
+        shadow_payload[
+            "player_projections"
+        ] = projection_rows
 
     if probability_resolution_diagnostics is not None:
         try:

--- a/tests/test_canonical_pitcher_projection_roles.py
+++ b/tests/test_canonical_pitcher_projection_roles.py
@@ -1,0 +1,178 @@
+from copy import deepcopy
+
+from mlb_app.simulation.projections.pitcher_role_enrichment import (
+    CANONICAL_PITCHER_PROJECTION_ROLE_ENRICHMENT_VERSION,
+    enrich_canonical_pitcher_projection_roles,
+)
+
+
+def payload():
+    return {
+        "schema_version":
+            "canonical_player_projection_rows_v1",
+        "players": [
+            {
+                "player_id": "batter_1",
+                "player_type": "batter",
+                "team_side": "away",
+                "metrics": {},
+            },
+            {
+                "player_id": "100",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "metrics": {},
+            },
+            {
+                "player_id": "101",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "metrics": {},
+            },
+            {
+                "player_id": "200",
+                "player_type": "pitcher",
+                "team_side": "home",
+                "metrics": {},
+            },
+        ],
+    }
+
+
+def record(
+    pitcher_id,
+    role,
+    *,
+    team_side="away",
+    trial_index=0,
+):
+    return {
+        "trial_index": trial_index,
+        "team_side": team_side,
+        "pitcher_id": pitcher_id,
+        "planned_role": role,
+    }
+
+
+def test_attaches_same_run_canonical_roles():
+    source = payload()
+
+    result = (
+        enrich_canonical_pitcher_projection_roles(
+            payload=source,
+            appearance_audit={
+                "records": [
+                    record("100", "opener"),
+                    record(
+                        "101",
+                        "bulk_follower",
+                    ),
+                    record(
+                        "200",
+                        "starter",
+                        team_side="home",
+                    ),
+                ],
+            },
+        )
+    )
+
+    pitchers = {
+        row["player_id"]: row
+        for row in result["players"]
+        if row["player_type"] == "pitcher"
+    }
+
+    assert pitchers["100"]["pitcher_role"] == (
+        "opener"
+    )
+    assert pitchers["101"]["pitcher_role"] == (
+        "bulk_follower"
+    )
+    assert pitchers["200"]["pitcher_role"] == (
+        "starter"
+    )
+
+    assert result[
+        "pitcher_role_enrichment_applied"
+    ] is True
+    assert result["pitcher_role_enrichment"][
+        "schema_version"
+    ] == (
+        CANONICAL_PITCHER_PROJECTION_ROLE_ENRICHMENT_VERSION
+    )
+    assert result["pitcher_role_enrichment"][
+        "inference_used"
+    ] is False
+
+
+def test_missing_role_evidence_remains_explicit():
+    result = (
+        enrich_canonical_pitcher_projection_roles(
+            payload=payload(),
+            appearance_audit={
+                "records": [
+                    record("100", "opener"),
+                ],
+            },
+        )
+    )
+
+    pitcher = next(
+        row
+        for row in result["players"]
+        if row["player_id"] == "101"
+    )
+
+    assert pitcher["pitcher_role"] is None
+    assert pitcher[
+        "pitcher_role_resolution_status"
+    ] == "missing"
+
+
+def test_conflicting_roles_are_not_inferred():
+    result = (
+        enrich_canonical_pitcher_projection_roles(
+            payload=payload(),
+            appearance_audit={
+                "records": [
+                    record("100", "starter"),
+                    record(
+                        "100",
+                        "opener",
+                        trial_index=1,
+                    ),
+                ],
+            },
+        )
+    )
+
+    pitcher = next(
+        row
+        for row in result["players"]
+        if row["player_id"] == "100"
+    )
+
+    assert pitcher["pitcher_role"] is None
+    assert pitcher[
+        "pitcher_role_resolution_status"
+    ] == "conflicting"
+    assert result["pitcher_role_enrichment"][
+        "conflicting_pitcher_count"
+    ] == 1
+
+
+def test_enrichment_does_not_mutate_inputs():
+    source = payload()
+    original = deepcopy(source)
+
+    enrich_canonical_pitcher_projection_roles(
+        payload=source,
+        appearance_audit={
+            "records": [
+                record("100", "starter"),
+            ],
+        },
+    )
+
+    assert source == original

--- a/tests/test_canonical_shadow_player_projections.py
+++ b/tests/test_canonical_shadow_player_projections.py
@@ -247,3 +247,65 @@ def test_disabled_shadow_has_no_player_projections():
     ]
 
     assert "player_projections" not in shadow
+
+def test_shadow_attaches_same_run_pitcher_role_evidence():
+    result = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        pitcher_appearance_sequence_audit={
+            "records": [
+                {
+                    "trial_index": 0,
+                    "team_side": "home",
+                    "pitcher_id": "200",
+                    "planned_role": "starter",
+                },
+            ],
+        },
+    )
+
+    projections = result["diagnostics"][
+        "canonical_shadow"
+    ]["player_projections"]
+
+    pitcher = next(
+        row
+        for row in projections["players"]
+        if row["player_id"] == "200"
+    )
+
+    assert pitcher["pitcher_role"] == "starter"
+    assert pitcher[
+        "pitcher_role_resolution_status"
+    ] == "resolved"
+    assert projections[
+        "pitcher_role_enrichment_applied"
+    ] is True
+    assert projections["pitcher_role_enrichment"][
+        "inference_used"
+    ] is False
+
+
+def test_pitcher_role_failure_preserves_projection_rows():
+    result = attach_canonical_shadow(
+        legacy_result=legacy_result(),
+        enabled=True,
+        canonical_payload=canonical_payload(),
+        pitcher_appearance_sequence_audit={
+            "records": "invalid",
+        },
+    )
+
+    projections = result["diagnostics"][
+        "canonical_shadow"
+    ]["player_projections"]
+
+    assert len(projections["players"]) == 2
+    assert projections[
+        "pitcher_role_enrichment_applied"
+    ] is False
+    assert projections["pitcher_role_enrichment"][
+        "status"
+    ] == "error"
+    assert projections["authoritative"] is False


### PR DESCRIPTION
## Summary

- enrich canonical pitcher projection rows with same-run pitching-role evidence from the canonical appearance-sequence audit
- surface Starter, Reliever, Opener, Bulk Follower, and tandem roles in the projections UI without inferring role from workload
- preserve canonical projection rows if role enrichment fails and keep the enrichment non-authoritative

## Why

Pitcher workload distributions are now dynamic and visible, but the projections table still needs explicit canonical role context so opener/bulk usage is understandable without guessing from BF or IP.

## Validation

- same-run production probe resolved starter/reliever and opener/bulk roles with `all_acceptance_signals_pass=true`
- role enrichment reported `inference_used=false`, `database_writes_performed=false`, and `production_authority_changed=false`
- focused backend regression: 64 passed
- frontend role/UI contract: 24 passed
- frontend production build passed during implementation validation
- Python compilation passed
- `git diff --check` passed

The four unrelated local untracked audit/backtest/debug scripts were not staged or committed.