### PR TITLE
Surface canonical pitcher availability and role taxonomy

### DIFF
--- a/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsUiContract.test.mjs
@@ -99,13 +99,26 @@ test('projections tab renders requested batter metrics', async () => {
   }
 })
 
-test('projections tab renders canonical pitcher role', async () => {
+test('projections tab separates pitcher role taxonomy', async () => {
   const source = await pageSource()
 
   assert.match(
     source,
-    /key: 'pitcherRoleLabel', label: 'Role'/,
+    /key: 'plannedPitcherRoleLabel', label: 'Planned Role'/,
   )
+  assert.match(
+    source,
+    /key: 'typicalBullpenRoleLabel', label: 'Typical Role'/,
+  )
+  assert.match(
+    source,
+    /key: 'gameAvailabilityStatusLabel', label: 'Availability'/,
+  )
+  assert.match(
+    source,
+    /key: 'appearanceProbabilityPercent', label: 'App %'/,
+  )
+  assert.match(source, /view\.pitcherSections\.map/)
 })
 
 test('projections tab renders pitcher workload distribution', async () => {
@@ -140,5 +153,26 @@ test('projections tab explains unavailable canonical states', async () => {
   assert.match(
     source,
     /same\s+canonical simulation run/i,
+  )
+})
+
+test('projections tab explains pitcher workload scope', async () => {
+  const source = await pageSource()
+
+  assert.match(
+    source,
+    /unconditional\s+game-level outcomes/i,
+  )
+  assert.match(
+    source,
+    /include nonappearances/i,
+  )
+  assert.match(
+    source,
+    /Appearance probability is shown separately/i,
+  )
+  assert.match(
+    source,
+    /no role is inferred from workload/i,
   )
 })

--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -107,6 +107,93 @@ function pitcherRoleLabel(value) {
   return labels[role] || '—'
 }
 
+function projectionGroupLabel(value) {
+  const labels = {
+    starter: 'Starters',
+    bullpen: 'Bullpen',
+  }
+
+  return labels[String(value || '').trim()]
+    || 'Unclassified'
+}
+
+function typicalBullpenRoleLabel(value) {
+  const labels = {
+    closer: 'Closer',
+    setup: 'Setup',
+    setup_reliever: 'Setup',
+    middle_reliever: 'Middle Relief',
+    long_reliever: 'Long Relief',
+  }
+
+  return labels[String(value || '').trim()]
+    || 'Unknown'
+}
+
+function availabilityStatusLabel(value) {
+  const labels = {
+    planned_primary_pitcher: 'Planned',
+    explicitly_eligible: 'Eligible',
+    active_roster_candidate_unknown: 'Unknown',
+    explicitly_ineligible: 'Unavailable',
+  }
+
+  return labels[String(value || '').trim()]
+    || 'Unknown'
+}
+
+function pitcherSections(rows) {
+  const sideOrder = ['away', 'home']
+  const groupOrder = ['starter', 'bullpen']
+
+  const sections = []
+
+  for (const side of sideOrder) {
+    for (const group of groupOrder) {
+      const sectionRows = rows.filter(
+        row => (
+          row.side === side
+          && row.pitcherProjectionGroup === group
+        ),
+      )
+
+      if (sectionRows.length) {
+        sections.push({
+          key: `${side}-${group}`,
+          title: (
+            `${side === 'away' ? 'Away' : 'Home'} `
+            + projectionGroupLabel(group)
+          ),
+          side,
+          group,
+          rows: sectionRows,
+        })
+      }
+    }
+  }
+
+  const unclassifiedRows = rows.filter(
+    row => (
+      !sideOrder.includes(row.side)
+      || !groupOrder.includes(
+        row.pitcherProjectionGroup,
+      )
+    ),
+  )
+
+  if (unclassifiedRows.length) {
+    sections.push({
+      key: 'unclassified',
+      title: 'Unclassified Pitchers',
+      side: null,
+      group: 'unclassified',
+      rows: unclassifiedRows,
+    })
+  }
+
+  return sections
+}
+
 function dfsValue(row, key) {
   const direct = number(row?.[key])
 
@@ -190,6 +277,55 @@ function pitcherRow(row) {
     pitcherRole: row?.pitcher_role ?? null,
     pitcherRoleLabel: pitcherRoleLabel(
       row?.pitcher_role,
+    ),
+    pitcherProjectionGroup: (
+      row?.pitcher_projection_group || null
+    ),
+    pitcherProjectionGroupLabel: (
+      projectionGroupLabel(
+        row?.pitcher_projection_group,
+      )
+    ),
+    plannedPitcherRole: (
+      row?.planned_pitcher_role || null
+    ),
+    plannedPitcherRoleLabel: pitcherRoleLabel(
+      row?.planned_pitcher_role,
+    ),
+    typicalBullpenRole: (
+      row?.typical_bullpen_role || null
+    ),
+    typicalBullpenRoleLabel: (
+      typicalBullpenRoleLabel(
+        row?.typical_bullpen_role,
+      )
+    ),
+    gameAvailabilityStatus: (
+      row?.game_availability_status || null
+    ),
+    gameAvailabilityStatusLabel: (
+      availabilityStatusLabel(
+        row?.game_availability_status,
+      )
+    ),
+    pitcherPoolMembershipStatus: (
+      row?.pitcher_pool_membership_status
+      || null
+    ),
+    pitcherRoleTaxonomyStatus: (
+      row?.pitcher_role_taxonomy_status
+      || null
+    ),
+    appearanceProbability: number(
+      row?.appearance_probability,
+    ),
+    appearanceProbabilityPercent: (
+      number(row?.appearance_probability) === null
+        ? null
+        : number(row?.appearance_probability) * 100
+    ),
+    workloadDistributionScope: (
+      'unconditional_game_level'
     ),
     authoritative: row?.authoritative === true,
     authoritativeSource: (
@@ -450,6 +586,14 @@ export function buildCanonicalProjectionsViewModel(
         )
   )
 
+  const pitchers = sortRows(
+    players
+      .filter(
+        row => row?.player_type === 'pitcher',
+      )
+      .map(pitcherRow),
+  )
+
   return {
     available,
     unavailable,
@@ -507,12 +651,10 @@ export function buildCanonicalProjectionsViewModel(
         )
         .map(batterRow),
     ),
-    pitchers: sortRows(
-      players
-        .filter(
-          row => row?.player_type === 'pitcher',
-        )
-        .map(pitcherRow),
+    pitchers,
+    pitcherSections: pitcherSections(pitchers),
+    pitcherWorkloadDistributionScope: (
+      'unconditional_game_level'
     ),
     errorMessage: (
       projections.error_message || null

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -71,6 +71,19 @@ function payload() {
               player_type: 'pitcher',
               team_side: 'home',
               pitcher_role: 'starter',
+              pitcher_projection_group: 'starter',
+              planned_pitcher_role: 'starter',
+              typical_bullpen_role: null,
+              game_availability_status: (
+                'planned_primary_pitcher'
+              ),
+              pitcher_pool_membership_status: (
+                'included_explicit_pitching_plan'
+              ),
+              pitcher_role_taxonomy_status: (
+                'resolved'
+              ),
+              appearance_probability: 1,
               authoritative: true,
               authoritative_source: (
                 'canonical_event_driven_'
@@ -642,4 +655,110 @@ test('recognizes activated production projections', () => {
     view.authoritativeSource,
     'canonical_event_driven_calibrated_baserunning',
   )
+})
+
+test('surfaces explicit pitcher pool and role taxonomy', () => {
+  const game = payload()
+  const players = game.diagnostics.canonical_shadow
+    .player_projections.players
+
+  players.push({
+    player_id: 'p-2',
+    full_name: 'Test Closer',
+    player_type: 'pitcher',
+    team_side: 'home',
+    pitcher_role: 'reliever',
+    pitcher_projection_group: 'bullpen',
+    planned_pitcher_role: 'reliever',
+    typical_bullpen_role: 'closer',
+    game_availability_status: (
+      'explicitly_eligible'
+    ),
+    pitcher_pool_membership_status: (
+      'included_explicitly_eligible'
+    ),
+    pitcher_role_taxonomy_status: 'resolved',
+    appearance_probability: 0.42,
+    metrics: {
+      batters_faced: metric(1.8),
+      outs_recorded: metric(1.1),
+    },
+  })
+
+  const view = buildCanonicalProjectionsViewModel(
+    game,
+  )
+  const starter = view.pitchers.find(
+    row => row.playerId === 'p-1',
+  )
+  const closer = view.pitchers.find(
+    row => row.playerId === 'p-2',
+  )
+
+  assert.equal(
+    starter.pitcherProjectionGroupLabel,
+    'Starters',
+  )
+  assert.equal(
+    starter.plannedPitcherRoleLabel,
+    'Starter',
+  )
+  assert.equal(
+    starter.gameAvailabilityStatusLabel,
+    'Planned',
+  )
+
+  assert.equal(
+    closer.pitcherProjectionGroupLabel,
+    'Bullpen',
+  )
+  assert.equal(
+    closer.typicalBullpenRoleLabel,
+    'Closer',
+  )
+  assert.equal(
+    closer.gameAvailabilityStatusLabel,
+    'Eligible',
+  )
+  assert.equal(
+    closer.appearanceProbabilityPercent,
+    42,
+  )
+
+  assert.deepEqual(
+    view.pitcherSections.map(
+      section => section.title,
+    ),
+    ['Home Starters', 'Home Bullpen'],
+  )
+})
+
+test('does not infer missing bullpen taxonomy', () => {
+  const game = payload()
+  const pitcher = game.diagnostics.canonical_shadow
+    .player_projections.players.find(
+      row => row.player_type === 'pitcher',
+    )
+
+  pitcher.pitcher_projection_group = 'bullpen'
+  pitcher.planned_pitcher_role = 'reliever'
+  pitcher.typical_bullpen_role = null
+  pitcher.game_availability_status = null
+  pitcher.appearance_probability = 0.8
+
+  const row = buildCanonicalProjectionsViewModel(
+    game,
+  ).pitchers[0]
+
+  assert.equal(row.typicalBullpenRole, null)
+  assert.equal(
+    row.typicalBullpenRoleLabel,
+    'Unknown',
+  )
+  assert.equal(
+    row.gameAvailabilityStatusLabel,
+    'Unknown',
+  )
+  assert.equal(row.pitcherProjectionGroup, 'bullpen')
+  assert.equal(row.plannedPitcherRole, 'reliever')
 })

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -886,8 +886,10 @@ const BATTER_PROJECTION_COLUMNS = [
 
 const PITCHER_PROJECTION_COLUMNS = [
   { key: 'name', label: 'Pitcher', format: 'text', align: 'left' },
-  { key: 'side', label: 'Side', format: 'text', align: 'left' },
-  { key: 'pitcherRoleLabel', label: 'Role', format: 'text', align: 'left' },
+  { key: 'plannedPitcherRoleLabel', label: 'Planned Role', format: 'text', align: 'left' },
+  { key: 'typicalBullpenRoleLabel', label: 'Typical Role', format: 'text', align: 'left' },
+  { key: 'gameAvailabilityStatusLabel', label: 'Availability', format: 'text', align: 'left' },
+  { key: 'appearanceProbabilityPercent', label: 'App %', digits: 0 },
   { key: 'battersFaced', label: 'BF' },
   { key: 'inningsPitched', label: 'IP' },
   { key: 'inningsPitchedP10', label: 'IP P10' },
@@ -1112,11 +1114,30 @@ function ProjectionsTab({ game }) {
         rows={view.batters}
       />
 
-      <ProjectionTable
-        title="Pitcher Projections"
-        columns={PITCHER_PROJECTION_COLUMNS}
-        rows={view.pitchers}
-      />
+      <div
+        style={{
+          color: '#8b949e',
+          fontSize: '12px',
+          lineHeight: 1.5,
+          marginTop: '14px',
+        }}
+      >
+        Pitcher workload percentiles are unconditional
+        game-level outcomes and include nonappearances.
+        Appearance probability is shown separately. Missing
+        availability or typical-role evidence remains Unknown;
+        no role is inferred from workload, roster order, name,
+        or appearance probability.
+      </div>
+
+      {view.pitcherSections.map(section => (
+        <ProjectionTable
+          key={section.key}
+          title={section.title}
+          columns={PITCHER_PROJECTION_COLUMNS}
+          rows={section.rows}
+        />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- separate canonical pitcher projections into team-specific **Starters** and **Bullpen** sections
- display planned pitcher role independently from typical bullpen role
- surface explicit game availability and appearance probability as separate fields
- preserve unknown availability and role evidence without inference
- retain BF, mean IP, IP P10, IP median, IP P90, outcome, and DFS projections
- explain that pitcher workload percentiles are unconditional game-level outcomes that include nonappearances

## UI contract

The projections view now consumes the canonical fields established by the pitcher pool and role reconciliation:

- `pitcher_projection_group`
- `planned_pitcher_role`
- `typical_bullpen_role`
- `game_availability_status`
- `pitcher_pool_membership_status`
- `pitcher_role_taxonomy_status`
- `appearance_probability`

Missing availability or typical-role evidence remains **Unknown**. The UI does not infer a role from workload, roster order, player name, or appearance probability.

## Validation

- focused canonical projections and diagnostics regression: 43 passed
- frontend production build passed
- working-tree and staged diff checks passed
- frontend-only path isolation passed
- no backend simulation files changed

The production build retains pre-existing duplicate-key and bundle-size warnings outside this slice.

## Scope

This slice changes presentation only. It does not alter pitcher pools, pitching plans, workload sampling, projection values, authority decisions, or game probabilities.