### PR TITLE
Enforce canonical active bullpen membership

### DIFF
--- a/mlb_app/dashboard_player_population.py
+++ b/mlb_app/dashboard_player_population.py
@@ -141,6 +141,87 @@ def evaluate_active_player(candidate: Dict[str, Any], *, as_of: dt.date, window_
     return False, "no_recent_verified_activity"
 
 
+def _safe_nonnegative_int(
+    value: Any,
+) -> Optional[int]:
+    if value in (None, "") or isinstance(
+        value,
+        bool,
+    ):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if parsed >= 0 else None
+
+
+def _season_pitching_usage(
+    row: Dict[str, Any],
+) -> Dict[str, Optional[int]]:
+    person = _person(row)
+
+    for stat_group in person.get("stats") or []:
+        if not isinstance(stat_group, dict):
+            continue
+
+        for split in stat_group.get("splits") or []:
+            if not isinstance(split, dict):
+                continue
+
+            stat = split.get("stat")
+
+            if not isinstance(stat, dict):
+                continue
+
+            raw_games_pitched = stat.get(
+                "gamesPitched"
+            )
+
+            if raw_games_pitched is None:
+                raw_games_pitched = stat.get(
+                    "gamesPlayed"
+                )
+
+            games_pitched = (
+                _safe_nonnegative_int(
+                    raw_games_pitched
+                )
+            )
+            games_started = (
+                _safe_nonnegative_int(
+                    stat.get("gamesStarted")
+                )
+            )
+
+            if (
+                games_pitched is None
+                or games_pitched <= 0
+                or games_started is None
+                or games_started > games_pitched
+            ):
+                continue
+
+            return {
+                "season_games_pitched":
+                    games_pitched,
+                "season_games_started":
+                    games_started,
+                "season_relief_appearances": max(
+                    games_pitched - games_started,
+                    0,
+                ),
+            }
+
+    return {
+        "season_games_pitched": None,
+        "season_games_started": None,
+        "season_relief_appearances": None,
+    }
+
+
 def fetch_active_roster(
     team_id: int,
     season: int,
@@ -152,7 +233,15 @@ def fetch_active_roster(
 
     response = request_get(
         f"{MLB_STATS_BASE}/teams/{int(team_id)}/roster",
-        params={"rosterType": "active", "season": int(season)},
+        params={
+            "rosterType": "active",
+            "season": int(season),
+            "hydrate": (
+                "person("
+                "stats(type=season,group=pitching)"
+                ")"
+            ),
+        },
         timeout=20,
     )
     response.raise_for_status()
@@ -165,6 +254,19 @@ def fetch_active_roster(
             team_name=team_name,
         )
         normalized["on_active_roster"] = True
+        normalized.update(
+            _season_pitching_usage(row)
+        )
+        normalized[
+            "season_pitching_usage_source"
+        ] = (
+            "mlb_stats_active_roster_"
+            "season_pitching"
+            if normalized[
+                "season_games_pitched"
+            ] is not None
+            else None
+        )
         records.append(normalized)
     return records
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -1383,6 +1383,9 @@ def build_model_projection_payload(
                     home_pregame_provider_observations=(
                         home_provider_observations
                     ),
+                    require_explicit_bullpen_membership=(
+                        True
+                    ),
                 )
             )
 

--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -110,6 +110,101 @@ def _pitcher_identifiers(
     return tuple(ordered)
 
 
+def _active_roster_usage_evidence(
+    records: Any,
+    *,
+    candidate_pitcher_ids: Sequence[str],
+) -> Dict[str, Dict[str, Any]]:
+    if not isinstance(records, Sequence) or isinstance(
+        records,
+        (str, bytes),
+    ):
+        return {}
+
+    candidates = set(candidate_pitcher_ids)
+    evidence = {}
+
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+
+        pitcher_id = _normalize_identifier(
+            record.get("mlb_player_id")
+            or record.get("player_id")
+            or record.get("pitcher_id")
+            or record.get("id")
+        )
+
+        if (
+            pitcher_id is None
+            or pitcher_id not in candidates
+        ):
+            continue
+
+        games_pitched = record.get(
+            "season_games_pitched"
+        )
+        games_started = record.get(
+            "season_games_started"
+        )
+        relief_appearances = record.get(
+            "season_relief_appearances"
+        )
+
+        if (
+            isinstance(games_pitched, bool)
+            or isinstance(games_started, bool)
+            or isinstance(relief_appearances, bool)
+        ):
+            continue
+
+        try:
+            games_pitched = int(games_pitched)
+            games_started = int(games_started)
+            relief_appearances = int(
+                relief_appearances
+            )
+        except (TypeError, ValueError):
+            continue
+
+        if (
+            games_pitched <= 0
+            or games_started < 0
+            or relief_appearances < 0
+            or games_started > games_pitched
+            or relief_appearances
+            != games_pitched - games_started
+        ):
+            continue
+
+        if relief_appearances > games_started:
+            evidence[pitcher_id] = {
+                "status": "eligible",
+                "role": "reliever",
+                "source": (
+                    "mlb_stats_active_roster_"
+                    "season_pitching"
+                ),
+                "reason": (
+                    "observed_relief_usage_dominant"
+                ),
+            }
+        else:
+            evidence[pitcher_id] = {
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": (
+                    "mlb_stats_active_roster_"
+                    "season_pitching"
+                ),
+                "reason": (
+                    "observed_start_usage_dominant"
+                ),
+            }
+
+    return evidence
+
+
 @dataclass(frozen=True)
 class CanonicalShadowBullpenSideDiscovery:
     team_id: Optional[str] = None
@@ -205,6 +300,67 @@ class CanonicalShadowBullpenSideDiscovery:
                 )
                 if self.eligibility is not None
                 else 0
+            ),
+            "require_explicit_bullpen_membership": (
+                self.eligibility.get(
+                    "require_explicit_bullpen_membership"
+                )
+                if self.eligibility is not None
+                else True
+            ),
+            "strict_membership_excluded_count": (
+                self.eligibility.get(
+                    "strict_membership_excluded_count"
+                )
+                if self.eligibility is not None
+                else 0
+            ),
+            "starter_like_excluded_count": (
+                self.eligibility.get(
+                    "starter_like_excluded_count"
+                )
+                if self.eligibility is not None
+                else 0
+            ),
+            "season_usage_evidence_pitcher_count": (
+                self.eligibility.get(
+                    "season_usage_evidence_pitcher_count"
+                )
+                if self.eligibility is not None
+                else 0
+            ),
+            "season_usage_role_classification_used": (
+                self.eligibility.get(
+                    "season_usage_role_classification_used"
+                )
+                if self.eligibility is not None
+                else False
+            ),
+            "season_usage_classification_policy": (
+                self.eligibility.get(
+                    "season_usage_classification_policy"
+                )
+                if self.eligibility is not None
+                else None
+            ),
+            "unknown_materialized_evidence_"
+            "preserves_season_usage": (
+                self.eligibility.get(
+                    "unknown_materialized_evidence_"
+                    "preserves_season_usage"
+                )
+                if self.eligibility is not None
+                else False
+            ),
+            "evidence_precedence": (
+                list(
+                    self.eligibility.get(
+                        "evidence_precedence"
+                    )
+                    or []
+                )
+                if self.eligibility is not None
+                else []
             ),
             "pregame_evidence_materialized": (
                 self.pregame_evidence is not None
@@ -344,6 +500,9 @@ def _discover_side(
     ] = None,
     pregame_provider_observations: Any = (),
     pregame_maximum_age_seconds: int = 21600,
+    require_explicit_bullpen_membership: (
+        bool
+    ) = False,
 ) -> CanonicalShadowBullpenSideDiscovery:
     normalized_team = _normalize_identifier(
         team_id
@@ -439,6 +598,12 @@ def _discover_side(
             pregame_evidence.planned_pitcher_ids
         )
 
+    season_usage_evidence = (
+        _active_roster_usage_evidence(
+            records,
+            candidate_pitcher_ids=pitcher_ids,
+        )
+    )
     direct_evidence = (
         dict(eligibility_evidence_by_pitcher_id)
         if isinstance(
@@ -447,10 +612,50 @@ def _discover_side(
         )
         else {}
     )
-    combined_evidence = {
-        **materialized_evidence_by_pitcher_id,
-        **direct_evidence,
-    }
+    combined_evidence = dict(
+        season_usage_evidence
+    )
+
+    for (
+        evidence_pitcher_id,
+        materialized_record,
+    ) in materialized_evidence_by_pitcher_id.items():
+        normalized_evidence_pitcher_id = (
+            _normalize_identifier(
+                evidence_pitcher_id
+            )
+        )
+
+        if normalized_evidence_pitcher_id is None:
+            continue
+
+        materialized_status = (
+            str(
+                (
+                    materialized_record.get("status")
+                    if isinstance(
+                        materialized_record,
+                        Mapping,
+                    )
+                    else None
+                )
+                or "unknown"
+            )
+            .strip()
+            .lower()
+        )
+
+        if (
+            materialized_status
+            in {"eligible", "ineligible"}
+            or normalized_evidence_pitcher_id
+            not in combined_evidence
+        ):
+            combined_evidence[
+                normalized_evidence_pitcher_id
+            ] = materialized_record
+
+    combined_evidence.update(direct_evidence)
     combined_planned_pitcher_ids = tuple(
         dict.fromkeys(
             materialized_planned_pitcher_ids
@@ -470,8 +675,35 @@ def _discover_side(
             planned_pitcher_ids=(
                 combined_planned_pitcher_ids
             ),
+            require_explicit_bullpen_membership=(
+                require_explicit_bullpen_membership
+            ),
         )
     )
+    eligibility[
+        "season_usage_evidence_pitcher_count"
+    ] = len(season_usage_evidence)
+    eligibility[
+        "season_usage_role_classification_used"
+    ] = bool(season_usage_evidence)
+    eligibility[
+        "season_usage_classification_policy"
+    ] = (
+        "relief_appearances_greater_than_starts"
+    )
+    eligibility[
+        "unknown_materialized_evidence_"
+        "preserves_season_usage"
+    ] = True
+    eligibility[
+        "evidence_precedence"
+    ] = [
+        "direct_explicit_evidence",
+        "materialized_known_provider_evidence",
+        "mlb_stats_season_pitching_usage",
+        "materialized_unknown_evidence",
+    ]
+
     eligible_pitcher_ids = tuple(
         eligibility[
             "eligible_bullpen_pitcher_ids"
@@ -525,12 +757,17 @@ def discover_canonical_shadow_bullpens(
     away_pregame_provider_observations: Any = (),
     home_pregame_provider_observations: Any = (),
     pregame_maximum_age_seconds: int = 21600,
+    require_explicit_bullpen_membership: (
+        bool
+    ) = False,
 ) -> CanonicalShadowBullpenDiscovery:
     """
     Discover active-roster bullpen IDs without activating canonical execution.
 
-    Active-roster pitchers are treated as a bootstrap pitching-plan candidate,
-    not a claim about game availability, leverage role, or expected usage.
+    Active-roster pitchers are treated as bootstrap candidates, not proof
+    of bullpen membership, game availability, leverage role, or expected
+    usage. Production may require explicit bullpen membership; compatibility
+    callers retain candidate-discovery behavior unless they opt into it.
     """
 
     if roster_fetcher is None:
@@ -566,6 +803,9 @@ def discover_canonical_shadow_bullpens(
             pregame_maximum_age_seconds=(
                 pregame_maximum_age_seconds
             ),
+            require_explicit_bullpen_membership=(
+                require_explicit_bullpen_membership
+            ),
         ),
         home=_discover_side(
             team_side="home",
@@ -591,6 +831,9 @@ def discover_canonical_shadow_bullpens(
             ),
             pregame_maximum_age_seconds=(
                 pregame_maximum_age_seconds
+            ),
+            require_explicit_bullpen_membership=(
+                require_explicit_bullpen_membership
             ),
         ),
     )

--- a/mlb_app/simulation/shadow/canonical_bullpen_eligibility.py
+++ b/mlb_app/simulation/shadow/canonical_bullpen_eligibility.py
@@ -32,6 +32,19 @@ VALID_PITCHER_ROLES = frozenset({
     "unknown",
 })
 
+EXPLICIT_BULLPEN_ROLES = frozenset({
+    "reliever",
+    "long_reliever",
+    "middle_reliever",
+    "setup",
+    "closer",
+})
+
+STARTER_LIKE_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+})
+
 
 def _identifier(value: Any) -> str | None:
     if value in (None, "") or isinstance(
@@ -182,14 +195,30 @@ def enforce_canonical_bullpen_eligibility(
         Mapping[Any, Any] | None
     ) = None,
     planned_pitcher_ids: Any = (),
+    require_explicit_bullpen_membership: (
+        bool
+    ) = False,
 ) -> dict[str, Any]:
     """
     Filter a bullpen pool using explicit evidence only.
 
-    Unknown or unavailable evidence fails open and retains the pitcher.
     Explicitly planned opener, bulk, or tandem pitchers are retained even
     when general role evidence classifies them as starters.
+
+    When require_explicit_bullpen_membership is false, unknown evidence
+    preserves the legacy fail-open behavior. When true, only valid,
+    explicitly eligible bullpen roles are retained; unknown, invalid, and
+    starter-like evidence fails closed.
     """
+
+    if not isinstance(
+        require_explicit_bullpen_membership,
+        bool,
+    ):
+        raise TypeError(
+            "require_explicit_bullpen_membership "
+            "must be a bool"
+        )
 
     candidates = _identifiers(
         candidate_pitcher_ids
@@ -212,6 +241,8 @@ def enforce_canonical_bullpen_eligibility(
     valid_evidence_count = 0
     unknown_role_count = 0
     planned_override_count = 0
+    strict_membership_excluded_count = 0
+    starter_like_excluded_count = 0
 
     for pitcher_id in candidates:
         evidence_present = (
@@ -261,6 +292,29 @@ def enforce_canonical_bullpen_eligibility(
                 )
             )
         elif (
+            require_explicit_bullpen_membership
+            and evidence["valid"]
+            and evidence["status"]
+            == "eligible"
+            and evidence["role"]
+            not in EXPLICIT_BULLPEN_ROLES
+        ):
+            retained = False
+            strict_membership_excluded_count += 1
+
+            if (
+                evidence["role"]
+                in STARTER_LIKE_ROLES
+            ):
+                starter_like_excluded_count += 1
+                decision_reason = (
+                    "starter_like_role_excluded"
+                )
+            else:
+                decision_reason = (
+                    "non_bullpen_role_excluded"
+                )
+        elif (
             evidence["valid"]
             and evidence["status"]
             == "eligible"
@@ -268,6 +322,12 @@ def enforce_canonical_bullpen_eligibility(
             retained = True
             decision_reason = (
                 "explicitly_eligible"
+            )
+        elif require_explicit_bullpen_membership:
+            retained = False
+            strict_membership_excluded_count += 1
+            decision_reason = (
+                "explicit_bullpen_membership_unavailable"
             )
         elif evidence_present:
             retained = True
@@ -351,6 +411,15 @@ def enforce_canonical_bullpen_eligibility(
             unknown_role_count,
         "planned_override_count":
             planned_override_count,
+        "strict_membership_excluded_count": (
+            strict_membership_excluded_count
+        ),
+        "starter_like_excluded_count": (
+            starter_like_excluded_count
+        ),
+        "require_explicit_bullpen_membership": (
+            require_explicit_bullpen_membership
+        ),
         "eligibility_evidence_complete":
             evidence_complete,
         "eligibility_evidence_coverage_rate":
@@ -379,7 +448,17 @@ def enforce_canonical_bullpen_eligibility(
         ),
         "records": records,
         "safety_checks": {
-            "unknown_evidence_fails_open": True,
+            "unknown_evidence_fails_open": (
+                not require_explicit_bullpen_membership
+            ),
+            "unknown_evidence_fails_closed": (
+                require_explicit_bullpen_membership
+            ),
+            "active_roster_membership_is_not_"
+            "bullpen_membership": True,
+            "workload_inference_used": False,
+            "roster_order_inference_used": False,
+            "appearance_rate_inference_used": False,
             "explicit_plans_take_precedence":
                 True,
             "database_writes_performed": False,

--- a/tests/test_canonical_bullpen_eligibility.py
+++ b/tests/test_canonical_bullpen_eligibility.py
@@ -264,3 +264,115 @@ def test_rejects_invalid_evidence_container():
         enforce(
             evidence_by_pitcher_id=object(),
         )
+
+
+def test_strict_membership_excludes_unknown_candidates():
+    result = enforce(
+        candidate_pitcher_ids=(
+            "101",
+            "102",
+        ),
+        starter_id="100",
+        evidence_by_pitcher_id=None,
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == []
+    assert result["excluded_pitcher_ids"] == [
+        "101",
+        "102",
+    ]
+    assert result[
+        "strict_membership_excluded_count"
+    ] == 2
+    assert result[
+        "require_explicit_bullpen_membership"
+    ] is True
+    assert result["safety_checks"][
+        "unknown_evidence_fails_closed"
+    ] is True
+
+
+def test_strict_membership_retains_explicit_relievers():
+    result = enforce(
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == [
+        "102",
+        "103",
+    ]
+    assert record(result, "102")[
+        "decision_reason"
+    ] == "explicitly_eligible"
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        "starter",
+        "probable_starter",
+    ],
+)
+def test_strict_membership_excludes_starter_like_roles(
+    role,
+):
+    result = enforce(
+        candidate_pitcher_ids=("101",),
+        starter_id="100",
+        evidence_by_pitcher_id={
+            "101": evidence(
+                status="eligible",
+                role=role,
+            ),
+        },
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == []
+    assert result["excluded_pitcher_ids"] == [
+        "101",
+    ]
+    assert record(result, "101")[
+        "decision_reason"
+    ] == "starter_like_role_excluded"
+    assert result[
+        "starter_like_excluded_count"
+    ] == 1
+
+
+def test_strict_membership_preserves_planned_bulk_pitcher():
+    result = enforce(
+        candidate_pitcher_ids=("101",),
+        starter_id="100",
+        planned_pitcher_ids=("101",),
+        evidence_by_pitcher_id={
+            "101": evidence(
+                status="ineligible",
+                role="probable_starter",
+            ),
+        },
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result[
+        "eligible_bullpen_pitcher_ids"
+    ] == ["101"]
+    assert record(result, "101")[
+        "decision_reason"
+    ] == "explicit_pitching_plan_override"
+
+
+def test_strict_membership_rejects_non_boolean_mode():
+    with pytest.raises(TypeError):
+        enforce(
+            require_explicit_bullpen_membership=(
+                "yes"
+            ),
+        )

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -484,3 +484,453 @@ def test_direct_evidence_api_remains_compatible():
     assert records["102"][
         "evidence_status"
     ] == "unknown"
+
+
+def test_strict_membership_requires_explicit_reliever_evidence():
+    result = discovery(
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result.status == "unavailable"
+    assert result.away.bullpen_pitcher_ids == ()
+    assert result.home.bullpen_pitcher_ids == ()
+
+    away = result.away.to_diagnostics()
+    home = result.home.to_diagnostics()
+
+    assert away[
+        "require_explicit_bullpen_membership"
+    ] is True
+    assert away[
+        "strict_membership_excluded_count"
+    ] == 2
+    assert home[
+        "strict_membership_excluded_count"
+    ] == 2
+
+
+def test_strict_membership_retains_only_explicit_bullpen_roles():
+    result = discovery(
+        require_explicit_bullpen_membership=True,
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "eligible",
+                "closer",
+                "confirmed_active_bullpen",
+            ),
+            "102": role_evidence(
+                "eligible",
+                "probable_starter",
+                "confirmed_rotation_member",
+            ),
+        },
+        home_eligibility_evidence_by_pitcher_id={
+            "201": role_evidence(
+                "eligible",
+                "setup",
+                "confirmed_active_bullpen",
+            ),
+            "202": role_evidence(
+                "ineligible",
+                "starter",
+                "confirmed_rotation_member",
+            ),
+        },
+    )
+
+    assert result.status == "ready"
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "201",
+    )
+
+    away_records = {
+        row["pitcher_id"]: row
+        for row in result.away.eligibility[
+            "records"
+        ]
+    }
+    home_records = {
+        row["pitcher_id"]: row
+        for row in result.home.eligibility[
+            "records"
+        ]
+    }
+
+    assert away_records["101"][
+        "decision_reason"
+    ] == "explicitly_eligible"
+    assert away_records["102"][
+        "decision_reason"
+    ] == "starter_like_role_excluded"
+    assert home_records["202"][
+        "retained"
+    ] is False
+
+
+def test_strict_membership_preserves_explicit_plan_override():
+    result = discovery(
+        require_explicit_bullpen_membership=True,
+        away_planned_pitcher_ids=("102",),
+        away_eligibility_evidence_by_pitcher_id={
+            "102": role_evidence(
+                "ineligible",
+                "probable_starter",
+                "general_rotation_exclusion",
+            ),
+        },
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "102",
+    )
+    assert result.away.eligibility[
+        "planned_override_count"
+    ] == 1
+
+
+def test_strict_membership_consumes_materialized_provider_evidence():
+    observed_at = "2026-08-09T17:30:00+00:00"
+
+    result = discovery(
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        require_explicit_bullpen_membership=True,
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "closer",
+                "source": "structured_provider",
+                "observed_at": observed_at,
+            },
+            {
+                "pitcher_id": "102",
+                "status": "eligible",
+                "role": "probable_starter",
+                "source": "structured_provider",
+                "observed_at": observed_at,
+            },
+        ),
+        home_pregame_provider_observations=(
+            {
+                "pitcher_id": "201",
+                "status": "eligible",
+                "role": "setup",
+                "source": "structured_provider",
+                "observed_at": observed_at,
+            },
+            {
+                "pitcher_id": "202",
+                "status": "ineligible",
+                "role": "starter",
+                "source": "structured_provider",
+                "observed_at": observed_at,
+            },
+        ),
+    )
+
+    assert result.status == "ready"
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "201",
+    )
+
+    away_records = {
+        row["pitcher_id"]: row
+        for row in result.away.eligibility[
+            "records"
+        ]
+    }
+    home_records = {
+        row["pitcher_id"]: row
+        for row in result.home.eligibility[
+            "records"
+        ]
+    }
+
+    assert away_records["101"][
+        "pitcher_role"
+    ] == "closer"
+    assert away_records["101"]["retained"] is True
+
+    assert away_records["102"][
+        "decision_reason"
+    ] == "starter_like_role_excluded"
+    assert away_records["102"]["retained"] is False
+
+    assert home_records["201"][
+        "pitcher_role"
+    ] == "setup"
+    assert home_records["201"]["retained"] is True
+
+    assert home_records["202"]["retained"] is False
+
+    assert result.away.pregame_evidence is not None
+    assert result.home.pregame_evidence is not None
+
+
+def test_strict_membership_uses_observed_season_usage():
+    def usage_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+                "season_games_pitched": 24,
+                "season_games_started": 24,
+                "season_relief_appearances": 0,
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 45,
+                "season_games_started": 0,
+                "season_relief_appearances": 45,
+            },
+            {
+                "mlb_player_id": starter + 2,
+                "player_type": "pitcher",
+                "season_games_pitched": 25,
+                "season_games_started": 25,
+                "season_relief_appearances": 0,
+            },
+            {
+                "mlb_player_id": starter + 3,
+                "player_type": "pitcher",
+                "season_games_pitched": 27,
+                "season_games_started": 11,
+                "season_relief_appearances": 16,
+            },
+        ]
+
+    result = discovery(
+        roster_fetcher=usage_roster,
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result.status == "ready"
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+        "103",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "201",
+        "203",
+    )
+
+    away_records = {
+        row["pitcher_id"]: row
+        for row in result.away.eligibility[
+            "records"
+        ]
+    }
+
+    assert away_records["101"][
+        "decision_reason"
+    ] == "explicitly_eligible"
+    assert away_records["102"][
+        "decision_reason"
+    ] == "observed_start_usage_dominant"
+
+    diagnostics = result.away.to_diagnostics()
+
+    assert diagnostics[
+        "season_usage_evidence_pitcher_count"
+    ] == 3
+    assert diagnostics[
+        "season_usage_role_classification_used"
+    ] is True
+    assert diagnostics[
+        "season_usage_classification_policy"
+    ] == (
+        "relief_appearances_greater_than_starts"
+    )
+
+
+def test_provider_evidence_overrides_season_usage():
+    def usage_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 20,
+                "season_games_started": 20,
+                "season_relief_appearances": 0,
+            },
+        ]
+
+    result = discovery(
+        roster_fetcher=usage_roster,
+        require_explicit_bullpen_membership=True,
+        away_eligibility_evidence_by_pitcher_id={
+            "101": role_evidence(
+                "eligible",
+                "long_reliever",
+                "provider_override",
+            ),
+        },
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.away.eligibility["records"][0][
+        "evidence_source"
+    ] == "pregame_role_evidence_v1"
+
+
+def test_materialized_unknown_preserves_season_usage_evidence():
+    def usage_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+                "season_games_pitched": 20,
+                "season_games_started": 20,
+                "season_relief_appearances": 0,
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 40,
+                "season_games_started": 0,
+                "season_relief_appearances": 40,
+            },
+            {
+                "mlb_player_id": starter + 2,
+                "player_type": "pitcher",
+                "season_games_pitched": 22,
+                "season_games_started": 22,
+                "season_relief_appearances": 0,
+            },
+        ]
+
+    result = discovery(
+        roster_fetcher=usage_roster,
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result.status == "ready"
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "201",
+    )
+
+    away_records = {
+        row["pitcher_id"]: row
+        for row in result.away.eligibility[
+            "records"
+        ]
+    }
+
+    assert away_records["101"][
+        "evidence_source"
+    ] == (
+        "mlb_stats_active_roster_"
+        "season_pitching"
+    )
+    assert away_records["102"][
+        "decision_reason"
+    ] == "observed_start_usage_dominant"
+
+    diagnostics = result.away.to_diagnostics()
+
+    assert diagnostics[
+        "unknown_materialized_evidence_"
+        "preserves_season_usage"
+    ] is True
+    assert diagnostics["evidence_precedence"] == [
+        "direct_explicit_evidence",
+        "materialized_known_provider_evidence",
+        "mlb_stats_season_pitching_usage",
+        "materialized_unknown_evidence",
+    ]
+
+
+def test_known_materialized_provider_evidence_overrides_usage():
+    def usage_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 30,
+                "season_games_started": 30,
+                "season_relief_appearances": 0,
+            },
+        ]
+
+    observed_at = "2026-08-09T17:30:00+00:00"
+
+    result = discovery(
+        roster_fetcher=usage_roster,
+        pregame_evidence_as_of=(
+            "2026-08-09T18:00:00+00:00"
+        ),
+        require_explicit_bullpen_membership=True,
+        away_pregame_provider_observations=(
+            {
+                "pitcher_id": "101",
+                "status": "eligible",
+                "role": "long_reliever",
+                "source": "structured_provider",
+                "observed_at": observed_at,
+            },
+        ),
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "101",
+    )
+
+    record = result.away.eligibility[
+        "records"
+    ][0]
+
+    assert record["evidence_source"] == (
+        "structured_provider"
+    )
+    assert record["pitcher_role"] == (
+        "long_reliever"
+    )

