### PR TITLE
Activate canonical environment context

### DIFF
--- a/frontend/src/pages/ModelProjectionsPage.environment.test.mjs
+++ b/frontend/src/pages/ModelProjectionsPage.environment.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const source = fs.readFileSync(
+  new URL(
+    './ModelProjectionsPage.jsx',
+    import.meta.url,
+  ),
+  'utf8',
+)
+
+test('environment tab renders component adjustments', () => {
+  assert.match(source, /Park Adjustment/)
+  assert.match(source, /Weather Adjustment/)
+  assert.match(
+    source,
+    /Full Environmental Adjustment/,
+  )
+  assert.match(source, /Final Multiplier/)
+  assert.match(source, /adjustments\.run_scoring/)
+  assert.match(source, /adjustments\.hits/)
+  assert.match(source, /adjustments\.home_runs/)
+})
+
+test('environment tab exposes roof-aware application', () => {
+  assert.match(source, /Weather Application/)
+  assert.match(source, /Roof Type/)
+  assert.match(source, /Roof State/)
+  assert.match(source, /Observed Weather/)
+  assert.match(source, /Applied Temperature/)
+  assert.match(source, /Applied Wind Speed/)
+  assert.match(source, /Park Factor Policy/)
+})

--- a/frontend/src/pages/ModelProjectionsPage.jsx
+++ b/frontend/src/pages/ModelProjectionsPage.jsx
@@ -589,32 +589,130 @@ function OffenseProfilePanel({ labelText, profile }) {
   )
 }
 
+function EnvironmentAdjustmentPanel({
+  title,
+  adjustment,
+}) {
+  return (
+    <GenericPanel title={title}>
+      <StatRow
+        k="Park Adjustment"
+        v={adjustment?.park_adjustment}
+        format="pct"
+      />
+      <StatRow
+        k="Weather Adjustment"
+        v={adjustment?.weather_adjustment}
+        format="pct"
+      />
+      <StatRow
+        k="Full Environmental Adjustment"
+        v={adjustment?.full_adjustment}
+        format="pct"
+      />
+      <StatRow
+        k="Final Multiplier"
+        v={adjustment?.final_index}
+        format="num"
+      />
+    </GenericPanel>
+  )
+}
+
 function EnvironmentTab({ workspace, game }) {
   const directInputs = getSharedDirectInputs(game)
   const profile = directInputs.environment_profile || workspace?.environmentProfile || {}
   const run = profile.run_environment || {}
   const weather = profile.weather || {}
   const metadata = profile.metadata || {}
+  const components = profile.environment_components || {}
+  const adjustments = components.adjustment_breakdown || {}
+  const weatherComponent = components.weather_component || {}
+  const roof = weatherComponent.roof_resolution || {}
 
   return (
-    <div style={s.splitGrid}>
-      <GenericPanel title="Run Environment" subtitle={label(run.scoring_environment_label)}>
-        <StatRow k="Run Scoring Index" v={run.run_scoring_index} format="num" />
-        <StatRow k="HR Boost Index" v={run.hr_boost_index} format="num" />
-        <StatRow k="Hit Boost Index" v={run.hit_boost_index} format="num" />
-        <StatRow k="Weather Impact" v={run.weather_run_impact} />
-        <StatRow k="Wind Impact" v={run.wind_run_impact} />
-      </GenericPanel>
+    <>
+      <div style={s.grid}>
+        <EnvironmentAdjustmentPanel
+          title="Run Scoring Environment"
+          adjustment={adjustments.run_scoring}
+        />
+        <EnvironmentAdjustmentPanel
+          title="Hit Environment"
+          adjustment={adjustments.hits}
+        />
+        <EnvironmentAdjustmentPanel
+          title="Home Run Environment"
+          adjustment={adjustments.home_runs}
+        />
+      </div>
 
-      <GenericPanel title="Weather">
-        <StatRow k="Temperature" v={weather.temperature_f} format="num" />
-        <StatRow k="Condition" v={weather.condition} />
-        <StatRow k="Wind Speed" v={weather.wind_speed_mph} format="num" />
-        <StatRow k="Wind Direction" v={weather.wind_direction} />
-      </GenericPanel>
+      <div style={{ ...s.splitGrid, marginTop: '14px' }}>
+        <GenericPanel
+          title="Environment Application"
+          subtitle={label(run.scoring_environment_label)}
+        >
+          <StatRow
+            k="Weather Application"
+            v={label(
+              weatherComponent
+                .weather_application_status
+            )}
+          />
+          <StatRow
+            k="Roof Type"
+            v={label(roof.roof_type)}
+          />
+          <StatRow
+            k="Roof State"
+            v={label(roof.roof_state)}
+          />
+          <StatRow
+            k="Calibration Version"
+            v={metadata.environment_calibration_version}
+          />
+          <StatRow
+            k="Park Factor Policy"
+            v={label(
+              metadata.park_factor_preservation_policy
+            )}
+          />
+        </GenericPanel>
 
-      <DataSection title="Metadata" data={metadata} />
-    </div>
+        <GenericPanel title="Observed Weather">
+          <StatRow
+            k="Temperature"
+            v={weather.temperature_f}
+            format="num"
+          />
+          <StatRow
+            k="Condition"
+            v={weather.condition}
+          />
+          <StatRow
+            k="Wind Speed"
+            v={weather.wind_speed_mph}
+            format="num"
+          />
+          <StatRow
+            k="Wind Direction"
+            v={weather.wind_direction}
+          />
+          <StatRow
+            k="Applied Temperature"
+            v={weatherComponent.applied_temperature_f}
+            format="num"
+          />
+          <StatRow
+            k="Applied Wind Speed"
+            v={weatherComponent.applied_wind_speed_mph}
+            format="num"
+          />
+        </GenericPanel>
+
+        <DataSection title="Metadata" data={metadata} />
+      </div>
+    </>
   )
 }
 

