### PR TITLE
Materialize canonical pregame pitcher evidence

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -1239,6 +1239,33 @@ def build_model_projection_payload(
                     home_team_name=home.get("team_name"),
                     home_starter_id=home.get("pitcher_id"),
                     season=date_obj.year,
+                    pregame_evidence_as_of=(
+                        matchup.get("game_time")
+                    ),
+                    away_pregame_pitching_plan=(
+                        matchup.get(
+                            "away_pregame_pitching_plan"
+                        )
+                    ),
+                    home_pregame_pitching_plan=(
+                        matchup.get(
+                            "home_pregame_pitching_plan"
+                        )
+                    ),
+                    away_pregame_provider_observations=(
+                        matchup.get(
+                            "away_pregame_pitcher_"
+                            "observations"
+                        )
+                        or ()
+                    ),
+                    home_pregame_provider_observations=(
+                        matchup.get(
+                            "home_pregame_pitcher_"
+                            "observations"
+                        )
+                        or ()
+                    ),
                 )
             )
 

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -89,6 +89,11 @@ from .observed_baserunning_evidence import (
     discover_composed_canonical_baserunning_evidence,
     discover_observed_canonical_baserunning_evidence,
 )
+from .pregame_pitcher_availability_role_evidence import (
+    SCHEMA_VERSION as CANONICAL_PREGAME_PITCHER_EVIDENCE_VERSION,
+    CanonicalPregamePitcherEvidenceMaterialization,
+    materialize_canonical_pregame_pitcher_evidence,
+)
 from .probability_provider_discovery import (
     CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION,
     CanonicalShadowProbabilityProviderDiscovery,
@@ -214,6 +219,9 @@ __all__ = [
     "CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION",
     "discover_composed_canonical_baserunning_evidence",
     "discover_observed_canonical_baserunning_evidence",
+    "CANONICAL_PREGAME_PITCHER_EVIDENCE_VERSION",
+    "CanonicalPregamePitcherEvidenceMaterialization",
+    "materialize_canonical_pregame_pitcher_evidence",
     "CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION",
     "CANONICAL_SHADOW_PROBABILITY_PROVIDER_DISCOVERY_VERSION",
     "CANONICAL_SHADOW_INPUT_PROVENANCE_VERSION",

--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -8,6 +8,10 @@ from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 from .canonical_bullpen_eligibility import (
     enforce_canonical_bullpen_eligibility,
 )
+from .pregame_pitcher_availability_role_evidence import (
+    CanonicalPregamePitcherEvidenceMaterialization,
+    materialize_canonical_pregame_pitcher_evidence,
+)
 
 
 CANONICAL_SHADOW_BULLPEN_DISCOVERY_VERSION = (
@@ -25,6 +29,39 @@ def _normalize_identifier(value: Any) -> Optional[str]:
     except (TypeError, ValueError):
         text = str(value).strip()
         return text or None
+
+
+
+
+def _normalize_identifiers(
+    values: Any,
+) -> Tuple[str, ...]:
+    if values is None:
+        return ()
+
+    if isinstance(values, (str, bytes)):
+        candidates = (values,)
+    elif isinstance(values, Sequence):
+        candidates = tuple(values)
+    else:
+        candidates = (values,)
+
+    result = []
+    seen = set()
+
+    for candidate in candidates:
+        identifier = _normalize_identifier(
+            candidate
+        )
+
+        if (
+            identifier is not None
+            and identifier not in seen
+        ):
+            result.append(identifier)
+            seen.add(identifier)
+
+    return tuple(result)
 
 
 def _pitcher_identifiers(
@@ -79,6 +116,9 @@ class CanonicalShadowBullpenSideDiscovery:
     starter_id: Optional[str] = None
     bullpen_pitcher_ids: Tuple[str, ...] = ()
     eligibility: Optional[Dict[str, Any]] = None
+    pregame_evidence: Optional[
+        CanonicalPregamePitcherEvidenceMaterialization
+    ] = None
     source_record_count: int = 0
     status: str = "unavailable"
     error_type: Optional[str] = None
@@ -166,6 +206,47 @@ class CanonicalShadowBullpenSideDiscovery:
                 if self.eligibility is not None
                 else 0
             ),
+            "pregame_evidence_materialized": (
+                self.pregame_evidence is not None
+            ),
+            "pregame_evidence_status": (
+                self.pregame_evidence.diagnostics.get(
+                    "status"
+                )
+                if self.pregame_evidence is not None
+                else "unavailable"
+            ),
+            "pregame_evidence_pitcher_count": (
+                self.pregame_evidence.diagnostics.get(
+                    "pitcher_count"
+                )
+                if self.pregame_evidence is not None
+                else 0
+            ),
+            "pregame_evidence_unknown_count": (
+                self.pregame_evidence.diagnostics.get(
+                    "unknown_pitcher_count"
+                )
+                if self.pregame_evidence is not None
+                else 0
+            ),
+            "pregame_evidence_conflict_count": (
+                self.pregame_evidence.diagnostics.get(
+                    "conflicting_pitcher_count"
+                )
+                if self.pregame_evidence is not None
+                else 0
+            ),
+            "pregame_evidence_stale_count": (
+                self.pregame_evidence.diagnostics.get(
+                    "stale_observation_count"
+                )
+                if self.pregame_evidence is not None
+                else 0
+            ),
+            "typical_role_inference_used": False,
+            "workload_inference_used": False,
+            "roster_order_inference_used": False,
             "exclusion_reason_counts": (
                 dict(
                     self.eligibility.get(
@@ -247,6 +328,7 @@ class CanonicalShadowBullpenDiscovery:
 
 def _discover_side(
     *,
+    team_side: str,
     team_id: Any,
     team_name: Any,
     starter_id: Any,
@@ -256,6 +338,12 @@ def _discover_side(
         Mapping[Any, Any]
     ] = None,
     planned_pitcher_ids: Any = (),
+    pregame_evidence_as_of: Any = None,
+    pregame_pitching_plan: Optional[
+        Mapping[str, Any]
+    ] = None,
+    pregame_provider_observations: Any = (),
+    pregame_maximum_age_seconds: int = 21600,
 ) -> CanonicalShadowBullpenSideDiscovery:
     normalized_team = _normalize_identifier(
         team_id
@@ -319,15 +407,68 @@ def _discover_side(
         records,
         starter_id=normalized_starter,
     )
+    pregame_evidence = None
+    materialized_evidence_by_pitcher_id = {}
+    materialized_planned_pitcher_ids = ()
+
+    if pregame_evidence_as_of is not None:
+        pregame_evidence = (
+            materialize_canonical_pregame_pitcher_evidence(
+                team_side=team_side,
+                scheduled_starter_id=(
+                    normalized_starter
+                ),
+                active_roster_pitcher_ids=(
+                    (normalized_starter,)
+                    + pitcher_ids
+                ),
+                as_of=pregame_evidence_as_of,
+                pitching_plan=pregame_pitching_plan,
+                provider_observations=(
+                    pregame_provider_observations
+                ),
+                maximum_age_seconds=(
+                    pregame_maximum_age_seconds
+                ),
+            )
+        )
+        materialized_evidence_by_pitcher_id = dict(
+            pregame_evidence.evidence_by_pitcher_id
+        )
+        materialized_planned_pitcher_ids = (
+            pregame_evidence.planned_pitcher_ids
+        )
+
+    direct_evidence = (
+        dict(eligibility_evidence_by_pitcher_id)
+        if isinstance(
+            eligibility_evidence_by_pitcher_id,
+            Mapping,
+        )
+        else {}
+    )
+    combined_evidence = {
+        **materialized_evidence_by_pitcher_id,
+        **direct_evidence,
+    }
+    combined_planned_pitcher_ids = tuple(
+        dict.fromkeys(
+            materialized_planned_pitcher_ids
+            + _normalize_identifiers(
+                planned_pitcher_ids
+            )
+        )
+    )
+
     eligibility = (
         enforce_canonical_bullpen_eligibility(
             candidate_pitcher_ids=pitcher_ids,
             starter_id=normalized_starter,
             evidence_by_pitcher_id=(
-                eligibility_evidence_by_pitcher_id
+                combined_evidence or None
             ),
             planned_pitcher_ids=(
-                planned_pitcher_ids
+                combined_planned_pitcher_ids
             ),
         )
     )
@@ -344,6 +485,7 @@ def _discover_side(
             eligible_pitcher_ids
         ),
         eligibility=eligibility,
+        pregame_evidence=pregame_evidence,
         source_record_count=len(records),
         status=(
             "ready"
@@ -373,6 +515,16 @@ def discover_canonical_shadow_bullpens(
     ] = None,
     away_planned_pitcher_ids: Any = (),
     home_planned_pitcher_ids: Any = (),
+    pregame_evidence_as_of: Any = None,
+    away_pregame_pitching_plan: Optional[
+        Mapping[str, Any]
+    ] = None,
+    home_pregame_pitching_plan: Optional[
+        Mapping[str, Any]
+    ] = None,
+    away_pregame_provider_observations: Any = (),
+    home_pregame_provider_observations: Any = (),
+    pregame_maximum_age_seconds: int = 21600,
 ) -> CanonicalShadowBullpenDiscovery:
     """
     Discover active-roster bullpen IDs without activating canonical execution.
@@ -390,6 +542,7 @@ def discover_canonical_shadow_bullpens(
 
     return CanonicalShadowBullpenDiscovery(
         away=_discover_side(
+            team_side="away",
             team_id=away_team_id,
             team_name=away_team_name,
             starter_id=away_starter_id,
@@ -401,8 +554,21 @@ def discover_canonical_shadow_bullpens(
             planned_pitcher_ids=(
                 away_planned_pitcher_ids
             ),
+            pregame_evidence_as_of=(
+                pregame_evidence_as_of
+            ),
+            pregame_pitching_plan=(
+                away_pregame_pitching_plan
+            ),
+            pregame_provider_observations=(
+                away_pregame_provider_observations
+            ),
+            pregame_maximum_age_seconds=(
+                pregame_maximum_age_seconds
+            ),
         ),
         home=_discover_side(
+            team_side="home",
             team_id=home_team_id,
             team_name=home_team_name,
             starter_id=home_starter_id,
@@ -413,6 +579,18 @@ def discover_canonical_shadow_bullpens(
             ),
             planned_pitcher_ids=(
                 home_planned_pitcher_ids
+            ),
+            pregame_evidence_as_of=(
+                pregame_evidence_as_of
+            ),
+            pregame_pitching_plan=(
+                home_pregame_pitching_plan
+            ),
+            pregame_provider_observations=(
+                home_pregame_provider_observations
+            ),
+            pregame_maximum_age_seconds=(
+                pregame_maximum_age_seconds
             ),
         ),
     )

--- a/mlb_app/simulation/shadow/pregame_pitcher_availability_role_evidence.py
+++ b/mlb_app/simulation/shadow/pregame_pitcher_availability_role_evidence.py
@@ -1,0 +1,535 @@
+"""Materialize explicit canonical pregame pitcher evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = (
+    "canonical_pregame_pitcher_availability_"
+    "and_role_evidence_v1"
+)
+
+VALID_AVAILABILITY_STATUSES = frozenset({
+    "eligible",
+    "ineligible",
+    "unknown",
+})
+
+VALID_PITCHER_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+    "reliever",
+    "long_reliever",
+    "middle_reliever",
+    "setup",
+    "closer",
+    "unknown",
+})
+
+PLAN_ROLE_BY_SEQUENCE_ROLE = {
+    "starter": "starter",
+    "probable_starter": "probable_starter",
+    "opener": "opener",
+    "bulk_follower": "bulk_follower",
+    "tandem_primary": "tandem_primary",
+    "tandem_secondary": "tandem_secondary",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalPregamePitcherEvidenceMaterialization:
+    """Read-only materialized evidence for one team."""
+
+    team_side: str
+    evidence_by_pitcher_id: Mapping[
+        str,
+        Mapping[str, Any],
+    ]
+    planned_pitcher_ids: tuple[str, ...]
+    diagnostics: Mapping[str, Any] = field(
+        default_factory=dict
+    )
+    schema_version: str = SCHEMA_VERSION
+    database_writes_performed: bool = False
+    production_authority_changed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.team_side not in {"away", "home"}:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                "unsupported pregame pitcher evidence schema"
+            )
+
+
+def _identifier(value: Any) -> str | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def _identifiers(values: Any) -> tuple[str, ...]:
+    if values is None:
+        return ()
+
+    if isinstance(values, (str, bytes)):
+        candidates = (values,)
+    elif isinstance(values, Sequence):
+        candidates = tuple(values)
+    else:
+        candidates = (values,)
+
+    result = []
+    seen = set()
+
+    for candidate in candidates:
+        identifier = _identifier(candidate)
+
+        if (
+            identifier is not None
+            and identifier not in seen
+        ):
+            result.append(identifier)
+            seen.add(identifier)
+
+    return tuple(result)
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        text = value.strip()
+
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        return None
+
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalized_as_of(value: Any) -> datetime:
+    parsed = _parse_time(value)
+
+    if parsed is None:
+        raise ValueError(
+            "as_of must be a timezone-aware datetime"
+        )
+
+    return parsed
+
+
+def _provider_record(
+    value: Any,
+    *,
+    as_of: datetime,
+    maximum_age_seconds: int,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {
+            "valid": False,
+            "status": "unknown",
+            "role": "unknown",
+            "source": None,
+            "observed_at": None,
+            "reason": "invalid_evidence_record",
+        }
+
+    status = str(
+        value.get("status") or "unknown"
+    ).strip().lower()
+    role = str(
+        value.get("role") or "unknown"
+    ).strip().lower()
+    source = (
+        str(value.get("source")).strip()
+        if value.get("source") not in {None, ""}
+        else None
+    )
+    observed_at = _parse_time(
+        value.get("observed_at")
+    )
+    reason = (
+        str(value.get("reason")).strip()
+        if value.get("reason") not in {None, ""}
+        else None
+    )
+
+    structurally_valid = (
+        status in VALID_AVAILABILITY_STATUSES
+        and role in VALID_PITCHER_ROLES
+        and source is not None
+        and observed_at is not None
+    )
+
+    if not structurally_valid:
+        return {
+            "valid": False,
+            "status": "unknown",
+            "role": "unknown",
+            "source": source,
+            "observed_at": (
+                observed_at.isoformat()
+                if observed_at is not None
+                else None
+            ),
+            "reason": "invalid_evidence_record",
+        }
+
+    age_seconds = (
+        as_of - observed_at
+    ).total_seconds()
+
+    if (
+        age_seconds < 0
+        or age_seconds > maximum_age_seconds
+    ):
+        return {
+            "valid": False,
+            "status": "unknown",
+            "role": "unknown",
+            "source": source,
+            "observed_at": observed_at.isoformat(),
+            "reason": "stale_or_future_evidence",
+        }
+
+    return {
+        "valid": True,
+        "status": status,
+        "role": role,
+        "source": source,
+        "observed_at": observed_at.isoformat(),
+        "reason": reason,
+    }
+
+
+def _plan_roles(
+    *,
+    scheduled_starter_id: str,
+    pitching_plan: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    roles = {
+        scheduled_starter_id: "starter",
+    }
+
+    if not isinstance(pitching_plan, Mapping):
+        return roles
+
+    sequence = pitching_plan.get(
+        "planned_sequence"
+    )
+
+    if not isinstance(sequence, Sequence) or isinstance(
+        sequence,
+        (str, bytes),
+    ):
+        return roles
+
+    for record in sequence:
+        if not isinstance(record, Mapping):
+            continue
+
+        pitcher_id = _identifier(
+            record.get("pitcher_id")
+        )
+        role = str(
+            record.get("role")
+            or record.get("pitcher_role")
+            or ""
+        ).strip().lower()
+
+        normalized_role = (
+            PLAN_ROLE_BY_SEQUENCE_ROLE.get(role)
+        )
+
+        if (
+            pitcher_id is not None
+            and normalized_role is not None
+        ):
+            roles[pitcher_id] = normalized_role
+
+    return roles
+
+
+def materialize_canonical_pregame_pitcher_evidence(
+    *,
+    team_side: str,
+    scheduled_starter_id: Any,
+    active_roster_pitcher_ids: Any,
+    as_of: Any,
+    pitching_plan: Mapping[str, Any] | None = None,
+    provider_observations: Any = (),
+    maximum_age_seconds: int = 21600,
+) -> CanonicalPregamePitcherEvidenceMaterialization:
+    """
+    Materialize explicit availability and role evidence.
+
+    Pitching-plan evidence takes precedence. Provider observations
+    require provenance and a fresh timestamp. Missing, malformed,
+    stale, future, or conflicting evidence becomes unknown and
+    therefore remains compatible with fail-open bullpen discovery.
+    """
+
+    if team_side not in {"away", "home"}:
+        raise ValueError(
+            "team_side must be away or home"
+        )
+
+    starter_id = _identifier(
+        scheduled_starter_id
+    )
+
+    if starter_id is None:
+        raise ValueError(
+            "scheduled_starter_id is required"
+        )
+
+    if (
+        isinstance(maximum_age_seconds, bool)
+        or not isinstance(maximum_age_seconds, int)
+        or maximum_age_seconds < 0
+    ):
+        raise ValueError(
+            "maximum_age_seconds must be non-negative"
+        )
+
+    normalized_as_of = _normalized_as_of(as_of)
+    roster_ids = _identifiers(
+        active_roster_pitcher_ids
+    )
+    plan_roles = _plan_roles(
+        scheduled_starter_id=starter_id,
+        pitching_plan=pitching_plan,
+    )
+
+    if provider_observations is None:
+        observations = ()
+    elif (
+        isinstance(provider_observations, Sequence)
+        and not isinstance(
+            provider_observations,
+            (str, bytes),
+        )
+    ):
+        observations = tuple(provider_observations)
+    else:
+        raise TypeError(
+            "provider_observations must be a sequence"
+        )
+
+    observations_by_pitcher_id: dict[
+        str,
+        list[dict[str, Any]],
+    ] = {}
+
+    invalid_observation_count = 0
+    stale_observation_count = 0
+
+    for raw_record in observations:
+        pitcher_id = (
+            _identifier(raw_record.get("pitcher_id"))
+            if isinstance(raw_record, Mapping)
+            else None
+        )
+        record = _provider_record(
+            raw_record,
+            as_of=normalized_as_of,
+            maximum_age_seconds=(
+                maximum_age_seconds
+            ),
+        )
+
+        if pitcher_id is None:
+            invalid_observation_count += 1
+            continue
+
+        if not record["valid"]:
+            if (
+                record["reason"]
+                == "stale_or_future_evidence"
+            ):
+                stale_observation_count += 1
+            else:
+                invalid_observation_count += 1
+
+        observations_by_pitcher_id.setdefault(
+            pitcher_id,
+            [],
+        ).append(record)
+
+    ordered_pitcher_ids = list(roster_ids)
+
+    for pitcher_id in plan_roles:
+        if pitcher_id not in ordered_pitcher_ids:
+            ordered_pitcher_ids.append(pitcher_id)
+
+    evidence_by_pitcher_id = {}
+    conflicting_pitcher_ids = []
+    unknown_pitcher_ids = []
+    plan_override_count = 0
+    valid_provider_pitcher_count = 0
+
+    for pitcher_id in ordered_pitcher_ids:
+        planned_role = plan_roles.get(pitcher_id)
+
+        if planned_role is not None:
+            evidence_by_pitcher_id[pitcher_id] = {
+                "status": "eligible",
+                "role": planned_role,
+                "source": (
+                    "canonical_pregame_pitching_plan"
+                ),
+                "reason": (
+                    "explicit_pitching_plan_assignment"
+                ),
+                "observed_at": (
+                    normalized_as_of.isoformat()
+                ),
+                "evidence_valid": True,
+                "plan_override": True,
+            }
+            plan_override_count += 1
+            continue
+
+        records = observations_by_pitcher_id.get(
+            pitcher_id,
+            [],
+        )
+        valid_records = [
+            record
+            for record in records
+            if record["valid"]
+        ]
+        distinct_contracts = {
+            (
+                record["status"],
+                record["role"],
+            )
+            for record in valid_records
+        }
+
+        if len(distinct_contracts) > 1:
+            conflicting_pitcher_ids.append(
+                pitcher_id
+            )
+            evidence_by_pitcher_id[pitcher_id] = {
+                "status": "unknown",
+                "role": "unknown",
+                "source": None,
+                "reason": (
+                    "conflicting_provider_evidence"
+                ),
+                "observed_at": None,
+                "evidence_valid": False,
+                "plan_override": False,
+            }
+        elif len(valid_records) == 1 or (
+            valid_records
+            and len(distinct_contracts) == 1
+        ):
+            record = valid_records[-1]
+            evidence_by_pitcher_id[pitcher_id] = {
+                "status": record["status"],
+                "role": record["role"],
+                "source": record["source"],
+                "reason": record["reason"],
+                "observed_at": (
+                    record["observed_at"]
+                ),
+                "evidence_valid": True,
+                "plan_override": False,
+            }
+            valid_provider_pitcher_count += 1
+        else:
+            unknown_pitcher_ids.append(pitcher_id)
+            evidence_by_pitcher_id[pitcher_id] = {
+                "status": "unknown",
+                "role": "unknown",
+                "source": None,
+                "reason": (
+                    "pregame_evidence_unavailable"
+                ),
+                "observed_at": None,
+                "evidence_valid": False,
+                "plan_override": False,
+            }
+
+    planned_pitcher_ids = tuple(
+        pitcher_id
+        for pitcher_id in ordered_pitcher_ids
+        if pitcher_id in plan_roles
+    )
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "materialized",
+        "team_side": team_side,
+        "as_of": normalized_as_of.isoformat(),
+        "maximum_age_seconds": maximum_age_seconds,
+        "pitcher_count": len(ordered_pitcher_ids),
+        "planned_pitcher_count": len(
+            planned_pitcher_ids
+        ),
+        "plan_override_count": plan_override_count,
+        "valid_provider_pitcher_count": (
+            valid_provider_pitcher_count
+        ),
+        "unknown_pitcher_count": len(
+            unknown_pitcher_ids
+        ),
+        "unknown_pitcher_ids": sorted(
+            unknown_pitcher_ids
+        ),
+        "conflicting_pitcher_count": len(
+            conflicting_pitcher_ids
+        ),
+        "conflicting_pitcher_ids": sorted(
+            conflicting_pitcher_ids
+        ),
+        "invalid_observation_count": (
+            invalid_observation_count
+        ),
+        "stale_observation_count": (
+            stale_observation_count
+        ),
+        "unknown_evidence_fails_open": True,
+        "typical_role_inference_used": False,
+        "workload_inference_used": False,
+        "roster_order_inference_used": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+    return (
+        CanonicalPregamePitcherEvidenceMaterialization(
+            team_side=team_side,
+            evidence_by_pitcher_id=(
+                evidence_by_pitcher_id
+            ),
+            planned_pitcher_ids=(
+                planned_pitcher_ids
+            ),
+            diagnostics=diagnostics,
+        )
+    )

--- a/tests/test_canonical_pregame_pitcher_availability_role_evidence.py
+++ b/tests/test_canonical_pregame_pitcher_availability_role_evidence.py
@@ -1,0 +1,306 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from mlb_app.simulation.shadow.pregame_pitcher_availability_role_evidence import (
+    SCHEMA_VERSION,
+    materialize_canonical_pregame_pitcher_evidence,
+)
+
+
+AS_OF = datetime(
+    2026,
+    8,
+    9,
+    18,
+    0,
+    tzinfo=timezone.utc,
+)
+
+
+def run(**overrides):
+    values = {
+        "team_side": "away",
+        "scheduled_starter_id": "100",
+        "active_roster_pitcher_ids": (
+            "100",
+            "101",
+            "102",
+            "103",
+        ),
+        "as_of": AS_OF,
+        "pitching_plan": None,
+        "provider_observations": (),
+    }
+    values.update(overrides)
+
+    return (
+        materialize_canonical_pregame_pitcher_evidence(
+            **values
+        )
+    )
+
+
+def test_scheduled_starter_is_explicitly_materialized():
+    result = run()
+
+    assert result.evidence_by_pitcher_id["100"][
+        "status"
+    ] == "eligible"
+    assert result.evidence_by_pitcher_id["100"][
+        "role"
+    ] == "starter"
+    assert result.evidence_by_pitcher_id["100"][
+        "source"
+    ] == "canonical_pregame_pitching_plan"
+    assert result.planned_pitcher_ids == ("100",)
+
+
+def test_explicit_opener_and_bulk_roles_are_preserved():
+    result = run(
+        pitching_plan={
+            "planned_sequence": [
+                {
+                    "pitcher_id": "100",
+                    "role": "opener",
+                },
+                {
+                    "pitcher_id": "101",
+                    "role": "bulk_follower",
+                },
+            ],
+        },
+    )
+
+    assert result.evidence_by_pitcher_id["100"][
+        "role"
+    ] == "opener"
+    assert result.evidence_by_pitcher_id["101"][
+        "role"
+    ] == "bulk_follower"
+    assert result.planned_pitcher_ids == (
+        "100",
+        "101",
+    )
+
+
+def test_explicit_bullpen_role_is_preserved():
+    result = run(
+        provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "closer",
+                "source": "provider_depth_chart_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+                "reason": "listed_active_closer",
+            },
+        ),
+    )
+
+    evidence = result.evidence_by_pitcher_id["101"]
+
+    assert evidence["status"] == "eligible"
+    assert evidence["role"] == "closer"
+    assert evidence["source"] == (
+        "provider_depth_chart_v1"
+    )
+    assert evidence["evidence_valid"] is True
+
+
+def test_explicit_unavailability_is_preserved():
+    result = run(
+        provider_observations=(
+            {
+                "pitcher_id": "102",
+                "status": "ineligible",
+                "role": "long_reliever",
+                "source": "provider_game_status_v1",
+                "observed_at": (
+                    "2026-08-09T17:45:00+00:00"
+                ),
+                "reason": "injured_list",
+            },
+        ),
+    )
+
+    evidence = result.evidence_by_pitcher_id["102"]
+
+    assert evidence["status"] == "ineligible"
+    assert evidence["role"] == "long_reliever"
+    assert evidence["reason"] == "injured_list"
+
+
+def test_missing_evidence_remains_unknown():
+    result = run()
+
+    evidence = result.evidence_by_pitcher_id["101"]
+
+    assert evidence["status"] == "unknown"
+    assert evidence["role"] == "unknown"
+    assert evidence["evidence_valid"] is False
+    assert result.diagnostics[
+        "unknown_evidence_fails_open"
+    ] is True
+
+
+def test_stale_evidence_becomes_unknown():
+    result = run(
+        maximum_age_seconds=3600,
+        provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "setup",
+                "source": "provider_depth_chart_v1",
+                "observed_at": (
+                    "2026-08-09T15:00:00+00:00"
+                ),
+            },
+        ),
+    )
+
+    evidence = result.evidence_by_pitcher_id["101"]
+
+    assert evidence["status"] == "unknown"
+    assert evidence["role"] == "unknown"
+    assert result.diagnostics[
+        "stale_observation_count"
+    ] == 1
+
+
+def test_conflicting_evidence_becomes_unknown():
+    result = run(
+        provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "closer",
+                "source": "provider_one_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+            },
+            {
+                "pitcher_id": "101",
+                "status": "ineligible",
+                "role": "closer",
+                "source": "provider_two_v1",
+                "observed_at": (
+                    "2026-08-09T17:45:00+00:00"
+                ),
+            },
+        ),
+    )
+
+    evidence = result.evidence_by_pitcher_id["101"]
+
+    assert evidence["status"] == "unknown"
+    assert evidence["role"] == "unknown"
+    assert evidence["reason"] == (
+        "conflicting_provider_evidence"
+    )
+    assert result.diagnostics[
+        "conflicting_pitcher_ids"
+    ] == ["101"]
+
+
+def test_pitching_plan_overrides_provider_evidence():
+    result = run(
+        pitching_plan={
+            "planned_sequence": [
+                {
+                    "pitcher_id": "101",
+                    "role": "bulk_follower",
+                },
+            ],
+        },
+        provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": "provider_rotation_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+            },
+        ),
+    )
+
+    evidence = result.evidence_by_pitcher_id["101"]
+
+    assert evidence["status"] == "eligible"
+    assert evidence["role"] == "bulk_follower"
+    assert evidence["plan_override"] is True
+
+
+def test_does_not_infer_roles_from_roster_order():
+    result = run()
+
+    for pitcher_id in ("101", "102", "103"):
+        assert result.evidence_by_pitcher_id[
+            pitcher_id
+        ]["role"] == "unknown"
+
+    assert result.diagnostics[
+        "roster_order_inference_used"
+    ] is False
+    assert result.diagnostics[
+        "workload_inference_used"
+    ] is False
+    assert result.diagnostics[
+        "typical_role_inference_used"
+    ] is False
+
+
+def test_result_is_read_only_and_non_authoritative():
+    result = run()
+
+    assert result.schema_version == SCHEMA_VERSION
+    assert (
+        result.database_writes_performed
+        is False
+    )
+    assert (
+        result.production_authority_changed
+        is False
+    )
+    assert result.diagnostics[
+        "database_writes_performed"
+    ] is False
+    assert result.diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "team_side",
+    ("", "neutral", "AWAY"),
+)
+def test_invalid_team_side_is_rejected(team_side):
+    with pytest.raises(
+        ValueError,
+        match="team_side must be away or home",
+    ):
+        run(team_side=team_side)
+
+
+def test_missing_starter_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match="scheduled_starter_id is required",
+    ):
+        run(scheduled_starter_id=None)
+
+
+def test_naive_as_of_time_is_rejected():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "as_of must be a timezone-aware datetime"
+        ),
+    ):
+        run(as_of=datetime(2026, 8, 9, 18, 0))

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -322,3 +322,165 @@ def test_eligibility_diagnostics_do_not_expose_ids():
         "excluded_pitcher_ids"
         not in diagnostics["away"]
     )
