### PR TITLE
Materialize canonical pitcher typical roles and opener/bulk evidence

### DIFF
--- a/mlb_app/dashboard_player_population.py
+++ b/mlb_app/dashboard_player_population.py
@@ -213,12 +213,44 @@ def _season_pitching_usage(
                     games_pitched - games_started,
                     0,
                 ),
+                "season_pitching_outs":
+                    _safe_nonnegative_int(
+                        stat.get("outs")
+                    ),
+                "season_games_finished":
+                    _safe_nonnegative_int(
+                        stat.get("gamesFinished")
+                    ),
+                "season_saves":
+                    _safe_nonnegative_int(
+                        stat.get("saves")
+                    ),
+                "season_save_opportunities":
+                    _safe_nonnegative_int(
+                        stat.get(
+                            "saveOpportunities"
+                        )
+                    ),
+                "season_holds":
+                    _safe_nonnegative_int(
+                        stat.get("holds")
+                    ),
+                "season_blown_saves":
+                    _safe_nonnegative_int(
+                        stat.get("blownSaves")
+                    ),
             }
 
     return {
         "season_games_pitched": None,
         "season_games_started": None,
         "season_relief_appearances": None,
+        "season_pitching_outs": None,
+        "season_games_finished": None,
+        "season_saves": None,
+        "season_save_opportunities": None,
+        "season_holds": None,
+        "season_blown_saves": None,
     }
 
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -29,6 +29,9 @@ from mlb_app.simulation.shadow.canonical_pitcher_role_and_innings_attribution_au
 from mlb_app.simulation.shadow.pregame_bullpen_evidence_provider import (
     fetch_canonical_pregame_bullpen_evidence,
 )
