### PR TITLE
Audit canonical pitcher projection activation readiness

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -5,6 +5,12 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+from mlb_app.simulation.shadow.canonical_pitcher_projection_activation_readiness import (
+    audit_canonical_pitcher_projection_activation_readiness,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_role_and_innings_attribution_audit import (
+    audit_canonical_pitcher_role_and_innings_attribution,
+)
 from mlb_app.simulation.shadow.production_monitoring_ledger import (
     CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
     CanonicalBaserunningProductionMonitoringRecord,
@@ -760,7 +766,7 @@ def _attach_production_shadow_comparison(
     if material is None:
         return legacy_result
 
-    return attach_canonical_shadow(
+    result = attach_canonical_shadow(
         legacy_result=legacy_result,
         enabled=True,
         canonical_payload=(
@@ -779,6 +785,81 @@ def _attach_production_shadow_comparison(
             .pitcher_appearance_sequence_audit
         ),
     )
+
+    shadow = (
+        result
+        .get("diagnostics", {})
+        .get("canonical_shadow", {})
+    )
+
+    try:
+        appearance_audit = (
+            material
+            .pitcher_appearance_sequence_audit
+        )
+        pitching_plans = appearance_audit[
+            "pitching_plans"
+        ]
+
+        role_and_innings_audit = (
+            audit_canonical_pitcher_role_and_innings_attribution(
+                projection_payload=(
+                    material.canonical_payload
+                ),
+                away_pitching_plan=(
+                    pitching_plans["away"]
+                ),
+                home_pitching_plan=(
+                    pitching_plans["home"]
+                ),
+            )
+        )
+
+        readiness = (
+            audit_canonical_pitcher_projection_activation_readiness(
+                projection_rows=shadow[
+                    "player_projections"
+                ],
+                appearance_audit=appearance_audit,
+                role_and_innings_audit=(
+                    role_and_innings_audit
+                ),
+            )
+        )
+    except Exception as exc:
+        readiness = {
+            "schema_version": (
+                "canonical_pitcher_projection_"
+                "activation_readiness_v1"
+            ),
+            "status": "error",
+            "audited": False,
+            "blockers": [
+                "readiness_audit_error",
+            ],
+            "error_type": (
+                exc.__class__.__name__
+            ),
+            "error_message": str(exc),
+            "decision": {
+                "pitcher_projection_activation_allowed":
+                    False,
+                "production_activation_allowed":
+                    False,
+                "recommended_next_slice": (
+                    "resolve_canonical_pitcher_"
+                    "projection_readiness_blockers"
+                ),
+            },
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+    shadow[
+        "pitcher_projection_activation_readiness"
+    ] = readiness
+
+    return result
 
 
 def _enrich_game_workspace_player_projections(

--- a/mlb_app/simulation/shadow/canonical_pitcher_projection_activation_readiness.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_projection_activation_readiness.py
@@ -1,0 +1,474 @@
+"""Audit canonical pitcher projection activation readiness."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_projection_activation_"
+    "readiness_v1"
+)
+
+PRIMARY_WORKLOAD_ROLES = frozenset({
+    "starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+})
+
+ORDERED_DISTRIBUTION_FIELDS = (
+    "minimum",
+    "p10",
+    "median",
+    "p90",
+    "maximum",
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return (
+        value
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    return None
+
+
+def _metric_summary(
+    row: Mapping[str, Any],
+    metric_name: str,
+) -> Mapping[str, Any]:
+    metrics = _mapping(row.get("metrics"))
+    metric = _mapping(metrics.get(metric_name))
+
+    if not metric:
+        return {}
+
+    return _mapping(
+        metric.get("summary", metric)
+    )
+
+
+def _distribution_valid(
+    summary: Mapping[str, Any],
+) -> bool:
+    ordered = tuple(
+        _number(summary.get(field_name))
+        for field_name
+        in ORDERED_DISTRIBUTION_FIELDS
+    )
+
+    if any(value is None for value in ordered):
+        return False
+
+    values = tuple(
+        value
+        for value in ordered
+        if value is not None
+    )
+
+    if any(value < 0 for value in values):
+        return False
+
+    if any(
+        left > right
+        for left, right
+        in zip(values, values[1:])
+    ):
+        return False
+
+    mean = _number(summary.get("mean"))
+
+    if mean is None:
+        return False
+
+    if not (
+        values[0]
+        <= mean
+        <= values[-1]
+    ):
+        return False
+
+    return True
+
+
+def _has_workload_spread(
+    summary: Mapping[str, Any],
+) -> bool:
+    minimum = _number(
+        summary.get("minimum")
+    )
+    maximum = _number(
+        summary.get("maximum")
+    )
+
+    return (
+        minimum is not None
+        and maximum is not None
+        and maximum > minimum
+    )
+
+
+def audit_canonical_pitcher_projection_activation_readiness(
+    *,
+    projection_rows: Mapping[str, Any],
+    appearance_audit: Mapping[str, Any],
+    role_and_innings_audit: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Decide whether canonical pitcher projections have enough
+    observed evidence for a later production-authority slice.
+
+    This function does not mutate projections, simulation inputs,
+    database state, or production authority.
+    """
+
+    if not isinstance(projection_rows, Mapping):
+        raise TypeError(
+            "projection_rows must be a mapping"
+        )
+
+    if not isinstance(appearance_audit, Mapping):
+        raise TypeError(
+            "appearance_audit must be a mapping"
+        )
+
+    if not isinstance(
+        role_and_innings_audit,
+        Mapping,
+    ):
+        raise TypeError(
+            "role_and_innings_audit must be a mapping"
+        )
+
+    blockers = set()
+
+    if (
+        projection_rows.get("schema_version")
+        != "canonical_player_projection_rows_v1"
+    ):
+        blockers.add(
+            "projection_rows_unavailable"
+        )
+
+    simulation_count = _number(
+        projection_rows.get("simulation_count")
+    )
+
+    if (
+        simulation_count is None
+        or simulation_count <= 0
+    ):
+        blockers.add(
+            "projection_simulation_count_unavailable"
+        )
+
+    players = projection_rows.get("players")
+
+    if not isinstance(players, list):
+        players = []
+        blockers.add(
+            "projection_rows_unavailable"
+        )
+
+    pitchers = [
+        row
+        for row in players
+        if (
+            isinstance(row, Mapping)
+            and row.get("player_type")
+            == "pitcher"
+        )
+    ]
+
+    if not pitchers:
+        blockers.add(
+            "pitcher_projection_rows_empty"
+        )
+
+    role_enrichment = _mapping(
+        projection_rows.get(
+            "pitcher_role_enrichment"
+        )
+    )
+
+    if (
+        projection_rows.get(
+            "pitcher_role_enrichment_applied"
+        )
+        is not True
+        or role_enrichment.get("status")
+        != "observed"
+    ):
+        blockers.add(
+            "pitcher_role_enrichment_not_ready"
+        )
+
+    if (
+        role_enrichment.get("inference_used")
+        is not False
+        or role_enrichment.get(
+            "missing_pitcher_count"
+        )
+        not in {0, 0.0}
+        or role_enrichment.get(
+            "conflicting_pitcher_count"
+        )
+        not in {0, 0.0}
+        or role_enrichment.get(
+            "invalid_record_count"
+        )
+        not in {0, 0.0}
+    ):
+        blockers.add(
+            "pitcher_role_evidence_incomplete"
+        )
+
+    unresolved_pitcher_count = sum(
+        row.get(
+            "pitcher_role_resolution_status"
+        )
+        != "resolved"
+        for row in pitchers
+    )
+
+    if unresolved_pitcher_count:
+        blockers.add(
+            "pitcher_role_evidence_incomplete"
+        )
+
+    appearance_anomalies = _mapping(
+        appearance_audit.get(
+            "anomaly_counts"
+        )
+    )
+
+    if (
+        appearance_audit.get("status")
+        != "observed"
+        or appearance_audit.get("audited")
+        is not True
+    ):
+        blockers.add(
+            "appearance_sequence_unavailable"
+        )
+
+    if appearance_anomalies:
+        blockers.add(
+            "appearance_sequence_anomalies"
+        )
+
+    if (
+        appearance_audit.get(
+            "starter_relief_detected"
+        )
+        is not False
+    ):
+        blockers.add(
+            "starter_relief_detected"
+        )
+
+    role_anomalies = _mapping(
+        role_and_innings_audit.get(
+            "anomaly_counts"
+        )
+    )
+
+    if (
+        role_and_innings_audit.get("status")
+        != "observed"
+        or role_and_innings_audit.get(
+            "audited"
+        )
+        is not True
+    ):
+        blockers.add(
+            "role_and_innings_audit_unavailable"
+        )
+
+    if role_anomalies:
+        blockers.add(
+            "role_and_innings_anomalies"
+        )
+
+    if (
+        _number(
+            role_and_innings_audit.get(
+                "role_attribution_complete_rate"
+            )
+        )
+        != 1.0
+    ):
+        blockers.add(
+            "role_attribution_incomplete"
+        )
+
+    invalid_distribution_pitcher_ids = []
+    missing_distribution_pitcher_ids = []
+    dynamic_workload_pitcher_ids = []
+
+    for row in pitchers:
+        pitcher_id = str(
+            row.get("player_id") or ""
+        )
+        role = str(
+            row.get("pitcher_role") or ""
+        )
+        outs_summary = _metric_summary(
+            row,
+            "outs_recorded",
+        )
+
+        if not outs_summary:
+            missing_distribution_pitcher_ids.append(
+                pitcher_id
+            )
+            continue
+
+        if not _distribution_valid(
+            outs_summary
+        ):
+            invalid_distribution_pitcher_ids.append(
+                pitcher_id
+            )
+            continue
+
+        if (
+            role in PRIMARY_WORKLOAD_ROLES
+            and _has_workload_spread(
+                outs_summary
+            )
+        ):
+            dynamic_workload_pitcher_ids.append(
+                pitcher_id
+            )
+
+    if missing_distribution_pitcher_ids:
+        blockers.add(
+            "outs_distribution_unavailable"
+        )
+
+    if invalid_distribution_pitcher_ids:
+        blockers.add(
+            "outs_distribution_invalid"
+        )
+
+    primary_role_pitcher_count = sum(
+        str(row.get("pitcher_role") or "")
+        in PRIMARY_WORKLOAD_ROLES
+        for row in pitchers
+    )
+
+    if (
+        primary_role_pitcher_count > 0
+        and not dynamic_workload_pitcher_ids
+    ):
+        blockers.add(
+            "dynamic_workload_evidence_unavailable"
+        )
+
+    source_audits = (
+        appearance_audit,
+        role_and_innings_audit,
+        role_enrichment,
+    )
+
+    if any(
+        audit.get(
+            "database_writes_performed"
+        )
+        is True
+        for audit in source_audits
+    ):
+        blockers.add(
+            "source_database_write_detected"
+        )
+
+    if any(
+        audit.get(
+            "production_authority_changed"
+        )
+        is True
+        for audit in source_audits
+    ):
+        blockers.add(
+            "source_production_authority_changed"
+        )
+
+    blockers = tuple(sorted(blockers))
+    ready = not blockers
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if ready
+            else "blocked"
+        ),
+        "audited": True,
+        "simulation_count":
+            simulation_count,
+        "pitcher_projection_count":
+            len(pitchers),
+        "primary_role_pitcher_count":
+            primary_role_pitcher_count,
+        "resolved_role_count": (
+            len(pitchers)
+            - unresolved_pitcher_count
+        ),
+        "dynamic_workload_pitcher_count":
+            len(dynamic_workload_pitcher_ids),
+        "dynamic_workload_pitcher_ids":
+            sorted(
+                dynamic_workload_pitcher_ids
+            ),
+        "missing_distribution_pitcher_ids":
+            sorted(
+                missing_distribution_pitcher_ids
+            ),
+        "invalid_distribution_pitcher_ids":
+            sorted(
+                invalid_distribution_pitcher_ids
+            ),
+        "appearance_anomaly_counts":
+            dict(appearance_anomalies),
+        "role_and_innings_anomaly_counts":
+            dict(role_anomalies),
+        "blockers": list(blockers),
+        "safety_checks": {
+            "projection_values_unchanged": True,
+            "event_streams_unchanged": True,
+            "pitching_plans_unchanged": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "decision": {
+            "pitcher_projection_activation_allowed":
+                ready,
+            "production_activation_allowed":
+                ready,
+            "recommended_next_slice": (
+                "activate_canonical_pitcher_"
+                "projection_authority"
+                if ready
+                else (
+                    "resolve_canonical_pitcher_"
+                    "projection_readiness_blockers"
+                )
+            ),
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/tests/test_canonical_pitcher_projection_activation_readiness.py
+++ b/tests/test_canonical_pitcher_projection_activation_readiness.py
@@ -1,0 +1,439 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_projection_activation_readiness import (
+    SCHEMA_VERSION,
+    audit_canonical_pitcher_projection_activation_readiness,
+)
+
+
+def metric(
+    *,
+    minimum,
+    p10,
+    median,
+    mean,
+    p90,
+    maximum,
+    count=100,
+):
+    return {
+        "count": count,
+        "minimum": minimum,
+        "p10": p10,
+        "median": median,
+        "mean": mean,
+        "p90": p90,
+        "p95": p90,
+        "maximum": maximum,
+    }
+
+
+def projection_rows():
+    return {
+        "schema_version":
+            "canonical_player_projection_rows_v1",
+        "simulation_count": 100,
+        "pitcher_role_enrichment_applied": True,
+        "pitcher_role_enrichment": {
+            "status": "observed",
+            "resolved_pitcher_count": 2,
+            "missing_pitcher_count": 0,
+            "conflicting_pitcher_count": 0,
+            "invalid_record_count": 0,
+            "inference_used": False,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "players": [
+            {
+                "player_id": "100",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "starter",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "batters_faced": metric(
+                        minimum=12,
+                        p10=18,
+                        median=25,
+                        mean=25,
+                        p90=32,
+                        maximum=36,
+                    ),
+                    "outs_recorded": metric(
+                        minimum=3,
+                        p10=9,
+                        median=17,
+                        mean=16,
+                        p90=20,
+                        maximum=24,
+                    ),
+                },
+            },
+            {
+                "player_id": "101",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "reliever",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "outs_recorded": metric(
+                        minimum=0,
+                        p10=1,
+                        median=3,
+                        mean=3,
+                        p90=5,
+                        maximum=6,
+                    ),
+                },
+            },
+        ],
+    }
+
+
+def appearance_audit():
+    return {
+        "status": "observed",
+        "audited": True,
+        "trial_count": 100,
+        "anomaly_counts": {},
+        "starter_relief_detected": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def role_audit():
+    return {
+        "status": "observed",
+        "audited": True,
+        "role_attribution_complete_rate": 1.0,
+        "anomaly_counts": {},
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def run(
+    *,
+    projections=None,
+    appearances=None,
+    roles=None,
+):
+    return (
+        audit_canonical_pitcher_projection_activation_readiness(
+            projection_rows=(
+                projections
+                if projections is not None
+                else projection_rows()
+            ),
+            appearance_audit=(
+                appearances
+                if appearances is not None
+                else appearance_audit()
+            ),
+            role_and_innings_audit=(
+                roles
+                if roles is not None
+                else role_audit()
+            ),
+        )
+    )
+
+
+def test_ready_evidence_allows_later_activation_slice():
+    result = run()
+
+    assert result["schema_version"] == (
+        SCHEMA_VERSION
+    )
+    assert result["status"] == "ready"
+    assert result["blockers"] == []
+    assert result[
+        "dynamic_workload_pitcher_ids"
+    ] == ["100"]
+    assert result["decision"][
+        "pitcher_projection_activation_allowed"
+    ] is True
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is True
+    assert result["decision"][
+        "recommended_next_slice"
+    ] == (
+        "activate_canonical_pitcher_"
+        "projection_authority"
+    )
+
+
+def test_sequence_anomaly_blocks_activation():
+    appearances = appearance_audit()
+    appearances["anomaly_counts"] = {
+        "pitcher_reentry": 1,
+    }
+
+    result = run(
+        appearances=appearances,
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "appearance_sequence_anomalies"
+        in result["blockers"]
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+
+
+def test_starter_relief_detection_blocks_activation():
+    appearances = appearance_audit()
+    appearances[
+        "starter_relief_detected"
+    ] = True
+
+    result = run(
+        appearances=appearances,
+    )
+
+    assert (
+        "starter_relief_detected"
+        in result["blockers"]
+    )
+
+
+def test_missing_role_evidence_blocks_activation():
+    projections = projection_rows()
+    projections["pitcher_role_enrichment"][
+        "missing_pitcher_count"
+    ] = 1
+    projections["players"][0][
+        "pitcher_role_resolution_status"
+    ] = "missing"
+    projections["players"][0][
+        "pitcher_role"
+    ] = None
+
+    result = run(
+        projections=projections,
+    )
+
+    assert (
+        "pitcher_role_evidence_incomplete"
+        in result["blockers"]
+    )
+
+
+def test_role_attribution_anomaly_blocks_activation():
+    roles = role_audit()
+    roles["anomaly_counts"] = {
+        "planned_starter_not_projected": 1,
+    }
+
+    result = run(
+        roles=roles,
+    )
+
+    assert (
+        "role_and_innings_anomalies"
+        in result["blockers"]
+    )
+
+
+def test_invalid_outs_distribution_blocks_activation():
+    projections = projection_rows()
+    projections["players"][0]["metrics"][
+        "outs_recorded"
+    ]["p90"] = 8
+
+    result = run(
+        projections=projections,
+    )
+
+    assert (
+        "outs_distribution_invalid"
+        in result["blockers"]
+    )
+    assert result[
+        "invalid_distribution_pitcher_ids"
+    ] == ["100"]
+
+
+def test_missing_outs_distribution_blocks_activation():
+    projections = projection_rows()
+    del projections["players"][0][
+        "metrics"
+    ]["outs_recorded"]
+
+    result = run(
+        projections=projections,
+    )
+
+    assert (
+        "outs_distribution_unavailable"
+        in result["blockers"]
+    )
+
+
+def test_metric_count_is_not_required_by_row_contract():
+    projections = projection_rows()
+
+    for row in projections["players"]:
+        row["metrics"]["outs_recorded"].pop(
+            "count",
+            None,
+        )
+
+    result = run(
+        projections=projections,
+    )
+
+    assert result["status"] == "ready"
+    assert result["simulation_count"] == 100
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is True
+
+
+def test_missing_simulation_count_blocks_activation():
+    projections = projection_rows()
+    del projections["simulation_count"]
+
+    result = run(
+        projections=projections,
+    )
+
+    assert (
+        "projection_simulation_count_unavailable"
+        in result["blockers"]
+    )
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+
+
+def test_primary_workload_requires_distribution_spread():
+    projections = projection_rows()
+    summary = projections["players"][0][
+        "metrics"
+    ]["outs_recorded"]
+
+    for field_name in (
+        "minimum",
+        "p10",
+        "median",
+        "mean",
+        "p90",
+        "p95",
+        "maximum",
+    ):
+        summary[field_name] = 15
+
+    result = run(
+        projections=projections,
+    )
+
+    assert (
+        "dynamic_workload_evidence_unavailable"
+        in result["blockers"]
+    )
+
+
+def test_more_than_twenty_seven_batters_does_not_block():
+    projections = projection_rows()
+
+    projections["players"][0]["metrics"][
+        "batters_faced"
+    ] = metric(
+        minimum=18,
+        p10=24,
+        median=29,
+        mean=30,
+        p90=36,
+        maximum=41,
+    )
+
+    result = run(
+        projections=projections,
+    )
+
+    assert result["status"] == "ready"
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is True
+
+
+def test_audit_is_read_only_and_non_authoritative():
+    projections = projection_rows()
+    appearances = appearance_audit()
+    roles = role_audit()
+
+    originals = (
+        deepcopy(projections),
+        deepcopy(appearances),
+        deepcopy(roles),
+    )
+
+    result = run(
+        projections=projections,
+        appearances=appearances,
+        roles=roles,
+    )
+
+    assert projections == originals[0]
+    assert appearances == originals[1]
+    assert roles == originals[2]
+    assert (
+        result["database_writes_performed"]
+        is False
+    )
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_source_authority_change_blocks_readiness():
+    appearances = appearance_audit()
+    appearances[
+        "production_authority_changed"
+    ] = True
+
+    result = run(
+        appearances=appearances,
+    )
+
+    assert (
+        "source_production_authority_changed"
+        in result["blockers"]
+    )
+
+
+def test_rejects_invalid_inputs():
+    with pytest.raises(
+        TypeError,
+        match="projection_rows",
+    ):
+        (
+            audit_canonical_pitcher_projection_activation_readiness(
+                projection_rows=object(),
+                appearance_audit=appearance_audit(),
+                role_and_innings_audit=role_audit(),
+            )
+        )
+
+    with pytest.raises(
+        TypeError,
+        match="appearance_audit",
+    ):
+        (
+            audit_canonical_pitcher_projection_activation_readiness(
+                projection_rows=projection_rows(),
+                appearance_audit=object(),
+                role_and_innings_audit=role_audit(),
+            )
+        )

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -147,7 +147,7 @@ def fallback_discovery():
     )
 
 
-def executed_shadow():
+def executed_shadow(*, simulation_count=2):
     return run_canonical_production_shadow(
         game_pk=123,
         lineups=lineups(),
@@ -158,7 +158,7 @@ def executed_shadow():
             fallback_discovery()
         ),
         bootstrap_ready=True,
-        simulation_count=2,
+        simulation_count=simulation_count,
     )
 
 
@@ -376,4 +376,61 @@ def test_realism_payload_exposes_frontend_capability_aliases():
         "steals_projection_wiring_status"
     ] == (
         "canonical_event_driven_production_authority"
+    )
+
+def test_comparator_attaches_pitcher_projection_readiness():
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    readiness = shadow[
+        "pitcher_projection_activation_readiness"
+    ]
+    projections = shadow["player_projections"]
+
+    assert readiness["status"] == "ready"
+    assert readiness["blockers"] == []
+    assert readiness["decision"][
+        "pitcher_projection_activation_allowed"
+    ] is True
+    assert readiness["decision"][
+        "production_activation_allowed"
+    ] is True
+    assert (
+        readiness["dynamic_workload_pitcher_count"]
+        > 0
+    )
+
+    # 6SY only surfaces the readiness verdict.
+    # Legacy production authority remains untouched.
+    assert shadow["authoritative_source"] == "legacy"
+    assert projections["authoritative"] is False
+    assert projections[
+        "authoritative_source"
+    ] == "legacy"
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]
+
+    assert (
+        readiness["database_writes_performed"]
+        is False
+    )
+    assert (
+        readiness["production_authority_changed"]
+        is False
     )


### PR DESCRIPTION
## Summary

- add a read-only activation-readiness gate for canonical pitcher projections
- combine projection-role resolution, role/innings attribution, per-trial appearance sequencing, and workload-distribution evidence into explicit blockers and an activation verdict
- attach the readiness result to production-shadow model projection diagnostics while keeping legacy projection authority unchanged

## Why

Canonical pitcher workload distributions and roles are now visible and validated, but production needs an explicit evidence gate before canonical pitcher projections can replace legacy authority. This slice creates that gate without performing the authority switch.

## Production evidence

A 100-trial traditional-starter probe and a 100-trial opener/bulk probe both returned `status=ready`, `production_activation_allowed=true`, dynamic workload evidence, no sequence anomalies, no starter-relief anomaly, no database writes, and no authority change.

The readiness gate intentionally does not impose a 27-batter or 27-out ceiling. It validates observed workload distribution coherence and uses the projection payload's top-level simulation count as sample evidence.

## Validation

- focused readiness tests passed
- real traditional and opener/bulk readiness probe: all acceptance signals passed
- complete relevant 6SY regression passed
- exact-once production integration contract passed
- Python compilation passed
- ruff passed when available / no lint failure
- working-tree and new-file whitespace checks passed

Production remains explicitly `authoritative_source=legacy`; a later slice is required to activate canonical pitcher projection authority.