### PR TITLE
Audit canonical pitcher projection pool and workload calibration

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import datetime
 from typing import Any, Dict, List, Optional
 
@@ -10,6 +12,9 @@ from mlb_app.simulation.projections.pitcher_projection_authority import (
 )
 from mlb_app.simulation.shadow.canonical_pitcher_projection_activation_readiness import (
     audit_canonical_pitcher_projection_activation_readiness,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_projection_pool_and_workload_calibration import (
+    audit_canonical_pitcher_projection_pool_and_workload_calibration,
 )
 from mlb_app.simulation.shadow.canonical_pitcher_role_and_innings_attribution_audit import (
     audit_canonical_pitcher_role_and_innings_attribution,
@@ -742,10 +747,69 @@ def _canonical_probability_payload(matchup: Dict[str, Any], projection_sim: Opti
     }
 
 
+def _canonical_pitcher_pool_audit_input(
+    bullpen_discovery: Any,
+) -> Dict[str, Any]:
+    """
+    Preserve private same-process eligibility evidence for 6TA.
+
+    CanonicalShadowBullpenDiscovery.to_diagnostics() deliberately
+    redacts pitcher identifiers and record-level evidence. This
+    adapter is consumed only by the read-only projection audit and
+    does not alter or publish the underlying discovery object.
+    """
+
+    result: Dict[str, Any] = {}
+
+    for team_side in ("away", "home"):
+        side = getattr(
+            bullpen_discovery,
+            team_side,
+            None,
+        )
+
+        if side is None:
+            result[team_side] = {}
+            continue
+
+        eligibility = getattr(
+            side,
+            "eligibility",
+            None,
+        )
+
+        result[team_side] = {
+            "starter_id": getattr(
+                side,
+                "starter_id",
+                None,
+            ),
+            "bullpen_pitcher_ids": list(
+                getattr(
+                    side,
+                    "bullpen_pitcher_ids",
+                    (),
+                )
+                or ()
+            ),
+            "eligibility": (
+                deepcopy(eligibility)
+                if isinstance(
+                    eligibility,
+                    dict,
+                )
+                else {}
+            ),
+        }
+
+    return result
+
+
 def _attach_production_shadow_comparison(
     *,
     legacy_result: Dict[str, Any],
     production_execution: Any,
+    bullpen_discovery: Any = None,
 ) -> Dict[str, Any]:
     """
     Attach executed canonical material to the existing shadow comparator.
@@ -912,6 +976,72 @@ def _attach_production_shadow_comparison(
     shadow[
         "pitcher_projection_authority"
     ] = authority
+
+    try:
+        pool_and_workload_audit = (
+            audit_canonical_pitcher_projection_pool_and_workload_calibration(
+                projections=shadow[
+                    "player_projections"
+                ],
+                appearance_audit=(
+                    material
+                    .pitcher_appearance_sequence_audit
+                ),
+                bullpen_discovery=(
+                    bullpen_discovery
+                    if isinstance(
+                        bullpen_discovery,
+                        dict,
+                    )
+                    else {}
+                ),
+            )
+        )
+    except Exception as exc:
+        pool_and_workload_audit = {
+            "schema_version": (
+                "canonical_pitcher_projection_"
+                "pool_and_workload_calibration_v1"
+            ),
+            "status": "error",
+            "audited": False,
+            "blockers": [
+                "pool_and_workload_audit_error",
+            ],
+            "error_type": (
+                exc.__class__.__name__
+            ),
+            "error_message": str(exc),
+            "safety_checks": {
+                "projection_values_unchanged": True,
+                "pitcher_pools_unchanged": True,
+                "pitching_plans_unchanged": True,
+                "event_streams_unchanged": True,
+                "database_writes_performed":
+                    False,
+                "production_authority_changed":
+                    False,
+            },
+            "decision": {
+                "pitcher_pool_change_allowed":
+                    False,
+                "workload_calibration_change_allowed":
+                    False,
+                "production_activation_allowed":
+                    False,
+                "recommended_next_slice": (
+                    "resolve_canonical_pitcher_"
+                    "projection_pool_audit_error"
+                ),
+            },
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+    shadow[
+        "pitcher_projection_pool_and_"
+        "workload_calibration"
+    ] = pool_and_workload_audit
 
     return result
 
@@ -1456,6 +1586,11 @@ def build_model_projection_payload(
                     legacy_result=shared_simulation,
                     production_execution=(
                         canonical_production_shadow_execution
+                    ),
+                    bullpen_discovery=(
+                        _canonical_pitcher_pool_audit_input(
+                            canonical_shadow_bullpen_discovery
+                        )
                     ),
                 )
             )

--- a/mlb_app/simulation/shadow/canonical_pitcher_projection_pool_and_workload_calibration.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_projection_pool_and_workload_calibration.py
@@ -1,0 +1,603 @@
+"""Audit canonical pitcher pools and workload distributions."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+from typing import Any
+
+from mlb_app.simulation.projections.aggregator import (
+    summarize_values,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_projection_pool_"
+    "and_workload_calibration_v1"
+)
+
+STARTER_LIKE_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+})
+
+PRIMARY_WORKLOAD_ROLES = frozenset({
+    "starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+})
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return (
+        value
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _sequence(value: Any) -> tuple[Any, ...]:
+    if (
+        isinstance(value, Sequence)
+        and not isinstance(
+            value,
+            (str, bytes, bytearray),
+        )
+    ):
+        return tuple(value)
+
+    return ()
+
+
+def _identifier(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed
+
+
+def _metric_summary(
+    row: Mapping[str, Any],
+    metric_name: str,
+) -> Mapping[str, Any]:
+    metrics = _mapping(row.get("metrics"))
+    return _mapping(metrics.get(metric_name))
+
+
+def _innings_summary(
+    outs_summary: Mapping[str, Any],
+) -> dict[str, float | int | None]:
+    result: dict[str, float | int | None] = {}
+
+    for key in (
+        "count",
+        "mean",
+        "median",
+        "p10",
+        "p25",
+        "p75",
+        "p90",
+        "minimum",
+        "maximum",
+    ):
+        value = _number(outs_summary.get(key))
+
+        if value is None:
+            result[key] = None
+        elif key == "count":
+            result[key] = int(value)
+        else:
+            result[key] = value / 3.0
+
+    return result
+
+
+def _conditional_summary(
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[
+    dict[str, Any] | None,
+    dict[str, Any] | None,
+]:
+    outs = [
+        float(record["outs_recorded"])
+        for record in records
+        if _number(record.get("outs_recorded"))
+        is not None
+    ]
+
+    if not outs:
+        return None, None
+
+    outs_summary = asdict(
+        summarize_values(outs)
+    )
+
+    return (
+        outs_summary,
+        _innings_summary(outs_summary),
+    )
+
+
+def _eligibility_records(
+    bullpen_discovery: Mapping[str, Any],
+) -> dict[
+    tuple[str, str],
+    Mapping[str, Any],
+]:
+    index: dict[
+        tuple[str, str],
+        Mapping[str, Any],
+    ] = {}
+
+    for team_side in ("away", "home"):
+        side = _mapping(
+            bullpen_discovery.get(team_side)
+        )
+        eligibility = _mapping(
+            side.get("eligibility")
+        )
+
+        for record in _sequence(
+            eligibility.get("records")
+        ):
+            record = _mapping(record)
+            pitcher_id = _identifier(
+                record.get("pitcher_id")
+            )
+
+            if pitcher_id:
+                index[
+                    (team_side, pitcher_id)
+                ] = record
+
+    return index
+
+
+def audit_canonical_pitcher_projection_pool_and_workload_calibration(
+    *,
+    projections: Mapping[str, Any],
+    appearance_audit: Mapping[str, Any],
+    bullpen_discovery: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Audit same-run pitcher pool and workload evidence.
+
+    This audit is observational. It does not alter pitcher pools,
+    pitching plans, projection rows, event streams, or authority.
+    It also does not infer closer, setup, or other typical bullpen
+    roles when explicit evidence is unavailable.
+    """
+
+    if not isinstance(projections, Mapping):
+        raise TypeError(
+            "projections must be a mapping"
+        )
+
+    if not isinstance(appearance_audit, Mapping):
+        raise TypeError(
+            "appearance_audit must be a mapping"
+        )
+
+    if not isinstance(bullpen_discovery, Mapping):
+        raise TypeError(
+            "bullpen_discovery must be a mapping"
+        )
+
+    players = [
+        row
+        for row in _sequence(
+            projections.get("players")
+        )
+        if (
+            isinstance(row, Mapping)
+            and row.get("player_type")
+            == "pitcher"
+        )
+    ]
+
+    trial_count_value = _number(
+        appearance_audit.get("trial_count")
+    )
+    trial_count = (
+        int(trial_count_value)
+        if (
+            trial_count_value is not None
+            and trial_count_value > 0
+        )
+        else 0
+    )
+
+    appearance_index: dict[
+        tuple[str, str],
+        list[Mapping[str, Any]],
+    ] = defaultdict(list)
+
+    invalid_appearance_record_count = 0
+
+    for raw_record in _sequence(
+        appearance_audit.get("records")
+    ):
+        record = _mapping(raw_record)
+        team_side = _identifier(
+            record.get("team_side")
+        )
+        pitcher_id = _identifier(
+            record.get("pitcher_id")
+        )
+
+        if (
+            team_side not in {"away", "home"}
+            or not pitcher_id
+        ):
+            invalid_appearance_record_count += 1
+            continue
+
+        appearance_index[
+            (team_side, pitcher_id)
+        ].append(record)
+
+    eligibility_index = _eligibility_records(
+        bullpen_discovery
+    )
+
+    pitcher_records = []
+    pool_conflicts = []
+    missing_eligibility_evidence = []
+    missing_appearance_evidence = []
+    historical_calibration_pitcher_ids = []
+    primary_pitcher_ids = []
+
+    for row in players:
+        team_side = _identifier(
+            row.get("team_side")
+        )
+        pitcher_id = _identifier(
+            row.get("player_id")
+        )
+        key = (team_side, pitcher_id)
+
+        planned_role = _identifier(
+            row.get("pitcher_role")
+        ) or None
+        role_status = _identifier(
+            row.get(
+                "pitcher_role_resolution_status"
+            )
+        ) or None
+
+        appearance_records = sorted(
+            appearance_index.get(key, []),
+            key=lambda record: (
+                int(
+                    _number(
+                        record.get("trial_index")
+                    )
+                    or 0
+                ),
+                int(
+                    _number(
+                        record.get(
+                            "appearance_index"
+                        )
+                    )
+                    or 0
+                ),
+            ),
+        )
+
+        appeared_trial_ids = {
+            int(record["trial_index"])
+            for record in appearance_records
+            if _number(
+                record.get("trial_index")
+            )
+            is not None
+        }
+        appearance_count = len(
+            appeared_trial_ids
+        )
+        appearance_rate = (
+            appearance_count / trial_count
+            if trial_count
+            else None
+        )
+
+        eligibility = _mapping(
+            eligibility_index.get(key)
+        )
+        evidence_present = bool(eligibility)
+        evidence_valid = (
+            eligibility.get("evidence_valid")
+            is True
+        )
+        typical_role = (
+            _identifier(
+                eligibility.get("pitcher_role")
+            )
+            if evidence_valid
+            else ""
+        ) or None
+
+        retained = (
+            eligibility.get("retained")
+            if evidence_present
+            else None
+        )
+        planned_override = (
+            eligibility.get("planned_pitcher")
+            is True
+        )
+
+        if retained is True:
+            availability_status = "eligible"
+        elif retained is False:
+            availability_status = "excluded"
+        elif planned_role in PRIMARY_WORKLOAD_ROLES:
+            availability_status = (
+                "planned_primary_pitcher"
+            )
+        else:
+            availability_status = "unknown"
+
+        pool_anomalies = []
+
+        if (
+            retained is True
+            and typical_role
+            in STARTER_LIKE_ROLES
+            and not planned_override
+        ):
+            pool_anomalies.append(
+                "starter_like_pitcher_retained_"
+                "in_bullpen"
+            )
+            pool_conflicts.append({
+                "team_side": team_side,
+                "pitcher_id": pitcher_id,
+                "planned_role": planned_role,
+                "typical_role": typical_role,
+                "decision_reason":
+                    eligibility.get(
+                        "decision_reason"
+                    ),
+            })
+
+        if (
+            planned_role == "reliever"
+            and not evidence_present
+        ):
+            missing_eligibility_evidence.append(
+                pitcher_id
+            )
+
+        if not appearance_records:
+            missing_appearance_evidence.append(
+                pitcher_id
+            )
+
+        unconditional_outs = dict(
+            _metric_summary(
+                row,
+                "outs_recorded",
+            )
+        )
+        unconditional_innings = (
+            _innings_summary(
+                unconditional_outs
+            )
+        )
+
+        (
+            conditional_outs,
+            conditional_innings,
+        ) = _conditional_summary(
+            appearance_records
+        )
+
+        calibration_status = (
+            "requires_historical_calibration"
+            if planned_role
+            in PRIMARY_WORKLOAD_ROLES
+            else (
+                "conditional_distribution_observed"
+                if conditional_outs is not None
+                else "appearance_evidence_unavailable"
+            )
+        )
+
+        if planned_role in PRIMARY_WORKLOAD_ROLES:
+            primary_pitcher_ids.append(
+                pitcher_id
+            )
+            historical_calibration_pitcher_ids.append(
+                pitcher_id
+            )
+
+        pitcher_records.append({
+            "team_side": team_side,
+            "pitcher_id": pitcher_id,
+            "planned_role": planned_role,
+            "planned_role_resolution_status":
+                role_status,
+            "typical_bullpen_role": typical_role,
+            "typical_role_inference_used": False,
+            "eligibility_evidence_present":
+                evidence_present,
+            "eligibility_evidence_valid":
+                evidence_valid,
+            "eligibility_evidence_source":
+                eligibility.get(
+                    "evidence_source"
+                ),
+            "eligibility_decision_reason":
+                eligibility.get(
+                    "decision_reason"
+                ),
+            "planned_pitcher_override":
+                planned_override,
+            "availability_status":
+                availability_status,
+            "appearance_count":
+                appearance_count,
+            "appearance_rate":
+                appearance_rate,
+            "unconditional_outs":
+                unconditional_outs,
+            "unconditional_innings":
+                unconditional_innings,
+            "conditional_on_appearance_outs":
+                conditional_outs,
+            "conditional_on_appearance_innings":
+                conditional_innings,
+            "workload_calibration_status":
+                calibration_status,
+            "historical_calibration_available":
+                False,
+            "pool_anomalies":
+                sorted(pool_anomalies),
+        })
+
+    blockers = []
+
+    if not players:
+        blockers.append(
+            "pitcher_projection_rows_unavailable"
+        )
+
+    if trial_count <= 0:
+        blockers.append(
+            "simulation_trial_count_unavailable"
+        )
+
+    if appearance_audit.get("status") not in {
+        "observed",
+        "ready",
+    }:
+        blockers.append(
+            "appearance_audit_unavailable"
+        )
+
+    status = (
+        "blocked"
+        if blockers
+        else "observed"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "audited": True,
+        "blockers": sorted(blockers),
+        "trial_count": trial_count,
+        "pitcher_projection_count":
+            len(players),
+        "primary_pitcher_count":
+            len(primary_pitcher_ids),
+        "primary_pitcher_ids":
+            sorted(set(primary_pitcher_ids)),
+        "pool_conflict_count":
+            len(pool_conflicts),
+        "pool_conflicts": sorted(
+            pool_conflicts,
+            key=lambda record: (
+                record["team_side"],
+                record["pitcher_id"],
+            ),
+        ),
+        "missing_eligibility_evidence_count":
+            len(
+                set(
+                    missing_eligibility_evidence
+                )
+            ),
+        "missing_eligibility_evidence_pitcher_ids":
+            sorted(
+                set(
+                    missing_eligibility_evidence
+                )
+            ),
+        "missing_appearance_evidence_count":
+            len(
+                set(
+                    missing_appearance_evidence
+                )
+            ),
+        "missing_appearance_evidence_pitcher_ids":
+            sorted(
+                set(
+                    missing_appearance_evidence
+                )
+            ),
+        "invalid_appearance_record_count":
+            invalid_appearance_record_count,
+        "historical_calibration_available":
+            False,
+        "historical_calibration_required":
+            bool(
+                historical_calibration_pitcher_ids
+            ),
+        "historical_calibration_pitcher_ids":
+            sorted(
+                set(
+                    historical_calibration_pitcher_ids
+                )
+            ),
+        "pitchers": sorted(
+            pitcher_records,
+            key=lambda record: (
+                record["team_side"],
+                record["planned_role"] or "",
+                record["pitcher_id"],
+            ),
+        ),
+        "interpretation": {
+            "unconditional_distribution_includes_nonappearances":
+                True,
+            "conditional_distribution_excludes_nonappearances":
+                True,
+            "typical_bullpen_roles_inferred":
+                False,
+            "starter_p90_calibration_claimed":
+                False,
+        },
+        "safety_checks": {
+            "projection_values_unchanged": True,
+            "pitcher_pools_unchanged": True,
+            "pitching_plans_unchanged": True,
+            "event_streams_unchanged": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "decision": {
+            "pitcher_pool_change_allowed": False,
+            "workload_calibration_change_allowed": False,
+            "production_activation_allowed": False,
+            "recommended_next_slice": (
+                "correct_canonical_pitcher_pool_"
+                "role_and_availability_evidence"
+                if pool_conflicts
+                else (
+                    "calibrate_canonical_starter_"
+                    "workload_distributions"
+                )
+            ),
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/tests/test_canonical_pitcher_projection_pool_and_workload_calibration.py
+++ b/tests/test_canonical_pitcher_projection_pool_and_workload_calibration.py
@@ -1,0 +1,458 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_projection_pool_and_workload_calibration import (
+    SCHEMA_VERSION,
+    audit_canonical_pitcher_projection_pool_and_workload_calibration,
+)
+
+
+def metric(
+    *,
+    count=100,
+    mean=0,
+    median=0,
+    p10=0,
+    p25=0,
+    p75=0,
+    p90=0,
+    minimum=0,
+    maximum=0,
+):
+    return {
+        "count": count,
+        "mean": mean,
+        "median": median,
+        "p10": p10,
+        "p25": p25,
+        "p75": p75,
+        "p90": p90,
+        "minimum": minimum,
+        "maximum": maximum,
+    }
+
+
+def projections():
+    return {
+        "schema_version":
+            "canonical_player_projection_rows_v1",
+        "simulation_count": 100,
+        "players": [
+            {
+                "player_id": "100",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "starter",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "outs_recorded": metric(
+                        mean=15,
+                        median=17,
+                        p10=8,
+                        p25=12,
+                        p75=19,
+                        p90=20,
+                        minimum=0,
+                        maximum=23,
+                    ),
+                },
+            },
+            {
+                "player_id": "101",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "reliever",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "outs_recorded": metric(
+                        mean=0.9,
+                        median=0,
+                        p10=0,
+                        p25=0,
+                        p75=0,
+                        p90=3,
+                        minimum=0,
+                        maximum=4,
+                    ),
+                },
+            },
+            {
+                "player_id": "102",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "reliever",
+                "pitcher_role_resolution_status":
+                    "resolved",
+                "metrics": {
+                    "outs_recorded": metric(
+                        mean=0.6,
+                        median=0,
+                        p10=0,
+                        p25=0,
+                        p75=0,
+                        p90=3,
+                        minimum=0,
+                        maximum=3,
+                    ),
+                },
+            },
+        ],
+    }
+
+
+def appearance_audit():
+    records = []
+
+    for trial_index in range(100):
+        records.append({
+            "trial_index": trial_index,
+            "team_side": "away",
+            "pitcher_id": "100",
+            "appearance_index": 0,
+            "planned_role": "starter",
+            "actual_role": "first_pitcher",
+            "outs_recorded": (
+                15
+                if trial_index < 50
+                else 20
+            ),
+        })
+
+    for trial_index, outs in (
+        (1, 3),
+        (5, 3),
+        (9, 4),
+        (20, 2),
+        (40, 3),
+        (60, 3),
+        (80, 3),
+        (95, 3),
+    ):
+        records.append({
+            "trial_index": trial_index,
+            "team_side": "away",
+            "pitcher_id": "101",
+            "appearance_index": 1,
+            "planned_role": "reliever",
+            "actual_role": "reliever",
+            "outs_recorded": outs,
+        })
+
+    return {
+        "schema_version":
+            "canonical_pitcher_appearance_"
+            "sequence_audit_v1",
+        "status": "observed",
+        "trial_count": 100,
+        "records": records,
+    }
+
+
+def bullpen_discovery():
+    return {
+        "away": {
+            "starter_id": "100",
+            "bullpen_pitcher_ids": [
+                "101",
+                "102",
+            ],
+            "eligibility": {
+                "schema_version":
+                    "canonical_bullpen_eligibility_v1",
+                "records": [
+                    {
+                        "pitcher_id": "101",
+                        "retained": True,
+                        "decision_reason":
+                            "explicitly_eligible",
+                        "planned_pitcher": False,
+                        "evidence_present": True,
+                        "evidence_valid": True,
+                        "evidence_status":
+                            "eligible",
+                        "pitcher_role":
+                            "starter",
+                        "evidence_source":
+                            "depth_chart",
+                    },
+                    {
+                        "pitcher_id": "102",
+                        "retained": True,
+                        "decision_reason":
+                            "explicitly_eligible",
+                        "planned_pitcher": False,
+                        "evidence_present": True,
+                        "evidence_valid": True,
+                        "evidence_status":
+                            "eligible",
+                        "pitcher_role":
+                            "closer",
+                        "evidence_source":
+                            "depth_chart",
+                    },
+                ],
+            },
+        },
+        "home": {
+            "starter_id": "200",
+            "bullpen_pitcher_ids": [],
+            "eligibility": {
+                "records": [],
+            },
+        },
+    }
+
+
+def run():
+    return (
+        audit_canonical_pitcher_projection_pool_and_workload_calibration(
+            projections=projections(),
+            appearance_audit=appearance_audit(),
+            bullpen_discovery=bullpen_discovery(),
+        )
+    )
+
+
+def pitcher(result, pitcher_id):
+    return next(
+        row
+        for row in result["pitchers"]
+        if row["pitcher_id"] == pitcher_id
+    )
+
+
+def test_reports_observed_read_only_audit():
+    result = run()
+
+    assert result["schema_version"] == SCHEMA_VERSION
+    assert result["status"] == "observed"
+    assert result["audited"] is True
+    assert result["trial_count"] == 100
+    assert result["pitcher_projection_count"] == 3
+    assert result["database_writes_performed"] is False
+    assert result["production_authority_changed"] is False
+    assert result["safety_checks"] == {
+        "projection_values_unchanged": True,
+        "pitcher_pools_unchanged": True,
+        "pitching_plans_unchanged": True,
+        "event_streams_unchanged": True,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
+def test_separates_unconditional_and_conditional_workload():
+    result = run()
+    reliever = pitcher(result, "101")
+
+    assert reliever["appearance_count"] == 8
+    assert reliever["appearance_rate"] == 0.08
+
+    assert reliever["unconditional_outs"][
+        "mean"
+    ] == 0.9
+    assert reliever["unconditional_outs"][
+        "median"
+    ] == 0
+
+    conditional = reliever[
+        "conditional_on_appearance_outs"
+    ]
+
+    assert conditional["count"] == 8
+    assert conditional["minimum"] == 2
+    assert conditional["maximum"] == 4
+    assert conditional["median"] == 3
+
+    assert reliever[
+        "conditional_on_appearance_innings"
+    ]["median"] == 1.0
+
+
+def test_flags_starter_like_pitcher_retained_in_bullpen():
+    result = run()
+    reliever = pitcher(result, "101")
+
+    assert result["pool_conflict_count"] == 1
+    assert result["pool_conflicts"] == [{
+        "team_side": "away",
+        "pitcher_id": "101",
+        "planned_role": "reliever",
+        "typical_role": "starter",
+        "decision_reason":
+            "explicitly_eligible",
+    }]
+    assert reliever["pool_anomalies"] == [
+        "starter_like_pitcher_retained_in_bullpen"
+    ]
+    assert result["decision"][
+        "recommended_next_slice"
+    ] == (
+        "correct_canonical_pitcher_pool_"
+        "role_and_availability_evidence"
+    )
+
+
+def test_surfaces_explicit_typical_bullpen_role():
+    result = run()
+    closer = pitcher(result, "102")
+
+    assert closer["typical_bullpen_role"] == (
+        "closer"
+    )
+    assert closer[
+        "typical_role_inference_used"
+    ] is False
+    assert closer["availability_status"] == (
+        "eligible"
+    )
+
+
+def test_does_not_infer_missing_typical_role():
+    source = bullpen_discovery()
+    source["away"]["eligibility"]["records"] = []
+
+    result = (
+        audit_canonical_pitcher_projection_pool_and_workload_calibration(
+            projections=projections(),
+            appearance_audit=appearance_audit(),
+            bullpen_discovery=source,
+        )
+    )
+    reliever = pitcher(result, "101")
+
+    assert reliever["typical_bullpen_role"] is None
+    assert reliever[
+        "typical_role_inference_used"
+    ] is False
+    assert reliever["availability_status"] == (
+        "unknown"
+    )
+    assert result[
+        "missing_eligibility_evidence_count"
+    ] == 2
+
+
+def test_primary_p90_requires_historical_calibration():
+    result = run()
+    starter = pitcher(result, "100")
+
+    assert starter[
+        "workload_calibration_status"
+    ] == "requires_historical_calibration"
+    assert starter[
+        "historical_calibration_available"
+    ] is False
+    assert result[
+        "historical_calibration_required"
+    ] is True
+    assert result[
+        "historical_calibration_pitcher_ids"
+    ] == ["100"]
+    assert result["interpretation"][
+        "starter_p90_calibration_claimed"
+    ] is False
+
+
+def test_primary_pitcher_is_not_marked_missing_from_bullpen():
+    result = run()
+    starter = pitcher(result, "100")
+
+    assert starter["availability_status"] == (
+        "planned_primary_pitcher"
+    )
+    assert result[
+        "missing_eligibility_evidence_pitcher_ids"
+    ] == []
+
+
+def test_missing_appearance_is_explicit():
+    result = run()
+    closer = pitcher(result, "102")
+
+    assert closer["appearance_count"] == 0
+    assert closer["appearance_rate"] == 0
+    assert closer[
+        "conditional_on_appearance_outs"
+    ] is None
+    assert closer[
+        "workload_calibration_status"
+    ] == "appearance_evidence_unavailable"
+    assert result[
+        "missing_appearance_evidence_pitcher_ids"
+    ] == ["102"]
+
+
+def test_planned_override_does_not_create_pool_conflict():
+    source = bullpen_discovery()
+    source["away"]["eligibility"][
+        "records"
+    ][0]["planned_pitcher"] = True
+
+    result = (
+        audit_canonical_pitcher_projection_pool_and_workload_calibration(
+            projections=projections(),
+            appearance_audit=appearance_audit(),
+            bullpen_discovery=source,
+        )
+    )
+
+    assert result["pool_conflict_count"] == 0
+
+
+def test_blocks_without_trial_count():
+    audit = appearance_audit()
+    audit["trial_count"] = 0
+
+    result = (
+        audit_canonical_pitcher_projection_pool_and_workload_calibration(
+            projections=projections(),
+            appearance_audit=audit,
+            bullpen_discovery=bullpen_discovery(),
+        )
+    )
+
+    assert result["status"] == "blocked"
+    assert (
+        "simulation_trial_count_unavailable"
+        in result["blockers"]
+    )
+
+
+def test_rejects_invalid_inputs():
+    with pytest.raises(
+        TypeError,
+        match="projections must be a mapping",
+    ):
+        audit_canonical_pitcher_projection_pool_and_workload_calibration(
+            projections=[],
+            appearance_audit=appearance_audit(),
+            bullpen_discovery=bullpen_discovery(),
+        )
+
+
+def test_does_not_mutate_inputs():
+    projection_source = projections()
+    appearance_source = appearance_audit()
+    bullpen_source = bullpen_discovery()
+
+    originals = deepcopy((
+        projection_source,
+        appearance_source,
+        bullpen_source,
+    ))
+
+    audit_canonical_pitcher_projection_pool_and_workload_calibration(
+        projections=projection_source,
+        appearance_audit=appearance_source,
+        bullpen_discovery=bullpen_source,
+    )
+
+    assert (
+        projection_source,
+        appearance_source,
+        bullpen_source,
+    ) == originals

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -388,6 +388,12 @@ def test_comparator_attaches_pitcher_projection_readiness():
             production_execution=executed_shadow(
                 simulation_count=100,
             ),
+            bullpen_discovery=(
+                model_projections
+                ._canonical_pitcher_pool_audit_input(
+                    bullpens()
+                )
+            ),
         )
     )
 
@@ -429,6 +435,71 @@ def test_comparator_attaches_pitcher_projection_readiness():
     authority = shadow[
         "pitcher_projection_authority"
     ]
+    pool_audit = shadow[
+        "pitcher_projection_pool_and_"
+        "workload_calibration"
+    ]
+
+    assert pool_audit["status"] == "observed"
+    assert pool_audit["audited"] is True
+    assert pool_audit["trial_count"] == 100
+    assert (
+        pool_audit["pitcher_projection_count"]
+        == 4
+    )
+    assert pool_audit[
+        "historical_calibration_required"
+    ] is True
+    assert pool_audit["interpretation"][
+        "unconditional_distribution_"
+        "includes_nonappearances"
+    ] is True
+    assert pool_audit["interpretation"][
+        "conditional_distribution_"
+        "excludes_nonappearances"
+    ] is True
+    assert pool_audit["interpretation"][
+        "typical_bullpen_roles_inferred"
+    ] is False
+    assert pool_audit["interpretation"][
+        "starter_p90_calibration_claimed"
+    ] is False
+    assert pool_audit[
+        "database_writes_performed"
+    ] is False
+    assert pool_audit[
+        "production_authority_changed"
+    ] is False
+
+    starter_rows = [
+        row
+        for row in pool_audit["pitchers"]
+        if row["planned_role"] == "starter"
+    ]
+    reliever_rows = [
+        row
+        for row in pool_audit["pitchers"]
+        if row["planned_role"] == "reliever"
+    ]
+
+    assert starter_rows
+    assert reliever_rows
+
+    assert all(
+        row["appearance_rate"] == 1.0
+        for row in starter_rows
+    )
+    assert all(
+        row[
+            "conditional_on_appearance_outs"
+        ] is not None
+        for row in starter_rows
+    )
+    assert all(
+        row["typical_role_inference_used"]
+        is False
+        for row in reliever_rows
+    )
 
     assert authority["status"] == "activated"
     assert authority[


### PR DESCRIPTION
## Summary

- audit canonical pitcher projection pools against explicit bullpen eligibility evidence
- distinguish planned pitcher role, typical bullpen role, and simulated appearance role without inference
- report unconditional game-level and conditional-on-appearance workload distributions
- identify starter-like pitchers retained in bullpen pools
- preserve explicit closer, setup, and long-relief classifications
- surface workload-calibration limitations without claiming starter P90 calibration

## Production evidence

The representative 100-trial production probe confirmed:

- explicit bullpen roles were preserved
- two starter-like bullpen conflicts were detected
- conditional workload distributions were observed
- no pitcher roles were inferred
- starter P90 calibration was not claimed
- projection values and pitcher pools were unchanged
- canonical pitcher projection authority remained activated
- game probabilities remained unchanged
- no database writes or production-authority changes occurred

## Validation

- final 6TA regression: 105 passed
- representative production acceptance signals: all passed
- compilation passed
- working-tree and new-file whitespace checks passed

## Scope

This slice is observational and read-only. It does not recalibrate workload distributions, alter pitcher pools, change pitching plans, or infer bullpen roles.