### PR TITLE
Reconcile canonical pitcher projection pool and role taxonomy

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+from mlb_app.simulation.projections.pitcher_pool_role_reconciliation import (
+    reconcile_canonical_pitcher_projection_pool_roles,
+)
 from mlb_app.simulation.projections.pitcher_projection_authority import (
     apply_canonical_pitcher_projection_authority,
 )
@@ -858,6 +861,57 @@ def _attach_production_shadow_comparison(
         .get("diagnostics", {})
         .get("canonical_shadow", {})
     )
+
+    try:
+        reconciled_projection_rows = (
+            reconcile_canonical_pitcher_projection_pool_roles(
+                payload=shadow[
+                    "player_projections"
+                ],
+                appearance_audit=(
+                    material
+                    .pitcher_appearance_sequence_audit
+                ),
+                bullpen_discovery=(
+                    bullpen_discovery
+                    if isinstance(
+                        bullpen_discovery,
+                        dict,
+                    )
+                    else {}
+                ),
+            )
+        )
+    except Exception as exc:
+        pool_role_reconciliation = {
+            "schema_version": (
+                "canonical_pitcher_projection_"
+                "pool_role_reconciliation_v1"
+            ),
+            "status": "error",
+            "error_type": (
+                exc.__class__.__name__
+            ),
+            "error_message": str(exc),
+            "typical_role_inference_used": False,
+            "unknown_evidence_fails_open": True,
+            "projection_rows_preserved": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+    else:
+        shadow["player_projections"] = (
+            reconciled_projection_rows
+        )
+        pool_role_reconciliation = (
+            reconciled_projection_rows[
+                "pitcher_pool_role_reconciliation"
+            ]
+        )
+
+    shadow[
+        "pitcher_projection_pool_role_reconciliation"
+    ] = pool_role_reconciliation
 
     try:
         appearance_audit = (

--- a/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
+++ b/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
@@ -1,0 +1,431 @@
+"""Reconcile canonical pitcher projection pools and role evidence."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+CANONICAL_PITCHER_POOL_ROLE_RECONCILIATION_VERSION = (
+    "canonical_pitcher_projection_pool_role_reconciliation_v1"
+)
+
+PLANNED_PRIMARY_ROLES = frozenset({
+    "starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+})
+
+STARTER_LIKE_TYPICAL_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+})
+
+
+def _text(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    return str(value).strip()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _side_evidence(
+    bullpen_discovery: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    evidence: dict[str, dict[str, Any]] = {}
+
+    for team_side in ("away", "home"):
+        side = _mapping(
+            bullpen_discovery.get(team_side)
+        )
+        starter_id = _text(
+            side.get("starter_id")
+        )
+        bullpen_ids = {
+            _text(identifier)
+            for identifier in (
+                side.get("bullpen_pitcher_ids")
+                or ()
+            )
+            if _text(identifier)
+        }
+        eligibility = _mapping(
+            side.get("eligibility")
+        )
+        records = eligibility.get("records")
+
+        record_index = {}
+
+        if isinstance(records, (list, tuple)):
+            for record in records:
+                record = _mapping(record)
+                pitcher_id = _text(
+                    record.get("pitcher_id")
+                )
+
+                if pitcher_id:
+                    record_index[pitcher_id] = (
+                        dict(record)
+                    )
+
+        evidence[team_side] = {
+            "starter_id": starter_id,
+            "bullpen_pitcher_ids": bullpen_ids,
+            "records": record_index,
+        }
+
+    return evidence
+
+
+def _appearance_evidence(
+    appearance_audit: Mapping[str, Any],
+) -> tuple[int, dict[tuple[str, str], int]]:
+    try:
+        trial_count = int(
+            appearance_audit.get("trial_count")
+            or 0
+        )
+    except (TypeError, ValueError):
+        trial_count = 0
+
+    trials_by_pitcher = defaultdict(set)
+    records = appearance_audit.get("records")
+
+    if isinstance(records, (list, tuple)):
+        for record in records:
+            record = _mapping(record)
+            team_side = _text(
+                record.get("team_side")
+            )
+            pitcher_id = _text(
+                record.get("pitcher_id")
+            )
+            trial_index = record.get("trial_index")
+
+            if (
+                team_side in {"away", "home"}
+                and pitcher_id
+                and trial_index is not None
+            ):
+                trials_by_pitcher[
+                    (team_side, pitcher_id)
+                ].add(trial_index)
+
+    counts = {
+        key: len(trials)
+        for key, trials in trials_by_pitcher.items()
+    }
+
+    return trial_count, counts
+
+
+def reconcile_canonical_pitcher_projection_pool_roles(
+    *,
+    payload: Mapping[str, Any],
+    appearance_audit: Mapping[str, Any],
+    bullpen_discovery: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Attach explicit pitcher-pool, role, and availability evidence.
+
+    Unknown active-roster evidence fails open. Rows are removed only
+    when valid explicit evidence marks an unplanned pitcher ineligible.
+    Typical bullpen roles are never inferred from row order, workload,
+    appearance rate, or player identity.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("payload must be a mapping")
+
+    if not isinstance(appearance_audit, Mapping):
+        raise TypeError(
+            "appearance_audit must be a mapping"
+        )
+
+    if not isinstance(bullpen_discovery, Mapping):
+        raise TypeError(
+            "bullpen_discovery must be a mapping"
+        )
+
+    result = deepcopy(dict(payload))
+    players = result.get("players")
+
+    if not isinstance(players, list):
+        raise TypeError(
+            "projection players must be a list"
+        )
+
+    side_evidence = _side_evidence(
+        bullpen_discovery
+    )
+    trial_count, appearance_counts = (
+        _appearance_evidence(appearance_audit)
+    )
+
+    reconciled_players = []
+    pitcher_count = 0
+    explicitly_eligible_count = 0
+    explicitly_ineligible_count = 0
+    unknown_availability_count = 0
+    planned_primary_count = 0
+    role_conflict_count = 0
+    excluded_pitcher_ids = []
+    role_conflict_pitcher_ids = []
+
+    for source_row in players:
+        if not isinstance(source_row, Mapping):
+            raise TypeError(
+                "projection player rows must be mappings"
+            )
+
+        row = deepcopy(dict(source_row))
+
+        if row.get("player_type") != "pitcher":
+            reconciled_players.append(row)
+            continue
+
+        pitcher_count += 1
+        team_side = _text(
+            row.get("team_side")
+        )
+        pitcher_id = _text(
+            row.get("player_id")
+        )
+        planned_role = _text(
+            row.get("pitcher_role")
+        )
+        side = side_evidence.get(
+            team_side,
+            {
+                "starter_id": "",
+                "bullpen_pitcher_ids": set(),
+                "records": {},
+            },
+        )
+        eligibility = _mapping(
+            side["records"].get(pitcher_id)
+        )
+
+        evidence_valid = (
+            eligibility.get("evidence_valid")
+            is True
+        )
+        evidence_status = (
+            _text(
+                eligibility.get(
+                    "evidence_status"
+                )
+            ).lower()
+            if evidence_valid
+            else "unknown"
+        )
+        typical_role = (
+            _text(
+                eligibility.get("pitcher_role")
+            ).lower()
+            if evidence_valid
+            else ""
+        )
+
+        if typical_role == "unknown":
+            typical_role = ""
+
+        planned_primary = (
+            planned_role in PLANNED_PRIMARY_ROLES
+            or (
+                pitcher_id
+                and pitcher_id
+                == side["starter_id"]
+            )
+            or (
+                eligibility.get(
+                    "planned_pitcher"
+                )
+                is True
+            )
+        )
+
+        if planned_primary:
+            availability_status = (
+                "planned_primary_pitcher"
+            )
+            membership_status = (
+                "included_explicit_pitching_plan"
+            )
+            planned_primary_count += 1
+            include = True
+        elif (
+            evidence_valid
+            and evidence_status == "ineligible"
+        ):
+            availability_status = (
+                "explicitly_ineligible"
+            )
+            membership_status = (
+                "excluded_explicitly_ineligible"
+            )
+            explicitly_ineligible_count += 1
+            include = False
+        elif (
+            evidence_valid
+            and evidence_status == "eligible"
+        ):
+            availability_status = (
+                "explicitly_eligible"
+            )
+            membership_status = (
+                "included_explicitly_eligible"
+            )
+            explicitly_eligible_count += 1
+            include = True
+        else:
+            availability_status = (
+                "active_roster_candidate_unknown"
+                if pitcher_id
+                in side["bullpen_pitcher_ids"]
+                else "availability_evidence_unknown"
+            )
+            membership_status = (
+                "included_unknown_evidence_fail_open"
+            )
+            unknown_availability_count += 1
+            include = True
+
+        if planned_role == "starter":
+            projection_group = "starter"
+        elif planned_role in {
+            "opener",
+            "bulk_follower",
+            "tandem_primary",
+            "tandem_secondary",
+        }:
+            projection_group = "opener_bulk"
+        elif planned_role == "reliever":
+            projection_group = "bullpen"
+        else:
+            projection_group = "unresolved"
+
+        role_conflict = (
+            include
+            and planned_role == "reliever"
+            and typical_role
+            in STARTER_LIKE_TYPICAL_ROLES
+        )
+
+        if role_conflict:
+            taxonomy_status = "conflicting"
+            role_conflict_count += 1
+            role_conflict_pitcher_ids.append(
+                pitcher_id
+            )
+        elif typical_role or planned_primary:
+            taxonomy_status = "resolved"
+        else:
+            taxonomy_status = "unresolved"
+
+        appearance_count = appearance_counts.get(
+            (team_side, pitcher_id),
+            0,
+        )
+        appearance_probability = (
+            appearance_count / trial_count
+            if trial_count > 0
+            else None
+        )
+
+        row[
+            "pitcher_projection_group"
+        ] = projection_group
+        row[
+            "planned_pitcher_role"
+        ] = planned_role or None
+        row[
+            "typical_bullpen_role"
+        ] = typical_role or None
+        row[
+            "typical_role_inference_used"
+        ] = False
+        row[
+            "game_availability_status"
+        ] = availability_status
+        row[
+            "pitcher_pool_membership_status"
+        ] = membership_status
+        row[
+            "pitcher_role_taxonomy_status"
+        ] = taxonomy_status
+        row[
+            "appearance_count"
+        ] = appearance_count
+        row[
+            "appearance_probability"
+        ] = appearance_probability
+
+        if include:
+            reconciled_players.append(row)
+        else:
+            excluded_pitcher_ids.append(
+                pitcher_id
+            )
+
+    result["players"] = reconciled_players
+    result[
+        "pitcher_pool_role_reconciliation_applied"
+    ] = True
+    result[
+        "pitcher_pool_role_reconciliation"
+    ] = {
+        "schema_version": (
+            CANONICAL_PITCHER_POOL_ROLE_RECONCILIATION_VERSION
+        ),
+        "status": "reconciled",
+        "source": (
+            "canonical_pitching_plan_appearance_and_"
+            "explicit_bullpen_eligibility"
+        ),
+        "pitcher_projection_count": pitcher_count,
+        "included_pitcher_count": (
+            pitcher_count
+            - explicitly_ineligible_count
+        ),
+        "excluded_pitcher_count": (
+            explicitly_ineligible_count
+        ),
+        "excluded_pitcher_ids": sorted(
+            set(excluded_pitcher_ids)
+        ),
+        "planned_primary_pitcher_count": (
+            planned_primary_count
+        ),
+        "explicitly_eligible_pitcher_count": (
+            explicitly_eligible_count
+        ),
+        "explicitly_ineligible_pitcher_count": (
+            explicitly_ineligible_count
+        ),
+        "unknown_availability_pitcher_count": (
+            unknown_availability_count
+        ),
+        "role_conflict_count": role_conflict_count,
+        "role_conflict_pitcher_ids": sorted(
+            set(role_conflict_pitcher_ids)
+        ),
+        "trial_count": trial_count,
+        "typical_role_inference_used": False,
+        "unknown_evidence_fails_open": True,
+        "explicit_plans_take_precedence": True,
+        "workload_calibration_changed": False,
+        "game_probability_authority_changed": False,
+        "database_writes_performed": False,
+        "production_authority_changed": (
+            explicitly_ineligible_count > 0
+        ),
+    }
+
+    return result

--- a/tests/test_canonical_pitcher_projection_pool_role_reconciliation.py
+++ b/tests/test_canonical_pitcher_projection_pool_role_reconciliation.py
@@ -1,0 +1,370 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.projections.pitcher_pool_role_reconciliation import (
+    CANONICAL_PITCHER_POOL_ROLE_RECONCILIATION_VERSION,
+    reconcile_canonical_pitcher_projection_pool_roles,
+)
+
+
+def metric(mean):
+    return {
+        "mean": mean,
+        "minimum": 0,
+        "maximum": mean,
+    }
+
+
+def payload():
+    return {
+        "schema_version":
+            "canonical_player_projection_rows_v1",
+        "players": [
+            {
+                "player_id": "100",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "starter",
+                "metrics": {
+                    "outs_recorded": metric(15),
+                },
+            },
+            {
+                "player_id": "101",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "reliever",
+                "metrics": {
+                    "outs_recorded": metric(3),
+                },
+            },
+            {
+                "player_id": "102",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "reliever",
+                "metrics": {
+                    "outs_recorded": metric(0.5),
+                },
+            },
+            {
+                "player_id": "103",
+                "team_side": "away",
+                "player_type": "pitcher",
+                "pitcher_role": "reliever",
+                "metrics": {
+                    "outs_recorded": metric(0),
+                },
+            },
+            {
+                "player_id": "batter_1",
+                "team_side": "away",
+                "player_type": "batter",
+                "metrics": {
+                    "hits": metric(1),
+                },
+            },
+        ],
+    }
+
+
+def appearance_audit():
+    records = []
+
+    for trial_index in range(10):
+        records.append({
+            "trial_index": trial_index,
+            "team_side": "away",
+            "pitcher_id": "100",
+        })
+
+    for trial_index in range(4):
+        records.append({
+            "trial_index": trial_index,
+            "team_side": "away",
+            "pitcher_id": "101",
+        })
+
+    return {
+        "trial_count": 10,
+        "records": records,
+    }
+
+
+def evidence_record(
+    pitcher_id,
+    *,
+    status,
+    role,
+    planned=False,
+):
+    return {
+        "pitcher_id": pitcher_id,
+        "retained": status != "ineligible",
+        "decision_reason": (
+            "explicitly_eligible"
+            if status == "eligible"
+            else "probable_starter_not_in_plan"
+        ),
+        "planned_pitcher": planned,
+        "evidence_present": True,
+        "evidence_valid": True,
+        "evidence_status": status,
+        "pitcher_role": role,
+        "evidence_source":
+            "pregame_role_evidence_v1",
+    }
+
+
+def bullpen_discovery():
+    return {
+        "away": {
+            "starter_id": "100",
+            "bullpen_pitcher_ids": [
+                "101",
+                "103",
+            ],
+            "eligibility": {
+                "records": [
+                    evidence_record(
+                        "101",
+                        status="eligible",
+                        role="closer",
+                    ),
+                    evidence_record(
+                        "102",
+                        status="ineligible",
+                        role="probable_starter",
+                    ),
+                    {
+                        "pitcher_id": "103",
+                        "retained": True,
+                        "decision_reason":
+                            "eligibility_evidence_unavailable",
+                        "planned_pitcher": False,
+                        "evidence_present": False,
+                        "evidence_valid": False,
+                        "evidence_status": "unknown",
+                        "pitcher_role": "unknown",
+                        "evidence_source": None,
+                    },
+                ],
+            },
+        },
+        "home": {},
+    }
+
+
+def run(**overrides):
+    kwargs = {
+        "payload": payload(),
+        "appearance_audit": appearance_audit(),
+        "bullpen_discovery": bullpen_discovery(),
+    }
+    kwargs.update(overrides)
+
+    return (
+        reconcile_canonical_pitcher_projection_pool_roles(
+            **kwargs
+        )
+    )
+
+
+def pitchers(result):
+    return {
+        row["player_id"]: row
+        for row in result["players"]
+        if row["player_type"] == "pitcher"
+    }
+
+
+def test_reconciles_explicit_pool_and_role_evidence():
+    result = run()
+    rows = pitchers(result)
+
+    assert set(rows) == {
+        "100",
+        "101",
+        "103",
+    }
+
+    assert rows["100"][
+        "pitcher_projection_group"
+    ] == "starter"
+    assert rows["100"][
+        "game_availability_status"
+    ] == "planned_primary_pitcher"
+
+    assert rows["101"][
+        "pitcher_projection_group"
+    ] == "bullpen"
+    assert rows["101"][
+        "typical_bullpen_role"
+    ] == "closer"
+    assert rows["101"][
+        "game_availability_status"
+    ] == "explicitly_eligible"
+
+    assert "102" not in rows
+    assert rows["103"][
+        "game_availability_status"
+    ] == "active_roster_candidate_unknown"
+
+
+def test_surfaces_appearance_probability():
+    rows = pitchers(run())
+
+    assert rows["100"]["appearance_count"] == 10
+    assert rows["100"][
+        "appearance_probability"
+    ] == 1.0
+    assert rows["101"]["appearance_count"] == 4
+    assert rows["101"][
+        "appearance_probability"
+    ] == 0.4
+    assert rows["103"]["appearance_count"] == 0
+    assert rows["103"][
+        "appearance_probability"
+    ] == 0.0
+
+
+def test_unknown_evidence_fails_open():
+    result = run()
+    reconciliation = result[
+        "pitcher_pool_role_reconciliation"
+    ]
+
+    assert "103" in pitchers(result)
+    assert reconciliation[
+        "unknown_evidence_fails_open"
+    ] is True
+    assert reconciliation[
+        "unknown_availability_pitcher_count"
+    ] == 1
+
+
+def test_explicit_ineligibility_excludes_only_pitcher_row():
+    result = run()
+    reconciliation = result[
+        "pitcher_pool_role_reconciliation"
+    ]
+
+    assert reconciliation[
+        "excluded_pitcher_ids"
+    ] == ["102"]
+    assert reconciliation[
+        "excluded_pitcher_count"
+    ] == 1
+    assert any(
+        row["player_id"] == "batter_1"
+        for row in result["players"]
+    )
+
+
+def test_planned_pitcher_overrides_ineligibility():
+    source = bullpen_discovery()
+    source["away"]["eligibility"][
+        "records"
+    ][1]["planned_pitcher"] = True
+
+    result = run(
+        bullpen_discovery=source,
+    )
+
+    assert "102" in pitchers(result)
+    assert pitchers(result)["102"][
+        "pitcher_pool_membership_status"
+    ] == "included_explicit_pitching_plan"
+
+
+def test_starter_like_eligible_reliever_is_conflicting():
+    source = bullpen_discovery()
+    source["away"]["eligibility"][
+        "records"
+    ][0]["pitcher_role"] = "starter"
+
+    result = run(
+        bullpen_discovery=source,
+    )
+    row = pitchers(result)["101"]
+
+    assert row[
+        "pitcher_role_taxonomy_status"
+    ] == "conflicting"
+    assert result[
+        "pitcher_pool_role_reconciliation"
+    ]["role_conflict_pitcher_ids"] == [
+        "101",
+    ]
+
+
+def test_does_not_infer_missing_typical_role():
+    row = pitchers(run())["103"]
+
+    assert row["typical_bullpen_role"] is None
+    assert row[
+        "typical_role_inference_used"
+    ] is False
+
+
+def test_preserves_projection_metrics_and_inputs():
+    source_payload = payload()
+    original_payload = deepcopy(source_payload)
+    original_discovery = bullpen_discovery()
+
+    result = run(
+        payload=source_payload,
+        bullpen_discovery=original_discovery,
+    )
+
+    assert source_payload == original_payload
+    assert pitchers(result)["101"]["metrics"] == (
+        pitchers(original_payload)["101"][
+            "metrics"
+        ]
+    )
+    assert result[
+        "pitcher_pool_role_reconciliation"
+    ]["workload_calibration_changed"] is False
+    assert result[
+        "pitcher_pool_role_reconciliation"
+    ]["game_probability_authority_changed"] is False
+
+
+def test_reports_schema_and_safety_contract():
+    reconciliation = run()[
+        "pitcher_pool_role_reconciliation"
+    ]
+
+    assert reconciliation["schema_version"] == (
+        CANONICAL_PITCHER_POOL_ROLE_RECONCILIATION_VERSION
+    )
+    assert reconciliation[
+        "typical_role_inference_used"
+    ] is False
+    assert reconciliation[
+        "database_writes_performed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("payload", None),
+        ("appearance_audit", None),
+        ("bullpen_discovery", None),
+    ],
+)
+def test_rejects_invalid_inputs(field, value):
+    kwargs = {
+        "payload": payload(),
+        "appearance_audit": appearance_audit(),
+        "bullpen_discovery": bullpen_discovery(),
+    }
+    kwargs[field] = value
+
+    with pytest.raises(TypeError):
+        reconcile_canonical_pitcher_projection_pool_roles(
+            **kwargs
+        )

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -681,3 +681,291 @@ def test_low_evidence_run_fails_closed_to_legacy():
         assert authority[
             "authoritative_source"
         ] == "legacy"
+
+def test_comparator_reconciles_pitcher_projection_pool_roles():
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+            bullpen_discovery=(
+                model_projections
+                ._canonical_pitcher_pool_audit_input(
+                    bullpens()
+                )
+            ),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    projections = shadow["player_projections"]
+    reconciliation = shadow[
+        "pitcher_projection_pool_role_reconciliation"
+    ]
+
+    assert reconciliation["status"] == "reconciled"
+    assert reconciliation[
+        "schema_version"
+    ] == (
+        "canonical_pitcher_projection_"
+        "pool_role_reconciliation_v1"
+    )
+    assert reconciliation[
+        "excluded_pitcher_count"
+    ] == 0
+    assert reconciliation[
+        "unknown_evidence_fails_open"
+    ] is True
+    assert reconciliation[
+        "typical_role_inference_used"
+    ] is False
+    assert reconciliation[
+        "game_probability_authority_changed"
+    ] is False
+    assert reconciliation[
+        "database_writes_performed"
+    ] is False
+    assert reconciliation[
+        "production_authority_changed"
+    ] is False
+
+    pitcher_rows = {
+        row["player_id"]: row
+        for row in projections["players"]
+        if row["player_type"] == "pitcher"
+    }
+
+    starter_rows = [
+        row
+        for row in pitcher_rows.values()
+        if row["planned_pitcher_role"]
+        == "starter"
+    ]
+    reliever_rows = [
+        row
+        for row in pitcher_rows.values()
+        if row["planned_pitcher_role"]
+        == "reliever"
+    ]
+
+    assert starter_rows
+    assert reliever_rows
+
+    assert all(
+        row["pitcher_projection_group"]
+        == "starter"
+        for row in starter_rows
+    )
+    assert all(
+        row["game_availability_status"]
+        == "planned_primary_pitcher"
+        for row in starter_rows
+    )
+
+    # Production currently has active-roster
+    # candidate evidence, not verified same-game
+    # role or availability evidence.
+    assert all(
+        row["pitcher_projection_group"]
+        == "bullpen"
+        for row in reliever_rows
+    )
+    assert all(
+        row["typical_bullpen_role"] is None
+        for row in reliever_rows
+    )
+    assert all(
+        row["typical_role_inference_used"]
+        is False
+        for row in reliever_rows
+    )
+    assert all(
+        row["game_availability_status"]
+        == "active_roster_candidate_unknown"
+        for row in reliever_rows
+    )
+
+    assert all(
+        row["appearance_probability"]
+        is not None
+        and 0.0
+        <= row["appearance_probability"]
+        <= 1.0
+        for row in pitcher_rows.values()
+    )
+
+    assert projections[
+        "pitcher_pool_role_reconciliation_applied"
+    ] is True
+    assert projections[
+        "pitcher_projections_authoritative"
+    ] is True
+    assert projections[
+        "batter_projections_authoritative"
+    ] is False
+
+    authority = shadow[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["status"] == "activated"
+    assert authority[
+        "authority_scope"
+    ] == "pitcher_rows_only"
+
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]
+
+def test_comparator_applies_explicit_pitcher_pool_role_evidence():
+    from copy import deepcopy
+
+    legacy = legacy_payload()
+    discovery = deepcopy(
+        model_projections
+        ._canonical_pitcher_pool_audit_input(
+            bullpens()
+        )
+    )
+
+    discovery["away"]["eligibility"] = {
+        "records": [
+            {
+                "pitcher_id": "101",
+                "retained": True,
+                "decision_reason":
+                    "explicitly_eligible",
+                "planned_pitcher": False,
+                "evidence_present": True,
+                "evidence_valid": True,
+                "evidence_status":
+                    "eligible",
+                "pitcher_role": "closer",
+                "evidence_source":
+                    "pregame_role_evidence_v1",
+            },
+        ],
+    }
+    discovery["home"]["eligibility"] = {
+        "records": [
+            {
+                "pitcher_id": "201",
+                "retained": False,
+                "decision_reason":
+                    "probable_starter_not_in_plan",
+                "planned_pitcher": False,
+                "evidence_present": True,
+                "evidence_valid": True,
+                "evidence_status":
+                    "ineligible",
+                "pitcher_role":
+                    "probable_starter",
+                "evidence_source":
+                    "pregame_role_evidence_v1",
+            },
+        ],
+    }
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+            bullpen_discovery=discovery,
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    projections = shadow[
+        "player_projections"
+    ]
+    reconciliation = shadow[
+        "pitcher_projection_pool_role_reconciliation"
+    ]
+
+    pitcher_rows = {
+        row["player_id"]: row
+        for row in projections["players"]
+        if row["player_type"] == "pitcher"
+    }
+    batter_rows = [
+        row
+        for row in projections["players"]
+        if row["player_type"] == "batter"
+    ]
+
+    assert set(pitcher_rows) == {
+        "100",
+        "101",
+        "200",
+    }
+    assert pitcher_rows["101"][
+        "typical_bullpen_role"
+    ] == "closer"
+    assert pitcher_rows["101"][
+        "game_availability_status"
+    ] == "explicitly_eligible"
+    assert pitcher_rows["101"][
+        "pitcher_pool_membership_status"
+    ] == "included_explicitly_eligible"
+
+    assert "201" not in pitcher_rows
+    assert reconciliation[
+        "excluded_pitcher_ids"
+    ] == ["201"]
+    assert reconciliation[
+        "explicitly_ineligible_pitcher_count"
+    ] == 1
+    assert reconciliation[
+        "production_authority_changed"
+    ] is True
+    assert reconciliation[
+        "game_probability_authority_changed"
+    ] is False
+    assert reconciliation[
+        "typical_role_inference_used"
+    ] is False
+    assert reconciliation[
+        "database_writes_performed"
+    ] is False
+
+    assert len(batter_rows) == 18
+
+    authority = shadow[
+        "pitcher_projection_authority"
+    ]
+
+    assert authority["status"] == "activated"
+    assert authority[
+        "production_activation"
+    ] is True
+    assert authority[
+        "authority_scope"
+    ] == "pitcher_rows_only"
+
+    assert projections[
+        "pitcher_projections_authoritative"
+    ] is True
+    assert projections[
+        "batter_projections_authoritative"
+    ] is False
+
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]


### PR DESCRIPTION
## Summary

- reconcile canonical pitcher projection rows with explicit pitching-plan, bullpen-pool, and availability evidence
- group scheduled starters, opener/bulk roles, and bullpen projections without inferring roles from workload or row order
- preserve explicit typical bullpen roles such as closer when valid evidence exists
- surface appearance probability separately from role and availability
- retain unknown active-roster candidates fail-open
- exclude only unplanned pitchers with valid explicit ineligibility evidence
- attach reconciliation before readiness and canonical pitcher-row authority

## Root cause

Canonical bullpen discovery currently begins with active-roster pitchers. That source is a candidate pool, not proof of same-game availability, leverage role, or expected usage. As a result, non-starting pitchers could be presented as generic relievers even when their true game role was unresolved.

## Production evidence

A representative 100-trial probe confirmed:

- starters and bullpen pitchers are grouped separately
- unknown active-roster candidates remain fail-open
- no typical bullpen roles are inferred
- appearance probabilities are attached
- explicit closer evidence is preserved
- an explicitly ineligible probable starter is removed
- canonical pitcher-row authority remains activated
- batter projection rows remain unchanged
- game probabilities remain unchanged
- no database writes occur

## Validation

- final explicit 6TB regression: 167 passed
- representative production acceptance signals: all passed
- compilation passed
- working-tree, staged, and new-file whitespace checks passed
- staged-file isolation passed

## Scope

This slice establishes the authoritative reconciliation contract. It does not invent same-game availability evidence, recalibrate pitcher workload percentiles, change batter projection authority, or activate canonical game-level probability authority.