### PR TITLE
Repair canonical batter Statcast profiles

### DIFF
--- a/frontend/src/pages/BatterPage.jsx
+++ b/frontend/src/pages/BatterPage.jsx
@@ -646,14 +646,14 @@ export default function BatterPage() {
                     Season Stats <span style={s.sourceBadge}>MLB Stats API</span>
                   </div>
                   <div style={s.statsGrid}>
-                    <StatCard label="AVG" value={fmt(ss.avg, 3)} />
-                    <StatCard label="OBP" value={fmt(ss.obp, 3)} />
-                    <StatCard label="SLG" value={fmt(ss.slg, 3)} />
+                    <StatCard label="AVG" value={fmt(ss.batting_avg ?? ss.avg, 3)} />
+                    <StatCard label="OBP" value={fmt(ss.on_base_pct ?? ss.obp, 3)} />
+                    <StatCard label="SLG" value={fmt(ss.slugging_pct ?? ss.slg, 3)} />
                     <StatCard label="OPS" value={fmt(ss.ops, 3)} />
                     <StatCard label="HR" value={num(ss.hr)} />
                     <StatCard label="RBI" value={num(ss.rbi)} />
                     <StatCard label="SB" value={num(ss.sb)} />
-                    <StatCard label="PA" value={num(ss.plate_appearances)} />
+                    <StatCard label="PA" value={num(ss.pa ?? ss.plate_appearances)} />
                   </div>
                 </div>
               )}

--- a/mlb_app/batter_data_contract.py
+++ b/mlb_app/batter_data_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from sqlalchemy import func
@@ -11,8 +12,8 @@ from .db_utils import (
     _calculate_batter_stats,
     _dedupe_terminal_pas,
     _is_true_ab_event,
-    _ordered_batter_terminal_query,
     get_batter_data_quality,
+    load_canonical_batter_events,
 )
 
 STATCAST_ROLLING_SOURCE = "postgres_statcast_events_deduped_terminal_pa"