+from mlb_app.simulation.shadow.pitcher_role_evidence_source import (
+    fetch_canonical_pitcher_role_evidence_source,
+)
 from mlb_app.simulation.shadow.production_monitoring_ledger import (
     CANONICAL_BASERUNNING_PRODUCTION_AUTHORITY,
     CanonicalBaserunningProductionMonitoringRecord,
@@ -757,6 +760,163 @@ def _canonical_probability_payload(matchup: Dict[str, Any], projection_sim: Opti
     }
 
 
+
+
+def _materialize_matchup_pitcher_role_evidence(
+    *,
+    bullpen_discovery: Any,
+    season: int,
+    as_of: Any,
+    cache: Dict[Any, Any],
+    fetcher: Any = None,
+    maximum_final_games: int = 10,
+) -> Dict[str, Any]:
+    """Materialize historical typical roles once per team/date."""
+
+    if fetcher is None:
+        fetcher = (
+            fetch_canonical_pitcher_role_evidence_source
+        )
+
+    if not isinstance(cache, dict):
+        raise TypeError("cache must be a dictionary")
+
+    evidence_by_pitcher_id: Dict[str, Any] = {}
+    diagnostics_by_side: Dict[str, Any] = {}
+
+    for team_side in ("away", "home"):
+        side = getattr(
+            bullpen_discovery,
+            team_side,
+            None,
+        )
+
+        try:
+            result = fetcher(
+                team_id=getattr(
+                    side,
+                    "team_id",
+                    None,
+                ),
+                season=season,
+                as_of=as_of,
+                active_roster_records=getattr(
+                    side,
+                    "active_roster_records",
+                    (),
+                ),
+                maximum_final_games=(
+                    maximum_final_games
+                ),
+                cache=cache,
+            )
+        except Exception as exc:
+            diagnostics_by_side[team_side] = {
+                "schema_version": (
+                    "canonical_pitcher_role_"
+                    "evidence_source_v1"
+                ),
+                "status": "error",
+                "team_side": team_side,
+                "error_type":
+                    exc.__class__.__name__,
+                "error_message": str(exc),
+                "pitcher_identifiers_exposed":
+                    False,
+                "planned_role_claimed": False,
+                "future_assignment_inferred":
+                    False,
+                "database_writes_performed":
+                    False,
+                "production_authority_changed":
+                    False,
+            }
+            continue
+
+        role_evidence = getattr(
+            result,
+            "role_evidence",
+            {},
+        )
+        side_evidence = (
+            role_evidence.get(
+                "evidence_by_pitcher_id",
+                {},
+            )
+            if isinstance(role_evidence, dict)
+            else {}
+        )
+
+        if isinstance(side_evidence, dict):
+            for pitcher_id, record in (
+                side_evidence.items()
+            ):
+                normalized_id = str(
+                    pitcher_id
+                ).strip()
+
+                if (
+                    normalized_id
+                    and isinstance(record, dict)
+                ):
+                    evidence_by_pitcher_id[
+                        normalized_id
+                    ] = deepcopy(record)
+
+        diagnostics = result.to_diagnostics()
+        allowed_keys = (
+            "schema_version",
+            "status",
+            "team_id",
+            "as_of_date",
+            "lookback_days",
+            "maximum_final_games",
+            "scheduled_final_game_count",
+            "fetched_final_game_count",
+            "feed_error_count",
+            "resolved_typical_role_count",
+            "detected_opener_bulk_pair_count",
+            "bounded_game_fetch",
+            "simulation_trial_fetches_performed",
+            "planned_role_claimed",
+            "future_assignment_inferred",
+            "database_writes_performed",
+            "production_authority_changed",
+        )
+
+        diagnostics_by_side[team_side] = {
+            key: deepcopy(diagnostics.get(key))
+            for key in allowed_keys
+        }
+        diagnostics_by_side[team_side].update({
+            "team_side": team_side,
+            "pitcher_identifiers_exposed": False,
+        })
+
+    return {
+        "schema_version": (
+            "canonical_matchup_pitcher_role_"
+            "evidence_v1"
+        ),
+        "status": (
+            "materialized"
+            if evidence_by_pitcher_id
+            else "unavailable"
+        ),
+        "evidence_by_pitcher_id":
+            evidence_by_pitcher_id,
+        "source_diagnostics_by_team_side":
+            diagnostics_by_side,
+        "explicit_pregame_roles_take_precedence":
+            True,
+        "historical_role_never_claims_today_plan":
+            True,
+        "simulation_trial_fetches_performed": 0,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+
 def _canonical_pitcher_pool_audit_input(
     bullpen_discovery: Any,
 ) -> Dict[str, Any]:
@@ -821,6 +981,7 @@ def _attach_production_shadow_comparison(
     production_execution: Any,
     bullpen_discovery: Any = None,
     pregame_pitcher_evidence_source_coverage: Any = None,
+    pitcher_role_evidence: Any = None,
 ) -> Dict[str, Any]:
     """
     Attach executed canonical material to the existing shadow comparator.
@@ -923,6 +1084,14 @@ def _attach_production_shadow_comparison(
                     )
                     else {}
                 ),
+                pitcher_role_evidence=(
+                    pitcher_role_evidence
+                    if isinstance(
+                        pitcher_role_evidence,
+                        dict,
+                    )
+                    else {}
+                ),
             )
         )
     except Exception as exc:
@@ -955,6 +1124,28 @@ def _attach_production_shadow_comparison(
     shadow[
         "pitcher_projection_pool_role_reconciliation"
     ] = pool_role_reconciliation
+
+    role_source_diagnostics = (
+        pitcher_role_evidence.get(
+            "source_diagnostics_by_team_side",
+            {},
+        )
+        if isinstance(
+            pitcher_role_evidence,
+            dict,
+        )
+        else {}
+    )
+    shadow[
+        "pitcher_role_evidence_source"
+    ] = deepcopy(
+        role_source_diagnostics
+        if isinstance(
+            role_source_diagnostics,
+            dict,
+        )
+        else {}
+    )
 
     try:
         appearance_audit = (
@@ -1296,6 +1487,11 @@ def build_model_projection_payload(
     matchups = generate_matchups_for_date(session, target_date)
     games: List[Dict[str, Any]] = []
     errors: List[Dict[str, Any]] = []
+    pitcher_role_evidence_source_cache: Dict[
+        Any,
+        Any,
+    ] = {}
+
     for matchup in matchups:
         try:
             away = _side_context(matchup, "away", session, date_obj.year)
@@ -1386,6 +1582,23 @@ def build_model_projection_payload(
                     require_explicit_bullpen_membership=(
                         True
                     ),
+                )
+            )
+
+            canonical_pitcher_role_evidence = (
+                _materialize_matchup_pitcher_role_evidence(
+                    bullpen_discovery=(
+                        canonical_shadow_bullpen_discovery
+                    ),
+                    season=date_obj.year,
+                    as_of=(
+                        matchup.get("game_time")
+                        or target_date
+                    ),
+                    cache=(
+                        pitcher_role_evidence_source_cache
+                    ),
+                    maximum_final_games=10,
                 )
             )
 
@@ -1843,6 +2056,9 @@ def build_model_projection_payload(
                     ),
                     pregame_pitcher_evidence_source_coverage=(
                         pregame_pitcher_evidence_source_coverage
+                    ),
+                    pitcher_role_evidence=(
+                        canonical_pitcher_role_evidence
                     ),
                 )
             )

--- a/mlb_app/simulation/projections/__init__.py
+++ b/mlb_app/simulation/projections/__init__.py
@@ -13,6 +13,15 @@ from .contracts import (
     StatisticalSummary,
     TeamProjection,
 )
+from .pitcher_appearance_history import (
+    SCHEMA_VERSION as CANONICAL_PITCHER_APPEARANCE_HISTORY_VERSION,
+    materialize_canonical_pitcher_appearance_history,
+)
+from .pitcher_typical_role_evidence import (
+    SCHEMA_VERSION as CANONICAL_PITCHER_TYPICAL_ROLE_EVIDENCE_VERSION,
+    materialize_canonical_pitcher_role_evidence,
+)
+
 from .serialization import (
     projection_payload_to_dict,
 )
@@ -22,6 +31,10 @@ from .validation import (
 )
 
 __all__ = [
+    "CANONICAL_PITCHER_APPEARANCE_HISTORY_VERSION",
+    "CANONICAL_PITCHER_TYPICAL_ROLE_EVIDENCE_VERSION",
+    "materialize_canonical_pitcher_appearance_history",
+    "materialize_canonical_pitcher_role_evidence",
     "CANONICAL_PROJECTION_SCHEMA_VERSION",
     "CanonicalProjectionPayload",
     "MetricProjection",

--- a/mlb_app/simulation/projections/pitcher_appearance_history.py
+++ b/mlb_app/simulation/projections/pitcher_appearance_history.py
@@ -1,0 +1,388 @@
+"""Historical MLB pitcher appearance-sequence evidence."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_appearance_history_v1"
+)
+
+
+def _identifier(value: Any) -> str | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if parsed >= 0 else None
+
+
+def _outs(pitching: Mapping[str, Any]) -> int | None:
+    direct = _nonnegative_int(
+        pitching.get("outs")
+    )
+
+    if direct is not None:
+        return direct
+
+    innings = pitching.get("inningsPitched")
+
+    if innings in (None, ""):
+        return None
+
+    try:
+        whole, partial = str(innings).split(".")
+        whole_outs = int(whole) * 3
+        partial_outs = int(partial)
+    except (TypeError, ValueError):
+        return None
+
+    if partial_outs not in {0, 1, 2}:
+        return None
+
+    return whole_outs + partial_outs
+
+
+def _team_side(
+    game_data: Mapping[str, Any],
+    team_id: str,
+) -> str | None:
+    teams = game_data.get("teams")
+
+    if not isinstance(teams, Mapping):
+        return None
+
+    for side in ("away", "home"):
+        team = teams.get(side)
+
+        if (
+            isinstance(team, Mapping)
+            and _identifier(team.get("id"))
+            == team_id
+        ):
+            return side
+
+    return None
+
+
+def materialize_canonical_pitcher_appearance_history(
+    *,
+    team_id: Any,
+    game_feeds: Any,
+    short_start_maximum_outs: int = 6,
+    bulk_follower_minimum_outs: int = 9,
+) -> dict[str, Any]:
+    """
+    Aggregate historical appearance sequences from final MLB feeds.
+
+    Short starts and early multi-inning followers are historical role
+    evidence. They never assert that the same assignment is planned
+    for today's game.
+    """
+
+    normalized_team_id = _identifier(team_id)
+
+    if normalized_team_id is None:
+        raise ValueError("team_id is required")
+
+    if (
+        not isinstance(game_feeds, Sequence)
+        or isinstance(game_feeds, (str, bytes))
+    ):
+        raise TypeError(
+            "game_feeds must be a sequence"
+        )
+
+    for value, name in (
+        (
+            short_start_maximum_outs,
+            "short_start_maximum_outs",
+        ),
+        (
+            bulk_follower_minimum_outs,
+            "bulk_follower_minimum_outs",
+        ),
+    ):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < 0
+        ):
+            raise ValueError(
+                f"{name} must be a non-negative integer"
+            )
+
+    evidence = {}
+    processed_game_pks = []
+    skipped_game_count = 0
+    malformed_appearance_count = 0
+    detected_pair_count = 0
+    detected_pairs = []
+
+    def pitcher_record(pitcher_id: str) -> dict[str, Any]:
+        return evidence.setdefault(
+            pitcher_id,
+            {
+                "pitcher_id": pitcher_id,
+                "appearance_count": 0,
+                "start_count": 0,
+                "short_start_count": 0,
+                "relief_appearance_count": 0,
+                "relief_outs": 0,
+                "early_multi_inning_relief_count": 0,
+                "bulk_follower_count": 0,
+                "games_observed": [],
+                "source": (
+                    "mlb_stats_final_game_"
+                    "appearance_sequence"
+                ),
+            },
+        )
+
+    for feed in game_feeds:
+        if not isinstance(feed, Mapping):
+            skipped_game_count += 1
+            continue
+
+        game_data = feed.get("gameData")
+        live_data = feed.get("liveData")
+
+        if (
+            not isinstance(game_data, Mapping)
+            or not isinstance(live_data, Mapping)
+        ):
+            skipped_game_count += 1
+            continue
+
+        status = game_data.get("status")
+        abstract_state = (
+            status.get("abstractGameState")
+            if isinstance(status, Mapping)
+            else None
+        )
+
+        if abstract_state not in {None, "Final"}:
+            skipped_game_count += 1
+            continue
+
+        side = _team_side(
+            game_data,
+            normalized_team_id,
+        )
+
+        if side is None:
+            skipped_game_count += 1
+            continue
+
+        game_pk = _identifier(
+            game_data.get("gamePk")
+            or feed.get("gamePk")
+        )
+
+        if game_pk is None:
+            skipped_game_count += 1
+            continue
+
+        boxscore = live_data.get("boxscore")
+
+        if not isinstance(boxscore, Mapping):
+            skipped_game_count += 1
+            continue
+
+        teams = boxscore.get("teams")
+        team_box = (
+            teams.get(side)
+            if isinstance(teams, Mapping)
+            else None
+        )
+
+        if not isinstance(team_box, Mapping):
+            skipped_game_count += 1
+            continue
+
+        ordered_ids = team_box.get("pitchers")
+        players = team_box.get("players")
+
+        if (
+            not isinstance(ordered_ids, Sequence)
+            or isinstance(ordered_ids, (str, bytes))
+            or not isinstance(players, Mapping)
+        ):
+            skipped_game_count += 1
+            continue
+
+        appearances = []
+
+        for sequence_index, raw_pitcher_id in enumerate(
+            ordered_ids
+        ):
+            pitcher_id = _identifier(
+                raw_pitcher_id
+            )
+
+            if pitcher_id is None:
+                malformed_appearance_count += 1
+                continue
+
+            player = players.get(f"ID{pitcher_id}")
+
+            if not isinstance(player, Mapping):
+                malformed_appearance_count += 1
+                continue
+
+            stats = player.get("stats")
+            pitching = (
+                stats.get("pitching")
+                if isinstance(stats, Mapping)
+                else None
+            )
+
+            if not isinstance(pitching, Mapping):
+                malformed_appearance_count += 1
+                continue
+
+            appearance_outs = _outs(pitching)
+
+            if appearance_outs is None:
+                malformed_appearance_count += 1
+                continue
+
+            games_started = _nonnegative_int(
+                pitching.get("gamesStarted")
+            )
+            started = (
+                games_started == 1
+                or sequence_index == 0
+            )
+            row = pitcher_record(pitcher_id)
+            row["appearance_count"] += 1
+            row["games_observed"].append(game_pk)
+
+            if started:
+                row["start_count"] += 1
+
+                if (
+                    appearance_outs
+                    <= short_start_maximum_outs
+                ):
+                    row["short_start_count"] += 1
+            else:
+                row["relief_appearance_count"] += 1
+                row["relief_outs"] += (
+                    appearance_outs
+                )
+
+            appearances.append({
+                "pitcher_id": pitcher_id,
+                "sequence_index": sequence_index,
+                "started": started,
+                "outs": appearance_outs,
+            })
+
+        if appearances:
+            processed_game_pks.append(game_pk)
+        else:
+            skipped_game_count += 1
+            continue
+
+        if len(appearances) < 2:
+            continue
+
+        first = appearances[0]
+        second = appearances[1]
+        opener_detected = (
+            first["started"] is True
+            and first["outs"]
+            <= short_start_maximum_outs
+        )
+        bulk_detected = (
+            second["started"] is False
+            and second["outs"]
+            >= bulk_follower_minimum_outs
+        )
+
+        if opener_detected and bulk_detected:
+            bulk_record = pitcher_record(
+                second["pitcher_id"]
+            )
+            bulk_record[
+                "early_multi_inning_relief_count"
+            ] += 1
+            bulk_record["bulk_follower_count"] += 1
+            detected_pair_count += 1
+            detected_pairs.append({
+                "game_pk": game_pk,
+                "opener_id": first["pitcher_id"],
+                "opener_outs": first["outs"],
+                "bulk_follower_id":
+                    second["pitcher_id"],
+                "bulk_follower_outs":
+                    second["outs"],
+                "source": (
+                    "mlb_stats_final_game_"
+                    "appearance_sequence"
+                ),
+            })
+
+    records = []
+
+    for pitcher_id in sorted(evidence):
+        row = deepcopy(evidence[pitcher_id])
+        row["games_observed"] = sorted(
+            set(row["games_observed"])
+        )
+        records.append(row)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "materialized"
+            if processed_game_pks
+            else "unavailable"
+        ),
+        "team_id": normalized_team_id,
+        "processed_game_count": len(
+            set(processed_game_pks)
+        ),
+        "processed_game_pks": sorted(
+            set(processed_game_pks)
+        ),
+        "skipped_game_count": skipped_game_count,
+        "malformed_appearance_count":
+            malformed_appearance_count,
+        "pitcher_count": len(records),
+        "detected_opener_bulk_pair_count":
+            detected_pair_count,
+        "detected_opener_bulk_pairs":
+            detected_pairs,
+        "evidence_by_pitcher_id": evidence,
+        "records": records,
+        "interpretation": {
+            "appearance_order_is_historical": True,
+            "short_starts_are_opener_evidence": True,
+            "early_length_is_bulk_evidence": True,
+            "planned_role_claimed": False,
+            "future_assignment_inferred": False,
+        },
+        "safety_checks": {
+            "game_feeds_unchanged": True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
+++ b/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
@@ -130,6 +130,9 @@ def reconcile_canonical_pitcher_projection_pool_roles(
     payload: Mapping[str, Any],
     appearance_audit: Mapping[str, Any],
     bullpen_discovery: Mapping[str, Any],
+    pitcher_role_evidence: (
+        Mapping[str, Any] | None
+    ) = None,
 ) -> dict[str, Any]:
     """
     Attach explicit pitcher-pool, role, and availability evidence.
@@ -153,6 +156,23 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             "bullpen_discovery must be a mapping"
         )
 
+    if (
+        pitcher_role_evidence is not None
+        and not isinstance(
+            pitcher_role_evidence,
+            Mapping,
+        )
+    ):
+        raise TypeError(
+            "pitcher_role_evidence must be a mapping"
+        )
+
+    role_evidence = _mapping(
+        _mapping(
+            pitcher_role_evidence
+        ).get("evidence_by_pitcher_id")
+    )
+
     result = deepcopy(dict(payload))
     players = result.get("players")
 
@@ -175,6 +195,9 @@ def reconcile_canonical_pitcher_projection_pool_roles(
     unknown_availability_count = 0
     planned_primary_count = 0
     role_conflict_count = 0
+    historical_typical_role_count = 0
+    explicit_typical_role_count = 0
+    inferred_typical_role_count = 0
     excluded_pitcher_ids = []
     role_conflict_pitcher_ids = []
 
@@ -225,7 +248,7 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             if evidence_valid
             else "unknown"
         )
-        typical_role = (
+        explicit_typical_role = (
             _text(
                 eligibility.get("pitcher_role")
             ).lower()
@@ -233,8 +256,71 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             else ""
         )
 
-        if typical_role == "unknown":
+        if explicit_typical_role == "unknown":
+            explicit_typical_role = ""
+
+        historical_role_record = _mapping(
+            role_evidence.get(pitcher_id)
+        )
+        historical_typical_role = _text(
+            historical_role_record.get(
+                "typical_role"
+            )
+        ).lower()
+
+        if historical_typical_role == "unknown":
+            historical_typical_role = ""
+
+        if explicit_typical_role:
+            typical_role = explicit_typical_role
+            typical_role_source = (
+                _text(eligibility.get("source"))
+                or "explicit_pregame_evidence"
+            )
+            typical_role_confidence = "explicit"
+            typical_role_inference_used = False
+        elif historical_typical_role:
+            typical_role = historical_typical_role
+            typical_role_source = (
+                _text(
+                    historical_role_record.get(
+                        "typical_role_source"
+                    )
+                    or historical_role_record.get(
+                        "source"
+                    )
+                )
+                or "historical_pitching_usage"
+            )
+            typical_role_confidence = (
+                _text(
+                    historical_role_record.get(
+                        "typical_role_confidence"
+                    )
+                    or historical_role_record.get(
+                        "confidence"
+                    )
+                )
+                or None
+            )
+            typical_role_inference_used = bool(
+                historical_role_record.get(
+                    "typical_role_inference_used"
+                )
+                if (
+                    "typical_role_inference_used"
+                    in historical_role_record
+                )
+                else historical_role_record.get(
+                    "inference_used",
+                    True,
+                )
+            )
+        else:
             typical_role = ""
+            typical_role_source = None
+            typical_role_confidence = None
+            typical_role_inference_used = False
 
         planned_primary = (
             planned_role in PLANNED_PRIMARY_ROLES
@@ -250,6 +336,14 @@ def reconcile_canonical_pitcher_projection_pool_roles(
                 is True
             )
         )
+
+        if explicit_typical_role:
+            explicit_typical_role_count += 1
+        elif historical_typical_role:
+            historical_typical_role_count += 1
+
+        if typical_role_inference_used:
+            inferred_typical_role_count += 1
 
         if planned_primary:
             availability_status = (
@@ -349,8 +443,14 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             "typical_bullpen_role"
         ] = typical_role or None
         row[
+            "typical_role_source"
+        ] = typical_role_source
+        row[
+            "typical_role_confidence"
+        ] = typical_role_confidence
+        row[
             "typical_role_inference_used"
-        ] = False
+        ] = typical_role_inference_used
         row[
             "game_availability_status"
         ] = availability_status
@@ -417,7 +517,20 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             set(role_conflict_pitcher_ids)
         ),
         "trial_count": trial_count,
-        "typical_role_inference_used": False,
+        "explicit_typical_role_count": (
+            explicit_typical_role_count
+        ),
+        "historical_typical_role_count": (
+            historical_typical_role_count
+        ),
+        "inferred_typical_role_count": (
+            inferred_typical_role_count
+        ),
+        "typical_role_inference_used": (
+            inferred_typical_role_count > 0
+        ),
+        "historical_role_never_claims_today_plan":
+            True,
         "unknown_evidence_fails_open": True,
         "explicit_plans_take_precedence": True,
         "workload_calibration_changed": False,

--- a/mlb_app/simulation/projections/pitcher_typical_role_evidence.py
+++ b/mlb_app/simulation/projections/pitcher_typical_role_evidence.py
@@ -1,0 +1,603 @@
+"""Evidence-backed canonical pitcher typical-role materialization."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_typical_role_evidence_v1"
+)
+
+TYPICAL_ROLES = frozenset({
+    "starter",
+    "opener",
+    "bulk_follower",
+    "swingman",
+    "closer",
+    "setup",
+    "middle_reliever",
+    "long_reliever",
+    "unknown",
+})
+
+PLANNED_GAME_ROLES = frozenset({
+    "starter",
+    "probable_starter",
+    "opener",
+    "bulk_follower",
+    "tandem_primary",
+    "tandem_secondary",
+})
+
+
+def _identifier(value: Any) -> str | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _nonnegative_int(value: Any) -> int | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if parsed >= 0 else None
+
+
+def _number(
+    mapping: Mapping[str, Any],
+    *keys: str,
+) -> int | None:
+    for key in keys:
+        parsed = _nonnegative_int(mapping.get(key))
+
+        if parsed is not None:
+            return parsed
+
+    return None
+
+
+def _pitcher_id(record: Mapping[str, Any]) -> str | None:
+    return _identifier(
+        record.get("mlb_player_id")
+        or record.get("player_id")
+        or record.get("pitcher_id")
+        or record.get("id")
+    )
+
+
+def _history_record(
+    history_by_pitcher_id: Mapping[Any, Any],
+    pitcher_id: str,
+) -> Mapping[str, Any]:
+    direct = history_by_pitcher_id.get(pitcher_id)
+
+    if isinstance(direct, Mapping):
+        return direct
+
+    try:
+        numeric = int(pitcher_id)
+    except (TypeError, ValueError):
+        return {}
+
+    numeric_record = history_by_pitcher_id.get(numeric)
+    return (
+        numeric_record
+        if isinstance(numeric_record, Mapping)
+        else {}
+    )
+
+
+def _planned_record(
+    planned_by_pitcher_id: Mapping[Any, Any],
+    pitcher_id: str,
+) -> dict[str, Any]:
+    raw = planned_by_pitcher_id.get(pitcher_id)
+
+    if raw is None:
+        try:
+            raw = planned_by_pitcher_id.get(
+                int(pitcher_id)
+            )
+        except (TypeError, ValueError):
+            raw = None
+
+    if not isinstance(raw, Mapping):
+        return {
+            "role": None,
+            "source": None,
+            "status": "unavailable",
+            "confirmed": False,
+        }
+
+    role = str(
+        raw.get("role")
+        or raw.get("pitcher_role")
+        or ""
+    ).strip().lower()
+    source = (
+        str(raw.get("source")).strip()
+        if raw.get("source") not in {None, ""}
+        else None
+    )
+    evidence_status = str(
+        raw.get("evidence_status")
+        or raw.get("status")
+        or ""
+    ).strip().lower()
+
+    confirmed = (
+        role in PLANNED_GAME_ROLES
+        and source is not None
+        and evidence_status
+        in {"confirmed", "explicit", "planned"}
+    )
+
+    return {
+        "role": role if confirmed else None,
+        "source": source if confirmed else None,
+        "status": (
+            "confirmed"
+            if confirmed
+            else "invalid_or_unconfirmed"
+        ),
+        "confirmed": confirmed,
+    }
+
+
+def _classify_typical_role(
+    record: Mapping[str, Any],
+    history: Mapping[str, Any],
+) -> dict[str, Any]:
+    games_pitched = _number(
+        record,
+        "season_games_pitched",
+        "games_pitched",
+    )
+    games_started = _number(
+        record,
+        "season_games_started",
+        "games_started",
+    )
+    relief_appearances = _number(
+        record,
+        "season_relief_appearances",
+        "relief_appearances",
+    )
+    saves = _number(
+        record,
+        "season_saves",
+        "saves",
+    )
+    holds = _number(
+        record,
+        "season_holds",
+        "holds",
+    )
+    games_finished = _number(
+        record,
+        "season_games_finished",
+        "games_finished",
+    )
+    pitching_outs = _number(
+        record,
+        "season_pitching_outs",
+        "pitching_outs",
+        "outs",
+    )
+
+    short_start_count = _number(
+        history,
+        "short_start_count",
+    ) or 0
+    early_multi_inning_relief_count = _number(
+        history,
+        "early_multi_inning_relief_count",
+        "bulk_follower_count",
+    ) or 0
+    observed_start_count = _number(
+        history,
+        "start_count",
+        "games_started",
+    )
+    observed_relief_count = _number(
+        history,
+        "relief_appearance_count",
+        "relief_appearances",
+    )
+    observed_relief_outs = _number(
+        history,
+        "relief_outs",
+    )
+
+    if observed_start_count is None:
+        observed_start_count = games_started
+
+    if observed_relief_count is None:
+        observed_relief_count = relief_appearances
+
+    if (
+        games_pitched is None
+        or games_started is None
+        or relief_appearances is None
+        or games_pitched <= 0
+        or games_started + relief_appearances
+        != games_pitched
+    ):
+        return {
+            "typical_role": "unknown",
+            "confidence": "unresolved",
+            "source": None,
+            "reason": "season_usage_evidence_incomplete",
+            "inference_used": False,
+        }
+
+    start_count = observed_start_count or 0
+    relief_count = observed_relief_count or 0
+
+    short_start_rate = (
+        short_start_count / start_count
+        if start_count > 0
+        else 0.0
+    )
+    bulk_rate = (
+        early_multi_inning_relief_count
+        / relief_count
+        if relief_count > 0
+        else 0.0
+    )
+
+    if (
+        start_count >= 3
+        and short_start_count >= 2
+        and short_start_rate >= 0.60
+    ):
+        return {
+            "typical_role": "opener",
+            "confidence": (
+                "high"
+                if short_start_count >= 4
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_historical_"
+                "appearance_sequence"
+            ),
+            "reason": "repeated_short_starts",
+            "inference_used": True,
+        }
+
+    if (
+        relief_count >= 3
+        and early_multi_inning_relief_count >= 2
+        and bulk_rate >= 0.30
+    ):
+        return {
+            "typical_role": "bulk_follower",
+            "confidence": (
+                "high"
+                if early_multi_inning_relief_count >= 4
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_historical_"
+                "appearance_sequence"
+            ),
+            "reason": (
+                "repeated_early_multi_inning_relief"
+            ),
+            "inference_used": True,
+        }
+
+    if (
+        games_started >= 3
+        and relief_appearances >= 3
+        and 0.20
+        <= games_started / games_pitched
+        <= 0.80
+    ):
+        return {
+            "typical_role": "swingman",
+            "confidence": (
+                "high"
+                if games_pitched >= 15
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_season_pitching_usage"
+            ),
+            "reason": (
+                "material_start_and_relief_usage"
+            ),
+            "inference_used": True,
+        }
+
+    if games_started >= relief_appearances:
+        return {
+            "typical_role": "starter",
+            "confidence": (
+                "high"
+                if games_started >= 5
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_season_pitching_usage"
+            ),
+            "reason": "start_usage_dominant",
+            "inference_used": True,
+        }
+
+    normalized_saves = saves or 0
+    normalized_holds = holds or 0
+    normalized_finished = games_finished or 0
+
+    if (
+        normalized_saves >= 5
+        and (
+            normalized_saves >= normalized_holds
+            or normalized_finished
+            / games_pitched >= 0.35
+        )
+    ):
+        return {
+            "typical_role": "closer",
+            "confidence": (
+                "high"
+                if normalized_saves >= 10
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_season_leverage_usage"
+            ),
+            "reason": (
+                "save_and_games_finished_usage"
+            ),
+            "inference_used": True,
+        }
+
+    if normalized_holds >= 5:
+        return {
+            "typical_role": "setup",
+            "confidence": (
+                "high"
+                if normalized_holds >= 10
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_season_leverage_usage"
+            ),
+            "reason": "hold_usage",
+            "inference_used": True,
+        }
+
+    relief_outs = (
+        observed_relief_outs
+        if observed_relief_outs is not None
+        else pitching_outs
+    )
+    outs_per_relief_appearance = (
+        relief_outs / relief_count
+        if (
+            relief_outs is not None
+            and relief_count > 0
+        )
+        else None
+    )
+
+    if (
+        relief_count >= 3
+        and outs_per_relief_appearance is not None
+        and outs_per_relief_appearance >= 4.5
+    ):
+        return {
+            "typical_role": "long_reliever",
+            "confidence": (
+                "high"
+                if relief_count >= 10
+                else "medium"
+            ),
+            "source": (
+                "mlb_stats_season_workload_usage"
+            ),
+            "reason": (
+                "multi_inning_relief_workload"
+            ),
+            "inference_used": True,
+        }
+
+    return {
+        "typical_role": "middle_reliever",
+        "confidence": (
+            "high"
+            if relief_appearances >= 15
+            else "medium"
+            if relief_appearances >= 5
+            else "low"
+        ),
+        "source": (
+            "mlb_stats_season_pitching_usage"
+        ),
+        "reason": "relief_usage_without_specialized_role",
+        "inference_used": True,
+    }
+
+
+def materialize_canonical_pitcher_role_evidence(
+    *,
+    active_roster_records: Any,
+    historical_appearance_evidence_by_pitcher_id: (
+        Mapping[Any, Any] | None
+    ) = None,
+    planned_role_evidence_by_pitcher_id: (
+        Mapping[Any, Any] | None
+    ) = None,
+) -> dict[str, Any]:
+    """
+    Materialize typical and planned pitcher roles separately.
+
+    Typical roles are evidence-backed historical classifications.
+    Planned roles require explicit, confirmed pregame evidence.
+    Historical inference never claims a pitcher is planned for
+    today's opener or bulk-follower assignment.
+    """
+
+    if (
+        not isinstance(active_roster_records, Sequence)
+        or isinstance(
+            active_roster_records,
+            (str, bytes),
+        )
+    ):
+        raise TypeError(
+            "active_roster_records must be a sequence"
+        )
+
+    history = (
+        historical_appearance_evidence_by_pitcher_id
+        if isinstance(
+            historical_appearance_evidence_by_pitcher_id,
+            Mapping,
+        )
+        else {}
+    )
+    planned = (
+        planned_role_evidence_by_pitcher_id
+        if isinstance(
+            planned_role_evidence_by_pitcher_id,
+            Mapping,
+        )
+        else {}
+    )
+
+    evidence_by_pitcher_id = {}
+    records = []
+    role_counts = {}
+    confidence_counts = {}
+    planned_role_count = 0
+    unresolved_pitcher_ids = []
+
+    for raw_record in active_roster_records:
+        if not isinstance(raw_record, Mapping):
+            continue
+
+        pitcher_id = _pitcher_id(raw_record)
+
+        if pitcher_id is None:
+            continue
+
+        historical_record = _history_record(
+            history,
+            pitcher_id,
+        )
+        typical = _classify_typical_role(
+            raw_record,
+            historical_record,
+        )
+        planned_record = _planned_record(
+            planned,
+            pitcher_id,
+        )
+
+        if planned_record["confirmed"]:
+            planned_role_count += 1
+
+        if typical["typical_role"] == "unknown":
+            unresolved_pitcher_ids.append(pitcher_id)
+
+        role = typical["typical_role"]
+        confidence = typical["confidence"]
+        role_counts[role] = role_counts.get(role, 0) + 1
+        confidence_counts[confidence] = (
+            confidence_counts.get(confidence, 0)
+            + 1
+        )
+
+        evidence = {
+            "pitcher_id": pitcher_id,
+            "typical_role": role,
+            "typical_role_confidence": confidence,
+            "typical_role_source": typical["source"],
+            "typical_role_reason": typical["reason"],
+            "typical_role_inference_used": (
+                typical["inference_used"]
+            ),
+            "planned_game_role":
+                planned_record["role"],
+            "planned_game_role_status":
+                planned_record["status"],
+            "planned_game_role_source":
+                planned_record["source"],
+            "planned_role_inferred_from_history":
+                False,
+            "historical_short_start_count": (
+                _number(
+                    historical_record,
+                    "short_start_count",
+                )
+                or 0
+            ),
+            "historical_bulk_follower_count": (
+                _number(
+                    historical_record,
+                    "early_multi_inning_relief_count",
+                    "bulk_follower_count",
+                )
+                or 0
+            ),
+        }
+        evidence_by_pitcher_id[pitcher_id] = evidence
+        records.append(deepcopy(evidence))
+
+    records.sort(key=lambda row: row["pitcher_id"])
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "materialized",
+        "pitcher_count": len(records),
+        "resolved_typical_role_count": (
+            len(records) - len(unresolved_pitcher_ids)
+        ),
+        "unresolved_typical_role_count": len(
+            unresolved_pitcher_ids
+        ),
+        "unresolved_pitcher_ids": sorted(
+            unresolved_pitcher_ids
+        ),
+        "confirmed_planned_role_count":
+            planned_role_count,
+        "typical_role_counts": dict(
+            sorted(role_counts.items())
+        ),
+        "confidence_counts": dict(
+            sorted(confidence_counts.items())
+        ),
+        "evidence_by_pitcher_id":
+            evidence_by_pitcher_id,
+        "records": records,
+        "interpretation": {
+            "typical_role_is_historical": True,
+            "planned_role_requires_explicit_evidence":
+                True,
+            "historical_role_never_claims_today_plan":
+                True,
+            "opener_bulk_history_uses_appearance_sequence":
+                True,
+        },
+        "safety_checks": {
+            "active_roster_records_unchanged": True,
+            "planned_roles_not_inferred_from_history":
+                True,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        },
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -70,6 +70,11 @@ from .production_execution import (
     CanonicalProductionShadowExecution,
     run_canonical_production_shadow,
 )