+
+def test_materialized_pregame_evidence_filters_pool():
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "closer",
+                "source": "provider_depth_chart_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+            },
+            {
+                "pitcher_id": "102",
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": "provider_rotation_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+                "reason": (
+                    "probable_starter_not_in_plan"
+                ),
+            },
+        ),
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.away.pregame_evidence is not None
+    diagnostics = result.away.to_diagnostics()
+
+    assert diagnostics[
+        "pregame_evidence_materialized"
+    ] is True
+    assert diagnostics[
+        "pregame_evidence_status"
+    ] == "materialized"
+    assert diagnostics[
+        "pregame_evidence_pitcher_count"
+    ] == 3
+    assert diagnostics[
+        "typical_role_inference_used"
+    ] is False
+
+
+def test_materialized_plan_overrides_ineligibility():
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        away_pregame_pitching_plan={
+            "planned_sequence": [
+                {
+                    "pitcher_id": "101",
+                    "role": "bulk_follower",
+                },
+            ],
+        },
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": "provider_rotation_v1",
+                "observed_at": (
+                    "2026-08-09T17:30:00+00:00"
+                ),
+            },
+        ),
+    )
+
+    assert "101" in (
+        result.away.bullpen_pitcher_ids
+    )
+    assert result.away.to_diagnostics()[
+        "planned_override_count"
+    ] == 1
+
+
+def test_unknown_materialized_evidence_fails_open():
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+        "102",
+    )
+    assert result.away.to_diagnostics()[
+        "pregame_evidence_unknown_count"
+    ] == 2
+
+
+def test_stale_materialized_evidence_fails_open():
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        pregame_maximum_age_seconds=3600,
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": "provider_rotation_v1",
+                "observed_at": (
+                    "2026-08-09T15:00:00+00:00"
+                ),
+            },
+        ),
+    )
+
+    assert "101" in (
+        result.away.bullpen_pitcher_ids
+    )
+    assert result.away.to_diagnostics()[
+        "pregame_evidence_stale_count"
+    ] == 1
+
+
+def test_direct_evidence_api_remains_compatible():
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "ineligible",
+                "probable_starter",
+                "direct_evidence_precedence",
+            ),
+        },
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "102",
+    )
+    assert result.away.to_diagnostics()[
+        "exclusion_reason_counts"
+    ] == {
+        "direct_evidence_precedence": 1,
+    }
+
+    records = {
+        record["pitcher_id"]: record
+        for record in result.away.eligibility[
+            "records"
+        ]
+    }
+
+    assert records["102"]["retained"] is True
+    assert records["102"][
+        "evidence_status"
+    ] == "unknown"

