### PR TITLE
Finalize canonical baserunning calibration from settled evidence

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -696,6 +696,12 @@ function buildProductionMonitoring(sharedSimulation) {
   const eligibility = objectValue(
     report.eligibility
   )
+  const finalization = objectValue(
+    report.calibration_finalization
+  )
+  const finalizationGate = objectValue(
+    finalization.calibration_gate
+  )
 
   return {
     available: Object.keys(report).length > 0,
@@ -778,6 +784,20 @@ function buildProductionMonitoring(sharedSimulation) {
     ),
     parameterReselectionPermitted:
       settlement.parameter_reselection_permitted === true,
+    calibrationFinalizationAvailable:
+      finalization.ready === true,
+    calibrationDecision:
+      finalization.decision || null,
+    calibrationGatePassed:
+      finalizationGate.calibration_gate_passed === true,
+    incumbentRetained:
+      finalization.incumbent_retained === true,
+    incumbentTransformDigest:
+      finalization.incumbent_transform_digest || null,
+    candidateReselected:
+      finalization.candidate_reselected === true,
+    calibrationFinalizationDigest:
+      finalization.finalization_digest || null,
   }
 }
 

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -659,6 +659,21 @@ test('exposes canonical production monitoring progress', () => {
       attempt_mae: 1.3,
       parameter_reselection_permitted: false,
     },
+    calibration_finalization: {
+      schema_version:
+        'canonical_baserunning_production_calibration_finalization_v1',
+      status: 'ready',
+      ready: true,
+      decision: 'retain_incumbent',
+      incumbent_transform_digest:
+        'a'.repeat(64),
+      incumbent_retained: true,
+      candidate_reselected: false,
+      finalization_digest: 'b'.repeat(64),
+      calibration_gate: {
+        calibration_gate_passed: true,
+      },
+    },
   }
 
   const view = (
@@ -707,6 +722,37 @@ test('exposes canonical production monitoring progress', () => {
   assert.equal(
     view.productionMonitoring.attemptMae,
     1.3,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .calibrationFinalizationAvailable,
+    true,
+  )
+  assert.equal(
+    view.productionMonitoring.calibrationDecision,
+    'retain_incumbent',
+  )
+  assert.equal(
+    view.productionMonitoring.calibrationGatePassed,
+    true,
+  )
+  assert.equal(
+    view.productionMonitoring.incumbentRetained,
+    true,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .incumbentTransformDigest,
+    'a'.repeat(64),
+  )
+  assert.equal(
+    view.productionMonitoring.candidateReselected,
+    false,
+  )
+  assert.equal(
+    view.productionMonitoring
+      .calibrationFinalizationDigest,
+    'b'.repeat(64),
   )
   assert.equal(
     view.productionMonitoring

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -1687,6 +1687,49 @@ function DiagnosticsTab({ game }) {
               }
               format="text"
             />
+            {monitoring.calibrationFinalizationAvailable ? (
+              <>
+                <StatRow
+                  k="Calibration Decision"
+                  v={
+                    monitoring.incumbentRetained
+                      ? 'Retain Incumbent'
+                      : 'Reopen Candidate Selection'
+                  }
+                  format="text"
+                />
+                <StatRow
+                  k="Production Calibration Gate"
+                  v={
+                    monitoring.calibrationGatePassed
+                      ? 'Passed'
+                      : 'Failed'
+                  }
+                  format="text"
+                />
+                <StatRow
+                  k="Incumbent Transform"
+                  v={
+                    monitoring.incumbentTransformDigest
+                      ? `${
+                          monitoring.incumbentTransformDigest
+                            .slice(0, 12)
+                        }…`
+                      : 'Unavailable'
+                  }
+                  format="text"
+                />
+                <StatRow
+                  k="Candidate Reselected"
+                  v={
+                    monitoring.candidateReselected
+                      ? 'Yes'
+                      : 'No'
+                  }
+                  format="text"
+                />
+              </>
+            ) : null}
           </GenericPanel>
         </div>
       ) : null}

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -68,6 +68,7 @@ from mlb_app.simulation.shadow import (
     discover_canonical_shadow_probability_provider,
     discover_confirmed_catcher_assignments,
     execute_live_baserunning_shadow_pair,
+    finalize_canonical_baserunning_production_settlements,
     load_baserunning_production_prior,
     load_canonical_baserunning_production_settlements,
     run_canonical_production_shadow,
@@ -92,12 +93,18 @@ def _load_production_settlement_diagnostics(
                 rows
             )
         )
+        finalization = (
+            finalize_canonical_baserunning_production_settlements(
+                rows
+            ).to_diagnostics()
+        )
         summary.update(
             {
                 "status": "ready",
                 "storage_available": True,
                 "error_type": None,
                 "error_message": None,
+                "_calibration_finalization": finalization,
             }
         )
         return summary
@@ -107,12 +114,18 @@ def _load_production_settlement_diagnostics(
                 ()
             )
         )
+        finalization = (
+            finalize_canonical_baserunning_production_settlements(
+                ()
+            ).to_diagnostics()
+        )
         summary.update(
             {
                 "status": "unavailable",
                 "storage_available": False,
                 "error_type": exc.__class__.__name__,
                 "error_message": str(exc),
+                "_calibration_finalization": finalization,
             }
         )
         return summary
@@ -2447,9 +2460,17 @@ def build_model_projection_payload(
                     session
                 )
             )
