### PR TITLE
Calibrate canonical bullpen appearance sequence and matchup usage

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -40,6 +40,7 @@ from mlb_app.simulation.shadow.production_monitoring_ledger import (
 )
 
 from .canonical_game_context import build_canonical_game_context
+from .dashboard_object_models import DashboardPlayer
 from .db_utils import get_pitch_arsenal_with_fallback, get_team_split
 from .matchup_generator import generate_matchups_for_date
 from .model_projection_formulas import bullpen_collapse_index, offensive_firepower_score, pitch_identity_disruption_score, pitching_volatility_score, safe_float
@@ -917,6 +918,184 @@ def _materialize_matchup_pitcher_role_evidence(
     }
 
 
+def _canonical_matchup_bullpen_usage_evidence(
+    *,
+    bullpen_discovery: Any,
+    pitcher_role_evidence: Any,
+) -> Dict[str, Dict[str, Any]]:
+    """
+    Merge canonical role evidence with private roster throwing hand.
+
+    Only pitchers already admitted to the strict canonical bullpen
+    membership are returned. Missing usage or fatigue evidence remains
+    absent and therefore neutral inside the simulation.
+    """
+
+    role_records = (
+        pitcher_role_evidence.get(
+            "evidence_by_pitcher_id",
+            {},
+        )
+        if isinstance(
+            pitcher_role_evidence,
+            dict,
+        )
+        else {}
+    )
+
+    evidence: Dict[str, Dict[str, Any]] = {}
+
+    for team_side in ("away", "home"):
+        side = getattr(
+            bullpen_discovery,
+            team_side,
+            None,
+        )
+        eligible_ids = {
+            str(value).strip()
+            for value in getattr(
+                side,
+                "bullpen_pitcher_ids",
+                (),
+            )
+            if str(value).strip()
+        }
+
+        roster_by_id: Dict[str, Dict[str, Any]] = {}
+
+        for raw_record in getattr(
+            side,
+            "active_roster_records",
+            (),
+        ):
+            if not isinstance(raw_record, dict):
+                try:
+                    raw_record = dict(raw_record)
+                except Exception:
+                    continue
+
+            raw_identifier = (
+                raw_record.get("mlb_player_id")
+                or raw_record.get("player_id")
+                or raw_record.get("pitcher_id")
+                or raw_record.get("person_id")
+                or raw_record.get("id")
+            )
+            identifier = str(
+                raw_identifier or ""
+            ).strip()
+
+            if identifier in eligible_ids:
+                roster_by_id[identifier] = dict(
+                    raw_record
+                )
+
+        for pitcher_id in sorted(eligible_ids):
+            role_record = role_records.get(
+                pitcher_id,
+                {},
+            )
+            record = (
+                deepcopy(role_record)
+                if isinstance(role_record, dict)
+                else {}
+            )
+            record["pitcher_id"] = pitcher_id
+
+            roster_record = roster_by_id.get(
+                pitcher_id,
+                {},
+            )
+            throwing_hand = str(
+                roster_record.get("throws")
+                or roster_record.get("handedness")
+                or ""
+            ).strip().upper()
+
+            if throwing_hand in {"L", "R"}:
+                record["throws"] = throwing_hand
+
+            evidence[pitcher_id] = record
+
+    return evidence
+
+
+def _canonical_matchup_batter_handedness(
+    *,
+    session: Session,
+    lineup_discovery: Any,
+) -> Dict[str, str]:
+    """
+    Read confirmed-lineup batter handedness once before simulation.
+
+    Failure is intentionally soft: missing directory rows produce neutral
+    matchup selection rather than suppressing the projection game.
+    """
+
+    identifiers = {
+        str(value).strip()
+        for value in (
+            tuple(
+                getattr(
+                    lineup_discovery,
+                    "away_player_ids",
+                    (),
+                )
+            )
+            + tuple(
+                getattr(
+                    lineup_discovery,
+                    "home_player_ids",
+                    (),
+                )
+            )
+        )
+        if str(value).strip()
+    }
+
+    integer_ids = []
+
+    for identifier in sorted(identifiers):
+        try:
+            integer_ids.append(int(identifier))
+        except (TypeError, ValueError):
+            continue
+
+    if not integer_ids:
+        return {}
+
+    try:
+        with session.begin_nested():
+            rows = (
+                session.query(
+                    DashboardPlayer.mlb_player_id,
+                    DashboardPlayer.bats,
+                )
+                .filter(
+                    DashboardPlayer.mlb_player_id.in_(
+                        integer_ids
+                    )
+                )
+                .all()
+            )
+    except Exception:
+        return {}
+
+    handedness: Dict[str, str] = {}
+
+    for player_id, bats in rows:
+        normalized_hand = str(
+            bats or ""
+        ).strip().upper()
+
+        if normalized_hand in {"L", "R", "S"}:
+            handedness[str(player_id)] = (
+                normalized_hand
+            )
+
+    return handedness
+
+
 def _canonical_pitcher_pool_audit_input(
     bullpen_discovery: Any,
 ) -> Dict[str, Any]:
@@ -1602,6 +1781,25 @@ def build_model_projection_payload(
                 )
             )
 
+            canonical_pitcher_usage_evidence = (
+                _canonical_matchup_bullpen_usage_evidence(
+                    bullpen_discovery=(
+                        canonical_shadow_bullpen_discovery
+                    ),
+                    pitcher_role_evidence=(
+                        canonical_pitcher_role_evidence
+                    ),
+                )
+            )
+            canonical_batter_handedness = (
+                _canonical_matchup_batter_handedness(
+                    session=session,
+                    lineup_discovery=(
+                        canonical_shadow_lineup_discovery
+                    ),
+                )
+            )
+
             canonical_readiness_matchup = dict(
                 matchup
             )
@@ -1774,6 +1972,12 @@ def build_model_projection_payload(
                     bootstrap_ready=bool(
                         canonical_shadow_bootstrap_readiness
                         .get("ready")
+                    ),
+                    pitcher_usage_evidence_by_id=(
+                        canonical_pitcher_usage_evidence
+                    ),
+                    batter_handedness_by_id=(
+                        canonical_batter_handedness
                     ),
                 )
             )