--- a/mlb_app/environment_profile.py
+++ b/mlb_app/environment_profile.py
@@ -7,6 +7,9 @@ be populated with real weather, park factor, and contextual inputs.
 
 import re
 
+from .environment.weather_atmospheric_contract import (
+    resolve_roof_state,
+)
 from .park_factors import get_park_factor_profile
 
 
@@ -54,12 +57,11 @@ def compute_environment_profile(raw_context: dict) -> dict:
         return speed, direction
 
     calibration = {
-        "environment_calibration_version": "env_calibration_v1",
+        "environment_calibration_version": "env_calibration_v2",
         "park_weight": 1.00,
         "temperature_weight": 1.00,
         "wind_weight": 1.00,
         "max_weather_adjustment": 0.075,
-        "max_total_adjustment": 0.150,
         "neutral_index": 1.000,
     }
 
@@ -68,11 +70,25 @@ def compute_environment_profile(raw_context: dict) -> dict:
             return None
         return max(lower, min(upper, value))
 
-    def _calibrated_index(base_index, adjustment):
-        base = base_index if base_index is not None else calibration["neutral_index"]
-        max_total = calibration["max_total_adjustment"]
-        raw = base + adjustment
-        return round(_clamp(raw, calibration["neutral_index"] - max_total, calibration["neutral_index"] + max_total), 3)
+    def _combined_environment_index(
+        base_index,
+        weather_adjustment,
+    ):
+        """
+        Preserve the complete sourced park factor and bound only
+        the incremental forecast-based weather contribution.
+        """
+        base = (
+            base_index
+            if base_index is not None
+            else calibration["neutral_index"]
+        )
+        bounded_weather = _clamp(
+            weather_adjustment,
+            -calibration["max_weather_adjustment"],
+            calibration["max_weather_adjustment"],
+        )
+        return round(base + bounded_weather, 3)
 
     def _park_label(run_factor):
         if run_factor is None:
@@ -87,11 +103,19 @@ def compute_environment_profile(raw_context: dict) -> dict:
             return "slight_pitcher_friendly"
         return "neutral"
 
-    def _park_factor_proxy(run_factor, multiplier, lower, upper):
+    def _park_factor_proxy(run_factor, multiplier):
+        """
+        Derive a positive factor without flattening the underlying
+        park signal through a generic upper or lower ceiling.
+        """
         if run_factor is None:
             return None
