### PR TITLE
Activate production pitcher role evidence

### DIFF
--- a/frontend/src/lib/canonicalProjectionsViewModel.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.mjs
@@ -119,6 +119,10 @@ function projectionGroupLabel(value) {
 
 function typicalBullpenRoleLabel(value) {
   const labels = {
+    starter: 'Starter',
+    opener: 'Opener',
+    bulk_follower: 'Bulk Follower',
+    swingman: 'Swingman',
     closer: 'Closer',
     setup: 'Setup',
     setup_reliever: 'Setup',

--- a/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalProjectionsViewModel.test.mjs
@@ -762,3 +762,44 @@ test('does not infer missing bullpen taxonomy', () => {
   assert.equal(row.pitcherProjectionGroup, 'bullpen')
   assert.equal(row.plannedPitcherRole, 'reliever')
 })
+
+
+test('formats the complete canonical typical-role taxonomy', () => {
+  const expected = new Map([
+    ['starter', 'Starter'],
+    ['opener', 'Opener'],
+    ['bulk_follower', 'Bulk Follower'],
+    ['swingman', 'Swingman'],
+    ['closer', 'Closer'],
+    ['setup', 'Setup'],
+    ['setup_reliever', 'Setup'],
+    ['middle_reliever', 'Middle Relief'],
+    ['long_reliever', 'Long Relief'],
+  ])
+
+  for (const [role, label] of expected) {
+    const game = payload()
+    const pitcher = game.diagnostics.canonical_shadow
+      .player_projections.players.find(
+        row => row.player_type === 'pitcher',
+      )
+
+    pitcher.typical_bullpen_role = role
+
+    const view = buildCanonicalProjectionsViewModel(
+      game,
+    )
+    const rendered = view.pitchers.find(
+      row => row.playerId === pitcher.player_id,
+    )
+
+    assert.equal(
+      rendered.typicalBullpenRole,
+      role,
+    )
+    assert.equal(
+      rendered.typicalBullpenRoleLabel,
+      label,
+    )
+  }
+})

--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -37,7 +37,7 @@ def matchups_date_key(date: str) -> str:
 
 
 MODEL_PROJECTION_WORKSPACE_VERSION = (
-    "model_projection_workspace_v4"
+    "model_projection_workspace_v5"
 )
 
 

--- a/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
+++ b/mlb_app/simulation/projections/pitcher_pool_role_reconciliation.py
@@ -24,6 +24,17 @@ STARTER_LIKE_TYPICAL_ROLES = frozenset({
     "probable_starter",
 })
 
+EXPLICIT_SPECIFIC_TYPICAL_ROLES = frozenset({
+    "opener",
+    "bulk_follower",
+    "swingman",
+    "closer",
+    "setup",
+    "setup_reliever",
+    "middle_reliever",
+    "long_reliever",
+})
+
 
 def _text(value: Any) -> str:
     if value in (None, ""):
@@ -259,6 +270,11 @@ def reconcile_canonical_pitcher_projection_pool_roles(
         if explicit_typical_role == "unknown":
             explicit_typical_role = ""
 
+        explicit_typical_role_is_specific = (
+            explicit_typical_role
+            in EXPLICIT_SPECIFIC_TYPICAL_ROLES
+        )
+
         historical_role_record = _mapping(
             role_evidence.get(pitcher_id)
         )
@@ -271,7 +287,7 @@ def reconcile_canonical_pitcher_projection_pool_roles(
         if historical_typical_role == "unknown":
             historical_typical_role = ""
 
-        if explicit_typical_role:
+        if explicit_typical_role_is_specific:
             typical_role = explicit_typical_role
             typical_role_source = (
                 _text(eligibility.get("source"))
@@ -337,7 +353,7 @@ def reconcile_canonical_pitcher_projection_pool_roles(
             )
         )
 
-        if explicit_typical_role:
+        if explicit_typical_role_is_specific:
             explicit_typical_role_count += 1
         elif historical_typical_role:
             historical_typical_role_count += 1
@@ -408,8 +424,12 @@ def reconcile_canonical_pitcher_projection_pool_roles(
         role_conflict = (
             include
             and planned_role == "reliever"
-            and typical_role
-            in STARTER_LIKE_TYPICAL_ROLES
+            and (
+                typical_role
+                in STARTER_LIKE_TYPICAL_ROLES
+                or explicit_typical_role
+                in STARTER_LIKE_TYPICAL_ROLES
+            )
         )
 
         if role_conflict:

--- a/tests/test_canonical_pitcher_role_evidence_reconciliation.py
+++ b/tests/test_canonical_pitcher_role_evidence_reconciliation.py
@@ -312,3 +312,31 @@ def test_public_projection_import_contract():
     assert callable(
         materialize_canonical_pitcher_role_evidence
     )
+
+
+def test_generic_pregame_reliever_preserves_historical_typical_role():
+    result = run(
+        discovery=bullpen_discovery(
+            explicit_role="reliever",
+        ),
+    )
+    row = rows(result)["101"]
+    reconciliation = result[
+        "pitcher_pool_role_reconciliation"
+    ]
+
+    assert row["planned_pitcher_role"] == "reliever"
+    assert row["typical_bullpen_role"] == "closer"
+    assert row["typical_role_source"] == (
+        "mlb_stats_season_pitching_usage"
+    )
+    assert row["typical_role_confidence"] == "high"
+    assert row[
+        "typical_role_inference_used"
+    ] is True
+    assert reconciliation[
+        "explicit_typical_role_count"
+    ] == 0
+    assert reconciliation[
+        "historical_typical_role_count"
+    ] == 2

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -170,16 +170,16 @@ def test_projection_workspace_version_changes_cache_namespace() -> None:
     )
 
 
-def test_model_projection_workspace_v4_invalidates_prior_role_payload_cache():
+def test_model_projection_workspace_v5_invalidates_prior_role_payload_cache():
     date = "2026-08-16"
 
     key = model_projection_date_key(date)
 
     assert MODEL_PROJECTION_WORKSPACE_VERSION == (
-        "model_projection_workspace_v4"
+        "model_projection_workspace_v5"
     )
     assert key.endswith(
-        "model_projection_workspace_v4:"
+        "model_projection_workspace_v5:"
         + date
     )
     assert (


### PR DESCRIPTION
## Summary

- preserve historical pitcher typical-role evidence when pregame membership only supplies generic `starter` or `reliever` roles
- retain explicit precedence for specific roles such as setup, closer, opener, and bulk follower
- preserve starter-like role conflict diagnostics independently from the displayed typical-role taxonomy
- render the complete canonical typical-role taxonomy in the projections UI
- advance the model projection workspace contract to v5 so stale v4 artifacts cannot hide the correction

## Root cause

Production role sourcing and reconciliation were running successfully, but generic pregame membership evidence was being treated as specific typical-role evidence. This replaced historical roles such as closer or setup with `reliever`. The UI correctly treats generic `reliever` as insufficient for the Typical Role column, so resolved backend evidence appeared as Unknown.

## Impact

Fresh v5 projection warms will retain specific historical roles, while today's planned role and active bullpen membership remain authoritative and separate. Existing conflict diagnostics and unknown-evidence safety behavior remain intact.

## Validation

- 193 focused backend regression tests passed
- 29 canonical projection frontend tests passed
- Python compilation passed
- working-tree and staged diff checks passed
- production artifact diagnosis confirmed role sources materialized successfully and reconciliation completed without unknown backend role rows
