### PR TITLE
Source canonical pregame bullpen availability and role evidence

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 
 import datetime
+import os
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
@@ -24,6 +25,9 @@ from mlb_app.simulation.shadow.canonical_pitcher_projection_pool_and_workload_ca
 )
 from mlb_app.simulation.shadow.canonical_pitcher_role_and_innings_attribution_audit import (
     audit_canonical_pitcher_role_and_innings_attribution,
+)
+from mlb_app.simulation.shadow.pregame_bullpen_evidence_provider import (
+    fetch_canonical_pregame_bullpen_evidence,
 )
 from mlb_app.simulation.shadow.production_monitoring_ledger import (
     CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
@@ -1222,6 +1226,49 @@ def _enrich_game_workspace_player_projections(
     return shared_simulation
 
 
+def _fetch_configured_pregame_bullpen_evidence(
+    *,
+    matchup: Dict[str, Any],
+    away_team_id: Any,
+    home_team_id: Any,
+    environment: Any = None,
+    fetcher: Any = None,
+) -> Any:
+    if not isinstance(matchup, dict):
+        raise TypeError(
+            "matchup must be a dictionary"
+        )
+
+    if environment is None:
+        environment = os.environ
+
+    if fetcher is None:
+        fetcher = (
+            fetch_canonical_pregame_bullpen_evidence
+        )
+
+    return fetcher(
+        game_pk=(
+            matchup.get("game_pk")
+            or matchup.get("gamePk")
+        ),
+        game_time=matchup.get("game_time"),
+        away_team_id=away_team_id,
+        home_team_id=home_team_id,
+        endpoint=environment.get(
+            "MLB_PREGAME_BULLPEN_EVIDENCE_URL"
+        ),
+        provider_name=environment.get(
+            "MLB_PREGAME_BULLPEN_"
+            "EVIDENCE_PROVIDER"
+        ),
+        api_token=environment.get(
+            "MLB_PREGAME_BULLPEN_"
+            "EVIDENCE_TOKEN"
+        ),
+    )
+
+
 def build_model_projection_payload(
     session: Session,
     target_date: str,
@@ -1269,6 +1316,45 @@ def build_model_projection_payload(
                 )
             )
 
+            canonical_pregame_bullpen_provider = (
+                _fetch_configured_pregame_bullpen_evidence(
+                    matchup=matchup,
+                    away_team_id=away.get(
+                        "team_id"
+                    ),
+                    home_team_id=home.get(
+                        "team_id"
+                    ),
+                )
+            )
+
+            away_provider_observations = (
+                tuple(
+                    matchup.get(
+                        "away_pregame_pitcher_"
+                        "observations"
+                    )
+                    or ()
+                )
+                + canonical_pregame_bullpen_provider
+                .to_observations(
+                    team_side="away"
+                )
+            )
+            home_provider_observations = (
+                tuple(
+                    matchup.get(
+                        "home_pregame_pitcher_"
+                        "observations"
+                    )
+                    or ()
+                )
+                + canonical_pregame_bullpen_provider
+                .to_observations(
+                    team_side="home"
+                )
+            )
+
             canonical_shadow_bullpen_discovery = (
                 discover_canonical_shadow_bullpens(
                     away_team_id=away.get("team_id"),
@@ -1292,18 +1378,10 @@ def build_model_projection_payload(
                         )
                     ),
                     away_pregame_provider_observations=(
-                        matchup.get(
-                            "away_pregame_pitcher_"
-                            "observations"
-                        )
-                        or ()
+                        away_provider_observations
                     ),
                     home_pregame_provider_observations=(
-                        matchup.get(
-                            "home_pregame_pitcher_"
-                            "observations"
-                        )
-                        or ()
+                        home_provider_observations
                     ),
                 )
             )
@@ -1644,6 +1722,13 @@ def build_model_projection_payload(
                 "canonicalShadowBullpenDiscovery"
             ] = (
                 canonical_shadow_bullpen_discovery
+                .to_diagnostics()
+            )
+
+            workspace[
+                "canonicalPregameBullpenEvidenceProvider"
+            ] = (
+                canonical_pregame_bullpen_provider
                 .to_diagnostics()
             )
 

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -89,6 +89,12 @@ from .observed_baserunning_evidence import (
     discover_composed_canonical_baserunning_evidence,
     discover_observed_canonical_baserunning_evidence,
 )
+from .pregame_bullpen_evidence_provider import (
+    PAYLOAD_SCHEMA_VERSION as CANONICAL_PREGAME_BULLPEN_PROVIDER_PAYLOAD_VERSION,
+    SCHEMA_VERSION as CANONICAL_PREGAME_BULLPEN_PROVIDER_VERSION,
+    CanonicalPregameBullpenEvidenceProviderResult,
+    fetch_canonical_pregame_bullpen_evidence,
+)
 from .pregame_pitcher_availability_role_evidence import (
     SCHEMA_VERSION as CANONICAL_PREGAME_PITCHER_EVIDENCE_VERSION,
     CanonicalPregamePitcherEvidenceMaterialization,
@@ -219,6 +225,10 @@ __all__ = [
     "CANONICAL_OBSERVED_BASERUNNING_DIGEST_VERSION",
     "discover_composed_canonical_baserunning_evidence",
     "discover_observed_canonical_baserunning_evidence",
+    "CANONICAL_PREGAME_BULLPEN_PROVIDER_PAYLOAD_VERSION",
+    "CANONICAL_PREGAME_BULLPEN_PROVIDER_VERSION",
+    "CanonicalPregameBullpenEvidenceProviderResult",
+    "fetch_canonical_pregame_bullpen_evidence",
     "CANONICAL_PREGAME_PITCHER_EVIDENCE_VERSION",
     "CanonicalPregamePitcherEvidenceMaterialization",
     "materialize_canonical_pregame_pitcher_evidence",

--- a/mlb_app/simulation/shadow/pregame_bullpen_evidence_provider.py
+++ b/mlb_app/simulation/shadow/pregame_bullpen_evidence_provider.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import datetime as dt
+from typing import Any, Callable, Mapping, Sequence
+
+import requests
+
+
+SCHEMA_VERSION = (
+    "canonical_pregame_bullpen_evidence_provider_v1"
+)
+PAYLOAD_SCHEMA_VERSION = (
+    "canonical_pregame_bullpen_observations_v1"
+)
+
+ALLOWED_TEAM_SIDES = frozenset({
+    "away",
+    "home",
+})
+ALLOWED_AVAILABILITY_STATUSES = frozenset({
+    "eligible",
+    "ineligible",
+    "unknown",
+})
+ALLOWED_TYPICAL_ROLES = frozenset({
+    "closer",
+    "setup",
+    "middle_reliever",
+    "long_reliever",
+})
+
+
+def _identifier(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+
+    normalized = str(value).strip()
+
+    return normalized or None
+
+
+def _text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip()
+
+    return normalized or None
+
+
+def _timestamp(value: Any) -> str | None:
+    normalized = _text(value)
+
+    if normalized is None:
+        return None
+
+    candidate = (
+        normalized[:-1] + "+00:00"
+        if normalized.endswith("Z")
+        else normalized
+    )
+
+    try:
+        parsed = dt.datetime.fromisoformat(
+            candidate
+        )
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return None
+
+    return parsed.isoformat()
+
+
+def _team_identifier(
+    *,
+    team_side: str,
+    away_team_id: Any,
+    home_team_id: Any,
+) -> str | None:
+    return _identifier(
+        away_team_id
+        if team_side == "away"
+        else home_team_id
+    )
+
+
+def _normalize_observation(
+    *,
+    row: Any,
+    away_team_id: Any,
+    home_team_id: Any,
+    provider_name: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    if not isinstance(row, Mapping):
+        return None, "observation_not_mapping"
+
+    team_side = _text(row.get("team_side"))
+
+    if team_side not in ALLOWED_TEAM_SIDES:
+        return None, "team_side_invalid"
+
+    expected_team_id = _team_identifier(
+        team_side=team_side,
+        away_team_id=away_team_id,
+        home_team_id=home_team_id,
+    )
+    observed_team_id = _identifier(
+        row.get("team_id")
+    )
+
+    if (
+        expected_team_id is None
+        or observed_team_id != expected_team_id
+    ):
+        return None, "team_identity_mismatch"
+
+    pitcher_id = _identifier(
+        row.get("pitcher_id")
+    )
+
+    if pitcher_id is None:
+        return None, "pitcher_identity_missing"
+
+    status = _text(row.get("status"))
+
+    if status not in ALLOWED_AVAILABILITY_STATUSES:
+        return None, "availability_status_invalid"
+
+    role = _text(row.get("role"))
+
+    if role is not None and role not in (
+        ALLOWED_TYPICAL_ROLES
+    ):
+        return None, "typical_role_invalid"
+
+    observed_at = _timestamp(
+        row.get("observed_at")
+    )
+
+    if observed_at is None:
+        return None, "observation_timestamp_invalid"
+
+    reason = _text(row.get("reason"))
+    provider_record_id = _identifier(
+        row.get("provider_record_id")
+    )
+
+    return {
+        "pitcher_id": pitcher_id,
+        "status": status,
+        "role": role,
+        "source": (
+            f"{provider_name}_pregame_bullpen_v1"
+        ),
+        "observed_at": observed_at,
+        "reason": reason,
+        "provider_record_id": provider_record_id,
+        "team_side": team_side,
+        "team_id": expected_team_id,
+    }, None
+
+
+@dataclass(frozen=True)
+class CanonicalPregameBullpenEvidenceProviderResult:
+    status: str
+    provider_name: str | None = None
+    endpoint_configured: bool = False
+    observations: tuple[
+        Mapping[str, Any],
+        ...,
+    ] = ()
+    source_record_count: int = 0
+    invalid_record_count: int = 0
+    invalid_reason_counts: Mapping[
+        str,
+        int,
+    ] | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+    def to_observations(
+        self,
+        *,
+        team_side: str,
+    ) -> tuple[dict[str, Any], ...]:
+        if team_side not in ALLOWED_TEAM_SIDES:
+            raise ValueError(
+                "team_side must be away or home"
+            )
+
+        return tuple(
+            deepcopy(dict(observation))
+            for observation in self.observations
+            if observation.get("team_side")
+            == team_side
+        )
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": self.status,
+            "provider_name": self.provider_name,
+            "endpoint_configured": (
+                self.endpoint_configured
+            ),
+            "source_record_count": (
+                self.source_record_count
+            ),
+            "valid_observation_count": len(
+                self.observations
+            ),
+            "invalid_record_count": (
+                self.invalid_record_count
+            ),
+            "invalid_reason_counts": dict(
+                sorted(
+                    (
+                        self.invalid_reason_counts
+                        or {}
+                    ).items()
+                )
+            ),
+            "away_observation_count": sum(
+                observation.get("team_side")
+                == "away"
+                for observation in self.observations
+            ),
+            "home_observation_count": sum(
+                observation.get("team_side")
+                == "home"
+                for observation in self.observations
+            ),
+            "error_type": self.error_type,
+            "error_message": self.error_message,
+            "pitcher_identifiers_exposed": False,
+            "raw_provider_payload_exposed": False,
+            "availability_inference_used": False,
+            "typical_role_inference_used": False,
+            "workload_inference_used": False,
+            "roster_order_inference_used": False,
+            "news_keyword_inference_used": False,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+
+def fetch_canonical_pregame_bullpen_evidence(
+    *,
+    game_pk: Any,
+    game_time: Any,
+    away_team_id: Any,
+    home_team_id: Any,
+    endpoint: str | None,
+    provider_name: str | None,
+    api_token: str | None = None,
+    request_get: Callable[..., Any] = requests.get,
+    timeout_seconds: float = 10.0,
+) -> CanonicalPregameBullpenEvidenceProviderResult:
+    """
+    Fetch explicit pregame bullpen evidence.
+
+    The endpoint is an externally configured structured
+    provider. MLB active-roster membership, news text,
+    workload, roster order, and simulation usage are not
+    converted into availability or typical-role evidence.
+    """
+
+    normalized_endpoint = _text(endpoint)
+    normalized_provider = _text(provider_name)
+
+    if (
+        normalized_endpoint is None
+        or normalized_provider is None
+    ):
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="provider_not_configured",
+                provider_name=normalized_provider,
+                endpoint_configured=(
+                    normalized_endpoint is not None
+                ),
+            )
+        )
+
+    normalized_game_pk = _identifier(game_pk)
+    normalized_game_time = _timestamp(game_time)
+    normalized_away_team_id = _identifier(
+        away_team_id
+    )
+    normalized_home_team_id = _identifier(
+        home_team_id
+    )
+
+    if (
+        normalized_game_pk is None
+        or normalized_game_time is None
+        or normalized_away_team_id is None
+        or normalized_home_team_id is None
+    ):
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="request_context_invalid",
+                provider_name=normalized_provider,
+                endpoint_configured=True,
+            )
+        )
+
+    headers = {
+        "Accept": "application/json",
+    }
+
+    normalized_token = _text(api_token)
+
+    if normalized_token is not None:
+        headers["Authorization"] = (
+            f"Bearer {normalized_token}"
+        )
+
+    try:
+        response = request_get(
+            normalized_endpoint,
+            params={
+                "game_pk": normalized_game_pk,
+                "game_time": normalized_game_time,
+                "away_team_id":
+                    normalized_away_team_id,
+                "home_team_id":
+                    normalized_home_team_id,
+            },
+            headers=headers,
+            timeout=float(timeout_seconds),
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="provider_error",
+                provider_name=normalized_provider,
+                endpoint_configured=True,
+                error_type=exc.__class__.__name__,
+                error_message=str(exc),
+            )
+        )
+
+    if not isinstance(payload, Mapping):
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="payload_invalid",
+                provider_name=normalized_provider,
+                endpoint_configured=True,
+                invalid_record_count=1,
+                invalid_reason_counts={
+                    "payload_not_mapping": 1,
+                },
+            )
+        )
+
+    if (
+        payload.get("schema_version")
+        != PAYLOAD_SCHEMA_VERSION
+    ):
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="schema_mismatch",
+                provider_name=normalized_provider,
+                endpoint_configured=True,
+                invalid_record_count=1,
+                invalid_reason_counts={
+                    "schema_version_invalid": 1,
+                },
+            )
+        )
+
+    rows = payload.get("observations")
+
+    if not isinstance(rows, Sequence) or isinstance(
+        rows,
+        (str, bytes, bytearray),
+    ):
+        return (
+            CanonicalPregameBullpenEvidenceProviderResult(
+                status="payload_invalid",
+                provider_name=normalized_provider,
+                endpoint_configured=True,
+                invalid_record_count=1,
+                invalid_reason_counts={
+                    "observations_not_sequence": 1,
+                },
+            )
+        )
+
+    observations = []
+    invalid_reason_counts: dict[str, int] = {}
+
+    for row in rows:
+        observation, invalid_reason = (
+            _normalize_observation(
+                row=row,
+                away_team_id=(
+                    normalized_away_team_id
+                ),
+                home_team_id=(
+                    normalized_home_team_id
+                ),
+                provider_name=(
+                    normalized_provider
+                ),
+            )
+        )
+
+        if observation is None:
+            reason = (
+                invalid_reason
+                or "observation_invalid"
+            )
+            invalid_reason_counts[reason] = (
+                invalid_reason_counts.get(
+                    reason,
+                    0,
+                )
+                + 1
+            )
+            continue
+
+        observations.append(observation)
+
+    observations.sort(
+        key=lambda observation: (
+            observation["team_side"],
+            observation["pitcher_id"],
+            observation["observed_at"],
+            observation["status"],
+            observation["role"] or "",
+        )
+    )
+
+    invalid_record_count = sum(
+        invalid_reason_counts.values()
+    )
+
+    if observations and invalid_record_count:
+        status = "partial"
+    elif observations:
+        status = "observed"
+    elif invalid_record_count:
+        status = "payload_invalid"
+    else:
+        status = "empty"
+
+    return CanonicalPregameBullpenEvidenceProviderResult(
+        status=status,
+        provider_name=normalized_provider,
+        endpoint_configured=True,
+        observations=tuple(observations),
+        source_record_count=len(rows),
+        invalid_record_count=invalid_record_count,
+        invalid_reason_counts=(
+            invalid_reason_counts
+        ),
+    )