--- a/mlb_app/simulation/game/bullpen_selector.py
+++ b/mlb_app/simulation/game/bullpen_selector.py
@@ -38,6 +38,10 @@ class CanonicalBullpenPitcher:
     minimum_inning: int = 1
     maximum_inning: int = 99
     maximum_score_margin: int | None = None
+    handedness: str | None = None
+    fatigue_index: float = 0.0
+    consecutive_days_worked: int = 0
+    recent_pitch_count: int = 0
 
     def __post_init__(self) -> None:
         if not self.pitcher_id:
@@ -71,6 +75,54 @@ class CanonicalBullpenPitcher:
                 "maximum_score_margin cannot be negative"
             )
 
+        if self.handedness not in (None, "L", "R"):
+            raise ValueError(
+                "handedness must be L, R, or None"
+            )
+
+        if (
+            isinstance(self.fatigue_index, bool)
+            or not isinstance(
+                self.fatigue_index,
+                (int, float),
+            )
+            or not 0.0 <= float(
+                self.fatigue_index
+            ) <= 1.0
+        ):
+            raise ValueError(
+                "fatigue_index must be between zero and one"
+            )
+
+        if (
+            isinstance(
+                self.consecutive_days_worked,
+                bool,
+            )
+            or not isinstance(
+                self.consecutive_days_worked,
+                int,
+            )
+            or self.consecutive_days_worked < 0
+        ):
+            raise ValueError(
+                "consecutive_days_worked must be a "
+                "non-negative integer"
+            )
+
+        if (
+            isinstance(self.recent_pitch_count, bool)
+            or not isinstance(
+                self.recent_pitch_count,
+                int,
+            )
+            or self.recent_pitch_count < 0
+        ):
+            raise ValueError(
+                "recent_pitch_count must be a "
+                "non-negative integer"
+            )
+
 
 @dataclass(frozen=True)
 class CanonicalBullpenSelectionContext:
@@ -80,6 +132,7 @@ class CanonicalBullpenSelectionContext:
     game_context: CanonicalPitchingDecisionContext
     bullpen: Tuple[CanonicalBullpenPitcher, ...]
     previously_used_pitcher_ids: Tuple[str, ...] = ()