-        value = 1.0 + ((run_factor - 1.0) * multiplier)
-        return round(_clamp(value, lower, upper), 3)
+        value = 1.0 + (
+            (run_factor - 1.0) * multiplier
+        )
+        if value <= 0.0:
+            return None
+        return round(value, 3)
 
     def _wind_direction_type(wind_direction):
         text = str(wind_direction or "").lower()
@@ -213,7 +237,7 @@ def compute_environment_profile(raw_context: dict) -> dict:
             -calibration["max_weather_adjustment"],
             calibration["max_weather_adjustment"],
         )
-        return _calibrated_index(base, weather_adjustment)
+        return _combined_environment_index(base, weather_adjustment)
 
     def _scoring_label(index):
         if index is None:
@@ -246,6 +270,80 @@ def compute_environment_profile(raw_context: dict) -> dict:
     venue_name = raw_context.get("venue_name")
     if not park_factor_profile and venue_name:
         park_factor_profile = get_park_factor_profile(venue_name)
+
+    venue_type = str(
+        park_factor_profile.get("venue_type")
+        or "unknown"
+    ).strip().lower()
+    raw_roof_status = raw_context.get("roof_status")
+    default_roof_status = (
+        park_factor_profile.get("default_roof_status")
+    )
+
+    roof_type = {
+        "outdoor": "open_air",
+        "open_air": "open_air",
+        "dome": "fixed_dome",
+        "fixed_dome": "fixed_dome",
+        "retractable": "retractable",
+    }.get(venue_type, "unknown")
+
+    if roof_type == "open_air":
+        roof_state = "not_applicable"
+    elif roof_type == "fixed_dome":
+        roof_state = "fixed_closed"
+    else:
+        roof_state = str(
+            raw_roof_status
+            if raw_roof_status is not None
+            else default_roof_status
+            or "unknown"
+        ).strip().lower()
+
+        roof_state = {
+            "roof open": "open",
+            "open roof": "open",
+            "roof closed": "closed",
+            "closed roof": "closed",
+            "dome": "fixed_closed",
+        }.get(roof_state, roof_state)
+
+        if roof_state not in {
+            "open",
+            "closed",
+            "fixed_closed",
+            "not_applicable",
+            "unknown",
+        }:
+            roof_state = "unknown"
+
+    roof_resolution = resolve_roof_state(
+        roof_type,
+        roof_state,
+    )
+
+    weather_application_allowed = (
+        roof_resolution.valid
+        and roof_resolution.weather_behavior
+        == "outdoor_weather_retained"
+    )
+
+    if weather_application_allowed:
+        applied_temperature_f = temperature_f
+        applied_wind_speed_mph = wind_speed_mph
+        applied_wind_direction = wind_direction
+        weather_application_status = "applied"
+    else:
+        applied_temperature_f = None
+        applied_wind_speed_mph = None
+        applied_wind_direction = None
+        weather_application_status = (
+            "neutralized_unknown_roof"
+            if roof_state == "unknown"
+            else "neutralized_indoor"
+            if roof_resolution.indoor_effective
+            else "neutralized_invalid_roof"
+        )
 
     raw_run_factor = raw_context.get("run_factor", raw_context.get("park_factor"))
     run_factor = _safe_float(raw_run_factor)
@@ -280,11 +378,17 @@ def compute_environment_profile(raw_context: dict) -> dict:
     park_factor_fallback_source = None
 
     if home_run_factor is None and run_factor is not None:
-        home_run_factor = _park_factor_proxy(run_factor, multiplier=1.10, lower=0.85, upper=1.15)
+        home_run_factor = _park_factor_proxy(
+            run_factor,
+            multiplier=1.10,
+        )
         park_factor_fallback_used = True
         park_factor_fallback_source = "run_factor_proxy"
     if hit_factor is None and run_factor is not None:
-        hit_factor = _park_factor_proxy(run_factor, multiplier=0.60, lower=0.90, upper=1.10)
+        hit_factor = _park_factor_proxy(
+            run_factor,
+            multiplier=0.60,
+        )
         park_factor_fallback_used = True
         park_factor_fallback_source = "run_factor_proxy"
 
@@ -297,11 +401,19 @@ def compute_environment_profile(raw_context: dict) -> dict:
     if hit_factor is None:
         hit_factor = calibration["neutral_index"]
 