--- a/tests/test_canonical_pregame_bullpen_evidence_provider.py
+++ b/tests/test_canonical_pregame_bullpen_evidence_provider.py
@@ -1,0 +1,700 @@
+from copy import deepcopy
+
+from mlb_app.simulation.shadow.pregame_bullpen_evidence_provider import (
+    PAYLOAD_SCHEMA_VERSION,
+    fetch_canonical_pregame_bullpen_evidence,
+)
+
+
+AS_OF = "2026-08-09T23:05:00+00:00"
+
+
+class Response:
+    def __init__(
+        self,
+        payload,
+        *,
+        error=None,
+    ):
+        self.payload = payload
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+    def json(self):
+        return deepcopy(self.payload)
+
+
+def row(
+    pitcher_id="101",
+    *,
+    team_side="away",
+    team_id="10",
+    status="eligible",
+    role="closer",
+    observed_at="2026-08-09T22:30:00+00:00",
+    reason=None,
+    provider_record_id="record-1",
+):
+    return {
+        "pitcher_id": pitcher_id,
+        "team_side": team_side,
+        "team_id": team_id,
+        "status": status,
+        "role": role,
+        "observed_at": observed_at,
+        "reason": reason,
+        "provider_record_id":
+            provider_record_id,
+    }
+
+
+def payload(*rows):
+    return {
+        "schema_version": PAYLOAD_SCHEMA_VERSION,
+        "observations": list(rows),
+    }
+
+
+def run(
+    source_payload=None,
+    **overrides,
+):
+    calls = []
+
+    if source_payload is None:
+        source_payload = payload(
+            row(),
+            row(
+                "201",
+                team_side="home",
+                team_id="20",
+                status="ineligible",
+                role="long_reliever",
+                reason="unavailable_after_usage",
+                provider_record_id="record-2",
+            ),
+        )
+
+    def request_get(
+        url,
+        *,
+        params,
+        headers,
+        timeout,
+    ):
+        calls.append({
+            "url": url,
+            "params": params,
+            "headers": headers,
+            "timeout": timeout,
+        })
+        return Response(source_payload)
+
+    values = {
+        "game_pk": "123",
+        "game_time": AS_OF,
+        "away_team_id": "10",
+        "home_team_id": "20",
+        "endpoint": (
+            "https://provider.example/"
+            "pregame-bullpen"
+        ),
+        "provider_name": "structured_provider",
+        "api_token": "secret-token",
+        "request_get": request_get,
+    }
+    values.update(overrides)
+
+    return (
+        fetch_canonical_pregame_bullpen_evidence(
+            **values
+        ),
+        calls,
+    )
+
+
+def test_provider_not_configured_does_not_request():
+    called = False
+
+    def request_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError(
+            "request must not be made"
+        )
+
+    result = (
+        fetch_canonical_pregame_bullpen_evidence(
+            game_pk="123",
+            game_time=AS_OF,
+            away_team_id="10",
+            home_team_id="20",
+            endpoint=None,
+            provider_name=None,
+            request_get=request_get,
+        )
+    )
+
+    assert result.status == (
+        "provider_not_configured"
+    )
+    assert result.observations == ()
+    assert called is False
+
+
+def test_fetches_structured_observations():
+    result, calls = run()
+
+    assert result.status == "observed"
+    assert len(result.observations) == 2
+    assert len(calls) == 1
+
+    call = calls[0]
+
+    assert call["params"]["game_pk"] == "123"
+    assert call["params"][
+        "away_team_id"
+    ] == "10"
+    assert call["headers"][
+        "Authorization"
+    ] == "Bearer secret-token"
+    assert call["timeout"] == 10.0
+
+
+def test_normalizes_materializer_observation_contract():
+    result, _ = run()
+
+    away = result.to_observations(
+        team_side="away"
+    )
+    home = result.to_observations(
+        team_side="home"
+    )
+
+    assert away == ({
+        "pitcher_id": "101",
+        "status": "eligible",
+        "role": "closer",
+        "source": (
+            "structured_provider_"
+            "pregame_bullpen_v1"
+        ),
+        "observed_at": (
+            "2026-08-09T22:30:00+00:00"
+        ),
+        "reason": None,
+        "provider_record_id": "record-1",
+        "team_side": "away",
+        "team_id": "10",
+    },)
+
+    assert home[0]["status"] == "ineligible"
+    assert home[0]["role"] == "long_reliever"
+
+
+def test_rejects_cross_team_observation():
+    result, _ = run(
+        source_payload=payload(
+            row(team_id="20"),
+        )
+    )
+
+    assert result.status == "payload_invalid"
+    assert result.observations == ()
+    assert result.invalid_reason_counts == {
+        "team_identity_mismatch": 1,
+    }
+
+
+def test_rejects_unsupported_role_without_inference():
+    result, _ = run(
+        source_payload=payload(
+            row(role="ace"),
+        )
+    )
+
+    assert result.observations == ()
+    assert result.invalid_reason_counts == {
+        "typical_role_invalid": 1,
+    }
+
+
+def test_rejects_missing_or_naive_timestamp():
+    result, _ = run(
+        source_payload=payload(
+            row(observed_at=None),
+            row(
+                "102",
+                observed_at=(
+                    "2026-08-09T22:30:00"
+                ),
+                provider_record_id="record-2",
+            ),
+        )
+    )
+
+    assert result.invalid_record_count == 2
+    assert result.invalid_reason_counts == {
+        "observation_timestamp_invalid": 2,
+    }
+
+
+def test_schema_mismatch_fails_closed():
+    result, _ = run(
+        source_payload={
+            "schema_version": "other",
+            "observations": [],
+        }
+    )
+
+    assert result.status == "schema_mismatch"
+    assert result.observations == ()
+
+
+def test_provider_error_is_diagnostic():
+    def request_get(*args, **kwargs):
+        raise TimeoutError("provider timeout")
+
+    result = (
+        fetch_canonical_pregame_bullpen_evidence(
+            game_pk="123",
+            game_time=AS_OF,
+            away_team_id="10",
+            home_team_id="20",
+            endpoint="https://provider.example",
+            provider_name="structured_provider",
+            request_get=request_get,
+        )
+    )
+
+    assert result.status == "provider_error"
+    assert result.error_type == "TimeoutError"
+    assert result.observations == ()
+
+
+def test_invalid_request_context_does_not_request():
+    called = False
+
+    def request_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError(
+            "request must not be made"
+        )
+
+    result = (
+        fetch_canonical_pregame_bullpen_evidence(
+            game_pk=None,
+            game_time=AS_OF,
+            away_team_id="10",
+            home_team_id="20",
+            endpoint="https://provider.example",
+            provider_name="structured_provider",
+            request_get=request_get,
+        )
+    )
+
+    assert result.status == (
+        "request_context_invalid"
+    )
+    assert called is False
+
+
+def test_diagnostics_redact_identifiers_and_payload():
+    result, _ = run()
+    diagnostics = result.to_diagnostics()
+
+    assert diagnostics[
+        "valid_observation_count"
+    ] == 2
+    assert diagnostics[
+        "away_observation_count"
+    ] == 1
+    assert diagnostics[
+        "home_observation_count"
+    ] == 1
+    assert diagnostics[
+        "pitcher_identifiers_exposed"
+    ] is False
+    assert diagnostics[
+        "raw_provider_payload_exposed"
+    ] is False
+    assert diagnostics[
+        "availability_inference_used"
+    ] is False
+    assert diagnostics[
+        "typical_role_inference_used"
+    ] is False
+    assert diagnostics[
+        "database_writes_performed"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_observations_and_diagnostics_are_defensive():
+    result, _ = run()
+
+    observations = result.to_observations(
+        team_side="away"
+    )
+    observations[0]["status"] = "changed"
+
+    assert result.observations[0][
+        "status"
+    ] == "eligible"
+
+    diagnostics = result.to_diagnostics()
+    diagnostics[
+        "invalid_reason_counts"
+    ]["changed"] = 1
+
+    assert "changed" not in (
+        result.invalid_reason_counts or {}
+    )
+
+
+def test_output_order_is_deterministic():
+    result, _ = run(
+        source_payload=payload(
+            row(
+                "202",
+                team_side="home",
+                team_id="20",
+                role="setup",
+                provider_record_id="record-3",
+            ),
+            row(
+                "102",
+                role="middle_reliever",
+                provider_record_id="record-2",
+            ),
+            row(),
+        )
+    )
+
+    assert [
+        (
+            observation["team_side"],
+            observation["pitcher_id"],
+        )
+        for observation in result.observations
+    ] == [
+        ("away", "101"),
+        ("away", "102"),
+        ("home", "202"),
+    ]
+def test_provider_observations_close_materialized_coverage_gap():
+    from mlb_app.simulation.shadow import (
+        discover_canonical_shadow_bullpens,
+    )
+    from mlb_app.simulation.shadow.canonical_pregame_pitcher_evidence_source_coverage import (
+        audit_canonical_pregame_pitcher_evidence_source_coverage,
+    )
+
+    provider_result, _ = run(
+        source_payload=payload(
+            row(
+                "101",
+                role="closer",
+            ),
+            row(
+                "102",
+                role="long_reliever",
+                provider_record_id="record-2",
+            ),
+            row(
+                "201",
+                team_side="home",
+                team_id="20",
+                role="setup",
+                provider_record_id="record-3",
+            ),
+            row(
+                "202",
+                team_side="home",
+                team_id="20",
+                role="middle_reliever",
+                provider_record_id="record-4",
+            ),
+        )
+    )
+
+    def roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = (
+            100
+            if int(team_id) == 10
+            else 200
+        )
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": starter + 2,
+                "player_type": "pitcher",
+            },
+        ]
+
+    discovery = discover_canonical_shadow_bullpens(
+        away_team_id=10,
+        away_team_name="Away",
+        away_starter_id=100,
+        home_team_id=20,
+        home_team_name="Home",
+        home_starter_id=200,
+        season=2026,
+        roster_fetcher=roster,
+        pregame_evidence_as_of=AS_OF,
+        away_pregame_provider_observations=(
+            provider_result.to_observations(
+                team_side="away"
+            )
+        ),
+        home_pregame_provider_observations=(
+            provider_result.to_observations(
+                team_side="home"
+            )
+        ),
+    )
+
+    coverage = (
+        audit_canonical_pregame_pitcher_evidence_source_coverage(
+            matchup={
+                "game_pk": 123,
+                "game_time": AS_OF,
+                "away_pitcher_status":
+                    "probable",
+                "away_pitcher_source": (
+                    "mlb_stats_probablePitcher"
+                ),
+                "home_pitcher_status":
+                    "probable",
+                "home_pitcher_source": (
+                    "mlb_stats_probablePitcher"
+                ),
+            },
+            bullpen_discovery=discovery,
+        )
+    )
+
+    assert provider_result.status == "observed"
+    assert discovery.away.pregame_evidence is not None
+    assert discovery.home.pregame_evidence is not None
+
+    assert coverage["status"] == "ready"
+    assert coverage["blockers"] == []
+    assert coverage[
+        "provider_evidence_coverage_rate"
+    ] == 1.0
+    assert coverage[
+        "explicit_availability_coverage_rate"
+    ] == 1.0
+    assert coverage[
+        "typical_role_coverage_rate"
+    ] == 1.0
+    assert coverage["decision"][
+        "provider_integration_ready"
+    ] is True
+    assert coverage["decision"][
+        "production_activation_allowed"
+    ] is False
+    assert coverage[
+        "production_authority_changed"
+    ] is False
+
+
+def test_unconfigured_provider_preserves_empty_observation_contract():
+    result = (
+        fetch_canonical_pregame_bullpen_evidence(
+            game_pk="123",
+            game_time=AS_OF,
+            away_team_id="10",
+            home_team_id="20",
+            endpoint=None,
+            provider_name=None,
+        )
+    )
+
+    assert result.status == (
+        "provider_not_configured"
+    )
+    assert result.to_observations(
+        team_side="away"
+    ) == ()
+    assert result.to_observations(
+        team_side="home"
+    ) == ()
+
+    diagnostics = result.to_diagnostics()
+
+    assert diagnostics[
+        "valid_observation_count"
+    ] == 0
+    assert diagnostics[
+        "availability_inference_used"
+    ] is False
+    assert diagnostics[
+        "typical_role_inference_used"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_public_shadow_provider_contract():
+    from mlb_app.simulation.shadow import (
+        CANONICAL_PREGAME_BULLPEN_PROVIDER_PAYLOAD_VERSION,
+        CANONICAL_PREGAME_BULLPEN_PROVIDER_VERSION,
+        CanonicalPregameBullpenEvidenceProviderResult,
+        fetch_canonical_pregame_bullpen_evidence as public_fetch,
+    )
+
+    assert (
+        CANONICAL_PREGAME_BULLPEN_PROVIDER_PAYLOAD_VERSION
+        == PAYLOAD_SCHEMA_VERSION
+    )
+    assert (
+        CANONICAL_PREGAME_BULLPEN_PROVIDER_VERSION
+        == (
+            "canonical_pregame_bullpen_"
+            "evidence_provider_v1"
+        )
+    )
+    assert public_fetch is (
+        fetch_canonical_pregame_bullpen_evidence
+    )
+    assert (
+        CanonicalPregameBullpenEvidenceProviderResult
+        is not None
+    )
+def test_production_adapter_passes_explicit_configuration_and_context():
+    from mlb_app import model_projections
+
+    calls = []
+    sentinel = object()
+
+    def fetcher(**kwargs):
+        calls.append(kwargs)
+        return sentinel
+
+    result = (
+        model_projections
+        ._fetch_configured_pregame_bullpen_evidence(
+            matchup={
+                "game_pk": 123,
+                "game_time": AS_OF,
+            },
+            away_team_id=10,
+            home_team_id=20,
+            environment={
+                "MLB_PREGAME_BULLPEN_EVIDENCE_URL":
+                    "https://provider.example/evidence",
+                "MLB_PREGAME_BULLPEN_EVIDENCE_PROVIDER":
+                    "structured_provider",
+                "MLB_PREGAME_BULLPEN_EVIDENCE_TOKEN":
+                    "secret-token",
+            },
+            fetcher=fetcher,
+        )
+    )
+
+    assert result is sentinel
+    assert calls == [{
+        "game_pk": 123,
+        "game_time": AS_OF,
+        "away_team_id": 10,
+        "home_team_id": 20,
+        "endpoint": (
+            "https://provider.example/evidence"
+        ),
+        "provider_name": "structured_provider",
+        "api_token": "secret-token",
+    }]
+
+
+def test_production_adapter_unconfigured_environment_is_inert():
+    from mlb_app import model_projections
+
+    calls = []
+
+    def fetcher(**kwargs):
+        calls.append(kwargs)
+
+        return (
+            fetch_canonical_pregame_bullpen_evidence(
+                request_get=(
+                    lambda *args, **kwargs:
+                    (_ for _ in ()).throw(
+                        AssertionError(
+                            "network request must not occur"
+                        )
+                    )
+                ),
+                **kwargs,
+            )
+        )
+
+    result = (
+        model_projections
+        ._fetch_configured_pregame_bullpen_evidence(
+            matchup={
+                "gamePk": 123,
+                "game_time": AS_OF,
+            },
+            away_team_id=10,
+            home_team_id=20,
+            environment={},
+            fetcher=fetcher,
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["endpoint"] is None
+    assert calls[0]["provider_name"] is None
+    assert calls[0]["api_token"] is None
+
+    assert result.status == (
+        "provider_not_configured"
+    )
+    assert result.observations == ()
+    assert result.to_diagnostics()[
+        "production_authority_changed"
+    ] is False
+
+
+def test_production_adapter_rejects_non_mapping_matchup():
+    from mlb_app import model_projections
+
+    try:
+        (
+            model_projections
+            ._fetch_configured_pregame_bullpen_evidence(
+                matchup=object(),
+                away_team_id=10,
+                home_team_id=20,
+                environment={},
+            )
+        )
+    except TypeError as exc:
+        assert str(exc) == (
+            "matchup must be a dictionary"
+        )
+    else:
+        raise AssertionError(
+            "expected TypeError"
+        )


### PR DESCRIPTION
## Summary

- add a provider-neutral, structured pregame bullpen evidence client
- validate game, team, pitcher, availability, role, timestamp, and schema contracts
- normalize configured observations into the existing 6TC materializer format
- source explicit eligible, ineligible, or unknown availability and typical closer, setup, middle-relief, or long-relief roles
- expose redacted provider diagnostics in the production projection workspace
- preserve existing behavior when the provider is unconfigured, invalid, unavailable, or times out

## Configuration

The integration is inert unless deployment supplies:

- `MLB_PREGAME_BULLPEN_EVIDENCE_URL`
- `MLB_PREGAME_BULLPEN_EVIDENCE_PROVIDER`
- `MLB_PREGAME_BULLPEN_EVIDENCE_TOKEN` when the configured endpoint requires authentication

This slice establishes the application-side contract and ingestion path. It does not select, purchase, provision, or claim the existence of a production provider endpoint.

## Acceptance evidence

The end-to-end provider probe confirmed:

- one structured provider request per game
- four provider observations normalized
- closer, setup, middle-relief, and long-relief roles preserved
- observations materialized through the existing 6TC freshness and conflict path
- provider, explicit availability, and typical-role coverage reached 100%
- provider integration readiness became true
- production activation remained blocked
- an unconfigured provider performed no network request and returned no observations
- provider timeouts failed closed
- active-roster, workload, roster-order, news-keyword, and simulation inference remained disabled
- raw provider payloads and pitcher identifiers were absent from diagnostics
- bullpen authority remained legacy
- pitcher pools, projections, and game probabilities remained unchanged
- no database writes or production-authority changes occurred

## Validation

- final explicit 6TE regression: 216 passed
- end-to-end provider acceptance probe: all signals passed
- compilation passed
- working-tree, staged, and new-file whitespace checks passed
- only the four intended 6TE files were committed

## Scope

This slice adds an optional structured evidence source boundary and production wiring. It does not infer evidence, configure deployment credentials, activate pitcher authority, recalibrate workloads, or independently change pitcher pools or simulation outcomes.