### PR TITLE
Populate pitcher whiff trends from canonical Statcast pitches

### DIFF
--- a/mlb_app/player_trends.py
+++ b/mlb_app/player_trends.py
@@ -44,6 +44,8 @@ METRICS: Dict[str, Dict[str, Dict[str, Any]]] = {
     "pitcher": {
         "k_pct": {"label": "Strikeout Rate", "favorable": "higher", "tolerance": .01},
         "bb_pct": {"label": "Walk Rate", "favorable": "lower", "tolerance": .01},
+        "whiff_pct": {"label": "Whiff Rate", "favorable": "higher", "tolerance": .01},
+        "contact_pct": {"label": "Contact Rate Allowed", "favorable": "lower", "tolerance": .01},
         "hard_hit_pct": {"label": "Hard-Hit Rate Allowed", "favorable": "lower", "tolerance": .01},
         "avg_velocity": {"label": "Average Pitch Velocity", "favorable": "higher", "tolerance": .3},
         "avg_spin_rate": {"label": "Average Spin Rate", "favorable": "higher", "tolerance": 25.0},
@@ -76,6 +78,8 @@ ROLLING_NUMERIC_FIELDS: Dict[str, Dict[str, str]] = {
     "pitcher": {
         "batters_faced": "Batters Faced",
         "pitch_count": "Pitch Count",
+        "swings": "Swings",
+        "whiffs": "Whiffs",
         "batted_ball_count": "Batted Balls Allowed",
         "hard_hit_count": "Hard-Hit Balls Allowed",
         "strikeouts": "Strikeouts",
@@ -396,6 +400,12 @@ def _aggregate_pitcher_period(
             ).label("batters_faced"),
             func.sum(case((StatcastEvent.events == "strikeout", 1), else_=0)).label("strikeouts"),
             func.sum(case((StatcastEvent.events == "walk", 1), else_=0)).label("walks"),
+            func.sum(
+                case((StatcastEvent.description.in_(list(SWING_DESCRIPTIONS)), 1), else_=0)
+            ).label("swings"),
+            func.sum(
+                case((StatcastEvent.description.in_(list(WHIFF_DESCRIPTIONS)), 1), else_=0)
+            ).label("whiffs"),
             func.count(StatcastEvent.launch_speed).label("batted_balls"),
             func.sum(case((StatcastEvent.launch_speed >= 95.0, 1), else_=0)).label("hard_hits"),
             func.avg(StatcastEvent.release_speed).label("avg_velocity"),
@@ -414,6 +424,8 @@ def _aggregate_pitcher_period(
         player_id = int(row.player_id)
         batters_faced = int(row.batters_faced or 0)
         batted_balls = int(row.batted_balls or 0)
+        swings = int(row.swings or 0)
+        whiffs = int(row.whiffs or 0)
         result[player_id] = {
             "sample_size": batters_faced,
             "batters_faced": batters_faced,
@@ -422,8 +434,12 @@ def _aggregate_pitcher_period(
             "hard_hit_count": int(row.hard_hits or 0),
             "strikeouts": int(row.strikeouts or 0),
             "walks": int(row.walks or 0),
+            "swings": swings,
+            "whiffs": whiffs,
             "k_pct": _ratio(int(row.strikeouts or 0), batters_faced),
             "bb_pct": _ratio(int(row.walks or 0), batters_faced),
+            "whiff_pct": _ratio(whiffs, swings),
+            "contact_pct": round(1 - (whiffs / swings), 3) if swings else None,
             "hard_hit_pct": _ratio(int(row.hard_hits or 0), batted_balls),
             "avg_velocity": float(row.avg_velocity) if row.avg_velocity is not None else None,
             "avg_spin_rate": float(row.avg_spin_rate) if row.avg_spin_rate is not None else None,

--- a/tests/test_player_trends_and_saved_report_analysis.py
+++ b/tests/test_player_trends_and_saved_report_analysis.py
@@ -37,7 +37,7 @@ def _player(player_id, player_type):
     )
 
 
-def _event(date, player_id, *, player_type, event, launch_speed=None):
+def _event(date, player_id, *, player_type, event, launch_speed=None, description=None):
     return StatcastEvent(
         game_date=date,
         game_pk=int(date.strftime("%m%d")),
@@ -46,7 +46,7 @@ def _event(date, player_id, *, player_type, event, launch_speed=None):
         pitcher_id=player_id if player_type == "pitcher" else 999,
         batter_id=player_id if player_type == "hitter" else 998,
         events=event,
-        description="hit_into_play" if launch_speed else "called_strike",
+        description=description or ("hit_into_play" if launch_speed else "called_strike"),
         launch_speed=launch_speed,
         release_speed=95.0 if player_type == "pitcher" else None,
     )
@@ -121,6 +121,47 @@ def test_pitcher_higher_strikeout_rate_is_improving(session):
     assert result["totalSize"] == 1
     assert result["records"][0]["trend_direction"] == "improving"
     assert result["records"][0]["absolute_change"] == 1.0
+
+
+def test_pitcher_whiff_rate_uses_canonical_pitch_descriptions(session):
+    session.add(_player(203, "pitcher"))
+    for day in (dt.date(2026, 7, 10), dt.date(2026, 7, 11)):
+        session.add(_event(
+            day,
+            203,
+            player_type="pitcher",
+            event="field_out",
+            description="foul",
+        ))
+    for day in (dt.date(2026, 7, 20), dt.date(2026, 7, 21)):
+        session.add(_event(
+            day,
+            203,
+            player_type="pitcher",
+            event="strikeout",
+            description="swinging_strike",
+        ))
+    session.commit()
+
+    result = query_player_trends(
+        session,
+        as_of_date=dt.date(2026, 7, 21),
+        trend_config={
+            "player_type": "pitcher",
+            "window_days": 7,
+            "comparison_baseline": "previous_n_days",
+            "minimum_sample_size": 2,
+            "trend_direction": "improving",
+            "selected_metrics": ["whiff_pct"],
+        },
+    )
+
+    row = result["records"][0]
+    assert row["window_swings"] == 2
+    assert row["window_whiffs"] == 2
+    assert row["window_whiff_pct"] == 1.0
+    assert row["baseline_whiff_pct"] == 0.0
+    assert row["trend_direction"] == "improving"
 
 
 def test_unsupported_prior_equivalent_period_is_not_advertised(session):


### PR DESCRIPTION
## What changed

- Counts pitcher swings and whiffs from the existing canonical Statcast pitch descriptions.
- Populates rolling and baseline pitcher `whiff_pct` and `contact_pct`.
- Registers both metrics as supported pitcher trend metrics with metric-aware favorable directions.
- Retains the raw swing and whiff counters in Player Trends snapshots.

## Why

Live 60- and 90-day Query Studio validation showed `window_whiff_pct` was null for every pitcher even though the underlying pitch descriptions already support deterministic swing/whiff calculation.

## Validation

- `29 passed` in:
  - `tests/test_player_trends_and_saved_report_analysis.py`
  - `tests/test_workbench_query.py`
- `git diff --check` passed.
- No league-average fallback or fabricated values are introduced.

## Separate finding

Rolling hitter runs and RBI cannot be added safely from the current `statcast_events` schema because it does not persist runner identities or score deltas. Today’s Model Projection Players object does expose projected runs and RBI.