### PR TITLE
Activate canonical bullpen role and usage payload

### DIFF
--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -37,7 +37,7 @@ def matchups_date_key(date: str) -> str:
 
 
 MODEL_PROJECTION_WORKSPACE_VERSION = (
-    "model_projection_workspace_v3"
+    "model_projection_workspace_v4"
 )
 
 

--- a/mlb_app/simulation/shadow/bullpen_discovery.py
+++ b/mlb_app/simulation/shadow/bullpen_discovery.py
@@ -178,19 +178,13 @@ def _active_roster_usage_evidence(
         ):
             continue
 
-        if relief_appearances > games_started:
-            evidence[pitcher_id] = {
-                "status": "eligible",
-                "role": "reliever",
-                "source": (
-                    "mlb_stats_active_roster_"
-                    "season_pitching"
-                ),
-                "reason": (
-                    "observed_relief_usage_dominant"
-                ),
-            }
-        else:
+        start_rate = games_started / games_pitched
+        material_start_usage = (
+            games_started >= 3
+            and start_rate >= 0.20
+        )
+
+        if games_started >= relief_appearances:
             evidence[pitcher_id] = {
                 "status": "ineligible",
                 "role": "probable_starter",
@@ -201,6 +195,34 @@ def _active_roster_usage_evidence(
                 "reason": (
                     "observed_start_usage_dominant"
                 ),
+                "season_start_rate": start_rate,
+            }
+        elif material_start_usage:
+            evidence[pitcher_id] = {
+                "status": "ineligible",
+                "role": "probable_starter",
+                "source": (
+                    "mlb_stats_active_roster_"
+                    "season_pitching"
+                ),
+                "reason": (
+                    "observed_mixed_start_usage_"
+                    "requires_explicit_plan"
+                ),
+                "season_start_rate": start_rate,
+            }
+        else:
+            evidence[pitcher_id] = {
+                "status": "eligible",
+                "role": "reliever",
+                "source": (
+                    "mlb_stats_active_roster_"
+                    "season_pitching"
+                ),
+                "reason": (
+                    "observed_relief_usage_dominant"
+                ),
+                "season_start_rate": start_rate,
             }
 
     return evidence
@@ -694,7 +716,7 @@ def _discover_side(
     eligibility[
         "season_usage_classification_policy"
     ] = (
-        "relief_appearances_greater_than_starts"
+        "material_start_usage_requires_explicit_plan"
     )
     eligibility[
         "unknown_materialized_evidence_"

--- a/tests/test_canonical_shadow_bullpen_discovery.py
+++ b/tests/test_canonical_shadow_bullpen_discovery.py
@@ -722,18 +722,14 @@ def test_strict_membership_uses_observed_season_usage():
     assert result.status == "ready"
     assert result.away.bullpen_pitcher_ids == (
         "101",
-        "103",
     )
     assert result.home.bullpen_pitcher_ids == (
         "201",
-        "203",
     )
 
     away_records = {
         row["pitcher_id"]: row
-        for row in result.away.eligibility[
-            "records"
-        ]
+        for row in result.away.eligibility["records"]
     }
 
     assert away_records["101"][
@@ -742,6 +738,16 @@ def test_strict_membership_uses_observed_season_usage():
     assert away_records["102"][
         "decision_reason"
     ] == "observed_start_usage_dominant"
+    assert away_records["103"][
+        "decision_reason"
+    ] == (
+        "observed_mixed_start_usage_"
+        "requires_explicit_plan"
+    )
+    assert away_records["103"]["retained"] is False
+    assert away_records["103"]["pitcher_role"] == (
+        "probable_starter"
+    )
 
     diagnostics = result.away.to_diagnostics()
 
@@ -754,7 +760,67 @@ def test_strict_membership_uses_observed_season_usage():
     assert diagnostics[
         "season_usage_classification_policy"
     ] == (
-        "relief_appearances_greater_than_starts"
+        "material_start_usage_requires_explicit_plan"
+    )
+
+
+def test_mixed_rotation_pitcher_requires_explicit_game_plan():
+    def mixed_roster(
+        team_id,
+        season,
+        team_name=None,
+    ):
+        starter = 100 if team_id == 10 else 200
+
+        return [
+            {
+                "mlb_player_id": starter,
+                "player_type": "pitcher",
+                "season_games_pitched": 20,
+                "season_games_started": 20,
+                "season_relief_appearances": 0,
+            },
+            {
+                "mlb_player_id": starter + 1,
+                "player_type": "pitcher",
+                "season_games_pitched": 17,
+                "season_games_started": 8,
+                "season_relief_appearances": 9,
+            },
+            {
+                "mlb_player_id": starter + 2,
+                "player_type": "pitcher",
+                "season_games_pitched": 40,
+                "season_games_started": 0,
+                "season_relief_appearances": 40,
+            },
+        ]
+
+    result = discovery(
+        roster_fetcher=mixed_roster,
+        require_explicit_bullpen_membership=True,
+    )
+
+    assert result.away.bullpen_pitcher_ids == (
+        "102",
+    )
+    assert result.home.bullpen_pitcher_ids == (
+        "202",
+    )
+
+    away_records = {
+        row["pitcher_id"]: row
+        for row in result.away.eligibility["records"]
+    }
+    mixed = away_records["101"]
+
+    assert mixed["retained"] is False
+    assert mixed["pitcher_role"] == (
+        "probable_starter"
+    )
+    assert mixed["decision_reason"] == (
+        "observed_mixed_start_usage_"
+        "requires_explicit_plan"
     )
 
 

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -170,19 +170,19 @@ def test_projection_workspace_version_changes_cache_namespace() -> None:
     )
 
 
-def test_model_projection_workspace_v3_invalidates_prior_payload_cache():
-    date = "2026-07-23"
+def test_model_projection_workspace_v4_invalidates_prior_role_payload_cache():
+    date = "2026-08-16"
 
     key = model_projection_date_key(date)
 
     assert MODEL_PROJECTION_WORKSPACE_VERSION == (
-        "model_projection_workspace_v3"
+        "model_projection_workspace_v4"
     )
     assert key.endswith(
-        "model_projection_workspace_v3:"
+        "model_projection_workspace_v4:"
         + date
     )
     assert (
-        "model_projection_workspace_v2"
+        "model_projection_workspace_v3"
         not in key
     )


### PR DESCRIPTION
## Summary

- advance the Model Projections workspace artifact contract to v4 so deployments cannot continue serving pre-role-materialization durable payloads
- make active-roster season usage fail closed for pitchers with material starting responsibility unless explicit current-game evidence assigns them to the bullpen
- preserve explicit pregame opener, bulk, tandem, and relief overrides
- add regression coverage for a Senga-style 17-game profile with 8 starts and 9 relief appearances

## Root cause

The projections route reads scheduled, warmed artifacts whose cache namespace is tied to the workspace contract. The deployed artifact still used the v3 namespace, so the UI could continue receiving rows created before canonical role materialization.

Separately, strict bullpen membership treated any pitcher with more relief appearances than starts as a reliever. That admitted mixed rotation pitchers such as an 8-start/9-relief pitcher even without an explicit plan for the current game.

## Impact

Freshly warmed v4 artifacts expose canonical Typical Role and simulation-derived appearance percentages to the existing UI. Mixed rotation pitchers no longer enter the bullpen solely because relief appearances narrowly exceed starts. Historical swingman taxonomy remains separate from current-game membership, and explicit plans retain precedence.

This does not change game-probability authority.

## Validation

- 272 backend tests passed
- 28 frontend canonical projection tests passed
- Python compilation passed
- working-tree and staged diff checks passed
- live uncached production payload probe:
  - 68 pitcher rows materialized
  - 60 bullpen rows contained appearance probabilities
  - 0 unknown Typical Roles
  - 0 mixed rotation pitchers in bullpen rows
  - live role sources resolved 12–13 roles per team with zero feed errors
  - workspace v4 artifact key confirmed