+from .pitcher_role_evidence_source import (
+    SCHEMA_VERSION as CANONICAL_PITCHER_ROLE_EVIDENCE_SOURCE_VERSION,
+    CanonicalPitcherRoleEvidenceSourceResult,
+    fetch_canonical_pitcher_role_evidence_source,
+)
 from .pitcher_baserunning_evidence import (
     CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION,
     CanonicalPitcherBaserunningObservation,
@@ -212,6 +217,9 @@ __all__ = [
     "CANONICAL_SHADOW_LINEUP_DISCOVERY_VERSION",
     "DEFAULT_PRODUCTION_SHADOW_SIMULATION_COUNT",
     "MIN_EXACT_BATTER_RECORDS_PER_SIDE",
+    "CANONICAL_PITCHER_ROLE_EVIDENCE_SOURCE_VERSION",
+    "CanonicalPitcherRoleEvidenceSourceResult",
+    "fetch_canonical_pitcher_role_evidence_source",
     "CANONICAL_PITCHER_BASERUNNING_EVIDENCE_VERSION",
     "CanonicalPitcherBaserunningObservation",
     "adapt_observed_pitcher_baserunning_evidence",

--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
 
@@ -215,6 +216,10 @@ class CanonicalShadowBullpenSideDiscovery:
         CanonicalPregamePitcherEvidenceMaterialization
     ] = None
     source_record_count: int = 0
+    active_roster_records: tuple[
+        Mapping[str, Any],
+        ...,
+    ] = ()
     status: str = "unavailable"
     error_type: Optional[str] = None
     error_message: Optional[str] = None
@@ -719,6 +724,18 @@ def _discover_side(
         eligibility=eligibility,
         pregame_evidence=pregame_evidence,
         source_record_count=len(records),
+        active_roster_records=tuple(
+            deepcopy(dict(record))
+            for record in records
+            if (
+                isinstance(record, Mapping)
+                and str(
+                    record.get("player_type")
+                    or ""
+                ).strip().lower()
+                == "pitcher"
+            )
+        ),
         status=(
             "ready"
             if eligible_pitcher_ids

--- a/mlb_app/simulation/shadow/pitcher_role_evidence_source.py
+++ b/mlb_app/simulation/shadow/pitcher_role_evidence_source.py
@@ -1,0 +1,415 @@
+"""Bounded MLB source for historical pitcher-role evidence."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import datetime as dt
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+import requests
+
+from mlb_app.simulation.projections.pitcher_appearance_history import (
+    materialize_canonical_pitcher_appearance_history,
+)
+from mlb_app.simulation.projections.pitcher_typical_role_evidence import (
+    materialize_canonical_pitcher_role_evidence,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_role_evidence_source_v1"
+)
+MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
+MLB_LIVE_FEED_BASE = (
+    "https://statsapi.mlb.com/api/v1.1/game"
+)
+DEFAULT_LOOKBACK_DAYS = 60
+DEFAULT_MAXIMUM_FINAL_GAMES = 15
+FINAL_STATES = frozenset({
+    "final",
+    "game over",
+    "completed early",
+})
+
+
+def _identifier(value: Any) -> str | None:
+    if value in (None, "") or isinstance(value, bool):
+        return None
+
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _date(value: Any) -> dt.date | None:
+    if isinstance(value, dt.datetime):
+        return value.date()
+
+    if isinstance(value, dt.date):
+        return value
+
+    if value in (None, ""):
+        return None
+
+    try:
+        return dt.datetime.fromisoformat(
+            str(value).replace("Z", "+00:00")
+        ).date()
+    except (TypeError, ValueError):
+        try:
+            return dt.date.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            return None
+
+
+def _positive_int(
+    value: Any,
+    *,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be positive")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name} must be positive"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(f"{name} must be positive")
+
+    return parsed
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _json_response(
+    request_get: Callable[..., Any],
+    url: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+    timeout: int,
+) -> Mapping[str, Any]:
+    response = request_get(
+        url,
+        params=dict(params or {}),
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    if not isinstance(payload, Mapping):
+        raise TypeError(
+            "MLB response payload must be a mapping"
+        )
+
+    return payload
+
+
+def _final_game_records(
+    schedule_payload: Mapping[str, Any],
+    *,
+    as_of_date: dt.date,
+) -> list[dict[str, Any]]:
+    records = []
+
+    for date_record in schedule_payload.get(
+        "dates",
+        (),
+    ):
+        if not isinstance(date_record, Mapping):
+            continue
+
+        for game in date_record.get("games", ()):
+            if not isinstance(game, Mapping):
+                continue
+
+            game_pk = _identifier(
+                game.get("gamePk")
+                or game.get("game_pk")
+            )
+
+            if game_pk is None:
+                continue
+
+            game_date = _date(
+                game.get("officialDate")
+                or game.get("gameDate")
+                or date_record.get("date")
+            )
+
+            if (
+                game_date is None
+                or game_date >= as_of_date
+            ):
+                continue
+
+            status = _mapping(game.get("status"))
+            detailed_state = str(
+                status.get("detailedState")
+                or status.get("abstractGameState")
+                or ""
+            ).strip().lower()
+
+            if detailed_state not in FINAL_STATES:
+                continue
+
+            records.append({
+                "game_pk": game_pk,
+                "game_date": game_date,
+            })
+
+    records.sort(
+        key=lambda row: (
+            row["game_date"],
+            int(row["game_pk"])
+            if row["game_pk"].isdigit()
+            else row["game_pk"],
+        )
+    )
+
+    return records
+
+
+@dataclass(frozen=True)
+class CanonicalPitcherRoleEvidenceSourceResult:
+    team_id: str
+    season: int
+    as_of_date: str
+    status: str
+    appearance_history: Mapping[str, Any]
+    role_evidence: Mapping[str, Any]
+    diagnostics: Mapping[str, Any]
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        return deepcopy(dict(self.diagnostics))
+
+
+def fetch_canonical_pitcher_role_evidence_source(
+    *,
+    team_id: Any,
+    season: Any,
+    as_of: Any,
+    active_roster_records: Any,
+    request_get: Callable[..., Any] = requests.get,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    maximum_final_games: int = (
+        DEFAULT_MAXIMUM_FINAL_GAMES
+    ),
+    timeout_seconds: int = 20,
+    cache: MutableMapping[Any, Any] | None = None,
+) -> CanonicalPitcherRoleEvidenceSourceResult:
+    """
+    Fetch bounded historical evidence once per team/date.
+
+    This source classifies historical typical roles only. It never
+    claims today's opener, bulk follower, or other planned assignment.
+    """
+
+    normalized_team_id = _identifier(team_id)
+
+    if normalized_team_id is None:
+        raise ValueError("team_id is required")
+
+    normalized_season = _positive_int(
+        season,
+        name="season",
+    )
+    normalized_as_of = _date(as_of)
+
+    if normalized_as_of is None:
+        raise ValueError("as_of must be a valid date")
+
+    normalized_lookback = _positive_int(
+        lookback_days,
+        name="lookback_days",
+    )
+    normalized_maximum = _positive_int(
+        maximum_final_games,
+        name="maximum_final_games",
+    )
+    normalized_timeout = _positive_int(
+        timeout_seconds,
+        name="timeout_seconds",
+    )
+
+    if (
+        not isinstance(active_roster_records, Sequence)
+        or isinstance(
+            active_roster_records,
+            (str, bytes),
+        )
+    ):
+        raise TypeError(
+            "active_roster_records must be a sequence"
+        )
+
+    if (
+        cache is not None
+        and not isinstance(cache, MutableMapping)
+    ):
+        raise TypeError(
+            "cache must be a mutable mapping"
+        )
+
+    cache_key = (
+        SCHEMA_VERSION,
+        normalized_team_id,
+        normalized_season,
+        normalized_as_of.isoformat(),
+        normalized_lookback,
+        normalized_maximum,
+    )
+
+    if cache is not None and cache_key in cache:
+        return deepcopy(cache[cache_key])
+
+    start_date = (
+        normalized_as_of
+        - dt.timedelta(days=normalized_lookback)
+    )
+    schedule_error = None
+    schedule_payload: Mapping[str, Any] = {}
+
+    try:
+        schedule_payload = _json_response(
+            request_get,
+            f"{MLB_STATS_BASE}/schedule",
+            params={
+                "sportId": 1,
+                "teamId": normalized_team_id,
+                "season": normalized_season,
+                "startDate": start_date.isoformat(),
+                "endDate": normalized_as_of.isoformat(),
+                "gameType": "R",
+            },
+            timeout=normalized_timeout,
+        )
+    except Exception as exc:
+        schedule_error = {
+            "error_type": exc.__class__.__name__,
+            "error_message": str(exc),
+        }
+
+    final_games = _final_game_records(
+        schedule_payload,
+        as_of_date=normalized_as_of,
+    )[-normalized_maximum:]
+
+    feeds = []
+    feed_errors = []
+
+    for game in final_games:
+        try:
+            feed = _json_response(
+                request_get,
+                (
+                    f"{MLB_LIVE_FEED_BASE}/"
+                    f"{game['game_pk']}/feed/live"
+                ),
+                timeout=normalized_timeout,
+            )
+        except Exception as exc:
+            feed_errors.append({
+                "game_pk": game["game_pk"],
+                "error_type":
+                    exc.__class__.__name__,
+                "error_message": str(exc),
+            })
+            continue
+
+        feeds.append(feed)
+
+    appearance_history = (
+        materialize_canonical_pitcher_appearance_history(
+            team_id=normalized_team_id,
+            game_feeds=feeds,
+        )
+    )
+    role_evidence = (
+        materialize_canonical_pitcher_role_evidence(
+            active_roster_records=(
+                active_roster_records
+            ),
+            historical_appearance_evidence_by_pitcher_id=(
+                appearance_history.get(
+                    "evidence_by_pitcher_id",
+                    {},
+                )
+            ),
+        )
+    )
+
+    if schedule_error is not None:
+        status = "unavailable"
+    elif not final_games:
+        status = "unavailable"
+    elif feed_errors and not feeds:
+        status = "unavailable"
+    elif feed_errors:
+        status = "partial"
+    else:
+        status = "materialized"
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "team_id": normalized_team_id,
+        "season": normalized_season,
+        "as_of_date":
+            normalized_as_of.isoformat(),
+        "lookback_days": normalized_lookback,
+        "maximum_final_games":
+            normalized_maximum,
+        "scheduled_final_game_count":
+            len(final_games),
+        "fetched_final_game_count": len(feeds),
+        "feed_error_count": len(feed_errors),
+        "feed_errors": deepcopy(feed_errors),
+        "schedule_error":
+            deepcopy(schedule_error),
+        "historical_pitcher_count":
+            appearance_history.get(
+                "pitcher_count",
+                0,
+            ),
+        "resolved_typical_role_count":
+            role_evidence.get(
+                "resolved_typical_role_count",
+                0,
+            ),
+        "detected_opener_bulk_pair_count":
+            appearance_history.get(
+                "detected_opener_bulk_pair_count",
+                0,
+            ),
+        "cache_key_uses_team_and_date": True,
+        "bounded_game_fetch": True,
+        "simulation_trial_fetches_performed": 0,
+        "planned_role_claimed": False,
+        "future_assignment_inferred": False,
+        "news_keyword_inference_used": False,
+        "database_writes_performed": False,
+        "production_authority_changed": False,
+    }
+
+    result = CanonicalPitcherRoleEvidenceSourceResult(
+        team_id=normalized_team_id,
+        season=normalized_season,
+        as_of_date=normalized_as_of.isoformat(),
+        status=status,
+        appearance_history=deepcopy(
+            appearance_history
+        ),
+        role_evidence=deepcopy(role_evidence),
+        diagnostics=diagnostics,
+    )
+
+    if cache is not None:
+        cache[cache_key] = deepcopy(result)
+
+    return result

--- a/tests/test_canonical_pitcher_appearance_history.py
+++ b/tests/test_canonical_pitcher_appearance_history.py
@@ -1,0 +1,378 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.projections.pitcher_appearance_history import (
+    materialize_canonical_pitcher_appearance_history,
+)
+
+
+def feed(
+    game_pk,
+    *,
+    team_id=113,
+    opponent_id=146,
+    pitchers,
+    state="Final",
+):
+    player_rows = {}
+
+    for pitcher in pitchers:
+        pitcher_id = str(pitcher["pitcher_id"])
+        pitching = {
+            "gamesStarted": (
+                1 if pitcher["started"] else 0
+            ),
+            "outs": pitcher["outs"],
+        }
+        player_rows[f"ID{pitcher_id}"] = {
+            "person": {
+                "id": int(pitcher_id),
+                "fullName": pitcher.get(
+                    "name",
+                    pitcher_id,
+                ),
+            },
+            "stats": {
+                "pitching": pitching,
+            },
+        }
+
+    return {
+        "gameData": {
+            "gamePk": game_pk,
+            "status": {
+                "abstractGameState": state,
+            },
+            "teams": {
+                "away": {
+                    "id": team_id,
+                },
+                "home": {
+                    "id": opponent_id,
+                },
+            },
+        },
+        "liveData": {
+            "boxscore": {
+                "teams": {
+                    "away": {
+                        "pitchers": [
+                            int(row["pitcher_id"])
+                            for row in pitchers
+                        ],
+                        "players": player_rows,
+                    },
+                    "home": {
+                        "pitchers": [],
+                        "players": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+def run(feeds, **kwargs):
+    return (
+        materialize_canonical_pitcher_appearance_history(
+            team_id=113,
+            game_feeds=feeds,
+            **kwargs,
+        )
+    )
+
+
+def test_materializes_ordered_appearances():
+    result = run([
+        feed(
+            1,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 18,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 3,
+                },
+            ],
+        ),
+    ])
+
+    assert result["processed_game_count"] == 1
+    assert result[
+        "evidence_by_pitcher_id"
+    ]["100"]["start_count"] == 1
+    assert result[
+        "evidence_by_pitcher_id"
+    ]["101"]["relief_appearance_count"] == 1
+
+
+def test_detects_opener_and_bulk_follower_pair():
+    result = run([
+        feed(
+            1,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 3,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 15,
+                },
+                {
+                    "pitcher_id": "102",
+                    "started": False,
+                    "outs": 9,
+                },
+            ],
+        ),
+    ])
+
+    assert result[
+        "detected_opener_bulk_pair_count"
+    ] == 1
+    pair = result[
+        "detected_opener_bulk_pairs"
+    ][0]
+
+    assert pair["opener_id"] == "100"
+    assert pair["bulk_follower_id"] == "101"
+    assert result[
+        "evidence_by_pitcher_id"
+    ]["100"]["short_start_count"] == 1
+    assert result[
+        "evidence_by_pitcher_id"
+    ]["101"]["bulk_follower_count"] == 1
+
+
+def test_does_not_call_ordinary_short_relief_bulk():
+    result = run([
+        feed(
+            1,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 3,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 6,
+                },
+            ],
+        ),
+    ])
+
+    assert result[
+        "detected_opener_bulk_pair_count"
+    ] == 0
+
+
+def test_does_not_call_long_follower_bulk_after_normal_start():
+    result = run([
+        feed(
+            1,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 15,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 12,
+                },
+            ],
+        ),
+    ])
+
+    assert result[
+        "detected_opener_bulk_pair_count"
+    ] == 0
+
+
+def test_repeated_games_accumulate_history():
+    result = run([
+        feed(
+            game_pk,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 3,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 12,
+                },
+            ],
+        )
+        for game_pk in (1, 2, 3)
+    ])
+
+    opener = result[
+        "evidence_by_pitcher_id"
+    ]["100"]
+    bulk = result[
+        "evidence_by_pitcher_id"
+    ]["101"]
+
+    assert opener["start_count"] == 3
+    assert opener["short_start_count"] == 3
+    assert bulk[
+        "early_multi_inning_relief_count"
+    ] == 3
+    assert bulk["relief_outs"] == 36
+
+
+def test_nonfinal_game_is_skipped():
+    result = run([
+        feed(
+            1,
+            state="Live",
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 3,
+                },
+            ],
+        ),
+    ])
+
+    assert result["status"] == "unavailable"
+    assert result["processed_game_count"] == 0
+    assert result["skipped_game_count"] == 1
+
+
+def test_missing_team_is_skipped():
+    result = (
+        materialize_canonical_pitcher_appearance_history(
+            team_id=999,
+            game_feeds=[
+                feed(
+                    1,
+                    pitchers=[
+                        {
+                            "pitcher_id": "100",
+                            "started": True,
+                            "outs": 3,
+                        },
+                    ],
+                ),
+            ],
+        )
+    )
+
+    assert result["status"] == "unavailable"
+
+
+def test_falls_back_to_innings_pitched():
+    source = feed(
+        1,
+        pitchers=[
+            {
+                "pitcher_id": "100",
+                "started": True,
+                "outs": 3,
+            },
+        ],
+    )
+    pitching = source["liveData"]["boxscore"][
+        "teams"
+    ]["away"]["players"]["ID100"]["stats"][
+        "pitching"
+    ]
+    pitching.pop("outs")
+    pitching["inningsPitched"] = "1.2"
+
+    result = run([source])
+
+    assert result[
+        "evidence_by_pitcher_id"
+    ]["100"]["short_start_count"] == 1
+
+
+def test_materialization_is_read_only():
+    feeds = [
+        feed(
+            1,
+            pitchers=[
+                {
+                    "pitcher_id": "100",
+                    "started": True,
+                    "outs": 3,
+                },
+                {
+                    "pitcher_id": "101",
+                    "started": False,
+                    "outs": 12,
+                },
+            ],
+        ),
+    ]
+    original = deepcopy(feeds)
+
+    result = run(feeds)
+
+    assert feeds == original
+    assert result[
+        "database_writes_performed"
+    ] is False
+    assert result[
+        "production_authority_changed"
+    ] is False
+    assert result["interpretation"][
+        "planned_role_claimed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [None, "feeds", {}, object()],
+)
+def test_rejects_invalid_feed_sequence(invalid):
+    with pytest.raises(TypeError):
+        run(invalid)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error"),
+    [
+        (
+            {"team_id": None, "game_feeds": []},
+            ValueError,
+        ),
+        (
+            {
+                "team_id": 113,
+                "game_feeds": [],
+                "short_start_maximum_outs": True,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "team_id": 113,
+                "game_feeds": [],
+                "bulk_follower_minimum_outs": -1,
+            },
+            ValueError,
+        ),
+    ],
+)
+def test_rejects_invalid_contract(kwargs, error):
+    with pytest.raises(error):
+        materialize_canonical_pitcher_appearance_history(
+            **kwargs,
+        )

--- a/tests/test_canonical_pitcher_role_evidence_reconciliation.py
+++ b/tests/test_canonical_pitcher_role_evidence_reconciliation.py
@@ -1,0 +1,314 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.projections.pitcher_pool_role_reconciliation import (
+    reconcile_canonical_pitcher_projection_pool_roles,
+)
+
+
+def payload():
+    return {
+        "players": [
+            {
+                "player_id": "100",
+                "player_name": "Starter",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "starter",
+            },
+            {
+                "player_id": "101",
+                "player_name": "Historical Closer",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "reliever",
+            },
+            {
+                "player_id": "102",
+                "player_name": "Historical Bulk",
+                "player_type": "pitcher",
+                "team_side": "away",
+                "pitcher_role": "reliever",
+            },
+            {
+                "player_id": "200",
+                "player_name": "Home Starter",
+                "player_type": "pitcher",
+                "team_side": "home",
+                "pitcher_role": "starter",
+            },
+        ],
+    }
+
+
+def appearance_audit():
+    return {
+        "trial_count": 2,
+        "records": [
+            {
+                "trial_index": 0,
+                "team_side": "away",
+                "pitcher_id": "100",
+            },
+            {
+                "trial_index": 1,
+                "team_side": "away",
+                "pitcher_id": "100",
+            },
+            {
+                "trial_index": 0,
+                "team_side": "away",
+                "pitcher_id": "101",
+            },
+            {
+                "trial_index": 0,
+                "team_side": "away",
+                "pitcher_id": "102",
+            },
+            {
+                "trial_index": 1,
+                "team_side": "away",
+                "pitcher_id": "102",
+            },
+            {
+                "trial_index": 0,
+                "team_side": "home",
+                "pitcher_id": "200",
+            },
+            {
+                "trial_index": 1,
+                "team_side": "home",
+                "pitcher_id": "200",
+            },
+        ],
+    }
+
+
+def bullpen_discovery(
+    *,
+    explicit_role=None,
+):
+    away_records = []
+
+    if explicit_role is not None:
+        away_records.append({
+            "pitcher_id": "101",
+            "evidence_valid": True,
+            "evidence_status": "eligible",
+            "pitcher_role": explicit_role,
+            "source": "explicit_provider",
+        })
+
+    return {
+        "away": {
+            "starter_id": "100",
+            "bullpen_pitcher_ids": [
+                "101",
+                "102",
+            ],
+            "eligibility": {
+                "records": away_records,
+            },
+        },
+        "home": {
+            "starter_id": "200",
+            "bullpen_pitcher_ids": [],
+            "eligibility": {
+                "records": [],
+            },
+        },
+    }
+
+
+def role_evidence():
+    return {
+        "evidence_by_pitcher_id": {
+            "101": {
+                "pitcher_id": "101",
+                "typical_role": "closer",
+                "typical_role_confidence": "high",
+                "typical_role_source":
+                    "mlb_stats_season_pitching_usage",
+                "typical_role_inference_used": True,
+                "planned_role": None,
+            },
+            "102": {
+                "pitcher_id": "102",
+                "typical_role": "bulk_follower",
+                "confidence": "medium",
+                "source":
+                    "mlb_final_game_appearance_history",
+                "inference_used": True,
+                "planned_role": None,
+            },
+        },
+    }
+
+
+def rows(result):
+    return {
+        row["player_id"]: row
+        for row in result["players"]
+        if row["player_type"] == "pitcher"
+    }
+
+
+def run(
+    *,
+    discovery=None,
+    evidence=None,
+):
+    return reconcile_canonical_pitcher_projection_pool_roles(
+        payload=payload(),
+        appearance_audit=appearance_audit(),
+        bullpen_discovery=(
+            discovery
+            if discovery is not None
+            else bullpen_discovery()
+        ),
+        pitcher_role_evidence=(
+            evidence
+            if evidence is not None
+            else role_evidence()
+        ),
+    )
+
+
+def test_attaches_historical_typical_roles():
+    result = run()
+    pitcher_rows = rows(result)
+
+    assert pitcher_rows["101"][
+        "typical_bullpen_role"
+    ] == "closer"
+    assert pitcher_rows["101"][
+        "typical_role_source"
+    ] == "mlb_stats_season_pitching_usage"
+    assert pitcher_rows["101"][
+        "typical_role_confidence"
+    ] == "high"
+    assert pitcher_rows["101"][
+        "typical_role_inference_used"
+    ] is True
+
+    assert pitcher_rows["102"][
+        "typical_bullpen_role"
+    ] == "bulk_follower"
+    assert pitcher_rows["102"][
+        "planned_pitcher_role"
+    ] == "reliever"
+    assert pitcher_rows["102"][
+        "pitcher_projection_group"
+    ] == "bullpen"
+
+
+def test_historical_bulk_role_never_becomes_planned_role():
+    result = run()
+    row = rows(result)["102"]
+
+    assert row["typical_bullpen_role"] == (
+        "bulk_follower"
+    )
+    assert row["planned_pitcher_role"] == "reliever"
+    assert result[
+        "pitcher_pool_role_reconciliation"
+    ][
+        "historical_role_never_claims_today_plan"
+    ] is True
+
+
+def test_explicit_pregame_role_takes_precedence():
+    result = run(
+        discovery=bullpen_discovery(
+            explicit_role="setup",
+        ),
+    )
+    row = rows(result)["101"]
+
+    assert row["typical_bullpen_role"] == "setup"
+    assert row["typical_role_source"] == (
+        "explicit_provider"
+    )
+    assert row["typical_role_confidence"] == (
+        "explicit"
+    )
+    assert row[
+        "typical_role_inference_used"
+    ] is False
+
+
+def test_reports_role_evidence_counts():
+    result = run()
+    reconciliation = result[
+        "pitcher_pool_role_reconciliation"
+    ]
+
+    assert reconciliation[
+        "explicit_typical_role_count"
+    ] == 0
+    assert reconciliation[
+        "historical_typical_role_count"
+    ] == 2
+    assert reconciliation[
+        "inferred_typical_role_count"
+    ] == 2
+    assert reconciliation[
+        "typical_role_inference_used"
+    ] is True
+
+
+def test_missing_history_preserves_unknown_contract():
+    result = run(evidence={})
+    row = rows(result)["101"]
+
+    assert row["typical_bullpen_role"] is None
+    assert row["typical_role_source"] is None
+    assert row["typical_role_confidence"] is None
+    assert row[
+        "typical_role_inference_used"
+    ] is False
+
+
+def test_role_evidence_input_is_not_mutated():
+    evidence = role_evidence()
+    original = deepcopy(evidence)
+
+    run(evidence=evidence)
+
+    assert evidence == original
+
+
+def test_rejects_non_mapping_role_evidence():
+    with pytest.raises(
+        TypeError,
+        match="pitcher_role_evidence must be a mapping",
+    ):
+        reconcile_canonical_pitcher_projection_pool_roles(
+            payload=payload(),
+            appearance_audit=appearance_audit(),
+            bullpen_discovery=bullpen_discovery(),
+            pitcher_role_evidence=[],
+        )
+
+
+def test_public_projection_import_contract():
+    from mlb_app.simulation.projections import (
+        CANONICAL_PITCHER_APPEARANCE_HISTORY_VERSION,
+        CANONICAL_PITCHER_TYPICAL_ROLE_EVIDENCE_VERSION,
+        materialize_canonical_pitcher_appearance_history,
+        materialize_canonical_pitcher_role_evidence,
+    )
+
+    assert (
+        CANONICAL_PITCHER_APPEARANCE_HISTORY_VERSION
+    )
+    assert (
+        CANONICAL_PITCHER_TYPICAL_ROLE_EVIDENCE_VERSION
+    )
+    assert callable(
+        materialize_canonical_pitcher_appearance_history
+    )
+    assert callable(
+        materialize_canonical_pitcher_role_evidence
+    )

--- a/tests/test_canonical_pitcher_role_evidence_source.py
+++ b/tests/test_canonical_pitcher_role_evidence_source.py
@@ -1,0 +1,461 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.pitcher_role_evidence_source import (
+    CanonicalPitcherRoleEvidenceSourceResult,
+    fetch_canonical_pitcher_role_evidence_source,
+)
+
+
+AS_OF = "2026-08-15T18:00:00+00:00"
+
+
+class Response:
+    def __init__(
+        self,
+        payload,
+        *,
+        error=None,
+    ):
+        self.payload = payload
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error is not None:
+            raise self.error
+
+    def json(self):
+        return deepcopy(self.payload)
+
+
+def schedule():
+    return {
+        "dates": [
+            {
+                "date": "2026-08-10",
+                "games": [
+                    {
+                        "gamePk": 9,
+                        "officialDate":
+                            "2026-08-10",
+                        "status": {
+                            "detailedState": "Final",
+                        },
+                    },
+                    {
+                        "gamePk": 10,
+                        "officialDate":
+                            "2026-08-10",
+                        "status": {
+                            "detailedState": "Final",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": "2026-08-11",
+                "games": [
+                    {
+                        "gamePk": 11,
+                        "officialDate":
+                            "2026-08-11",
+                        "status": {
+                            "abstractGameState":
+                                "Final",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": "2026-08-15",
+                "games": [
+                    {
+                        "gamePk": 12,
+                        "officialDate":
+                            "2026-08-15",
+                        "status": {
+                            "detailedState":
+                                "Scheduled",
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def feed(
+    game_pk,
+    *,
+    opener_outs=6,
+    bulk_outs=12,
+):
+    return {
+        "gamePk": game_pk,
+        "gameData": {
+            "status": {
+                "detailedState": "Final",
+            },
+            "teams": {
+                "away": {"id": 10},
+                "home": {"id": 20},
+            },
+        },
+        "liveData": {
+            "boxscore": {
+                "teams": {
+                    "away": {
+                        "pitchers": [
+                            100,
+                            101,
+                            102,
+                        ],
+                        "players": {
+                            "ID100": {
+                                "person": {"id": 100},
+                                "stats": {
+                                    "pitching": {
+                                        "gamesStarted": 1,
+                                        "outs": opener_outs,
+                                    },
+                                },
+                            },
+                            "ID101": {
+                                "person": {"id": 101},
+                                "stats": {
+                                    "pitching": {
+                                        "gamesStarted": 0,
+                                        "outs": bulk_outs,
+                                    },
+                                },
+                            },
+                            "ID102": {
+                                "person": {"id": 102},
+                                "stats": {
+                                    "pitching": {
+                                        "gamesStarted": 0,
+                                        "outs": 3,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "home": {
+                        "pitchers": [],
+                        "players": {},
+                    },
+                },
+            },
+        },
+    }
+
+
+def roster():
+    return [
+        {
+            "mlb_player_id": 100,
+            "season_games_pitched": 2,
+            "season_games_started": 2,
+            "season_relief_appearances": 0,
+            "season_pitching_outs": 12,
+            "season_games_finished": 0,
+            "season_saves": 0,
+            "season_holds": 0,
+        },
+        {
+            "mlb_player_id": 101,
+            "season_games_pitched": 20,
+            "season_games_started": 0,
+            "season_relief_appearances": 20,
+            "season_pitching_outs": 120,
+            "season_games_finished": 2,
+            "season_saves": 0,
+            "season_holds": 0,
+        },
+        {
+            "mlb_player_id": 102,
+            "season_games_pitched": 30,
+            "season_games_started": 0,
+            "season_relief_appearances": 30,
+            "season_pitching_outs": 90,
+            "season_games_finished": 20,
+            "season_saves": 12,
+            "season_holds": 2,
+        },
+    ]
+
+
+def request_get_factory(
+    *,
+    failed_game_pk=None,
+):
+    calls = []
+
+    def request_get(
+        url,
+        *,
+        params=None,
+        timeout=None,
+    ):
+        calls.append({
+            "url": url,
+            "params": deepcopy(params),
+            "timeout": timeout,
+        })
+
+        if url.endswith("/schedule"):
+            return Response(schedule())
+
+        game_pk = int(
+            url.split("/game/", 1)[1].split("/", 1)[0]
+        )
+
+        if game_pk == failed_game_pk:
+            return Response(
+                {},
+                error=RuntimeError(
+                    "feed unavailable"
+                ),
+            )
+
+        return Response(feed(game_pk))
+
+    return request_get, calls
+
+
+def run(
+    *,
+    request_get=None,
+    cache=None,
+    maximum_final_games=15,
+):
+    if request_get is None:
+        request_get, _ = request_get_factory()
+
+    return fetch_canonical_pitcher_role_evidence_source(
+        team_id=10,
+        season=2026,
+        as_of=AS_OF,
+        active_roster_records=roster(),
+        request_get=request_get,
+        maximum_final_games=maximum_final_games,
+        cache=cache,
+    )
+
+
+def test_fetches_schedule_and_bounded_final_feeds():
+    request_get, calls = request_get_factory()
+
+    result = run(
+        request_get=request_get,
+        maximum_final_games=1,
+    )
+
+    assert result.status == "materialized"
+    assert len(calls) == 2
+    assert calls[0]["url"].endswith(
+        "/api/v1/schedule"
+    )
+    assert calls[1]["url"].endswith(
+        "/api/v1.1/game/11/feed/live"
+    )
+    assert result.to_diagnostics()[
+        "scheduled_final_game_count"
+    ] == 1
+    assert result.to_diagnostics()[
+        "fetched_final_game_count"
+    ] == 1
+
+
+def test_materializes_history_and_typical_roles():
+    result = run()
+    history = result.appearance_history
+    evidence = result.role_evidence[
+        "evidence_by_pitcher_id"
+    ]
+
+    assert history[
+        "detected_opener_bulk_pair_count"
+    ] == 3
+    assert history[
+        "evidence_by_pitcher_id"
+    ]["100"]["short_start_count"] == 3
+    assert history[
+        "evidence_by_pitcher_id"
+    ]["101"][
+        "early_multi_inning_relief_count"
+    ] == 3
+
+    assert evidence["100"][
+        "typical_role"
+    ] == "opener"
+    assert evidence["101"][
+        "typical_role"
+    ] == "bulk_follower"
+    assert evidence["102"][
+        "typical_role"
+    ] == "closer"
+
+
+def test_history_never_claims_today_assignment():
+    result = run()
+    diagnostics = result.to_diagnostics()
+
+    assert diagnostics[
+        "planned_role_claimed"
+    ] is False
+    assert diagnostics[
+        "future_assignment_inferred"
+    ] is False
+
+    for record in result.role_evidence["records"]:
+        assert record.get("planned_role") is None
+
+
+def test_partial_feed_failure_fails_soft():
+    request_get, _ = request_get_factory(
+        failed_game_pk=11,
+    )
+
+    result = run(request_get=request_get)
+
+    assert result.status == "partial"
+    assert result.to_diagnostics()[
+        "fetched_final_game_count"
+    ] == 2
+    assert result.to_diagnostics()[
+        "feed_error_count"
+    ] == 1
+    assert result.role_evidence[
+        "pitcher_count"
+    ] == 3
+
+
+def test_cache_prevents_duplicate_requests():
+    request_get, calls = request_get_factory()
+    cache = {}
+
+    first = run(
+        request_get=request_get,
+        cache=cache,
+    )
+    first_call_count = len(calls)
+
+    second = run(
+        request_get=request_get,
+        cache=cache,
+    )
+
+    assert first == second
+    assert first_call_count == 4
+    assert len(calls) == first_call_count
+
+
+def test_cache_result_is_defensive():
+    request_get, _ = request_get_factory()
+    cache = {}
+
+    first = run(
+        request_get=request_get,
+        cache=cache,
+    )
+    diagnostics = first.to_diagnostics()
+    diagnostics["status"] = "mutated"
+
+    second = run(
+        request_get=request_get,
+        cache=cache,
+    )
+
+    assert second.to_diagnostics()[
+        "status"
+    ] == "materialized"
+
+
+def test_roster_and_provider_inputs_are_unchanged():
+    active_roster = roster()
+    original_roster = deepcopy(active_roster)
+    request_get, _ = request_get_factory()
+
+    fetch_canonical_pitcher_role_evidence_source(
+        team_id=10,
+        season=2026,
+        as_of=AS_OF,
+        active_roster_records=active_roster,
+        request_get=request_get,
+    )
+
+    assert active_roster == original_roster
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"team_id": None}, "team_id is required"),
+        ({"as_of": "invalid"}, "as_of must be a valid date"),
+        (
+            {"maximum_final_games": 0},
+            "maximum_final_games must be positive",
+        ),
+        (
+            {"lookback_days": 0},
+            "lookback_days must be positive",
+        ),
+    ],
+)
+def test_rejects_invalid_context(kwargs, message):
+    request_get, _ = request_get_factory()
+    arguments = {
+        "team_id": 10,
+        "season": 2026,
+        "as_of": AS_OF,
+        "active_roster_records": roster(),
+        "request_get": request_get,
+    }
+    arguments.update(kwargs)
+
+    with pytest.raises(
+        ValueError,
+        match=message,
+    ):
+        fetch_canonical_pitcher_role_evidence_source(
+            **arguments
+        )
+
+
+def test_rejects_invalid_roster_contract():
+    request_get, _ = request_get_factory()
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "active_roster_records must be a sequence"
+        ),
+    ):
+        fetch_canonical_pitcher_role_evidence_source(
+            team_id=10,
+            season=2026,
+            as_of=AS_OF,
+            active_roster_records={},
+            request_get=request_get,
+        )
+
+
+def test_result_contract_is_public():
+    from mlb_app.simulation.shadow import (
+        CANONICAL_PITCHER_ROLE_EVIDENCE_SOURCE_VERSION,
+        CanonicalPitcherRoleEvidenceSourceResult,
+        fetch_canonical_pitcher_role_evidence_source,
+    )
+
+    assert (
+        CANONICAL_PITCHER_ROLE_EVIDENCE_SOURCE_VERSION
+    )
+    assert (
+        CanonicalPitcherRoleEvidenceSourceResult
+        is not None
+    )
+    assert callable(
+        fetch_canonical_pitcher_role_evidence_source
+    )

--- a/tests/test_canonical_pitcher_typical_role_evidence.py
+++ b/tests/test_canonical_pitcher_typical_role_evidence.py
@@ -1,0 +1,291 @@
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.projections.pitcher_typical_role_evidence import (
+    materialize_canonical_pitcher_role_evidence,
+)
+
+
+def pitcher(
+    pitcher_id,
+    *,
+    games_pitched,
+    games_started,
+    saves=0,
+    holds=0,
+    games_finished=0,
+    outs=0,
+):
+    return {
+        "mlb_player_id": pitcher_id,
+        "player_type": "pitcher",
+        "season_games_pitched": games_pitched,
+        "season_games_started": games_started,
+        "season_relief_appearances": (
+            games_pitched - games_started
+        ),
+        "season_saves": saves,
+        "season_holds": holds,
+        "season_games_finished": games_finished,
+        "season_pitching_outs": outs,
+    }
+
+
+def evidence(rows, **kwargs):
+    return materialize_canonical_pitcher_role_evidence(
+        active_roster_records=rows,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_role"),
+    [
+        (
+            pitcher(
+                "starter",
+                games_pitched=24,
+                games_started=24,
+                outs=420,
+            ),
+            "starter",
+        ),
+        (
+            pitcher(
+                "closer",
+                games_pitched=50,
+                games_started=0,
+                saves=28,
+                holds=2,
+                games_finished=39,
+                outs=150,
+            ),
+            "closer",
+        ),
+        (
+            pitcher(
+                "setup",
+                games_pitched=55,
+                games_started=0,
+                saves=1,
+                holds=19,
+                games_finished=5,
+                outs=150,
+            ),
+            "setup",
+        ),
+        (
+            pitcher(
+                "long",
+                games_pitched=20,
+                games_started=0,
+                outs=120,
+            ),
+            "long_reliever",
+        ),
+        (
+            pitcher(
+                "middle",
+                games_pitched=45,
+                games_started=0,
+                outs=120,
+            ),
+            "middle_reliever",
+        ),
+        (
+            pitcher(
+                "swing",
+                games_pitched=20,
+                games_started=8,
+                outs=210,
+            ),
+            "swingman",
+        ),
+    ],
+)
+def test_materializes_season_usage_roles(
+    row,
+    expected_role,
+):
+    result = evidence([row])
+
+    assert result["records"][0][
+        "typical_role"
+    ] == expected_role
+    assert result["records"][0][
+        "typical_role_inference_used"
+    ] is True
+
+
+def test_repeated_short_starts_materialize_opener():
+    rows = [
+        pitcher(
+            "100",
+            games_pitched=12,
+            games_started=8,
+            outs=90,
+        ),
+    ]
+
+    result = evidence(
+        rows,
+        historical_appearance_evidence_by_pitcher_id={
+            "100": {
+                "start_count": 8,
+                "short_start_count": 6,
+                "relief_appearance_count": 4,
+                "relief_outs": 24,
+            },
+        },
+    )
+
+    row = result["records"][0]
+
+    assert row["typical_role"] == "opener"
+    assert row[
+        "typical_role_source"
+    ] == (
+        "mlb_stats_historical_"
+        "appearance_sequence"
+    )
+
+
+def test_repeated_early_length_materializes_bulk_follower():
+    rows = [
+        pitcher(
+            "101",
+            games_pitched=18,
+            games_started=0,
+            outs=180,
+        ),
+    ]
+
+    result = evidence(
+        rows,
+        historical_appearance_evidence_by_pitcher_id={
+            "101": {
+                "relief_appearance_count": 18,
+                "early_multi_inning_relief_count": 7,
+                "relief_outs": 180,
+            },
+        },
+    )
+
+    row = result["records"][0]
+
+    assert row[
+        "typical_role"
+    ] == "bulk_follower"
+    assert row[
+        "historical_bulk_follower_count"
+    ] == 7
+
+
+def test_confirmed_plan_is_separate_from_typical_role():
+    rows = [
+        pitcher(
+            "101",
+            games_pitched=30,
+            games_started=0,
+            holds=12,
+            outs=90,
+        ),
+    ]
+
+    result = evidence(
+        rows,
+        planned_role_evidence_by_pitcher_id={
+            "101": {
+                "role": "opener",
+                "source": "official_team_game_notes",
+                "evidence_status": "confirmed",
+            },
+        },
+    )
+    row = result["records"][0]
+
+    assert row["typical_role"] == "setup"
+    assert row["planned_game_role"] == "opener"
+    assert (
+        row["planned_game_role_status"]
+        == "confirmed"
+    )
+    assert row[
+        "planned_role_inferred_from_history"
+    ] is False
+
+
+def test_unconfirmed_plan_is_not_promoted():
+    result = evidence(
+        [
+            pitcher(
+                "101",
+                games_pitched=30,
+                games_started=0,
+                outs=90,
+            ),
+        ],
+        planned_role_evidence_by_pitcher_id={
+            "101": {
+                "role": "bulk_follower",
+                "source": "historical_guess",
+                "evidence_status": "inferred",
+            },
+        },
+    )
+    row = result["records"][0]
+
+    assert row["planned_game_role"] is None
+    assert (
+        row["planned_game_role_status"]
+        == "invalid_or_unconfirmed"
+    )
+
+
+def test_incomplete_usage_remains_unknown():
+    result = evidence([
+        {
+            "mlb_player_id": "101",
+            "player_type": "pitcher",
+        },
+    ])
+
+    assert result["records"][0][
+        "typical_role"
+    ] == "unknown"
+    assert result[
+        "unresolved_pitcher_ids"
+    ] == ["101"]
+
+
+def test_materialization_is_read_only():
+    rows = [
+        pitcher(
+            "101",
+            games_pitched=40,
+            games_started=0,
+            holds=10,
+            outs=120,
+        ),
+    ]
+    original = deepcopy(rows)
+
+    result = evidence(rows)
+
+    assert rows == original
+    assert result[
+        "database_writes_performed"
+    ] is False
+    assert result[
+        "production_authority_changed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [None, "records", {}, object()],
+)
+def test_rejects_invalid_roster_sequence(invalid):
+    with pytest.raises(TypeError):
+        evidence(invalid)

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -934,3 +934,102 @@ def test_known_materialized_provider_evidence_overrides_usage():
     assert record["pitcher_role"] == (
         "long_reliever"
     )
+
+def test_preserves_private_active_roster_records_for_same_process_consumers():
+    source_records = active_roster(
+        10,
+        2026,
+        team_name="Away",
+    )
+
+    result = discovery(
+        roster_fetcher=lambda *args, **kwargs:
+            source_records,
+    )
+
+    assert result.away.source_record_count == 4
+    assert len(
+        result.away.active_roster_records
+    ) == 3
+    assert result.away.active_roster_records == (
+        source_records[0],
+        source_records[1],
+        source_records[2],
+    )
+    assert all(
+        record["player_type"] == "pitcher"
+        for record in (
+            result.away.active_roster_records
+        )
+    )
+
+    source_records[1]["player_type"] = "mutated"
+
+    assert result.away.active_roster_records[1][
+        "player_type"
+    ] == "pitcher"
+
+
+def test_private_active_roster_records_remain_redacted_from_diagnostics():
+    result = discovery()
+    side_diagnostics = result.away.to_diagnostics()
+    diagnostics = result.to_diagnostics()
+
+    assert "active_roster_records" not in (
+        side_diagnostics
+    )
+    assert "active_roster_records" not in (
+        diagnostics["away"]
+    )
+    assert "bullpen_pitcher_ids" not in (
+        side_diagnostics
+    )
+    assert side_diagnostics[
+        "pitcher_identifiers_exposed"
+    ] is False
+
+
+def test_private_active_roster_records_preserve_season_usage():
+    def usage_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+                "season_games_pitched": 20,
+                "season_games_started": 20,
+                "season_relief_appearances": 0,
+                "season_saves": 0,
+                "season_holds": 0,
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 40,
+                "season_games_started": 0,
+                "season_relief_appearances": 40,
+                "season_saves": 18,
+                "season_holds": 2,
+            },
+        ]
+
+    result = discovery(
+        roster_fetcher=usage_roster,
+    )
+    records = {
+        str(record["mlb_player_id"]): record
+        for record in (
+            result.away.active_roster_records
+        )
+    }
+
+    assert records["101"][
+        "season_games_pitched"
+    ] == 40
+    assert records["101"]["season_saves"] == 18
+    assert records["101"]["season_holds"] == 2

--- a/tests/test_model_projection_pitcher_role_evidence_wiring.py
+++ b/tests/test_model_projection_pitcher_role_evidence_wiring.py
@@ -1,0 +1,196 @@
+from copy import deepcopy
+from dataclasses import dataclass
+
+import pytest
+
+from mlb_app import model_projections
+
+
+@dataclass
+class Side:
+    team_id: str
+    active_roster_records: tuple
+
+
+@dataclass
+class Discovery:
+    away: Side
+    home: Side
+
+
+class Result:
+    def __init__(self, team_id, role):
+        pitcher_id = str(team_id * 10 + 1)
+        self.role_evidence = {
+            "evidence_by_pitcher_id": {
+                pitcher_id: {
+                    "pitcher_id": pitcher_id,
+                    "typical_role": role,
+                    "confidence": "high",
+                    "source": "test_history",
+                    "inference_used": True,
+                },
+            },
+        }
+        self._diagnostics = {
+            "schema_version":
+                "canonical_pitcher_role_"
+                "evidence_source_v1",
+            "status": "materialized",
+            "team_id": str(team_id),
+            "as_of_date": "2026-08-15",
+            "lookback_days": 60,
+            "maximum_final_games": 10,
+            "scheduled_final_game_count": 10,
+            "fetched_final_game_count": 10,
+            "feed_error_count": 0,
+            "resolved_typical_role_count": 1,
+            "detected_opener_bulk_pair_count": 0,
+            "bounded_game_fetch": True,
+            "simulation_trial_fetches_performed": 0,
+            "planned_role_claimed": False,
+            "future_assignment_inferred": False,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+    def to_diagnostics(self):
+        return deepcopy(self._diagnostics)
+
+
+def discovery():
+    return Discovery(
+        away=Side(
+            team_id="10",
+            active_roster_records=({
+                "mlb_player_id": 101,
+                "player_type": "pitcher",
+            },),
+        ),
+        home=Side(
+            team_id="20",
+            active_roster_records=({
+                "mlb_player_id": 201,
+                "player_type": "pitcher",
+            },),
+        ),
+    )
+
+
+def test_materializes_both_sides_with_shared_cache():
+    calls = []
+    cache = {}
+
+    def fetcher(**kwargs):
+        calls.append(kwargs)
+        team_id = int(kwargs["team_id"])
+        return Result(
+            team_id,
+            "closer"
+            if team_id == 10
+            else "setup",
+        )
+
+    result = (
+        model_projections
+        ._materialize_matchup_pitcher_role_evidence(
+            bullpen_discovery=discovery(),
+            season=2026,
+            as_of="2026-08-15",
+            cache=cache,
+            fetcher=fetcher,
+        )
+    )
+
+    assert len(calls) == 2
+    assert all(
+        call["cache"] is cache
+        for call in calls
+    )
+    assert result["evidence_by_pitcher_id"][
+        "101"
+    ]["typical_role"] == "closer"
+    assert result["evidence_by_pitcher_id"][
+        "201"
+    ]["typical_role"] == "setup"
+    assert result[
+        "simulation_trial_fetches_performed"
+    ] == 0
+
+
+def test_source_diagnostics_are_redacted():
+    result = (
+        model_projections
+        ._materialize_matchup_pitcher_role_evidence(
+            bullpen_discovery=discovery(),
+            season=2026,
+            as_of="2026-08-15",
+            cache={},
+            fetcher=lambda **kwargs: Result(
+                int(kwargs["team_id"]),
+                "middle_reliever",
+            ),
+        )
+    )
+
+    diagnostics = result[
+        "source_diagnostics_by_team_side"
+    ]
+
+    assert set(diagnostics) == {
+        "away",
+        "home",
+    }
+    assert all(
+        row["pitcher_identifiers_exposed"]
+        is False
+        for row in diagnostics.values()
+    )
+    assert all(
+        "evidence_by_pitcher_id" not in row
+        for row in diagnostics.values()
+    )
+
+
+def test_one_side_failure_fails_open():
+    def fetcher(**kwargs):
+        if str(kwargs["team_id"]) == "10":
+            raise RuntimeError("away unavailable")
+        return Result(20, "setup")
+
+    result = (
+        model_projections
+        ._materialize_matchup_pitcher_role_evidence(
+            bullpen_discovery=discovery(),
+            season=2026,
+            as_of="2026-08-15",
+            cache={},
+            fetcher=fetcher,
+        )
+    )
+
+    assert set(
+        result["evidence_by_pitcher_id"]
+    ) == {"201"}
+    assert result[
+        "source_diagnostics_by_team_side"
+    ]["away"]["status"] == "error"
+    assert result[
+        "source_diagnostics_by_team_side"
+    ]["home"]["status"] == "materialized"
+
+
+def test_rejects_non_dictionary_cache():
+    with pytest.raises(
+        TypeError,
+        match="cache must be a dictionary",
+    ):
+        (
+            model_projections
+            ._materialize_matchup_pitcher_role_evidence(
+                bullpen_discovery=discovery(),
+                season=2026,
+                as_of="2026-08-15",
+                cache=[],
+            )
+        )


### PR DESCRIPTION
## Summary
- materialize historical pitcher appearance sequences from bounded final MLB game feeds
- classify evidence-backed typical roles from season usage and ordered appearances
- distinguish historical typical role from today's explicit planned role
- preserve explicit pregame plan/provider precedence
- feed typical-role provenance and confidence into canonical projection rows
- reuse private normalized active-roster pitcher records and a per-run team/date cache
- attach redacted role-source diagnostics without changing simulation authority

## Role taxonomy
- starter
- opener
- bulk follower
- swingman
- closer
- setup
- long reliever
- middle reliever
- unknown when evidence is insufficient

## Safety
- historical opener/bulk patterns never claim today's assignment
- explicit pregame roles override historical classifications
- source failures fail open by side
- no history requests occur inside simulation trials
- active-roster identifiers remain redacted from source diagnostics
- projection values, appearance probabilities, and game probabilities are unchanged
- no database writes or production-authority changes

## Production evidence
Representative Cincinnati live probe:
- 10 recent final feeds fetched successfully
- 15 historical pitchers observed
- 13 typical roles resolved
- starter-dominant pitchers remained starters
- leverage and workload roles classified
- no recent opener/bulk pair was falsely asserted
- cache reuse confirmed
- all acceptance signals passed

## Validation
- complete 6TH regression: 296 passed
- focused production wiring regression passed
- live Cincinnati evidence probe passed
- compilation passed
- working-tree and new-file whitespace checks passed

## Scope
This slice materializes and surfaces historical role evidence. It does not infer today's opener or bulk follower, alter appearance percentages, recalibrate workloads, modify simulation sequencing, write to the database, or change game-probability authority.