--- a/tests/test_model_projection_canonical_bullpen_readiness.py
+++ b/tests/test_model_projection_canonical_bullpen_readiness.py
@@ -114,3 +114,78 @@ def test_failed_roster_discovery_keeps_bullpens_blocked():
     assert report["requirements"][
         "home_bullpen"
     ]["ready"] is False
+
+def test_pregame_evidence_uses_scheduled_game_time():
+    discovery = discover_canonical_shadow_bullpens(
+        away_team_id=10,
+        away_team_name="Real Away Team",
+        away_starter_id=100,
+        home_team_id=20,
+        home_team_name="Real Home Team",
+        home_starter_id=200,
+        season=2026,
+        roster_fetcher=roster,
+        pregame_evidence_as_of=(
+            "2026-08-09T23:05:00+00:00"
+        ),
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "closer",
+                "source": "provider_depth_chart_v1",
+                "observed_at": (
+                    "2026-08-09T22:30:00+00:00"
+                ),
+            },
+        ),
+        home_pregame_provider_observations=(
+            {
+                "pitcher_id": "201",
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": "provider_rotation_v1",
+                "observed_at": (
+                    "2026-08-09T22:30:00+00:00"
+                ),
+                "reason": (
+                    "probable_starter_not_in_plan"
+                ),
+            },
+        ),
+    )
+
+    assert discovery.away.pregame_evidence is not None
+    assert discovery.home.pregame_evidence is not None
+
+    assert discovery.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert discovery.home.bullpen_pitcher_ids == ()
+
+    away_diagnostics = (
+        discovery.away.to_diagnostics()
+    )
+    home_diagnostics = (
+        discovery.home.to_diagnostics()
+    )
+
+    assert away_diagnostics[
+        "pregame_evidence_materialized"
+    ] is True
+    assert home_diagnostics[
+        "pregame_evidence_materialized"
+    ] is True
+    assert away_diagnostics[
+        "pregame_evidence_stale_count"
+    ] == 0
+    assert home_diagnostics[
+        "excluded_pitcher_count"
+    ] == 1
+
+    assert discovery.to_diagnostics()[
+        "activation_permitted"
+    ] is False
+    assert discovery.to_diagnostics()[
+        "authoritative_source"
+    ] == "legacy"


