### PR TITLE
Activate canonical extra-innings and walk-off realism

### DIFF
--- a/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.mjs
@@ -44,6 +44,7 @@ const REALISM_FEATURES = [
     aliases: [
       'extra_innings',
       'extra_innings_enabled',
+      'extras_enabled',
     ],
   },
   {
@@ -63,6 +64,7 @@ const REALISM_FEATURES = [
       'walk_offs',
       'walk_off_enabled',
       'walk_off_shortening',
+      'walkoff_shortening_enabled',
     ],
   },
   {

--- a/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
+++ b/frontend/src/lib/canonicalDiagnosticsViewModel.test.mjs
@@ -14,9 +14,9 @@ function sharedSimulation() {
     game_state_realism_diagnostics: {
       base_out_state: true,
       runner_advancement_enabled: true,
-      extra_innings: 'enabled',
+      extras_enabled: true,
       ghost_runner_enabled: true,
-      walk_off_shortening: true,
+      walkoff_shortening_enabled: true,
       double_play_scoring: true,
       sacrifice_fly_scoring_enabled: true,
       steals_model: 'deferred_not_active',
@@ -408,7 +408,15 @@ test('normalizes realism feature aliases and states', () => {
     'enabled',
   )
   assert.equal(
+    features.extra_innings,
+    'enabled',
+  )
+  assert.equal(
     features.automatic_runner,
+    'enabled',
+  )
+  assert.equal(
+    features.walk_offs,
     'enabled',
   )
   assert.equal(
@@ -418,6 +426,43 @@ test('normalizes realism feature aliases and states', () => {
   assert.equal(
     features.stolen_bases,
     'deferred',
+  )
+})
+
+test('explicit unavailable runtime realism does not fall through to implementation flags', () => {
+  const payload = sharedSimulation()
+
+  payload.game_state_realism_diagnostics = {
+    extra_innings_enabled: null,
+    extras_enabled: true,
+    automatic_runner_enabled: null,
+    ghost_runner_enabled: true,
+    walk_off_enabled: null,
+    walkoff_shortening_enabled: true,
+  }
+
+  const view = buildCanonicalDiagnosticsViewModel(
+    payload,
+  )
+
+  const features = Object.fromEntries(
+    view.realism.features.map(feature => [
+      feature.key,
+      feature.status,
+    ]),
+  )
+
+  assert.equal(
+    features.extra_innings,
+    'unknown',
+  )
+  assert.equal(
+    features.automatic_runner,
+    'unknown',
+  )
+  assert.equal(
+    features.walk_offs,
+    'unknown',
   )
 })
 

--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -68,6 +68,7 @@ from mlb_app.simulation.shadow import (
     discover_canonical_shadow_probability_provider,
     discover_confirmed_catcher_assignments,
     execute_live_baserunning_shadow_pair,
+    evaluate_canonical_extras_walkoff_activation,
     finalize_canonical_baserunning_production_settlements,
     load_baserunning_production_prior,
     load_canonical_baserunning_production_settlements,
@@ -131,7 +132,9 @@ def _load_production_settlement_diagnostics(
         return summary
 
 
-def _build_game_state_realism_diagnostics() -> dict:
+def _build_game_state_realism_diagnostics(
+    shared_simulation: Any = None,
+) -> dict:
     """Layer 6OF guarded diagnostic payload.
 
     Diagnostic-only wiring for game-state realism features.
@@ -140,6 +143,45 @@ def _build_game_state_realism_diagnostics() -> dict:
     probabilities. It exposes whether key Layer 6 game-state realism concepts
     are intended to be represented in the Model Projections payload.
     """
+    activation = {}
+
+    if isinstance(shared_simulation, dict):
+        shared_diagnostics = (
+            shared_simulation.get(
+                "diagnostics",
+                {},
+            )
+        )
+        canonical_shadow = (
+            shared_diagnostics.get(
+                "canonical_shadow",
+                {},
+            )
+            if isinstance(
+                shared_diagnostics,
+                dict,
+            )
+            else {}
+        )
+        activation = (
+            canonical_shadow.get(
+                "canonical_extras_walkoff_activation",
+                {},
+            )
+            if isinstance(
+                canonical_shadow,
+                dict,
+            )
+            else {}
+        )
+
+    activation = (
+        activation
+        if isinstance(activation, dict)
+        else {}
+    )
+    active = activation.get("active") is True
+
     return {
         "base_out_state_enabled": True,
         "base_out_transition_model_status": "diagnostic_wired",
@@ -154,10 +196,27 @@ def _build_game_state_realism_diagnostics() -> dict:
             "events": ["single", "double", "ground_ball", "fly_ball"],
             "final_probability_replacement": False,
         },
+        "extra_innings_enabled": (
+            True if active else None
+        ),
+        "automatic_runner_enabled": (
+            True if active else None
+        ),
+        "walk_off_enabled": (
+            True if active else None
+        ),
         "extras_enabled": True,
         "ghost_runner_enabled": True,
         "walkoff_shortening_enabled": True,
-        "extras_walkoff_model_status": "diagnostic_wired",
+        "extras_walkoff_model_status": (
+            activation.get(
+                "status",
+                "canonical_execution_not_available",
+            )
+        ),
+        "extras_walkoff_activation": deepcopy(
+            activation
+        ),
         "double_play_enabled": True,
         "multi_out_scoring": True,
         "double_play_rate_source": "existing_simulation_transition_logic",
@@ -1221,6 +1280,23 @@ def _attach_production_shadow_comparison(
         result
         .get("diagnostics", {})
         .get("canonical_shadow", {})
+    )
+
+    extras_walkoff_activation = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=(
+                material.canonical_payload
+            ),
+            execution_inputs=(
+                material
+                .canonical_shadow_execution_inputs
+            ),
+        )
+    )
+    shadow[
+        "canonical_extras_walkoff_activation"
+    ] = (
+        extras_walkoff_activation.to_diagnostics()
     )
 
     if isinstance(
@@ -2576,7 +2652,11 @@ def build_model_projection_payload(
 
             games.append({
                 "game_pk": matchup.get("game_pk"),
-                "game_state_realism": _build_game_state_realism_diagnostics(),
+                "game_state_realism": (
+                    _build_game_state_realism_diagnostics(
+                        shared_simulation
+                    )
+                ),
                 "canonical_shadow_lineup_discovery": (
                     canonical_shadow_lineup_discovery
                     .to_diagnostics()

--- a/mlb_app/simulation/shadow/__init__.py
+++ b/mlb_app/simulation/shadow/__init__.py
@@ -710,3 +710,10 @@ from .production_calibration_finalization import (
     finalize_canonical_baserunning_production_calibration,
     finalize_canonical_baserunning_production_settlements,
 )
+
+
+from .extras_walkoff_activation import (
+    CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION,
+    CanonicalExtrasWalkoffActivation,
+    evaluate_canonical_extras_walkoff_activation,
+)

--- a/mlb_app/simulation/shadow/extras_walkoff_activation.py
+++ b/mlb_app/simulation/shadow/extras_walkoff_activation.py
@@ -1,0 +1,312 @@
+"""Validate canonical extra-innings and walk-off activation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any, Mapping, Tuple
+
+
+CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION = (
+    "canonical_extras_walkoff_activation_v1"
+)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return (
+        value
+        if isinstance(value, Mapping)
+        else {}
+    )
+
+
+def _probability(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(result)
+        or not 0.0 <= result <= 1.0
+    ):
+        return None
+
+    return result
+
+
+def _positive_integer(value: Any) -> int | None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+    ):
+        return None
+
+    return value
+
+
+@dataclass(frozen=True)
+class CanonicalExtrasWalkoffActivation:
+    """Runtime-derived activation state for canonical game endings."""
+
+    status: str
+    blockers: Tuple[str, ...]
+    simulation_count: int | None
+    extra_innings_probability: float | None
+    walk_off_probability: float | None
+    game_validation_pass_rate: float | None
+    box_score_reconciliation_pass_rate: float | None
+    maximum_extra_innings: int | None
+    automatic_runner_configured: bool
+    trial_warnings: Tuple[str, ...] = ()
+    schema_version: str = (
+        CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        if self.status not in {
+            "active",
+            "blocked",
+            "unavailable",
+        }:
+            raise ValueError(
+                "unsupported extras/walk-off activation status"
+            )
+
+        if self.schema_version != (
+            CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION
+        ):
+            raise ValueError(
+                "unsupported extras/walk-off activation schema"
+            )
+
+    @property
+    def active(self) -> bool:
+        return (
+            self.status == "active"
+            and not self.blockers
+        )
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "active": self.active,
+            "blockers": list(self.blockers),
+            "simulation_count": self.simulation_count,
+            "extra_innings_probability": (
+                self.extra_innings_probability
+            ),
+            "walk_off_probability": (
+                self.walk_off_probability
+            ),
+            "game_validation_pass_rate": (
+                self.game_validation_pass_rate
+            ),
+            "box_score_reconciliation_pass_rate": (
+                self.box_score_reconciliation_pass_rate
+            ),
+            "maximum_extra_innings": (
+                self.maximum_extra_innings
+            ),
+            "extra_innings_active": self.active,
+            "automatic_runner_active": (
+                self.active
+                and self.automatic_runner_configured
+            ),
+            "walk_off_shortening_active": self.active,
+            "automatic_runner_configured": (
+                self.automatic_runner_configured
+            ),
+            "trial_warnings": list(
+                self.trial_warnings
+            ),
+            "behavioral_validation": (
+                "passed"
+                if self.active
+                else "not_passed"
+            ),
+            "empirical_calibration_status": (
+                "canonical_historical_validation_"
+                "not_claimed"
+            ),
+            "legacy_evidence_status": (
+                "reference_only_inconclusive"
+            ),
+            "legacy_candidate_promoted": False,
+            "parameter_reselection_performed": False,
+            "database_writes_performed": False,
+            "production_authority_changed": False,
+        }
+
+
+def evaluate_canonical_extras_walkoff_activation(
+    *,
+    canonical_payload: Any,
+    execution_inputs: Any,
+) -> CanonicalExtrasWalkoffActivation:
+    """
+    Evaluate already-executed canonical material.
+
+    This function does not run simulations, tune parameters, promote a
+    historical prototype, write storage, or change production authority.
+    """
+
+    payload = _mapping(canonical_payload)
+    outcomes = _mapping(payload.get("outcomes"))
+    diagnostics = _mapping(
+        payload.get("trial_diagnostics")
+    )
+
+    game_config = getattr(
+        execution_inputs,
+        "game_config",
+        None,
+    )
+
+    simulation_count = _positive_integer(
+        outcomes.get("simulation_count")
+    )
+    extra_probability = _probability(
+        outcomes.get("extra_innings_probability")
+    )
+    walk_off_probability = _probability(
+        outcomes.get("walk_off_probability")
+    )
+    game_validation_rate = _probability(
+        diagnostics.get(
+            "game_validation_pass_rate"
+        )
+    )
+    reconciliation_rate = _probability(
+        diagnostics.get(
+            "box_score_reconciliation_pass_rate"
+        )
+    )
+
+    maximum_extra_innings = getattr(
+        game_config,
+        "max_extra_innings",
+        None,
+    )
+    if (
+        isinstance(maximum_extra_innings, bool)
+        or not isinstance(
+            maximum_extra_innings,
+            int,
+        )
+        or maximum_extra_innings < 0
+    ):
+        maximum_extra_innings = None
+
+    automatic_runner_configured = (
+        getattr(
+            game_config,
+            "automatic_runner_enabled",
+            False,
+        )
+        is True
+    )
+
+    raw_warnings = diagnostics.get(
+        "warnings",
+        (),
+    )
+    trial_warnings = tuple(
+        str(value)
+        for value in (
+            raw_warnings
+            if isinstance(
+                raw_warnings,
+                (list, tuple),
+            )
+            else ()
+        )
+    )
+
+    blockers = []
+
+    if not payload:
+        blockers.append(
+            "canonical_payload_unavailable"
+        )
+
+    if not outcomes:
+        blockers.append(
+            "canonical_outcomes_unavailable"
+        )
+
+    if simulation_count is None:
+        blockers.append(
+            "canonical_simulation_count_unavailable"
+        )
+
+    if extra_probability is None:
+        blockers.append(
+            "extra_innings_probability_unavailable"
+        )
+
+    if walk_off_probability is None:
+        blockers.append(
+            "walk_off_probability_unavailable"
+        )
+
+    if game_validation_rate != 1.0:
+        blockers.append(
+            "game_validation_incomplete"
+        )
+
+    if reconciliation_rate != 1.0:
+        blockers.append(
+            "box_score_reconciliation_incomplete"
+        )
+
+    if maximum_extra_innings is None:
+        blockers.append(
+            "game_config_unavailable"
+        )
+    elif maximum_extra_innings <= 0:
+        blockers.append(
+            "extra_innings_disabled"
+        )
+
+    if not automatic_runner_configured:
+        blockers.append(
+            "automatic_runner_disabled"
+        )
+
+    if not payload or not outcomes:
+        status = "unavailable"
+    elif blockers:
+        status = "blocked"
+    else:
+        status = "active"
+
+    return CanonicalExtrasWalkoffActivation(
+        status=status,
+        blockers=tuple(blockers),
+        simulation_count=simulation_count,
+        extra_innings_probability=(
+            extra_probability
+        ),
+        walk_off_probability=(
+            walk_off_probability
+        ),
+        game_validation_pass_rate=(
+            game_validation_rate
+        ),
+        box_score_reconciliation_pass_rate=(
+            reconciliation_rate
+        ),
+        maximum_extra_innings=(
+            maximum_extra_innings
+        ),
+        automatic_runner_configured=(
+            automatic_runner_configured
+        ),
+        trial_warnings=trial_warnings,
+    )

--- a/tests/test_canonical_extras_walkoff_activation.py
+++ b/tests/test_canonical_extras_walkoff_activation.py
@@ -1,0 +1,236 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.simulation.shadow.extras_walkoff_activation import (
+    CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION,
+    evaluate_canonical_extras_walkoff_activation,
+)
+
+
+def payload(**outcome_overrides):
+    outcomes = {
+        "simulation_count": 1000,
+        "extra_innings_probability": 0.09,
+        "walk_off_probability": 0.08,
+    }
+    outcomes.update(outcome_overrides)
+
+    return {
+        "outcomes": outcomes,
+        "trial_diagnostics": {
+            "game_validation_pass_rate": 1.0,
+            "box_score_reconciliation_pass_rate": 1.0,
+            "warnings": [],
+        },
+    }
+
+
+def inputs(
+    *,
+    max_extra_innings=6,
+    automatic_runner_enabled=True,
+):
+    return SimpleNamespace(
+        game_config=SimpleNamespace(
+            max_extra_innings=max_extra_innings,
+            automatic_runner_enabled=(
+                automatic_runner_enabled
+            ),
+        )
+    )
+
+
+def test_valid_canonical_execution_activates_mechanics():
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=payload(),
+            execution_inputs=inputs(),
+        )
+    )
+    diagnostics = result.to_diagnostics()
+
+    assert result.active is True
+    assert result.status == "active"
+    assert result.blockers == ()
+    assert diagnostics[
+        "schema_version"
+    ] == (
+        CANONICAL_EXTRAS_WALKOFF_ACTIVATION_VERSION
+    )
+    assert diagnostics[
+        "extra_innings_active"
+    ] is True
+    assert diagnostics[
+        "automatic_runner_active"
+    ] is True
+    assert diagnostics[
+        "walk_off_shortening_active"
+    ] is True
+    assert diagnostics[
+        "behavioral_validation"
+    ] == "passed"
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_missing_payload_fails_safe_as_unavailable():
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=None,
+            execution_inputs=None,
+        )
+    )
+
+    assert result.active is False
+    assert result.status == "unavailable"
+    assert (
+        "canonical_payload_unavailable"
+        in result.blockers
+    )
+    assert (
+        "canonical_outcomes_unavailable"
+        in result.blockers
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "blocker"),
+    (
+        (
+            "simulation_count",
+            0,
+            "canonical_simulation_count_unavailable",
+        ),
+        (
+            "extra_innings_probability",
+            float("nan"),
+            "extra_innings_probability_unavailable",
+        ),
+        (
+            "walk_off_probability",
+            1.1,
+            "walk_off_probability_unavailable",
+        ),
+    ),
+)
+def test_invalid_outcomes_block_activation(
+    field,
+    value,
+    blocker,
+):
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=payload(
+                **{field: value}
+            ),
+            execution_inputs=inputs(),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert blocker in result.blockers
+
+
+def test_incomplete_validation_blocks_activation():
+    value = payload()
+    value["trial_diagnostics"][
+        "game_validation_pass_rate"
+    ] = 0.999
+
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=value,
+            execution_inputs=inputs(),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert (
+        "game_validation_incomplete"
+        in result.blockers
+    )
+
+
+def test_incomplete_reconciliation_blocks_activation():
+    value = payload()
+    value["trial_diagnostics"][
+        "box_score_reconciliation_pass_rate"
+    ] = 0.99
+
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=value,
+            execution_inputs=inputs(),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert (
+        "box_score_reconciliation_incomplete"
+        in result.blockers
+    )
+
+
+def test_disabled_extra_innings_blocks_activation():
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=payload(),
+            execution_inputs=inputs(
+                max_extra_innings=0,
+            ),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert (
+        "extra_innings_disabled"
+        in result.blockers
+    )
+
+
+def test_disabled_automatic_runner_blocks_activation():
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=payload(),
+            execution_inputs=inputs(
+                automatic_runner_enabled=False,
+            ),
+        )
+    )
+
+    assert result.status == "blocked"
+    assert (
+        "automatic_runner_disabled"
+        in result.blockers
+    )
+
+
+def test_trial_warnings_are_exposed_without_reclassification():
+    value = payload()
+    value["trial_diagnostics"]["warnings"] = [
+        "game_tied_at_extra_innings_cap",
+    ]
+
+    result = (
+        evaluate_canonical_extras_walkoff_activation(
+            canonical_payload=value,
+            execution_inputs=inputs(),
+        )
+    )
+    diagnostics = result.to_diagnostics()
+
+    assert result.active is True
+    assert diagnostics["trial_warnings"] == [
+        "game_tied_at_extra_innings_cap",
+    ]
+    assert diagnostics[
+        "legacy_evidence_status"
+    ] == "reference_only_inconclusive"
+    assert diagnostics[
+        "legacy_candidate_promoted"
+    ] is False
+    assert diagnostics[
+        "parameter_reselection_performed"
+    ] is False

--- a/tests/test_model_projection_production_shadow_comparator.py
+++ b/tests/test_model_projection_production_shadow_comparator.py
@@ -1082,3 +1082,94 @@ def test_comparator_marks_missing_source_coverage_unavailable():
     assert coverage[
         "production_authority_changed"
     ] is False
+
+
+def test_comparator_attaches_extras_walkoff_activation():
+    result = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=executed_shadow(
+                simulation_count=5,
+            ),
+        )
+    )
+
+    activation = result["diagnostics"][
+        "canonical_shadow"
+    ][
+        "canonical_extras_walkoff_activation"
+    ]
+
+    assert activation["status"] == "active"
+    assert activation["active"] is True
+    assert activation["simulation_count"] == 5
+    assert (
+        0.0
+        <= activation["extra_innings_probability"]
+        <= 1.0
+    )
+    assert (
+        0.0
+        <= activation["walk_off_probability"]
+        <= 1.0
+    )
+    assert activation[
+        "game_validation_pass_rate"
+    ] == 1.0
+    assert activation[
+        "box_score_reconciliation_pass_rate"
+    ] == 1.0
+    assert activation[
+        "automatic_runner_active"
+    ] is True
+    assert activation[
+        "legacy_candidate_promoted"
+    ] is False
+    assert activation[
+        "production_authority_changed"
+    ] is False
+
+
+def test_game_realism_requires_executed_activation():
+    unavailable = (
+        model_projections
+        ._build_game_state_realism_diagnostics()
+    )
+
+    assert unavailable[
+        "extra_innings_enabled"
+    ] is None
+    assert unavailable[
+        "automatic_runner_enabled"
+    ] is None
+    assert unavailable[
+        "walk_off_enabled"
+    ] is None
+
+    compared = (
+        model_projections
+        ._attach_production_shadow_comparison(
+            legacy_result=legacy_payload(),
+            production_execution=executed_shadow(),
+        )
+    )
+    active = (
+        model_projections
+        ._build_game_state_realism_diagnostics(
+            compared
+        )
+    )
+
+    assert active[
+        "extra_innings_enabled"
+    ] is True
+    assert active[
+        "automatic_runner_enabled"
+    ] is True
+    assert active[
+        "walk_off_enabled"
+    ] is True
+    assert active[
+        "extras_walkoff_model_status"
+    ] == "active"


### PR DESCRIPTION
## Summary

- validates canonical extra-innings, automatic-runner, and walk-off execution at runtime
- exposes explicit activation diagnostics without changing production authority
- treats legacy backtests as inconclusive reference evidence only
- prevents static implementation flags from presenting unavailable runtime features as active
- surfaces canonical realism states through the diagnostics UI

## Validation

- 129 direct dependency tests passed
- 16 frontend diagnostics tests passed
- upstream failures isolated as pre-existing
- compilation and diff checks passed

## Production safety

- no parameter reselection
- no database writes
- no production authority change
- fail-closed diagnostics