+    upcoming_batter_handedness: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(
@@ -123,6 +176,23 @@ class CanonicalBullpenSelectionContext:
             raise ValueError(
                 "previously used pitcher identifiers "
                 "must be unique"
+            )
+
+        if len(self.upcoming_batter_handedness) > 5:
+            raise ValueError(
+                "upcoming batter handedness pocket "
+                "cannot exceed five hitters"
+            )
+
+        if any(
+            handedness not in ("L", "R", "S")
+            for handedness in (
+                self.upcoming_batter_handedness
+            )
+        ):
+            raise ValueError(
+                "upcoming batter handedness values "
+                "must be L, R, or S"
             )
 
 
@@ -174,8 +244,9 @@ class CanonicalBullpenSelector:
     Transparent deterministic bullpen selector.
 
     Selection is role-aware, leverage-aware, inning-aware, and stable
-    under identical inputs. It does not yet model handedness, fatigue,
-    or recent real-world workload.
+    under identical inputs. Within the appropriate role tier, explicit
+    handedness, fatigue, consecutive-day, and recent-pitch evidence
+    calibrate which eligible reliever enters.
     """
 
     version: str = CANONICAL_BULLPEN_SELECTOR_VERSION
@@ -226,6 +297,10 @@ class CanonicalBullpenSelector:
                     self._role_rank(
                         pitcher.role,
                         target_roles,
+                    ),
+                    self._matchup_usage_score(
+                        pitcher=pitcher,
+                        context=context,
                     ),
                     pitcher.appearance_priority,
                     pitcher.pitcher_id,
@@ -346,6 +421,69 @@ class CanonicalBullpenSelector:
         target_roles: Tuple[CanonicalBullpenRole, ...],
     ) -> int:
         return target_roles.index(role)
+
+    @staticmethod
+    def _matchup_usage_score(
+        *,
+        pitcher: CanonicalBullpenPitcher,
+        context: CanonicalBullpenSelectionContext,
+    ) -> float:
+        """
+        Return a lower-is-better within-role usage score.
+
+        Role suitability remains the primary ordering key. This score
+        never allows a handedness preference to replace the correct
+        closer, setup, middle, or long-relief tier.
+
+        One or two consecutive days remain usable. Meaningful
+        consecutive-day fatigue begins with the third day, while
+        explicit fatigue and recent pitch volume contribute gradual
+        penalties.
+        """
+
+        score = 0.0
+
+        score += 40.0 * float(
+            pitcher.fatigue_index
+        )
+
+        if pitcher.consecutive_days_worked >= 3:
+            score += 18.0 * (
+                pitcher.consecutive_days_worked - 2
+            )
+
+        score += min(
+            25.0,
+            0.25 * pitcher.recent_pitch_count,
+        )
+
+        pitcher_hand = pitcher.handedness
+        pocket = context.upcoming_batter_handedness
+
+        if pitcher_hand is not None and pocket:
+            favorable = 0
+            unfavorable = 0
+
+            for batter_hand in pocket:
+                if batter_hand == "S":
+                    # A switch hitter is expected to bat from the
+                    # opposite side and is therefore unfavorable to
+                    # either conventional pitcher hand.
+                    unfavorable += 1
+                elif batter_hand == pitcher_hand:
+                    favorable += 1
+                else:
+                    unfavorable += 1
+
+            known = favorable + unfavorable
+
+            if known:
+                score += 12.0 * (
+                    (unfavorable - favorable)
+                    / known
+                )
+
+        return round(score, 6)
 
     @staticmethod
     def _selection_reason(

--- a/mlb_app/simulation/game/pa_resolver_factory.py
+++ b/mlb_app/simulation/game/pa_resolver_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Mapping, Optional, Tuple
 
 from mlb_app.simulation.events import (
     GameState,
@@ -88,6 +88,9 @@ class CanonicalPlateAppearanceResolverFactory:
     home_bullpen: Optional[
         Tuple[CanonicalBullpenPitcher, ...]
     ] = None
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
+    ] = None
     version: str = (
         CANONICAL_PA_RESOLVER_FACTORY_VERSION
     )
@@ -166,6 +169,9 @@ class CanonicalPlateAppearanceResolverFactory:
                 ),
                 away_bullpen=self.away_bullpen,
                 home_bullpen=self.home_bullpen,
+                batter_handedness_by_id=(
+                    self.batter_handedness_by_id
+                ),
             )
 
         return _CanonicalPlateAppearanceResolver(

--- a/mlb_app/simulation/game/pitching_manager.py
+++ b/mlb_app/simulation/game/pitching_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from typing import Dict, Mapping, Optional, Tuple
 
 from mlb_app.simulation.events import GameState, PlayEvent
 
@@ -61,6 +61,9 @@ class CanonicalPitchingManager:
     bullpen_selector: CanonicalBullpenSelector
     away_bullpen: Tuple[CanonicalBullpenPitcher, ...]
     home_bullpen: Tuple[CanonicalBullpenPitcher, ...]
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
+    ] = None
     opener_hook_policy: Optional[
         CanonicalStarterHookPolicy
     ] = None
@@ -561,6 +564,12 @@ class CanonicalPitchingManager:
                             team_side
                         ]
                     ),
+                    upcoming_batter_handedness=(
+                        self._upcoming_batter_handedness(
+                            team_side=team_side,
+                            state=state,
+                        )
+                    ),
                 )
             )
 
@@ -583,6 +592,50 @@ class CanonicalPitchingManager:
         )
 
         return replacement
+
+    def _upcoming_batter_handedness(
+        self,
+        *,
+        team_side: str,
+        state: GameState,
+        pocket_size: int = 5,
+    ) -> Tuple[str, ...]:
+        """
+        Return the next known hitter-handedness pocket.
+
+        The mapping is assembled before trials. Missing or invalid
+        evidence is omitted so the selector falls back to its existing
+        deterministic ordering without database access or inference.
+        """
+
+        if (
+            self.batter_handedness_by_id is None
+            or pocket_size < 1
+        ):
+            return ()
+
+        lineup = (
+            self.matchup_input.away_lineup
+            if team_side == "home"
+            else self.matchup_input.home_lineup
+        )
+
+        pocket = []
+
+        for offset in range(pocket_size):
+            batter_id = lineup.batter(
+                state.batting_order_index + offset
+            )
+            handedness = (
+                self.batter_handedness_by_id.get(
+                    batter_id
+                )
+            )
+
+            if handedness in {"L", "R", "S"}:
+                pocket.append(handedness)
+
+        return tuple(pocket)
 
     def _preferred_replacement_pitcher_id(
         self,

--- a/mlb_app/simulation/shadow/execution_factory.py
+++ b/mlb_app/simulation/shadow/execution_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from mlb_app.simulation.box_score import (
     BatterDfsScoringRules,
@@ -61,19 +61,184 @@ CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION = (
 )
 
 
+_ROLE_BY_EVIDENCE = {
+    "closer": CanonicalBullpenRole.CLOSER,
+    "setup": CanonicalBullpenRole.SETUP,
+    "setup_reliever": CanonicalBullpenRole.SETUP,
+    "long_relief": CanonicalBullpenRole.LONG_RELIEF,
+    "long_reliever": CanonicalBullpenRole.LONG_RELIEF,
+    "bulk_follower": CanonicalBullpenRole.LONG_RELIEF,
+    "swingman": CanonicalBullpenRole.LONG_RELIEF,
+    "middle_relief": CanonicalBullpenRole.MIDDLE_RELIEF,
+    "middle_reliever": CanonicalBullpenRole.MIDDLE_RELIEF,
+    "opener": CanonicalBullpenRole.MIDDLE_RELIEF,
+    "unknown": CanonicalBullpenRole.MIDDLE_RELIEF,
+}
+
+
+def _evidence_record(
+    evidence_by_pitcher_id: Optional[
+        Mapping[Any, Any]
+    ],
+    pitcher_id: str,
+) -> Mapping[str, Any]:
+    if not isinstance(
+        evidence_by_pitcher_id,
+        Mapping,
+    ):
+        return {}
+
+    record = (
+        evidence_by_pitcher_id.get(pitcher_id)
+    )
+
+    if record is None:
+        try:
+            numeric_id = int(pitcher_id)
+        except (TypeError, ValueError):
+            numeric_id = None
+
+        if numeric_id is not None:
+            record = evidence_by_pitcher_id.get(
+                numeric_id
+            )
+
+    return record if isinstance(record, Mapping) else {}
+
+
+def _canonical_bullpen_role(
+    record: Mapping[str, Any],
+) -> CanonicalBullpenRole:
+    planned_role = record.get(
+        "planned_game_role"
+    )
+
+    if (
+        record.get("planned_game_role_status")
+        == "confirmed"
+        and planned_role
+    ):
+        role_value = planned_role
+    else:
+        role_value = (
+            record.get("typical_role")
+            or record.get("role")
+        )
+
+    normalized = str(
+        role_value or "unknown"
+    ).strip().lower()
+
+    return _ROLE_BY_EVIDENCE.get(
+        normalized,
+        CanonicalBullpenRole.MIDDLE_RELIEF,
+    )
+
+
+def _nonnegative_int(
+    value: Any,
+    default: int = 0,
+) -> int:
+    if isinstance(value, bool):
+        return default
+
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return default
+
+    return normalized if normalized >= 0 else default
+
+
+def _fatigue_index(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+
+    try:
+        normalized = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if not 0.0 <= normalized <= 1.0:
+        return 0.0
+
+    return normalized
+
+
 def _baseline_bullpen(
     pitcher_ids: tuple[str, ...],
+    evidence_by_pitcher_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
 ) -> tuple[CanonicalBullpenPitcher, ...]:
-    """Adapt an identity-only pitching plan into stable bullpen inputs."""
+    """
+    Adapt a canonical pitching plan and optional pretrial evidence.
 
-    return tuple(
-        CanonicalBullpenPitcher(
-            pitcher_id=pitcher_id,
-            role=CanonicalBullpenRole.MIDDLE_RELIEF,
-            appearance_priority=index,
+    Missing or invalid role, handedness, and workload evidence remains
+    neutral. This adapter performs no discovery or storage reads.
+    """
+
+    bullpen = []
+
+    for index, pitcher_id in enumerate(
+        pitcher_ids
+    ):
+        record = _evidence_record(
+            evidence_by_pitcher_id,
+            pitcher_id,
         )
-        for index, pitcher_id in enumerate(pitcher_ids)
-    )
+
+        handedness = str(
+            record.get("handedness")
+            or record.get("throws")
+            or ""
+        ).strip().upper()
+
+        if handedness not in {"L", "R"}:
+            handedness = None
+
+        available_value = record.get("available")
+        available = (
+            available_value
+            if isinstance(available_value, bool)
+            else True
+        )
+
+        bullpen.append(
+            CanonicalBullpenPitcher(
+                pitcher_id=pitcher_id,
+                role=_canonical_bullpen_role(
+                    record
+                ),
+                available=available,
+                appearance_priority=_nonnegative_int(
+                    record.get(
+                        "appearance_priority"
+                    ),
+                    index,
+                ),
+                handedness=handedness,
+                fatigue_index=_fatigue_index(
+                    record.get("fatigue_index")
+                ),
+                consecutive_days_worked=(
+                    _nonnegative_int(
+                        record.get(
+                            "consecutive_days_worked"
+                        )
+                    )
+                ),
+                recent_pitch_count=(
+                    _nonnegative_int(
+                        record.get(
+                            "recent_pitch_count"
+                        )
+                    )
+                ),
+            )
+        )
+
+    return tuple(bullpen)
 
 
 @dataclass(frozen=True)
@@ -106,6 +271,12 @@ class CanonicalShadowExecutionBundleFactory:
     ] = None
     pitcher_dfs_rules: Optional[
         PitcherDfsScoringRules
+    ] = None
+    pitcher_usage_evidence_by_id: Optional[
+        Mapping[Any, Any]
+    ] = None
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
     ] = None
     factory_version: str = (
         CANONICAL_SHADOW_EXECUTION_BUNDLE_FACTORY_VERSION
@@ -252,12 +423,17 @@ class CanonicalShadowExecutionBundleFactory:
                 away_bullpen=_baseline_bullpen(
                     self.matchup_input
                     .away_pitching_plan
-                    .bullpen_pitcher_ids
+                    .bullpen_pitcher_ids,
+                    self.pitcher_usage_evidence_by_id,
                 ),
                 home_bullpen=_baseline_bullpen(
                     self.matchup_input
                     .home_pitching_plan
-                    .bullpen_pitcher_ids
+                    .bullpen_pitcher_ids,
+                    self.pitcher_usage_evidence_by_id,
+                ),
+                batter_handedness_by_id=(
+                    self.batter_handedness_by_id
                 ),
             )
         )
@@ -353,6 +529,12 @@ def build_canonical_shadow_execution_bundle_factory(
     pitcher_dfs_rules: Optional[
         PitcherDfsScoringRules
     ] = None,
+    pitcher_usage_evidence_by_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
+    ] = None,
 ) -> CanonicalShadowExecutionBundleFactory:
     """Build an explicit, non-default canonical shadow factory."""
 
@@ -376,4 +558,10 @@ def build_canonical_shadow_execution_bundle_factory(
         ),
         batter_dfs_rules=batter_dfs_rules,
         pitcher_dfs_rules=pitcher_dfs_rules,
+        pitcher_usage_evidence_by_id=(
+            pitcher_usage_evidence_by_id
+        ),
+        batter_handedness_by_id=(
+            batter_handedness_by_id
+        ),
     )

--- a/mlb_app/simulation/shadow/input_assembly.py
+++ b/mlb_app/simulation/shadow/input_assembly.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import hashlib
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 from mlb_app.simulation.box_score import (
     BatterDfsScoringRules,
@@ -71,6 +71,12 @@ class CanonicalShadowExecutionInputs:
     ] = None
     pitcher_dfs_rules: Optional[
         PitcherDfsScoringRules
+    ] = None
+    pitcher_usage_evidence_by_id: Optional[
+        Mapping[Any, Any]
+    ] = None
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
     ] = None
     assembly_version: str = (
         CANONICAL_SHADOW_INPUT_ASSEMBLY_VERSION
@@ -275,6 +281,26 @@ class CanonicalShadowExecutionInputs:
             ),
             repr(self.batter_dfs_rules),
             repr(self.pitcher_dfs_rules),
+            repr(sorted(
+                (
+                    str(key),
+                    repr(value),
+                )
+                for key, value in (
+                    self.pitcher_usage_evidence_by_id
+                    or {}
+                ).items()
+            )),
+            repr(sorted(
+                (
+                    str(key),
+                    str(value),
+                )
+                for key, value in (
+                    self.batter_handedness_by_id
+                    or {}
+                ).items()
+            )),
         )
 
         return hashlib.sha256(
@@ -300,6 +326,12 @@ class CanonicalShadowExecutionInputs:
             game_config=self.game_config,
             batter_dfs_rules=self.batter_dfs_rules,
             pitcher_dfs_rules=self.pitcher_dfs_rules,
+            pitcher_usage_evidence_by_id=(
+                self.pitcher_usage_evidence_by_id
+            ),
+            batter_handedness_by_id=(
+                self.batter_handedness_by_id
+            ),
         )
 
 
@@ -326,6 +358,12 @@ def assemble_canonical_shadow_execution_inputs(
     pitcher_dfs_rules: Optional[
         PitcherDfsScoringRules
     ] = None,
+    pitcher_usage_evidence_by_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
+    ] = None,
 ) -> CanonicalShadowExecutionInputs:
     """Assemble validated external inputs without discovery or activation."""
 
@@ -349,4 +387,10 @@ def assemble_canonical_shadow_execution_inputs(
         ),
         batter_dfs_rules=batter_dfs_rules,
         pitcher_dfs_rules=pitcher_dfs_rules,
+        pitcher_usage_evidence_by_id=(
+            pitcher_usage_evidence_by_id
+        ),
+        batter_handedness_by_id=(
+            batter_handedness_by_id
+        ),
     )

--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -326,6 +326,12 @@ def run_canonical_production_shadow(
             Mapping[str, Any],
         ]
     ] = None,
+    pitcher_usage_evidence_by_id: Optional[
+        Mapping[Any, Any]
+    ] = None,
+    batter_handedness_by_id: Optional[
+        Mapping[str, str]
+    ] = None,
 ) -> CanonicalProductionShadowExecution:
     """
     Execute a small canonical batch when every production input is ready.
@@ -455,6 +461,12 @@ def run_canonical_production_shadow(
                 ),
                 pitcher_dfs_rules=(
                     DRAFTKINGS_CLASSIC_PITCHER_RULES
+                ),
+                pitcher_usage_evidence_by_id=(
+                    pitcher_usage_evidence_by_id
+                ),
+                batter_handedness_by_id=(
+                    batter_handedness_by_id
                 ),
             )
         )

--- a/tests/test_canonical_bullpen_execution_evidence.py
+++ b/tests/test_canonical_bullpen_execution_evidence.py
@@ -1,0 +1,152 @@
+from mlb_app.simulation.game import (
+    CanonicalBullpenRole,
+)
+from mlb_app.simulation.shadow.execution_factory import (
+    _baseline_bullpen,
+)
+
+
+def by_id(values):
+    return {
+        value.pitcher_id: value
+        for value in values
+    }
+
+
+def test_materializes_role_and_handedness_evidence():
+    bullpen = by_id(
+        _baseline_bullpen(
+            ("100", "101", "102", "103"),
+            {
+                "100": {
+                    "typical_role": "closer",
+                    "throws": "R",
+                },
+                101: {
+                    "typical_role": "setup",
+                    "handedness": "L",
+                },
+                "102": {
+                    "typical_role": "long_reliever",
+                    "throws": "L",
+                },
+                "103": {
+                    "typical_role": "middle_reliever",
+                    "throws": "R",
+                },
+            },
+        )
+    )
+
+    assert bullpen["100"].role is (
+        CanonicalBullpenRole.CLOSER
+    )
+    assert bullpen["101"].role is (
+        CanonicalBullpenRole.SETUP
+    )
+    assert bullpen["102"].role is (
+        CanonicalBullpenRole.LONG_RELIEF
+    )
+    assert bullpen["103"].role is (
+        CanonicalBullpenRole.MIDDLE_RELIEF
+    )
+    assert bullpen["100"].handedness == "R"
+    assert bullpen["101"].handedness == "L"
+
+
+def test_confirmed_planned_role_precedes_typical_role():
+    value = _baseline_bullpen(
+        ("100",),
+        {
+            "100": {
+                "typical_role": "closer",
+                "planned_game_role": "bulk_follower",
+                "planned_game_role_status": "confirmed",
+            },
+        },
+    )[0]
+
+    assert value.role is (
+        CanonicalBullpenRole.LONG_RELIEF
+    )
+
+
+def test_historical_opener_does_not_claim_today_plan():
+    value = _baseline_bullpen(
+        ("100",),
+        {
+            "100": {
+                "typical_role": "opener",
+                "planned_game_role": None,
+                "planned_game_role_status": "unknown",
+            },
+        },
+    )[0]
+
+    assert value.role is (
+        CanonicalBullpenRole.MIDDLE_RELIEF
+    )
+
+
+def test_materializes_explicit_workload_evidence():
+    value = _baseline_bullpen(
+        ("100",),
+        {
+            "100": {
+                "fatigue_index": 0.35,
+                "consecutive_days_worked": 3,
+                "recent_pitch_count": 27,
+                "available": True,
+            },
+        },
+    )[0]
+
+    assert value.fatigue_index == 0.35
+    assert value.consecutive_days_worked == 3
+    assert value.recent_pitch_count == 27
+    assert value.available is True
+
+
+def test_invalid_or_missing_evidence_is_neutral():
+    value = _baseline_bullpen(
+        ("100",),
+        {
+            "100": {
+                "typical_role": "unsupported",
+                "throws": "X",
+                "fatigue_index": 2.0,
+                "consecutive_days_worked": -1,
+                "recent_pitch_count": "unknown",
+                "available": "yes",
+            },
+        },
+    )[0]
+
+    assert value.role is (
+        CanonicalBullpenRole.MIDDLE_RELIEF
+    )
+    assert value.handedness is None
+    assert value.fatigue_index == 0.0
+    assert value.consecutive_days_worked == 0
+    assert value.recent_pitch_count == 0
+    assert value.available is True
+
+
+def test_identity_only_fallback_is_preserved():
+    values = _baseline_bullpen(
+        ("100", "101"),
+    )
+
+    assert tuple(
+        value.pitcher_id
+        for value in values
+    ) == ("100", "101")
+    assert all(
+        value.role
+        is CanonicalBullpenRole.MIDDLE_RELIEF
+        for value in values
+    )
+    assert tuple(
+        value.appearance_priority
+        for value in values
+    ) == (0, 1)

--- a/tests/test_canonical_bullpen_matchup_usage.py
+++ b/tests/test_canonical_bullpen_matchup_usage.py
@@ -1,0 +1,361 @@
+from dataclasses import replace
+
+import pytest
+
+from mlb_app.simulation.game.bullpen_selector import (
+    CanonicalBullpenPitcher,
+    CanonicalBullpenRole,
+    CanonicalBullpenSelectionContext,
+    build_canonical_bullpen_selector,
+)
+from mlb_app.simulation.game.pitcher_lifecycle import (
+    CanonicalPitcherLifecycleState,
+    CanonicalPitcherRole,
+    CanonicalPitchingDecision,
+    CanonicalPitchingDecisionAction,
+    CanonicalPitchingDecisionContext,
+)
+
+
+def decision():
+    return CanonicalPitchingDecision(
+        action=CanonicalPitchingDecisionAction.REPLACE,
+        current_pitcher_id="starter",
+        replacement_pitcher_id=(
+            "pending_bullpen_selection"
+        ),
+        reason="test_replacement",
+    )
+
+
+def game_context(
+    *,
+    inning=6,
+    fielding_team_score=3,
+    batting_team_score=3,
+):
+    return CanonicalPitchingDecisionContext(
+        lifecycle=CanonicalPitcherLifecycleState(
+            team_side="home",
+            pitcher_id="starter",
+            role=CanonicalPitcherRole.STARTER,
+            entered_inning=1,
+            entered_half="top",
+            batters_faced=24,
+        ),
+        upcoming_batter_id="away_batter_0",
+        inning=inning,
+        half="top",
+        outs=0,
+        runners_on_base=0,
+        fielding_team_score=fielding_team_score,
+        batting_team_score=batting_team_score,
+        available_reliever_ids=(
+            "left",
+            "right",
+            "fresh",
+            "worked_two",
+            "worked_three",
+            "priority",
+        ),
+    )
+
+
+def pitcher(
+    pitcher_id,
+    *,
+    handedness=None,
+    fatigue_index=0.0,
+    consecutive_days_worked=0,
+    recent_pitch_count=0,
+    appearance_priority=0,
+    role=CanonicalBullpenRole.MIDDLE_RELIEF,
+):
+    return CanonicalBullpenPitcher(
+        pitcher_id=pitcher_id,
+        role=role,
+        handedness=handedness,
+        fatigue_index=fatigue_index,
+        consecutive_days_worked=(
+            consecutive_days_worked
+        ),
+        recent_pitch_count=recent_pitch_count,
+        appearance_priority=appearance_priority,
+    )
+
+
+def select(
+    bullpen,
+    *,
+    pocket=(),
+    context=None,
+):
+    return build_canonical_bullpen_selector().select(
+        CanonicalBullpenSelectionContext(
+            pitching_decision=decision(),
+            game_context=context or game_context(),
+            bullpen=tuple(bullpen),
+            upcoming_batter_handedness=tuple(
+                pocket
+            ),
+        )
+    )
+
+
+def test_left_handed_pocket_prefers_left_hander():
+    result = select(
+        (
+            pitcher("right", handedness="R"),
+            pitcher("left", handedness="L"),
+        ),
+        pocket=("L", "L", "R"),
+    )
+
+    assert result.pitcher_id == "left"
+    assert result.candidate_pitcher_ids == (
+        "left",
+        "right",
+    )
+
+
+def test_right_handed_pocket_prefers_right_hander():
+    result = select(
+        (
+            pitcher("left", handedness="L"),
+            pitcher("right", handedness="R"),
+        ),
+        pocket=("R", "R", "L"),
+    )
+
+    assert result.pitcher_id == "right"
+
+
+def test_five_hitter_pocket_is_supported():
+    result = select(
+        (
+            pitcher("right", handedness="R"),
+            pitcher("left", handedness="L"),
+        ),
+        pocket=("L", "L", "L", "R", "S"),
+    )
+
+    assert result.pitcher_id == "left"
+
+
+def test_switch_hitters_are_opposite_side_matchups():
+    result = select(
+        (
+            pitcher(
+                "left",
+                handedness="L",
+                appearance_priority=1,
+            ),
+            pitcher(
+                "right",
+                handedness="R",
+                appearance_priority=0,
+            ),
+        ),
+        pocket=("S",),
+    )
+
+    # Both candidates receive the same switch-hitter penalty,
+    # so existing appearance priority remains authoritative.
+    assert result.pitcher_id == "right"
+
+
+def test_two_consecutive_days_remain_fully_usable():
+    result = select(
+        (
+            pitcher(
+                "worked_two",
+                consecutive_days_worked=2,
+                appearance_priority=0,
+            ),
+            pitcher(
+                "fresh",
+                consecutive_days_worked=0,
+                appearance_priority=1,
+            ),
+        )
+    )
+
+    assert result.pitcher_id == "worked_two"
+
+
+def test_meaningful_fatigue_begins_on_third_day():
+    result = select(
+        (
+            pitcher(
+                "worked_three",
+                consecutive_days_worked=3,
+                appearance_priority=0,
+            ),
+            pitcher(
+                "fresh",
+                consecutive_days_worked=0,
+                appearance_priority=1,
+            ),
+        )
+    )
+
+    assert result.pitcher_id == "fresh"
+
+
+def test_explicit_fatigue_and_pitch_volume_reduce_usage():
+    result = select(
+        (
+            pitcher(
+                "priority",
+                fatigue_index=0.8,
+                recent_pitch_count=35,
+                appearance_priority=0,
+            ),
+            pitcher(
+                "fresh",
+                fatigue_index=0.1,
+                recent_pitch_count=8,
+                appearance_priority=1,
+            ),
+        )
+    )
+
+    assert result.pitcher_id == "fresh"
+
+
+def test_role_order_remains_more_important_than_matchup():
+    save_context = game_context(
+        inning=9,
+        fielding_team_score=4,
+        batting_team_score=3,
+    )
+
+    result = select(
+        (
+            pitcher(
+                "left",
+                role=CanonicalBullpenRole.SETUP,
+                handedness="L",
+            ),
+            pitcher(
+                "right",
+                role=CanonicalBullpenRole.CLOSER,
+                handedness="R",
+                fatigue_index=1.0,
+                consecutive_days_worked=3,
+                recent_pitch_count=40,
+            ),
+        ),
+        pocket=("L", "L", "L"),
+        context=save_context,
+    )
+
+    assert result.pitcher_id == "right"
+    assert result.reason == "save_situation_closer"
+
+
+def test_missing_new_evidence_preserves_existing_ordering():
+    result = select(
+        (
+            pitcher(
+                "left",
+                appearance_priority=2,
+            ),
+            pitcher(
+                "right",
+                appearance_priority=1,
+            ),
+        )
+    )
+
+    assert result.pitcher_id == "right"
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    (
+        (
+            {"handedness": "X"},
+            "handedness",
+        ),
+        (
+            {"fatigue_index": -0.1},
+            "fatigue_index",
+        ),
+        (
+            {"fatigue_index": 1.1},
+            "fatigue_index",
+        ),
+        (
+            {"consecutive_days_worked": -1},
+            "consecutive_days_worked",
+        ),
+        (
+            {"recent_pitch_count": -1},
+            "recent_pitch_count",
+        ),
+    ),
+)
+def test_rejects_invalid_pitcher_usage_evidence(
+    changes,
+    message,
+):
+    with pytest.raises(ValueError, match=message):
+        pitcher("left", **changes)
+
+
+def test_rejects_invalid_or_oversized_handedness_pocket():
+    with pytest.raises(
+        ValueError,
+        match="cannot exceed five",
+    ):
+        select(
+            (pitcher("left"),),
+            pocket=("L",) * 6,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="must be L, R, or S",
+    ):
+        select(
+            (pitcher("left"),),
+            pocket=("X",),
+        )
+
+
+def test_usage_score_is_deterministic():
+    bullpen = (
+        pitcher(
+            "left",
+            handedness="L",
+            fatigue_index=0.25,
+            consecutive_days_worked=2,
+            recent_pitch_count=12,
+        ),
+        pitcher(
+            "right",
+            handedness="R",
+            fatigue_index=0.10,
+            consecutive_days_worked=3,
+            recent_pitch_count=8,
+        ),
+    )
+
+    context = CanonicalBullpenSelectionContext(
+        pitching_decision=decision(),
+        game_context=game_context(),
+        bullpen=bullpen,
+        upcoming_batter_handedness=(
+            "L",
+            "L",
+            "R",
+            "S",
+        ),
+    )
+
+    selector = build_canonical_bullpen_selector()
+
+    assert selector.select(context) == (
+        selector.select(context)
+    )