-    wind_adjustments = _wind_adjustments(wind_speed_mph, wind_direction)
+    wind_adjustments = _wind_adjustments(
+        applied_wind_speed_mph,
+        applied_wind_direction,
+    )
 
     run_scoring_index = raw_context.get(
         "run_scoring_index",
-        _run_scoring_index(run_factor, temperature_f, wind_speed_mph, wind_direction),
+        _run_scoring_index(
+            run_factor,
+            applied_temperature_f,
+            applied_wind_speed_mph,
+            applied_wind_direction,
+        ),
     )
     base_index = run_factor if run_factor is not None else calibration["neutral_index"]
     hr_base_index = home_run_factor if home_run_factor is not None else base_index
@@ -309,11 +421,30 @@ def compute_environment_profile(raw_context: dict) -> dict:
 
     hr_boost_index = raw_context.get(
         "hr_boost_index",
-        _calibrated_index(hr_base_index, _temperature_adjustment(temperature_f) + wind_adjustments["wind_hr_adjustment"]),
+        _combined_environment_index(
+            hr_base_index,
+            _temperature_adjustment(
+                applied_temperature_f
+            )
+            + wind_adjustments[
+                "wind_hr_adjustment"
+            ],
+        ),
     )
     hit_boost_index = raw_context.get(
         "hit_boost_index",
-        _calibrated_index(hit_base_index, (_temperature_adjustment(temperature_f) * 0.35) + wind_adjustments["wind_hit_adjustment"]),
+        _combined_environment_index(
+            hit_base_index,
+            (
+                _temperature_adjustment(
+                    applied_temperature_f
+                )
+                * 0.35
+            )
+            + wind_adjustments[
+                "wind_hit_adjustment"
+            ],
+        ),
     )
 
     missing_inputs = []
@@ -337,7 +468,84 @@ def compute_environment_profile(raw_context: dict) -> dict:
         if raw_context.get(key) is not None
     ]
 
-    temperature_adjustment = _temperature_adjustment(temperature_f)
+    temperature_adjustment = _temperature_adjustment(
+        applied_temperature_f
+    )
+
+    weather_run_adjustment = _clamp(
+        temperature_adjustment
+        + wind_adjustments["wind_run_adjustment"],
+        -calibration["max_weather_adjustment"],
+        calibration["max_weather_adjustment"],
+    )
+    weather_hr_adjustment = _clamp(
+        temperature_adjustment
+        + wind_adjustments["wind_hr_adjustment"],
+        -calibration["max_weather_adjustment"],
+        calibration["max_weather_adjustment"],
+    )
+    weather_hit_adjustment = _clamp(
+        (temperature_adjustment * 0.35)
+        + wind_adjustments["wind_hit_adjustment"],
+        -calibration["max_weather_adjustment"],
+        calibration["max_weather_adjustment"],
+    )
+
+    def _adjustment_breakdown(
+        *,
+        park_factor,
+        weather_adjustment,
+        final_index,
+    ):
+        park_adjustment = round(
+            park_factor - calibration["neutral_index"],
+            3,
+        )
+        applied_weather_adjustment = round(
+            weather_adjustment,
+            4,
+        )
+        full_adjustment = round(
+            final_index - calibration["neutral_index"],
+            3,
+        )
+        expected_final = round(
+            park_factor + applied_weather_adjustment,
+            3,
+        )
+
+        return {
+            "park_factor": round(park_factor, 3),
+            "park_adjustment": park_adjustment,
+            "weather_adjustment": (
+                applied_weather_adjustment
+            ),
+            "full_adjustment": full_adjustment,
+            "final_index": round(final_index, 3),
+            "reconciles_to_components": (
+                abs(expected_final - final_index)
+                <= 0.001
+            ),
+        }
+
+    environment_adjustment_breakdown = {
+        "run_scoring": _adjustment_breakdown(
+            park_factor=run_factor,
+            weather_adjustment=weather_run_adjustment,
+            final_index=run_scoring_index,
+        ),
+        "hits": _adjustment_breakdown(
+            park_factor=hit_factor,
+            weather_adjustment=weather_hit_adjustment,
+            final_index=hit_boost_index,
+        ),
+        "home_runs": _adjustment_breakdown(
+            park_factor=home_run_factor,
+            weather_adjustment=weather_hr_adjustment,
+            final_index=hr_boost_index,
+        ),
+    }
+
     if raw_run_factor is not None:
         park_component_source = "real_or_schedule_provided"
     elif static_park_factor_used:
