### PR TITLE
Audit canonical pregame pitcher evidence source coverage

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -16,6 +16,9 @@ from mlb_app.simulation.projections.pitcher_projection_authority import (
 from mlb_app.simulation.shadow.canonical_pitcher_projection_activation_readiness import (
     audit_canonical_pitcher_projection_activation_readiness,
 )
+from mlb_app.simulation.shadow.canonical_pregame_pitcher_evidence_source_coverage import (
+    audit_canonical_pregame_pitcher_evidence_source_coverage,
+)
 from mlb_app.simulation.shadow.canonical_pitcher_projection_pool_and_workload_calibration import (
     audit_canonical_pitcher_projection_pool_and_workload_calibration,
 )
@@ -813,6 +816,7 @@ def _attach_production_shadow_comparison(
     legacy_result: Dict[str, Any],
     production_execution: Any,
     bullpen_discovery: Any = None,
+    pregame_pitcher_evidence_source_coverage: Any = None,
 ) -> Dict[str, Any]:
     """
     Attach executed canonical material to the existing shadow comparator.
@@ -861,6 +865,41 @@ def _attach_production_shadow_comparison(
         .get("diagnostics", {})
         .get("canonical_shadow", {})
     )
+
+    if isinstance(
+        pregame_pitcher_evidence_source_coverage,
+        dict,
+    ):
+        source_coverage = deepcopy(
+            pregame_pitcher_evidence_source_coverage
+        )
+    else:
+        source_coverage = {
+            "schema_version": (
+                "canonical_pregame_pitcher_evidence_"
+                "source_coverage_v1"
+            ),
+            "status": "unavailable",
+            "audited": False,
+            "blockers": [
+                "pregame_pitcher_evidence_source_"
+                "coverage_unavailable",
+            ],
+            "decision": {
+                "provider_integration_ready": False,
+                "production_activation_allowed": False,
+                "recommended_next_slice": (
+                    "source_canonical_pregame_"
+                    "bullpen_evidence"
+                ),
+            },
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+    shadow[
+        "pregame_pitcher_evidence_source_coverage"
+    ] = source_coverage
 
     try:
         reconciled_projection_rows = (
@@ -1662,6 +1701,47 @@ def build_model_projection_payload(
             except Exception as shared_exc:
                 shared_simulation = {"status": "error", "error": str(shared_exc), "meta": {"game_pk": matchup.get("game_pk") or matchup.get("gamePk"), "source_route": "/models/projections"}}
 
+            try:
+                pregame_pitcher_evidence_source_coverage = (
+                    audit_canonical_pregame_pitcher_evidence_source_coverage(
+                        matchup=matchup,
+                        bullpen_discovery=(
+                            canonical_shadow_bullpen_discovery
+                        ),
+                    )
+                )
+            except Exception as source_coverage_exc:
+                pregame_pitcher_evidence_source_coverage = {
+                    "schema_version": (
+                        "canonical_pregame_pitcher_"
+                        "evidence_source_coverage_v1"
+                    ),
+                    "status": "error",
+                    "audited": False,
+                    "blockers": [
+                        "source_coverage_audit_error",
+                    ],
+                    "error_type": (
+                        source_coverage_exc
+                        .__class__.__name__
+                    ),
+                    "error_message": str(
+                        source_coverage_exc
+                    ),
+                    "decision": {
+                        "provider_integration_ready":
+                            False,
+                        "production_activation_allowed":
+                            False,
+                        "recommended_next_slice": (
+                            "source_canonical_pregame_"
+                            "bullpen_evidence"
+                        ),
+                    },
+                    "database_writes_performed": False,
+                    "production_authority_changed": False,
+                }
+
             shared_simulation = (
                 _attach_production_shadow_comparison(
                     legacy_result=shared_simulation,
@@ -1672,6 +1752,9 @@ def build_model_projection_payload(
                         _canonical_pitcher_pool_audit_input(
                             canonical_shadow_bullpen_discovery
                         )
+                    ),
+                    pregame_pitcher_evidence_source_coverage=(
+                        pregame_pitcher_evidence_source_coverage
                     ),
                 )
             )

--- a/mlb_app/simulation/shadow/canonical_pregame_pitcher_evidence_source_coverage.py
+++ b/mlb_app/simulation/shadow/canonical_pregame_pitcher_evidence_source_coverage.py
@@ -1,0 +1,545 @@
+"""Audit canonical pregame pitcher evidence source coverage."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .bullpen_discovery import (
+    CanonicalShadowBullpenDiscovery,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pregame_pitcher_evidence_"
+    "source_coverage_v1"
+)
+
+SCHEDULED_STARTER_SOURCE = (
+    "mlb_stats_probablePitcher"
+)
+
+PITCHING_PLAN_SOURCE = (
+    "canonical_pregame_pitching_plan"
+)
+
+TYPICAL_BULLPEN_ROLES = frozenset({
+    "closer",
+    "setup",
+    "middle_reliever",
+    "long_reliever",
+})
+
+
+def _rate(
+    numerator: int,
+    denominator: int,
+) -> float:
+    if denominator <= 0:
+        return 0.0
+
+    return round(
+        numerator / denominator,
+        6,
+    )
+
+
+def _matchup_source(
+    matchup: Mapping[str, Any],
+    *,
+    side: str,
+) -> tuple[str, str | None]:
+    status = str(
+        matchup.get(f"{side}_pitcher_status")
+        or "missing"
+    ).strip().lower()
+    source_value = matchup.get(
+        f"{side}_pitcher_source"
+    )
+    source = (
+        str(source_value).strip()
+        if source_value not in {None, ""}
+        else None
+    )
+
+    return status, source
+
+
+def _side_evidence(
+    discovery: CanonicalShadowBullpenDiscovery,
+    *,
+    side: str,
+) -> tuple[Any, Mapping[str, Any]]:
+    side_discovery = getattr(
+        discovery,
+        side,
+    )
+    materialization = (
+        side_discovery.pregame_evidence
+    )
+
+    if materialization is None:
+        return side_discovery, {}
+
+    evidence = (
+        materialization.evidence_by_pitcher_id
+    )
+
+    if not isinstance(evidence, Mapping):
+        return side_discovery, {}
+
+    return side_discovery, evidence
+
+
+def _audit_side(
+    *,
+    side: str,
+    matchup: Mapping[str, Any],
+    discovery: CanonicalShadowBullpenDiscovery,
+) -> dict[str, Any]:
+    side_discovery, evidence = _side_evidence(
+        discovery,
+        side=side,
+    )
+    starter_status, starter_source = (
+        _matchup_source(
+            matchup,
+            side=side,
+        )
+    )
+    starter_id = (
+        side_discovery.starter_id
+    )
+
+    starter_source_valid = (
+        starter_id is not None
+        and starter_status == "probable"
+        and starter_source
+        == SCHEDULED_STARTER_SOURCE
+    )
+
+    active_roster_pitcher_count = len(
+        evidence
+    )
+
+    if (
+        starter_id is not None
+        and starter_id not in evidence
+    ):
+        active_roster_pitcher_count += 1
+
+    bullpen_candidate_count = len(
+        side_discovery.bullpen_pitcher_ids
+    )
+
+    provider_evidence_count = 0
+    valid_provider_evidence_count = 0
+    explicit_availability_count = 0
+    typical_role_count = 0
+    unknown_evidence_count = 0
+    invalid_evidence_count = 0
+    source_counts = Counter()
+    role_counts = Counter()
+    status_counts = Counter()
+
+    for pitcher_id, raw_record in (
+        evidence.items()
+    ):
+        if not isinstance(raw_record, Mapping):
+            invalid_evidence_count += 1
+            continue
+
+        source_value = raw_record.get("source")
+        source = (
+            str(source_value).strip()
+            if source_value not in {None, ""}
+            else None
+        )
+        status = str(
+            raw_record.get("status")
+            or "unknown"
+        ).strip().lower()
+        role = str(
+            raw_record.get("role")
+            or "unknown"
+        ).strip().lower()
+        valid = (
+            raw_record.get("evidence_valid")
+            is True
+        )
+
+        status_counts[status] += 1
+        role_counts[role] += 1
+
+        if source is not None:
+            source_counts[source] += 1
+
+        if (
+            source is not None
+            and source != PITCHING_PLAN_SOURCE
+        ):
+            provider_evidence_count += 1
+
+            if valid:
+                valid_provider_evidence_count += 1
+
+                if status in {
+                    "eligible",
+                    "ineligible",
+                }:
+                    explicit_availability_count += 1
+
+                if role in TYPICAL_BULLPEN_ROLES:
+                    typical_role_count += 1
+
+        if status == "unknown":
+            unknown_evidence_count += 1
+
+        if not valid:
+            invalid_evidence_count += 1
+
+    materialization = (
+        side_discovery.pregame_evidence
+    )
+    materialization_diagnostics = (
+        materialization.diagnostics
+        if materialization is not None
+        and isinstance(
+            materialization.diagnostics,
+            Mapping,
+        )
+        else {}
+    )
+
+    return {
+        "team_side": side,
+        "scheduled_starter_present": (
+            starter_id is not None
+        ),
+        "scheduled_starter_status": (
+            starter_status
+        ),
+        "scheduled_starter_source": (
+            starter_source
+        ),
+        "scheduled_starter_source_valid": (
+            starter_source_valid
+        ),
+        "active_roster_pitcher_count": (
+            active_roster_pitcher_count
+        ),
+        "bullpen_candidate_count": (
+            bullpen_candidate_count
+        ),
+        "materialization_available": (
+            materialization is not None
+        ),
+        "provider_evidence_count": (
+            provider_evidence_count
+        ),
+        "valid_provider_evidence_count": (
+            valid_provider_evidence_count
+        ),
+        "explicit_availability_count": (
+            explicit_availability_count
+        ),
+        "typical_role_count": (
+            typical_role_count
+        ),
+        "unknown_evidence_count": (
+            unknown_evidence_count
+        ),
+        "invalid_evidence_count": (
+            invalid_evidence_count
+        ),
+        "stale_observation_count": int(
+            materialization_diagnostics.get(
+                "stale_observation_count"
+            )
+            or 0
+        ),
+        "conflicting_pitcher_count": int(
+            materialization_diagnostics.get(
+                "conflicting_pitcher_count"
+            )
+            or 0
+        ),
+        "provider_evidence_coverage_rate": (
+            _rate(
+                valid_provider_evidence_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "explicit_availability_coverage_rate": (
+            _rate(
+                explicit_availability_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "typical_role_coverage_rate": (
+            _rate(
+                typical_role_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "source_counts": dict(
+            sorted(source_counts.items())
+        ),
+        "role_counts": dict(
+            sorted(role_counts.items())
+        ),
+        "status_counts": dict(
+            sorted(status_counts.items())
+        ),
+        "pitcher_identifiers_exposed": False,
+    }
+
+
+def audit_canonical_pregame_pitcher_evidence_source_coverage(
+    *,
+    matchup: Mapping[str, Any],
+    bullpen_discovery: CanonicalShadowBullpenDiscovery,
+) -> dict[str, Any]:
+    """
+    Audit source coverage without changing pitcher evidence.
+
+    Active-roster membership is not interpreted as game availability.
+    Simulation usage, workload, roster order, and news keywords are not
+    treated as explicit role or availability evidence.
+    """
+
+    if not isinstance(matchup, Mapping):
+        raise TypeError(
+            "matchup must be a mapping"
+        )
+
+    if not isinstance(
+        bullpen_discovery,
+        CanonicalShadowBullpenDiscovery,
+    ):
+        raise TypeError(
+            "bullpen_discovery must be a canonical "
+            "shadow bullpen discovery"
+        )
+
+    away = _audit_side(
+        side="away",
+        matchup=matchup,
+        discovery=bullpen_discovery,
+    )
+    home = _audit_side(
+        side="home",
+        matchup=matchup,
+        discovery=bullpen_discovery,
+    )
+
+    sides = (away, home)
+
+    scheduled_starter_count = sum(
+        int(side["scheduled_starter_present"])
+        for side in sides
+    )
+    scheduled_starter_source_valid_count = sum(
+        int(
+            side[
+                "scheduled_starter_source_valid"
+            ]
+        )
+        for side in sides
+    )
+    bullpen_candidate_count = sum(
+        side["bullpen_candidate_count"]
+        for side in sides
+    )
+    valid_provider_evidence_count = sum(
+        side["valid_provider_evidence_count"]
+        for side in sides
+    )
+    explicit_availability_count = sum(
+        side["explicit_availability_count"]
+        for side in sides
+    )
+    typical_role_count = sum(
+        side["typical_role_count"]
+        for side in sides
+    )
+    unknown_evidence_count = sum(
+        side["unknown_evidence_count"]
+        for side in sides
+    )
+    invalid_evidence_count = sum(
+        side["invalid_evidence_count"]
+        for side in sides
+    )
+    stale_observation_count = sum(
+        side["stale_observation_count"]
+        for side in sides
+    )
+    conflicting_pitcher_count = sum(
+        side["conflicting_pitcher_count"]
+        for side in sides
+    )
+
+    blockers = []
+
+    if (
+        scheduled_starter_source_valid_count
+        < scheduled_starter_count
+    ):
+        blockers.append(
+            "scheduled_starter_source_incomplete"
+        )
+
+    if (
+        bullpen_candidate_count > 0
+        and explicit_availability_count
+        < bullpen_candidate_count
+    ):
+        blockers.append(
+            "bullpen_availability_source_incomplete"
+        )
+
+    if (
+        bullpen_candidate_count > 0
+        and typical_role_count
+        < bullpen_candidate_count
+    ):
+        blockers.append(
+            "typical_bullpen_role_source_incomplete"
+        )
+
+    if stale_observation_count > 0:
+        blockers.append(
+            "stale_pregame_evidence_observed"
+        )
+
+    if conflicting_pitcher_count > 0:
+        blockers.append(
+            "conflicting_pregame_evidence_observed"
+        )
+
+    provider_integration_ready = (
+        len(blockers) == 0
+        and bullpen_candidate_count > 0
+    )
+
+    status = (
+        "ready"
+        if provider_integration_ready
+        else "coverage_gaps_observed"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "audited": True,
+        "game_pk": (
+            matchup.get("game_pk")
+            or matchup.get("gamePk")
+        ),
+        "game_time_present": bool(
+            matchup.get("game_time")
+        ),
+        "away": away,
+        "home": home,
+        "scheduled_starter_count": (
+            scheduled_starter_count
+        ),
+        "scheduled_starter_source_valid_count": (
+            scheduled_starter_source_valid_count
+        ),
+        "scheduled_starter_source_coverage_rate": (
+            _rate(
+                scheduled_starter_source_valid_count,
+                scheduled_starter_count,
+            )
+        ),
+        "bullpen_candidate_count": (
+            bullpen_candidate_count
+        ),
+        "valid_provider_evidence_count": (
+            valid_provider_evidence_count
+        ),
+        "provider_evidence_coverage_rate": (
+            _rate(
+                valid_provider_evidence_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "explicit_availability_count": (
+            explicit_availability_count
+        ),
+        "explicit_availability_coverage_rate": (
+            _rate(
+                explicit_availability_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "typical_role_count": (
+            typical_role_count
+        ),
+        "typical_role_coverage_rate": (
+            _rate(
+                typical_role_count,
+                bullpen_candidate_count,
+            )
+        ),
+        "unknown_evidence_count": (
+            unknown_evidence_count
+        ),
+        "invalid_evidence_count": (
+            invalid_evidence_count
+        ),
+        "stale_observation_count": (
+            stale_observation_count
+        ),
+        "conflicting_pitcher_count": (
+            conflicting_pitcher_count
+        ),
+        "blockers": sorted(set(blockers)),
+        "decision": {
+            "provider_integration_ready": (
+                provider_integration_ready
+            ),
+            "production_activation_allowed": False,
+            "recommended_next_slice": (
+                "source_canonical_pregame_"
+                "bullpen_evidence"
+            ),
+        },
+        "source_capabilities": {
+            "mlb_stats_probable_pitcher": {
+                "scheduled_starter_supported": True,
+                "game_availability_supported": False,
+                "typical_bullpen_role_supported": False,
+            },
+            "mlb_stats_active_roster": {
+                "active_roster_membership_supported": True,
+                "game_availability_supported": False,
+                "typical_bullpen_role_supported": False,
+            },
+        },
+        "interpretation": {
+            "active_roster_membership_is_not_game_availability":
+                True,
+            "news_keywords_are_not_structured_evidence":
+                True,
+            "simulation_usage_is_not_pregame_evidence":
+                True,
+            "workload_is_not_role_evidence": True,
+            "roster_order_is_not_role_evidence": True,
+            "unknown_evidence_fails_open": True,
+        },
+        "safety_checks": {
+            "pitcher_evidence_unchanged": True,
+            "pitcher_pools_unchanged": True,
+            "pitching_plans_unchanged": True,
+            "projection_values_unchanged": True,
+            "game_probabilities_unchanged": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/tests/test_canonical_pregame_pitcher_evidence_source_coverage.py
+++ b/tests/test_canonical_pregame_pitcher_evidence_source_coverage.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow import (
+    discover_canonical_shadow_bullpens,
+)
+from mlb_app.simulation.shadow.canonical_pregame_pitcher_evidence_source_coverage import (
+    SCHEMA_VERSION,
+    audit_canonical_pregame_pitcher_evidence_source_coverage,
+)
+
+
+AS_OF = "2026-08-09T23:05:00+00:00"
+
+
+def roster(team_id, season, team_name=None):
+    starter = 100 if team_id == 10 else 200
+
+    return [
+        {
+            "mlb_player_id": starter,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 1,
+            "player_type": "pitcher",
+        },
+        {
+            "mlb_player_id": starter + 2,
+            "player_type": "pitcher",
+        },
+    ]
+
+
+def matchup():
+    return {
+        "game_pk": 123,
+        "game_time": AS_OF,
+        "away_pitcher_status": "probable",
+        "away_pitcher_source": (
+            "mlb_stats_probablePitcher"
+        ),
+        "home_pitcher_status": "probable",
+        "home_pitcher_source": (
+            "mlb_stats_probablePitcher"
+        ),
+    }
+
+
+def discovery(**overrides):
+    values = {
+        "away_team_id": 10,
+        "away_team_name": "Away Team",
+        "away_starter_id": 100,
+        "home_team_id": 20,
+        "home_team_name": "Home Team",
+        "home_starter_id": 200,
+        "season": 2026,
+        "roster_fetcher": roster,
+        "pregame_evidence_as_of": AS_OF,
+    }
+    values.update(overrides)
+
+    return discover_canonical_shadow_bullpens(
+        **values
+    )
+
+
+def run(**overrides):
+    values = {
+        "matchup": matchup(),
+        "bullpen_discovery": discovery(),
+    }
+    values.update(overrides)
+
+    return (
+        audit_canonical_pregame_pitcher_evidence_source_coverage(
+            **values
+        )
+    )
+
+
+def observation(
+    pitcher_id,
+    *,
+    status="eligible",
+    role="closer",
+    source="provider_depth_chart_v1",
+    observed_at="2026-08-09T22:30:00+00:00",
+    reason=None,
+):
+    return {
+        "pitcher_id": pitcher_id,
+        "status": status,
+        "role": role,
+        "source": source,
+        "observed_at": observed_at,
+        "reason": reason,
+    }
+
+
+def test_default_production_sources_show_real_gap():
+    result = run()
+
+    assert result["status"] == (
+        "coverage_gaps_observed"
+    )
+    assert result[
+        "scheduled_starter_source_coverage_rate"
+    ] == 1.0
+    assert result[
+        "provider_evidence_coverage_rate"
+    ] == 0.0
+    assert result[
+        "explicit_availability_coverage_rate"
+    ] == 0.0
+    assert result[
+        "typical_role_coverage_rate"
+    ] == 0.0
+    assert result["unknown_evidence_count"] == 4
+
+    assert result["blockers"] == [
+        "bullpen_availability_source_incomplete",
+        "typical_bullpen_role_source_incomplete",
+    ]
+
+
+def test_explicit_provider_evidence_is_counted():
+    source = discovery(
+        away_pregame_provider_observations=(
+            observation("101", role="closer"),
+            observation(
+                "102",
+                role="long_reliever",
+            ),
+        ),
+        home_pregame_provider_observations=(
+            observation("201", role="setup"),
+            observation(
+                "202",
+                role="middle_reliever",
+            ),
+        ),
+    )
+
+    result = run(
+        bullpen_discovery=source,
+    )
+
+    assert result["status"] == "ready"
+    assert result[
+        "valid_provider_evidence_count"
+    ] == 4
+    assert result[
+        "provider_evidence_coverage_rate"
+    ] == 1.0
+    assert result[
+        "explicit_availability_coverage_rate"
+    ] == 1.0
+    assert result[
+        "typical_role_coverage_rate"
+    ] == 1.0
+    assert result["blockers"] == []
+    assert result["decision"][
+        "provider_integration_ready"
+    ] is True
+    assert result["decision"][
+        "production_activation_allowed"
+    ] is False
+
+
+def test_explicit_unavailability_counts_as_coverage():
+    source = discovery(
+        away_pregame_provider_observations=(
+            observation(
+                "101",
+                status="ineligible",
+                role="long_reliever",
+                source="provider_game_status_v1",
+                reason="unavailable_after_usage",
+            ),
+        ),
+    )
+
+    result = run(
+        bullpen_discovery=source,
+    )
+
+    assert result["away"][
+        "explicit_availability_count"
+    ] == 1
+    assert result["away"][
+        "typical_role_count"
+    ] == 1
+
+
+def test_stale_evidence_is_reported_not_accepted():
+    source = discovery(
+        pregame_maximum_age_seconds=3600,
+        away_pregame_provider_observations=(
+            observation(
+                "101",
+                observed_at=(
+                    "2026-08-09T20:00:00+00:00"
+                ),
+            ),
+        ),
+    )
+
+    result = run(
+        bullpen_discovery=source,
+    )
+
+    assert result["stale_observation_count"] == 1
+    assert (
+        "stale_pregame_evidence_observed"
+        in result["blockers"]
+    )
+    assert result[
+        "valid_provider_evidence_count"
+    ] == 0
+
+
+def test_conflicting_evidence_is_reported():
+    source = discovery(
+        away_pregame_provider_observations=(
+            observation(
+                "101",
+                status="eligible",
+            ),
+            observation(
+                "101",
+                status="ineligible",
+            ),
+        ),
+    )
+
+    result = run(
+        bullpen_discovery=source,
+    )
+
+    assert result[
+        "conflicting_pitcher_count"
+    ] == 1
+    assert (
+        "conflicting_pregame_evidence_observed"
+        in result["blockers"]
+    )
+
+
+def test_missing_starter_source_is_reported():
+    source_matchup = matchup()
+    source_matchup[
+        "away_pitcher_source"
+    ] = None
+
+    result = run(
+        matchup=source_matchup,
+    )
+
+    assert result[
+        "scheduled_starter_source_valid_count"
+    ] == 1
+    assert result[
+        "scheduled_starter_source_coverage_rate"
+    ] == 0.5
+    assert (
+        "scheduled_starter_source_incomplete"
+        in result["blockers"]
+    )
+
+
+def test_active_roster_is_not_availability_evidence():
+    result = run()
+
+    capabilities = result[
+        "source_capabilities"
+    ]["mlb_stats_active_roster"]
+
+    assert capabilities[
+        "active_roster_membership_supported"
+    ] is True
+    assert capabilities[
+        "game_availability_supported"
+    ] is False
+    assert capabilities[
+        "typical_bullpen_role_supported"
+    ] is False
+
+
+def test_audit_does_not_mutate_inputs():
+    source_matchup = matchup()
+    source_discovery = discovery()
+
+    before_matchup = deepcopy(source_matchup)
+    before_diagnostics = deepcopy(
+        source_discovery.to_diagnostics()
+    )
+    before_away_pool = (
+        source_discovery
+        .away
+        .bullpen_pitcher_ids
+    )
+    before_home_pool = (
+        source_discovery
+        .home
+        .bullpen_pitcher_ids
+    )
+
+    run(
+        matchup=source_matchup,
+        bullpen_discovery=source_discovery,
+    )
+
+    assert source_matchup == before_matchup
+    assert (
+        source_discovery.to_diagnostics()
+        == before_diagnostics
+    )
+    assert (
+        source_discovery
+        .away
+        .bullpen_pitcher_ids
+        == before_away_pool
+    )
+    assert (
+        source_discovery
+        .home
+        .bullpen_pitcher_ids
+        == before_home_pool
+    )
+
+
+def test_reports_schema_interpretation_and_safety():
+    result = run()
+
+    assert result["schema_version"] == (
+        SCHEMA_VERSION
+    )
+    assert result["audited"] is True
+    assert result["interpretation"][
+        "active_roster_membership_is_not_game_availability"
+    ] is True
+    assert result["interpretation"][
+        "news_keywords_are_not_structured_evidence"
+    ] is True
+    assert result["interpretation"][
+        "simulation_usage_is_not_pregame_evidence"
+    ] is True
+    assert result["safety_checks"][
+        "pitcher_pools_unchanged"
+    ] is True
+    assert result["safety_checks"][
+        "game_probabilities_unchanged"
+    ] is True
+    assert result[
+        "database_writes_performed"
+    ] is False
+    assert result[
+        "production_authority_changed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "invalid_matchup",
+    (None, [], "matchup"),
+)
+def test_invalid_matchup_is_rejected(
+    invalid_matchup,
+):
+    with pytest.raises(
+        TypeError,
+        match="matchup must be a mapping",
+    ):
+        run(matchup=invalid_matchup)
+
+
+def test_invalid_discovery_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match=(
+            "bullpen_discovery must be a canonical"
+        ),
+    ):
+        run(bullpen_discovery={})

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -969,3 +969,116 @@ def test_comparator_applies_explicit_pitcher_pool_role_evidence():
     assert result[
         "home_win_probability"
     ] == legacy["home_win_probability"]
+def test_comparator_attaches_pregame_pitcher_evidence_source_coverage():
+    legacy = legacy_payload()
+    coverage = {
+        "schema_version": (
+            "canonical_pregame_pitcher_evidence_"
+            "source_coverage_v1"
+        ),
+        "status": "observed",
+        "audited": True,
+        "blockers": [
+            "bullpen_availability_source_incomplete",
+            "typical_bullpen_role_source_incomplete",
+        ],
+        "scheduled_starter_source_coverage_rate": 1.0,
+        "provider_evidence_coverage_rate": 0.0,
+        "explicit_availability_coverage_rate": 0.0,
+        "typical_role_coverage_rate": 0.0,
+        "decision": {
+            "provider_integration_ready": False,
+            "production_activation_allowed": False,
+            "recommended_next_slice": (
+                "source_canonical_pregame_"
+                "bullpen_evidence"
+            ),
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+            bullpen_discovery=(
+                model_projections
+                ._canonical_pitcher_pool_audit_input(
+                    bullpens()
+                )
+            ),
+            pregame_pitcher_evidence_source_coverage=(
+                coverage
+            ),
+        )
+    )
+
+    shadow = result["diagnostics"][
+        "canonical_shadow"
+    ]
+    attached = shadow[
+        "pregame_pitcher_evidence_source_coverage"
+    ]
+
+    assert attached == coverage
+    assert attached is not coverage
+    assert attached["status"] == "observed"
+    assert attached["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert attached[
+        "database_writes_performed"
+    ] is False
+    assert attached[
+        "production_authority_changed"
+    ] is False
+
+    assert shadow["authoritative_source"] == "legacy"
+    assert result[
+        "away_win_probability"
+    ] == legacy["away_win_probability"]
+    assert result[
+        "home_win_probability"
+    ] == legacy["home_win_probability"]
+
+
+def test_comparator_marks_missing_source_coverage_unavailable():
+    legacy = legacy_payload()
+
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy,
+            production_execution=executed_shadow(
+                simulation_count=100,
+            ),
+            bullpen_discovery=(
+                model_projections
+                ._canonical_pitcher_pool_audit_input(
+                    bullpens()
+                )
+            ),
+        )
+    )
+
+    coverage = result["diagnostics"][
+        "canonical_shadow"
+    ][
+        "pregame_pitcher_evidence_source_coverage"
+    ]
+
+    assert coverage["status"] == "unavailable"
+    assert coverage["audited"] is False
+    assert coverage["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert coverage[
+        "database_writes_performed"
+    ] is False
+    assert coverage[
+        "production_authority_changed"
+    ] is False


### PR DESCRIPTION
## Summary

- audit canonical pregame pitcher evidence source coverage for scheduled starters and bullpen candidates
- quantify structured provider, explicit availability, and typical bullpen-role coverage
- report unknown, invalid, stale, and conflicting evidence without exposing pitcher identifiers
- attach the read-only coverage audit to production-shadow diagnostics
- fail closed when coverage diagnostics are unavailable or the audit errors

## Production evidence

The production-shaped probe confirmed:

- scheduled starter source coverage is 100% through MLB Stats probable-pitcher evidence
- current default bullpen provider coverage is 0%
- current explicit bullpen availability coverage is 0%
- current typical bullpen-role coverage is 0%
- four default bullpen candidates remain unknown
- active-roster membership is not treated as game availability
- news keywords, simulation usage, workload, and roster order are not treated as structured evidence
- complete synthetic provider evidence produces 100% provider, availability, and typical-role coverage
- complete evidence makes provider integration ready but does not permit production activation
- pitcher pools, pitching plans, projection values, and game probabilities remain unchanged
- no database writes or production-authority changes occur

## Validation

- final explicit 6TD regression: 198 passed
- corrected production-shaped acceptance probe: all signals passed
- compilation passed
- working-tree, staged, and new-file whitespace checks passed
- only the four intended 6TD files were staged and committed

## Scope

This slice is observational and read-only. It does not add a provider, infer bullpen roles, change pitcher availability, modify pitcher pools, recalibrate workloads, alter simulation outcomes, or activate production authority.