### PR TITLE
Activate canonical pitcher projection authority

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -54,7 +54,27 @@ test('projections tab describes same-run coherence', async () => {
   )
   assert.match(
     source,
+    /Pitchers authoritative/,
+  )
+  assert.match(
+    source,
     /Non-authoritative shadow/,
+  )
+  assert.match(
+    source,
+    /view\.pitcherProjectionsAuthoritative/,
+  )
+})
+
+test('projections tab describes mixed row authority', async () => {
+  const source = await pageSource()
+
+  assert.match(source, /Authority Scope/)
+  assert.match(source, /Pitcher Authority/)
+  assert.match(source, /Batter Authority/)
+  assert.match(
+    source,
+    /view\.pitcherAuthoritativeSource/,
   )
 })
 

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -191,6 +191,10 @@ function pitcherRow(row) {
     pitcherRoleLabel: pitcherRoleLabel(
       row?.pitcher_role,
     ),
+    authoritative: row?.authoritative === true,
+    authoritativeSource: (
+      row?.authoritative_source || 'legacy'
+    ),
     battersFaced: metricValue(
       row,
       'batters_faced',
@@ -473,6 +477,23 @@ export function buildCanonicalProjectionsViewModel(
     authoritativeSource: (
       projections.authoritative_source ||
       shadow.authoritative_source ||
+      'legacy'
+    ),
+    authorityScope: (
+      projections.authority_scope || 'legacy'
+    ),
+    pitcherProjectionsAuthoritative: (
+      projections
+        .pitcher_projections_authoritative === true
+    ),
+    batterProjectionsAuthoritative: (
+      projections
+        .batter_projections_authoritative === true
+    ),
+    pitcherAuthoritativeSource: (
+      projections
+        .pitcher_projection_authority
+        ?.authoritative_source ||
       'legacy'
     ),
     identityEnrichmentApplied: (

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -32,7 +32,17 @@ function payload() {
           simulation_count: 25,
           identity_enrichment_applied: false,
           authoritative: false,
-          authoritative_source: 'legacy',
+          authoritative_source: 'mixed',
+          authority_scope: 'mixed',
+          pitcher_projections_authoritative: true,
+          batter_projections_authoritative: false,
+          pitcher_projection_authority: {
+            status: 'activated',
+            authoritative_source: (
+              'canonical_event_driven_'
+              + 'pitcher_projection'
+            ),
+          },
           players: [
             {
               player_id: 'b-1',
@@ -61,6 +71,11 @@ function payload() {
               player_type: 'pitcher',
               team_side: 'home',
               pitcher_role: 'starter',
+              authoritative: true,
+              authoritative_source: (
+                'canonical_event_driven_'
+                + 'pitcher_projection'
+              ),
               metrics: {
                 batters_faced: metric(24),
                 outs_recorded: metric(
@@ -108,7 +123,20 @@ test('builds same-run projection metadata', () => {
   assert.equal(view.authoritative, false)
   assert.equal(
     view.authoritativeSource,
-    'legacy',
+    'mixed',
+  )
+  assert.equal(view.authorityScope, 'mixed')
+  assert.equal(
+    view.pitcherProjectionsAuthoritative,
+    true,
+  )
+  assert.equal(
+    view.batterProjectionsAuthoritative,
+    false,
+  )
+  assert.equal(
+    view.pitcherAuthoritativeSource,
+    'canonical_event_driven_pitcher_projection',
   )
 })
 
@@ -153,6 +181,11 @@ test('derives pitcher innings from canonical outs recorded', () => {
   )
   assert.equal(pitcher.inningsPitchedP90, 7)
   assert.equal(pitcher.battersFaced, 24)
+  assert.equal(pitcher.authoritative, true)
+  assert.equal(
+    pitcher.authoritativeSource,
+    'canonical_event_driven_pitcher_projection',
+  )
   assert.equal(pitcher.dfsMean, 18)
   assert.equal(pitcher.dfsFloor, 8)
   assert.equal(pitcher.dfsMedian, 17)

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1016,7 +1016,10 @@ function ProjectionsTab({ game }) {
 
         <Tag
           tone={
-            view.authoritative
+            (
+              view.authoritative ||
+              view.pitcherProjectionsAuthoritative
+            )
               ? 'success'
               : 'diagnostic'
           }
@@ -1024,7 +1027,11 @@ function ProjectionsTab({ game }) {
           {
             view.authoritative
               ? 'Authoritative production'
-              : 'Non-authoritative shadow'
+              : (
+                  view.pitcherProjectionsAuthoritative
+                    ? 'Pitchers authoritative'
+                    : 'Non-authoritative shadow'
+                )
           }
         </Tag>
       </div>
@@ -1062,6 +1069,29 @@ function ProjectionsTab({ game }) {
           <StatRow
             k="Authoritative Source"
             v={view.authoritativeSource}
+            format="text"
+          />
+          <StatRow
+            k="Authority Scope"
+            v={view.authorityScope}
+            format="text"
+          />
+          <StatRow
+            k="Pitcher Authority"
+            v={
+              view.pitcherProjectionsAuthoritative
+                ? view.pitcherAuthoritativeSource
+                : 'legacy'
+            }
+            format="text"
+          />
+          <StatRow
+            k="Batter Authority"
+            v={
+              view.batterProjectionsAuthoritative
+                ? view.authoritativeSource
+                : 'legacy'
+            }
             format="text"
           />
           <StatRow

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -5,6 +5,9 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+from mlb_app.simulation.projections.pitcher_projection_authority import (
+    apply_canonical_pitcher_projection_authority,
+)
 from mlb_app.simulation.shadow.canonical_pitcher_projection_activation_readiness import (
     audit_canonical_pitcher_projection_activation_readiness,
 )
@@ -858,6 +861,57 @@ def _attach_production_shadow_comparison(
     shadow[
         "pitcher_projection_activation_readiness"
     ] = readiness
+
+    try:
+        activated_projection_rows = (
+            apply_canonical_pitcher_projection_authority(
+                projection_rows=shadow[
+                    "player_projections"
+                ],
+                readiness=readiness,
+            )
+        )
+    except Exception as exc:
+        authority = {
+            "schema_version": (
+                "canonical_pitcher_projection_"
+                "authority_v1"
+            ),
+            "status": "error",
+            "activation_requested": True,
+            "readiness_allows_activation":
+                False,
+            "production_activation": False,
+            "fallback_used": True,
+            "fallback_reason": (
+                "authority_application_error"
+            ),
+            "error_type": (
+                exc.__class__.__name__
+            ),
+            "error_message": str(exc),
+            "authority_scope": (
+                "pitcher_rows_only"
+            ),
+            "database_writes_performed":
+                False,
+            "production_authority_changed":
+                False,
+            "authoritative_source": "legacy",
+        }
+    else:
+        shadow["player_projections"] = (
+            activated_projection_rows
+        )
+        authority = (
+            activated_projection_rows[
+                "pitcher_projection_authority"
+            ]
+        )
+
+    shadow[
+        "pitcher_projection_authority"
+    ] = authority
 
     return result
 

--- a/mlb_app/simulation/projections/pitcher_projection_authority.py
+++ b/mlb_app/simulation/projections/pitcher_projection_authority.py
@@ -1,0 +1,286 @@
+"""Activate canonical pitcher projection authority with rollback."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+import os
+from typing import Any
+
+
+CANONICAL_PITCHER_PROJECTION_AUTHORITY_VERSION = (
+    "canonical_pitcher_projection_authority_v1"
+)
+
+CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV = (
+    "MLB_CANONICAL_PITCHER_PROJECTIONS_ENABLED"
+)
+
+CANONICAL_PITCHER_PROJECTION_SOURCE = (
+    "canonical_event_driven_pitcher_projection"
+)
+
+_FALSE_VALUES = frozenset({
+    "",
+    "0",
+    "false",
+    "no",
+    "off",
+})
+
+
+def canonical_pitcher_projections_enabled(
+    value: Any = None,
+) -> bool:
+    """
+    Resolve an explicit override, then the rollback environment flag.
+
+    Canonical pitcher projection authority is active by default after
+    this release. Setting the rollback flag to a false value preserves
+    the existing legacy authority.
+    """
+
+    raw = (
+        value
+        if value is not None
+        else os.getenv(
+            CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV,
+            "true",
+        )
+    )
+
+    if isinstance(raw, bool):
+        return raw
+
+    return (
+        str(raw).strip().lower()
+        not in _FALSE_VALUES
+    )
+
+
+def _readiness_allows_activation(
+    readiness: Mapping[str, Any],
+) -> bool:
+    decision = readiness.get("decision")
+
+    if not isinstance(decision, Mapping):
+        return False
+
+    blockers = readiness.get("blockers")
+
+    if not isinstance(blockers, (list, tuple)):
+        return False
+
+    return (
+        readiness.get("status") == "ready"
+        and readiness.get("audited") is True
+        and not blockers
+        and decision.get(
+            "pitcher_projection_activation_allowed"
+        )
+        is True
+        and decision.get(
+            "production_activation_allowed"
+        )
+        is True
+        and readiness.get(
+            "database_writes_performed"
+        )
+        is False
+        and readiness.get(
+            "production_authority_changed"
+        )
+        is False
+    )
+
+
+def apply_canonical_pitcher_projection_authority(
+    *,
+    projection_rows: Mapping[str, Any],
+    readiness: Mapping[str, Any],
+    enabled: Any = None,
+) -> dict[str, Any]:
+    """
+    Promote only ready canonical pitcher projection rows.
+
+    Batter projection authority, game probabilities, simulation
+    outcomes, database state, and the caller's inputs are unchanged.
+    Missing or blocked readiness fails closed to legacy authority.
+    """
+
+    if not isinstance(projection_rows, Mapping):
+        raise TypeError(
+            "projection_rows must be a mapping"
+        )
+
+    if not isinstance(readiness, Mapping):
+        raise TypeError(
+            "readiness must be a mapping"
+        )
+
+    result = deepcopy(dict(projection_rows))
+    players = result.get("players")
+
+    if not isinstance(players, list):
+        raise TypeError(
+            "projection players must be a list"
+        )
+
+    activation_requested = (
+        canonical_pitcher_projections_enabled(
+            enabled
+        )
+    )
+    readiness_allows_activation = (
+        _readiness_allows_activation(
+            readiness
+        )
+    )
+
+    pitcher_rows = [
+        row
+        for row in players
+        if (
+            isinstance(row, Mapping)
+            and row.get("player_type")
+            == "pitcher"
+        )
+    ]
+    batter_rows = [
+        row
+        for row in players
+        if (
+            isinstance(row, Mapping)
+            and row.get("player_type")
+            == "batter"
+        )
+    ]
+
+    pitcher_rows_available = bool(
+        pitcher_rows
+    )
+
+    activated = (
+        activation_requested
+        and readiness_allows_activation
+        and pitcher_rows_available
+    )
+
+    if activated:
+        fallback_reason = None
+    elif not activation_requested:
+        fallback_reason = (
+            "rollback_flag_disabled"
+        )
+    elif not readiness_allows_activation:
+        fallback_reason = (
+            "pitcher_projection_readiness_blocked"
+        )
+    else:
+        fallback_reason = (
+            "pitcher_projection_rows_unavailable"
+        )
+
+    activated_pitcher_ids = []
+
+    for row in players:
+        if not isinstance(row, dict):
+            raise TypeError(
+                "projection player rows must be dictionaries"
+            )
+
+        if row.get("player_type") == "pitcher":
+            row["authoritative"] = activated
+            row["authoritative_source"] = (
+                CANONICAL_PITCHER_PROJECTION_SOURCE
+                if activated
+                else "legacy"
+            )
+            row[
+                "production_authority_changed"
+            ] = activated
+
+            if activated:
+                activated_pitcher_ids.append(
+                    str(
+                        row.get("player_id")
+                        or ""
+                    )
+                )
+
+        elif row.get("player_type") == "batter":
+            # Batter authority is deliberately outside 6SZ.
+            row["authoritative"] = False
+            row["authoritative_source"] = (
+                "legacy"
+            )
+            row[
+                "production_authority_changed"
+            ] = False
+
+    authority = {
+        "schema_version": (
+            CANONICAL_PITCHER_PROJECTION_AUTHORITY_VERSION
+        ),
+        "status": (
+            "activated"
+            if activated
+            else "fallback"
+        ),
+        "activation_requested":
+            activation_requested,
+        "readiness_allows_activation":
+            readiness_allows_activation,
+        "production_activation": activated,
+        "fallback_used": not activated,
+        "fallback_reason": fallback_reason,
+        "authority_scope": (
+            "pitcher_rows_only"
+        ),
+        "pitcher_projection_count":
+            len(pitcher_rows),
+        "batter_projection_count":
+            len(batter_rows),
+        "activated_pitcher_ids": sorted(
+            pitcher_id
+            for pitcher_id
+            in activated_pitcher_ids
+            if pitcher_id
+        ),
+        "rollback_environment_variable": (
+            CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV
+        ),
+        "database_writes_performed": False,
+        "production_authority_changed":
+            activated,
+        "authoritative_source": (
+            CANONICAL_PITCHER_PROJECTION_SOURCE
+            if activated
+            else "legacy"
+        ),
+    }
+
+    result[
+        "pitcher_projection_authority"
+    ] = authority
+    result[
+        "pitcher_projections_authoritative"
+    ] = activated
+    result[
+        "batter_projections_authoritative"
+    ] = False
+    result["authority_scope"] = (
+        "mixed"
+        if activated
+        else "legacy"
+    )
+
+    # The complete player payload is mixed when only pitchers activate.
+    result["authoritative"] = False
+    result["authoritative_source"] = (
+        "mixed"
+        if activated
+        else "legacy"
+    )
+
+    return result

--- a/tests/test_canonical_pitcher_projection_authority.py
+++ b/tests/test_canonical_pitcher_projection_authority.py
@@ -1,0 +1,438 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.projections.pitcher_projection_authority import (
+    CANONICAL_PITCHER_PROJECTION_AUTHORITY_VERSION,
+    CANONICAL_PITCHER_PROJECTION_SOURCE,
+    CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV,
+    apply_canonical_pitcher_projection_authority,
+    canonical_pitcher_projections_enabled,
+)
+
+
+def projection_rows():
+    return {
+        "schema_version":
+            "canonical_player_projection_rows_v1",
+        "simulation_count": 100,
+        "authoritative": False,
+        "authoritative_source": "legacy",
+        "players": [
+            {
+                "player_id": "batter_1",
+                "player_type": "batter",
+                "team_side": "away",
+                "metrics": {
+                    "plate_appearances": {
+                        "mean": 4.4,
+                    },
+                },
+            },
+            {
+                "player_id": "100",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "starter",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "batters_faced": {
+                        "mean": 29.0,
+                    },
+                    "outs_recorded": {
+                        "minimum": 3.0,
+                        "p10": 9.0,
+                        "median": 17.0,
+                        "mean": 16.0,
+                        "p90": 21.0,
+                        "maximum": 24.0,
+                    },
+                },
+            },
+            {
+                "player_id": "101",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "reliever",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "outs_recorded": {
+                        "minimum": 0.0,
+                        "p10": 1.0,
+                        "median": 3.0,
+                        "mean": 3.0,
+                        "p90": 5.0,
+                        "maximum": 8.0,
+                    },
+                },
+            },
+        ],
+    }
+
+
+def readiness():
+    return {
+        "schema_version": (
+            "canonical_pitcher_projection_"
+            "activation_readiness_v1"
+        ),
+        "status": "ready",
+        "audited": True,
+        "blockers": [],
+        "decision": {
+            "pitcher_projection_activation_allowed":
+                True,
+            "production_activation_allowed":
+                True,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def row(result, player_id):
+    return next(
+        value
+        for value in result["players"]
+        if value["player_id"] == player_id
+    )
+
+
+def test_ready_projection_activates_pitcher_rows_only():
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=readiness(),
+            enabled=True,
+        )
+    )
+
+    authority = result[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["schema_version"] == (
+        CANONICAL_PITCHER_PROJECTION_AUTHORITY_VERSION
+    )
+    assert authority["status"] == "activated"
+    assert authority[
+        "production_activation"
+    ] is True
+    assert authority[
+        "production_authority_changed"
+    ] is True
+    assert authority[
+        "authoritative_source"
+    ] == CANONICAL_PITCHER_PROJECTION_SOURCE
+    assert authority["activated_pitcher_ids"] == [
+        "100",
+        "101",
+    ]
+
+    starter = row(result, "100")
+    reliever = row(result, "101")
+    batter = row(result, "batter_1")
+
+    assert starter["authoritative"] is True
+    assert reliever["authoritative"] is True
+    assert starter[
+        "authoritative_source"
+    ] == CANONICAL_PITCHER_PROJECTION_SOURCE
+    assert reliever[
+        "authoritative_source"
+    ] == CANONICAL_PITCHER_PROJECTION_SOURCE
+
+    assert batter["authoritative"] is False
+    assert batter[
+        "authoritative_source"
+    ] == "legacy"
+
+    assert result[
+        "pitcher_projections_authoritative"
+    ] is True
+    assert result[
+        "batter_projections_authoritative"
+    ] is False
+    assert result["authority_scope"] == "mixed"
+    assert result["authoritative"] is False
+    assert result[
+        "authoritative_source"
+    ] == "mixed"
+
+
+def test_blocked_readiness_falls_back_to_legacy():
+    blocked = readiness()
+    blocked["status"] = "blocked"
+    blocked["blockers"] = [
+        "appearance_sequence_anomalies",
+    ]
+    blocked["decision"][
+        "production_activation_allowed"
+    ] = False
+
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=blocked,
+            enabled=True,
+        )
+    )
+
+    authority = result[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["status"] == "fallback"
+    assert authority[
+        "production_activation"
+    ] is False
+    assert authority["fallback_reason"] == (
+        "pitcher_projection_readiness_blocked"
+    )
+    assert row(
+        result,
+        "100",
+    )["authoritative"] is False
+    assert result[
+        "authoritative_source"
+    ] == "legacy"
+
+
+def test_error_readiness_falls_back_to_legacy():
+    failed = readiness()
+    failed["status"] = "error"
+    failed["audited"] = False
+
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=failed,
+            enabled=True,
+        )
+    )
+
+    assert result[
+        "pitcher_projection_authority"
+    ]["fallback_reason"] == (
+        "pitcher_projection_readiness_blocked"
+    )
+
+
+def test_rollback_flag_disables_activation():
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=readiness(),
+            enabled=False,
+        )
+    )
+
+    authority = result[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority[
+        "activation_requested"
+    ] is False
+    assert authority["fallback_reason"] == (
+        "rollback_flag_disabled"
+    )
+    assert authority[
+        "production_authority_changed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("0", False),
+        ("off", False),
+        ("", False),
+    ),
+)
+def test_activation_flag_values(
+    value,
+    expected,
+):
+    assert (
+        canonical_pitcher_projections_enabled(
+            value
+        )
+        is expected
+    )
+
+
+def test_activation_flag_reads_environment(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV,
+        "false",
+    )
+
+    assert (
+        canonical_pitcher_projections_enabled()
+        is False
+    )
+
+    monkeypatch.setenv(
+        CANONICAL_PITCHER_PROJECTIONS_ENABLED_ENV,
+        "true",
+    )
+
+    assert (
+        canonical_pitcher_projections_enabled()
+        is True
+    )
+
+
+def test_missing_pitcher_rows_falls_back():
+    projections = projection_rows()
+    projections["players"] = [
+        projections["players"][0],
+    ]
+
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projections,
+            readiness=readiness(),
+            enabled=True,
+        )
+    )
+
+    authority = result[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["fallback_reason"] == (
+        "pitcher_projection_rows_unavailable"
+    )
+    assert authority[
+        "production_activation"
+    ] is False
+
+
+def test_more_than_twenty_seven_batters_remains_valid():
+    projections = projection_rows()
+    projections["players"][1]["metrics"][
+        "batters_faced"
+    ]["mean"] = 31.0
+
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projections,
+            readiness=readiness(),
+            enabled=True,
+        )
+    )
+
+    assert row(
+        result,
+        "100",
+    )["authoritative"] is True
+    assert row(
+        result,
+        "100",
+    )["metrics"]["batters_faced"]["mean"] == (
+        31.0
+    )
+
+
+def test_activation_does_not_mutate_inputs():
+    projections = projection_rows()
+    gate = readiness()
+    original_projections = deepcopy(
+        projections
+    )
+    original_gate = deepcopy(gate)
+
+    apply_canonical_pitcher_projection_authority(
+        projection_rows=projections,
+        readiness=gate,
+        enabled=True,
+    )
+
+    assert projections == original_projections
+    assert gate == original_gate
+
+
+def test_activation_preserves_projection_values():
+    projections = projection_rows()
+
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projections,
+            readiness=readiness(),
+            enabled=True,
+        )
+    )
+
+    assert row(
+        result,
+        "100",
+    )["metrics"] == row(
+        projections,
+        "100",
+    )["metrics"]
+
+    assert row(
+        result,
+        "batter_1",
+    )["metrics"] == row(
+        projections,
+        "batter_1",
+    )["metrics"]
+
+
+def test_no_database_writes_are_performed():
+    result = (
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=readiness(),
+            enabled=True,
+        )
+    )
+
+    assert result[
+        "pitcher_projection_authority"
+    ]["database_writes_performed"] is False
+
+
+def test_rejects_invalid_inputs():
+    with pytest.raises(
+        TypeError,
+        match="projection_rows",
+    ):
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=object(),
+            readiness=readiness(),
+        )
+
+    with pytest.raises(
+        TypeError,
+        match="readiness",
+    ):
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=projection_rows(),
+            readiness=object(),
+        )
+
+    malformed = projection_rows()
+    malformed["players"] = object()
+
+    with pytest.raises(
+        TypeError,
+        match="players",
+    ):
+        apply_canonical_pitcher_projection_authority(
+            projection_rows=malformed,
+            readiness=readiness(),
+        )

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -418,7 +418,64 @@ def test_comparator_attaches_pitcher_projection_readiness():
     assert projections["authoritative"] is False
     assert projections[
         "authoritative_source"
-    ] == "legacy"
+    ] == "mixed"
+    assert projections[
+        "pitcher_projections_authoritative"
+    ] is True
+    assert projections[
+        "batter_projections_authoritative"
+    ] is False
+
+    authority = shadow[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["status"] == "activated"
+    assert authority[
+        "production_activation"
+    ] is True
+    assert authority[
+        "authority_scope"
+    ] == "pitcher_rows_only"
+    assert authority[
+        "production_authority_changed"
+    ] is True
+
+    pitcher_rows = [
+        row
+        for row in projections["players"]
+        if row["player_type"] == "pitcher"
+    ]
+    batter_rows = [
+        row
+        for row in projections["players"]
+        if row["player_type"] == "batter"
+    ]
+
+    assert pitcher_rows
+    assert all(
+        row["authoritative"] is True
+        for row in pitcher_rows
+    )
+    assert all(
+        row["authoritative_source"]
+        == (
+            "canonical_event_driven_"
+            "pitcher_projection"
+        )
+        for row in pitcher_rows
+    )
+
+    assert batter_rows
+    assert all(
+        row["authoritative"] is False
+        for row in batter_rows
+    )
+    assert all(
+        row["authoritative_source"]
+        == "legacy"
+        for row in batter_rows
+    )
     assert result[
         "away_win_probability"
     ] == legacy["away_win_probability"]
@@ -434,3 +491,122 @@ def test_comparator_attaches_pitcher_projection_readiness():
         readiness["production_authority_changed"]
         is False
     )
+
+def test_pitcher_projection_authority_rolls_back_with_flag(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "MLB_CANONICAL_PITCHER_PROJECTIONS_ENABLED",
+        "false",
+    )
+
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    readiness = shadow[
+        "pitcher_projection_activation_readiness"
+    ]
+    authority = shadow[
+        "pitcher_projection_authority"
+    ]
+    projections = shadow["player_projections"]
+
+    # The evidence remains ready, but the immediate
+    # environment rollback retains legacy authority.
+    assert readiness["status"] == "ready"
+    assert readiness["decision"][
+        "production_activation_allowed"
+    ] is True
+
+    assert authority["status"] == "fallback"
+    assert authority[
+        "activation_requested"
+    ] is False
+    assert authority[
+        "production_activation"
+    ] is False
+    assert authority["fallback_reason"] == (
+        "rollback_flag_disabled"
+    )
+    assert authority[
+        "production_authority_changed"
+    ] is False
+
+    assert projections[
+        "pitcher_projections_authoritative"
+    ] is False
+    assert projections[
+        "authoritative_source"
+    ] == "legacy"
+
+    pitcher_rows = [
+        row
+        for row in projections["players"]
+        if row["player_type"] == "pitcher"
+    ]
+
+    assert pitcher_rows
+    assert all(
+        row["authoritative"] is False
+        for row in pitcher_rows
+    )
+    assert all(
+        row["authoritative_source"]
+        == "legacy"
+        for row in pitcher_rows
+    )
+
+    # Game-level outputs are not part of 6SZ.
+    assert shadow["authoritative_source"] == "legacy"
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]
+
+
+def test_low_evidence_run_fails_closed_to_legacy():
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=executed_shadow(
+                simulation_count=2,
+            ),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    readiness = shadow[
+        "pitcher_projection_activation_readiness"
+    ]
+    authority = shadow[
+        "pitcher_projection_authority"
+    ]
+
+    if readiness["status"] != "ready":
+        assert authority["status"] == "fallback"
+        assert authority[
+            "production_activation"
+        ] is False
+        assert authority["fallback_reason"] == (
+            "pitcher_projection_readiness_blocked"
+        )
+        assert authority[
+            "authoritative_source"
+        ] == "legacy"


### PR DESCRIPTION
## Summary

- activate canonical event-driven pitcher projection rows when the 6SY readiness audit passes
- preserve legacy authority for batter projections and game-level probabilities
- fail closed when readiness is blocked, activation errors, or the rollback flag is disabled
- expose the mixed authority scope accurately in the projections UI as **Pitchers authoritative**
- retain dynamic starter, opener, bulk-follower, and reliever workload distributions without imposing a 27-batter ceiling

## Safety and rollback

- activation is limited to pitcher projection rows
- batter projection rows remain legacy-authoritative
- game win probabilities remain unchanged
- no database writes are performed
- `MLB_CANONICAL_PITCHER_PROJECTIONS_ENABLED` provides immediate rollback

## Validation

- 100-trial baseline and opener/bulk production authority probes passed all acceptance signals
- 109 backend tests passed
- 25 frontend contract tests passed
- frontend production build passed
- Python compilation passed
- working-tree and staged diff checks passed
- only the eight intended 6SZ files were staged and committed

Known Vite duplicate-key and bundle-size warnings are pre-existing and did not fail the production build.