### PR TITLE
Repair canonical pitcher Statcast pitch identity

### DIFF
--- a/mlb_app/app.py
+++ b/mlb_app/app.py
@@ -84,6 +84,7 @@ from .db_utils import (
 )
 from .scoring import compute_win_probability, score_individual_matchup, get_park_factor
 from .statcast_utils import fetch_pitch_arsenal_leaderboard
+from .statcast_event_identity import dedupe_statcast_events as _dedupe_statcast_events
 from .hitting_matchups import build_batter_pitch_type_summary
 from .odds_provider import (
     fetch_draftkings_odds,
@@ -367,59 +368,6 @@ def _normalize_arsenal_to_dicts(raw_arsenal) -> List[Dict[str, Any]]:
         }
         for r in raw_arsenal
     ]
-
-
-def _dedupe_statcast_events(events: List[StatcastEvent]) -> List[StatcastEvent]:
-    """
-    Remove duplicate Statcast pitch rows before any matchup or player stat calculation.
-
-    Primary key uses MLB pitch identity when available:
-        game_pk + at_bat_number + pitch_number + pitcher_id + batter_id + pitch_type
-
-    Fallback key is intentionally conservative for older rows missing game ordering fields.
-    """
-    seen = set()
-    deduped: List[StatcastEvent] = []
-
-    for event in events:
-        if (
-            event.game_pk is not None
-            and event.at_bat_number is not None
-            and event.pitch_number is not None
-        ):
-            key = (
-                event.game_pk,
-                event.at_bat_number,
-                event.pitch_number,
-                event.pitcher_id,
-                event.batter_id,
-                event.pitch_type,
-            )
-        else:
-            key = (
-                event.game_date,
-                event.pitcher_id,
-                event.batter_id,
-                event.pitch_type,
-                event.events,
-                event.release_speed,
-                event.release_spin_rate,
-                event.launch_speed,
-                event.launch_angle,
-                event.balls,
-                event.strikes,
-                event.inning,
-                event.inning_topbot,
-                event.outs_when_up,
-            )
-
-        if key in seen:
-            continue
-
-        seen.add(key)
-        deduped.append(event)
-
-    return deduped
 
 
 def _terminal_events(events: List[StatcastEvent]) -> List[StatcastEvent]:

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -30,7 +30,7 @@ from .db_utils import (
     get_batter_multi_season,
     get_player_splits_multi_season,
 )
