### PR TITLE
Fix Final game box scores on mobile

### DIFF
--- a/frontend/src/lib/finalPageContract.test.mjs
+++ b/frontend/src/lib/finalPageContract.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test'
 const app = await readFile(new URL('../App.jsx', import.meta.url), 'utf8')
 const finalPage = await readFile(new URL('../pages/FinalGamePage.jsx', import.meta.url), 'utf8')
 const livePage = await readFile(new URL('../pages/LiveScoreboardPage.jsx', import.meta.url), 'utf8')
+const theme = await readFile(new URL('../styles/theme.css', import.meta.url), 'utf8')
 
 test('Final list and detail routes are registered and Live hands final games off', () => {
   assert.match(app, /path="\/final"/)
@@ -26,3 +27,11 @@ test('primary ribbon uses grouped menus instead of every route as a top-level li
   assert.match(app, /<NavLink to="\/final"/)
 })
 
+test('Final detail keeps wide box scores usable on mobile without clipping the page', () => {
+  assert.match(finalPage, /role="region" aria-label=\{label\} tabIndex="0"/)
+  assert.match(finalPage, /variant="batting"/)
+  assert.match(finalPage, /variant="pitching"/)
+  assert.match(theme, /\.final-detail-page[\s\S]*?min-width: 0/)
+  assert.match(theme, /\.final-table-scroll[\s\S]*?overflow-x: auto/)
+  assert.match(theme, /\.final-table-batting th:nth-child\(2\)[\s\S]*?position: sticky/)
+})

--- a/frontend/src/pages/FinalGamePage.jsx
+++ b/frontend/src/pages/FinalGamePage.jsx
@@ -6,10 +6,10 @@ function value(input) {
   return input === undefined || input === null || input === '' ? '—' : String(input)
 }
 
-function DataTable({ headers, rows, renderRow }) {
+function DataTable({ headers, rows, renderRow, label, variant = 'standard' }) {
   return (
-    <div className="final-table-scroll">
-      <table className="final-table">
+    <div className="final-table-scroll" role="region" aria-label={label} tabIndex="0">
+      <table className={`final-table final-table-${variant}`}>
         <thead><tr>{headers.map(header => <th key={header}>{header}</th>)}</tr></thead>
         <tbody>
           {rows.map((row, index) => (
@@ -34,6 +34,8 @@ function Linescore({ data }) {
     <section className="final-panel">
       <div className="final-section-title">Linescore</div>
       <DataTable
+        label="Game linescore"
+        variant="linescore"
         headers={['Team', ...innings.map(inning => inning.num), 'R', 'H', 'E', 'LOB']}
         rows={rows}
         renderRow={row => [
@@ -65,6 +67,8 @@ function TeamBoxScore({ team, label }) {
       </header>
       <div className="final-section-title">Batting</div>
       <DataTable
+        label={`${team?.name || label} batting box score`}
+        variant="batting"
         headers={['#', 'Batter', 'POS', 'AB', 'R', 'H', 'RBI', 'HR', 'BB', 'K', 'AVG', 'OPS']}
         rows={batters}
         renderRow={batter => [
@@ -76,6 +80,8 @@ function TeamBoxScore({ team, label }) {
       />
       <div className="final-section-title final-pitching-title">Pitching</div>
       <DataTable
+        label={`${team?.name || label} pitching box score`}
+        variant="pitching"
         headers={['Pitcher', 'IP', 'H', 'R', 'ER', 'BB', 'K', 'HR', 'PC-ST', 'ERA']}
         rows={pitchers}
         renderRow={pitcher => [
@@ -152,4 +158,3 @@ export default function FinalGamePage() {
     </div>
   )
 }
-

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -381,6 +381,7 @@ input:focus, select:focus, textarea:focus {
 .final-detail-page {
   display: grid;
   gap: 18px;
+  min-width: 0;
 }
 
 .final-back-link {
@@ -395,6 +396,7 @@ input:focus, select:focus, textarea:focus {
 .final-panel,
 .final-team-box,
 .final-summary-panel {
+  min-width: 0;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   background: linear-gradient(180deg, rgba(22, 31, 48, 0.96), rgba(13, 19, 32, 0.96));
@@ -513,13 +515,21 @@ input:focus, select:focus, textarea:focus {
 }
 
 .final-table-scroll {
+  width: 100%;
   max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
   margin-top: 10px;
+  border-radius: var(--radius-sm);
+  scrollbar-width: thin;
 }
 
 .final-table {
+  display: table;
   width: 100%;
+  max-width: none;
   min-width: 760px;
   border-collapse: collapse;
   font-size: 12px;
@@ -921,7 +931,8 @@ input:focus, select:focus, textarea:focus {
 
   .final-score-hero {
     grid-template-columns: 1fr 1fr;
-    padding: 20px;
+    gap: 14px 10px;
+    padding: 16px;
   }
 
   .final-score-state {
@@ -929,12 +940,21 @@ input:focus, select:focus, textarea:focus {
     grid-row: 1;
   }
 
+  .final-score-state small {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   .final-score-team {
     grid-row: 2;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .final-score-team h1 {
     font-size: 16px;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
   }
 
   .final-score-team strong {
@@ -944,6 +964,68 @@ input:focus, select:focus, textarea:focus {
   .final-team-heading,
   .final-scoring-list > div {
     align-items: flex-start;
+  }
+
+  .final-summary-panel,
+  .final-panel,
+  .final-team-box {
+    padding: 16px;
+  }
+
+  .final-team-heading {
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+  }
+
+  .final-table {
+    font-size: 11px;
+  }
+
+  .final-table th,
+  .final-table td {
+    padding: 8px 7px;
+  }
+
+  .final-table-linescore {
+    min-width: 620px;
+  }
+
+  .final-table-pitching {
+    min-width: 650px;
+  }
+
+  .final-table-batting {
+    min-width: 720px;
+  }
+
+  .final-table-batting th:nth-child(2),
+  .final-table-batting td:nth-child(2),
+  .final-table-pitching th:first-child,
+  .final-table-pitching td:first-child,
+  .final-table-linescore th:first-child,
+  .final-table-linescore td:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: #0f1726;
+    box-shadow: 1px 0 0 rgba(148, 163, 184, 0.16);
+  }
+
+  .final-table-batting th:first-child,
+  .final-table-batting td:first-child {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    width: 30px;
+    min-width: 30px;
+    background: #0f1726;
+  }
+
+  .final-table-batting th:nth-child(2),
+  .final-table-batting td:nth-child(2) {
+    left: 30px;
   }
 
   .final-scoring-list > div {


### PR DESCRIPTION
## What changed

- Prevents Final detail cards and tables from forcing the page wider than a phone viewport.
- Keeps horizontal movement contained within the linescore, batting, and pitching tables.
- Pins the identifying team/player columns while users swipe through stats.
- Tightens mobile score-header spacing and allows long team/venue text to wrap.
- Stacks the team box-score header cleanly on small screens.
- Adds accessible labels and keyboard focus to each scrollable stats region.

## Root cause

The Final tables intentionally have desktop-scale minimum widths, but their grid parents retained the default `min-width: auto`. Combined with page-level horizontal clipping, this pushed the cards outside the mobile viewport and cut off content instead of exposing the table scroller.

## Validation

- `node --test src/lib/finalPageContract.test.mjs` — **4 passed**
- `npm run build` — **passed**
- `git diff --check` — **passed**

The build retains the existing LandingV2 duplicate-key and large-chunk warnings; this focused follow-up does not touch those areas.

Follow-up to merged PR #1343.