### PR DESCRIPTION
## Summary

- materialize explicit canonical pregame pitcher availability and role evidence
- preserve scheduled starter and explicit pitching-plan assignments
- accept timestamped provider observations for bullpen availability and roles
- treat missing, stale, future, malformed, or conflicting evidence as unknown
- fail open for unknown evidence without inferring roles from roster order or workload
- feed materialized evidence and planned pitcher IDs into canonical bullpen eligibility
- wire deterministic freshness to the MLB scheduled game timestamp

## Production evidence

The representative 100-trial probe confirmed:

- scheduled away and home starters were materialized
- unknown bullpen evidence preserved the existing pitcher pools
- explicit closer evidence was retained
- an explicit probable-starter exclusion removed only that pitcher from the pool
- baseline and default-materialized canonical projection payloads were identical
- all three executions completed
- no role, workload, or roster-order inference occurred
- legacy authority remained preserved
- no production-authority change occurred

## Validation

- final explicit 6TC regression: 218 passed
- representative 100-trial acceptance signals: all passed
- public shadow import contract passed
- compilation passed
- working-tree and new-file whitespace checks passed

## Scope

This slice establishes and wires the read-only evidence boundary. It does not invent bullpen roles, recalibrate workloads, alter game probabilities under missing evidence, or perform database writes. Explicit evidence may change only the eligible canonical pitcher pool as intended.