+            calibration_finalization = (
+                settlement_summary.pop(
+                    "_calibration_finalization"
+                )
+            )
             production_monitoring[
                 "settlement"
             ] = settlement_summary
+            production_monitoring[
+                "calibration_finalization"
+            ] = calibration_finalization
             workspace[
                 "canonicalBaserunningProductionMonitoring"
             ] = production_monitoring

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -701,3 +701,12 @@ from .production_monitoring_settlement import (
     store_canonical_baserunning_production_settlement,
     summarize_canonical_baserunning_production_settlements,
 )
+
+from .production_calibration_finalization import (
+    CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION,
+    CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_POLICY_VERSION,
+    CanonicalBaserunningProductionCalibrationFinalization,
+    build_canonical_baserunning_production_calibration_policy,
+    finalize_canonical_baserunning_production_calibration,
+    finalize_canonical_baserunning_production_settlements,
+)

--- a/mlb_app/simulation/shadow/production_calibration_finalization.py
+++ b/mlb_app/simulation/shadow/production_calibration_finalization.py
@@ -1,0 +1,393 @@
+"""Finalize canonical baserunning calibration from settled evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from typing import Any, Dict, Mapping
+
+from .baserunning_calibration_comparison import (
+    CanonicalBaserunningCalibrationComparison,
+)
+from .baserunning_calibration_gate import (
+    CanonicalBaserunningCalibrationGate,
+    CanonicalBaserunningCalibrationPolicy,
+    evaluate_baserunning_calibration_gate,
+)
+from .historical_baserunning_holdout_validation import (
+    CanonicalHistoricalBaserunningHoldoutPlan,
+    build_historical_baserunning_holdout_plan,
+)
+from .production_monitoring_ledger import (
+    CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET,
+)
+from .production_monitoring_settlement import (
+    summarize_canonical_baserunning_production_settlements,
+)
+
+
+CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION = (
+    "canonical_baserunning_production_calibration_finalization_v1"
+)
+CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_POLICY_VERSION = (
+    "canonical_baserunning_production_calibration_policy_v1"
+)
+
+
+def build_canonical_baserunning_production_calibration_policy(
+) -> CanonicalBaserunningCalibrationPolicy:
+    return CanonicalBaserunningCalibrationPolicy(
+        minimum_game_count=(
+            CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+        ),
+        maximum_stolen_base_error_per_game=0.25,
+        maximum_caught_stealing_error_per_game=0.10,
+        maximum_attempt_error_per_game=0.30,
+        maximum_success_rate_absolute_error=0.10,
+        policy_version=(
+            CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_POLICY_VERSION
+        ),
+    )
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _number(
+    source: Mapping[str, Any],
+    field_name: str,
+) -> float:
+    value = source.get(field_name)
+
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < 0.0
+    ):
+        raise ValueError(
+            f"{field_name} must be nonnegative and finite"
+        )
+
+    return float(value)
+
+
+@dataclass(frozen=True)
+class CanonicalBaserunningProductionCalibrationFinalization:
+    status: str
+    decision: str
+    settlement_complete: bool
+    settled_game_count: int
+    incumbent_transform_digest: str
+    comparison: CanonicalBaserunningCalibrationComparison
+    calibration_gate: CanonicalBaserunningCalibrationGate
+    finalization_digest: str
+    schema_version: str = (
+        CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in {"ready", "unavailable"}:
+            raise ValueError("unsupported finalization status")
+
+        if self.decision not in {
+            "retain_incumbent",
+            "reopen_candidate_selection",
+            "pending_settlement",
+        }:
+            raise ValueError("unsupported finalization decision")
+
+        if self.settled_game_count < 0:
+            raise ValueError(
+                "settled_game_count must be nonnegative"
+            )
+
+        for field_name in (
+            "incumbent_transform_digest",
+            "finalization_digest",
+        ):
+            value = getattr(self, field_name)
+            if (
+                not isinstance(value, str)
+                or len(value) != 64
+                or any(
+                    character not in "0123456789abcdef"
+                    for character in value
+                )
+            ):
+                raise ValueError(
+                    f"{field_name} must be a SHA256 digest"
+                )
+
+        if not isinstance(
+            self.comparison,
+            CanonicalBaserunningCalibrationComparison,
+        ):
+            raise TypeError("comparison must be canonical")
+
+        if not isinstance(
+            self.calibration_gate,
+            CanonicalBaserunningCalibrationGate,
+        ):
+            raise TypeError("calibration_gate must be canonical")
+
+        if (
+            self.decision == "retain_incumbent"
+            and not self.calibration_gate.calibration_gate_passed
+        ):
+            raise ValueError(
+                "retained incumbent must pass calibration gate"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return self.status == "ready"
+
+    def to_diagnostics(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "ready": self.ready,
+            "decision": self.decision,
+            "settlement_complete": self.settlement_complete,
+            "settled_game_count": self.settled_game_count,
+            "incumbent_transform_digest": (
+                self.incumbent_transform_digest
+            ),
+            "comparison": self.comparison.to_diagnostics(),
+            "calibration_gate": (
+                self.calibration_gate.to_diagnostics()
+            ),
+            "finalization_digest": self.finalization_digest,
+            "incumbent_retained": (
+                self.decision == "retain_incumbent"
+            ),
+            "candidate_reselected": False,
+            "production_activation": True,
+            "production_authority_changed": False,
+        }
+
+
+def finalize_canonical_baserunning_production_calibration(
+    settlement: Mapping[str, Any],
+    *,
+    holdout_plan: (
+        CanonicalHistoricalBaserunningHoldoutPlan | None
+    ) = None,
+) -> CanonicalBaserunningProductionCalibrationFinalization:
+    if not isinstance(settlement, Mapping):
+        raise TypeError("settlement must be a mapping")
+
+    plan = (
+        holdout_plan
+        if holdout_plan is not None
+        else build_historical_baserunning_holdout_plan()
+    )
+    if not isinstance(
+        plan,
+        CanonicalHistoricalBaserunningHoldoutPlan,
+    ):
+        raise TypeError("holdout_plan must be canonical")
+
+    settled_game_count = int(
+        _number(settlement, "settled_game_count")
+    )
+    settlement_complete = (
+        settlement.get("settlement_complete") is True
+        and settlement.get(
+            "parameter_reselection_permitted"
+        ) is True
+    )
+
+    if not settlement_complete:
+        comparison = CanonicalBaserunningCalibrationComparison(
+            status="unavailable",
+        )
+        gate = CanonicalBaserunningCalibrationGate(
+            status="unavailable",
+        )
+        digest_payload = {
+            "schema_version": (
+                CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION
+            ),
+            "decision": "pending_settlement",
+            "settlement_complete": False,
+            "settled_game_count": settled_game_count,
+            "incumbent_transform_digest": (
+                plan.probability_transform.digest
+            ),
+            "comparison": comparison.to_diagnostics(),
+            "calibration_gate": gate.to_diagnostics(),
+        }
+
+        return CanonicalBaserunningProductionCalibrationFinalization(
+            status="unavailable",
+            decision="pending_settlement",
+            settlement_complete=False,
+            settled_game_count=settled_game_count,
+            incumbent_transform_digest=(
+                plan.probability_transform.digest
+            ),
+            comparison=comparison,
+            calibration_gate=gate,
+            finalization_digest=_digest(digest_payload),
+        )
+
+    projected_sb = _number(
+        settlement,
+        "projected_stolen_bases",
+    )
+    observed_sb = int(
+        _number(settlement, "observed_stolen_bases")
+    )
+    projected_cs = _number(
+        settlement,
+        "projected_caught_stealing",
+    )
+    observed_cs = int(
+        _number(settlement, "observed_caught_stealing")
+    )
+
+    projected_attempts = round(
+        projected_sb + projected_cs,
+        6,
+    )
+    observed_attempts = observed_sb + observed_cs
+    projected_success_rate = (
+        round(projected_sb / projected_attempts, 6)
+        if projected_attempts > 0.0
+        else None
+    )
+    observed_success_rate = (
+        round(observed_sb / observed_attempts, 6)
+        if observed_attempts > 0
+        else None
+    )
+    success_rate_error = (
+        round(
+            abs(
+                projected_success_rate
+                - observed_success_rate
+            ),
+            6,
+        )
+        if (
+            projected_success_rate is not None
+            and observed_success_rate is not None
+        )
+        else None
+    )
+
+    comparison = CanonicalBaserunningCalibrationComparison(
+        status="ready",
+        game_count=settled_game_count,
+        projected_stolen_bases=projected_sb,
+        observed_stolen_bases=observed_sb,
+        stolen_base_absolute_error=round(
+            abs(projected_sb - observed_sb),
+            6,
+        ),
+        projected_caught_stealing=projected_cs,
+        observed_caught_stealing=observed_cs,
+        caught_stealing_absolute_error=round(
+            abs(projected_cs - observed_cs),
+            6,
+        ),
+        projected_attempts=projected_attempts,
+        observed_attempts=observed_attempts,
+        attempt_absolute_error=round(
+            abs(projected_attempts - observed_attempts),
+            6,
+        ),
+        projected_success_rate=projected_success_rate,
+        observed_success_rate=observed_success_rate,
+        success_rate_absolute_error=success_rate_error,
+        observed_source_version=(
+            "canonical_baserunning_production_settlement_v1"
+        ),
+    )
+
+    gate = evaluate_baserunning_calibration_gate(
+        comparison,
+        build_canonical_baserunning_production_calibration_policy(),
+    )
+
+    status = "ready"
+    decision = (
+        "retain_incumbent"
+        if gate.calibration_gate_passed
+        else "reopen_candidate_selection"
+    )
+
+    digest_payload = {
+        "schema_version": (
+            CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION
+        ),
+        "decision": decision,
+        "settlement_complete": settlement_complete,
+        "settled_game_count": settled_game_count,
+        "incumbent_transform_digest": (
+            plan.probability_transform.digest
+        ),
+        "comparison": comparison.to_diagnostics(),
+        "calibration_gate": gate.to_diagnostics(),
+    }
+
+    return CanonicalBaserunningProductionCalibrationFinalization(
+        status=status,
+        decision=decision,
+        settlement_complete=settlement_complete,
+        settled_game_count=settled_game_count,
+        incumbent_transform_digest=(
+            plan.probability_transform.digest
+        ),
+        comparison=comparison,
+        calibration_gate=gate,
+        finalization_digest=_digest(digest_payload),
+    )
+
+def finalize_canonical_baserunning_production_settlements(
+    rows: tuple[Any, ...],
+) -> CanonicalBaserunningProductionCalibrationFinalization:
+    """
+    Finalize the earliest fixed production settlement window.
+
+    Ongoing monitoring may contain more than the target number of games.
+    Games after the deterministic first target-sized window cannot alter
+    the calibration decision or finalization digest.
+    """
+
+    if not isinstance(rows, tuple):
+        raise TypeError("settlement rows must be a tuple")
+
+    ordered_rows = tuple(
+        sorted(
+            rows,
+            key=lambda row: (
+                str(row.game_date),
+                int(row.game_pk),
+            ),
+        )
+    )
+    frozen_rows = ordered_rows[
+        :CANONICAL_BASERUNNING_PRODUCTION_MONITORING_TARGET
+    ]
+    frozen_summary = (
+        summarize_canonical_baserunning_production_settlements(
+            frozen_rows
+        )
+    )
+
+    return finalize_canonical_baserunning_production_calibration(
+        frozen_summary
+    )

--- a/tests/test_canonical_baserunning_production_calibration_finalization.py
+++ b/tests/test_canonical_baserunning_production_calibration_finalization.py
@@ -1,0 +1,229 @@
+from datetime import date
+from types import SimpleNamespace
+
+from mlb_app.simulation.shadow.production_calibration_finalization import (
+    CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION,
+    CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_POLICY_VERSION,
+    build_canonical_baserunning_production_calibration_policy,
+    finalize_canonical_baserunning_production_calibration,
+    finalize_canonical_baserunning_production_settlements,
+)
+
+
+def settlement(**overrides):
+    value = {
+        "settled_game_count": 331,
+        "settlement_complete": True,
+        "parameter_reselection_permitted": True,
+        "projected_stolen_bases": 389.6,
+        "observed_stolen_bases": 439,
+        "projected_caught_stealing": 159.6,
+        "observed_caught_stealing": 143,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_settled_production_evidence_retains_incumbent():
+    result = (
+        finalize_canonical_baserunning_production_calibration(
+            settlement()
+        )
+    )
+    diagnostics = result.to_diagnostics()
+
+    assert result.ready is True
+    assert result.decision == "retain_incumbent"
+    assert result.calibration_gate.calibration_gate_passed is True
+    assert result.comparison.game_count == 331
+    assert (
+        result.comparison.stolen_base_absolute_error
+        == 49.4
+    )
+    assert (
+        result.comparison.caught_stealing_absolute_error
+        == 16.6
+    )
+    assert (
+        result.comparison.attempt_absolute_error
+        == 32.8
+    )
+    assert diagnostics["incumbent_retained"] is True
+    assert diagnostics["candidate_reselected"] is False
+    assert diagnostics["production_authority_changed"] is False
+
+
+def test_incomplete_settlement_remains_pending():
+    result = (
+        finalize_canonical_baserunning_production_calibration(
+            settlement(
+                settled_game_count=99,
+                settlement_complete=False,
+                parameter_reselection_permitted=False,
+            )
+        )
+    )
+
+    assert result.ready is False
+    assert result.decision == "pending_settlement"
+    assert result.settlement_complete is False
+
+
+def test_failed_production_gate_reopens_candidate_selection():
+    result = (
+        finalize_canonical_baserunning_production_calibration(
+            settlement(
+                projected_stolen_bases=200.0,
+                projected_caught_stealing=250.0,
+            )
+        )
+    )
+
+    assert result.ready is True
+    assert result.decision == "reopen_candidate_selection"
+    assert result.calibration_gate.calibration_gate_passed is False
+    assert result.to_diagnostics()[
+        "candidate_reselected"
+    ] is False
+
+
+def test_finalization_is_deterministic():
+    first = (
+        finalize_canonical_baserunning_production_calibration(
+            settlement()
+        )
+    )
+    second = (
+        finalize_canonical_baserunning_production_calibration(
+            settlement()
+        )
+    )
+
+    assert first == second
+    assert first.finalization_digest == (
+        second.finalization_digest
+    )
+    assert len(first.finalization_digest) == 64
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_FINALIZATION_VERSION
+        == (
+            "canonical_baserunning_production_"
+            "calibration_finalization_v1"
+        )
+    )
+
+def test_empty_summary_fails_safe_as_pending():
+    result = (
+        finalize_canonical_baserunning_production_calibration(
+            {
+                "settled_game_count": 0,
+                "settlement_complete": False,
+                "parameter_reselection_permitted": False,
+            }
+        )
+    )
+
+    assert result.ready is False
+    assert result.decision == "pending_settlement"
+    assert result.comparison.ready is False
+    assert result.calibration_gate.ready is False
+
+def settlement_row(
+    game_pk,
+    *,
+    projected_stolen_bases=1.0,
+    projected_caught_stealing=0.5,
+    observed_stolen_bases=1,
+    observed_caught_stealing=1,
+):
+    return SimpleNamespace(
+        game_pk=game_pk,
+        game_date=date(
+            2026,
+            7,
+            1 + ((game_pk - 1) // 15),
+        ),
+        comparison_json={
+            "projected_stolen_bases":
+                projected_stolen_bases,
+            "projected_caught_stealing":
+                projected_caught_stealing,
+            "stolen_base_absolute_error": abs(
+                projected_stolen_bases
+                - observed_stolen_bases
+            ),
+            "caught_stealing_absolute_error": abs(
+                projected_caught_stealing
+                - observed_caught_stealing
+            ),
+            "attempt_absolute_error": abs(
+                projected_stolen_bases
+                + projected_caught_stealing
+                - observed_stolen_bases
+                - observed_caught_stealing
+            ),
+        },
+        observed_stolen_bases=observed_stolen_bases,
+        observed_caught_stealing=observed_caught_stealing,
+    )
+
+
+def test_production_policy_uses_frozen_window_target():
+    policy = (
+        build_canonical_baserunning_production_calibration_policy()
+    )
+
+    assert policy.minimum_game_count == 100
+    assert policy.policy_version == (
+        CANONICAL_BASERUNNING_PRODUCTION_CALIBRATION_POLICY_VERSION
+    )
+
+
+def test_games_after_frozen_window_do_not_change_decision():
+    first_hundred = tuple(
+        settlement_row(game_pk)
+        for game_pk in range(1, 101)
+    )
+    later_games = tuple(
+        settlement_row(
+            game_pk,
+            projected_stolen_bases=20.0,
+            projected_caught_stealing=20.0,
+        )
+        for game_pk in range(101, 111)
+    )
+
+    frozen = (
+        finalize_canonical_baserunning_production_settlements(
+            first_hundred
+        )
+    )
+    extended = (
+        finalize_canonical_baserunning_production_settlements(
+            later_games + first_hundred
+        )
+    )
+
+    assert frozen.settled_game_count == 100
+    assert extended.settled_game_count == 100
+    assert frozen.decision == extended.decision
+    assert frozen.finalization_digest == (
+        extended.finalization_digest
+    )
+
+
+def test_under_target_window_remains_pending():
+    result = (
+        finalize_canonical_baserunning_production_settlements(
+            tuple(
+                settlement_row(game_pk)
+                for game_pk in range(1, 100)
+            )
+        )
+    )
+
+    assert result.ready is False
+    assert result.decision == "pending_settlement"


### PR DESCRIPTION
## Summary

- freeze the first 100 production baserunning settlements deterministically by game date and game ID
- evaluate the active 0.52 / +0.09 transform against an explicit production calibration policy
- produce retain-incumbent, reopen-candidate-selection, or pending-settlement decisions without changing production authority
- attach calibration finalization diagnostics to the projection workspace and surface the decision, gate, transform digest, and reselection status in the UI
- keep post-window games available for ongoing monitoring without allowing them to mutate the frozen decision or digest

The settled evidence passes the production thresholds, so this slice retains the incumbent transform. Candidate reselection remains false and production authority is unchanged.

## Validation

- 154 backend tests passed
- 24 focused frontend tests passed
- Python compilation passed
- working-tree and new-file whitespace checks passed
- intended-path isolation and staged-file checks passed

The broader frontend baseline still has six failures in unchanged dashboard workspace/model-tracker paths; the changed frontend tests pass and those failing paths are not part of this diff.

## Scope notes

A selected-payload canonical shadow may still be blocked when confirmed lineups or the exact probability artifact are absent. That readiness work is separate from this baserunning calibration finalization.