--- a/tests/test_canonical_pitching_manager.py
+++ b/tests/test_canonical_pitching_manager.py
@@ -985,3 +985,119 @@ def test_manager_falls_back_when_bulk_unavailable_under_opener_hook():
     )
 
     assert pitcher == "home_long"
+
+def test_manager_builds_upcoming_handedness_pocket():
+    matchup_input = matchup()
+
+    value = CanonicalPitchingManager(
+        matchup_input=matchup_input,
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_long",
+                role=CanonicalBullpenRole.MIDDLE_RELIEF,
+                handedness="L",
+            ),
+            CanonicalBullpenPitcher(
+                pitcher_id="home_middle",
+                role=CanonicalBullpenRole.MIDDLE_RELIEF,
+                handedness="R",
+            ),
+        ),
+        batter_handedness_by_id={
+            "away_batter_0": "L",
+            "away_batter_1": "L",
+            "away_batter_2": "R",
+            "away_batter_3": "L",
+            "away_batter_4": "S",
+        },
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    selected = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=6,
+            half="top",
+            batting_order_index=0,
+        ),
+        batter_id="away_batter_0",
+    )
+
+    assert selected == "home_long"
+
+
+def test_manager_handedness_pocket_wraps_lineup_order():
+    matchup_input = matchup()
+
+    value = CanonicalPitchingManager(
+        matchup_input=matchup_input,
+        starter_hook_policy=CanonicalStarterHookPolicy(
+            minimum_batters_faced=3,
+            target_batters_faced=3,
+            maximum_batters_faced=3,
+        ),
+        bullpen_selector=(
+            build_canonical_bullpen_selector()
+        ),
+        away_bullpen=bullpen("away"),
+        home_bullpen=(
+            CanonicalBullpenPitcher(
+                pitcher_id="home_long",
+                role=CanonicalBullpenRole.MIDDLE_RELIEF,
+                handedness="L",
+            ),
+            CanonicalBullpenPitcher(
+                pitcher_id="home_middle",
+                role=CanonicalBullpenRole.MIDDLE_RELIEF,
+                handedness="R",
+            ),
+        ),
+        batter_handedness_by_id={
+            "away_batter_8": "R",
+            "away_batter_0": "R",
+            "away_batter_1": "R",
+            "away_batter_2": "L",
+            "away_batter_3": "S",
+        },
+    )
+
+    value._active["home"] = replace(
+        value.active_lifecycle("home"),
+        batters_faced=3,
+    )
+
+    selected = value.pitcher_for_plate_appearance(
+        state=GameState(
+            inning=6,
+            half="top",
+            batting_order_index=8,
+        ),
+        batter_id="away_batter_8",
+    )
+
+    assert selected == "home_middle"
+
+
+def test_manager_missing_handedness_preserves_fallback():
+    value = manager()
+
+    assert value._upcoming_batter_handedness(
+        team_side="home",
+        state=GameState(
+            inning=6,
+            half="top",
+            batting_order_index=0,
+        ),
+    ) == ()