@@ -367,15 +575,28 @@ def compute_environment_profile(raw_context: dict) -> dict:
             "temperature_weight": calibration["temperature_weight"],
             "wind_weight": calibration["wind_weight"],
             "max_weather_adjustment": calibration["max_weather_adjustment"],
-            "max_total_adjustment": calibration["max_total_adjustment"],
+            "park_factor_preservation_policy": (
+                "preserve_sourced_park_factor_"
+                "bound_weather_only_v1"
+            ),
             "wind_raw": wind_raw,
             "wind_parsed_from_text": parsed_wind_speed is not None or bool(parsed_wind_direction),
             "park_factor_fallback_used": park_factor_fallback_used,
             "park_factor_fallback_source": park_factor_fallback_source,
             "combined_index_method": combined_index_method,
+            "roof_weather_policy": (
+                "explicit_open_or_open_air_weather_"
+                "otherwise_neutral_v1"
+            ),
+            "weather_application_status": (
+                weather_application_status
+            ),
         },
         "environment_components": {
             "combined_index_method": combined_index_method,
+            "adjustment_breakdown": (
+                environment_adjustment_breakdown
+            ),
             "park_component": {
                 "run_factor": run_factor,
                 "home_run_factor": home_run_factor,
@@ -397,6 +618,24 @@ def compute_environment_profile(raw_context: dict) -> dict:
                 "temperature_f": temperature_f,
                 "wind_speed_mph": wind_speed_mph,
                 "wind_direction": wind_direction,
+                "applied_temperature_f": (
+                    applied_temperature_f
+                ),
+                "applied_wind_speed_mph": (
+                    applied_wind_speed_mph
+                ),
+                "applied_wind_direction": (
+                    applied_wind_direction
+                ),
+                "weather_application_allowed": (
+                    weather_application_allowed
+                ),
+                "weather_application_status": (
+                    weather_application_status
+                ),
+                "roof_resolution": (
+                    roof_resolution.to_dict()
+                ),
                 "wind_direction_type": wind_adjustments["wind_direction_type"],
                 "wind_speed_tier": wind_adjustments["wind_speed_tier"],
                 "temperature_adjustment": temperature_adjustment,

--- a/mlb_app/shared_artifacts.py
+++ b/mlb_app/shared_artifacts.py
@@ -37,7 +37,7 @@ def matchups_date_key(date: str) -> str:
 
 
 MODEL_PROJECTION_WORKSPACE_VERSION = (
-    "model_projection_workspace_v5"
+    "model_projection_workspace_v6"
 )
 
 

--- a/tests/test_environment_profile_calibration.py
+++ b/tests/test_environment_profile_calibration.py
@@ -1,0 +1,299 @@
+from mlb_app.environment_profile import (
+    compute_environment_profile,
+)
+
+
+def run_environment(**values):
+    result = compute_environment_profile(values)
+    return result["run_environment"]
+
+
+def metadata(**values):
+    result = compute_environment_profile(values)
+    return result["metadata"]
+
+
+def test_authoritative_park_factors_are_not_capped():
+    result = run_environment(
+        run_factor=1.18,
+        home_run_factor=1.20,
+        hit_factor=1.12,
+    )
+
+    assert result["run_scoring_index"] == 1.18
+    assert result["hr_boost_index"] == 1.20
+    assert result["hit_boost_index"] == 1.12
+
+
+def test_pitcher_friendly_park_factors_are_not_floored():
+    result = run_environment(
+        run_factor=0.82,
+        home_run_factor=0.80,
+        hit_factor=0.88,
+    )
+
+    assert result["run_scoring_index"] == 0.82
+    assert result["hr_boost_index"] == 0.80
+    assert result["hit_boost_index"] == 0.88
+
+
+def test_weather_is_incremental_to_full_park_factor():
+    result = run_environment(
+        venue_name="Wrigley Field",
+        run_factor=1.18,
+        home_run_factor=1.20,
+        hit_factor=1.12,
+        temperature_f=95,
+        wind_speed_mph=15,
+        wind_direction="Out To CF",
+    )
+
+    assert result["run_scoring_index"] > 1.18
+    assert result["hr_boost_index"] > 1.20
+    assert result["hit_boost_index"] > 1.12
+
+
+def test_weather_adjustment_remains_bounded():
+    values = {
+        "venue_name": "Wrigley Field",
+        "run_factor": 1.18,
+        "home_run_factor": 1.20,
+        "hit_factor": 1.12,
+        "temperature_f": 95,
+        "wind_speed_mph": 30,
+        "wind_direction": "Out To CF",
+    }
+    result = run_environment(**values)
+    policy = metadata(**values)
+
+    maximum = policy["max_weather_adjustment"]
+
+    assert result["run_scoring_index"] > 1.18
+    assert result["hr_boost_index"] > 1.20
+    assert result["hit_boost_index"] > 1.12
+    assert (
+        result["run_scoring_index"] - 1.18
+        <= maximum
+    )
+    assert (
+        result["hr_boost_index"] - 1.20
+        <= maximum
+    )
+    assert (
+        result["hit_boost_index"] - 1.12
+        <= maximum
+    )
+
+
+def test_run_factor_proxies_preserve_full_signal():
+    result = compute_environment_profile({
+        "run_factor": 1.30,
+    })
+    environment = result["run_environment"]
+    park = result["environment_components"][
+        "park_component"
+    ]
+
+    assert environment["run_scoring_index"] == 1.30
+    assert environment["hr_boost_index"] == 1.33
+    assert environment["hit_boost_index"] == 1.18
+    assert park["proxy_from_run_factor_used"] is True
+
+
+def test_v2_metadata_documents_uncapped_park_policy():
+    result = metadata(
+        run_factor=1.18,
+        home_run_factor=1.20,
+        hit_factor=1.12,
+    )
+
+    assert (
+        result["environment_calibration_version"]
+        == "env_calibration_v2"
+    )
+    assert result[
+        "park_factor_preservation_policy"
+    ] == (
+        "preserve_sourced_park_factor_"
+        "bound_weather_only_v1"
+    )
+    assert "max_total_adjustment" not in result
+
+def test_open_air_venue_applies_weather():
+    result = compute_environment_profile({
+        "venue_name": "Wrigley Field",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert weather["weather_application_allowed"] is True
+    assert weather["weather_application_status"] == "applied"
+    assert weather["applied_temperature_f"] == 95.0
+
+
+def test_explicit_open_retractable_roof_applies_weather():
+    result = compute_environment_profile({
+        "venue_name": "Chase Field",
+        "roof_status": "open",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert weather["weather_application_allowed"] is True
+    assert weather["roof_resolution"]["roof_state"] == "open"
+
+
+def test_closed_retractable_roof_neutralizes_weather():
+    result = compute_environment_profile({
+        "venue_name": "Chase Field",
+        "roof_status": "closed",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    environment = result["run_environment"]
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert environment["run_scoring_index"] == 1.01
+    assert environment["hr_boost_index"] == 1.02
+    assert environment["hit_boost_index"] == 1.01
+    assert weather["weather_application_allowed"] is False
+    assert (
+        weather["weather_application_status"]
+        == "neutralized_indoor"
+    )
+
+
+def test_unknown_retractable_roof_fails_closed_for_weather():
+    result = compute_environment_profile({
+        "venue_name": "Chase Field",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    environment = result["run_environment"]
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert environment["run_scoring_index"] == 1.01
+    assert environment["hr_boost_index"] == 1.02
+    assert environment["hit_boost_index"] == 1.01
+    assert weather["weather_application_allowed"] is False
+    assert (
+        weather["weather_application_status"]
+        == "neutralized_unknown_roof"
+    )
+    assert weather["temperature_f"] == 95.0
+    assert weather["applied_temperature_f"] is None
+
+
+def test_fixed_dome_neutralizes_weather():
+    result = compute_environment_profile({
+        "venue_name": "Tropicana Field",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    environment = result["run_environment"]
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert environment["run_scoring_index"] == 0.98
+    assert environment["hr_boost_index"] == 0.96
+    assert environment["hit_boost_index"] == 0.99
+    assert weather["weather_application_allowed"] is False
+    assert (
+        weather["roof_resolution"]["indoor_effective"]
+        is True
+    )
+
+
+def test_unknown_venue_does_not_apply_unverified_weather():
+    result = compute_environment_profile({
+        "venue_name": "Unknown Test Venue",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    environment = result["run_environment"]
+    weather = result["environment_components"][
+        "weather_component"
+    ]
+
+    assert environment["run_scoring_index"] == 1.0
+    assert environment["hr_boost_index"] == 1.0
+    assert environment["hit_boost_index"] == 1.0
+    assert weather["weather_application_allowed"] is False
+
+def test_adjustment_breakdown_reconciles_park_weather_and_final():
+    result = compute_environment_profile({
+        "venue_name": "Wrigley Field",
+        "run_factor": 1.18,
+        "home_run_factor": 1.20,
+        "hit_factor": 1.12,
+        "temperature_f": 95,
+        "wind_speed_mph": 15,
+        "wind_direction": "Out To CF",
+    })
+
+    breakdown = result["environment_components"][
+        "adjustment_breakdown"
+    ]
+
+    expected = {
+        "run_scoring": 1.18,
+        "hits": 1.12,
+        "home_runs": 1.20,
+    }
+
+    for key, park_factor in expected.items():
+        row = breakdown[key]
+
+        assert row["park_factor"] == park_factor
+        assert row["park_adjustment"] == round(
+            park_factor - 1.0,
+            3,
+        )
+        assert row["weather_adjustment"] > 0.0
+        assert row["full_adjustment"] == round(
+            row["final_index"] - 1.0,
+            3,
+        )
+        assert row["reconciles_to_components"] is True
+
+
+def test_neutralized_weather_has_zero_applied_adjustments():
+    result = compute_environment_profile({
+        "venue_name": "Chase Field",
+        "roof_status": "closed",
+        "temperature_f": 95,
+        "wind_speed_mph": 20,
+        "wind_direction": "Out To CF",
+    })
+
+    breakdown = result["environment_components"][
+        "adjustment_breakdown"
+    ]
+
+    for row in breakdown.values():
+        assert row["weather_adjustment"] == 0.0
+        assert row["final_index"] == row["park_factor"]
+        assert row["reconciles_to_components"] is True

--- a/tests/test_shared_artifacts.py
+++ b/tests/test_shared_artifacts.py
@@ -170,16 +170,16 @@ def test_projection_workspace_version_changes_cache_namespace() -> None:
     )
 
 
-def test_model_projection_workspace_v5_invalidates_prior_role_payload_cache():
+def test_model_projection_workspace_v6_invalidates_prior_environment_payload_cache():
     date = "2026-08-16"
 
     key = model_projection_date_key(date)
 
     assert MODEL_PROJECTION_WORKSPACE_VERSION == (
-        "model_projection_workspace_v5"
+        "model_projection_workspace_v6"
     )
     assert key.endswith(
-        "model_projection_workspace_v5:"
+        "model_projection_workspace_v6:"
         + date
     )
     assert (


### PR DESCRIPTION
## Summary

- preserves complete sourced park factors without generic environment caps
- bounds only incremental weather effects
- applies weather only for verified outdoor or explicitly open-roof games
- neutralizes weather for domes, closed roofs, unknown retractable roofs, and unknown venues
- exposes auditable park, weather, full-adjustment, and final-index components for run scoring, hits, and home runs
- displays roof and weather-application status in the Environment UI
- invalidates prior projection artifacts through workspace cache v6

## PA outcome behavior

- run-scoring and hit indices directly adjust singles, doubles, and triples
- the home-run index directly adjusts home-run probability
- contact outs absorb the distributional balance
- strikeouts, walks, HBP, and reached-on-error are not directly modified by environment

## Validation

- 106 backend environment and consumer tests passed
- 22 PA outcome-model tests passed
- 21 frontend UI contract tests passed
- compilation and diff checks passed
- environment adjustment arithmetic reconciles exactly

## Production safety

- no database writes
- no unrelated files included
- raw weather remains visible when roof policy neutralizes its simulation effect
- explicit upstream environment indices remain authoritative
- unrelated matchup-profile import failure was independently isolated as pre-existing