-from .pitcher_intelligence import build_pitcher_intelligence_profile
+from .pitcher_intelligence import MLB_TIMEZONE, build_pitcher_intelligence_profile
 from .pitcher_leaderboards import build_pitcher_leaderboards
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
@@ -225,7 +225,7 @@ def pitchers_leaderboards(season: Optional[int] = None, limit: int = Query(10, g
 @router.get("/pitcher/{id}/intelligence")
 def pitcher_intelligence(id: int, season: Optional[int] = None, days_back: int = Query(365, ge=1, le=3650)) -> Dict[str, Any]:
     if season is None:
-        season = datetime.date.today().year
+        season = datetime.datetime.now(MLB_TIMEZONE).year
     Session = _get_session()
     with Session() as session:
         return build_pitcher_intelligence_profile(session, id, season, days_back=days_back)
@@ -234,7 +234,7 @@ def pitcher_intelligence(id: int, season: Optional[int] = None, days_back: int =
 @router.get("/batter/{id}/profile")
 def batter_profile(id: int, season: Optional[int] = None) -> Dict[str, Any]:
     if season is None:
-        season = datetime.date.today().year
+        season = datetime.datetime.now(MLB_TIMEZONE).year
     Session = _get_session()
     with Session() as session:
         agg, agg_label = get_batter_aggregate_with_fallback(session, id, season)

--- a/mlb_app/database.py
+++ b/mlb_app/database.py
@@ -75,6 +75,19 @@ class StatcastEvent(Base):
         Index("ix_statcast_events_date_pitcher", "game_date", "pitcher_id"),
         Index("ix_statcast_events_date_batter", "game_date", "batter_id"),
         Index("ix_statcast_events_batter_order", "batter_id", "game_date", "game_pk", "at_bat_number", "pitch_number"),
+        Index(
+            "ux_statcast_events_pitch_identity",
+            "game_pk",
+            "at_bat_number",
+            "pitch_number",
+            unique=True,
+            postgresql_where=text(
+                "game_pk IS NOT NULL AND at_bat_number IS NOT NULL AND pitch_number IS NOT NULL"
+            ),
+            sqlite_where=text(
+                "game_pk IS NOT NULL AND at_bat_number IS NOT NULL AND pitch_number IS NOT NULL"
+            ),
+        ),
     )
 
 

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -15,6 +15,7 @@ from .database import (
     StatcastEvent,
     TeamSplit,
 )
+from .statcast_event_identity import dedupe_statcast_events
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
 WALK_EVENTS = {"walk", "intent_walk"}
@@ -483,6 +484,7 @@ def get_pitcher_rolling_by_games(session: Session, pitcher_id: int, n_games: int
         .filter(StatcastEvent.pitcher_id == pitcher_id, StatcastEvent.game_date.in_(date_list))
         .all()
     )
+    events = dedupe_statcast_events(events)
     if not events:
         return None
 
@@ -735,17 +737,7 @@ def _pitch_event_identity(e: StatcastEvent) -> Tuple[Any, ...]:
 
 
 def _dedupe_pitch_events(events: List[StatcastEvent]) -> List[StatcastEvent]:
-    seen = set()
-    out: List[StatcastEvent] = []
-
-    for e in events:
-        key = _pitch_event_identity(e)
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(e)
-
-    return out
+    return dedupe_statcast_events(events)
 
 
 def _terminal_pa_identity(e: StatcastEvent) -> Tuple[Any, ...]:

--- a/mlb_app/etl.py
+++ b/mlb_app/etl.py
@@ -43,6 +43,7 @@ from .statcast_utils import (
     calculate_batter_aggregates,
     build_pitch_arsenal_from_statcast,
 )
+from .statcast_event_identity import load_canonical_statcast_events
 
 load_dotenv()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -311,13 +312,31 @@ def _upsert_statcast_dataframe(
     fallback_pitcher_id: Optional[int] = None,
     commit_every: int = 1000,
 ) -> Dict[str, int]:
-    stats = {"inserted": 0, "updated": 0, "noop": 0, "skipped": 0}
+    stats = {"inserted": 0, "updated": 0, "noop": 0, "skipped": 0, "input_duplicates": 0}
     if df is None or df.empty:
         return stats
 
-    for idx, (_, row) in enumerate(df.iterrows(), start=1):
+    canonical_values: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
+    legacy_values: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        values = _event_values_from_row(row, fallback_pitcher_id)
+        primary = _primary_pitch_identity(values)
+        if primary is None:
+            legacy_values.append(values)
+            continue
+        existing_values = canonical_values.get(primary)
+        if existing_values is None:
+            canonical_values[primary] = values
+            continue
+        stats["input_duplicates"] += 1
+        for key, value in values.items():
+            if value is not None:
+                existing_values[key] = value
+
+    prepared_values = [*canonical_values.values(), *legacy_values]
+    for idx, values in enumerate(prepared_values, start=1):
         try:
-            status = _upsert_statcast_event(session, _event_values_from_row(row, fallback_pitcher_id))
+            status = _upsert_statcast_event(session, values)
             stats[status] = stats.get(status, 0) + 1
         except Exception as exc:
             log.debug("Statcast row upsert skipped: %s", exc)
@@ -435,15 +454,25 @@ def _query_statcast_events_for_window(
     pitcher_id: Optional[int] = None,
     batter_id: Optional[int] = None,
 ) -> List[StatcastEvent]:
-    query = session.query(StatcastEvent).filter(
+    filters = [
         StatcastEvent.game_date >= start_date,
         StatcastEvent.game_date <= end_date,
-    )
+    ]
     if pitcher_id is not None:
-        query = query.filter(StatcastEvent.pitcher_id == pitcher_id)
+        filters.append(StatcastEvent.pitcher_id == pitcher_id)
     if batter_id is not None:
-        query = query.filter(StatcastEvent.batter_id == batter_id)
-    return query.all()
+        filters.append(StatcastEvent.batter_id == batter_id)
+    events, _ = load_canonical_statcast_events(
+        session,
+        *filters,
+        order_by=(
+            StatcastEvent.game_date.asc(),
+            StatcastEvent.game_pk.asc(),
+            StatcastEvent.at_bat_number.asc(),
+            StatcastEvent.pitch_number.asc(),
+        ),
+    )
+    return events
 
 
 def _load_pitcher_aggregate(session, pitcher_id: int, df: pd.DataFrame, end_date: date) -> None:

--- a/mlb_app/pitcher_intelligence.py
+++ b/mlb_app/pitcher_intelligence.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import datetime as dt
 from collections import defaultdict
 from typing import Any, Dict, Iterable, Optional
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
 from mlb_app.database import PitcherAggregate, StatcastEvent
+from mlb_app.statcast_event_identity import load_canonical_statcast_events
 
 SWINGS = {
     "swinging_strike",
@@ -47,6 +49,7 @@ BUCKET_DEFINITIONS = {
     "heart": "abs(plate_x) <= 0.33 and 2.10 <= plate_z <= 3.30",
     "barrel_approximation": "launch_speed >= 98 and 8 <= launch_angle <= 50",
 }
+MLB_TIMEZONE = ZoneInfo("America/New_York")
 
 
 def _float(value: Any) -> Optional[float]:
@@ -291,24 +294,22 @@ def _release_profile(session: Session, pitcher_id: int, season: int) -> Dict[str
 
 
 def build_pitcher_intelligence_profile(session: Session, pitcher_id: int, season: int, days_back: int = 365) -> Dict[str, Any]:
-    today = dt.datetime.utcnow().date()
-    start_date = max(dt.date(int(season), 1, 1), today - dt.timedelta(days=max(int(days_back), 1)))
-    raw_events = session.query(StatcastEvent).filter(
+    today = dt.datetime.now(MLB_TIMEZONE).date()
+    season_start = dt.date(int(season), 1, 1)
+    end_date = min(today, dt.date(int(season), 12, 31))
+    start_date = max(season_start, end_date - dt.timedelta(days=max(int(days_back), 1)))
+    events, identity_diagnostics = load_canonical_statcast_events(
+        session,
         StatcastEvent.pitcher_id == int(pitcher_id),
         StatcastEvent.game_date >= start_date,
-        StatcastEvent.game_date <= today,
-    ).all()
-
-    seen = set()
-    events = []
-    for event in raw_events:
-        key = (event.game_pk, event.at_bat_number, event.pitch_number, event.pitcher_id, event.batter_id, event.pitch_type)
-        if event.game_pk is None or event.at_bat_number is None or event.pitch_number is None:
-            key = id(event)
-        if key in seen:
-            continue
-        seen.add(key)
-        events.append(event)
+        StatcastEvent.game_date <= end_date,
+        order_by=(
+            StatcastEvent.game_date.asc(),
+            StatcastEvent.game_pk.asc(),
+            StatcastEvent.at_bat_number.asc(),
+            StatcastEvent.pitch_number.asc(),
+        ),
+    )
 
     overall = _empty_counter()
     by_pitch = defaultdict(_empty_counter)
@@ -362,12 +363,27 @@ def build_pitcher_intelligence_profile(session: Session, pitcher_id: int, season
         "season": int(season),
         "days_back": int(days_back),
         "data_window": {"date_start": start_date.isoformat(), "date_end": max(dates).isoformat() if dates else None},
-        "sample_size": {"raw_rows": len(raw_events), "deduped_pitch_rows": len(events), "pitch_types": len(arsenal), "batted_balls": summary["batted_balls"], "pa_ended": summary["pa_ended"]},
+        "sample_size": {
+            "raw_rows": identity_diagnostics["raw_rows"],
+            "deduped_pitch_rows": len(events),
+            "canonical_pitch_rows": identity_diagnostics["canonical_pitch_rows"],
+            "legacy_pitch_rows": identity_diagnostics["legacy_pitch_rows"],
+            "incomplete_identity_rows": identity_diagnostics["incomplete_identity_rows"],
+            "duplicate_rows_removed": identity_diagnostics["duplicate_rows_removed"],
+            "pitch_types": len(arsenal),
+            "batted_balls": summary["batted_balls"],
+            "pa_ended": summary["pa_ended"],
+        },
         "summary": {**summary, "pitch_types_used": [row["pitch_type"] for row in arsenal], "best_pitch": _best(arsenal, "quality_score", True, 20), "riskiest_pitch": _best(arsenal, "damage_score", True, 20)},
         "arsenal": arsenal,
         "location_profile": {"source": "plate_x_plate_z", "bucket_definitions": BUCKET_DEFINITIONS, "buckets": location_rows, "most_attacked_location_bucket": _best(location_rows, "pitches", True, 1), "most_damaged_location_bucket": _best(location_rows, "damage_score", True, 5)},
         "release_profile": release,
         "missing_inputs": sorted(set(missing_inputs)),
-        "quality_flags": [flag for flag in ["no_statcast_events" if not events else None, "barrel_rate_is_internal_approximation" if summary["batted_balls"] else None] if flag],
-        "metadata": {"model_version": "pitcher_intelligence_v1", "location_source": "plate_x/plate_z", "release_source": "pitcher_aggregates", "barrel_definition": BUCKET_DEFINITIONS["barrel_approximation"]},
+        "quality_flags": [flag for flag in [
+            "no_statcast_events" if not events else None,
+            "legacy_duplicate_rows_removed" if identity_diagnostics["duplicate_rows_removed"] else None,
+            "incomplete_pitch_identity_rows_present" if identity_diagnostics["incomplete_identity_rows"] else None,
+            "barrel_rate_is_internal_approximation" if summary["batted_balls"] else None,
+        ] if flag],
+        "metadata": {"model_version": "pitcher_intelligence_v2", "pitch_identity": "game_pk/at_bat_number/pitch_number", "location_source": "plate_x/plate_z", "release_source": "pitcher_aggregates", "barrel_definition": BUCKET_DEFINITIONS["barrel_approximation"]},
     }

--- a/mlb_app/pitcher_leaderboards.py
+++ b/mlb_app/pitcher_leaderboards.py
@@ -4,7 +4,7 @@ import datetime as dt
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import requests
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
 from mlb_app.database import PitchArsenal, PitcherAggregate, StatcastEvent
@@ -53,17 +53,61 @@ def _team(pid: int, identities: Dict[int, Dict[str, Optional[str]]]) -> Optional
 
 
 def _event_samples(session: Session, season: int) -> Dict[int, Dict[str, int]]:
+    season_start = dt.date(int(season), 1, 1)
+    season_end = dt.date(int(season), 12, 31)
+    canonical_pitches = (
+        session.query(
+            StatcastEvent.pitcher_id.label("pitcher_id"),
+            StatcastEvent.game_pk.label("game_pk"),
+            StatcastEvent.at_bat_number.label("at_bat_number"),
+            StatcastEvent.pitch_number.label("pitch_number"),
+            func.max(case((StatcastEvent.launch_speed.isnot(None), 1), else_=0)).label("is_bbe"),
+        )
+        .filter(
+            StatcastEvent.game_date >= season_start,
+            StatcastEvent.game_date <= season_end,
+            StatcastEvent.pitcher_id.isnot(None),
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+        )
+        .group_by(
+            StatcastEvent.pitcher_id,
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+        )
+        .subquery()
+    )
     rows = (
         session.query(
-            StatcastEvent.pitcher_id,
-            func.count(StatcastEvent.id),
-            func.count(StatcastEvent.launch_speed),
+            canonical_pitches.c.pitcher_id,
+            func.count(),
+            func.sum(canonical_pitches.c.is_bbe),
         )
-        .filter(StatcastEvent.game_date >= dt.date(int(season), 1, 1))
-        .group_by(StatcastEvent.pitcher_id)
+        .group_by(canonical_pitches.c.pitcher_id)
         .all()
     )
-    return {int(pid): {"pitches": int(pitches or 0), "batted_balls": int(bbe or 0)} for pid, pitches, bbe in rows if pid}
+    samples = {
+        int(pid): {"pitches": int(pitches or 0), "batted_balls": int(bbe or 0)}
+        for pid, pitches, bbe in rows
+        if pid
+    }
+
+    # The season arsenal is an independent Savant aggregate and is a safer
+    # minimum-sample fallback for pitchers whose legacy rows lack pitch IDs.
+    arsenal_rows = (
+        session.query(PitchArsenal.pitcher_id, func.sum(PitchArsenal.pitch_count))
+        .filter(PitchArsenal.season == int(season))
+        .group_by(PitchArsenal.pitcher_id)
+        .all()
+    )
+    for pitcher_id, pitch_count in arsenal_rows:
+        if not pitcher_id:
+            continue
+        sample = samples.setdefault(int(pitcher_id), {"pitches": 0, "batted_balls": 0})
+        sample["pitches"] = max(sample["pitches"], int(pitch_count or 0))
+    return samples
 
 
 def _latest_aggregates(session: Session, season: int) -> List[PitcherAggregate]:

--- a/mlb_app/pitcher_profile_store.py
+++ b/mlb_app/pitcher_profile_store.py
@@ -102,6 +102,34 @@ def _event_metrics(session: Session, pitcher_id: int, season: int) -> Dict[str, 
     row = session.execute(
         text(
             """
+            WITH ranked_pitches AS (
+                SELECT statcast_events.*,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY game_pk, at_bat_number, pitch_number
+                           ORDER BY (
+                               CASE WHEN description IS NOT NULL AND LOWER(TRIM(description)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                               CASE WHEN events IS NOT NULL AND LOWER(TRIM(events)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                               CASE WHEN pitch_type IS NOT NULL AND LOWER(TRIM(pitch_type)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                               CASE WHEN release_speed IS NOT NULL THEN 1 ELSE 0 END +
+                               CASE WHEN release_spin_rate IS NOT NULL THEN 1 ELSE 0 END +
+                               CASE WHEN plate_x IS NOT NULL THEN 1 ELSE 0 END +
+                               CASE WHEN plate_z IS NOT NULL THEN 1 ELSE 0 END +
+                               CASE WHEN estimated_woba_using_speedangle IS NOT NULL THEN 1 ELSE 0 END +
+                               CASE WHEN estimated_ba_using_speedangle IS NOT NULL THEN 1 ELSE 0 END
+                           ) DESC,
+                           id DESC
+                       ) AS pitch_rank
+                FROM statcast_events
+                WHERE pitcher_id = :pitcher_id
+                  AND game_date >= :start_date
+                  AND game_date <= :end_date
+                  AND game_pk IS NOT NULL
+                  AND at_bat_number IS NOT NULL
+                  AND pitch_number IS NOT NULL
+            ),
+            canonical_pitches AS (
+                SELECT * FROM ranked_pitches WHERE pitch_rank = 1
+            )
             SELECT
                 SUM(CASE WHEN launch_speed IS NOT NULL THEN 1 ELSE 0 END) AS bbe,
                 AVG(estimated_woba_using_speedangle) AS xwoba_allowed,
@@ -117,10 +145,7 @@ def _event_metrics(session: Session, pitcher_id: int, season: int) -> Dict[str, 
                 SUM(CASE WHEN launch_angle < 10 THEN 1 ELSE 0 END) AS gb,
                 SUM(CASE WHEN launch_angle >= 25 THEN 1 ELSE 0 END) AS fb,
                 SUM(CASE WHEN events = 'home_run' THEN 1 ELSE 0 END) AS hr
-            FROM statcast_events
-            WHERE pitcher_id = :pitcher_id
-              AND game_date >= :start_date
-              AND game_date <= :end_date
+            FROM canonical_pitches
             """
         ),
         {"pitcher_id": pitcher_id, "start_date": f"{season}-01-01", "end_date": f"{season}-12-31"},

--- a/mlb_app/player_trends.py
+++ b/mlb_app/player_trends.py
@@ -8,6 +8,7 @@ from sqlalchemy import and_, case, func
 
 from .dashboard_object_models import DashboardPlayer, PlayerTrendSnapshot
 from .database import StatcastEvent
+from .statcast_event_identity import canonical_event_ids_subquery
 from .dashboard_report_types import describe_report_type
 from .db_utils import (
     HBP_EVENTS,
@@ -373,6 +374,13 @@ def _aggregate_pitcher_period(
     player_ids: List[int],
 ) -> Dict[int, Dict[str, Any]]:
     """Compute the pitcher rolling-page metrics in one grouped SQL query."""
+    filters = (
+        StatcastEvent.game_date >= start,
+        StatcastEvent.game_date <= end,
+        StatcastEvent.pitcher_id.isnot(None),
+        StatcastEvent.pitcher_id.in_(player_ids),
+    )
+    canonical_ids = canonical_event_ids_subquery(session, *filters)
     rows = (
         session.query(
             StatcastEvent.pitcher_id.label("player_id"),
@@ -397,12 +405,7 @@ def _aggregate_pitcher_period(
             func.avg(StatcastEvent.pfx_x).label("avg_horiz_break"),
             func.avg(StatcastEvent.pfx_z).label("avg_vert_break"),
         )
-        .filter(
-            StatcastEvent.game_date >= start,
-            StatcastEvent.game_date <= end,
-            StatcastEvent.pitcher_id.isnot(None),
-            StatcastEvent.pitcher_id.in_(player_ids),
-        )
+        .join(canonical_ids, StatcastEvent.id == canonical_ids.c.event_id)
         .group_by(StatcastEvent.pitcher_id)
         .all()
     )

--- a/mlb_app/statcast_event_identity.py
+++ b/mlb_app/statcast_event_identity.py
@@ -1,0 +1,270 @@
+"""Canonical pitch identity and duplicate-safe Statcast reads.
+
+MLB identifies a pitch inside a game by ``game_pk + at_bat_number +
+pitch_number``.  Older application loads did not always populate those fields,
+so legacy rows are only used for pitcher/date scopes that have no canonical
+rows at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Sequence, Tuple
+
+from sqlalchemy import and_, case, func, or_
+from sqlalchemy.orm import Session
+
+from .database import StatcastEvent
+
+
+NULLISH_TEXT = {"", "nan", "none", "null", "na", "n/a"}
+
+
+def has_canonical_pitch_identity(event: StatcastEvent) -> bool:
+    return (
+        event.game_pk is not None
+        and event.at_bat_number is not None
+        and event.pitch_number is not None
+    )
+
+
+def canonical_pitch_key(event: StatcastEvent) -> Tuple[Any, ...] | None:
+    if not has_canonical_pitch_identity(event):
+        return None
+    return (event.game_pk, event.at_bat_number, event.pitch_number)
+
+
+def _clean_text(value: Any) -> Any:
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    return None if normalized in NULLISH_TEXT else normalized
+
+
+def _legacy_pitch_key(event: StatcastEvent) -> Tuple[Any, ...]:
+    """Best available identity for rows created before MLB ordering was stored."""
+
+    return (
+        event.game_date,
+        event.pitcher_id,
+        event.batter_id,
+        _clean_text(event.pitch_type),
+        _clean_text(event.description),
+        _clean_text(event.events),
+        event.inning,
+        _clean_text(event.inning_topbot),
+        event.outs_when_up,
+        event.balls,
+        event.strikes,
+        event.release_speed,
+        event.release_spin_rate,
+        event.pfx_x,
+        event.pfx_z,
+        event.plate_x,
+        event.plate_z,
+        event.launch_speed,
+        event.launch_angle,
+        _clean_text(event.stand),
+        _clean_text(event.p_throws),
+    )
+
+
+def _scope(event: StatcastEvent) -> Tuple[Any, ...]:
+    return (event.game_date, event.pitcher_id)
+
+
+def _event_quality(event: StatcastEvent) -> Tuple[int, int]:
+    fields = (
+        event.pitch_type,
+        event.description,
+        event.events,
+        event.release_speed,
+        event.release_spin_rate,
+        event.pfx_x,
+        event.pfx_z,
+        event.plate_x,
+        event.plate_z,
+        event.launch_speed,
+        event.launch_angle,
+        event.estimated_woba_using_speedangle,
+        event.estimated_ba_using_speedangle,
+        event.stand,
+        event.p_throws,
+        event.home_team,
+        event.away_team,
+    )
+    populated = sum(
+        value is not None and (not isinstance(value, str) or _clean_text(value) is not None)
+        for value in fields
+    )
+    return populated, int(event.id or 0)
+
+
+def dedupe_statcast_events(events: Iterable[StatcastEvent]) -> List[StatcastEvent]:
+    """Return one best row per pitch and suppress shadowed legacy copies.
+
+    If a pitcher/date has canonical MLB pitch identities, incomplete legacy
+    rows from that same scope are ignored.  This prevents old overlapping ETL
+    snapshots from being added to the canonical game rows.
+    """
+
+    rows = list(events)
+    canonical_scopes = {_scope(event) for event in rows if has_canonical_pitch_identity(event)}
+    selected: dict[Tuple[Any, ...], Tuple[int, StatcastEvent]] = {}
+
+    for position, event in enumerate(rows):
+        canonical = canonical_pitch_key(event)
+        if canonical is None and _scope(event) in canonical_scopes:
+            continue
+        key = ("canonical", *canonical) if canonical is not None else ("legacy", *_legacy_pitch_key(event))
+        existing = selected.get(key)
+        if existing is None:
+            selected[key] = (position, event)
+            continue
+        if _event_quality(event) > _event_quality(existing[1]):
+            selected[key] = (existing[0], event)
+
+    return [event for _, event in sorted(selected.values(), key=lambda item: item[0])]
+
+
+def canonical_event_ids_subquery(session: Session, *filters: Any):
+    """Return IDs for the richest row at each canonical MLB pitch identity."""
+
+    text_quality = sum(
+        case(
+            (
+                and_(
+                    column.isnot(None),
+                    func.lower(func.trim(column)).notin_(tuple(NULLISH_TEXT)),
+                ),
+                1,
+            ),
+            else_=0,
+        )
+        for column in (StatcastEvent.pitch_type, StatcastEvent.description, StatcastEvent.events)
+    )
+    numeric_quality = sum(
+        case((column.isnot(None), 1), else_=0)
+        for column in (
+            StatcastEvent.release_speed,
+            StatcastEvent.release_spin_rate,
+            StatcastEvent.pfx_x,
+            StatcastEvent.pfx_z,
+            StatcastEvent.plate_x,
+            StatcastEvent.plate_z,
+            StatcastEvent.launch_speed,
+            StatcastEvent.launch_angle,
+            StatcastEvent.estimated_woba_using_speedangle,
+            StatcastEvent.estimated_ba_using_speedangle,
+        )
+    )
+    quality = text_quality + numeric_quality
+    ranked = (
+        session.query(
+            StatcastEvent.id.label("event_id"),
+            func.row_number()
+            .over(
+                partition_by=(
+                    StatcastEvent.game_pk,
+                    StatcastEvent.at_bat_number,
+                    StatcastEvent.pitch_number,
+                ),
+                order_by=(quality.desc(), StatcastEvent.id.desc()),
+            )
+            .label("pitch_rank"),
+        )
+        .filter(
+            *filters,
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+        )
+        .subquery()
+    )
+    return (
+        session.query(ranked.c.event_id)
+        .filter(ranked.c.pitch_rank == 1)
+        .subquery()
+    )
+
+
+def load_canonical_statcast_events(
+    session: Session,
+    *filters: Any,
+    order_by: Sequence[Any] | None = None,
+) -> Tuple[List[StatcastEvent], dict[str, int]]:
+    """Load duplicate-safe events plus warehouse quality diagnostics."""
+
+    raw_query = session.query(StatcastEvent).filter(*filters)
+    raw_rows = int(raw_query.with_entities(func.count(StatcastEvent.id)).scalar() or 0)
+    complete_rows = int(
+        raw_query.with_entities(func.count(StatcastEvent.id))
+        .filter(
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+        )
+        .scalar()
+        or 0
+    )
+
+    ids = canonical_event_ids_subquery(session, *filters)
+    canonical_query = session.query(StatcastEvent).join(ids, StatcastEvent.id == ids.c.event_id)
+    if order_by:
+        canonical_query = canonical_query.order_by(*order_by)
+    canonical = canonical_query.all()
+
+    # Preserve genuinely legacy-only dates, but never add legacy snapshots on
+    # top of canonical rows for the same pitcher and date.
+    legacy: List[StatcastEvent] = []
+    if complete_rows == 0:
+        legacy = dedupe_statcast_events(raw_query.all())
+    elif complete_rows < raw_rows:
+        canonical_scopes = (
+            session.query(
+                StatcastEvent.game_date.label("game_date"),
+                StatcastEvent.pitcher_id.label("pitcher_id"),
+            )
+            .filter(
+                *filters,
+                StatcastEvent.game_pk.isnot(None),
+                StatcastEvent.at_bat_number.isnot(None),
+                StatcastEvent.pitch_number.isnot(None),
+            )
+            .distinct()
+            .subquery()
+        )
+        legacy_rows = (
+            raw_query.outerjoin(
+                canonical_scopes,
+                and_(
+                    canonical_scopes.c.game_date == StatcastEvent.game_date,
+                    canonical_scopes.c.pitcher_id == StatcastEvent.pitcher_id,
+                ),
+            )
+            .filter(
+                or_(
+                    StatcastEvent.game_pk.is_(None),
+                    StatcastEvent.at_bat_number.is_(None),
+                    StatcastEvent.pitch_number.is_(None),
+                ),
+                canonical_scopes.c.game_date.is_(None),
+            )
+            .all()
+        )
+        legacy = dedupe_statcast_events(legacy_rows)
+
+    events = canonical + legacy
+    if order_by:
+        # SQL ordering applies to canonical rows; legacy-only rows are rare and
+        # are sorted deterministically for downstream calculations.
+        events.sort(key=lambda event: (event.game_date, int(event.id or 0)))
+
+    diagnostics = {
+        "raw_rows": raw_rows,
+        "complete_identity_rows": complete_rows,
+        "incomplete_identity_rows": max(raw_rows - complete_rows, 0),
+        "canonical_pitch_rows": len(canonical),
+        "legacy_pitch_rows": len(legacy),
+        "duplicate_rows_removed": max(raw_rows - len(events), 0),
+    }
+    return events, diagnostics

--- a/scripts/repair_statcast_pitch_identity.py
+++ b/scripts/repair_statcast_pitch_identity.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Audit and repair duplicate rows in ``statcast_events``.
+
+Dry-run is the default.  ``--apply`` performs one transaction that:
+
+1. keeps the richest/latest row for every canonical MLB pitch identity;
+2. removes incomplete legacy rows shadowed by canonical rows for the same
+   pitcher and date;
+3. collapses exact remaining legacy copies; and
+4. installs a partial unique index that prevents canonical duplicates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from sqlalchemy import func, or_, text
+from sqlalchemy.orm import aliased
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from mlb_app.database import StatcastEvent, get_engine, get_session
+
+
+INDEX_NAME = "ux_statcast_events_pitch_identity"
+
+
+def _scope_filter(pitcher_id: Optional[int]):
+    return (StatcastEvent.pitcher_id == int(pitcher_id),) if pitcher_id is not None else ()
+
+
+def audit(session, pitcher_id: Optional[int] = None) -> Dict[str, int]:
+    scope = _scope_filter(pitcher_id)
+    complete = (
+        StatcastEvent.game_pk.isnot(None),
+        StatcastEvent.at_bat_number.isnot(None),
+        StatcastEvent.pitch_number.isnot(None),
+    )
+    incomplete = or_(
+        StatcastEvent.game_pk.is_(None),
+        StatcastEvent.at_bat_number.is_(None),
+        StatcastEvent.pitch_number.is_(None),
+    )
+    total_rows = int(session.query(func.count(StatcastEvent.id)).filter(*scope).scalar() or 0)
+    complete_rows = int(
+        session.query(func.count(StatcastEvent.id)).filter(*scope, *complete).scalar() or 0
+    )
+    canonical_groups = (
+        session.query(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+        )
+        .filter(*scope, *complete)
+        .group_by(
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+        )
+        .subquery()
+    )
+    canonical_pitches = int(session.query(func.count()).select_from(canonical_groups).scalar() or 0)
+
+    canonical = aliased(StatcastEvent)
+    shadowed_query = session.query(func.count(StatcastEvent.id)).filter(*scope, incomplete).filter(
+        session.query(canonical.id)
+        .filter(
+            canonical.pitcher_id == StatcastEvent.pitcher_id,
+            canonical.game_date == StatcastEvent.game_date,
+            canonical.game_pk.isnot(None),
+            canonical.at_bat_number.isnot(None),
+            canonical.pitch_number.isnot(None),
+        )
+        .exists()
+    )
+    shadowed_legacy_rows = int(shadowed_query.scalar() or 0)
+    return {
+        "total_rows": total_rows,
+        "complete_identity_rows": complete_rows,
+        "canonical_pitches": canonical_pitches,
+        "duplicate_complete_rows": max(complete_rows - canonical_pitches, 0),
+        "incomplete_identity_rows": max(total_rows - complete_rows, 0),
+        "shadowed_legacy_rows": shadowed_legacy_rows,
+    }
+
+
+def _sql_scope(pitcher_id: Optional[int], alias: str = "") -> tuple[str, Dict[str, Any]]:
+    if pitcher_id is None:
+        return "", {}
+    prefix = f"{alias}." if alias else ""
+    return f" AND {prefix}pitcher_id = :pitcher_id", {"pitcher_id": int(pitcher_id)}
+
+
+def repair(engine, pitcher_id: Optional[int] = None) -> Dict[str, Any]:
+    Session = get_session(engine)
+    with Session() as session:
+        before = audit(session, pitcher_id)
+
+    scope_sql, params = _sql_scope(pitcher_id)
+    legacy_partition = ", ".join(
+        (
+            "game_date",
+            "pitcher_id",
+            "batter_id",
+            "pitch_type",
+            "description",
+            "events",
+            "inning",
+            "inning_topbot",
+            "outs_when_up",
+            "balls",
+            "strikes",
+            "release_speed",
+            "release_spin_rate",
+            "pfx_x",
+            "pfx_z",
+            "plate_x",
+            "plate_z",
+            "launch_speed",
+            "launch_angle",
+            "stand",
+            "p_throws",
+        )
+    )
+
+    with engine.begin() as connection:
+        duplicate_result = connection.execute(
+            text(
+                f"""
+                WITH ranked AS (
+                    SELECT id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY game_pk, at_bat_number, pitch_number
+                               ORDER BY (
+                                   CASE WHEN description IS NOT NULL AND LOWER(TRIM(description)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                                   CASE WHEN events IS NOT NULL AND LOWER(TRIM(events)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                                   CASE WHEN pitch_type IS NOT NULL AND LOWER(TRIM(pitch_type)) NOT IN ('', 'nan', 'none', 'null', 'na', 'n/a') THEN 1 ELSE 0 END +
+                                   CASE WHEN release_speed IS NOT NULL THEN 1 ELSE 0 END +
+                                   CASE WHEN release_spin_rate IS NOT NULL THEN 1 ELSE 0 END +
+                                   CASE WHEN plate_x IS NOT NULL THEN 1 ELSE 0 END +
+                                   CASE WHEN plate_z IS NOT NULL THEN 1 ELSE 0 END +
+                                   CASE WHEN estimated_woba_using_speedangle IS NOT NULL THEN 1 ELSE 0 END +
+                                   CASE WHEN estimated_ba_using_speedangle IS NOT NULL THEN 1 ELSE 0 END
+                               ) DESC,
+                               id DESC
+                           ) AS pitch_rank
+                    FROM statcast_events
+                    WHERE game_pk IS NOT NULL
+                      AND at_bat_number IS NOT NULL
+                      AND pitch_number IS NOT NULL
+                      {scope_sql}
+                )
+                DELETE FROM statcast_events
+                WHERE id IN (SELECT id FROM ranked WHERE pitch_rank > 1)
+                """
+            ),
+            params,
+        )
+
+        legacy_scope_sql, legacy_params = _sql_scope(pitcher_id, "statcast_events")
+        shadowed_result = connection.execute(
+            text(
+                f"""
+                DELETE FROM statcast_events
+                WHERE (
+                    game_pk IS NULL OR at_bat_number IS NULL OR pitch_number IS NULL
+                )
+                {legacy_scope_sql}
+                AND EXISTS (
+                    SELECT 1
+                    FROM statcast_events AS canonical
+                    WHERE canonical.pitcher_id = statcast_events.pitcher_id
+                      AND canonical.game_date = statcast_events.game_date
+                      AND canonical.game_pk IS NOT NULL
+                      AND canonical.at_bat_number IS NOT NULL
+                      AND canonical.pitch_number IS NOT NULL
+                )
+                """
+            ),
+            legacy_params,
+        )
+
+        legacy_result = connection.execute(
+            text(
+                f"""
+                WITH ranked_legacy AS (
+                    SELECT id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY {legacy_partition}
+                               ORDER BY id DESC
+                           ) AS legacy_rank
+                    FROM statcast_events
+                    WHERE (game_pk IS NULL OR at_bat_number IS NULL OR pitch_number IS NULL)
+                    {scope_sql}
+                )
+                DELETE FROM statcast_events
+                WHERE id IN (SELECT id FROM ranked_legacy WHERE legacy_rank > 1)
+                """
+            ),
+            params,
+        )
+
+        # A player-scoped repair cannot safely create a table-wide barrier.
+        if pitcher_id is None:
+            connection.execute(
+                text(
+                    f"""
+                    CREATE UNIQUE INDEX IF NOT EXISTS {INDEX_NAME}
+                    ON statcast_events (game_pk, at_bat_number, pitch_number)
+                    WHERE game_pk IS NOT NULL
+                      AND at_bat_number IS NOT NULL
+                      AND pitch_number IS NOT NULL
+                    """
+                )
+            )
+
+        TransactionSession = get_session(connection)
+        with TransactionSession() as validation_session:
+            after = audit(validation_session, pitcher_id)
+        if after["canonical_pitches"] != before["canonical_pitches"]:
+            raise RuntimeError("Repair changed the canonical pitch count; transaction rolled back.")
+        if after["duplicate_complete_rows"] != 0:
+            raise RuntimeError("Canonical duplicates remain after repair; transaction rolled back.")
+
+    return {
+        "scope": {"pitcher_id": pitcher_id},
+        "before": before,
+        "after": after,
+        "deleted": {
+            "complete_duplicates": max(before["duplicate_complete_rows"] - after["duplicate_complete_rows"], 0),
+            "shadowed_legacy": max(before["shadowed_legacy_rows"] - after["shadowed_legacy_rows"], 0),
+            "remaining_legacy_duplicates": max(
+                before["total_rows"]
+                - after["total_rows"]
+                - before["duplicate_complete_rows"]
+                - before["shadowed_legacy_rows"],
+                0,
+            ),
+        },
+        "rowcount_hints": {
+            "complete_delete": duplicate_result.rowcount,
+            "shadowed_delete": shadowed_result.rowcount,
+            "legacy_delete": legacy_result.rowcount,
+        },
+        "unique_index_installed": pitcher_id is None,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Perform the repair transaction.")
+    parser.add_argument("--pitcher-id", type=int, help="Limit audit/repair to one MLB pitcher ID.")
+    args = parser.parse_args()
+
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise SystemExit("DATABASE_URL is required; no database was changed.")
+    engine = get_engine(database_url)
+    Session = get_session(engine)
+    if not args.apply:
+        with Session() as session:
+            result = {
+                "mode": "dry_run",
+                "scope": {"pitcher_id": args.pitcher_id},
+                "audit": audit(session, args.pitcher_id),
+                "next_step": "Re-run with --apply after reviewing these counts.",
+            }
+    else:
+        result = {"mode": "applied", **repair(engine, args.pitcher_id)}
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_datewide_statcast_refresh.py
+++ b/tests/test_datewide_statcast_refresh.py
@@ -137,6 +137,20 @@ def test_refresh_statcast_events_for_date_updates_existing_non_null_values(monke
         assert row.events == "strikeout"
 
 
+def test_refresh_collapses_duplicate_pitch_identities_inside_one_source_batch(monkeypatch, tmp_path):
+    Session = _session_factory(tmp_path)
+    duplicated = pd.concat([_sample_statcast_df(), _sample_statcast_df().iloc[[0]]], ignore_index=True)
+    monkeypatch.setattr(etl, "fetch_statcast_all_events", lambda start, end: duplicated)
+
+    with Session() as session:
+        result = etl.refresh_statcast_events_for_date(session, "2026-05-18")
+
+        assert result["rows_returned"] == 3
+        assert result["input_duplicates"] == 1
+        assert result["inserted"] == 2
+        assert session.query(StatcastEvent).count() == 2
+
+
 def test_recompute_recent_aggregates_from_events_creates_pitcher_and_batter_90d_rows(monkeypatch, tmp_path):
     Session = _session_factory(tmp_path)
     monkeypatch.setattr(etl, "fetch_statcast_all_events", lambda start, end: _sample_statcast_df())

--- a/tests/test_pitcher_intelligence.py
+++ b/tests/test_pitcher_intelligence.py
@@ -1,12 +1,17 @@
 import datetime as dt
 
+from sqlalchemy import text
+
 from mlb_app.database import PitcherAggregate, StatcastEvent, create_tables, get_engine, get_session
 from mlb_app.pitcher_intelligence import build_pitcher_intelligence_profile, location_bucket
 
 
-def _session():
+def _session(*, allow_duplicates=False):
     engine = get_engine("sqlite:///:memory:")
     create_tables(engine)
+    if allow_duplicates:
+        with engine.begin() as connection:
+            connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
     Session = get_session(engine)
     return Session()
 
@@ -56,7 +61,7 @@ def test_pitcher_intelligence_returns_stable_shape_and_metrics():
     payload = build_pitcher_intelligence_profile(session, pitcher_id=100, season=dt.date.today().year, days_back=365)
 
     assert payload["source"] == "statcast_events"
-    assert payload["metadata"]["model_version"] == "pitcher_intelligence_v1"
+    assert payload["metadata"]["model_version"] == "pitcher_intelligence_v2"
     assert payload["sample_size"]["deduped_pitch_rows"] == 3
     assert len(payload["arsenal"]) == 2
     ff = next(row for row in payload["arsenal"] if row["pitch_type"] == "FF")
@@ -99,3 +104,50 @@ def test_pitcher_intelligence_reports_missing_plate_location():
 
     assert "plate_x_plate_z" in payload["missing_inputs"]
     assert payload["location_profile"]["buckets"] == []
+
+
+def test_pitcher_intelligence_uses_one_richest_canonical_pitch_and_ignores_shadowed_legacy_rows():
+    session = _session(allow_duplicates=True)
+    session.add_all([
+        _event(description=None, pitch_type="nan", release_speed=None),
+        _event(description="swinging_strike", pitch_type="FF", release_speed=99.0),
+        _event(game_pk=None, at_bat_number=None, pitch_number=None, description="swinging_strike"),
+        _event(game_pk=None, at_bat_number=None, pitch_number=None, description="swinging_strike"),
+    ])
+    session.commit()
+
+    payload = build_pitcher_intelligence_profile(
+        session,
+        pitcher_id=100,
+        season=dt.date.today().year,
+        days_back=365,
+    )
+
+    assert payload["sample_size"]["raw_rows"] == 4
+    assert payload["sample_size"]["deduped_pitch_rows"] == 1
+    assert payload["sample_size"]["canonical_pitch_rows"] == 1
+    assert payload["sample_size"]["incomplete_identity_rows"] == 2
+    assert payload["sample_size"]["duplicate_rows_removed"] == 3
+    assert payload["summary"]["pitches"] == 1
+    assert payload["summary"]["swings"] == 1
+    assert payload["arsenal"][0]["pitch_type"] == "FF"
+
+
+def test_pitcher_intelligence_caps_requested_season_at_december_31():
+    session = _session()
+    requested_season = dt.date.today().year - 1
+    session.add_all([
+        _event(game_date=dt.date(requested_season, 7, 1)),
+        _event(game_date=dt.date(requested_season + 1, 4, 1), game_pk=2),
+    ])
+    session.commit()
+
+    payload = build_pitcher_intelligence_profile(
+        session,
+        pitcher_id=100,
+        season=requested_season,
+        days_back=3650,
+    )
+
+    assert payload["sample_size"]["deduped_pitch_rows"] == 1
+    assert payload["data_window"]["date_end"] == f"{requested_season}-07-01"

--- a/tests/test_pitcher_statcast_profile_integrity.py
+++ b/tests/test_pitcher_statcast_profile_integrity.py
@@ -1,0 +1,75 @@
+import datetime as dt
+
+from sqlalchemy import text
+
+from mlb_app.database import PitchArsenal, StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.pitcher_leaderboards import _event_samples
+from mlb_app.pitcher_profile_store import _event_metrics
+
+
+def _session_with_legacy_duplicates():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    with engine.begin() as connection:
+        connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
+    return get_session(engine)()
+
+
+def _event(**overrides):
+    values = {
+        "game_date": dt.date(2026, 8, 9),
+        "game_pk": 823751,
+        "at_bat_number": 1,
+        "pitch_number": 1,
+        "pitcher_id": 694819,
+        "batter_id": 100,
+        "pitch_type": "FF",
+        "description": "hit_into_play",
+        "events": "field_out",
+        "release_speed": 100.0,
+        "release_spin_rate": 2500.0,
+        "launch_speed": 100.0,
+        "launch_angle": 20.0,
+        "estimated_woba_using_speedangle": 0.250,
+        "estimated_ba_using_speedangle": 0.200,
+    }
+    values.update(overrides)
+    return StatcastEvent(**values)
+
+
+def test_pitcher_leaderboard_samples_count_canonical_pitches_not_raw_rows():
+    session = _session_with_legacy_duplicates()
+    session.add_all([_event(), _event(), _event(game_pk=None, at_bat_number=None, pitch_number=None)])
+    session.add(PitchArsenal(season=2026, pitcher_id=694819, pitch_type="FF", pitch_count=1))
+    session.commit()
+
+    samples = _event_samples(session, 2026)
+
+    assert samples[694819] == {"pitches": 1, "batted_balls": 1}
+
+
+def test_pitcher_profile_event_metrics_use_richest_canonical_copy():
+    session = _session_with_legacy_duplicates()
+    session.add_all([
+        _event(
+            pitch_type="nan",
+            description=None,
+            events=None,
+            release_speed=None,
+            release_spin_rate=None,
+            launch_speed=None,
+            launch_angle=None,
+            estimated_woba_using_speedangle=None,
+            estimated_ba_using_speedangle=None,
+        ),
+        _event(),
+        _event(game_pk=None, at_bat_number=None, pitch_number=None, estimated_woba_using_speedangle=0.900),
+    ])
+    session.commit()
+
+    metrics = _event_metrics(session, 694819, 2026)
+
+    assert metrics["xwoba_allowed"] == 0.25
+    assert metrics["xba_allowed"] == 0.2
+    assert metrics["hard_hit_pct"] == 1.0
+    assert metrics["avg_velocity"] == 100.0

--- a/tests/test_statcast_event_identity.py
+++ b/tests/test_statcast_event_identity.py
@@ -1,0 +1,76 @@
+import datetime as dt
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.statcast_event_identity import dedupe_statcast_events
+from scripts.repair_statcast_pitch_identity import audit, repair
+
+
+def _event(**overrides):
+    values = {
+        "game_date": dt.date(2026, 8, 9),
+        "game_pk": 823751,
+        "at_bat_number": 1,
+        "pitch_number": 1,
+        "pitcher_id": 694819,
+        "batter_id": 100,
+        "pitch_type": "FF",
+        "description": "called_strike",
+        "release_speed": 101.0,
+    }
+    values.update(overrides)
+    return StatcastEvent(**values)
+
+
+def test_python_dedupe_prefers_canonical_rows_and_richest_correction():
+    poor = _event(id=1, pitch_type="nan", description=None, release_speed=None)
+    rich = _event(id=2, events="strikeout")
+    legacy = _event(id=3, game_pk=None, at_bat_number=None, pitch_number=None)
+
+    result = dedupe_statcast_events([poor, legacy, rich])
+
+    assert result == [rich]
+    assert result[0].events == "strikeout"
+
+
+def test_repair_removes_duplicates_and_installs_unique_pitch_barrier(tmp_path):
+    database_path = tmp_path / "statcast-repair.sqlite"
+    engine = get_engine(f"sqlite:///{database_path}")
+    create_tables(engine)
+    with engine.begin() as connection:
+        connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
+
+    Session = get_session(engine)
+    with Session() as session:
+        session.add_all([
+            _event(description=None, release_speed=None),
+            _event(events="strikeout"),
+            _event(game_pk=None, at_bat_number=None, pitch_number=None),
+            _event(game_pk=None, at_bat_number=None, pitch_number=None),
+        ])
+        session.commit()
+        before = audit(session)
+
+    assert before == {
+        "total_rows": 4,
+        "complete_identity_rows": 2,
+        "canonical_pitches": 1,
+        "duplicate_complete_rows": 1,
+        "incomplete_identity_rows": 2,
+        "shadowed_legacy_rows": 2,
+    }
+
+    result = repair(engine)
+
+    assert result["after"]["total_rows"] == 1
+    assert result["after"]["canonical_pitches"] == 1
+    assert result["after"]["duplicate_complete_rows"] == 0
+    assert result["unique_index_installed"] is True
+
+    with Session() as session:
+        session.add(_event())
+        with pytest.raises(IntegrityError):
+            session.commit()


### PR DESCRIPTION
## Summary

- define one canonical MLB pitch identity `(game_pk, at_bat_number, pitch_number)` and use it across pitcher intelligence, profiles, trends, and leaderboards
- fix requested-season bounds and make report-date defaults explicitly use `America/New_York`
- deduplicate ETL input before upsert and add a partial unique database index for complete pitch identities
- add an audit-first, transactional repair command for duplicate legacy Statcast rows

## Production symptom

Jacob Misiorowski (MLBAM 694819) showed 127,935 stored rows and 54,031 reported 2026 pitches. Baseball Savant has 1,985 unique 2026 pitch IDs for the same player. Skubal and Cease showed the same inflation pattern, confirming this is a systemic identity/deduplication defect rather than real pitch volume.

The immediate read-path fix collapses those repeated rows to their canonical MLB pitch identity. In a production-shaped fixture with 49,625 stored rows representing 1,985 pitches, the result is exactly 1,985 tracked pitches.

## Validation

- 21 targeted tests pass
- synthetic 49,625-row corruption fixture resolves to 1,985 canonical pitches in 0.32 seconds
- repair transaction preserves canonical pitch counts and validates that no complete duplicate identities remain
- Python compilation and whitespace checks pass
- the broad all-repository test command was stopped because an unrelated test attempted cloud metadata access; two existing collection errors remain in `test_matchup_profile_contract.py` and `test_pitcher_handedness_resolution.py` due to a missing `get_player_splits` import

## Deployment / database cleanup

Deploying this branch corrects the displayed/read counts immediately. Existing duplicate database rows should then be audited and repaired against the production `DATABASE_URL`:

```bash
python scripts/repair_statcast_pitch_identity.py --pitcher-id 694819
python scripts/repair_statcast_pitch_identity.py
python scripts/repair_statcast_pitch_identity.py --apply
```

The first two commands are dry runs. The final command performs one validated transaction, removes duplicate/shadow rows, and installs the unique partial index for existing databases.