--- a/tests/test_model_projection_bullpen_matchup_usage_wiring.py
+++ b/tests/test_model_projection_bullpen_matchup_usage_wiring.py
@@ -1,0 +1,218 @@
+from contextlib import nullcontext
+from dataclasses import dataclass
+
+from mlb_app import model_projections
+
+
+@dataclass
+class Side:
+    bullpen_pitcher_ids: tuple
+    active_roster_records: tuple
+
+
+@dataclass
+class Bullpens:
+    away: Side
+    home: Side
+
+
+@dataclass
+class Lineups:
+    away_player_ids: tuple
+    home_player_ids: tuple
+
+
+def bullpens():
+    return Bullpens(
+        away=Side(
+            bullpen_pitcher_ids=("101", "102"),
+            active_roster_records=(
+                {
+                    "mlb_player_id": 100,
+                    "throws": "R",
+                },
+                {
+                    "mlb_player_id": 101,
+                    "throws": "L",
+                },
+                {
+                    "mlb_player_id": 102,
+                    "throws": "R",
+                },
+            ),
+        ),
+        home=Side(
+            bullpen_pitcher_ids=("201",),
+            active_roster_records=(
+                {
+                    "mlb_player_id": 200,
+                    "throws": "R",
+                },
+                {
+                    "mlb_player_id": 201,
+                    "throws": "L",
+                },
+            ),
+        ),
+    )
+
+
+def test_usage_evidence_contains_only_strict_bullpen_members():
+    result = (
+        model_projections
+        ._canonical_matchup_bullpen_usage_evidence(
+            bullpen_discovery=bullpens(),
+            pitcher_role_evidence={
+                "evidence_by_pitcher_id": {
+                    "100": {
+                        "typical_role": "starter",
+                    },
+                    "101": {
+                        "typical_role": "closer",
+                    },
+                    "102": {
+                        "typical_role":
+                            "middle_reliever",
+                    },
+                    "201": {
+                        "typical_role": "setup",
+                    },
+                },
+            },
+        )
+    )
+
+    assert set(result) == {
+        "101",
+        "102",
+        "201",
+    }
+    assert result["101"]["typical_role"] == (
+        "closer"
+    )
+    assert result["101"]["throws"] == "L"
+    assert result["102"]["throws"] == "R"
+    assert result["201"]["throws"] == "L"
+    assert "100" not in result
+
+
+def test_usage_evidence_does_not_fabricate_fatigue():
+    result = (
+        model_projections
+        ._canonical_matchup_bullpen_usage_evidence(
+            bullpen_discovery=bullpens(),
+            pitcher_role_evidence={
+                "evidence_by_pitcher_id": {},
+            },
+        )
+    )
+
+    assert result["101"] == {
+        "pitcher_id": "101",
+        "throws": "L",
+    }
+    assert "fatigue_index" not in result["101"]
+    assert (
+        "consecutive_days_worked"
+        not in result["101"]
+    )
+    assert "recent_pitch_count" not in result["101"]
+
+
+class Query:
+    def __init__(self, rows):
+        self.rows = rows
+        self.requested_ids = None
+
+    def filter(self, expression):
+        self.requested_ids = set(
+            expression.right.value
+        )
+        return self
+
+    def all(self):
+        return [
+            row
+            for row in self.rows
+            if row[0] in self.requested_ids
+        ]
+
+
+class Session:
+    def __init__(self, rows):
+        self.rows = rows
+        self.query_count = 0
+
+    def begin_nested(self):
+        return nullcontext()
+
+    def query(self, *columns):
+        self.query_count += 1
+        return Query(self.rows)
+
+
+def test_confirmed_lineup_handedness_is_loaded_once():
+    session = Session([
+        (1, "L"),
+        (2, "R"),
+        (3, "S"),
+        (4, "B"),
+        (999, "L"),
+    ])
+
+    result = (
+        model_projections
+        ._canonical_matchup_batter_handedness(
+            session=session,
+            lineup_discovery=Lineups(
+                away_player_ids=("1", "2"),
+                home_player_ids=("3", "4"),
+            ),
+        )
+    )
+
+    assert result == {
+        "1": "L",
+        "2": "R",
+        "3": "S",
+    }
+    assert session.query_count == 1
+    assert "999" not in result
+
+
+class FailingSession:
+    def begin_nested(self):
+        raise RuntimeError("directory unavailable")
+
+
+def test_handedness_query_failure_fails_soft():
+    result = (
+        model_projections
+        ._canonical_matchup_batter_handedness(
+            session=FailingSession(),
+            lineup_discovery=Lineups(
+                away_player_ids=("1",),
+                home_player_ids=("2",),
+            ),
+        )
+    )
+
+    assert result == {}
+
+
+def test_missing_confirmed_lineups_avoid_database_query():
+    session = Session([])
+
+    result = (
+        model_projections
+        ._canonical_matchup_batter_handedness(
+            session=session,
+            lineup_discovery=Lineups(
+                away_player_ids=(),
+                home_player_ids=(),
+            ),
+        )
+    )
+
+    assert result == {}
+    assert session.query_count == 0