@@ -44,21 +45,50 @@ def parse_window_list(raw: Optional[str], defaults: Iterable[int], *, minimum: i
 def _quality_with_source(session: Session, batter_id: int, removed: int = 0) -> Dict[str, Any]:
     quality = dict(get_batter_data_quality(session, batter_id) or {})
     quality["source"] = STATCAST_ROLLING_SOURCE
-    quality["dedupe_policy"] = "terminal PA identity: game_pk + at_bat_number + pitcher_id + batter_id"
+    quality["dedupe_policy"] = "canonical MLB pitch identity, then terminal PA identity"
     quality["duplicate_terminal_pa_rows_removed_in_window"] = removed
+    quality["duplicate_terminal_pa_rows_removed_in_warehouse"] = removed
     warnings = list(quality.get("warnings") or [])
     if removed:
-        warnings.append(f"Removed {removed} duplicate terminal PA row(s) before calculating this rolling window.")
+        warnings.append(
+            f"Ignored {removed} duplicate terminal PA row(s) in the warehouse before calculating this window."
+        )
     quality["warnings"] = warnings
     return quality
 
 
 def _clean_terminal_events(session: Session, batter_id: int, requested: int, *, multiplier: int = 4) -> Tuple[List[StatcastEvent], int]:
-    raw_limit = max(requested * multiplier, requested + 50)
-    raw_events = _ordered_batter_terminal_query(session, batter_id).limit(raw_limit).all()
-    deduped = _dedupe_terminal_pas(raw_events)
-    removed = max(len(raw_events) - len(deduped), 0)
-    return deduped, removed
+    del multiplier  # Kept in the signature for callers using the older contract.
+    canonical_events, _ = load_canonical_batter_events(session, batter_id)
+    canonical_events = [
+        event for event in canonical_events if event.events in TERMINAL_EVENTS
+    ]
+    canonical_events.sort(
+        key=lambda event: (
+            event.game_date or datetime.date.min,
+            int(event.game_pk or 0),
+            int(event.at_bat_number or 0),
+            int(event.pitch_number or 0),
+            int(event.id or 0),
+        ),
+        reverse=True,
+    )
+    deduped = _dedupe_terminal_pas(canonical_events)
+    raw_terminal_cache_key = f"raw_batter_terminal_count:{int(batter_id)}"
+    raw_terminal_count = session.info.get(raw_terminal_cache_key)
+    if raw_terminal_count is None:
+        raw_terminal_count = int(
+            session.query(func.count(StatcastEvent.id))
+            .filter(
+                StatcastEvent.batter_id == batter_id,
+                StatcastEvent.events.in_(TERMINAL_EVENTS),
+            )
+            .scalar()
+            or 0
+        )
+        session.info[raw_terminal_cache_key] = raw_terminal_count
+    removed = max(raw_terminal_count - len(deduped), 0)
+    return deduped[:requested], removed
 
 
 def clean_rolling_by_pa(session: Session, batter_id: int, n_pa: int) -> Optional[Dict[str, Any]]:
@@ -115,20 +145,28 @@ def clean_rolling_by_games(session: Session, batter_id: int, n_games: int) -> Op
     if not game_rows:
         return None
     game_pks = [row.game_pk for row in game_rows]
-    raw_events = (
-        session.query(StatcastEvent)
+    raw_event_count = int(
+        session.query(func.count(StatcastEvent.id))
         .filter(
             StatcastEvent.batter_id == batter_id,
             StatcastEvent.game_pk.in_(game_pks),
             StatcastEvent.events.in_(TERMINAL_EVENTS),
         )
-        .all()
+        .scalar()
+        or 0
     )
-    events = _dedupe_terminal_pas(raw_events)
-    removed = max(len(raw_events) - len(events), 0)
+    canonical_events, _ = load_canonical_batter_events(session, batter_id)
+    events = _dedupe_terminal_pas(
+        [
+            event
+            for event in canonical_events
+            if event.game_pk in game_pks and event.events in TERMINAL_EVENTS
+        ]
+    )
+    removed = max(raw_event_count - len(events), 0)
     if not events:
         return None
-    stats = _calculate_batter_stats(events, raw_event_count=len(raw_events))
+    stats = _calculate_batter_stats(events, raw_event_count=raw_event_count)
     stats.update({
         "actual_games": len(game_pks),
         "requested_games": n_games,

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -28,6 +28,7 @@ from .db_utils import (
     get_batter_data_quality,
     get_batter_leaderboards,
     get_batter_multi_season,
+    get_batter_statcast_profile,
     get_player_splits_multi_season,
 )
 from .pitcher_intelligence import MLB_TIMEZONE, build_pitcher_intelligence_profile
@@ -108,6 +109,9 @@ def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
         pa = s.get("plateAppearances") or 0
         k = s.get("strikeOuts") or 0
         bb = s.get("baseOnBalls") or 0
+        batting_avg = _safe_float(s.get("avg"))
+        on_base_pct = _safe_float(s.get("obp"))
+        slugging_pct = _safe_float(s.get("slg"))
         return {
             "g": s.get("gamesPlayed"),
             "ab": s.get("atBats"),
@@ -121,13 +125,18 @@ def _fetch_batter_live_data(player_id: int, season: int) -> Dict[str, Any]:
             "sb": s.get("stolenBases"),
             "bb": bb,
             "k": k,
-            "batting_avg": _safe_float(s.get("avg")),
-            "on_base_pct": _safe_float(s.get("obp")),
-            "slugging_pct": _safe_float(s.get("slg")),
+            "batting_avg": batting_avg,
+            "on_base_pct": on_base_pct,
+            "slugging_pct": slugging_pct,
             "ops": _safe_float(s.get("ops")),
             "k_pct": round(k / pa, 3) if pa > 0 else None,
             "bb_pct": round(bb / pa, 3) if pa > 0 else None,
             "home_runs": s.get("homeRuns"),
+            # Stable aliases retained for existing profile clients.
+            "avg": batting_avg,
+            "obp": on_base_pct,
+            "slg": slugging_pct,
+            "plate_appearances": pa,
         }
 
     try:
@@ -177,6 +186,68 @@ def _aggregate_to_dict(agg) -> Optional[Dict[str, Any]]:
     if not agg:
         return None
     return {"avg_exit_velocity": agg.avg_exit_velocity, "avg_launch_angle": agg.avg_launch_angle, "hard_hit_pct": agg.hard_hit_pct, "barrel_pct": agg.barrel_pct, "k_pct": agg.k_pct, "bb_pct": agg.bb_pct, "batting_avg": agg.batting_avg, "end_date": agg.end_date.isoformat() if agg.end_date else None, "window": agg.window, "source": "postgres_batter_aggregates"}
+
+
+def _statcast_profile_to_aggregate(profile: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not profile:
+        return None
+    fields = (
+        "avg_exit_velocity",
+        "avg_launch_angle",
+        "hard_hit_pct",
+        "barrel_pct",
+        "k_pct",
+        "bb_pct",
+        "batting_avg",
+        "end_date",
+        "window",
+        "source",
+        "actual_pa",
+        "canonical_pitch_rows",
+        "duplicate_rows_removed",
+    )
+    return {field: profile.get(field) for field in fields}
+
+
+def _canonical_multi_season_rows(
+    session,
+    batter_id: int,
+    seasons: list[int],
+    current_season: int,
+    current_profile: Optional[Dict[str, Any]],
+) -> list[Dict[str, Any]]:
+    stored_by_season = {
+        int(row["season"]): row
+        for row in get_batter_multi_season(session, batter_id, seasons)
+        if row.get("season") is not None
+    }
+    rows: list[Dict[str, Any]] = []
+    for profile_season in seasons:
+        profile = current_profile if profile_season == current_season else get_batter_statcast_profile(
+            session,
+            batter_id,
+            start_date=datetime.date(profile_season, 1, 1),
+            end_date=datetime.date(profile_season, 12, 31),
+        )
+        if not profile:
+            rows.append(stored_by_season.get(profile_season, {"season": profile_season, "label": str(profile_season)}))
+            continue
+        rows.append(
+            {
+                "season": profile_season,
+                "label": "YTD (90d)" if profile_season == current_season else str(profile_season),
+                "avg_exit_velocity": profile.get("avg_exit_velocity"),
+                "avg_launch_angle": profile.get("avg_launch_angle"),
+                "hard_hit_pct": profile.get("hard_hit_pct"),
+                "barrel_pct": profile.get("barrel_pct"),
+                "k_pct": profile.get("k_pct"),
+                "bb_pct": profile.get("bb_pct"),
+                "batting_avg": profile.get("batting_avg"),
+                "actual_pa": profile.get("actual_pa"),
+                "source": profile.get("source"),
+            }
+        )
+    return rows
 
 
 @router.get("/data/freshness")
@@ -237,8 +308,35 @@ def batter_profile(id: int, season: Optional[int] = None) -> Dict[str, Any]:
         season = datetime.datetime.now(MLB_TIMEZONE).year
     Session = _get_session()
     with Session() as session:
-        agg, agg_label = get_batter_aggregate_with_fallback(session, id, season)
+        today = datetime.datetime.now(MLB_TIMEZONE).date()
+        season_start = datetime.date(season, 1, 1)
+        season_end = min(datetime.date(season, 12, 31), today)
+        data_quality = get_batter_data_quality(session, id)
+        latest_text = data_quality.get("latest_event_date")
+        latest_date = datetime.date.fromisoformat(latest_text) if latest_text else None
+        profile_end = (
+            latest_date
+            if latest_date is not None and season_start <= latest_date <= season_end
+            else season_end
+        )
+        profile_start = max(season_start, profile_end - datetime.timedelta(days=89))
+        statcast_profile = get_batter_statcast_profile(
+            session,
+            id,
+            start_date=profile_start,
+            end_date=profile_end,
+        )
+        stored_agg, stored_agg_label = get_batter_aggregate_with_fallback(session, id, season)
+        aggregate = _statcast_profile_to_aggregate(statcast_profile) or _aggregate_to_dict(stored_agg)
+        agg_label = "Canonical Statcast · Last 90 Days" if statcast_profile else stored_agg_label
         seasons = [season, season - 1, season - 2]
+        multi_season = _canonical_multi_season_rows(
+            session,
+            id,
+            seasons,
+            season,
+            statcast_profile,
+        )
         live = _fetch_batter_live_data(id, season)
         local_splits = get_player_splits_multi_season(session, id, seasons)
         splits = local_splits or live.get("splits")
@@ -251,16 +349,18 @@ def batter_profile(id: int, season: Optional[int] = None) -> Dict[str, Any]:
             "season_stats_warnings": live.get("season_stats_warnings", []),
             "season_stats_contract": "Official season hitting line only. Do not replace with local Statcast aggregate semantics.",
             "aggregate_label": agg_label,
-            "aggregate": _aggregate_to_dict(agg),
-            "aggregate_source": "postgres_batter_aggregates",
-            "multi_season": dedupe_rows(get_batter_multi_season(session, id, seasons), ["season", "label"]),
-            "multi_season_source": "postgres_batter_aggregates",
+            "aggregate": aggregate,
+            "aggregate_source": aggregate.get("source") if aggregate else None,
+            "statcast": statcast_profile,
+            "statcast_source": statcast_profile.get("source") if statcast_profile else None,
+            "multi_season": dedupe_rows(multi_season, ["season", "label"]),
+            "multi_season_source": "postgres_statcast_events_canonical_pitch_identity",
             "splits": splits,
             "splits_source": LOCAL_SPLITS_SOURCE if local_splits else live.get("splits_source"),
             "year_by_year": dedupe_rows(live.get("year_by_year", []), ["season"]),
             "year_by_year_source": live.get("year_by_year_source"),
             "rolling_sources": {"pa": STATCAST_ROLLING_SOURCE, "ab": STATCAST_ROLLING_SOURCE, "games": STATCAST_ROLLING_SOURCE, "splits": STATCAST_ROLLING_SOURCE, "pitch_types": STATCAST_ROLLING_SOURCE},
-            "data_quality": get_batter_data_quality(session, id),
+            "data_quality": data_quality,
         }
 
 

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -15,7 +15,7 @@ from .database import (
     StatcastEvent,
     TeamSplit,
 )
-from .statcast_event_identity import dedupe_statcast_events
+from .statcast_event_identity import dedupe_statcast_events, load_canonical_statcast_events
 
 HIT_EVENTS = {"single", "double", "triple", "home_run"}
 WALK_EVENTS = {"walk", "intent_walk"}
@@ -400,23 +400,42 @@ def _freshness_from_latest(latest: Optional[datetime.date]) -> Dict[str, Any]:
     }
 
 
+def load_canonical_batter_events(
+    session: Session,
+    batter_id: int,
+) -> Tuple[List[StatcastEvent], Dict[str, int]]:
+    """Load a batter's canonical pitches once per request/session."""
+
+    cache_key = f"canonical_batter_events:{int(batter_id)}"
+    cached = session.info.get(cache_key)
+    if cached is not None:
+        return cached
+
+    loaded = load_canonical_statcast_events(
+        session,
+        StatcastEvent.batter_id == batter_id,
+    )
+    session.info[cache_key] = loaded
+    return loaded
+
+
 def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
-    total = session.query(func.count(StatcastEvent.id)).filter(StatcastEvent.batter_id == batter_id).scalar() or 0
-    latest = (
-        session.query(func.max(StatcastEvent.game_date))
-        .filter(StatcastEvent.batter_id == batter_id)
-        .scalar()
+    quality_cache_key = f"canonical_batter_quality:{int(batter_id)}"
+    cached_quality = session.info.get(quality_cache_key)
+    if cached_quality is not None:
+        return dict(cached_quality)
+
+    events, diagnostics = load_canonical_batter_events(session, batter_id)
+    terminal_events = _dedupe_terminal_pas(events)
+    total = len(events)
+    terminal_count = len(terminal_events)
+    latest = max((event.game_date for event in events if event.game_date), default=None)
+    full_order = any(
+        event.game_pk is not None
+        and event.at_bat_number is not None
+        and event.pitch_number is not None
+        for event in events
     )
-    terminal_count = (
-        session.query(func.count(StatcastEvent.id))
-        .filter(
-            StatcastEvent.batter_id == batter_id,
-            StatcastEvent.events.in_(TERMINAL_EVENTS),
-        )
-        .scalar()
-        or 0
-    )
-    full_order = _has_full_event_order(session, batter_id)
     freshness = _freshness_from_latest(latest)
 
     warnings: List[str] = []
@@ -424,6 +443,13 @@ def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
         warnings.append(
             f"Statcast data is stale: latest event is {freshness['latest_event_date'] or 'unavailable'}, "
             f"as-of date is {freshness['as_of_date']}."
+        )
+
+    duplicate_rows_removed = int(diagnostics.get("duplicate_rows_removed") or 0)
+    if duplicate_rows_removed:
+        warnings.append(
+            f"Ignored {duplicate_rows_removed} duplicate or shadow Statcast row(s); "
+            "counts below use canonical MLB pitch identity."
         )
 
     if total == 0:
@@ -435,9 +461,14 @@ def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
         ordering_quality = "date_only"
         warnings.append("Rolling PA order is date-level only; intra-game PA order unavailable.")
 
-    return {
+    result = {
         "has_statcast": total > 0,
         "total_event_rows": total,
+        "raw_event_rows": int(diagnostics.get("raw_rows") or 0),
+        "canonical_pitch_rows": int(diagnostics.get("canonical_pitch_rows") or 0),
+        "legacy_pitch_rows": int(diagnostics.get("legacy_pitch_rows") or 0),
+        "incomplete_identity_rows": int(diagnostics.get("incomplete_identity_rows") or 0),
+        "duplicate_rows_removed": duplicate_rows_removed,
         "terminal_event_rows": terminal_count,
         "latest_event_date": freshness["latest_event_date"],
         "as_of_date": freshness["as_of_date"],
@@ -447,8 +478,82 @@ def get_batter_data_quality(session: Session, batter_id: int) -> Dict[str, Any]:
         "rolling_game_available": total > 0,
         "ordering_quality": ordering_quality,
         "warnings": warnings,
-        "source": "postgres_statcast_events",
+        "source": "postgres_statcast_events_canonical_pitch_identity",
     }
+    session.info[quality_cache_key] = result
+    return dict(result)
+
+
+def get_batter_statcast_profile(
+    session: Session,
+    batter_id: int,
+    *,
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> Optional[Dict[str, Any]]:
+    """Build a duplicate-safe batter profile directly from canonical pitches."""
+
+    all_events, _ = load_canonical_batter_events(session, batter_id)
+    events = [
+        event
+        for event in all_events
+        if event.game_date is not None and start_date <= event.game_date <= end_date
+    ]
+    events.sort(
+        key=lambda event: (
+            event.game_date,
+            int(event.game_pk or 0),
+            int(event.at_bat_number or 0),
+            int(event.pitch_number or 0),
+            int(event.id or 0),
+        )
+    )
+    if not events:
+        return None
+
+    raw_window_query = session.query(StatcastEvent).filter(
+        StatcastEvent.batter_id == batter_id,
+        StatcastEvent.game_date >= start_date,
+        StatcastEvent.game_date <= end_date,
+    )
+    raw_rows = int(raw_window_query.with_entities(func.count(StatcastEvent.id)).scalar() or 0)
+    complete_rows = int(
+        raw_window_query.with_entities(func.count(StatcastEvent.id))
+        .filter(
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+        )
+        .scalar()
+        or 0
+    )
+    canonical_rows = sum(
+        event.game_pk is not None
+        and event.at_bat_number is not None
+        and event.pitch_number is not None
+        for event in events
+    )
+    legacy_rows = len(events) - canonical_rows
+
+    stats = _calculate_batter_stats(events, raw_event_count=len(events))
+    stats.update(
+        {
+            "raw_event_rows": raw_rows,
+            "canonical_pitch_rows": canonical_rows,
+            "legacy_pitch_rows": legacy_rows,
+            "incomplete_identity_rows": max(raw_rows - complete_rows, 0),
+            "duplicate_rows_removed": max(raw_rows - len(events), 0),
+            "data_window": "Last 90 Days",
+            "window": "90d",
+            "start_date": start_date.isoformat(),
+            "end_date": max(
+                (event.game_date for event in events if event.game_date),
+                default=end_date,
+            ).isoformat(),
+            "source": "postgres_statcast_events_canonical_pitch_identity",
+        }
+    )
+    return stats
 
 
 def _ordered_batter_terminal_query(session: Session, batter_id: int):
@@ -643,12 +748,20 @@ def get_batter_at_bats(
     n: int = 50,
     offset: int = 0,
 ) -> Tuple[int, List[Dict[str, Any]]]:
-    base = session.query(StatcastEvent).filter(
-        StatcastEvent.batter_id == batter_id,
-        StatcastEvent.events.in_(TERMINAL_EVENTS),
+    canonical_events, _ = load_canonical_batter_events(session, batter_id)
+    canonical_events.sort(
+        key=lambda event: (
+            event.game_date or datetime.date.min,
+            int(event.game_pk or 0),
+            int(event.at_bat_number or 0),
+            int(event.pitch_number or 0),
+            int(event.id or 0),
+        ),
+        reverse=True,
     )
-    total = base.count()
-    events = _ordered_batter_terminal_query(session, batter_id).offset(offset).limit(n).all()
+    terminal_events = _dedupe_terminal_pas(canonical_events)
+    total = len(terminal_events)
+    events = terminal_events[offset : offset + n]
 
     rows = [
         {
@@ -1375,6 +1488,8 @@ __all__ = [
     "get_pitcher_aggregate_with_fallback",
     "get_batter_aggregate",
     "get_batter_aggregate_with_fallback",
+    "get_batter_statcast_profile",
+    "load_canonical_batter_events",
     "get_pitch_arsenal",
     "get_pitch_arsenal_with_fallback",
     "get_player_split",

--- a/tests/test_batter_data_contract.py
+++ b/tests/test_batter_data_contract.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+from sqlalchemy import text
+
 from mlb_app.batter_data_contract import dedupe_rows, parse_window_list
 from mlb_app.data_integrity_audit import build_duplicate_audit
 from mlb_app.database import Base, StatcastEvent, get_engine, get_session
@@ -23,6 +25,8 @@ def test_dedupe_rows_removes_repeated_source_rows():
 def test_duplicate_audit_reports_statcast_pitch_and_pa_duplicates():
     engine = get_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
     Session = get_session(engine)
 
     with Session() as session:

--- a/tests/test_batter_statcast_profile_integrity.py
+++ b/tests/test_batter_statcast_profile_integrity.py
@@ -1,0 +1,114 @@
+import datetime as dt
+
+from sqlalchemy import text
+
+from mlb_app.batter_data_contract import clean_rolling_by_pa
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.db_utils import (
+    get_batter_at_bats,
+    get_batter_data_quality,
+    get_batter_statcast_profile,
+)
+
+
+def _session_with_legacy_duplicates():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    with engine.begin() as connection:
+        connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
+    return get_session(engine)()
+
+
+def _event(**overrides):
+    values = {
+        "game_date": dt.date(2026, 8, 9),
+        "game_pk": 823751,
+        "at_bat_number": 1,
+        "pitch_number": 4,
+        "pitcher_id": 100,
+        "batter_id": 592450,
+        "pitch_type": "FF",
+        "description": "hit_into_play",
+        "events": "home_run",
+        "launch_speed": 110.0,
+        "launch_angle": 27.0,
+    }
+    values.update(overrides)
+    return StatcastEvent(**values)
+
+
+def test_batter_profile_and_quality_use_canonical_pitches_not_raw_rows():
+    session = _session_with_legacy_duplicates()
+    session.add_all(
+        [
+            _event(description=None, events=None, launch_speed=None, launch_angle=None),
+            _event(),
+            _event(game_pk=None, at_bat_number=None, pitch_number=None),
+            _event(game_pk=None, at_bat_number=None, pitch_number=None),
+            _event(
+                at_bat_number=2,
+                pitch_number=3,
+                events="strikeout",
+                description="swinging_strike",
+                launch_speed=None,
+                launch_angle=None,
+            ),
+        ]
+    )
+    session.commit()
+
+    profile = get_batter_statcast_profile(
+        session,
+        592450,
+        start_date=dt.date(2026, 5, 12),
+        end_date=dt.date(2026, 8, 9),
+    )
+    quality = get_batter_data_quality(session, 592450)
+
+    assert profile is not None
+    assert profile["raw_event_rows"] == 5
+    assert profile["canonical_pitch_rows"] == 2
+    assert profile["duplicate_rows_removed"] == 3
+    assert profile["actual_pa"] == 2
+    assert profile["actual_ab"] == 2
+    assert profile["hits"] == 1
+    assert profile["home_runs"] == 1
+    assert profile["strikeouts"] == 1
+    assert profile["batting_avg"] == 0.5
+    assert profile["avg_exit_velocity"] == 110.0
+
+    assert quality["raw_event_rows"] == 5
+    assert quality["total_event_rows"] == 2
+    assert quality["terminal_event_rows"] == 2
+    assert quality["duplicate_rows_removed"] == 3
+    assert quality["source"] == "postgres_statcast_events_canonical_pitch_identity"
+
+
+def test_batter_rolling_and_ordered_at_bats_page_canonical_plate_appearances():
+    session = _session_with_legacy_duplicates()
+    duplicates = [_event() for _ in range(20)]
+    second_pa = _event(
+        at_bat_number=2,
+        pitch_number=5,
+        events="walk",
+        description="ball",
+        launch_speed=None,
+        launch_angle=None,
+    )
+    session.add_all([*duplicates, second_pa])
+    session.commit()
+
+    rolling = clean_rolling_by_pa(session, 592450, 100)
+    total, at_bats = get_batter_at_bats(session, 592450, n=100)
+
+    assert rolling is not None
+    assert rolling["actual_pa"] == 2
+    assert rolling["hits"] == 1
+    assert rolling["walks"] == 1
+    assert rolling["duplicate_rows_removed"] == 19
+    assert total == 2
+    assert len(at_bats) == 2
+    assert {(row["game_pk"], row["at_bat_number"]) for row in at_bats} == {
+        (823751, 1),
+        (823751, 2),
+    }


### PR DESCRIPTION
## Summary

- make batter profiles, rolling windows, data-quality counts, and ordered at-bats use canonical MLB pitch identity
- build current and historical local Statcast profile metrics from canonical rows instead of corrupted stored aggregates
- preserve a true 90-day window ending at each batter's latest available event and retain explicit stale-data warnings
- fix the season-stat API/UI field mismatch that blanked AVG, OBP, SLG, and PA
- expose raw, canonical, legacy, incomplete, and removed-row diagnostics on batter profiles

## Production evidence

Before this fix:

- Aaron Judge: 66,877 raw event rows / 15,386 raw terminal rows
- Juan Soto: 41,129 raw event rows / 9,585 raw terminal rows
- Judge's stored 90-day aggregate showed 84.75 mph average exit velocity and an 8.2% strikeout rate
- the rolling endpoint had to discard 271 duplicate terminal rows just to assemble his latest 100 PA

The official MLB Stats API season line was correct. The local Statcast profile, stored aggregate fallback, raw quality counts, and frontend field wiring were not consistently correct.

## Validation

- 24 targeted backend tests pass
- frontend production build passes
- Python compilation and whitespace validation pass
- production-shaped stress fixture: 49,625 stored rows collapse to 1,985 canonical pitches and 397 plate appearances in 0.30 seconds
- duplicate regression confirms profile, rolling, and ordered-at-bat totals all agree

The frontend build reports pre-existing duplicate-style-key and bundle-size warnings in `LandingV2Page.jsx`; this PR does not modify that page.

## Deployment note

This corrects batter numbers at read time immediately after deployment. Existing physical duplicate rows remain until the previously added transactional repair command is run against production, but they no longer inflate batter profile calculations.