--- a/tests/test_dashboard_player_population.py
+++ b/tests/test_dashboard_player_population.py
@@ -162,3 +162,197 @@ def test_repeated_population_is_idempotent_for_identity_and_activity_counts():
     player = session.query(DashboardPlayer).one()
     assert player.lineup_appearance_count == 1
     assert player.most_recent_lineup_date == AS_OF
+
+
+def test_active_roster_materializes_season_pitching_usage():
+    calls = []
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "roster": [
+                    {
+                        "person": {
+                            "id": 101,
+                            "fullName": "Relief Pitcher",
+                            "stats": [
+                                {
+                                    "splits": [
+                                        {
+                                            "stat": {
+                                                "gamesPitched": 30,
+                                                "gamesStarted": 2,
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        "position": {
+                            "type": "Pitcher",
+                            "abbreviation": "P",
+                        },
+                    },
+                    {
+                        "person": {
+                            "id": 102,
+                            "fullName": "Starting Pitcher",
+                            "stats": [
+                                {
+                                    "splits": [
+                                        {
+                                            "stat": {
+                                                "gamesPitched": 20,
+                                                "gamesStarted": 20,
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        "position": {
+                            "type": "Pitcher",
+                            "abbreviation": "P",
+                        },
+                    },
+                ],
+            }
+
+    def request_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return Response()
+
+    rows = fetch_active_roster(
+        114,
+        2026,
+        team_name="Guardians",
+        request_get=request_get,
+    )
+    indexed = {
+        row["mlb_player_id"]: row
+        for row in rows
+    }
+
+    assert indexed[101][
+        "season_games_pitched"
+    ] == 30
+    assert indexed[101][
+        "season_games_started"
+    ] == 2
+    assert indexed[101][
+        "season_relief_appearances"
+    ] == 28
+
+    assert indexed[102][
+        "season_relief_appearances"
+    ] == 0
+
+    assert calls[0][1]["params"]["hydrate"] == (
+        "person("
+        "stats(type=season,group=pitching)"
+        ")"
+    )
+
+
+def test_active_roster_missing_pitching_stats_remains_explicit():
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "roster": [
+                    {
+                        "person": {
+                            "id": 101,
+                            "fullName": "Unknown Pitcher",
+                        },
+                        "position": {
+                            "type": "Pitcher",
+                            "abbreviation": "P",
+                        },
+                    },
+                ],
+            }
+
+    rows = fetch_active_roster(
+        114,
+        2026,
+        request_get=lambda *args, **kwargs: (
+            Response()
+        ),
+    )
+
+    assert rows[0][
+        "season_games_pitched"
+    ] is None
+    assert rows[0][
+        "season_games_started"
+    ] is None
+    assert rows[0][
+        "season_relief_appearances"
+    ] is None
+    assert rows[0][
+        "season_pitching_usage_source"
+    ] is None
+
+
+def test_active_roster_preserves_zero_games_started():
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "roster": [
+                    {
+                        "person": {
+                            "id": 101,
+                            "fullName": "Pure Reliever",
+                            "stats": [
+                                {
+                                    "splits": [
+                                        {
+                                            "stat": {
+                                                "gamesPitched": 51,
+                                                "gamesStarted": 0,
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        "position": {
+                            "type": "Pitcher",
+                            "abbreviation": "P",
+                        },
+                    },
+                ],
+            }
+
+    rows = fetch_active_roster(
+        114,
+        2026,
+        request_get=lambda *args, **kwargs: (
+            Response()
+        ),
+    )
+
+    assert rows[0][
+        "season_games_pitched"
+    ] == 51
+    assert rows[0][
+        "season_games_started"
+    ] == 0
+    assert rows[0][
+        "season_relief_appearances"
+    ] == 51
+    assert rows[0][
+        "season_pitching_usage_source"
+    ] == (
+        "mlb_stats_active_roster_"
+        "season_pitching"
+    )


### PR DESCRIPTION
## Summary

- enforce explicit bullpen membership in the production canonical discovery path
- hydrate active-roster pitchers with MLB season pitching usage
- retain relievers and relief-dominant swingmen while excluding rotation-dominant pitchers
- preserve explicit pitching-plan and structured provider evidence precedence
- keep legacy callers fail-open while production uses strict membership
- expose the membership policy and evidence coverage through diagnostics

## Production evidence

### League-wide active-roster validation

A live 2026 MLB active-roster probe exercised the production strict-membership path across all 30 teams and confirmed:

- all 30 teams were returned and audited
- every team produced a populated strict bullpen pool
- zero starter-dominant pitchers were retained
- zero relief-dominant pitchers were omitted
- retained bullpen and starter-dominant sets were disjoint
- every retained pitcher had relief appearances greater than starts
- scheduled starters were excluded independently of season usage
- active-roster season-usage evidence was complete for the audited pitcher pools
- post-probe focused regression passed: 75 tests

The Cincinnati contract specifically excludes Brady Singer, Chase Burns, and Nick Lodolo when they are starter-dominant active-roster pitchers.

### Representative Cleveland–Pittsburgh validation

The earlier live probe also confirmed:

- Cleveland's eight active relievers were retained
- Cleveland rotation pitchers were removed
- Pittsburgh's bullpen was retained, including relief-dominant swingman Carmen Mlodzinski
- Pittsburgh rotation pitchers were removed
- both bullpen pools remained populated and ready
- no player-name, roster-order, workload, or appearance-rate inference was used

## Validation

- final focused regression: 249 passed
- league-wide 30-team membership acceptance signals: all passed
- league-wide post-probe regression: 75 passed
- representative Cleveland–Pittsburgh acceptance signals: all passed
- compilation passed
- working-tree and staged whitespace checks passed
- exactly seven intended files were staged and committed

## Scope

This slice governs active bullpen membership only. It does not implement fatigue, handedness-aware bullpen sequencing, or matchup-sensitive appearance probabilities. Those behaviors remain separate follow-up slices.