### PR DESCRIPTION
## Summary

- calibrate canonical bullpen selection by planned/typical role, inning, leverage, and the upcoming batter handedness pocket
- preserve strict active-bullpen membership so starters cannot re-enter the reliever pool
- pass pitcher throwing hand, confirmed-lineup batter handedness, and explicit usage evidence into immutable production-shadow inputs
- keep relievers usable after one or two consecutive days and begin meaningful fatigue penalties on the third day
- preserve opener-to-bulk-follower sequencing and derive appearance percentages from actual simulated appearances

## Why

Bullpen projections still needed realistic appearance sequencing. Reliever usage should respond to the next hitters' handedness without allowing matchup preference to override the correct role tier. Workload evidence must also remain conservative: no fatigue is fabricated when recent usage is unavailable.

## Safety

- confirmed bullpen membership remains authoritative
- historical opener evidence never claims today's planned opener assignment
- missing handedness or workload evidence remains neutral
- no database reads occur inside simulation trials
- canonical game probability authority remains unchanged
- unrelated local scripts were excluded

## Validation

- 226 focused regression tests passed
- 100-trial dynamic starter workload probe passed
- opener/bulk sequencing probe passed
- 101 focused production-wiring tests passed
- Python compilation passed
- working-tree and staged diff checks passed
- new-file whitespace checks passed

Commit: `212135bdd0cb01a95c9a758bcc1192004da69247`