### PR TITLE
Calibrate and activate canonical pitcher matchup profiles

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -8,6 +8,26 @@ from typing import Any, Dict, List, Optional
 
 from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session
+
+from mlb_app.database import StatcastEvent
+from mlb_app.statcast_event_identity import (
+    load_canonical_statcast_events,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_runtime_batch import (
+    build_canonical_pitcher_matchup_profile_runtime_batch,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_source import (
+    source_canonical_pitcher_matchup_profile,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_activation import (
+    APPROVED_CROSS_SEASON_AUDIT_DIGEST,
+    APPROVED_ELIGIBILITY_DIGEST,
+    APPROVED_HISTORICAL_EVALUATION_DIGEST,
+    select_canonical_pitcher_matchup_profile_pa_model,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_comparator import (
+    compare_canonical_pitcher_matchup_profile_pa_outcomes,
+)
 from mlb_app.simulation.projections.pitcher_pool_role_reconciliation import (
     reconcile_canonical_pitcher_projection_pool_roles,
 )
@@ -560,8 +580,125 @@ def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
     away_bullpen_profile = build_bullpen_profile(team_id=away_team_id, team_name=away_team_name)
     home_bullpen_profile = build_bullpen_profile(team_id=home_team_id, team_name=home_team_name)
 
-    away_vs_home_starter_pa = _team_offense_prior_pa_model(away_team_id, away_team_name, home_pitcher_profile, environment_profile)
-    home_vs_away_starter_pa = _team_offense_prior_pa_model(home_team_id, home_team_name, away_pitcher_profile, environment_profile)
+    away_offense_profile = build_team_offense_prior(
+        team_id=away_team_id,
+        team_name=away_team_name,
+    )
+    home_offense_profile = build_team_offense_prior(
+        team_id=home_team_id,
+        team_name=home_team_name,
+    )
+
+    away_vs_home_starter_pa = _team_offense_prior_pa_model(
+        away_team_id,
+        away_team_name,
+        home_pitcher_profile,
+        environment_profile,
+        offense_profile=away_offense_profile,
+    )
+    home_vs_away_starter_pa = _team_offense_prior_pa_model(
+        home_team_id,
+        home_team_name,
+        away_pitcher_profile,
+        environment_profile,
+        offense_profile=home_offense_profile,
+    )
+
+    away_vs_home_pitcher_profile_shadow = (
+        compare_canonical_pitcher_matchup_profile_pa_outcomes(
+            candidate=(
+                home.get(
+                    "pitcher_matchup_profile_candidate"
+                )
+                or {}
+            ),
+            production_pitcher_profile=(
+                home_pitcher_profile
+            ),
+            batter_profile=away_offense_profile,
+            environment_profile=environment_profile,
+        )
+    )
+    home_vs_away_pitcher_profile_shadow = (
+        compare_canonical_pitcher_matchup_profile_pa_outcomes(
+            candidate=(
+                away.get(
+                    "pitcher_matchup_profile_candidate"
+                )
+                or {}
+            ),
+            production_pitcher_profile=(
+                away_pitcher_profile
+            ),
+            batter_profile=home_offense_profile,
+            environment_profile=environment_profile,
+        )
+    )
+
+    pitcher_profile_pa_activation_requested = (
+        os.getenv(
+            "MLB_ENABLE_CANONICAL_PITCHER_MATCHUP_PROFILE_PA",
+            "",
+        )
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    )
+    away_vs_home_pitcher_profile_activation = (
+        select_canonical_pitcher_matchup_profile_pa_model(
+            production_model=(
+                away_vs_home_starter_pa
+            ),
+            comparison=(
+                away_vs_home_pitcher_profile_shadow
+            ),
+            activation_requested=(
+                pitcher_profile_pa_activation_requested
+            ),
+            eligibility_digest=(
+                APPROVED_ELIGIBILITY_DIGEST
+            ),
+            historical_evaluation_digest=(
+                APPROVED_HISTORICAL_EVALUATION_DIGEST
+            ),
+            cross_season_audit_digest=(
+                APPROVED_CROSS_SEASON_AUDIT_DIGEST
+            ),
+        )
+    )
+    home_vs_away_pitcher_profile_activation = (
+        select_canonical_pitcher_matchup_profile_pa_model(
+            production_model=(
+                home_vs_away_starter_pa
+            ),
+            comparison=(
+                home_vs_away_pitcher_profile_shadow
+            ),
+            activation_requested=(
+                pitcher_profile_pa_activation_requested
+            ),
+            eligibility_digest=(
+                APPROVED_ELIGIBILITY_DIGEST
+            ),
+            historical_evaluation_digest=(
+                APPROVED_HISTORICAL_EVALUATION_DIGEST
+            ),
+            cross_season_audit_digest=(
+                APPROVED_CROSS_SEASON_AUDIT_DIGEST
+            ),
+        )
+    )
+    away_vs_home_starter_pa = (
+        away_vs_home_pitcher_profile_activation[
+            "model"
+        ]
+    )
+    home_vs_away_starter_pa = (
+        home_vs_away_pitcher_profile_activation[
+            "model"
+        ]
+    )
+
     away_vs_home_bullpen_pa = _team_offense_prior_pa_model(away_team_id, away_team_name, home_bullpen_profile, environment_profile)
     home_vs_away_bullpen_pa = _team_offense_prior_pa_model(home_team_id, home_team_name, away_bullpen_profile, environment_profile)
 
@@ -675,6 +812,71 @@ def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
         "homeBullpenProfile": home_bullpen_profile,
         "awayPAOutcomeModel": away_vs_home_starter_pa,
         "homePAOutcomeModel": home_vs_away_starter_pa,
+        "pitcherMatchupProfilePAShadowComparisons": {
+            "awayOffenseVsHomeStarter": (
+                away_vs_home_pitcher_profile_shadow
+            ),
+            "homeOffenseVsAwayStarter": (
+                home_vs_away_pitcher_profile_shadow
+            ),
+            "comparison_role": (
+                "production_activation_source"
+                if pitcher_profile_pa_activation_requested
+                else "paired_shadow_diagnostic_only"
+            ),
+            "simulation_inputs_changed": (
+                away_vs_home_pitcher_profile_activation[
+                    "activated"
+                ]
+                or home_vs_away_pitcher_profile_activation[
+                    "activated"
+                ]
+            ),
+            "final_probabilities_changed": False,
+            "production_authority": (
+                away_vs_home_pitcher_profile_activation[
+                    "activated"
+                ]
+                or home_vs_away_pitcher_profile_activation[
+                    "activated"
+                ]
+            ),
+            "production_authority_changed": (
+                away_vs_home_pitcher_profile_activation[
+                    "activated"
+                ]
+                or home_vs_away_pitcher_profile_activation[
+                    "activated"
+                ]
+            ),
+        },
+        "pitcherMatchupProfilePAActivation": {
+            "requested": (
+                pitcher_profile_pa_activation_requested
+            ),
+            "awayOffenseVsHomeStarter": (
+                away_vs_home_pitcher_profile_activation[
+                    "diagnostics"
+                ]
+            ),
+            "homeOffenseVsAwayStarter": (
+                home_vs_away_pitcher_profile_activation[
+                    "diagnostics"
+                ]
+            ),
+            "simulation_inputs_changed": (
+                away_vs_home_pitcher_profile_activation[
+                    "activated"
+                ]
+                or home_vs_away_pitcher_profile_activation[
+                    "activated"
+                ]
+            ),
+            "final_side_probabilities_changed": False,
+            "final_side_probability_source": (
+                "matchups.canonical_matchup_win_probability_v2"
+            ),
+        },
         "awayVsHomeBullpenPAOutcomeModel": away_vs_home_bullpen_pa,
         "homeVsAwayBullpenPAOutcomeModel": home_vs_away_bullpen_pa,
         "awayMatchupAnalysis": _matchup_workspace_analysis(away, home),
@@ -766,23 +968,290 @@ def _projection_offense_inputs(
     )
 
 
-def _side_context(matchup: Dict[str, Any], side: str, session: Session, season: int) -> Dict[str, Any]:
+def _materialize_pitcher_matchup_profile_runtime_batch(
+    *,
+    session: Session,
+    matchups: List[Dict[str, Any]],
+    game_date: Any,
+    event_loader: Any = None,
+    batch_builder: Any = None,
+) -> Dict[str, Any]:
+    """Load terminal evidence once and build all shadow candidates."""
+    event_loader = (
+        event_loader
+        or load_canonical_statcast_events
+    )
+    batch_builder = (
+        batch_builder
+        or build_canonical_pitcher_matchup_profile_runtime_batch
+    )
+
+    pitcher_ids = tuple(sorted({
+        int(pitcher_id)
+        for matchup in matchups
+        if isinstance(matchup, dict)
+        for side in ("away", "home")
+        for pitcher_id in [
+            matchup.get(
+                f"{side}_pitcher_id"
+            )
+        ]
+        if pitcher_id not in (
+            None,
+            0,
+            "",
+        )
+    }))
+
+    if not pitcher_ids:
+        return {
+            "candidates": {},
+            "diagnostics": {
+                "status": "unavailable",
+                "blockers": [
+                    "no_probable_pitcher_ids",
+                ],
+                "single_terminal_event_load": False,
+                "production_authority": False,
+                "production_authority_changed": False,
+            },
+        }
+
+    window_start = (
+        game_date
+        - datetime.timedelta(days=90)
+    )
+
+    try:
+        events, identity = event_loader(
+            session,
+            StatcastEvent.game_date
+            >= window_start,
+            StatcastEvent.game_date
+            < game_date,
+            StatcastEvent.events.isnot(None),
+            order_by=(
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.id,
+            ),
+        )
+        result = batch_builder(
+            events,
+            pitcher_ids=pitcher_ids,
+            game_date=game_date,
+            window_days=90,
+        )
+
+        diagnostics = dict(
+            result.get("diagnostics") or {}
+        )
+        diagnostics.update({
+            "single_terminal_event_load": True,
+            "terminal_event_count": len(events),
+            "identity_diagnostics": dict(
+                identity or {}
+            ),
+            "production_authority": False,
+            "production_authority_changed": False,
+        })
+
+        return {
+            "candidates": dict(
+                result.get("candidates") or {}
+            ),
+            "diagnostics": diagnostics,
+        }
+    except Exception as exc:
+        return {
+            "candidates": {},
+            "diagnostics": {
+                "status": "error",
+                "blockers": [
+                    "runtime_candidate_batch_failed",
+                ],
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "single_terminal_event_load": True,
+                "production_authority": False,
+                "production_authority_changed": False,
+            },
+        }
+
+
+def _side_context(
+    matchup: Dict[str, Any],
+    side: str,
+    session: Session,
+    season: int,
+    game_date: Any,
+    pitcher_matchup_profile_candidates: Optional[
+        Dict[str, Any]
+    ] = None,
+    pitcher_matchup_profile_batch_diagnostics: Optional[
+        Dict[str, Any]
+    ] = None,
+) -> Dict[str, Any]:
     pitcher_id = matchup.get(f"{side}_pitcher_id")
-    arsenal = matchup.get(f"{side}_pitch_arsenal") or {}
-    arsenal_source = "matchup_generator" if arsenal else "missing_pitch_arsenal"
+    supplied_pitcher_features = (
+        matchup.get(f"{side}_pitcher_features")
+        or {}
+    )
+    if not isinstance(
+        supplied_pitcher_features,
+        dict,
+    ):
+        supplied_pitcher_features = {}
+
+    if pitcher_id:
+        pitcher_profile_source = (
+            source_canonical_pitcher_matchup_profile(
+                session,
+                pitcher_id=int(pitcher_id),
+                game_date=game_date,
+                matchup_features=(
+                    supplied_pitcher_features
+                ),
+            )
+        )
+        pitcher_features = (
+            pitcher_profile_source[
+                "pitcher_features"
+            ]
+        )
+        pitcher_profile_diagnostics = (
+            pitcher_profile_source[
+                "diagnostics"
+            ]
+        )
+    else:
+        pitcher_features = dict(
+            supplied_pitcher_features
+        )
+        pitcher_profile_diagnostics = {
+            "schema_version": (
+                "canonical_pitcher_matchup_"
+                "profile_source_v1"
+            ),
+            "status": "unavailable",
+            "pitcher_id": None,
+            "game_date": str(game_date),
+            "cutoff_rule": (
+                "aggregate_end_date_strictly_"
+                "before_game_date"
+            ),
+            "selected_window": None,
+            "selected_end_date": None,
+            "days_before_game": None,
+            "populated_fields": [],
+            "missing_fields": [
+                "k_pct",
+                "bb_pct",
+                "hard_hit_pct",
+                "xwoba",
+                "xba",
+            ],
+            "field_provenance": {},
+            "source_digest": None,
+            "blockers": [
+                "missing_pitcher_id",
+            ],
+        }
+
+    candidate_key = (
+        str(int(pitcher_id))
+        if pitcher_id
+        else None
+    )
+    pitcher_matchup_profile_candidate = (
+        (
+            pitcher_matchup_profile_candidates
+            or {}
+        ).get(candidate_key)
+        if candidate_key is not None
+        else None
+    )
+
+    if not isinstance(
+        pitcher_matchup_profile_candidate,
+        dict,
+    ):
+        pitcher_matchup_profile_candidate = {
+            "profile_rates": {},
+            "diagnostics": {
+                "status": "unavailable",
+                "pitcher_id": (
+                    int(pitcher_id)
+                    if pitcher_id
+                    else None
+                ),
+                "blockers": [
+                    (
+                        "runtime_candidate_unavailable"
+                        if pitcher_id
+                        else "missing_pitcher_id"
+                    ),
+                ],
+                "production_authority": False,
+                "production_authority_changed": False,
+                "activation_status": (
+                    "shadow_candidate_unavailable"
+                ),
+            },
+        }
+
+    arsenal = matchup.get(
+        f"{side}_pitch_arsenal"
+    ) or {}
+    arsenal_source = (
+        "matchup_generator"
+        if arsenal
+        else "missing_pitch_arsenal"
+    )
     if not arsenal and pitcher_id:
-        records, arsenal_season = get_pitch_arsenal_with_fallback(session, int(pitcher_id), season)
-        arsenal = _arsenal_records_to_dict(records)
-        arsenal_source = f"pitch_arsenal_fallback_{arsenal_season}" if arsenal else "missing_pitch_arsenal"
+        records, arsenal_season = (
+            get_pitch_arsenal_with_fallback(
+                session,
+                int(pitcher_id),
+                season,
+            )
+        )
+        arsenal = _arsenal_records_to_dict(
+            records
+        )
+        arsenal_source = (
+            f"pitch_arsenal_fallback_{arsenal_season}"
+            if arsenal
+            else "missing_pitch_arsenal"
+        )
+
     team_id = matchup.get(f"{side}_team_id")
-    team_name = matchup.get(f"{side}_team_name")
+    team_name = matchup.get(
+        f"{side}_team_name"
+    )
     ctx = {
         "side": side,
         "team_id": team_id,
         "team_name": team_name,
         "pitcher_id": pitcher_id,
-        "pitcher_name": matchup.get(f"{side}_pitcher_name"),
-        "pitcher_features": matchup.get(f"{side}_pitcher_features") or {},
+        "pitcher_name": matchup.get(
+            f"{side}_pitcher_name"
+        ),
+        "pitcher_features": pitcher_features,
+        "pitcher_matchup_profile_source": (
+            pitcher_profile_diagnostics
+        ),
+        "pitcher_matchup_profile_candidate": (
+            pitcher_matchup_profile_candidate
+        ),
+        "pitcher_matchup_profile_runtime_batch": (
+            dict(
+                pitcher_matchup_profile_batch_diagnostics
+                or {}
+            )
+        ),
         "pitch_arsenal": arsenal,
         "pitch_arsenal_source": arsenal_source,
         "offense_inputs": _projection_offense_inputs(
@@ -792,7 +1261,11 @@ def _side_context(matchup: Dict[str, Any], side: str, session: Session, season: 
             team_id=team_id,
             season=season,
         ),
-        "bullpen_inputs": _bullpen_inputs(session, team_id, team_name),
+        "bullpen_inputs": _bullpen_inputs(
+            session,
+            team_id,
+            team_name,
+        ),
     }
     ctx["models"] = [
         pitching_volatility_score(ctx["pitcher_features"], ctx["pitch_arsenal"]),
@@ -1753,6 +2226,25 @@ def build_model_projection_payload(
     except ValueError as exc:
         raise ValueError("date must be YYYY-MM-DD") from exc
     matchups = generate_matchups_for_date(session, target_date)
+    pitcher_matchup_profile_runtime_batch = (
+        _materialize_pitcher_matchup_profile_runtime_batch(
+            session=session,
+            matchups=matchups,
+            game_date=date_obj,
+        )
+    )
+    pitcher_matchup_profile_candidates = (
+        pitcher_matchup_profile_runtime_batch.get(
+            "candidates",
+            {},
+        )
+    )
+    pitcher_matchup_profile_batch_diagnostics = (
+        pitcher_matchup_profile_runtime_batch.get(
+            "diagnostics",
+            {},
+        )
+    )
     games: List[Dict[str, Any]] = []
     errors: List[Dict[str, Any]] = []
     pitcher_role_evidence_source_cache: Dict[
@@ -1762,8 +2254,24 @@ def build_model_projection_payload(
 
     for matchup in matchups:
         try:
-            away = _side_context(matchup, "away", session, date_obj.year)
-            home = _side_context(matchup, "home", session, date_obj.year)
+            away = _side_context(
+                matchup,
+                "away",
+                session,
+                date_obj.year,
+                date_obj,
+                pitcher_matchup_profile_candidates,
+                pitcher_matchup_profile_batch_diagnostics,
+            )
+            home = _side_context(
+                matchup,
+                "home",
+                session,
+                date_obj.year,
+                date_obj,
+                pitcher_matchup_profile_candidates,
+                pitcher_matchup_profile_batch_diagnostics,
+            )
             simulation_cards = _build_projection_simulation_cards(matchup, away, home)
             away["models"].extend(simulation_cards.get("away", []))
             home["models"].extend(simulation_cards.get("home", []))

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_activation_eligibility.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_activation_eligibility.py
@@ -1,0 +1,340 @@
+"""Evaluate canonical pitcher-profile production activation eligibility.
+
+Eligibility records that calibration and historical evidence satisfy the
+selection contract. It never changes production inputs or authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_activation_eligibility_v1"
+)
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _nonnegative_float(
+    value: Any,
+    name: str,
+) -> float:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_nonnegative"
+        )
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_nonnegative"
+        ) from exc
+
+    if parsed < 0.0:
+        raise ValueError(
+            f"{name}_must_be_nonnegative"
+        )
+
+    return parsed
+
+
+def _mapping(
+    value: Any,
+    name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"{name}_must_be_mapping"
+        )
+    return deepcopy(dict(value))
+
+
+def evaluate_canonical_pitcher_matchup_profile_activation_eligibility(
+    *,
+    calibration_policy: Mapping[str, Any],
+    historical_evaluation: Mapping[str, Any],
+    minimum_samples: int = 300,
+    minimum_observed_pa: int = 900,
+    minimum_seasons: int = 3,
+    minimum_absolute_log_loss_improvement: float = 0.0,
+    minimum_absolute_brier_improvement: float = 0.0,
+) -> dict[str, Any]:
+    """Return an evidence-only production activation eligibility decision."""
+
+    required_samples = _positive_integer(
+        minimum_samples,
+        "minimum_samples",
+    )
+    required_pa = _positive_integer(
+        minimum_observed_pa,
+        "minimum_observed_pa",
+    )
+    required_seasons = _positive_integer(
+        minimum_seasons,
+        "minimum_seasons",
+    )
+    required_log_loss = _nonnegative_float(
+        minimum_absolute_log_loss_improvement,
+        "minimum_absolute_log_loss_improvement",
+    )
+    required_brier = _nonnegative_float(
+        minimum_absolute_brier_improvement,
+        "minimum_absolute_brier_improvement",
+    )
+    calibration = _mapping(
+        calibration_policy,
+        "calibration_policy",
+    )
+    historical = _mapping(
+        historical_evaluation,
+        "historical_evaluation",
+    )
+    calibration_diagnostics = dict(
+        calibration.get("diagnostics")
+        or calibration
+    )
+    historical_diagnostics = dict(
+        historical.get("diagnostics")
+        or {}
+    )
+    overall = dict(
+        historical.get("overall") or {}
+    )
+    by_season = dict(
+        historical.get("by_season") or {}
+    )
+
+    blockers = []
+
+    calibration_ready = (
+        calibration_diagnostics.get(
+            "status"
+        )
+        == "ready"
+        and calibration_diagnostics.get(
+            "activation_status"
+        )
+        == "candidate_policy_ready"
+    )
+    if not calibration_ready:
+        blockers.append(
+            "calibration_policy_not_ready"
+        )
+
+    if calibration_diagnostics.get(
+        "production_authority_changed"
+    ) is not False:
+        blockers.append(
+            "calibration_authority_contract_invalid"
+        )
+
+    historical_gate_passed = (
+        historical_diagnostics.get(
+            "selection_gate_passed"
+        )
+        is True
+        and historical_diagnostics.get(
+            "activation_status"
+        )
+        == "historical_pa_gate_passed"
+    )
+    if not historical_gate_passed:
+        blockers.append(
+            "historical_pa_gate_not_passed"
+        )
+
+    try:
+        sample_count = int(
+            overall.get("sample_count", 0)
+        )
+    except (TypeError, ValueError):
+        sample_count = 0
+    try:
+        observed_pa = int(
+            overall.get("observed_pa", 0)
+        )
+    except (TypeError, ValueError):
+        observed_pa = 0
+
+    if sample_count < required_samples:
+        blockers.append(
+            "historical_sample_count_below_minimum"
+        )
+    if observed_pa < required_pa:
+        blockers.append(
+            "historical_observed_pa_below_minimum"
+        )
+    if len(by_season) < required_seasons:
+        blockers.append(
+            "historical_season_count_below_minimum"
+        )
+
+    try:
+        log_loss_improvement = float(
+            overall.get(
+                "absolute_log_loss_improvement"
+            )
+        )
+    except (TypeError, ValueError):
+        log_loss_improvement = float(
+            "-inf"
+        )
+    try:
+        brier_improvement = float(
+            overall.get(
+                "absolute_brier_improvement"
+            )
+        )
+    except (TypeError, ValueError):
+        brier_improvement = float(
+            "-inf"
+        )
+
+    if log_loss_improvement <= (
+        required_log_loss
+    ):
+        blockers.append(
+            "absolute_log_loss_improvement_below_minimum"
+        )
+    if brier_improvement <= required_brier:
+        blockers.append(
+            "absolute_brier_improvement_below_minimum"
+        )
+
+    regressed_seasons = tuple(
+        str(value)
+        for value in (
+            historical_diagnostics.get(
+                "regressed_seasons"
+            )
+            or ()
+        )
+    )
+    if regressed_seasons:
+        blockers.append(
+            "season_log_loss_instability"
+        )
+
+    invalid_historical_authority = any((
+        historical_diagnostics.get(
+            "production_authority"
+        )
+        is not False,
+        historical_diagnostics.get(
+            "production_authority_changed"
+        )
+        is not False,
+    ))
+    if invalid_historical_authority:
+        blockers.append(
+            "historical_authority_contract_invalid"
+        )
+
+    blockers = list(dict.fromkeys(blockers))
+    eligible = not blockers
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if eligible
+            else "blocked"
+        ),
+        "activation_status": (
+            "candidate_activation_eligible"
+            if eligible
+            else "candidate_activation_blocked"
+        ),
+        "activation_eligible": eligible,
+        "blockers": blockers,
+        "calibration_policy_ready": (
+            calibration_ready
+        ),
+        "historical_pa_gate_passed": (
+            historical_gate_passed
+        ),
+        "sample_count": sample_count,
+        "minimum_samples": required_samples,
+        "observed_pa": observed_pa,
+        "minimum_observed_pa": required_pa,
+        "season_count": len(by_season),
+        "minimum_seasons": required_seasons,
+        "absolute_log_loss_improvement": (
+            log_loss_improvement
+        ),
+        "minimum_absolute_log_loss_improvement": (
+            required_log_loss
+        ),
+        "absolute_brier_improvement": (
+            brier_improvement
+        ),
+        "minimum_absolute_brier_improvement": (
+            required_brier
+        ),
+        "regressed_seasons": (
+            regressed_seasons
+        ),
+        "eligibility_only": True,
+        "activation_executed": False,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "calibration_policy_digest": (
+            calibration_diagnostics.get(
+                "calibration_policy_digest"
+            )
+            or calibration_diagnostics.get(
+                "policy_digest"
+            )
+        ),
+        "historical_evaluation_digest": (
+            historical_diagnostics.get(
+                "evaluation_digest"
+            )
+        ),
+    }
+    diagnostics["eligibility_digest"] = (
+        _digest(diagnostics)
+    )
+
+    return {
+        "eligible": eligible,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_application.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_application.py
@@ -1,0 +1,307 @@
+"""Apply calibrated shrinkage to canonical pitcher-profile evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from .canonical_pitcher_matchup_profile_holdout import (
+    METRIC_SPECS,
+)
+
+
+APPLICATION_VERSION = (
+    "canonical_pitcher_matchup_profile_application_v1"
+)
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(parsed):
+        return None
+
+    return parsed
+
+
+def _rate(value: Any) -> float | None:
+    parsed = _number(value)
+
+    if (
+        parsed is None
+        or parsed < 0.0
+        or parsed > 1.0
+    ):
+        return None
+
+    return parsed
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _metric_counts(
+    evidence: Mapping[str, Any],
+    metric: str,
+) -> tuple[int, int] | None:
+    overall = evidence.get("overall")
+    if not isinstance(overall, Mapping):
+        return None
+
+    specification = METRIC_SPECS.get(metric)
+    if specification is None:
+        return None
+
+    _, component, numerator_key = specification
+
+    component_values = overall.get(component)
+    denominators = overall.get(
+        "metric_denominators"
+    )
+
+    if (
+        not isinstance(
+            component_values,
+            Mapping,
+        )
+        or not isinstance(
+            denominators,
+            Mapping,
+        )
+    ):
+        return None
+
+    numerator = _number(
+        component_values.get(numerator_key)
+    )
+    denominator = _number(
+        denominators.get(metric)
+    )
+
+    if (
+        numerator is None
+        or denominator is None
+        or numerator < 0
+        or denominator < 0
+        or numerator > denominator
+        or not numerator.is_integer()
+        or not denominator.is_integer()
+    ):
+        return None
+
+    return int(numerator), int(denominator)
+
+
+def apply_canonical_pitcher_matchup_profile_calibration(
+    evidence: Mapping[str, Any],
+    *,
+    calibration_policy: Mapping[str, Any],
+    league_priors: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Apply pooled calibrated pseudo-counts without production authority."""
+    if not isinstance(evidence, Mapping):
+        raise TypeError("evidence must be a mapping")
+
+    if (
+        calibration_policy.get("status")
+        != "ready"
+    ):
+        raise ValueError(
+            "calibration policy must be ready"
+        )
+    if (
+        calibration_policy.get(
+            "production_authority"
+        )
+        is not False
+    ):
+        raise ValueError(
+            "calibration policy must not have "
+            "production authority"
+        )
+    if (
+        calibration_policy.get(
+            "production_authority_changed"
+        )
+        is not False
+    ):
+        raise ValueError(
+            "calibration policy changed "
+            "production authority"
+        )
+    if (
+        calibration_policy.get(
+            "segment_parameters_selected"
+        )
+        is not False
+    ):
+        raise ValueError(
+            "segment parameters must remain deferred"
+        )
+
+    selected = calibration_policy.get(
+        "selected_pseudo_counts"
+    )
+    if not isinstance(selected, Mapping):
+        raise ValueError(
+            "selected pseudo-counts are required"
+        )
+
+    profile_rates = {}
+    metric_diagnostics = {}
+
+    for metric, raw_pseudo_count in sorted(
+        selected.items()
+    ):
+        reasons = []
+        pseudo_count = _number(
+            raw_pseudo_count
+        )
+        prior = _rate(
+            league_priors.get(metric)
+        )
+        counts = _metric_counts(
+            evidence,
+            metric,
+        )
+
+        if (
+            pseudo_count is None
+            or pseudo_count < 0
+        ):
+            reasons.append(
+                "invalid_pseudo_count"
+            )
+
+        if prior is None:
+            reasons.append(
+                "league_prior_unavailable"
+            )
+
+        if counts is None:
+            reasons.append(
+                "sufficient_statistics_unavailable"
+            )
+
+        if reasons:
+            metric_diagnostics[metric] = {
+                "status": "unavailable",
+                "reasons": reasons,
+                "production_authority": False,
+            }
+            continue
+
+        successes, trials = counts
+        denominator = (
+            trials + pseudo_count
+        )
+
+        if denominator <= 0:
+            metric_diagnostics[metric] = {
+                "status": "unavailable",
+                "reasons": [
+                    "nonpositive_shrinkage_denominator"
+                ],
+                "production_authority": False,
+            }
+            continue
+
+        observed_rate = (
+            successes / trials
+            if trials > 0
+            else None
+        )
+        reliability = trials / denominator
+        calibrated_rate = (
+            successes
+            + pseudo_count * prior
+        ) / denominator
+
+        profile_rates[metric] = round(
+            calibrated_rate,
+            12,
+        )
+        metric_diagnostics[metric] = {
+            "status": "ready",
+            "successes": successes,
+            "trials": trials,
+            "observed_rate": (
+                round(observed_rate, 12)
+                if observed_rate is not None
+                else None
+            ),
+            "league_prior": prior,
+            "pseudo_count": pseudo_count,
+            "reliability": round(
+                reliability,
+                12,
+            ),
+            "calibrated_rate": round(
+                calibrated_rate,
+                12,
+            ),
+            "production_authority": False,
+        }
+
+    blocked_metrics = dict(
+        calibration_policy.get(
+            "blocked_metrics",
+            {},
+        )
+    )
+
+    requested_count = len(selected)
+    ready_count = len(profile_rates)
+
+    if requested_count == 0 or ready_count == 0:
+        status = "unavailable"
+    elif ready_count < requested_count:
+        status = "partial"
+    else:
+        status = "ready"
+
+    diagnostics = {
+        "schema_version": APPLICATION_VERSION,
+        "status": status,
+        "application_scope": (
+            "overall_pooled_metrics_only"
+        ),
+        "requested_metric_count": (
+            requested_count
+        ),
+        "ready_metric_count": ready_count,
+        "blocked_metrics": blocked_metrics,
+        "metric_diagnostics": (
+            metric_diagnostics
+        ),
+        "segment_parameters_applied": False,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "activation_status": (
+            "shadow_candidate_applied"
+        ),
+    }
+    diagnostics["application_digest"] = (
+        _digest(diagnostics)
+    )
+
+    return {
+        "profile_rates": profile_rates,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_calibration_policy.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_calibration_policy.py
@@ -1,0 +1,330 @@
+"""Finalize calibrated canonical pitcher-profile pseudo-counts.
+
+This policy consumes a shadow calibration artifact and selects only pooled
+parameters that satisfy improvement, cross-season stability, and boundary
+plateau gates. It never changes production authority and does not select
+segment-specific parameters.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+CALIBRATION_POLICY_VERSION = (
+    "canonical_pitcher_matchup_profile_calibration_policy_v1"
+)
+MAX_LAST_STEP_ABSOLUTE_GAIN = 0.0001
+MAX_LAST_STEP_SHARE_OF_TOTAL_GAIN = 0.01
+
+
+def _numeric(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _candidate_grid(
+    result: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    return sorted(
+        (
+            row
+            for row in result.get(
+                "pooled_grid",
+                (),
+            )
+            if isinstance(row, Mapping)
+            and _numeric(
+                row.get("pseudo_count")
+            )
+            is not None
+            and _numeric(
+                row.get("binomial_log_loss")
+            )
+            is not None
+        ),
+        key=lambda row: float(
+            row["pseudo_count"]
+        ),
+    )
+
+
+def _evaluate_metric(
+    metric: str,
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    reasons = []
+    grid = _candidate_grid(result)
+    selected = result.get("pooled_candidate")
+
+    if not grid:
+        reasons.append("candidate_grid_unavailable")
+    if not isinstance(selected, Mapping):
+        reasons.append("pooled_candidate_unavailable")
+
+    if reasons:
+        return {
+            "metric": metric,
+            "status": "blocked",
+            "reasons": reasons,
+        }
+
+    selected_count = _numeric(
+        selected.get("pseudo_count")
+    )
+    selected_loss = _numeric(
+        selected.get("binomial_log_loss")
+    )
+
+    if (
+        selected_count is None
+        or selected_loss is None
+    ):
+        return {
+            "metric": metric,
+            "status": "blocked",
+            "reasons": [
+                "pooled_candidate_invalid"
+            ],
+        }
+
+    baseline = next(
+        (
+            row
+            for row in grid
+            if float(row["pseudo_count"])
+            == 0.0
+        ),
+        None,
+    )
+
+    if baseline is None:
+        reasons.append("unshrunk_baseline_unavailable")
+        baseline_loss = None
+    else:
+        baseline_loss = float(
+            baseline["binomial_log_loss"]
+        )
+
+    selected_index = next(
+        (
+            index
+            for index, row in enumerate(grid)
+            if float(row["pseudo_count"])
+            == selected_count
+        ),
+        None,
+    )
+
+    if selected_index is None:
+        reasons.append(
+            "selected_candidate_not_in_grid"
+        )
+        previous = None
+    else:
+        previous = (
+            grid[selected_index - 1]
+            if selected_index > 0
+            else None
+        )
+
+    total_gain = (
+        baseline_loss - selected_loss
+        if baseline_loss is not None
+        else None
+    )
+    last_step_gain = (
+        float(previous["binomial_log_loss"])
+        - selected_loss
+        if previous is not None
+        else None
+    )
+    last_step_share = (
+        last_step_gain / total_gain
+        if (
+            last_step_gain is not None
+            and total_gain is not None
+            and total_gain > 0
+        )
+        else None
+    )
+
+    maximum_candidate = max(
+        float(row["pseudo_count"])
+        for row in grid
+    )
+    selected_at_boundary = (
+        selected_count == maximum_candidate
+    )
+
+    season_range = result.get(
+        "cross_season_candidate_range",
+        {},
+    )
+    season_spread = (
+        _numeric(season_range.get("spread"))
+        if isinstance(season_range, Mapping)
+        else None
+    )
+    season_stable = (
+        season_spread is not None
+        and season_spread == 0.0
+    )
+
+    plateaued_boundary = (
+        selected_at_boundary
+        and season_stable
+        and last_step_gain is not None
+        and 0.0 <= last_step_gain
+        <= MAX_LAST_STEP_ABSOLUTE_GAIN
+        and last_step_share is not None
+        and last_step_share
+        <= MAX_LAST_STEP_SHARE_OF_TOTAL_GAIN
+    )
+
+    if total_gain is None or total_gain <= 0:
+        reasons.append(
+            "no_improvement_over_unshrunk"
+        )
+
+    if not season_stable:
+        reasons.append(
+            "cross_season_candidate_instability"
+        )
+
+    if (
+        selected_at_boundary
+        and not plateaued_boundary
+    ):
+        reasons.append(
+            "unresolved_upper_grid_boundary"
+        )
+
+    return {
+        "metric": metric,
+        "status": (
+            "selected"
+            if not reasons
+            else "blocked"
+        ),
+        "pseudo_count": selected_count,
+        "total_log_loss_gain": total_gain,
+        "selected_at_upper_boundary": (
+            selected_at_boundary
+        ),
+        "plateaued_boundary": (
+            plateaued_boundary
+        ),
+        "previous_candidate": (
+            float(previous["pseudo_count"])
+            if previous is not None
+            else None
+        ),
+        "last_step_log_loss_gain": (
+            last_step_gain
+        ),
+        "last_step_share_of_total_gain": (
+            last_step_share
+        ),
+        "cross_season_candidate_range": (
+            dict(season_range)
+            if isinstance(
+                season_range,
+                Mapping,
+            )
+            else {}
+        ),
+        "reasons": reasons,
+    }
+
+
+def finalize_canonical_pitcher_matchup_profile_calibration(
+    artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Select stable pooled parameters without production activation."""
+    if artifact.get("shadow_only") is not True:
+        raise ValueError(
+            "calibration artifact must be shadow-only"
+        )
+    if (
+        artifact.get(
+            "production_authority_changed"
+        )
+        is not False
+    ):
+        raise ValueError(
+            "calibration artifact changed production authority"
+        )
+    if artifact.get("parameter_selected") is not False:
+        raise ValueError(
+            "input artifact already selected parameters"
+        )
+
+    calibration = artifact.get("calibration")
+    if not isinstance(calibration, Mapping):
+        raise ValueError(
+            "calibration payload is required"
+        )
+
+    metric_results = calibration.get(
+        "metric_results"
+    )
+    if not isinstance(metric_results, Mapping):
+        raise ValueError(
+            "metric results are required"
+        )
+
+    evaluations = {
+        metric: _evaluate_metric(
+            metric,
+            result,
+        )
+        for metric, result in sorted(
+            metric_results.items()
+        )
+        if isinstance(result, Mapping)
+    }
+
+    selected = {
+        metric: evaluation["pseudo_count"]
+        for metric, evaluation in evaluations.items()
+        if evaluation["status"] == "selected"
+    }
+    blocked = {
+        metric: evaluation["reasons"]
+        for metric, evaluation in evaluations.items()
+        if evaluation["status"] == "blocked"
+    }
+
+    return {
+        "schema_version": (
+            CALIBRATION_POLICY_VERSION
+        ),
+        "status": (
+            "ready"
+            if selected
+            else "blocked"
+        ),
+        "selection_scope": (
+            "pooled_metrics_only"
+        ),
+        "parameter_selected": bool(selected),
+        "selected_pseudo_counts": selected,
+        "blocked_metrics": blocked,
+        "metric_evaluations": evaluations,
+        "segment_parameters_selected": False,
+        "segment_policy": (
+            "deferred_pending_season_disjoint_"
+            "segment_stability"
+        ),
+        "production_authority_changed": False,
+        "production_authority": False,
+        "activation_status": (
+            "candidate_policy_ready"
+            if selected
+            else "blocked"
+        ),
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_evidence.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_evidence.py
@@ -1,0 +1,594 @@
+"""Cutoff-safe evidence for canonical pitcher matchup profiles."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import math
+from collections import defaultdict
+from typing import Any, Iterable
+
+
+CANONICAL_PITCHER_MATCHUP_PROFILE_EVIDENCE_VERSION = (
+    "canonical_pitcher_matchup_profile_evidence_v1"
+)
+
+WINDOW_DAYS = 90
+
+TERMINAL_EVENTS = {
+    "single",
+    "double",
+    "triple",
+    "home_run",
+    "strikeout",
+    "strikeout_double_play",
+    "field_out",
+    "force_out",
+    "walk",
+    "intent_walk",
+    "hit_by_pitch",
+    "double_play",
+    "grounded_into_double_play",
+    "fielders_choice",
+    "fielders_choice_out",
+    "sac_fly",
+    "sac_bunt",
+}
+
+STRIKEOUT_EVENTS = {
+    "strikeout",
+    "strikeout_double_play",
+}
+
+WALK_EVENTS = {"walk"}
+
+CONTACT_CLASSIFICATION = {
+    "source": "internal_launch_angle_classification_v1",
+    "ground_ball": "launch_angle < 10",
+    "line_drive": "10 <= launch_angle < 25",
+    "fly_ball": "25 <= launch_angle < 50",
+    "popup": "launch_angle >= 50",
+    "sweet_spot": "8 <= launch_angle <= 32",
+    "barrel_approximation": (
+        "launch_speed >= 98 and 8 <= launch_angle <= 50"
+    ),
+    "barrel_denominator": "batted balls with exit velocity and launch angle",
+    "hard_hit": "launch_speed >= 95",
+    "official_statcast_classification": False,
+}
+
+
+def _value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _finite(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if math.isfinite(parsed) else None
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str):
+        return dt.date.fromisoformat(value)
+    raise TypeError("date value must be ISO text or date")
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(numerator / denominator, 6)
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(sum(values) / len(values), 6)
+
+
+def _percentile(
+    values: list[float],
+    percentile: float,
+) -> float | None:
+    if not values:
+        return None
+
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return round(ordered[0], 3)
+
+    position = (len(ordered) - 1) * percentile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+
+    if lower == upper:
+        value = ordered[lower]
+    else:
+        weight = position - lower
+        value = (
+            ordered[lower] * (1.0 - weight)
+            + ordered[upper] * weight
+        )
+
+    return round(value, 3)
+
+
+def _pitch_identity(row: Any) -> tuple[Any, ...]:
+    game_pk = _value(row, "game_pk")
+    at_bat = _value(row, "at_bat_number")
+    pitch_number = _value(row, "pitch_number")
+
+    if (
+        game_pk is not None
+        and at_bat is not None
+        and pitch_number is not None
+    ):
+        return (
+            "canonical",
+            game_pk,
+            at_bat,
+            pitch_number,
+        )
+
+    return (
+        "legacy",
+        _value(row, "id"),
+        _value(row, "game_date"),
+        _value(row, "batter_id"),
+        _value(row, "events"),
+        _value(row, "description"),
+        _value(row, "launch_speed"),
+        _value(row, "launch_angle"),
+    )
+
+
+def _pa_identity(row: Any) -> tuple[Any, ...]:
+    game_pk = _value(row, "game_pk")
+    at_bat = _value(row, "at_bat_number")
+
+    if game_pk is not None and at_bat is not None:
+        return ("canonical", game_pk, at_bat)
+
+    return (
+        "legacy",
+        _value(row, "game_date"),
+        _value(row, "batter_id"),
+        _value(row, "id"),
+    )
+
+
+def _sort_key(row: Any) -> tuple[Any, ...]:
+    return (
+        _date(_value(row, "game_date")),
+        _value(row, "game_pk") or -1,
+        _value(row, "at_bat_number") or -1,
+        _value(row, "pitch_number") or -1,
+        _value(row, "id") or -1,
+    )
+
+
+def _empty_counter() -> dict[str, Any]:
+    return {
+        "plate_appearances": 0,
+        "strikeouts": 0,
+        "unintentional_walks": 0,
+        "batted_balls": 0,
+        "hard_hits": 0,
+        "barrels_approx": 0,
+        "sweet_spot_batted_balls": 0,
+        "ground_balls": 0,
+        "line_drives": 0,
+        "fly_balls": 0,
+        "popups": 0,
+        "exit_velocities": [],
+        "launch_angles": [],
+        "xwoba_values": [],
+        "xba_values": [],
+    }
+
+
+def _add_plate_appearance(
+    counter: dict[str, Any],
+    row: Any,
+) -> None:
+    event = _value(row, "events")
+    counter["plate_appearances"] += 1
+
+    if event in STRIKEOUT_EVENTS:
+        counter["strikeouts"] += 1
+    if event in WALK_EVENTS:
+        counter["unintentional_walks"] += 1
+
+
+def _add_contact(
+    counter: dict[str, Any],
+    row: Any,
+) -> None:
+    exit_velocity = _finite(
+        _value(row, "launch_speed")
+    )
+    launch_angle = _finite(
+        _value(row, "launch_angle")
+    )
+
+    if exit_velocity is None:
+        return
+
+    counter["batted_balls"] += 1
+    counter["exit_velocities"].append(exit_velocity)
+
+    if exit_velocity >= 95:
+        counter["hard_hits"] += 1
+
+    if launch_angle is not None:
+        counter["launch_angles"].append(launch_angle)
+
+        if launch_angle < 10:
+            counter["ground_balls"] += 1
+        elif launch_angle < 25:
+            counter["line_drives"] += 1
+        elif launch_angle < 50:
+            counter["fly_balls"] += 1
+        else:
+            counter["popups"] += 1
+
+        if 8 <= launch_angle <= 32:
+            counter["sweet_spot_batted_balls"] += 1
+
+        if (
+            exit_velocity >= 98
+            and 8 <= launch_angle <= 50
+        ):
+            counter["barrels_approx"] += 1
+
+    xwoba = _finite(
+        _value(
+            row,
+            "estimated_woba_using_speedangle",
+        )
+    )
+    if xwoba is not None:
+        counter["xwoba_values"].append(xwoba)
+
+    xba = _finite(
+        _value(
+            row,
+            "estimated_ba_using_speedangle",
+        )
+    )
+    if xba is not None:
+        counter["xba_values"].append(xba)
+
+
+def _summarize(counter: dict[str, Any]) -> dict[str, Any]:
+    pa = counter["plate_appearances"]
+    bbe = counter["batted_balls"]
+    launch_angle_count = len(
+        counter["launch_angles"]
+    )
+
+    return {
+        "sample_size": {
+            "plate_appearances": pa,
+            "batted_balls": bbe,
+            "launch_angle_batted_balls": (
+                launch_angle_count
+            ),
+            "barrel_eligible_batted_balls": (
+                launch_angle_count
+            ),
+            "xwoba_batted_balls": len(
+                counter["xwoba_values"]
+            ),
+            "xba_batted_balls": len(
+                counter["xba_values"]
+            ),
+        },
+        "discipline": {
+            "strikeouts": counter["strikeouts"],
+            "unintentional_walks": (
+                counter["unintentional_walks"]
+            ),
+            "k_rate": _rate(
+                counter["strikeouts"],
+                pa,
+            ),
+            "bb_rate": _rate(
+                counter["unintentional_walks"],
+                pa,
+            ),
+        },
+        "contact_quality": {
+            "hard_hits": counter["hard_hits"],
+            "barrels_approx": (
+                counter["barrels_approx"]
+            ),
+            "hard_hit_rate_allowed": _rate(
+                counter["hard_hits"],
+                bbe,
+            ),
+            "barrel_rate_allowed_approx": _rate(
+                counter["barrels_approx"],
+                launch_angle_count,
+            ),
+            "avg_exit_velocity_allowed": _mean(
+                counter["exit_velocities"]
+            ),
+            "median_exit_velocity_allowed": (
+                _percentile(
+                    counter["exit_velocities"],
+                    0.50,
+                )
+            ),
+            "p90_exit_velocity_allowed": (
+                _percentile(
+                    counter["exit_velocities"],
+                    0.90,
+                )
+            ),
+            "max_exit_velocity_allowed": (
+                round(
+                    max(counter["exit_velocities"]),
+                    3,
+                )
+                if counter["exit_velocities"]
+                else None
+            ),
+            "xwoba_allowed": _mean(
+                counter["xwoba_values"]
+            ),
+            "xba_allowed": _mean(
+                counter["xba_values"]
+            ),
+        },
+        "launch_angle_distribution": {
+            "sweet_spot_batted_balls": (
+                counter["sweet_spot_batted_balls"]
+            ),
+            "ground_balls": counter["ground_balls"],
+            "line_drives": counter["line_drives"],
+            "fly_balls": counter["fly_balls"],
+            "popups": counter["popups"],
+            "avg_launch_angle_allowed": _mean(
+                counter["launch_angles"]
+            ),
+            "sweet_spot_rate_allowed": _rate(
+                counter["sweet_spot_batted_balls"],
+                launch_angle_count,
+            ),
+            "ground_ball_rate": _rate(
+                counter["ground_balls"],
+                launch_angle_count,
+            ),
+            "line_drive_rate": _rate(
+                counter["line_drives"],
+                launch_angle_count,
+            ),
+            "fly_ball_rate": _rate(
+                counter["fly_balls"],
+                launch_angle_count,
+            ),
+            "popup_rate": _rate(
+                counter["popups"],
+                launch_angle_count,
+            ),
+        },
+        "metric_denominators": {
+            "k_rate": pa,
+            "bb_rate": pa,
+            "hard_hit_rate_allowed": bbe,
+            "barrel_rate_allowed_approx": (
+                launch_angle_count
+            ),
+            "sweet_spot_rate_allowed": (
+                launch_angle_count
+            ),
+            "ground_ball_rate": launch_angle_count,
+            "line_drive_rate": launch_angle_count,
+            "fly_ball_rate": launch_angle_count,
+            "popup_rate": launch_angle_count,
+            "avg_exit_velocity_allowed": bbe,
+            "median_exit_velocity_allowed": bbe,
+            "p90_exit_velocity_allowed": bbe,
+            "max_exit_velocity_allowed": bbe,
+            "avg_launch_angle_allowed": (
+                launch_angle_count
+            ),
+            "xwoba_allowed": len(
+                counter["xwoba_values"]
+            ),
+            "xba_allowed": len(
+                counter["xba_values"]
+            ),
+        },
+    }
+
+
+def build_canonical_pitcher_matchup_profile_evidence(
+    events: Iterable[Any],
+    *,
+    pitcher_id: int,
+    game_date: dt.date | str,
+    window_days: int = WINDOW_DAYS,
+) -> dict[str, Any]:
+    """Build immutable pregame evidence without production authority."""
+    cutoff = _date(game_date)
+    start_date = cutoff - dt.timedelta(
+        days=max(int(window_days), 1)
+    )
+
+    filtered = []
+    seen_pitch_identities = set()
+    eligible_raw_event_count = 0
+
+    for row in events:
+        if _value(row, "pitcher_id") != pitcher_id:
+            continue
+
+        row_date = _date(_value(row, "game_date"))
+        if not start_date <= row_date < cutoff:
+            continue
+
+        eligible_raw_event_count += 1
+        identity = _pitch_identity(row)
+
+        if identity in seen_pitch_identities:
+            continue
+
+        seen_pitch_identities.add(identity)
+        filtered.append(row)
+
+    filtered.sort(key=_sort_key)
+
+    terminal_by_pa = {}
+    contact_by_pa = {}
+
+    for row in filtered:
+        pa_identity = _pa_identity(row)
+
+        if _value(row, "events") in TERMINAL_EVENTS:
+            terminal_by_pa[pa_identity] = row
+
+        if _finite(_value(row, "launch_speed")) is not None:
+            contact_by_pa[pa_identity] = row
+
+    overall = _empty_counter()
+    platoon = defaultdict(_empty_counter)
+    tto = defaultdict(_empty_counter)
+    encounters = defaultdict(int)
+
+    for pa_identity, row in sorted(
+        terminal_by_pa.items(),
+        key=lambda item: _sort_key(item[1]),
+    ):
+        _add_plate_appearance(overall, row)
+
+        stand = _value(row, "stand")
+        platoon_key = (
+            stand
+            if stand in {"L", "R"}
+            else "unknown"
+        )
+        _add_plate_appearance(
+            platoon[platoon_key],
+            row,
+        )
+
+        encounter_key = (
+            (
+                "canonical",
+                _value(row, "game_pk"),
+            )
+            if _value(row, "game_pk") is not None
+            else (
+                "legacy_date",
+                _date(
+                    _value(row, "game_date")
+                ).isoformat(),
+            ),
+            _value(row, "batter_id"),
+        )
+        encounters[encounter_key] += 1
+        encounter = encounters[encounter_key]
+
+        if encounter == 1:
+            tto_key = "1"
+        elif encounter == 2:
+            tto_key = "2"
+        else:
+            tto_key = "3_plus"
+
+        _add_plate_appearance(tto[tto_key], row)
+
+        contact = contact_by_pa.get(pa_identity)
+        if contact is not None:
+            _add_contact(overall, contact)
+            _add_contact(
+                platoon[platoon_key],
+                contact,
+            )
+            _add_contact(tto[tto_key], contact)
+
+    evidence = {
+        "schema_version": (
+            CANONICAL_PITCHER_MATCHUP_PROFILE_EVIDENCE_VERSION
+        ),
+        "status": (
+            "ready"
+            if terminal_by_pa and contact_by_pa
+            else "partial"
+            if terminal_by_pa
+            else "unavailable"
+        ),
+        "pitcher_id": int(pitcher_id),
+        "game_date": cutoff.isoformat(),
+        "window": {
+            "window_days": int(window_days),
+            "start_date_inclusive": (
+                start_date.isoformat()
+            ),
+            "cutoff_date_exclusive": cutoff.isoformat(),
+            "cutoff_rule": (
+                "statcast_event_game_date_"
+                "strictly_before_game_date"
+            ),
+        },
+        "overall": _summarize(overall),
+        "platoon_splits": {
+            key: _summarize(platoon[key])
+            for key in ("L", "R", "unknown")
+        },
+        "times_through_order_splits": {
+            key: _summarize(tto[key])
+            for key in ("1", "2", "3_plus")
+        },
+        "classification": CONTACT_CLASSIFICATION,
+        "diagnostics": {
+            "raw_event_count": eligible_raw_event_count,
+            "deduped_pitch_count": len(filtered),
+            "duplicate_pitch_count": (
+                eligible_raw_event_count - len(filtered)
+            ),
+            "terminal_plate_appearance_count": len(
+                terminal_by_pa
+            ),
+            "contact_plate_appearance_count": len(
+                contact_by_pa
+            ),
+            "production_authority": False,
+            "shrinkage_applied": False,
+            "activation_status": (
+                "evidence_only_pending_calibration"
+            ),
+        },
+    }
+
+    digest_payload = {
+        key: value
+        for key, value in evidence.items()
+        if key != "diagnostics"
+    }
+    evidence["diagnostics"]["evidence_digest"] = (
+        hashlib.sha256(
+            json.dumps(
+                digest_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+    )
+
+    return evidence

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_holdout.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_holdout.py
@@ -1,0 +1,419 @@
+"""Historical holdouts for canonical pitcher-profile shrinkage."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from .canonical_pitcher_matchup_profile_evidence import (
+    build_canonical_pitcher_matchup_profile_evidence,
+)
+
+
+CANONICAL_PITCHER_MATCHUP_PROFILE_HOLDOUT_VERSION = (
+    "canonical_pitcher_matchup_profile_holdout_v1"
+)
+
+DEFAULT_TRAINING_WINDOW_DAYS = 90
+DEFAULT_HOLDOUT_WINDOW_DAYS = 30
+
+METRIC_SPECS = {
+    "k_rate": (
+        "discipline",
+        "discipline",
+        "strikeouts",
+    ),
+    "bb_rate": (
+        "discipline",
+        "discipline",
+        "unintentional_walks",
+    ),
+    "hard_hit_rate_allowed": (
+        "contact",
+        "contact_quality",
+        "hard_hits",
+    ),
+    "barrel_rate_allowed_approx": (
+        "contact",
+        "contact_quality",
+        "barrels_approx",
+    ),
+    "sweet_spot_rate_allowed": (
+        "launch_angle",
+        "launch_angle_distribution",
+        "sweet_spot_batted_balls",
+    ),
+    "ground_ball_rate": (
+        "launch_angle",
+        "launch_angle_distribution",
+        "ground_balls",
+    ),
+    "line_drive_rate": (
+        "launch_angle",
+        "launch_angle_distribution",
+        "line_drives",
+    ),
+    "fly_ball_rate": (
+        "launch_angle",
+        "launch_angle_distribution",
+        "fly_balls",
+    ),
+    "popup_rate": (
+        "launch_angle",
+        "launch_angle_distribution",
+        "popups",
+    ),
+}
+
+
+def _value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str):
+        return dt.date.fromisoformat(value)
+    raise TypeError("cutoff must be ISO text or date")
+
+
+def _segments(
+    evidence: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    platoon = evidence.get("platoon_splits") or {}
+    tto = (
+        evidence.get("times_through_order_splits")
+        or {}
+    )
+
+    return {
+        "overall": evidence.get("overall") or {},
+        "vsL": platoon.get("L") or {},
+        "vsR": platoon.get("R") or {},
+        "tto1": tto.get("1") or {},
+        "tto2": tto.get("2") or {},
+        "tto3_plus": tto.get("3_plus") or {},
+    }
+
+
+def _metric_counts(
+    summary: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    denominators = (
+        summary.get("metric_denominators") or {}
+    )
+    rows = {}
+
+    for metric, (
+        family,
+        component,
+        numerator_key,
+    ) in METRIC_SPECS.items():
+        component_values = summary.get(component) or {}
+        numerator = component_values.get(numerator_key)
+        denominator = denominators.get(metric)
+
+        if numerator is None or denominator is None:
+            continue
+
+        rows[metric] = {
+            "family": family,
+            "successes": int(numerator),
+            "trials": int(denominator),
+        }
+
+    return rows
+
+
+def _minimum(
+    value: int | Mapping[str, int],
+    family: str,
+) -> int:
+    if isinstance(value, Mapping):
+        selected = value.get(
+            family,
+            value.get("default", 1),
+        )
+    else:
+        selected = value
+
+    parsed = int(selected)
+    if parsed < 1:
+        raise ValueError(
+            "minimum trials must be positive"
+        )
+
+    return parsed
+
+
+def materialize_canonical_pitcher_matchup_profile_holdouts(
+    events: Iterable[Any],
+    *,
+    cutoffs: Sequence[dt.date | str],
+    training_window_days: int = (
+        DEFAULT_TRAINING_WINDOW_DAYS
+    ),
+    holdout_window_days: int = (
+        DEFAULT_HOLDOUT_WINDOW_DAYS
+    ),
+    minimum_training_trials: int | Mapping[str, int] = 1,
+    minimum_holdout_trials: int | Mapping[str, int] = 1,
+) -> dict[str, Any]:
+    """Materialize leakage-safe samples for shrinkage calibration."""
+    training_days = int(training_window_days)
+    holdout_days = int(holdout_window_days)
+
+    if training_days < 1 or holdout_days < 1:
+        raise ValueError(
+            "training and holdout windows must be positive"
+        )
+
+    cutoff_dates = tuple(sorted({
+        _date(cutoff)
+        for cutoff in cutoffs
+    }))
+    if not cutoff_dates:
+        raise ValueError("at least one cutoff is required")
+
+    earliest = cutoff_dates[0] - dt.timedelta(
+        days=training_days
+    )
+    latest = cutoff_dates[-1] + dt.timedelta(
+        days=holdout_days
+    )
+
+    events_by_pitcher = defaultdict(list)
+    raw_event_count = 0
+
+    for row in events:
+        pitcher_id = _value(row, "pitcher_id")
+        game_date = _date(_value(row, "game_date"))
+
+        if pitcher_id in (None, 0):
+            continue
+        if not earliest <= game_date < latest:
+            continue
+
+        raw_event_count += 1
+        events_by_pitcher[int(pitcher_id)].append(row)
+
+    samples = []
+    cutoff_diagnostics = []
+
+    for cutoff in cutoff_dates:
+        holdout_end = cutoff + dt.timedelta(
+            days=holdout_days
+        )
+        pitcher_material = {}
+        league_totals = defaultdict(
+            lambda: {
+                "successes": 0,
+                "trials": 0,
+            }
+        )
+
+        for pitcher_id in sorted(events_by_pitcher):
+            pitcher_events = events_by_pitcher[pitcher_id]
+            training = (
+                build_canonical_pitcher_matchup_profile_evidence(
+                    pitcher_events,
+                    pitcher_id=pitcher_id,
+                    game_date=cutoff,
+                    window_days=training_days,
+                )
+            )
+            holdout = (
+                build_canonical_pitcher_matchup_profile_evidence(
+                    pitcher_events,
+                    pitcher_id=pitcher_id,
+                    game_date=holdout_end,
+                    window_days=holdout_days,
+                )
+            )
+
+            training_segments = _segments(training)
+            holdout_segments = _segments(holdout)
+            pitcher_rows = []
+
+            for segment in sorted(training_segments):
+                training_counts = _metric_counts(
+                    training_segments[segment]
+                )
+                holdout_counts = _metric_counts(
+                    holdout_segments[segment]
+                )
+
+                for metric in sorted(METRIC_SPECS):
+                    training_row = training_counts.get(metric)
+                    holdout_row = holdout_counts.get(metric)
+
+                    if training_row is None:
+                        continue
+
+                    family = training_row["family"]
+                    total_key = (segment, metric)
+                    league_totals[total_key][
+                        "successes"
+                    ] += training_row["successes"]
+                    league_totals[total_key][
+                        "trials"
+                    ] += training_row["trials"]
+
+                    if holdout_row is None:
+                        continue
+
+                    pitcher_rows.append({
+                        "pitcher_id": pitcher_id,
+                        "season": cutoff.year,
+                        "cutoff": cutoff.isoformat(),
+                        "holdout_end_exclusive": (
+                            holdout_end.isoformat()
+                        ),
+                        "segment": segment,
+                        "metric": metric,
+                        "family": family,
+                        "training_successes": (
+                            training_row["successes"]
+                        ),
+                        "training_trials": (
+                            training_row["trials"]
+                        ),
+                        "holdout_successes": (
+                            holdout_row["successes"]
+                        ),
+                        "holdout_trials": (
+                            holdout_row["trials"]
+                        ),
+                    })
+
+            pitcher_material[pitcher_id] = pitcher_rows
+
+        rejected_threshold = 0
+        rejected_prior = 0
+        cutoff_sample_count = 0
+
+        for pitcher_id in sorted(pitcher_material):
+            for row in pitcher_material[pitcher_id]:
+                family = row["family"]
+
+                if row["training_trials"] < _minimum(
+                    minimum_training_trials,
+                    family,
+                ):
+                    rejected_threshold += 1
+                    continue
+                if row["holdout_trials"] < _minimum(
+                    minimum_holdout_trials,
+                    family,
+                ):
+                    rejected_threshold += 1
+                    continue
+
+                total = league_totals[
+                    (row["segment"], row["metric"])
+                ]
+                prior_successes = (
+                    total["successes"]
+                    - row["training_successes"]
+                )
+                prior_trials = (
+                    total["trials"]
+                    - row["training_trials"]
+                )
+
+                if prior_trials <= 0:
+                    rejected_prior += 1
+                    continue
+
+                prior_probability = (
+                    prior_successes / prior_trials
+                )
+
+                samples.append({
+                    **row,
+                    "prior_successes_excluding_pitcher": (
+                        prior_successes
+                    ),
+                    "prior_trials_excluding_pitcher": (
+                        prior_trials
+                    ),
+                    "prior_probability": (
+                        prior_probability
+                    ),
+                    "prior_scope": (
+                        "same_cutoff_segment_metric_"
+                        "excluding_pitcher"
+                    ),
+                })
+                cutoff_sample_count += 1
+
+        cutoff_diagnostics.append({
+            "cutoff": cutoff.isoformat(),
+            "holdout_end_exclusive": (
+                holdout_end.isoformat()
+            ),
+            "pitcher_count": len(pitcher_material),
+            "sample_count": cutoff_sample_count,
+            "rejected_threshold_count": (
+                rejected_threshold
+            ),
+            "rejected_prior_count": rejected_prior,
+        })
+
+    samples.sort(key=lambda row: (
+        row["cutoff"],
+        row["pitcher_id"],
+        row["segment"],
+        row["metric"],
+    ))
+
+    digest = hashlib.sha256(
+        json.dumps(
+            samples,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    return {
+        "schema_version": (
+            CANONICAL_PITCHER_MATCHUP_PROFILE_HOLDOUT_VERSION
+        ),
+        "status": "ready" if samples else "blocked",
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "parameter_selected": False,
+        "training_window_days": training_days,
+        "holdout_window_days": holdout_days,
+        "cutoffs": [
+            cutoff.isoformat()
+            for cutoff in cutoff_dates
+        ],
+        "raw_event_count": raw_event_count,
+        "pitcher_count": len(events_by_pitcher),
+        "sample_count": len(samples),
+        "samples": samples,
+        "cutoff_diagnostics": cutoff_diagnostics,
+        "sample_digest": digest,
+        "cutoff_contract": {
+            "training": (
+                "[cutoff-training_window, cutoff)"
+            ),
+            "holdout": (
+                "[cutoff, cutoff+holdout_window)"
+            ),
+            "prior": (
+                "same cutoff, segment, and metric "
+                "excluding evaluated pitcher"
+            ),
+        },
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_league_prior.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_league_prior.py
@@ -1,0 +1,306 @@
+"""Build cutoff-safe league priors for pitcher-profile shrinkage."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .canonical_pitcher_matchup_profile_evidence import (
+    build_canonical_pitcher_matchup_profile_evidence,
+)
+from .canonical_pitcher_matchup_profile_holdout import (
+    METRIC_SPECS,
+)
+
+
+LEAGUE_PRIOR_VERSION = (
+    "canonical_pitcher_matchup_profile_league_prior_v1"
+)
+
+
+def _value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value).strip()[:10]
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date must be a valid date"
+        ) from exc
+
+
+def _pitcher_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if parsed > 0 else None
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(parsed):
+        return None
+
+    return parsed
+
+
+def _counts(
+    summary: Mapping[str, Any],
+    metric: str,
+) -> tuple[int, int] | None:
+    specification = METRIC_SPECS.get(metric)
+    if specification is None:
+        return None
+
+    _, component, numerator_key = specification
+    component_values = summary.get(component)
+    denominators = summary.get(
+        "metric_denominators"
+    )
+
+    if (
+        not isinstance(
+            component_values,
+            Mapping,
+        )
+        or not isinstance(
+            denominators,
+            Mapping,
+        )
+    ):
+        return None
+
+    numerator = _number(
+        component_values.get(numerator_key)
+    )
+    denominator = _number(
+        denominators.get(metric)
+    )
+
+    if (
+        numerator is None
+        or denominator is None
+        or numerator < 0
+        or denominator <= 0
+        or numerator > denominator
+        or not numerator.is_integer()
+        or not denominator.is_integer()
+    ):
+        return None
+
+    return int(numerator), int(denominator)
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def build_canonical_pitcher_matchup_profile_league_priors(
+    events: Iterable[Any],
+    *,
+    game_date: dt.date | str,
+    excluded_pitcher_id: int,
+    window_days: int = 90,
+    metrics: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Build pregame league priors excluding the evaluated pitcher."""
+    cutoff = _date(game_date)
+    excluded = _pitcher_id(
+        excluded_pitcher_id
+    )
+    days = int(window_days)
+
+    if excluded is None:
+        raise ValueError(
+            "excluded_pitcher_id must be positive"
+        )
+    if days < 1:
+        raise ValueError(
+            "window_days must be positive"
+        )
+
+    selected_metrics = tuple(sorted(
+        set(metrics or METRIC_SPECS)
+    ))
+    unknown_metrics = tuple(
+        metric
+        for metric in selected_metrics
+        if metric not in METRIC_SPECS
+    )
+
+    if unknown_metrics:
+        raise ValueError(
+            "unknown metrics: "
+            + ", ".join(unknown_metrics)
+        )
+
+    grouped = defaultdict(list)
+    raw_event_count = 0
+    excluded_event_count = 0
+    invalid_pitcher_event_count = 0
+
+    for row in events:
+        raw_event_count += 1
+        pitcher = _pitcher_id(
+            _value(row, "pitcher_id")
+        )
+
+        if pitcher is None:
+            invalid_pitcher_event_count += 1
+            continue
+
+        if pitcher == excluded:
+            excluded_event_count += 1
+            continue
+
+        grouped[pitcher].append(row)
+
+    totals = {
+        metric: {
+            "successes": 0,
+            "trials": 0,
+            "contributing_pitchers": 0,
+        }
+        for metric in selected_metrics
+    }
+
+    for pitcher in sorted(grouped):
+        evidence = (
+            build_canonical_pitcher_matchup_profile_evidence(
+                grouped[pitcher],
+                pitcher_id=pitcher,
+                game_date=cutoff,
+                window_days=days,
+            )
+        )
+        overall = evidence.get("overall")
+
+        if not isinstance(overall, Mapping):
+            continue
+
+        for metric in selected_metrics:
+            row_counts = _counts(
+                overall,
+                metric,
+            )
+            if row_counts is None:
+                continue
+
+            successes, trials = row_counts
+            totals[metric]["successes"] += (
+                successes
+            )
+            totals[metric]["trials"] += trials
+            totals[metric][
+                "contributing_pitchers"
+            ] += 1
+
+    priors = {}
+    metric_diagnostics = {}
+
+    for metric in selected_metrics:
+        total = totals[metric]
+        trials = total["trials"]
+
+        if trials > 0:
+            prior = (
+                total["successes"] / trials
+            )
+            priors[metric] = round(
+                prior,
+                12,
+            )
+            status = "ready"
+            reasons = []
+        else:
+            status = "unavailable"
+            reasons = [
+                "league_trials_unavailable"
+            ]
+
+        metric_diagnostics[metric] = {
+            "status": status,
+            "successes": total["successes"],
+            "trials": trials,
+            "contributing_pitchers": (
+                total["contributing_pitchers"]
+            ),
+            "prior": priors.get(metric),
+            "reasons": reasons,
+        }
+
+    if not priors:
+        status = "unavailable"
+    elif len(priors) < len(selected_metrics):
+        status = "partial"
+    else:
+        status = "ready"
+
+    diagnostics = {
+        "schema_version": LEAGUE_PRIOR_VERSION,
+        "status": status,
+        "game_date": cutoff.isoformat(),
+        "window_days": days,
+        "cutoff_rule": (
+            "events_strictly_before_game_date"
+        ),
+        "prior_scope": (
+            "all_other_pitchers_in_window"
+        ),
+        "excluded_pitcher_id": excluded,
+        "raw_event_count": raw_event_count,
+        "excluded_event_count": (
+            excluded_event_count
+        ),
+        "invalid_pitcher_event_count": (
+            invalid_pitcher_event_count
+        ),
+        "candidate_pitcher_count": len(grouped),
+        "metric_diagnostics": (
+            metric_diagnostics
+        ),
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["prior_digest"] = _digest(
+        diagnostics
+    )
+
+    return {
+        "league_priors": priors,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_activation.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_activation.py
@@ -1,0 +1,310 @@
+"""Select audited pitcher-profile PA probabilities for production use.
+
+The selector is fail closed. Production probabilities remain authoritative
+unless activation is explicitly requested and the comparator payload satisfies
+the pinned historical-evidence contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_activation_v1"
+)
+
+APPROVED_ELIGIBILITY_DIGEST = (
+    "c8f491ab1668da64de6bae4066b1e7a4"
+    "62af68f1b4e74bba296a9546561cf9c4"
+)
+APPROVED_HISTORICAL_EVALUATION_DIGEST = (
+    "b0197ea2a54ab4834ac6d1aed0e2b818"
+    "5f0fe5006b2be841847d1481328a4160"
+)
+APPROVED_CROSS_SEASON_AUDIT_DIGEST = (
+    "7f85e5340c1e20e3b634fc52b9720ce0"
+    "0e97f720031fcba1354ed2b464da1260"
+)
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _mapping(
+    value: Any,
+) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return deepcopy(dict(value))
+    return {}
+
+
+def _probabilities(
+    value: Any,
+) -> dict[str, float] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    normalized = {}
+
+    for key, raw_value in value.items():
+        if (
+            isinstance(raw_value, bool)
+            or not isinstance(
+                raw_value,
+                (int, float),
+            )
+        ):
+            return None
+
+        number = float(raw_value)
+
+        if (
+            not math.isfinite(number)
+            or not 0.0 <= number <= 1.0
+        ):
+            return None
+
+        normalized[str(key)] = number
+
+    if not normalized:
+        return None
+    if not math.isclose(
+        sum(normalized.values()),
+        1.0,
+        rel_tol=0.0,
+        abs_tol=1e-9,
+    ):
+        return None
+
+    return normalized
+
+
+def select_canonical_pitcher_matchup_profile_pa_model(
+    *,
+    production_model: Mapping[str, Any],
+    comparison: Mapping[str, Any],
+    activation_requested: bool,
+    eligibility_digest: str,
+    historical_evaluation_digest: str,
+    cross_season_audit_digest: str,
+) -> dict[str, Any]:
+    """Select production or audited candidate PA probabilities."""
+
+    if not isinstance(
+        activation_requested,
+        bool,
+    ):
+        raise ValueError(
+            "activation_requested_must_be_boolean"
+        )
+
+    production = _mapping(production_model)
+    comparison_value = _mapping(comparison)
+    production_probabilities = (
+        _probabilities(
+            production.get("probabilities")
+        )
+    )
+    blockers = []
+
+    if production_probabilities is None:
+        blockers.append(
+            "production_probabilities_invalid"
+        )
+
+    evidence_matches = {
+        "eligibility_digest": (
+            str(eligibility_digest)
+            == APPROVED_ELIGIBILITY_DIGEST
+        ),
+        "historical_evaluation_digest": (
+            str(historical_evaluation_digest)
+            == APPROVED_HISTORICAL_EVALUATION_DIGEST
+        ),
+        "cross_season_audit_digest": (
+            str(cross_season_audit_digest)
+            == APPROVED_CROSS_SEASON_AUDIT_DIGEST
+        ),
+    }
+
+    if activation_requested:
+        for name, matched in (
+            evidence_matches.items()
+        ):
+            if not matched:
+                blockers.append(
+                    f"{name}_not_approved"
+                )
+
+        if comparison_value.get(
+            "status"
+        ) != "ready":
+            blockers.append(
+                "candidate_comparison_not_ready"
+            )
+        if comparison_value.get(
+            "executed"
+        ) is not True:
+            blockers.append(
+                "candidate_comparison_not_executed"
+            )
+        if comparison_value.get(
+            "production_inputs_unchanged"
+        ) is not True:
+            blockers.append(
+                "comparison_authority_contract_invalid"
+            )
+        if comparison_value.get(
+            "production_authority_changed"
+        ) is not False:
+            blockers.append(
+                "comparison_authority_contract_invalid"
+            )
+
+    candidate_probabilities = (
+        _probabilities(
+            comparison_value.get(
+                "shadow_probabilities"
+            )
+        )
+        if activation_requested
+        else None
+    )
+
+    if (
+        activation_requested
+        and candidate_probabilities is None
+    ):
+        blockers.append(
+            "candidate_probabilities_invalid"
+        )
+
+    if (
+        activation_requested
+        and production_probabilities
+        is not None
+        and candidate_probabilities
+        is not None
+        and set(candidate_probabilities)
+        != set(production_probabilities)
+    ):
+        blockers.append(
+            "candidate_outcome_keys_mismatch"
+        )
+
+    blockers = list(dict.fromkeys(blockers))
+    activated = (
+        activation_requested
+        and not blockers
+    )
+
+    selected_model = deepcopy(production)
+
+    if activated:
+        selected_model["probabilities"] = (
+            candidate_probabilities
+        )
+        selected_model["model_version"] = (
+            comparison_value.get(
+                "shadow_model_version"
+            )
+            or selected_model.get(
+                "model_version"
+            )
+        )
+        selected_model[
+            "pitcher_matchup_profile_activation"
+        ] = {
+            "schema_version": SCHEMA_VERSION,
+            "source": (
+                "audited_canonical_pitcher_matchup_profile"
+            ),
+            "eligibility_digest": (
+                APPROVED_ELIGIBILITY_DIGEST
+            ),
+            "historical_evaluation_digest": (
+                APPROVED_HISTORICAL_EVALUATION_DIGEST
+            ),
+            "cross_season_audit_digest": (
+                APPROVED_CROSS_SEASON_AUDIT_DIGEST
+            ),
+        }
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "activated"
+            if activated
+            else (
+                "blocked"
+                if activation_requested
+                else "inactive"
+            )
+        ),
+        "activation_status": (
+            "production_candidate_activated"
+            if activated
+            else (
+                "production_activation_blocked"
+                if activation_requested
+                else "production_activation_not_requested"
+            )
+        ),
+        "activation_requested": (
+            activation_requested
+        ),
+        "activation_executed": activated,
+        "blockers": blockers,
+        "selected_probability_source": (
+            "audited_canonical_pitcher_matchup_profile"
+            if activated
+            else "existing_production_pa_model"
+        ),
+        "evidence_matches": evidence_matches,
+        "outcome_keys": (
+            tuple(
+                sorted(
+                    selected_model.get(
+                        "probabilities",
+                        {},
+                    )
+                )
+            )
+        ),
+        "fail_closed": True,
+        "production_inputs_unchanged": (
+            not activated
+        ),
+        "production_authority": activated,
+        "production_authority_changed": (
+            activated
+        ),
+    }
+    diagnostics["activation_digest"] = (
+        _digest({
+            "diagnostics": diagnostics,
+            "selected_probabilities": (
+                selected_model.get(
+                    "probabilities"
+                )
+            ),
+        })
+    )
+
+    return {
+        "model": selected_model,
+        "activated": activated,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_comparator.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_comparator.py
@@ -1,0 +1,362 @@
+"""Paired PA comparison for canonical pitcher matchup candidates.
+
+This module is deliberately shadow-only. It maps only calibrated, supported
+pitcher metrics into a copied pitcher profile and compares the existing PA
+model against that candidate without changing production inputs.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_comparator_v1"
+)
+
+SUPPORTED_RATE_MAPPINGS = {
+    "k_rate": (
+        "bat_missing",
+        "k_rate",
+    ),
+    "barrel_rate_allowed_approx": (
+        "contact_management",
+        "barrel_rate_allowed",
+    ),
+    "hard_hit_rate_allowed": (
+        "contact_management",
+        "hard_hit_rate_allowed",
+    ),
+}
+
+DEFERRED_RATE_REASONS = {
+    "bb_rate": "cross_season_candidate_instability",
+    "ground_ball_rate": (
+        "pa_outcome_v1_has_no_contact_type_input"
+    ),
+    "line_drive_rate": (
+        "pa_outcome_v1_has_no_contact_type_input"
+    ),
+    "fly_ball_rate": (
+        "pa_outcome_v1_has_no_contact_type_input"
+    ),
+    "popup_rate": (
+        "pa_outcome_v1_has_no_contact_type_input"
+    ),
+    "sweet_spot_rate_allowed": (
+        "pa_outcome_v1_has_no_sweet_spot_input"
+    ),
+}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _reconcile_probability_rounding(
+    probabilities: Mapping[str, Any],
+) -> dict[str, Any]:
+    reconciled = dict(probabilities)
+
+    if "out" not in reconciled:
+        return reconciled
+
+    values = tuple(reconciled.values())
+
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        for value in values
+    ):
+        return reconciled
+
+    residual = round(
+        1.0
+        - sum(
+            float(value)
+            for value in values
+        ),
+        12,
+    )
+
+    if abs(residual) > 0.0005:
+        return reconciled
+
+    adjusted_out = round(
+        float(reconciled["out"])
+        + residual,
+        12,
+    )
+
+    if not 0.0 <= adjusted_out <= 1.0:
+        return reconciled
+
+    reconciled["out"] = adjusted_out
+    return reconciled
+
+
+def _candidate_status(
+    candidate: Mapping[str, Any],
+) -> str | None:
+    diagnostics = _mapping(
+        candidate.get("diagnostics")
+    )
+    return diagnostics.get("status")
+
+
+def _set_nested_rate(
+    profile: dict[str, Any],
+    path: tuple[str, str],
+    value: Any,
+) -> bool:
+    if not isinstance(value, (int, float)):
+        return False
+
+    normalized = float(value)
+
+    if not 0.0 <= normalized <= 1.0:
+        return False
+
+    family, metric = path
+    container = profile.get(family)
+
+    if not isinstance(container, dict):
+        container = {}
+        profile[family] = container
+
+    container[metric] = normalized
+    return True
+
+
+def compare_canonical_pitcher_matchup_profile_pa_outcomes(
+    *,
+    candidate: Mapping[str, Any],
+    production_pitcher_profile: Mapping[str, Any],
+    batter_profile: Mapping[str, Any],
+    environment_profile: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Run immutable production/candidate PA models side by side."""
+    candidate_payload = _mapping(candidate)
+    production_profile = deepcopy(
+        _mapping(production_pitcher_profile)
+    )
+
+    diagnostics = _mapping(
+        candidate_payload.get("diagnostics")
+    )
+    candidate_status = _candidate_status(
+        candidate_payload
+    )
+
+    if candidate_status != "ready":
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "blocked",
+            "executed": False,
+            "blockers": [
+                "pitcher_matchup_profile_candidate_not_ready"
+            ],
+            "candidate_status": candidate_status,
+            "shadow_only": True,
+            "production_inputs_unchanged": True,
+            "production_authority": False,
+            "production_authority_changed": False,
+        }
+
+    if (
+        diagnostics.get("production_authority")
+        is not False
+        or diagnostics.get(
+            "production_authority_changed"
+        )
+        is not False
+    ):
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "blocked",
+            "executed": False,
+            "blockers": [
+                "candidate_authority_contract_invalid"
+            ],
+            "candidate_status": candidate_status,
+            "shadow_only": True,
+            "production_inputs_unchanged": True,
+            "production_authority": False,
+            "production_authority_changed": False,
+        }
+
+    candidate_profile = deepcopy(
+        production_profile
+    )
+    profile_rates = _mapping(
+        candidate_payload.get("profile_rates")
+    )
+    applied_rates: dict[str, float] = {}
+    rejected_rates: dict[str, str] = {}
+
+    for source_metric, target_path in (
+        SUPPORTED_RATE_MAPPINGS.items()
+    ):
+        value = profile_rates.get(source_metric)
+
+        if _set_nested_rate(
+            candidate_profile,
+            target_path,
+            value,
+        ):
+            applied_rates[source_metric] = float(
+                value
+            )
+        else:
+            rejected_rates[source_metric] = (
+                "missing_or_invalid_candidate_rate"
+            )
+
+    deferred_rates = {
+        metric: reason
+        for metric, reason in (
+            DEFERRED_RATE_REASONS.items()
+        )
+        if metric in profile_rates
+        or metric == "bb_rate"
+    }
+
+    if not applied_rates:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "blocked",
+            "executed": False,
+            "blockers": [
+                "no_supported_candidate_rates"
+            ],
+            "applied_rates": {},
+            "rejected_rates": rejected_rates,
+            "deferred_rates": deferred_rates,
+            "shadow_only": True,
+            "production_inputs_unchanged": True,
+            "production_authority": False,
+            "production_authority_changed": False,
+        }
+
+    production_result = (
+        build_pa_outcome_probabilities(
+            batter_profile=_mapping(
+                batter_profile
+            ),
+            pitcher_profile=production_profile,
+            environment_profile=_mapping(
+                environment_profile
+            ),
+        )
+    )
+    shadow_result = (
+        build_pa_outcome_probabilities(
+            batter_profile=_mapping(
+                batter_profile
+            ),
+            pitcher_profile=candidate_profile,
+            environment_profile=_mapping(
+                environment_profile
+            ),
+        )
+    )
+
+    production_probabilities = dict(
+        production_result.get(
+            "probabilities",
+            {},
+        )
+    )
+    shadow_probabilities = (
+        _reconcile_probability_rounding(
+            shadow_result.get(
+                "probabilities",
+                {},
+            )
+        )
+    )
+
+    outcome_keys = sorted(
+        set(production_probabilities)
+        | set(shadow_probabilities)
+    )
+    probability_deltas = {
+        outcome: round(
+            float(
+                shadow_probabilities.get(
+                    outcome,
+                    0.0,
+                )
+            )
+            - float(
+                production_probabilities.get(
+                    outcome,
+                    0.0,
+                )
+            ),
+            12,
+        )
+        for outcome in outcome_keys
+    }
+
+    maximum_delta = max(
+        (
+            abs(value)
+            for value in probability_deltas.values()
+        ),
+        default=0.0,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ready",
+        "executed": True,
+        "comparison_role": (
+            "paired_shadow_pa_probability_diagnostic"
+        ),
+        "production_model_version": (
+            production_result.get("model_version")
+        ),
+        "shadow_model_version": (
+            shadow_result.get("model_version")
+        ),
+        "production_probabilities": (
+            production_probabilities
+        ),
+        "shadow_probabilities": (
+            shadow_probabilities
+        ),
+        "probability_deltas": probability_deltas,
+        "maximum_absolute_probability_delta": (
+            round(maximum_delta, 12)
+        ),
+        "production_probability_sum": round(
+            sum(production_probabilities.values()),
+            12,
+        ),
+        "shadow_probability_sum": round(
+            sum(shadow_probabilities.values()),
+            12,
+        ),
+        "candidate_pitcher_profile": (
+            candidate_profile
+        ),
+        "applied_rates": applied_rates,
+        "rejected_rates": rejected_rates,
+        "deferred_rates": deferred_rates,
+        "mapping_policy": (
+            "supported_calibrated_pooled_metrics_only"
+        ),
+        "segment_parameters_applied": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_candidates.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_candidates.py
@@ -1,0 +1,402 @@
+"""Materialize cutoff-safe pitcher-profile candidates for historical games.
+
+Every requested candidate is built from one shared event collection. The
+runtime candidate enforces its own strict pregame cutoff and calibrated
+shadow-only authority contract.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Iterable, Mapping
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_runtime_candidate import (
+    build_canonical_pitcher_matchup_profile_runtime_candidate,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_candidates_v1"
+)
+
+
+def _value(row: Any, name: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name)
+    return getattr(row, name, None)
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value)
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date_must_be_iso_date"
+        ) from exc
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _candidate_status(
+    candidate: Mapping[str, Any],
+) -> str:
+    diagnostics = candidate.get(
+        "diagnostics"
+    )
+
+    if not isinstance(diagnostics, Mapping):
+        return "unavailable"
+
+    status = diagnostics.get("status")
+
+    if status in {
+        "ready",
+        "partial",
+        "unavailable",
+    }:
+        return str(status)
+
+    return "unavailable"
+
+
+def materialize_canonical_pitcher_matchup_profile_pa_historical_candidates(
+    events: Iterable[Any],
+    *,
+    requests: Iterable[Any],
+    window_days: int = 90,
+) -> dict[str, Any]:
+    """Build one cutoff-safe candidate per historical game-pitcher."""
+    if (
+        not isinstance(window_days, int)
+        or isinstance(window_days, bool)
+        or window_days <= 0
+    ):
+        raise ValueError(
+            "window_days_must_be_positive_integer"
+        )
+
+    event_rows = list(events)
+    request_rows = list(requests)
+    normalized_requests: dict[
+        tuple[int, int],
+        dict[str, Any],
+    ] = {}
+    conflicting_keys: set[
+        tuple[int, int]
+    ] = set()
+    rejected_requests = []
+    duplicate_request_count = 0
+
+    for index, request in enumerate(
+        request_rows
+    ):
+        try:
+            game_pk = _positive_integer(
+                _value(request, "game_pk"),
+                "game_pk",
+            )
+            pitcher_id = _positive_integer(
+                _value(request, "pitcher_id"),
+                "pitcher_id",
+            )
+            game_date = _date(
+                _value(request, "game_date")
+            )
+        except ValueError as exc:
+            rejected_requests.append({
+                "index": index,
+                "reason": str(exc),
+            })
+            continue
+
+        key = (
+            game_pk,
+            pitcher_id,
+        )
+        normalized = {
+            "game_pk": game_pk,
+            "pitcher_id": pitcher_id,
+            "game_date": game_date,
+        }
+
+        if key in conflicting_keys:
+            duplicate_request_count += 1
+            continue
+
+        existing = normalized_requests.get(
+            key
+        )
+
+        if existing is None:
+            normalized_requests[key] = (
+                normalized
+            )
+            continue
+
+        if (
+            existing["game_date"]
+            == game_date
+        ):
+            duplicate_request_count += 1
+            continue
+
+        normalized_requests.pop(
+            key,
+            None,
+        )
+        conflicting_keys.add(key)
+        rejected_requests.append({
+            "index": index,
+            "game_pk": game_pk,
+            "pitcher_id": pitcher_id,
+            "reason": (
+                "conflicting_game_pitcher_request"
+            ),
+        })
+
+    candidates: dict[
+        tuple[int, int],
+        dict[str, Any],
+    ] = {}
+    candidate_records = []
+    status_counts = {
+        "ready": 0,
+        "partial": 0,
+        "unavailable": 0,
+    }
+
+    for key, request in sorted(
+        normalized_requests.items(),
+        key=lambda item: (
+            item[1]["game_date"],
+            item[0][0],
+            item[0][1],
+        ),
+    ):
+        game_pk, pitcher_id = key
+        game_date = request["game_date"]
+
+        try:
+            candidate = (
+                build_canonical_pitcher_matchup_profile_runtime_candidate(
+                    event_rows,
+                    pitcher_id=pitcher_id,
+                    game_date=game_date,
+                    window_days=window_days,
+                )
+            )
+        except (
+            TypeError,
+            ValueError,
+        ) as exc:
+            rejected_requests.append({
+                "game_pk": game_pk,
+                "pitcher_id": pitcher_id,
+                "game_date": (
+                    game_date.isoformat()
+                ),
+                "reason": (
+                    "candidate_materialization_failed:"
+                    + str(exc)
+                ),
+            })
+            continue
+
+        candidate = deepcopy(candidate)
+        status = _candidate_status(
+            candidate
+        )
+        diagnostics = candidate.get(
+            "diagnostics"
+        )
+
+        if not isinstance(
+            diagnostics,
+            Mapping,
+        ):
+            diagnostics = {}
+
+        authority_valid = (
+            diagnostics.get(
+                "production_authority"
+            )
+            is False
+            and diagnostics.get(
+                "production_authority_changed"
+            )
+            is False
+        )
+
+        if not authority_valid:
+            rejected_requests.append({
+                "game_pk": game_pk,
+                "pitcher_id": pitcher_id,
+                "game_date": (
+                    game_date.isoformat()
+                ),
+                "reason": (
+                    "candidate_authority_contract_invalid"
+                ),
+            })
+            continue
+
+        candidates[key] = candidate
+        status_counts[status] += 1
+        candidate_records.append({
+            "game_pk": game_pk,
+            "pitcher_id": pitcher_id,
+            "game_date": (
+                game_date.isoformat()
+            ),
+            "status": status,
+            "cutoff_rule": diagnostics.get(
+                "cutoff_rule"
+            ),
+            "evidence_status": (
+                diagnostics.get(
+                    "evidence_status"
+                )
+            ),
+            "league_prior_status": (
+                diagnostics.get(
+                    "league_prior_status"
+                )
+            ),
+            "application_status": (
+                diagnostics.get(
+                    "application_status"
+                )
+            ),
+            "candidate_digest": (
+                diagnostics.get(
+                    "runtime_candidate_digest"
+                )
+            ),
+        })
+
+    ready_count = status_counts["ready"]
+
+    if (
+        candidates
+        and ready_count == len(candidates)
+        and not rejected_requests
+    ):
+        status = "ready"
+    elif candidates:
+        status = "partial"
+    else:
+        status = "unavailable"
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "event_row_count": len(
+            event_rows
+        ),
+        "raw_request_count": len(
+            request_rows
+        ),
+        "unique_request_count": len(
+            normalized_requests
+        ),
+        "duplicate_request_count": (
+            duplicate_request_count
+        ),
+        "candidate_count": len(
+            candidates
+        ),
+        "ready_candidate_count": (
+            ready_count
+        ),
+        "partial_candidate_count": (
+            status_counts["partial"]
+        ),
+        "unavailable_candidate_count": (
+            status_counts["unavailable"]
+        ),
+        "candidate_status_counts": (
+            status_counts
+        ),
+        "rejected_request_count": len(
+            rejected_requests
+        ),
+        "rejected_requests": (
+            rejected_requests
+        ),
+        "candidate_records": (
+            candidate_records
+        ),
+        "candidate_identity": (
+            "game_pk_pitcher_id"
+        ),
+        "cutoff_rule": (
+            "events_strictly_before_each_game_date"
+        ),
+        "window_days": window_days,
+        "single_shared_event_collection": True,
+        "event_collection_reused": True,
+        "calibrated_pooled_metrics_only": True,
+        "segment_parameters_applied": False,
+        "shadow_only": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["candidate_window_digest"] = (
+        _digest({
+            "candidate_records": (
+                candidate_records
+            ),
+            "diagnostics": diagnostics,
+        })
+    )
+
+    return {
+        "candidates": candidates,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_evaluation.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_evaluation.py
@@ -1,0 +1,588 @@
+"""Historical paired scoring for canonical pitcher PA candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections import defaultdict
+from copy import deepcopy
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_"
+    "historical_evaluation_v1"
+)
+
+OUTCOME_KEYS = (
+    "k",
+    "bb",
+    "hbp",
+    "single",
+    "double",
+    "triple",
+    "hr",
+    "reached_on_error",
+    "out",
+)
+
+PROBABILITY_SUM_TOLERANCE = 0.002
+PROBABILITY_FLOOR = 1e-12
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _probabilities(
+    value: Any,
+) -> dict[str, float]:
+    source = _mapping(value)
+    probabilities = {}
+
+    for outcome in OUTCOME_KEYS:
+        raw = source.get(outcome)
+
+        if not isinstance(raw, (int, float)):
+            raise ValueError(
+                f"missing probability: {outcome}"
+            )
+
+        probability = float(raw)
+
+        if (
+            not math.isfinite(probability)
+            or probability < 0.0
+            or probability > 1.0
+        ):
+            raise ValueError(
+                f"invalid probability: {outcome}"
+            )
+
+        probabilities[outcome] = probability
+
+    total = sum(probabilities.values())
+
+    if abs(total - 1.0) > (
+        PROBABILITY_SUM_TOLERANCE
+    ):
+        raise ValueError(
+            "probability distribution must sum to one"
+        )
+
+    if total <= 0.0:
+        raise ValueError(
+            "probability distribution is empty"
+        )
+
+    return {
+        outcome: (
+            probabilities[outcome] / total
+        )
+        for outcome in OUTCOME_KEYS
+    }
+
+
+def _observed_counts(
+    value: Any,
+) -> dict[str, int]:
+    source = _mapping(value)
+    counts = {}
+
+    for outcome in OUTCOME_KEYS:
+        raw = source.get(outcome, 0)
+
+        if (
+            not isinstance(raw, int)
+            or isinstance(raw, bool)
+            or raw < 0
+        ):
+            raise ValueError(
+                f"invalid observed count: {outcome}"
+            )
+
+        counts[outcome] = raw
+
+    if sum(counts.values()) <= 0:
+        raise ValueError(
+            "observed PA count must be positive"
+        )
+
+    return counts
+
+
+def _score_distribution(
+    probabilities: Mapping[str, float],
+    observed_counts: Mapping[str, int],
+) -> dict[str, float | int]:
+    trials = sum(observed_counts.values())
+    log_loss_sum = 0.0
+    brier_sum = 0.0
+    probability_square_sum = sum(
+        float(probabilities[outcome]) ** 2
+        for outcome in OUTCOME_KEYS
+    )
+
+    for outcome in OUTCOME_KEYS:
+        count = int(
+            observed_counts[outcome]
+        )
+
+        if count <= 0:
+            continue
+
+        probability = max(
+            float(probabilities[outcome]),
+            PROBABILITY_FLOOR,
+        )
+        log_loss_sum += (
+            -count * math.log(probability)
+        )
+        brier_sum += count * (
+            probability_square_sum
+            - (2.0 * probability)
+            + 1.0
+        )
+
+    return {
+        "trials": trials,
+        "log_loss_sum": log_loss_sum,
+        "brier_sum": brier_sum,
+    }
+
+
+def _empty_accumulator() -> dict[str, Any]:
+    return {
+        "sample_count": 0,
+        "observed_pa": 0,
+        "production_log_loss_sum": 0.0,
+        "candidate_log_loss_sum": 0.0,
+        "production_brier_sum": 0.0,
+        "candidate_brier_sum": 0.0,
+    }
+
+
+def _add_score(
+    accumulator: dict[str, Any],
+    *,
+    production: Mapping[str, float | int],
+    candidate: Mapping[str, float | int],
+) -> None:
+    trials = int(production["trials"])
+
+    if trials != int(candidate["trials"]):
+        raise ValueError(
+            "paired scores must use equal trials"
+        )
+
+    accumulator["sample_count"] += 1
+    accumulator["observed_pa"] += trials
+    accumulator[
+        "production_log_loss_sum"
+    ] += float(production["log_loss_sum"])
+    accumulator[
+        "candidate_log_loss_sum"
+    ] += float(candidate["log_loss_sum"])
+    accumulator[
+        "production_brier_sum"
+    ] += float(production["brier_sum"])
+    accumulator[
+        "candidate_brier_sum"
+    ] += float(candidate["brier_sum"])
+
+
+def _finalize(
+    accumulator: Mapping[str, Any],
+) -> dict[str, Any]:
+    observed_pa = int(
+        accumulator["observed_pa"]
+    )
+    sample_count = int(
+        accumulator["sample_count"]
+    )
+
+    if observed_pa <= 0:
+        return {
+            "sample_count": sample_count,
+            "observed_pa": 0,
+            "status": "unavailable",
+        }
+
+    production_log_loss = (
+        float(
+            accumulator[
+                "production_log_loss_sum"
+            ]
+        )
+        / observed_pa
+    )
+    candidate_log_loss = (
+        float(
+            accumulator[
+                "candidate_log_loss_sum"
+            ]
+        )
+        / observed_pa
+    )
+    production_brier = (
+        float(
+            accumulator[
+                "production_brier_sum"
+            ]
+        )
+        / observed_pa
+    )
+    candidate_brier = (
+        float(
+            accumulator[
+                "candidate_brier_sum"
+            ]
+        )
+        / observed_pa
+    )
+
+    return {
+        "status": "ready",
+        "sample_count": sample_count,
+        "observed_pa": observed_pa,
+        "production_log_loss": round(
+            production_log_loss,
+            12,
+        ),
+        "candidate_log_loss": round(
+            candidate_log_loss,
+            12,
+        ),
+        "absolute_log_loss_improvement": (
+            round(
+                production_log_loss
+                - candidate_log_loss,
+                12,
+            )
+        ),
+        "relative_log_loss_improvement_pct": (
+            round(
+                (
+                    (
+                        production_log_loss
+                        - candidate_log_loss
+                    )
+                    / production_log_loss
+                    * 100.0
+                )
+                if production_log_loss > 0
+                else 0.0,
+                8,
+            )
+        ),
+        "production_brier_score": round(
+            production_brier,
+            12,
+        ),
+        "candidate_brier_score": round(
+            candidate_brier,
+            12,
+        ),
+        "absolute_brier_improvement": round(
+            production_brier
+            - candidate_brier,
+            12,
+        ),
+    }
+
+
+def evaluate_canonical_pitcher_matchup_profile_pa_history(
+    samples: Iterable[Mapping[str, Any]],
+    *,
+    minimum_samples: int = 30,
+    minimum_observed_pa: int = 1000,
+    season_log_loss_regression_tolerance: float = 0.0,
+) -> dict[str, Any]:
+    """Evaluate paired probabilities against realized PA outcome counts."""
+    if (
+        not isinstance(minimum_samples, int)
+        or isinstance(minimum_samples, bool)
+        or minimum_samples <= 0
+    ):
+        raise ValueError(
+            "minimum_samples must be positive"
+        )
+
+    if (
+        not isinstance(minimum_observed_pa, int)
+        or isinstance(
+            minimum_observed_pa,
+            bool,
+        )
+        or minimum_observed_pa <= 0
+    ):
+        raise ValueError(
+            "minimum_observed_pa must be positive"
+        )
+
+    tolerance = float(
+        season_log_loss_regression_tolerance
+    )
+
+    if (
+        not math.isfinite(tolerance)
+        or tolerance < 0.0
+    ):
+        raise ValueError(
+            "season regression tolerance must be nonnegative"
+        )
+
+    values = sorted(
+        (
+            deepcopy(dict(sample))
+            for sample in samples
+        ),
+        key=_digest,
+    )
+    accepted = []
+    rejected = []
+    overall = _empty_accumulator()
+    by_season = defaultdict(
+        _empty_accumulator
+    )
+    identities = set()
+
+    for index, sample in enumerate(values):
+        try:
+            season = int(sample["season"])
+            game_pk = str(sample["game_pk"])
+            comparison_id = str(
+                sample.get(
+                    "comparison_id",
+                    f"{season}:{game_pk}:{index}",
+                )
+            )
+
+            identity = (
+                season,
+                game_pk,
+                comparison_id,
+            )
+
+            if identity in identities:
+                raise ValueError(
+                    "duplicate comparison identity"
+                )
+
+            identities.add(identity)
+
+            production_probabilities = (
+                _probabilities(
+                    sample.get(
+                        "production_probabilities"
+                    )
+                )
+            )
+            candidate_probabilities = (
+                _probabilities(
+                    sample.get(
+                        "candidate_probabilities"
+                    )
+                )
+            )
+            observed_counts = (
+                _observed_counts(
+                    sample.get(
+                        "observed_counts"
+                    )
+                )
+            )
+
+            production_score = (
+                _score_distribution(
+                    production_probabilities,
+                    observed_counts,
+                )
+            )
+            candidate_score = (
+                _score_distribution(
+                    candidate_probabilities,
+                    observed_counts,
+                )
+            )
+
+            _add_score(
+                overall,
+                production=production_score,
+                candidate=candidate_score,
+            )
+            _add_score(
+                by_season[season],
+                production=production_score,
+                candidate=candidate_score,
+            )
+
+            accepted.append({
+                "season": season,
+                "game_pk": game_pk,
+                "comparison_id": comparison_id,
+                "observed_pa": (
+                    production_score["trials"]
+                ),
+            })
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            rejected.append({
+                "index": index,
+                "reason": str(exc),
+            })
+
+    overall_result = _finalize(overall)
+    season_results = {
+        str(season): _finalize(
+            by_season[season]
+        )
+        for season in sorted(by_season)
+    }
+
+    blockers = []
+
+    if len(accepted) < minimum_samples:
+        blockers.append(
+            "insufficient_sample_count"
+        )
+
+    if (
+        int(overall_result.get(
+            "observed_pa",
+            0,
+        ))
+        < minimum_observed_pa
+    ):
+        blockers.append(
+            "insufficient_observed_pa"
+        )
+
+    if (
+        overall_result.get("status")
+        != "ready"
+    ):
+        blockers.append(
+            "paired_scores_unavailable"
+        )
+    else:
+        if (
+            overall_result[
+                "absolute_log_loss_improvement"
+            ]
+            <= 0.0
+        ):
+            blockers.append(
+                "candidate_log_loss_not_improved"
+            )
+
+        if (
+            overall_result[
+                "absolute_brier_improvement"
+            ]
+            < 0.0
+        ):
+            blockers.append(
+                "candidate_brier_score_regressed"
+            )
+
+    regressed_seasons = []
+
+    for season, result in (
+        season_results.items()
+    ):
+        if result.get("status") != "ready":
+            regressed_seasons.append(season)
+            continue
+
+        if (
+            result[
+                "candidate_log_loss"
+            ]
+            - result[
+                "production_log_loss"
+            ]
+            > tolerance
+        ):
+            regressed_seasons.append(season)
+
+    if regressed_seasons:
+        blockers.append(
+            "season_log_loss_instability"
+        )
+
+    selection_gate_passed = not blockers
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            "ready"
+            if accepted
+            else "unavailable"
+        ),
+        "accepted_sample_count": len(
+            accepted
+        ),
+        "rejected_sample_count": len(
+            rejected
+        ),
+        "minimum_samples": minimum_samples,
+        "minimum_observed_pa": (
+            minimum_observed_pa
+        ),
+        "season_log_loss_regression_tolerance": (
+            tolerance
+        ),
+        "season_count": len(
+            season_results
+        ),
+        "regressed_seasons": (
+            regressed_seasons
+        ),
+        "blockers": blockers,
+        "selection_gate_passed": (
+            selection_gate_passed
+        ),
+        "activation_status": (
+            "historical_pa_gate_passed"
+            if selection_gate_passed
+            else "historical_pa_gate_blocked"
+        ),
+        "shadow_only": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["evaluation_digest"] = (
+        _digest({
+            "accepted": accepted,
+            "rejected": rejected,
+            "overall": overall_result,
+            "by_season": season_results,
+            "diagnostics": diagnostics,
+        })
+    )
+
+    return {
+        "overall": overall_result,
+        "by_season": season_results,
+        "accepted_samples": accepted,
+        "rejected_samples": rejected,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_executor.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_executor.py
@@ -1,0 +1,270 @@
+"""Execute the canonical pitcher-profile historical PA evaluation pipeline.
+
+The executor composes realized outcome materialization, cutoff-safe probability
+pairing, and historical scoring. It remains shadow-only and has no database or
+production activation authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Iterable, Mapping
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_evaluation import (
+    evaluate_canonical_pitcher_matchup_profile_pa_history,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_outcomes import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_samples import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_samples,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_executor_v1"
+)
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _authority_contract(
+    value: Any,
+) -> bool:
+    diagnostics = _mapping(value)
+
+    return (
+        diagnostics.get(
+            "production_authority"
+        )
+        is False
+        and diagnostics.get(
+            "production_authority_changed"
+        )
+        is False
+    )
+
+
+def execute_canonical_pitcher_matchup_profile_pa_historical_evaluation(
+    events: Iterable[Any],
+    *,
+    statistics: CanonicalHistoricalProbabilityStatisticsWindow,
+    candidates_by_game_pitcher: Mapping[
+        tuple[int, int],
+        Mapping[str, Any],
+    ],
+    minimum_samples: int = 30,
+    minimum_observed_pa: int = 1000,
+    season_log_loss_regression_tolerance: float = 0.0,
+) -> dict[str, Any]:
+    """Execute the immutable paired historical PA evaluation."""
+    outcomes = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            events
+        )
+    )
+
+    paired = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_samples(
+            outcomes,
+            statistics=statistics,
+            candidates_by_game_pitcher=(
+                candidates_by_game_pitcher
+            ),
+        )
+    )
+
+    evaluation = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            paired["samples"],
+            minimum_samples=minimum_samples,
+            minimum_observed_pa=(
+                minimum_observed_pa
+            ),
+            season_log_loss_regression_tolerance=(
+                season_log_loss_regression_tolerance
+            ),
+        )
+    )
+
+    outcome_diagnostics = _mapping(
+        outcomes.get("diagnostics")
+    )
+    paired_diagnostics = _mapping(
+        paired.get("diagnostics")
+    )
+    evaluation_diagnostics = _mapping(
+        evaluation.get("diagnostics")
+    )
+
+    authority_contracts = {
+        "outcomes": _authority_contract(
+            outcome_diagnostics
+        ),
+        "paired_samples": (
+            _authority_contract(
+                paired_diagnostics
+            )
+            and paired_diagnostics.get(
+                "production_inputs_unchanged"
+            )
+            is True
+        ),
+        "evaluation": (
+            _authority_contract(
+                evaluation_diagnostics
+            )
+        ),
+    }
+
+    accepted_sample_count = int(
+        evaluation_diagnostics.get(
+            "accepted_sample_count",
+            0,
+        )
+        or 0
+    )
+
+    if not all(authority_contracts.values()):
+        status = "blocked"
+        blockers = [
+            "shadow_authority_contract_invalid"
+        ]
+    elif (
+        accepted_sample_count > 0
+        and outcome_diagnostics.get("status")
+        == "ready"
+        and paired_diagnostics.get("status")
+        == "ready"
+    ):
+        status = "ready"
+        blockers = []
+    elif accepted_sample_count > 0:
+        status = "partial"
+        blockers = []
+    else:
+        status = "unavailable"
+        blockers = [
+            "no_evaluator_ready_historical_samples"
+        ]
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "blockers": blockers,
+        "raw_event_count": (
+            outcome_diagnostics.get(
+                "raw_row_count",
+                0,
+            )
+        ),
+        "terminal_pa_count": (
+            outcome_diagnostics.get(
+                "terminal_pa_count",
+                0,
+            )
+        ),
+        "outcome_sample_count": (
+            outcome_diagnostics.get(
+                "sample_count",
+                0,
+            )
+        ),
+        "paired_sample_count": (
+            paired_diagnostics.get(
+                "materialized_sample_count",
+                0,
+            )
+        ),
+        "accepted_sample_count": (
+            accepted_sample_count
+        ),
+        "observed_pa": (
+            _mapping(
+                evaluation.get("overall")
+            ).get("observed_pa", 0)
+        ),
+        "outcome_status": (
+            outcome_diagnostics.get("status")
+        ),
+        "paired_sample_status": (
+            paired_diagnostics.get("status")
+        ),
+        "evaluation_status": (
+            evaluation_diagnostics.get(
+                "status"
+            )
+        ),
+        "evaluation_activation_status": (
+            evaluation_diagnostics.get(
+                "activation_status"
+            )
+        ),
+        "authority_contracts": (
+            authority_contracts
+        ),
+        "pipeline": (
+            "terminal_outcomes_to_paired_samples_to_evaluation"
+        ),
+        "cutoff_policy": (
+            "statistics_and_candidates_supplied_as_pregame_inputs"
+        ),
+        "database_accessed": False,
+        "calibration_parameters_selected": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "outcome_digest": (
+            outcome_diagnostics.get(
+                "outcome_digest"
+            )
+        ),
+        "sample_digest": (
+            paired_diagnostics.get(
+                "sample_digest"
+            )
+        ),
+        "evaluation_digest": (
+            evaluation_diagnostics.get(
+                "evaluation_digest"
+            )
+        ),
+    }
+    diagnostics["execution_digest"] = _digest({
+        "diagnostics": diagnostics,
+        "evaluation_overall": (
+            evaluation.get("overall")
+        ),
+        "evaluation_by_season": (
+            evaluation.get("by_season")
+        ),
+    })
+
+    return {
+        "outcomes": outcomes,
+        "paired_samples": paired,
+        "evaluation": evaluation,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_outcomes.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_outcomes.py
@@ -1,0 +1,369 @@
+"""Cutoff-independent realized PA outcomes for pitcher-profile scoring.
+
+This module materializes only observed historical outcomes. It does not build
+pregame probabilities, select calibration parameters, or change production
+authority.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_outcomes_v1"
+)
+
+OUTCOME_KEYS = (
+    "k",
+    "bb",
+    "hbp",
+    "single",
+    "double",
+    "triple",
+    "hr",
+    "reached_on_error",
+    "out",
+)
+
+_EVENT_OUTCOMES = {
+    "strikeout": "k",
+    "strikeout_double_play": "k",
+    "walk": "bb",
+    "intent_walk": "bb",
+    "hit_by_pitch": "hbp",
+    "single": "single",
+    "double": "double",
+    "triple": "triple",
+    "home_run": "hr",
+    "field_error": "reached_on_error",
+    "field_out": "out",
+    "force_out": "out",
+    "grounded_into_double_play": "out",
+    "double_play": "out",
+    "triple_play": "out",
+    "fielders_choice": "out",
+    "fielders_choice_out": "out",
+    "sac_fly": "out",
+    "sac_bunt": "out",
+}
+
+
+def _value(row: Any, name: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name)
+    return getattr(row, name, None)
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value)
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date_must_be_iso_date"
+        ) from exc
+
+
+def _event(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip().lower()
+
+    if normalized in {
+        "",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    return normalized
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _empty_counts() -> dict[str, int]:
+    return {
+        outcome: 0
+        for outcome in OUTCOME_KEYS
+    }
+
+
+def materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+    events: Iterable[Any],
+) -> dict[str, Any]:
+    """Deduplicate terminal Statcast PAs and aggregate realized outcomes."""
+    rows = list(events)
+    terminal_by_identity: dict[
+        tuple[int, int],
+        dict[str, Any],
+    ] = {}
+    conflicting_identities: set[
+        tuple[int, int]
+    ] = set()
+    rejected_rows: list[dict[str, Any]] = []
+    nonterminal_pitch_rows = 0
+    duplicate_terminal_rows = 0
+
+    for index, row in enumerate(rows):
+        event_name = _event(
+            _value(row, "events")
+        )
+
+        if event_name is None:
+            nonterminal_pitch_rows += 1
+            continue
+
+        try:
+            game_pk = _positive_integer(
+                _value(row, "game_pk"),
+                "game_pk",
+            )
+            at_bat_number = _positive_integer(
+                _value(row, "at_bat_number"),
+                "at_bat_number",
+            )
+            pitcher_id = _positive_integer(
+                _value(row, "pitcher_id"),
+                "pitcher_id",
+            )
+            batter_id = _positive_integer(
+                _value(row, "batter_id"),
+                "batter_id",
+            )
+            game_date = _date(
+                _value(row, "game_date")
+            )
+        except ValueError as exc:
+            rejected_rows.append({
+                "index": index,
+                "reason": str(exc),
+            })
+            continue
+
+        outcome = _EVENT_OUTCOMES.get(
+            event_name
+        )
+
+        if outcome is None:
+            rejected_rows.append({
+                "index": index,
+                "game_pk": game_pk,
+                "at_bat_number": (
+                    at_bat_number
+                ),
+                "event": event_name,
+                "reason": (
+                    "unsupported_terminal_event"
+                ),
+            })
+            continue
+
+        identity = (
+            game_pk,
+            at_bat_number,
+        )
+        terminal = {
+            "game_pk": game_pk,
+            "game_date": game_date.isoformat(),
+            "season": game_date.year,
+            "at_bat_number": at_bat_number,
+            "pitcher_id": pitcher_id,
+            "batter_id": batter_id,
+            "event": event_name,
+            "outcome": outcome,
+        }
+
+        if identity in conflicting_identities:
+            duplicate_terminal_rows += 1
+            continue
+
+        existing = terminal_by_identity.get(
+            identity
+        )
+
+        if existing is None:
+            terminal_by_identity[
+                identity
+            ] = terminal
+            continue
+
+        comparable_fields = (
+            "game_date",
+            "pitcher_id",
+            "batter_id",
+            "outcome",
+        )
+
+        if all(
+            existing[field] == terminal[field]
+            for field in comparable_fields
+        ):
+            duplicate_terminal_rows += 1
+            continue
+
+        terminal_by_identity.pop(
+            identity,
+            None,
+        )
+        conflicting_identities.add(
+            identity
+        )
+        rejected_rows.append({
+            "index": index,
+            "game_pk": game_pk,
+            "at_bat_number": (
+                at_bat_number
+            ),
+            "reason": (
+                "conflicting_terminal_pa_identity"
+            ),
+        })
+
+    grouped: dict[
+        tuple[int, int, int],
+        dict[str, Any],
+    ] = {}
+
+    for terminal in terminal_by_identity.values():
+        group_key = (
+            terminal["game_pk"],
+            terminal["pitcher_id"],
+            terminal["batter_id"],
+        )
+        group = grouped.get(group_key)
+
+        if group is None:
+            group = {
+                "season": terminal["season"],
+                "game_pk": terminal["game_pk"],
+                "game_date": (
+                    terminal["game_date"]
+                ),
+                "pitcher_id": (
+                    terminal["pitcher_id"]
+                ),
+                "batter_id": (
+                    terminal["batter_id"]
+                ),
+                "comparison_id": (
+                    f"{terminal['game_pk']}:"
+                    f"{terminal['pitcher_id']}:"
+                    f"{terminal['batter_id']}"
+                ),
+                "observed_counts": (
+                    _empty_counts()
+                ),
+            }
+            grouped[group_key] = group
+
+        group["observed_counts"][
+            terminal["outcome"]
+        ] += 1
+
+    samples = [
+        grouped[key]
+        for key in sorted(grouped)
+    ]
+
+    if samples and rejected_rows:
+        status = "partial"
+    elif samples:
+        status = "ready"
+    else:
+        status = "unavailable"
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "raw_row_count": len(rows),
+        "nonterminal_pitch_row_count": (
+            nonterminal_pitch_rows
+        ),
+        "terminal_pa_count": len(
+            terminal_by_identity
+        ),
+        "duplicate_terminal_row_count": (
+            duplicate_terminal_rows
+        ),
+        "conflicting_terminal_pa_count": (
+            len(conflicting_identities)
+        ),
+        "sample_count": len(samples),
+        "rejected_row_count": len(
+            rejected_rows
+        ),
+        "rejected_rows": rejected_rows,
+        "grouping_policy": (
+            "game_pitcher_batter"
+        ),
+        "terminal_identity": (
+            "game_pk_at_bat_number"
+        ),
+        "intentional_walk_policy": (
+            "mapped_to_canonical_bb"
+        ),
+        "unsupported_event_policy": (
+            "fail_closed"
+        ),
+        "shadow_only": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["outcome_digest"] = _digest({
+        "samples": samples,
+        "diagnostics": diagnostics,
+    })
+
+    return {
+        "samples": samples,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_samples.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_samples.py
@@ -1,0 +1,511 @@
+"""Pair historical PA outcomes with production and pitcher-profile models.
+
+This materializer consumes already cutoff-safe historical statistics and
+cutoff-specific pitcher candidates. It does not query future data, select
+calibration parameters, or change production authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any, Mapping
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_comparator import (
+    compare_canonical_pitcher_matchup_profile_pa_outcomes,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+from mlb_app.simulation.shadow.historical_probability_workspace_reconstruction import (
+    build_historical_probability_offense_profile,
+    build_historical_probability_pitcher_profile,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_samples_v1"
+)
+
+OUTCOME_KEYS = (
+    "k",
+    "bb",
+    "hbp",
+    "single",
+    "double",
+    "triple",
+    "hr",
+    "reached_on_error",
+    "out",
+)
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _candidate_key(
+    value: Any,
+) -> tuple[int, int]:
+    if (
+        not isinstance(value, tuple)
+        or len(value) != 2
+    ):
+        raise ValueError(
+            "candidate_key_must_be_game_pitcher_tuple"
+        )
+
+    return (
+        _positive_integer(
+            value[0],
+            "candidate_game_pk",
+        ),
+        _positive_integer(
+            value[1],
+            "candidate_pitcher_id",
+        ),
+    )
+
+
+def _observed_counts(
+    value: Any,
+) -> dict[str, int]:
+    source = _mapping(value)
+    counts = {}
+
+    if tuple(source) != OUTCOME_KEYS:
+        raise ValueError(
+            "observed_counts_must_use_canonical_order"
+        )
+
+    for outcome in OUTCOME_KEYS:
+        raw = source.get(outcome)
+
+        if (
+            not isinstance(raw, int)
+            or isinstance(raw, bool)
+            or raw < 0
+        ):
+            raise ValueError(
+                "observed_counts_must_be_nonnegative_integers"
+            )
+
+        counts[outcome] = raw
+
+    if sum(counts.values()) <= 0:
+        raise ValueError(
+            "observed_counts_must_be_positive"
+        )
+
+    return counts
+
+
+def _normalize_candidates(
+    candidates: Mapping[Any, Any],
+) -> dict[tuple[int, int], dict[str, Any]]:
+    if not isinstance(candidates, Mapping):
+        raise TypeError(
+            "candidates_by_game_pitcher_must_be_mapping"
+        )
+
+    normalized = {}
+
+    for raw_key, raw_candidate in (
+        candidates.items()
+    ):
+        key = _candidate_key(raw_key)
+
+        if key in normalized:
+            raise ValueError(
+                "duplicate_candidate_game_pitcher"
+            )
+
+        if not isinstance(
+            raw_candidate,
+            Mapping,
+        ):
+            raise TypeError(
+                "candidate_payload_must_be_mapping"
+            )
+
+        normalized[key] = deepcopy(
+            dict(raw_candidate)
+        )
+
+    return normalized
+
+
+def materialize_canonical_pitcher_matchup_profile_pa_historical_samples(
+    outcomes: Mapping[str, Any],
+    *,
+    statistics: CanonicalHistoricalProbabilityStatisticsWindow,
+    candidates_by_game_pitcher: Mapping[
+        tuple[int, int],
+        Mapping[str, Any],
+    ],
+) -> dict[str, Any]:
+    """Build evaluator-ready paired historical PA samples."""
+    if not isinstance(outcomes, Mapping):
+        raise TypeError(
+            "outcomes_must_be_mapping"
+        )
+
+    if not isinstance(
+        statistics,
+        CanonicalHistoricalProbabilityStatisticsWindow,
+    ):
+        raise TypeError(
+            "statistics_must_be_canonical_window"
+        )
+
+    raw_samples = outcomes.get("samples")
+
+    if not isinstance(raw_samples, list):
+        raise TypeError(
+            "outcome_samples_must_be_list"
+        )
+
+    candidates = _normalize_candidates(
+        candidates_by_game_pitcher
+    )
+    statistics_games = {
+        game.game_pk: game
+        for game in statistics.games
+    }
+
+    materialized = []
+    rejected = []
+    identities = set()
+
+    values = sorted(
+        (
+            deepcopy(dict(sample))
+            for sample in raw_samples
+            if isinstance(sample, Mapping)
+        ),
+        key=_digest,
+    )
+
+    invalid_shape_count = (
+        len(raw_samples) - len(values)
+    )
+
+    for index, sample in enumerate(values):
+        comparison_id = str(
+            sample.get(
+                "comparison_id",
+                f"invalid:{index}",
+            )
+        )
+
+        try:
+            game_pk = _positive_integer(
+                sample.get("game_pk"),
+                "game_pk",
+            )
+            pitcher_id = _positive_integer(
+                sample.get("pitcher_id"),
+                "pitcher_id",
+            )
+            batter_id = _positive_integer(
+                sample.get("batter_id"),
+                "batter_id",
+            )
+            season = _positive_integer(
+                sample.get("season"),
+                "season",
+            )
+            game_date = str(
+                sample["game_date"]
+            )
+            observed_counts = _observed_counts(
+                sample.get("observed_counts")
+            )
+
+            identity = (
+                game_pk,
+                pitcher_id,
+                batter_id,
+                comparison_id,
+            )
+
+            if identity in identities:
+                raise ValueError(
+                    "duplicate_historical_comparison"
+                )
+
+            identities.add(identity)
+
+            statistics_game = (
+                statistics_games.get(game_pk)
+            )
+
+            if statistics_game is None:
+                raise ValueError(
+                    "historical_statistics_game_unavailable"
+                )
+
+            if (
+                statistics_game.game_date
+                != game_date
+            ):
+                raise ValueError(
+                    "historical_statistics_game_date_mismatch"
+                )
+
+            records = {
+                record.record_key: record
+                for record in (
+                    statistics_game.players
+                )
+            }
+
+            batter_record = records.get(
+                ("hitting", str(batter_id))
+            )
+            pitcher_record = records.get(
+                ("pitching", str(pitcher_id))
+            )
+
+            if batter_record is None:
+                raise ValueError(
+                    "historical_batter_statistics_unavailable"
+                )
+
+            if pitcher_record is None:
+                raise ValueError(
+                    "historical_pitcher_statistics_unavailable"
+                )
+
+            if not batter_record.sample_available:
+                raise ValueError(
+                    "historical_batter_sample_unavailable"
+                )
+
+            if not pitcher_record.sample_available:
+                raise ValueError(
+                    "historical_pitcher_sample_unavailable"
+                )
+
+            candidate = candidates.get(
+                (game_pk, pitcher_id)
+            )
+
+            if candidate is None:
+                raise ValueError(
+                    "historical_pitcher_candidate_unavailable"
+                )
+
+            batter_profile = (
+                build_historical_probability_offense_profile(
+                    dict(batter_record.counts)
+                )
+            )
+            pitcher_profile = (
+                build_historical_probability_pitcher_profile(
+                    dict(pitcher_record.counts)
+                )
+            )
+
+            comparison = (
+                compare_canonical_pitcher_matchup_profile_pa_outcomes(
+                    candidate=candidate,
+                    production_pitcher_profile=(
+                        pitcher_profile
+                    ),
+                    batter_profile=batter_profile,
+                    environment_profile={},
+                )
+            )
+
+            if (
+                comparison.get("status")
+                != "ready"
+                or comparison.get("executed")
+                is not True
+            ):
+                blockers = comparison.get(
+                    "blockers"
+                ) or []
+                blocker = (
+                    str(blockers[0])
+                    if blockers
+                    else "unknown"
+                )
+                raise ValueError(
+                    "historical_pa_comparison_blocked:"
+                    + blocker
+                )
+
+            if (
+                comparison.get(
+                    "production_inputs_unchanged"
+                )
+                is not True
+                or comparison.get(
+                    "production_authority_changed"
+                )
+                is not False
+            ):
+                raise ValueError(
+                    "historical_pa_authority_contract_invalid"
+                )
+
+            materialized.append({
+                "season": season,
+                "game_pk": str(game_pk),
+                "comparison_id": comparison_id,
+                "pitcher_id": pitcher_id,
+                "batter_id": batter_id,
+                "game_date": game_date,
+                "production_probabilities": dict(
+                    comparison[
+                        "production_probabilities"
+                    ]
+                ),
+                "candidate_probabilities": dict(
+                    comparison[
+                        "shadow_probabilities"
+                    ]
+                ),
+                "observed_counts": (
+                    observed_counts
+                ),
+                "maximum_absolute_probability_delta": (
+                    comparison[
+                        "maximum_absolute_probability_delta"
+                    ]
+                ),
+                "applied_rates": dict(
+                    comparison["applied_rates"]
+                ),
+                "deferred_rates": dict(
+                    comparison["deferred_rates"]
+                ),
+            })
+        except (
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            rejected.append({
+                "index": index,
+                "comparison_id": comparison_id,
+                "reason": str(exc),
+            })
+
+    materialized.sort(
+        key=lambda sample: (
+            sample["season"],
+            int(sample["game_pk"]),
+            sample["pitcher_id"],
+            sample["batter_id"],
+            sample["comparison_id"],
+        )
+    )
+
+    if materialized and (
+        rejected
+        or invalid_shape_count
+    ):
+        status = "partial"
+    elif materialized:
+        status = "ready"
+    else:
+        status = "unavailable"
+
+    outcome_diagnostics = _mapping(
+        outcomes.get("diagnostics")
+    )
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "outcome_sample_count": len(
+            raw_samples
+        ),
+        "materialized_sample_count": len(
+            materialized
+        ),
+        "rejected_sample_count": len(
+            rejected
+        ),
+        "invalid_sample_shape_count": (
+            invalid_shape_count
+        ),
+        "candidate_count": len(candidates),
+        "statistics_game_count": len(
+            statistics_games
+        ),
+        "rejected_samples": rejected,
+        "pairing_policy": (
+            "game_pitcher_batter_cutoff_safe"
+        ),
+        "candidate_identity": (
+            "game_pk_pitcher_id"
+        ),
+        "historical_environment_policy": (
+            "neutral_environment_no_archived_forecast_v1"
+        ),
+        "outcome_digest": (
+            outcome_diagnostics.get(
+                "outcome_digest"
+            )
+        ),
+        "statistics_window_digest": (
+            statistics.digest
+        ),
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["sample_digest"] = _digest({
+        "samples": materialized,
+        "diagnostics": diagnostics,
+    })
+
+    return {
+        "samples": materialized,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_starters.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_starters.py
@@ -1,0 +1,481 @@
+"""Identify historical starters and their realized Statcast plate appearances.
+
+The home starter is the first pitcher recorded in the top half; the away
+starter is the first pitcher recorded in the bottom half. Only terminal PAs
+against those inferred starters are exposed for historical scoring.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_starters_v1"
+)
+
+
+def _value(row: Any, name: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name)
+    return getattr(row, name, None)
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _optional_integer(
+    value: Any,
+    default: int,
+) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+
+    return parsed
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value)
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date_must_be_iso_date"
+        ) from exc
+
+
+def _half(value: Any) -> str:
+    normalized = str(
+        value or ""
+    ).strip().lower()
+
+    if normalized in {
+        "top",
+        "t",
+    }:
+        return "top"
+
+    if normalized in {
+        "bot",
+        "bottom",
+        "b",
+    }:
+        return "bottom"
+
+    raise ValueError(
+        "inning_topbot_must_be_top_or_bottom"
+    )
+
+
+def _event(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip().lower()
+
+    if normalized in {
+        "",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    return normalized
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _identity(row: Any) -> tuple[int, int]:
+    return (
+        _positive_integer(
+            _value(row, "game_pk"),
+            "game_pk",
+        ),
+        _positive_integer(
+            _value(row, "at_bat_number"),
+            "at_bat_number",
+        ),
+    )
+
+
+def _order(row: Any) -> tuple[int, int, int]:
+    return (
+        _optional_integer(
+            _value(row, "inning"),
+            999,
+        ),
+        _optional_integer(
+            _value(row, "at_bat_number"),
+            999999,
+        ),
+        _optional_integer(
+            _value(row, "pitch_number"),
+            999,
+        ),
+    )
+
+
+def source_canonical_pitcher_matchup_profile_pa_historical_starters(
+    events: Iterable[Any],
+) -> dict[str, Any]:
+    """Infer starters and select their terminal historical PAs."""
+    rows = list(events)
+    terminal_by_identity: dict[
+        tuple[int, int],
+        Any,
+    ] = {}
+    duplicate_terminal_count = 0
+    conflicting_identities: set[
+        tuple[int, int]
+    ] = set()
+    rejected_rows = []
+
+    for index, row in enumerate(rows):
+        if _event(
+            _value(row, "events")
+        ) is None:
+            continue
+
+        try:
+            identity = _identity(row)
+            game_date = _date(
+                _value(row, "game_date")
+            )
+            pitcher_id = _positive_integer(
+                _value(row, "pitcher_id"),
+                "pitcher_id",
+            )
+            batter_id = _positive_integer(
+                _value(row, "batter_id"),
+                "batter_id",
+            )
+            half = _half(
+                _value(row, "inning_topbot")
+            )
+        except ValueError as exc:
+            rejected_rows.append({
+                "index": index,
+                "reason": str(exc),
+            })
+            continue
+
+        if identity in conflicting_identities:
+            duplicate_terminal_count += 1
+            continue
+
+        normalized = {
+            "row": row,
+            "game_pk": identity[0],
+            "at_bat_number": identity[1],
+            "game_date": game_date,
+            "pitcher_id": pitcher_id,
+            "batter_id": batter_id,
+            "half": half,
+            "event": _event(
+                _value(row, "events")
+            ),
+            "order": _order(row),
+        }
+        existing = terminal_by_identity.get(
+            identity
+        )
+
+        if existing is None:
+            terminal_by_identity[
+                identity
+            ] = normalized
+            continue
+
+        comparable = (
+            "game_date",
+            "pitcher_id",
+            "batter_id",
+            "half",
+            "event",
+        )
+
+        if all(
+            existing[name] == normalized[name]
+            for name in comparable
+        ):
+            duplicate_terminal_count += 1
+            continue
+
+        terminal_by_identity.pop(
+            identity,
+            None,
+        )
+        conflicting_identities.add(
+            identity
+        )
+        rejected_rows.append({
+            "index": index,
+            "game_pk": identity[0],
+            "at_bat_number": identity[1],
+            "reason": (
+                "conflicting_terminal_pa_identity"
+            ),
+        })
+
+    games = defaultdict(list)
+
+    for terminal in (
+        terminal_by_identity.values()
+    ):
+        games[terminal["game_pk"]].append(
+            terminal
+        )
+
+    starter_records = []
+    requests = []
+    starter_events = []
+    rejected_games = []
+
+    for game_pk in sorted(games):
+        terminals = sorted(
+            games[game_pk],
+            key=lambda value: value["order"],
+        )
+        game_dates = {
+            value["game_date"]
+            for value in terminals
+        }
+
+        if len(game_dates) != 1:
+            rejected_games.append({
+                "game_pk": game_pk,
+                "reason": (
+                    "conflicting_game_dates"
+                ),
+            })
+            continue
+
+        game_date = next(iter(game_dates))
+        top = [
+            value
+            for value in terminals
+            if value["half"] == "top"
+        ]
+        bottom = [
+            value
+            for value in terminals
+            if value["half"] == "bottom"
+        ]
+
+        if not top or not bottom:
+            rejected_games.append({
+                "game_pk": game_pk,
+                "game_date": (
+                    game_date.isoformat()
+                ),
+                "reason": (
+                    "both_game_halves_required"
+                ),
+            })
+            continue
+
+        home_starter = top[0]["pitcher_id"]
+        away_starter = bottom[0][
+            "pitcher_id"
+        ]
+
+        home_starter_pas = [
+            value
+            for value in top
+            if value["pitcher_id"]
+            == home_starter
+        ]
+        away_starter_pas = [
+            value
+            for value in bottom
+            if value["pitcher_id"]
+            == away_starter
+        ]
+
+        starter_records.append({
+            "game_pk": game_pk,
+            "game_date": (
+                game_date.isoformat()
+            ),
+            "away_starter_id": (
+                away_starter
+            ),
+            "home_starter_id": (
+                home_starter
+            ),
+            "away_starter_pa_count": len(
+                away_starter_pas
+            ),
+            "home_starter_pa_count": len(
+                home_starter_pas
+            ),
+        })
+        requests.extend([
+            {
+                "game_pk": game_pk,
+                "pitcher_id": (
+                    away_starter
+                ),
+                "game_date": game_date,
+                "side": "away",
+            },
+            {
+                "game_pk": game_pk,
+                "pitcher_id": (
+                    home_starter
+                ),
+                "game_date": game_date,
+                "side": "home",
+            },
+        ])
+        starter_events.extend(
+            value["row"]
+            for value in (
+                home_starter_pas
+                + away_starter_pas
+            )
+        )
+
+    starter_events.sort(
+        key=lambda row: (
+            _positive_integer(
+                _value(row, "game_pk"),
+                "game_pk",
+            ),
+            _positive_integer(
+                _value(row, "at_bat_number"),
+                "at_bat_number",
+            ),
+        )
+    )
+    requests.sort(
+        key=lambda value: (
+            value["game_date"],
+            value["game_pk"],
+            value["pitcher_id"],
+        )
+    )
+
+    if (
+        starter_records
+        and (
+            rejected_rows
+            or rejected_games
+        )
+    ):
+        status = "partial"
+    elif starter_records:
+        status = "ready"
+    else:
+        status = "unavailable"
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "raw_event_count": len(rows),
+        "terminal_pa_count": len(
+            terminal_by_identity
+        ),
+        "duplicate_terminal_count": (
+            duplicate_terminal_count
+        ),
+        "conflicting_terminal_count": (
+            len(conflicting_identities)
+        ),
+        "game_count": len(games),
+        "ready_game_count": len(
+            starter_records
+        ),
+        "rejected_game_count": len(
+            rejected_games
+        ),
+        "starter_request_count": len(
+            requests
+        ),
+        "starter_pa_count": len(
+            starter_events
+        ),
+        "rejected_row_count": len(
+            rejected_rows
+        ),
+        "rejected_rows": rejected_rows,
+        "rejected_games": rejected_games,
+        "starter_records": (
+            starter_records
+        ),
+        "starter_inference": {
+            "home": (
+                "first_pitcher_in_top_half"
+            ),
+            "away": (
+                "first_pitcher_in_bottom_half"
+            ),
+        },
+        "scoring_scope": (
+            "terminal_pas_against_inferred_starters"
+        ),
+        "shadow_only": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    diagnostics["starter_window_digest"] = (
+        _digest({
+            "starter_records": (
+                starter_records
+            ),
+            "requests": requests,
+            "diagnostics": diagnostics,
+        })
+    )
+
+    return {
+        "starter_events": starter_events,
+        "requests": requests,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_statcast_statistics.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_statcast_statistics.py
@@ -1,0 +1,608 @@
+"""Build cutoff-safe historical PA statistics from local Statcast events.
+
+The source emits the existing canonical historical statistics contract for one
+target game. Only same-season terminal PAs strictly before the target game date
+are eligible.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any, Iterable, Mapping, Sequence
+
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    HITTING_STAT_KEYS,
+    PITCHING_STAT_KEYS,
+    CanonicalHistoricalProbabilityGameStatistics,
+    CanonicalHistoricalProbabilityPlayerStatistics,
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_statcast_statistics_v1"
+)
+
+_HIT_EVENTS = {
+    "single": "single",
+    "double": "double",
+    "triple": "triple",
+    "home_run": "hr",
+}
+
+_STRIKEOUT_EVENTS = {
+    "strikeout",
+    "strikeout_double_play",
+}
+
+_WALK_EVENTS = {
+    "walk",
+    "intent_walk",
+}
+
+_NO_AT_BAT_EVENTS = {
+    "walk",
+    "intent_walk",
+    "hit_by_pitch",
+    "catcher_interf",
+    "sac_fly",
+    "sac_bunt",
+}
+
+_SUPPORTED_TERMINAL_EVENTS = {
+    *_HIT_EVENTS,
+    *_STRIKEOUT_EVENTS,
+    *_WALK_EVENTS,
+    "hit_by_pitch",
+    "catcher_interf",
+    "field_error",
+    "field_out",
+    "force_out",
+    "grounded_into_double_play",
+    "double_play",
+    "triple_play",
+    "fielders_choice",
+    "fielders_choice_out",
+    "sac_fly",
+    "sac_bunt",
+}
+
+
+def _value(row: Any, name: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name)
+    return getattr(row, name, None)
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value)
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date_must_be_iso_date"
+        ) from exc
+
+
+def _event(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip().lower()
+
+    if normalized in {
+        "",
+        "nan",
+        "none",
+        "null",
+    }:
+        return None
+
+    return normalized
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        encoded
+    ).hexdigest()
+
+
+def _digest_value(
+    value: Any,
+    name: str,
+) -> str:
+    normalized = str(value)
+
+    if (
+        len(normalized) != 64
+        or any(
+            character
+            not in "0123456789abcdef"
+            for character in normalized
+        )
+    ):
+        raise ValueError(
+            f"{name}_must_be_sha256_digest"
+        )
+
+    return normalized
+
+
+def _identifiers(
+    values: Sequence[Any],
+    name: str,
+) -> tuple[int, ...]:
+    if isinstance(values, (str, bytes)):
+        raise TypeError(
+            f"{name}_must_be_sequence"
+        )
+
+    normalized = tuple(
+        sorted({
+            _positive_integer(
+                value,
+                name,
+            )
+            for value in values
+        })
+    )
+
+    if not normalized:
+        raise ValueError(
+            f"{name}_must_not_be_empty"
+        )
+
+    return normalized
+
+
+def _empty_hitting() -> dict[str, int]:
+    return {
+        key: 0
+        for key, _ in HITTING_STAT_KEYS
+    }
+
+
+def _empty_pitching() -> dict[str, int]:
+    return {
+        key: 0
+        for key, _ in PITCHING_STAT_KEYS
+    }
+
+
+def _ordered_counts(
+    keys: tuple[tuple[str, str], ...],
+    values: Mapping[str, int],
+) -> tuple[tuple[str, int], ...]:
+    return tuple(
+        (
+            key,
+            int(values.get(key, 0)),
+        )
+        for key, _ in keys
+    )
+
+
+def source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics(
+    events: Iterable[Any],
+    *,
+    game_pk: int,
+    game_date: dt.date | str,
+    batter_ids: Sequence[int],
+    pitcher_ids: Sequence[int],
+    observed_window_digest: str,
+    lineup_bullpen_window_digest: str,
+) -> dict[str, Any]:
+    """Build one strict-pregame canonical statistics window."""
+    target_game_pk = _positive_integer(
+        game_pk,
+        "game_pk",
+    )
+    cutoff = _date(game_date)
+    batters = _identifiers(
+        batter_ids,
+        "batter_id",
+    )
+    pitchers = _identifiers(
+        pitcher_ids,
+        "pitcher_id",
+    )
+    observed_digest = _digest_value(
+        observed_window_digest,
+        "observed_window_digest",
+    )
+    lineup_digest = _digest_value(
+        lineup_bullpen_window_digest,
+        "lineup_bullpen_window_digest",
+    )
+
+    rows = list(events)
+    terminal_by_identity = {}
+    conflicting_identities = set()
+    duplicate_terminal_count = 0
+    rejected_rows = []
+    excluded_future_or_same_day = 0
+    excluded_other_season = 0
+    nonterminal_pitch_count = 0
+
+    for index, row in enumerate(rows):
+        event_name = _event(
+            _value(row, "events")
+        )
+
+        if event_name is None:
+            nonterminal_pitch_count += 1
+            continue
+
+        try:
+            row_date = _date(
+                _value(row, "game_date")
+            )
+            row_game_pk = _positive_integer(
+                _value(row, "game_pk"),
+                "row_game_pk",
+            )
+            at_bat_number = _positive_integer(
+                _value(row, "at_bat_number"),
+                "at_bat_number",
+            )
+            pitcher_id = _positive_integer(
+                _value(row, "pitcher_id"),
+                "row_pitcher_id",
+            )
+            batter_id = _positive_integer(
+                _value(row, "batter_id"),
+                "row_batter_id",
+            )
+        except ValueError as exc:
+            rejected_rows.append({
+                "index": index,
+                "reason": str(exc),
+            })
+            continue
+
+        if row_date.year != cutoff.year:
+            excluded_other_season += 1
+            continue
+
+        if row_date >= cutoff:
+            excluded_future_or_same_day += 1
+            continue
+
+        if event_name not in (
+            _SUPPORTED_TERMINAL_EVENTS
+        ):
+            rejected_rows.append({
+                "index": index,
+                "event": event_name,
+                "reason": (
+                    "unsupported_terminal_event"
+                ),
+            })
+            continue
+
+        identity = (
+            row_game_pk,
+            at_bat_number,
+        )
+        normalized = {
+            "game_date": row_date,
+            "pitcher_id": pitcher_id,
+            "batter_id": batter_id,
+            "event": event_name,
+        }
+
+        if identity in conflicting_identities:
+            duplicate_terminal_count += 1
+            continue
+
+        existing = terminal_by_identity.get(
+            identity
+        )
+
+        if existing is None:
+            terminal_by_identity[
+                identity
+            ] = normalized
+            continue
+
+        if existing == normalized:
+            duplicate_terminal_count += 1
+            continue
+
+        terminal_by_identity.pop(
+            identity,
+            None,
+        )
+        conflicting_identities.add(
+            identity
+        )
+        rejected_rows.append({
+            "index": index,
+            "game_pk": row_game_pk,
+            "at_bat_number": (
+                at_bat_number
+            ),
+            "reason": (
+                "conflicting_terminal_pa_identity"
+            ),
+        })
+
+    hitting = defaultdict(
+        _empty_hitting
+    )
+    pitching = defaultdict(
+        _empty_pitching
+    )
+
+    for terminal in (
+        terminal_by_identity.values()
+    ):
+        batter = hitting[
+            terminal["batter_id"]
+        ]
+        pitcher = pitching[
+            terminal["pitcher_id"]
+        ]
+        event_name = terminal["event"]
+
+        batter["pa"] += 1
+        pitcher["batters_faced"] += 1
+
+        if event_name not in _NO_AT_BAT_EVENTS:
+            batter["ab"] += 1
+            pitcher["ab"] += 1
+
+        hit_key = _HIT_EVENTS.get(
+            event_name
+        )
+
+        if hit_key is not None:
+            batter["hits"] += 1
+            pitcher["hits"] += 1
+
+            if hit_key != "single":
+                batter[hit_key] += 1
+                pitcher[hit_key] += 1
+
+        if event_name in _WALK_EVENTS:
+            batter["bb"] += 1
+            pitcher["bb"] += 1
+
+        if event_name in _STRIKEOUT_EVENTS:
+            batter["k"] += 1
+            pitcher["k"] += 1
+
+        if event_name == "hit_by_pitch":
+            batter["hbp"] += 1
+            pitcher["hbp"] += 1
+
+    players = []
+
+    for batter_id in batters:
+        values = hitting.get(
+            batter_id,
+            _empty_hitting(),
+        )
+        sample_available = (
+            values["pa"] > 0
+        )
+
+        players.append(
+            CanonicalHistoricalProbabilityPlayerStatistics(
+                player_id=str(batter_id),
+                role="hitting",
+                counts=_ordered_counts(
+                    HITTING_STAT_KEYS,
+                    values,
+                ),
+                sample_available=(
+                    sample_available
+                ),
+            )
+        )
+
+    for pitcher_id in pitchers:
+        values = pitching.get(
+            pitcher_id,
+            _empty_pitching(),
+        )
+        sample_available = (
+            values["batters_faced"] > 0
+        )
+
+        players.append(
+            CanonicalHistoricalProbabilityPlayerStatistics(
+                player_id=str(pitcher_id),
+                role="pitching",
+                counts=_ordered_counts(
+                    PITCHING_STAT_KEYS,
+                    values,
+                ),
+                sample_available=(
+                    sample_available
+                ),
+            )
+        )
+
+    snapshot_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "game_pk": target_game_pk,
+        "game_date": cutoff.isoformat(),
+        "statistics_through_date": (
+            cutoff - dt.timedelta(days=1)
+        ).isoformat(),
+        "players": [
+            {
+                "player_id": player.player_id,
+                "role": player.role,
+                "counts": player.counts,
+                "sample_available": (
+                    player.sample_available
+                ),
+            }
+            for player in players
+        ],
+    }
+    snapshot_digest = _digest(
+        snapshot_payload
+    )
+
+    game = (
+        CanonicalHistoricalProbabilityGameStatistics(
+            game_pk=target_game_pk,
+            game_date=cutoff.isoformat(),
+            statistics_through_date=(
+                cutoff - dt.timedelta(days=1)
+            ).isoformat(),
+            players=tuple(players),
+            snapshot_digest=snapshot_digest,
+        )
+    )
+    window_digest = _digest({
+        "schema_version": SCHEMA_VERSION,
+        "observed_window_digest": (
+            observed_digest
+        ),
+        "lineup_bullpen_window_digest": (
+            lineup_digest
+        ),
+        "game": snapshot_payload,
+    })
+    statistics = (
+        CanonicalHistoricalProbabilityStatisticsWindow(
+            observed_window_digest=(
+                observed_digest
+            ),
+            lineup_bullpen_window_digest=(
+                lineup_digest
+            ),
+            games=(game,),
+            digest=window_digest,
+        )
+    )
+
+    observed_player_count = sum(
+        player.sample_available
+        for player in players
+    )
+
+    if observed_player_count == len(players):
+        status = (
+            "partial"
+            if rejected_rows
+            else "ready"
+        )
+    elif observed_player_count > 0:
+        status = "partial"
+    else:
+        status = "unavailable"
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "game_pk": target_game_pk,
+        "game_date": cutoff.isoformat(),
+        "statistics_through_date": (
+            cutoff - dt.timedelta(days=1)
+        ).isoformat(),
+        "raw_event_count": len(rows),
+        "eligible_terminal_pa_count": len(
+            terminal_by_identity
+        ),
+        "duplicate_terminal_count": (
+            duplicate_terminal_count
+        ),
+        "conflicting_terminal_count": (
+            len(conflicting_identities)
+        ),
+        "nonterminal_pitch_count": (
+            nonterminal_pitch_count
+        ),
+        "excluded_future_or_same_day_count": (
+            excluded_future_or_same_day
+        ),
+        "excluded_other_season_count": (
+            excluded_other_season
+        ),
+        "requested_batter_count": len(
+            batters
+        ),
+        "requested_pitcher_count": len(
+            pitchers
+        ),
+        "observed_player_role_count": (
+            observed_player_count
+        ),
+        "zero_sample_player_role_count": (
+            len(players)
+            - observed_player_count
+        ),
+        "rejected_row_count": len(
+            rejected_rows
+        ),
+        "rejected_rows": rejected_rows,
+        "cutoff_rule": (
+            "same_season_terminal_pas_strictly_before_game_date"
+        ),
+        "intentional_walk_policy": (
+            "included_in_historical_bb"
+        ),
+        "source": (
+            "local_statcast_terminal_pa_history"
+        ),
+        "snapshot_digest": (
+            snapshot_digest
+        ),
+        "statistics_window_digest": (
+            statistics.digest
+        ),
+        "shadow_only": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+
+    return {
+        "statistics": statistics,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
@@ -1,0 +1,572 @@
+"""Assemble multi-game historical PA evaluation from Statcast events.
+
+This orchestration layer reuses one immutable event collection to infer
+starters, construct cutoff-safe statistics and pitcher candidates, and execute
+the paired historical PA evaluation.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_candidates import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_candidates,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_executor import (
+    execute_canonical_pitcher_matchup_profile_pa_historical_evaluation,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_starters import (
+    source_canonical_pitcher_matchup_profile_pa_historical_starters,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_statcast_statistics import (
+    source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_statcast_window_v1"
+)
+
+
+def _value(row: Any, name: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(name)
+    return getattr(row, name, None)
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _positive_integer(
+    value: Any,
+    name: str,
+) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise ValueError(
+            f"{name}_must_be_positive_integer"
+        )
+
+    return parsed
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str):
+        try:
+            return dt.date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(
+                "game_date_must_be_iso_date"
+            ) from exc
+    raise ValueError(
+        "game_date_must_be_iso_date"
+    )
+
+
+def _unavailable(
+    *,
+    events: list[Any],
+    starters: Mapping[str, Any],
+    blocker: str,
+    observed_window_digest: str,
+    lineup_bullpen_window_digest: str,
+) -> dict[str, Any]:
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "unavailable",
+        "activation_status": (
+            "historical_pa_evaluation_unavailable"
+        ),
+        "blockers": [blocker],
+        "raw_event_count": len(events),
+        "game_count": 0,
+        "starter_request_count": 0,
+        "statistics_game_count": 0,
+        "candidate_count": 0,
+        "single_shared_event_collection": True,
+        "lookback_events_reused_for_evaluation": True,
+        "starter_inference_pass_count": 1,
+        "candidate_materialization_pass_count": 0,
+        "statistics_materialization_count": 0,
+        "database_accessed": False,
+        "calibration_parameters_selected": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "observed_window_digest": (
+            observed_window_digest
+        ),
+        "lineup_bullpen_window_digest": (
+            lineup_bullpen_window_digest
+        ),
+    }
+    diagnostics["window_execution_digest"] = (
+        _digest(diagnostics)
+    )
+
+    return {
+        "starters": dict(starters),
+        "statistics": None,
+        "candidates": None,
+        "execution": None,
+        "diagnostics": diagnostics,
+    }
+
+
+def execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+    events: Iterable[Any],
+    *,
+    observed_window_digest: str,
+    lineup_bullpen_window_digest: str,
+    candidate_window_days: int = 90,
+    evaluation_game_pks: Iterable[int] | None = None,
+    minimum_samples: int = 30,
+    minimum_observed_pa: int = 1000,
+    season_log_loss_regression_tolerance: float = 0.0,
+) -> dict[str, Any]:
+    """Execute cutoff-safe historical PA comparison across Statcast games."""
+
+    observed_digest = str(
+        observed_window_digest
+    ).strip()
+    lineup_digest = str(
+        lineup_bullpen_window_digest
+    ).strip()
+
+    if not observed_digest:
+        raise ValueError(
+            "observed_window_digest_required"
+        )
+    if not lineup_digest:
+        raise ValueError(
+            "lineup_bullpen_window_digest_required"
+        )
+
+    window_days = _positive_integer(
+        candidate_window_days,
+        "candidate_window_days",
+    )
+    rows = list(events)
+
+    starters = (
+        source_canonical_pitcher_matchup_profile_pa_historical_starters(
+            rows
+        )
+    )
+    starter_events = list(
+        starters.get("starter_events") or ()
+    )
+    requests = list(
+        starters.get("requests") or ()
+    )
+
+    selected_game_pks = None
+
+    if evaluation_game_pks is not None:
+        selected_game_pks = {
+            _positive_integer(
+                value,
+                "evaluation_game_pk",
+            )
+            for value in evaluation_game_pks
+        }
+
+        if not selected_game_pks:
+            raise ValueError(
+                "evaluation_game_pks_must_not_be_empty"
+            )
+
+        requests = [
+            request
+            for request in requests
+            if _positive_integer(
+                _value(request, "game_pk"),
+                "game_pk",
+            )
+            in selected_game_pks
+        ]
+        starter_events = [
+            event
+            for event in starter_events
+            if _positive_integer(
+                _value(event, "game_pk"),
+                "game_pk",
+            )
+            in selected_game_pks
+        ]
+
+    if not requests:
+        return _unavailable(
+            events=rows,
+            starters=starters,
+            blocker="no_historical_starter_requests",
+            observed_window_digest=(
+                observed_digest
+            ),
+            lineup_bullpen_window_digest=(
+                lineup_digest
+            ),
+        )
+
+    requests_by_game: dict[
+        int,
+        list[dict[str, Any]],
+    ] = defaultdict(list)
+
+    for request in requests:
+        game_pk = _positive_integer(
+            _value(request, "game_pk"),
+            "game_pk",
+        )
+        pitcher_id = _positive_integer(
+            _value(request, "pitcher_id"),
+            "pitcher_id",
+        )
+        game_date = _date(
+            _value(request, "game_date")
+        )
+
+        requests_by_game[game_pk].append({
+            "game_pk": game_pk,
+            "pitcher_id": pitcher_id,
+            "game_date": game_date,
+            "side": _value(request, "side"),
+        })
+
+    statistics_games = []
+    statistics_diagnostics = []
+    rejected_games = []
+
+    for game_pk in sorted(requests_by_game):
+        game_requests = sorted(
+            requests_by_game[game_pk],
+            key=lambda value: (
+                value["pitcher_id"],
+                str(value.get("side")),
+            ),
+        )
+        game_dates = {
+            request["game_date"]
+            for request in game_requests
+        }
+
+        if len(game_dates) != 1:
+            rejected_games.append({
+                "game_pk": game_pk,
+                "reason": (
+                    "conflicting_game_dates"
+                ),
+            })
+            continue
+
+        game_date = next(iter(game_dates))
+        pitcher_ids = tuple(sorted({
+            request["pitcher_id"]
+            for request in game_requests
+        }))
+        batter_ids = tuple(sorted({
+            _positive_integer(
+                _value(event, "batter_id"),
+                "batter_id",
+            )
+            for event in starter_events
+            if _value(event, "game_pk") == game_pk
+            and _value(event, "batter_id") is not None
+        }))
+
+        if not batter_ids:
+            rejected_games.append({
+                "game_pk": game_pk,
+                "reason": (
+                    "no_historical_batters"
+                ),
+            })
+            continue
+
+        statistics_result = (
+            source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics(
+                rows,
+                game_pk=game_pk,
+                game_date=game_date,
+                batter_ids=batter_ids,
+                pitcher_ids=pitcher_ids,
+                observed_window_digest=(
+                    observed_digest
+                ),
+                lineup_bullpen_window_digest=(
+                    lineup_digest
+                ),
+            )
+        )
+        statistics = statistics_result[
+            "statistics"
+        ]
+        statistics_games.extend(
+            statistics.games
+        )
+        statistics_diagnostics.append(
+            dict(
+                statistics_result.get(
+                    "diagnostics"
+                )
+                or {}
+            )
+        )
+
+    if not statistics_games:
+        result = _unavailable(
+            events=rows,
+            starters=starters,
+            blocker=(
+                "no_historical_statistics_games"
+            ),
+            observed_window_digest=(
+                observed_digest
+            ),
+            lineup_bullpen_window_digest=(
+                lineup_digest
+            ),
+        )
+        result["diagnostics"][
+            "rejected_games"
+        ] = rejected_games
+        return result
+
+    statistics_games = sorted(
+        statistics_games,
+        key=lambda game: (
+            game.game_date,
+            game.game_pk,
+        ),
+    )
+    statistics_window_digest = _digest({
+        "schema_version": SCHEMA_VERSION,
+        "observed_window_digest": (
+            observed_digest
+        ),
+        "lineup_bullpen_window_digest": (
+            lineup_digest
+        ),
+        "games": [
+            {
+                "game_pk": game.game_pk,
+                "game_date": game.game_date,
+                "statistics_through_date": (
+                    game.statistics_through_date
+                ),
+                "snapshot_digest": (
+                    game.snapshot_digest
+                ),
+            }
+            for game in statistics_games
+        ],
+    })
+    statistics_window = (
+        CanonicalHistoricalProbabilityStatisticsWindow(
+            observed_window_digest=(
+                observed_digest
+            ),
+            lineup_bullpen_window_digest=(
+                lineup_digest
+            ),
+            games=tuple(statistics_games),
+            digest=statistics_window_digest,
+        )
+    )
+
+    candidates = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_candidates(
+            rows,
+            requests=requests,
+            window_days=window_days,
+        )
+    )
+    execution = (
+        execute_canonical_pitcher_matchup_profile_pa_historical_evaluation(
+            starter_events,
+            statistics=statistics_window,
+            candidates_by_game_pitcher=(
+                candidates.get("candidates")
+                or {}
+            ),
+            minimum_samples=minimum_samples,
+            minimum_observed_pa=(
+                minimum_observed_pa
+            ),
+            season_log_loss_regression_tolerance=(
+                season_log_loss_regression_tolerance
+            ),
+        )
+    )
+
+    starter_diagnostics = dict(
+        starters.get("diagnostics") or {}
+    )
+    candidate_diagnostics = dict(
+        candidates.get("diagnostics") or {}
+    )
+    execution_diagnostics = dict(
+        execution.get("diagnostics") or {}
+    )
+    evaluation_diagnostics = dict(
+        (
+            execution.get("evaluation")
+            or {}
+        ).get("diagnostics")
+        or {}
+    )
+
+    component_statuses = (
+        starter_diagnostics.get("status"),
+        *(
+            value.get("status")
+            for value in statistics_diagnostics
+        ),
+        candidate_diagnostics.get("status"),
+        execution_diagnostics.get("status"),
+    )
+
+    if evaluation_diagnostics.get(
+        "selection_gate_passed"
+    ):
+        status = "ready"
+        activation_status = (
+            "historical_pa_gate_passed"
+        )
+    elif any(
+        value == "unavailable"
+        for value in component_statuses
+    ):
+        status = "unavailable"
+        activation_status = (
+            "historical_pa_evaluation_unavailable"
+        )
+    else:
+        status = "partial"
+        activation_status = (
+            evaluation_diagnostics.get(
+                "activation_status"
+            )
+            or "historical_pa_gate_blocked"
+        )
+
+    diagnostics = {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "activation_status": (
+            activation_status
+        ),
+        "raw_event_count": len(rows),
+        "evaluation_game_filter_applied": (
+            selected_game_pks is not None
+        ),
+        "requested_evaluation_game_count": (
+            len(selected_game_pks)
+            if selected_game_pks is not None
+            else None
+        ),
+        "game_count": len(
+            requests_by_game
+        ),
+        "starter_request_count": len(
+            requests
+        ),
+        "starter_event_count": len(
+            starter_events
+        ),
+        "statistics_game_count": len(
+            statistics_games
+        ),
+        "candidate_count": len(
+            candidates.get("candidates")
+            or {}
+        ),
+        "rejected_game_count": len(
+            rejected_games
+        ),
+        "rejected_games": rejected_games,
+        "component_statuses": (
+            component_statuses
+        ),
+        "statistics_diagnostics": (
+            statistics_diagnostics
+        ),
+        "single_shared_event_collection": True,
+        "lookback_events_reused_for_evaluation": True,
+        "starter_inference_pass_count": 1,
+        "candidate_materialization_pass_count": 1,
+        "statistics_materialization_count": (
+            len(statistics_games)
+        ),
+        "cutoff_policy": (
+            "per_game_same_season_strictly_before_game_date"
+        ),
+        "pipeline": (
+            "starters_to_statistics_and_candidates_to_historical_evaluation"
+        ),
+        "database_accessed": False,
+        "calibration_parameters_selected": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "starter_window_digest": (
+            starter_diagnostics.get(
+                "starter_window_digest"
+            )
+        ),
+        "statistics_window_digest": (
+            statistics_window_digest
+        ),
+        "candidate_window_digest": (
+            candidate_diagnostics.get(
+                "candidate_window_digest"
+            )
+        ),
+        "execution_digest": (
+            execution_diagnostics.get(
+                "execution_digest"
+            )
+        ),
+    }
+    diagnostics["window_execution_digest"] = (
+        _digest(diagnostics)
+    )
+
+    return {
+        "starters": starters,
+        "statistics": statistics_window,
+        "candidates": candidates,
+        "execution": execution,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_runtime_batch.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_runtime_batch.py
@@ -1,0 +1,600 @@
+"""Batch runtime assembly for canonical pitcher matchup profiles."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .canonical_pitcher_matchup_profile_application import (
+    apply_canonical_pitcher_matchup_profile_calibration,
+)
+from .canonical_pitcher_matchup_profile_evidence import (
+    build_canonical_pitcher_matchup_profile_evidence,
+)
+from .canonical_pitcher_matchup_profile_holdout import (
+    METRIC_SPECS,
+)
+from .canonical_pitcher_matchup_profile_runtime_candidate import (
+    BLOCKED_METRICS,
+    CALIBRATED_POOLED_PSEUDO_COUNTS,
+    calibrated_candidate_policy,
+)
+
+
+RUNTIME_BATCH_VERSION = (
+    "canonical_pitcher_matchup_profile_runtime_batch_v1"
+)
+
+
+def _value(row: Any, key: str) -> Any:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value).strip()[:10]
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date must be a valid date"
+        ) from exc
+
+
+def _pitcher_id(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if parsed > 0 else None
+
+
+def _counts(
+    summary: Mapping[str, Any],
+    metric: str,
+) -> tuple[int, int] | None:
+    specification = METRIC_SPECS.get(metric)
+    if specification is None:
+        return None
+
+    _, component, numerator_key = specification
+    component_values = summary.get(component)
+    denominators = summary.get(
+        "metric_denominators"
+    )
+
+    if (
+        not isinstance(
+            component_values,
+            Mapping,
+        )
+        or not isinstance(
+            denominators,
+            Mapping,
+        )
+    ):
+        return None
+
+    numerator = component_values.get(
+        numerator_key
+    )
+    denominator = denominators.get(metric)
+
+    if (
+        not isinstance(numerator, int)
+        or isinstance(numerator, bool)
+        or not isinstance(denominator, int)
+        or isinstance(denominator, bool)
+        or numerator < 0
+        or denominator < 0
+        or numerator > denominator
+    ):
+        return None
+
+    return numerator, denominator
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def build_canonical_pitcher_matchup_profile_runtime_batch(
+    events: Iterable[Any],
+    *,
+    pitcher_ids: Iterable[int],
+    game_date: dt.date | str,
+    window_days: int = 90,
+) -> dict[str, Any]:
+    """Build many exclusion-safe candidates from one evidence pass."""
+    cutoff = _date(game_date)
+    days = int(window_days)
+
+    if days < 1:
+        raise ValueError(
+            "window_days must be positive"
+        )
+
+    requested = tuple(sorted({
+        pitcher
+        for value in pitcher_ids
+        for pitcher in [_pitcher_id(value)]
+        if pitcher is not None
+    }))
+
+    if not requested:
+        raise ValueError(
+            "at least one positive pitcher_id is required"
+        )
+
+    grouped = defaultdict(list)
+    raw_event_count = 0
+    invalid_pitcher_event_count = 0
+
+    for row in events:
+        raw_event_count += 1
+        pitcher = _pitcher_id(
+            _value(row, "pitcher_id")
+        )
+
+        if pitcher is None:
+            invalid_pitcher_event_count += 1
+            continue
+
+        grouped[pitcher].append(row)
+
+    metrics = tuple(sorted(
+        CALIBRATED_POOLED_PSEUDO_COUNTS
+    ))
+    league_totals = {
+        metric: {
+            "successes": 0,
+            "trials": 0,
+        }
+        for metric in metrics
+    }
+    pitcher_counts = {}
+    requested_evidence = {}
+    evidence_build_count = 0
+
+    for pitcher in sorted(grouped):
+        evidence = (
+            build_canonical_pitcher_matchup_profile_evidence(
+                grouped[pitcher],
+                pitcher_id=pitcher,
+                game_date=cutoff,
+                window_days=days,
+            )
+        )
+        evidence_build_count += 1
+        overall = evidence.get("overall")
+        rows = {}
+
+        if isinstance(overall, Mapping):
+            for metric in metrics:
+                metric_counts = _counts(
+                    overall,
+                    metric,
+                )
+                if metric_counts is None:
+                    continue
+
+                successes, trials = metric_counts
+                rows[metric] = {
+                    "successes": successes,
+                    "trials": trials,
+                }
+                league_totals[metric][
+                    "successes"
+                ] += successes
+                league_totals[metric][
+                    "trials"
+                ] += trials
+
+        pitcher_counts[pitcher] = rows
+
+        if pitcher in requested:
+            requested_evidence[pitcher] = (
+                evidence
+            )
+
+    policy = calibrated_candidate_policy()
+    candidates = {}
+
+    for pitcher in requested:
+        own_counts = pitcher_counts.get(
+            pitcher,
+            {},
+        )
+        priors = {}
+        prior_diagnostics = {}
+
+        for metric in metrics:
+            total = league_totals[metric]
+            own = own_counts.get(
+                metric,
+                {
+                    "successes": 0,
+                    "trials": 0,
+                },
+            )
+            successes = (
+                total["successes"]
+                - own["successes"]
+            )
+            trials = (
+                total["trials"]
+                - own["trials"]
+            )
+
+            if trials > 0:
+                prior = successes / trials
+                priors[metric] = round(
+                    prior,
+                    12,
+                )
+                status = "ready"
+                reasons = []
+            else:
+                status = "unavailable"
+                reasons = [
+                    "league_trials_unavailable"
+                ]
+
+            prior_diagnostics[metric] = {
+                "status": status,
+                "successes": successes,
+                "trials": trials,
+                "prior": priors.get(metric),
+                "excluded_pitcher_id": pitcher,
+                "reasons": reasons,
+            }
+
+        requested_evidence_present = (
+            pitcher in requested_evidence
+        )
+        evidence = requested_evidence.get(
+            pitcher,
+            {
+                "overall": {},
+                "diagnostics": {
+                    "status": "unavailable",
+                    "reasons": [
+                        "pitcher_evidence_unavailable",
+                    ],
+                    "evidence_digest": None,
+                },
+            },
+        )
+        application = (
+            apply_canonical_pitcher_matchup_profile_calibration(
+                evidence,
+                calibration_policy=policy,
+                league_priors=priors,
+            )
+        )
+
+        evidence_diagnostics = dict(
+            evidence.get("diagnostics") or {}
+        )
+        application_diagnostics = dict(
+            application.get("diagnostics")
+            or {}
+        )
+
+        explicit_evidence_status = (
+            evidence_diagnostics.get("status")
+        )
+
+        if explicit_evidence_status:
+            evidence_status = (
+                explicit_evidence_status
+            )
+            evidence_status_source = (
+                "explicit_evidence_diagnostics"
+            )
+        elif requested_evidence_present:
+            evidence_status = "ready"
+            evidence_status_source = (
+                "single_pass_sufficient_statistics"
+            )
+            evidence_diagnostics.update({
+                "status": "ready",
+                "status_source": (
+                    evidence_status_source
+                ),
+                "reasons": [],
+                "evidence_digest": (
+                    evidence_diagnostics.get(
+                        "evidence_digest"
+                    )
+                ),
+            })
+        else:
+            evidence_status = "unavailable"
+            evidence_status_source = (
+                "requested_pitcher_evidence_missing"
+            )
+            evidence_diagnostics.update({
+                "status": "unavailable",
+                "status_source": (
+                    evidence_status_source
+                ),
+                "reasons": [
+                    "pitcher_evidence_unavailable",
+                ],
+                "evidence_digest": None,
+            })
+
+        application_status = (
+            application_diagnostics.get(
+                "status"
+            )
+            or "unavailable"
+        )
+        prior_status = (
+            "ready"
+            if prior_diagnostics
+            and all(
+                row.get("status") == "ready"
+                for row in (
+                    prior_diagnostics.values()
+                )
+            )
+            else "unavailable"
+        )
+
+        if application_status == "ready":
+            candidate_status = "ready"
+            activation_status = (
+                "shadow_candidate_materialized"
+            )
+        elif application_status == "partial":
+            candidate_status = "partial"
+            activation_status = (
+                "shadow_candidate_partial"
+            )
+        else:
+            candidate_status = "unavailable"
+            activation_status = (
+                "shadow_candidate_unavailable"
+            )
+
+        candidate_blockers = []
+
+        if evidence_status != "ready":
+            candidate_blockers.append(
+                "pitcher_evidence_unavailable"
+            )
+
+        if prior_status != "ready":
+            candidate_blockers.append(
+                "league_priors_unavailable"
+            )
+
+        metric_diagnostics = (
+            application_diagnostics.get(
+                "metric_diagnostics"
+            )
+            or {}
+        )
+
+        for metric_row in (
+            metric_diagnostics.values()
+        ):
+            for reason in (
+                metric_row.get("reasons")
+                or ()
+            ):
+                if (
+                    reason
+                    not in candidate_blockers
+                ):
+                    candidate_blockers.append(
+                        reason
+                    )
+
+        if (
+            application_status == "partial"
+            and "partial_calibrated_profile_rates"
+            not in candidate_blockers
+        ):
+            candidate_blockers.append(
+                "partial_calibrated_profile_rates"
+            )
+
+        if (
+            application_status
+            == "unavailable"
+            and not candidate_blockers
+        ):
+            candidate_blockers.append(
+                "calibrated_profile_unavailable"
+            )
+
+        diagnostics = {
+            "schema_version": (
+                RUNTIME_BATCH_VERSION
+            ),
+            "status": candidate_status,
+            "pitcher_id": pitcher,
+            "blockers": list(
+                candidate_blockers
+            ),
+            "evidence_status": evidence_status,
+            "evidence_status_source": (
+                evidence_status_source
+            ),
+            "league_prior_status": prior_status,
+            "application_status": (
+                application_status
+            ),
+            "game_date": cutoff.isoformat(),
+            "window_days": days,
+            "cutoff_rule": (
+                "events_strictly_before_game_date"
+            ),
+            "prior_scope": (
+                "all_other_pitchers_in_window"
+            ),
+            "event_window_reused": True,
+            "batch_evidence_pass": True,
+            "selected_pseudo_counts": dict(
+                CALIBRATED_POOLED_PSEUDO_COUNTS
+            ),
+            "blocked_metrics": {
+                metric: list(reasons)
+                for metric, reasons in (
+                    BLOCKED_METRICS.items()
+                )
+            },
+            "segment_parameters_applied": False,
+            "production_authority": False,
+            "production_authority_changed": False,
+            "activation_status": (
+                activation_status
+            ),
+            "evidence_digest": (
+                evidence.get(
+                    "diagnostics",
+                    {},
+                ).get("evidence_digest")
+            ),
+            "application_digest": (
+                application["diagnostics"].get(
+                    "application_digest"
+                )
+            ),
+        }
+        diagnostics[
+            "runtime_candidate_digest"
+        ] = _digest(diagnostics)
+
+        candidates[str(pitcher)] = {
+            "profile_rates": dict(
+                application["profile_rates"]
+            ),
+            "diagnostics": diagnostics,
+            "prior_diagnostics": (
+                prior_diagnostics
+            ),
+            "league_prior_diagnostics": (
+                prior_diagnostics
+            ),
+            "evidence_diagnostics": (
+                evidence_diagnostics
+            ),
+            "application_diagnostics": (
+                application_diagnostics
+            ),
+        }
+
+    candidate_status_counts = {
+        status: sum(
+            1
+            for candidate in candidates.values()
+            if (
+                candidate.get(
+                    "diagnostics",
+                    {},
+                ).get("status")
+                == status
+            )
+        )
+        for status in (
+            "ready",
+            "partial",
+            "unavailable",
+        )
+    }
+    ready_candidate_count = (
+        candidate_status_counts["ready"]
+    )
+    partial_candidate_count = (
+        candidate_status_counts["partial"]
+    )
+    unavailable_candidate_count = (
+        candidate_status_counts[
+            "unavailable"
+        ]
+    )
+    ready_candidate_coverage = (
+        round(
+            ready_candidate_count
+            / len(candidates),
+            12,
+        )
+        if candidates
+        else 0.0
+    )
+
+    batch_diagnostics = {
+        "schema_version": RUNTIME_BATCH_VERSION,
+        "status": (
+            "ready"
+            if candidates
+            else "unavailable"
+        ),
+        "game_date": cutoff.isoformat(),
+        "window_days": days,
+        "requested_pitcher_ids": list(
+            requested
+        ),
+        "candidate_count": len(candidates),
+        "ready_candidate_count": (
+            ready_candidate_count
+        ),
+        "partial_candidate_count": (
+            partial_candidate_count
+        ),
+        "unavailable_candidate_count": (
+            unavailable_candidate_count
+        ),
+        "candidate_status_counts": dict(
+            candidate_status_counts
+        ),
+        "ready_candidate_coverage": (
+            ready_candidate_coverage
+        ),
+        "raw_event_count": raw_event_count,
+        "candidate_pitcher_count": len(
+            grouped
+        ),
+        "evidence_build_count": (
+            evidence_build_count
+        ),
+        "invalid_pitcher_event_count": (
+            invalid_pitcher_event_count
+        ),
+        "single_shared_evidence_pass": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+    batch_diagnostics["batch_digest"] = (
+        _digest(batch_diagnostics)
+    )
+
+    return {
+        "candidates": candidates,
+        "diagnostics": batch_diagnostics,
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_runtime_candidate.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_runtime_candidate.py
@@ -1,0 +1,266 @@
+"""Assemble shadow runtime candidates for canonical pitcher profiles."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .canonical_pitcher_matchup_profile_application import (
+    apply_canonical_pitcher_matchup_profile_calibration,
+)
+from .canonical_pitcher_matchup_profile_evidence import (
+    build_canonical_pitcher_matchup_profile_evidence,
+)
+from .canonical_pitcher_matchup_profile_league_prior import (
+    build_canonical_pitcher_matchup_profile_league_priors,
+)
+
+
+RUNTIME_CANDIDATE_VERSION = (
+    "canonical_pitcher_matchup_profile_runtime_candidate_v1"
+)
+CALIBRATION_ARTIFACT_VERSION = (
+    "canonical_pitcher_matchup_profile_shrinkage_audit_v1"
+)
+CALIBRATION_POLICY_VERSION = (
+    "canonical_pitcher_matchup_profile_calibration_policy_v1"
+)
+
+CALIBRATED_POOLED_PSEUDO_COUNTS = {
+    "barrel_rate_allowed_approx": 400.0,
+    "fly_ball_rate": 200.0,
+    "ground_ball_rate": 50.0,
+    "hard_hit_rate_allowed": 200.0,
+    "k_rate": 100.0,
+    "line_drive_rate": 1600.0,
+    "popup_rate": 100.0,
+    "sweet_spot_rate_allowed": 800.0,
+}
+BLOCKED_METRICS = {
+    "bb_rate": [
+        "cross_season_candidate_instability"
+    ],
+}
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value).strip()[:10]
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date must be a valid date"
+        ) from exc
+
+
+def _pitcher_id(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ValueError(
+            "pitcher_id must be positive"
+        )
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "pitcher_id must be positive"
+        ) from exc
+
+    if parsed < 1:
+        raise ValueError(
+            "pitcher_id must be positive"
+        )
+
+    return parsed
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def calibrated_candidate_policy() -> dict[str, Any]:
+    """Return the immutable pooled candidate policy."""
+    return {
+        "schema_version": (
+            CALIBRATION_POLICY_VERSION
+        ),
+        "status": "ready",
+        "selection_scope": (
+            "pooled_metrics_only"
+        ),
+        "parameter_selected": True,
+        "selected_pseudo_counts": dict(
+            CALIBRATED_POOLED_PSEUDO_COUNTS
+        ),
+        "blocked_metrics": {
+            metric: list(reasons)
+            for metric, reasons in (
+                BLOCKED_METRICS.items()
+            )
+        },
+        "segment_parameters_selected": False,
+        "segment_policy": (
+            "deferred_pending_season_disjoint_"
+            "segment_stability"
+        ),
+        "production_authority": False,
+        "production_authority_changed": False,
+        "activation_status": (
+            "candidate_policy_ready"
+        ),
+        "calibration_artifact_version": (
+            CALIBRATION_ARTIFACT_VERSION
+        ),
+    }
+
+
+def build_canonical_pitcher_matchup_profile_runtime_candidate(
+    events: Iterable[Any],
+    *,
+    pitcher_id: int,
+    game_date: dt.date | str,
+    window_days: int = 90,
+) -> dict[str, Any]:
+    """Build a calibrated shadow candidate from one shared event window."""
+    normalized_pitcher_id = _pitcher_id(
+        pitcher_id
+    )
+    cutoff = _date(game_date)
+    rows = list(events)
+
+    evidence = (
+        build_canonical_pitcher_matchup_profile_evidence(
+            rows,
+            pitcher_id=normalized_pitcher_id,
+            game_date=cutoff,
+            window_days=window_days,
+        )
+    )
+    prior_result = (
+        build_canonical_pitcher_matchup_profile_league_priors(
+            rows,
+            game_date=cutoff,
+            excluded_pitcher_id=(
+                normalized_pitcher_id
+            ),
+            window_days=window_days,
+            metrics=(
+                CALIBRATED_POOLED_PSEUDO_COUNTS
+            ),
+        )
+    )
+    policy = calibrated_candidate_policy()
+
+    application = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence,
+            calibration_policy=policy,
+            league_priors=prior_result[
+                "league_priors"
+            ],
+        )
+    )
+
+    evidence_status = (
+        evidence.get("diagnostics", {})
+        .get("status")
+    )
+    prior_status = (
+        prior_result["diagnostics"].get(
+            "status"
+        )
+    )
+    application_status = (
+        application["diagnostics"].get(
+            "status"
+        )
+    )
+
+    if application_status == "ready":
+        status = "ready"
+    elif application_status == "partial":
+        status = "partial"
+    else:
+        status = "unavailable"
+
+    diagnostics = {
+        "schema_version": (
+            RUNTIME_CANDIDATE_VERSION
+        ),
+        "status": status,
+        "pitcher_id": normalized_pitcher_id,
+        "game_date": cutoff.isoformat(),
+        "window_days": int(window_days),
+        "cutoff_rule": (
+            "events_strictly_before_game_date"
+        ),
+        "event_window_reused": True,
+        "evidence_status": evidence_status,
+        "league_prior_status": prior_status,
+        "application_status": (
+            application_status
+        ),
+        "selected_pseudo_counts": dict(
+            CALIBRATED_POOLED_PSEUDO_COUNTS
+        ),
+        "blocked_metrics": {
+            metric: list(reasons)
+            for metric, reasons in (
+                BLOCKED_METRICS.items()
+            )
+        },
+        "segment_parameters_applied": False,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "activation_status": (
+            "shadow_candidate_materialized"
+        ),
+        "evidence_digest": (
+            evidence.get("diagnostics", {})
+            .get("evidence_digest")
+        ),
+        "prior_digest": (
+            prior_result["diagnostics"].get(
+                "prior_digest"
+            )
+        ),
+        "application_digest": (
+            application["diagnostics"].get(
+                "application_digest"
+            )
+        ),
+    }
+    diagnostics["runtime_candidate_digest"] = (
+        _digest(diagnostics)
+    )
+
+    return {
+        "profile_rates": dict(
+            application["profile_rates"]
+        ),
+        "diagnostics": diagnostics,
+        "evidence_diagnostics": (
+            evidence.get("diagnostics", {})
+        ),
+        "league_prior_diagnostics": (
+            prior_result["diagnostics"]
+        ),
+        "application_diagnostics": (
+            application["diagnostics"]
+        ),
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_shrinkage.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_shrinkage.py
@@ -1,0 +1,426 @@
+"""Holdout calibration for canonical pitcher-profile shrinkage."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+
+CANONICAL_PITCHER_MATCHUP_PROFILE_SHRINKAGE_VERSION = (
+    "canonical_pitcher_matchup_profile_shrinkage_v1"
+)
+
+DEFAULT_PSEUDO_COUNT_GRID = (
+    0,
+    25,
+    50,
+    100,
+    200,
+    400,
+)
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return parsed if math.isfinite(parsed) else None
+
+
+def _candidates(
+    values: Sequence[int | float],
+) -> tuple[float, ...]:
+    candidates = tuple(float(value) for value in values)
+
+    if not candidates:
+        raise ValueError(
+            "candidate pseudo-count grid must not be empty"
+        )
+    if any(
+        not math.isfinite(value) or value < 0
+        for value in candidates
+    ):
+        raise ValueError(
+            "candidate pseudo-counts must be finite "
+            "and nonnegative"
+        )
+    if len(set(candidates)) != len(candidates):
+        raise ValueError(
+            "candidate pseudo-counts must be unique"
+        )
+
+    return candidates
+
+
+def _prepare(
+    samples: Iterable[Mapping[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    ready = []
+    rejected = []
+
+    for index, raw in enumerate(samples):
+        reasons = []
+        metric = raw.get("metric")
+        family = raw.get("family")
+        segment = raw.get("segment") or "overall"
+        season = raw.get("season")
+        training_successes = _number(
+            raw.get("training_successes")
+        )
+        training_trials = _number(
+            raw.get("training_trials")
+        )
+        holdout_successes = _number(
+            raw.get("holdout_successes")
+        )
+        holdout_trials = _number(
+            raw.get("holdout_trials")
+        )
+        prior_probability = _number(
+            raw.get("prior_probability")
+        )
+
+        if not isinstance(metric, str) or not metric:
+            reasons.append("missing_metric")
+        if not isinstance(family, str) or not family:
+            reasons.append("missing_family")
+        if season is None:
+            reasons.append("missing_season")
+        if training_trials is None or training_trials <= 0:
+            reasons.append("invalid_training_trials")
+        if (
+            training_successes is None
+            or training_successes < 0
+            or (
+                training_trials is not None
+                and training_successes > training_trials
+            )
+        ):
+            reasons.append("invalid_training_successes")
+        if holdout_trials is None or holdout_trials <= 0:
+            reasons.append("invalid_holdout_trials")
+        if (
+            holdout_successes is None
+            or holdout_successes < 0
+            or (
+                holdout_trials is not None
+                and holdout_successes > holdout_trials
+            )
+        ):
+            reasons.append("invalid_holdout_successes")
+        if (
+            prior_probability is None
+            or not 0 <= prior_probability <= 1
+        ):
+            reasons.append("invalid_prior_probability")
+
+        if reasons:
+            rejected.append({
+                "sample_index": index,
+                "reasons": sorted(set(reasons)),
+            })
+            continue
+
+        ready.append({
+            "metric": metric,
+            "family": family,
+            "segment": str(segment),
+            "season": int(season),
+            "training_successes": int(
+                training_successes
+            ),
+            "training_trials": int(training_trials),
+            "holdout_successes": int(
+                holdout_successes
+            ),
+            "holdout_trials": int(holdout_trials),
+            "prior_probability": float(
+                prior_probability
+            ),
+        })
+
+    return ready, rejected
+
+
+def _prediction(
+    sample: Mapping[str, Any],
+    pseudo_count: float,
+) -> tuple[float, float]:
+    trials = float(sample["training_trials"])
+    reliability = trials / (trials + pseudo_count)
+    observed = (
+        float(sample["training_successes"])
+        / trials
+    )
+    prior = float(sample["prior_probability"])
+    probability = (
+        reliability * observed
+        + (1.0 - reliability) * prior
+    )
+
+    return probability, reliability
+
+
+def _score(
+    samples: Sequence[Mapping[str, Any]],
+    pseudo_count: float,
+) -> dict[str, Any]:
+    log_loss_sum = 0.0
+    brier_sum = 0.0
+    absolute_error_sum = 0.0
+    total_trials = 0
+    reliabilities = []
+
+    for sample in samples:
+        probability, reliability = _prediction(
+            sample,
+            pseudo_count,
+        )
+        probability = min(
+            max(probability, 1e-12),
+            1.0 - 1e-12,
+        )
+        successes = int(sample["holdout_successes"])
+        trials = int(sample["holdout_trials"])
+        failures = trials - successes
+        observed = successes / trials
+
+        log_loss_sum += -(
+            successes * math.log(probability)
+            + failures * math.log(1.0 - probability)
+        )
+        brier_sum += (
+            successes * ((1.0 - probability) ** 2)
+            + failures * (probability**2)
+        )
+        absolute_error_sum += (
+            trials * abs(probability - observed)
+        )
+        total_trials += trials
+        reliabilities.append(reliability)
+
+    return {
+        "pseudo_count": pseudo_count,
+        "sample_count": len(samples),
+        "holdout_trials": total_trials,
+        "binomial_log_loss": (
+            log_loss_sum / total_trials
+            if total_trials
+            else None
+        ),
+        "brier_score": (
+            brier_sum / total_trials
+            if total_trials
+            else None
+        ),
+        "weighted_absolute_error": (
+            absolute_error_sum / total_trials
+            if total_trials
+            else None
+        ),
+        "mean_training_reliability": (
+            sum(reliabilities) / len(reliabilities)
+            if reliabilities
+            else None
+        ),
+    }
+
+
+def _grid(
+    samples: Sequence[Mapping[str, Any]],
+    candidates: Sequence[float],
+) -> list[dict[str, Any]]:
+    return [
+        _score(samples, candidate)
+        for candidate in candidates
+    ]
+
+
+def _rank(
+    grid: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    if not grid:
+        raise ValueError("candidate grid is empty")
+
+    return dict(min(
+        grid,
+        key=lambda row: (
+            row["binomial_log_loss"],
+            row["brier_score"],
+            row["weighted_absolute_error"],
+            row["pseudo_count"],
+        ),
+    ))
+
+
+def _metric_result(
+    samples: Sequence[Mapping[str, Any]],
+    candidates: Sequence[float],
+) -> dict[str, Any]:
+    seasons = sorted({
+        int(sample["season"])
+        for sample in samples
+    })
+    blockers = []
+
+    if not samples:
+        blockers.append("no_eligible_samples")
+    if len(seasons) < 2:
+        blockers.append(
+            "insufficient_cross_season_coverage"
+        )
+
+    if blockers:
+        return {
+            "status": "blocked",
+            "blockers": blockers,
+            "sample_count": len(samples),
+            "seasons": seasons,
+        }
+
+    pooled_grid = _grid(samples, candidates)
+    pooled_candidate = _rank(pooled_grid)
+    folds = []
+    selected_candidates = []
+
+    for validation_season in seasons:
+        training = [
+            sample
+            for sample in samples
+            if sample["season"] != validation_season
+        ]
+        validation = [
+            sample
+            for sample in samples
+            if sample["season"] == validation_season
+        ]
+        selected = _rank(_grid(training, candidates))
+        pseudo_count = selected["pseudo_count"]
+        selected_candidates.append(pseudo_count)
+
+        folds.append({
+            "validation_season": validation_season,
+            "training_seasons": sorted({
+                int(sample["season"])
+                for sample in training
+            }),
+            "selected_pseudo_count": pseudo_count,
+            "training_scores": selected,
+            "validation_scores": _score(
+                validation,
+                pseudo_count,
+            ),
+            "candidate_reselected_on_validation": False,
+        })
+
+    segment_diagnostics = {}
+
+    for segment in sorted({
+        str(sample["segment"])
+        for sample in samples
+    }):
+        subset = [
+            sample
+            for sample in samples
+            if sample["segment"] == segment
+        ]
+        segment_diagnostics[segment] = {
+            "sample_count": len(subset),
+            "best_candidate": _rank(
+                _grid(subset, candidates)
+            ),
+        }
+
+    return {
+        "status": "ready",
+        "sample_count": len(samples),
+        "holdout_trials": sum(
+            int(sample["holdout_trials"])
+            for sample in samples
+        ),
+        "seasons": seasons,
+        "pooled_candidate": pooled_candidate,
+        "pooled_grid": pooled_grid,
+        "cross_season_folds": folds,
+        "cross_season_candidate_range": {
+            "minimum": min(selected_candidates),
+            "maximum": max(selected_candidates),
+            "spread": (
+                max(selected_candidates)
+                - min(selected_candidates)
+            ),
+        },
+        "segment_diagnostics": segment_diagnostics,
+    }
+
+
+def calibrate_canonical_pitcher_matchup_profile_shrinkage(
+    samples: Iterable[Mapping[str, Any]],
+    *,
+    candidate_pseudo_counts: Sequence[int | float] = (
+        DEFAULT_PSEUDO_COUNT_GRID
+    ),
+) -> dict[str, Any]:
+    """Calibrate rate shrinkage with season-disjoint holdouts."""
+    candidates = _candidates(candidate_pseudo_counts)
+    ready, rejected = _prepare(samples)
+    grouped = defaultdict(list)
+
+    for sample in ready:
+        grouped[sample["metric"]].append(sample)
+
+    metric_results = {
+        metric: _metric_result(
+            metric_samples,
+            candidates,
+        )
+        for metric, metric_samples in sorted(
+            grouped.items()
+        )
+    }
+    blocked_metrics = sorted(
+        metric
+        for metric, result in metric_results.items()
+        if result["status"] != "ready"
+    )
+
+    return {
+        "schema_version": (
+            CANONICAL_PITCHER_MATCHUP_PROFILE_SHRINKAGE_VERSION
+        ),
+        "status": (
+            "ready"
+            if metric_results and not blocked_metrics
+            else "blocked"
+        ),
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "parameter_selected": False,
+        "selection_role": "candidate_evidence_only",
+        "candidate_pseudo_counts": list(candidates),
+        "eligible_sample_count": len(ready),
+        "rejected_sample_count": len(rejected),
+        "rejected_samples": rejected,
+        "metric_results": metric_results,
+        "blocked_metrics": blocked_metrics,
+        "objective": {
+            "primary": (
+                "holdout_trial_weighted_"
+                "binomial_log_loss"
+            ),
+            "supporting": [
+                "holdout_trial_weighted_brier_score",
+                "holdout_trial_weighted_absolute_error",
+            ],
+            "validation": (
+                "leave_one_season_out_cross_validation"
+            ),
+        },
+    }

--- a/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_source.py
+++ b/mlb_app/simulation/shadow/canonical_pitcher_matchup_profile_source.py
@@ -1,0 +1,207 @@
+"""Cutoff-safe pitcher matchup profile evidence sourcing."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from mlb_app.database import PitcherAggregate
+
+
+CANONICAL_PITCHER_MATCHUP_PROFILE_SOURCE_VERSION = (
+    "canonical_pitcher_matchup_profile_source_v1"
+)
+
+PROFILE_FIELDS = (
+    "k_pct",
+    "bb_pct",
+    "hard_hit_pct",
+    "xwoba",
+    "xba",
+)
+
+
+def _date(value: Any) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+
+    try:
+        return dt.date.fromisoformat(
+            str(value).strip()[:10]
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "game_date must be a valid date"
+        ) from exc
+
+
+def _finite_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(number):
+        return None
+
+    return number
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def source_canonical_pitcher_matchup_profile(
+    session: Session,
+    *,
+    pitcher_id: int,
+    game_date: Any,
+    matchup_features: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Fill missing matchup profile fields from prior 90-day evidence.
+
+    Aggregate evidence must end strictly before the target game date.
+    Same-day and future rows are never eligible.
+    """
+
+    if isinstance(pitcher_id, bool):
+        raise ValueError("pitcher_id must be a positive integer")
+
+    try:
+        normalized_pitcher_id = int(pitcher_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "pitcher_id must be a positive integer"
+        ) from exc
+
+    if normalized_pitcher_id < 1:
+        raise ValueError(
+            "pitcher_id must be a positive integer"
+        )
+
+    normalized_game_date = _date(game_date)
+    supplied = dict(matchup_features or {})
+
+    aggregate = (
+        session.query(PitcherAggregate)
+        .filter(
+            PitcherAggregate.pitcher_id
+            == normalized_pitcher_id,
+            PitcherAggregate.window == "90d",
+            PitcherAggregate.end_date
+            < normalized_game_date,
+        )
+        .order_by(
+            PitcherAggregate.end_date.desc(),
+            PitcherAggregate.id.desc(),
+        )
+        .first()
+    )
+
+    merged = dict(supplied)
+    field_provenance = {}
+
+    for field in PROFILE_FIELDS:
+        supplied_value = _finite_number(
+            supplied.get(field)
+        )
+
+        if supplied_value is not None:
+            field_provenance[field] = {
+                "source": "matchup_payload",
+                "filled_from_aggregate": False,
+            }
+            continue
+
+        aggregate_value = (
+            _finite_number(getattr(aggregate, field))
+            if aggregate is not None
+            else None
+        )
+
+        if aggregate_value is not None:
+            merged[field] = aggregate_value
+            field_provenance[field] = {
+                "source": "pitcher_aggregate_90d",
+                "filled_from_aggregate": True,
+            }
+        else:
+            field_provenance[field] = {
+                "source": "missing",
+                "filled_from_aggregate": False,
+            }
+
+    populated_fields = tuple(
+        field
+        for field in PROFILE_FIELDS
+        if _finite_number(merged.get(field))
+        is not None
+    )
+    missing_fields = tuple(
+        field
+        for field in PROFILE_FIELDS
+        if field not in populated_fields
+    )
+
+    if not populated_fields:
+        status = "unavailable"
+    elif missing_fields:
+        status = "partial"
+    else:
+        status = "ready"
+
+    selected_end_date = (
+        aggregate.end_date.isoformat()
+        if aggregate is not None
+        else None
+    )
+    days_before_game = (
+        (normalized_game_date - aggregate.end_date).days
+        if aggregate is not None
+        else None
+    )
+
+    diagnostics = {
+        "schema_version": (
+            CANONICAL_PITCHER_MATCHUP_PROFILE_SOURCE_VERSION
+        ),
+        "status": status,
+        "pitcher_id": normalized_pitcher_id,
+        "game_date": normalized_game_date.isoformat(),
+        "cutoff_rule": "aggregate_end_date_strictly_before_game_date",
+        "selected_window": (
+            aggregate.window
+            if aggregate is not None
+            else None
+        ),
+        "selected_end_date": selected_end_date,
+        "days_before_game": days_before_game,
+        "populated_fields": list(populated_fields),
+        "missing_fields": list(missing_fields),
+        "field_provenance": field_provenance,
+    }
+    diagnostics["source_digest"] = _digest(
+        diagnostics
+    )
+
+    return {
+        "pitcher_features": merged,
+        "diagnostics": diagnostics,
+    }

--- a/mlb_app/simulation/shadow/historical_probability_artifact_materialization.py
+++ b/mlb_app/simulation/shadow/historical_probability_artifact_materialization.py
@@ -36,8 +36,8 @@ from .historical_probability_statistics_source import (
 )
 from .historical_probability_workspace_reconstruction import (
     CanonicalHistoricalPaProbabilityWorkspaceWindow,
-    _offense_profile,
-    _pitcher_profile,
+    build_historical_probability_offense_profile,
+    build_historical_probability_pitcher_profile,
 )
 from .probability_provider_discovery import (
     discover_canonical_shadow_probability_provider,
@@ -106,10 +106,10 @@ def _distribution(
     pitcher: CanonicalHistoricalProbabilityPlayerStatistics,
 ):
     model = build_pa_outcome_probabilities(
-        batter_profile=_offense_profile(
+        batter_profile=build_historical_probability_offense_profile(
             _counts(batter)
         ),
-        pitcher_profile=_pitcher_profile(
+        pitcher_profile=build_historical_probability_pitcher_profile(
             _counts(pitcher)
         ),
         environment_profile=None,

--- a/mlb_app/simulation/shadow/historical_probability_workspace_reconstruction.py
+++ b/mlb_app/simulation/shadow/historical_probability_workspace_reconstruction.py
@@ -101,7 +101,7 @@ def _rate(
     return numerator / denominator
 
 
-def _offense_profile(
+def build_historical_probability_offense_profile(
     counts: Mapping[str, int],
 ) -> Dict[str, Any]:
     pa = counts.get("pa", 0)
@@ -143,7 +143,7 @@ def _offense_profile(
     }
 
 
-def _pitcher_profile(
+def build_historical_probability_pitcher_profile(
     counts: Mapping[str, int],
 ) -> Dict[str, Any]:
     batters_faced = counts.get(
@@ -189,10 +189,10 @@ def _model(
     pitcher_counts: Mapping[str, int],
 ) -> Dict[str, Any]:
     result = build_pa_outcome_probabilities(
-        batter_profile=_offense_profile(
+        batter_profile=build_historical_probability_offense_profile(
             offense_counts
         ),
-        pitcher_profile=_pitcher_profile(
+        pitcher_profile=build_historical_probability_pitcher_profile(
             pitcher_counts
         ),
         environment_profile=None,

--- a/scripts/audit_canonical_pitcher_matchup_profile_pa_cross_season.py
+++ b/scripts/audit_canonical_pitcher_matchup_profile_pa_cross_season.py
@@ -1,0 +1,505 @@
+"""Run a bounded cross-season historical pitcher-profile PA audit."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from typing import Any
+
+from mlb_app.database import StatcastEvent
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_evaluation import (
+    evaluate_canonical_pitcher_matchup_profile_pa_history,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_statcast_window import (
+    execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_cross_season_audit_v1"
+)
+
+
+def _date(value: str) -> dt.date:
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "date must use YYYY-MM-DD"
+        ) from exc
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "value must be a positive integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            "value must be a positive integer"
+        )
+
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "value must be nonnegative"
+        ) from exc
+
+    if parsed < 0.0:
+        raise argparse.ArgumentTypeError(
+            "value must be nonnegative"
+        )
+
+    return parsed
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Evaluate pooled pitcher-profile PA "
+            "candidates across independent seasons."
+        )
+    )
+    parser.add_argument(
+        "--evaluation-date",
+        action="append",
+        required=True,
+        type=_date,
+        help=(
+            "Evaluation date in YYYY-MM-DD form. "
+            "Repeat once per season."
+        ),
+    )
+    parser.add_argument(
+        "--max-games-per-date",
+        type=_positive_integer,
+        default=2,
+        help=(
+            "Maximum games evaluated on each date."
+        ),
+    )
+    parser.add_argument(
+        "--window-days",
+        type=_positive_integer,
+        default=90,
+        help=(
+            "Independent lookback for each date."
+        ),
+    )
+    parser.add_argument(
+        "--minimum-samples",
+        type=_positive_integer,
+        default=30,
+        help=(
+            "Minimum combined paired samples."
+        ),
+    )
+    parser.add_argument(
+        "--minimum-observed-pa",
+        type=_positive_integer,
+        default=100,
+        help=(
+            "Minimum combined observed PAs."
+        ),
+    )
+    parser.add_argument(
+        "--season-regression-tolerance",
+        type=_nonnegative_float,
+        default=0.0,
+        help=(
+            "Allowed per-season log-loss regression."
+        ),
+    )
+    return parser
+
+
+def _selected_games(
+    rows: list[Any],
+    *,
+    evaluation_date: dt.date,
+    maximum: int,
+) -> tuple[int, ...]:
+    identities = sorted({
+        int(row.game_pk)
+        for row in rows
+        if row.game_pk is not None
+        and row.game_date
+        == evaluation_date
+    })
+    return tuple(identities[:maximum])
+
+
+def _load_events(
+    session: Any,
+    *,
+    evaluation_date: dt.date,
+    window_days: int,
+) -> tuple[
+    list[Any],
+    dt.date,
+]:
+    load_start = (
+        evaluation_date
+        - dt.timedelta(days=window_days)
+    )
+    load_end = (
+        evaluation_date
+        + dt.timedelta(days=1)
+    )
+    rows = (
+        session.query(StatcastEvent)
+        .filter(
+            StatcastEvent.game_date
+            >= load_start,
+            StatcastEvent.game_date
+            < load_end,
+            StatcastEvent.events.isnot(None),
+        )
+        .order_by(
+            StatcastEvent.game_date,
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+            StatcastEvent.id,
+        )
+        .all()
+    )
+    return rows, load_start
+
+
+def _window_digests(
+    *,
+    evaluation_date: dt.date,
+    load_start: dt.date,
+    window_days: int,
+) -> tuple[str, str]:
+    identity = {
+        "schema_version": SCHEMA_VERSION,
+        "evaluation_date": (
+            evaluation_date.isoformat()
+        ),
+        "load_start": (
+            load_start.isoformat()
+        ),
+        "load_end_exclusive": (
+            evaluation_date
+            + dt.timedelta(days=1)
+        ).isoformat(),
+        "window_days": window_days,
+        "terminal_rows_only": True,
+    }
+    return (
+        _digest({
+            **identity,
+            "source": (
+                "local_statcast_terminal_pa_history"
+            ),
+        }),
+        _digest({
+            **identity,
+            "source": (
+                "inferred_historical_starters"
+            ),
+        }),
+    )
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    evaluation_dates = tuple(sorted(set(
+        args.evaluation_date
+    )))
+
+    if len(evaluation_dates) < 2:
+        raise SystemExit(
+            "STOP: at least two distinct "
+            "evaluation dates are required."
+        )
+    if len({
+        value.year
+        for value in evaluation_dates
+    }) < 2:
+        raise SystemExit(
+            "STOP: evaluation dates must span "
+            "at least two seasons."
+        )
+
+    started = dt.datetime.now(
+        dt.timezone.utc
+    )
+    session_factory = _session_factory()
+    session = session_factory()
+    combined_samples = []
+    window_records = []
+
+    try:
+        for evaluation_date in (
+            evaluation_dates
+        ):
+            rows, load_start = _load_events(
+                session,
+                evaluation_date=(
+                    evaluation_date
+                ),
+                window_days=(
+                    args.window_days
+                ),
+            )
+            selected_game_pks = (
+                _selected_games(
+                    rows,
+                    evaluation_date=(
+                        evaluation_date
+                    ),
+                    maximum=(
+                        args.max_games_per_date
+                    ),
+                )
+            )
+
+            if not rows:
+                raise SystemExit(
+                    "STOP: no terminal events for "
+                    f"{evaluation_date}."
+                )
+            if not selected_game_pks:
+                raise SystemExit(
+                    "STOP: no evaluation games for "
+                    f"{evaluation_date}."
+                )
+
+            (
+                observed_digest,
+                lineup_digest,
+            ) = _window_digests(
+                evaluation_date=evaluation_date,
+                load_start=load_start,
+                window_days=args.window_days,
+            )
+            result = (
+                execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+                    rows,
+                    observed_window_digest=(
+                        observed_digest
+                    ),
+                    lineup_bullpen_window_digest=(
+                        lineup_digest
+                    ),
+                    candidate_window_days=(
+                        args.window_days
+                    ),
+                    evaluation_game_pks=(
+                        selected_game_pks
+                    ),
+                    minimum_samples=1,
+                    minimum_observed_pa=1,
+                    season_log_loss_regression_tolerance=(
+                        args.season_regression_tolerance
+                    ),
+                )
+            )
+            diagnostics = dict(
+                result.get("diagnostics")
+                or {}
+            )
+            execution = dict(
+                result.get("execution")
+                or {}
+            )
+            paired = dict(
+                execution.get(
+                    "paired_samples"
+                )
+                or {}
+            )
+            samples = list(
+                paired.get("samples")
+                or ()
+            )
+
+            if not samples:
+                raise SystemExit(
+                    "STOP: no paired samples for "
+                    f"{evaluation_date}."
+                )
+            if diagnostics.get(
+                "production_authority_changed"
+            ) is not False:
+                raise SystemExit(
+                    "STOP: window authority changed."
+                )
+
+            combined_samples.extend(samples)
+            window_records.append({
+                "season": evaluation_date.year,
+                "evaluation_date": (
+                    evaluation_date.isoformat()
+                ),
+                "load_start_date": (
+                    load_start.isoformat()
+                ),
+                "selected_game_pks": list(
+                    selected_game_pks
+                ),
+                "selected_game_count": len(
+                    selected_game_pks
+                ),
+                "terminal_event_count": len(
+                    rows
+                ),
+                "paired_sample_count": len(
+                    samples
+                ),
+                "status": diagnostics.get(
+                    "status"
+                ),
+                "activation_status": (
+                    diagnostics.get(
+                        "activation_status"
+                    )
+                ),
+                "window_execution_digest": (
+                    diagnostics.get(
+                        "window_execution_digest"
+                    )
+                ),
+            })
+    finally:
+        session.close()
+
+    evaluation = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            combined_samples,
+            minimum_samples=(
+                args.minimum_samples
+            ),
+            minimum_observed_pa=(
+                args.minimum_observed_pa
+            ),
+            season_log_loss_regression_tolerance=(
+                args.season_regression_tolerance
+            ),
+        )
+    )
+    evaluation_diagnostics = dict(
+        evaluation.get("diagnostics") or {}
+    )
+    elapsed = (
+        dt.datetime.now(dt.timezone.utc)
+        - started
+    ).total_seconds()
+
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "status": (
+            evaluation_diagnostics.get(
+                "status"
+            )
+        ),
+        "activation_status": (
+            evaluation_diagnostics.get(
+                "activation_status"
+            )
+        ),
+        "evaluation_dates": [
+            value.isoformat()
+            for value in evaluation_dates
+        ],
+        "season_count": len({
+            value.year
+            for value in evaluation_dates
+        }),
+        "max_games_per_date": (
+            args.max_games_per_date
+        ),
+        "window_days": args.window_days,
+        "combined_sample_count": len(
+            combined_samples
+        ),
+        "overall": evaluation.get(
+            "overall"
+        ),
+        "by_season": evaluation.get(
+            "by_season"
+        ),
+        "selection_gate_passed": (
+            evaluation_diagnostics.get(
+                "selection_gate_passed"
+            )
+        ),
+        "regressed_seasons": (
+            evaluation_diagnostics.get(
+                "regressed_seasons"
+            )
+            or []
+        ),
+        "blockers": (
+            evaluation_diagnostics.get(
+                "blockers"
+            )
+            or []
+        ),
+        "windows": window_records,
+        "database_accessed": True,
+        "database_mutated": False,
+        "independent_lookback_per_date": True,
+        "combined_raw_paired_samples": True,
+        "calibration_parameters_selected": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "evaluation_digest": (
+            evaluation_diagnostics.get(
+                "evaluation_digest"
+            )
+        ),
+        "elapsed_seconds": round(
+            elapsed,
+            3,
+        ),
+    }
+    summary["cross_season_audit_digest"] = (
+        _digest({
+            key: value
+            for key, value in summary.items()
+            if key != "elapsed_seconds"
+        })
+    )
+
+    print(
+        json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
+++ b/scripts/audit_canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
@@ -1,0 +1,423 @@
+"""Run a bounded real-data historical pitcher-profile PA audit."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+from typing import Any
+
+from mlb_app.database import StatcastEvent
+from mlb_app.model_projection_routes import (
+    _session_factory,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_statcast_window import (
+    execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_pa_historical_statcast_audit_v1"
+)
+
+
+def _date(value: str) -> dt.date:
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "date must use YYYY-MM-DD"
+        ) from exc
+
+
+def _positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "value must be a positive integer"
+        ) from exc
+
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            "value must be a positive integer"
+        )
+
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "value must be nonnegative"
+        ) from exc
+
+    if parsed < 0.0:
+        raise argparse.ArgumentTypeError(
+            "value must be nonnegative"
+        )
+
+    return parsed
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a bounded cutoff-safe historical "
+            "pitcher-profile PA evaluation."
+        )
+    )
+    parser.add_argument(
+        "--start-date",
+        required=True,
+        type=_date,
+        help="First evaluation date, YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--end-date",
+        required=True,
+        type=_date,
+        help="Last evaluation date, YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--max-games",
+        type=_positive_integer,
+        default=5,
+        help=(
+            "Maximum evaluation games selected in "
+            "canonical date/game order."
+        ),
+    )
+    parser.add_argument(
+        "--window-days",
+        type=_positive_integer,
+        default=90,
+        help="Pregame pitcher evidence lookback.",
+    )
+    parser.add_argument(
+        "--minimum-samples",
+        type=_positive_integer,
+        default=1,
+        help="Minimum paired evaluator samples.",
+    )
+    parser.add_argument(
+        "--minimum-observed-pa",
+        type=_positive_integer,
+        default=1,
+        help="Minimum observed evaluator PAs.",
+    )
+    parser.add_argument(
+        "--season-regression-tolerance",
+        type=_nonnegative_float,
+        default=0.0,
+        help=(
+            "Allowed per-season log-loss regression."
+        ),
+    )
+    return parser
+
+
+def _selected_games(
+    rows: list[Any],
+    *,
+    start_date: dt.date,
+    end_date: dt.date,
+    max_games: int,
+) -> tuple[int, ...]:
+    identities = sorted({
+        (
+            row.game_date,
+            int(row.game_pk),
+        )
+        for row in rows
+        if row.game_pk is not None
+        and start_date
+        <= row.game_date
+        <= end_date
+    })
+
+    return tuple(
+        game_pk
+        for _, game_pk in identities[
+            :max_games
+        ]
+    )
+
+
+def _summary(
+    *,
+    args: argparse.Namespace,
+    load_start: dt.date,
+    rows: list[Any],
+    selected_game_pks: tuple[int, ...],
+    result: dict[str, Any],
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    diagnostics = dict(
+        result.get("diagnostics") or {}
+    )
+    execution = dict(
+        result.get("execution") or {}
+    )
+    evaluation = dict(
+        execution.get("evaluation") or {}
+    )
+    evaluation_diagnostics = dict(
+        evaluation.get("diagnostics") or {}
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": diagnostics.get("status"),
+        "activation_status": (
+            diagnostics.get(
+                "activation_status"
+            )
+        ),
+        "evaluation_start_date": (
+            args.start_date.isoformat()
+        ),
+        "evaluation_end_date": (
+            args.end_date.isoformat()
+        ),
+        "load_start_date": (
+            load_start.isoformat()
+        ),
+        "window_days": args.window_days,
+        "max_games": args.max_games,
+        "selected_game_pks": list(
+            selected_game_pks
+        ),
+        "selected_game_count": len(
+            selected_game_pks
+        ),
+        "terminal_event_count": len(rows),
+        "statistics_game_count": (
+            diagnostics.get(
+                "statistics_game_count"
+            )
+        ),
+        "starter_request_count": (
+            diagnostics.get(
+                "starter_request_count"
+            )
+        ),
+        "candidate_count": (
+            diagnostics.get(
+                "candidate_count"
+            )
+        ),
+        "evaluation_overall": (
+            evaluation.get("overall")
+        ),
+        "evaluation_status": (
+            evaluation_diagnostics.get(
+                "status"
+            )
+        ),
+        "selection_gate_passed": (
+            evaluation_diagnostics.get(
+                "selection_gate_passed"
+            )
+        ),
+        "evaluation_blockers": (
+            evaluation_diagnostics.get(
+                "blockers"
+            )
+            or []
+        ),
+        "single_shared_event_collection": (
+            diagnostics.get(
+                "single_shared_event_collection"
+            )
+        ),
+        "lookback_events_reused_for_evaluation": (
+            diagnostics.get(
+                "lookback_events_reused_for_evaluation"
+            )
+        ),
+        "database_accessed": True,
+        "database_mutated": False,
+        "shadow_only": True,
+        "production_inputs_unchanged": True,
+        "production_authority": False,
+        "production_authority_changed": False,
+        "window_execution_digest": (
+            diagnostics.get(
+                "window_execution_digest"
+            )
+        ),
+        "elapsed_seconds": round(
+            elapsed_seconds,
+            3,
+        ),
+    }
+
+
+def main() -> int:
+    args = _parser().parse_args()
+
+    if args.end_date < args.start_date:
+        raise SystemExit(
+            "STOP: end date precedes start date."
+        )
+
+    load_start = (
+        args.start_date
+        - dt.timedelta(
+            days=args.window_days
+        )
+    )
+    load_end = (
+        args.end_date
+        + dt.timedelta(days=1)
+    )
+    query_identity = {
+        "schema_version": SCHEMA_VERSION,
+        "load_start": load_start.isoformat(),
+        "load_end_exclusive": (
+            load_end.isoformat()
+        ),
+        "evaluation_start": (
+            args.start_date.isoformat()
+        ),
+        "evaluation_end": (
+            args.end_date.isoformat()
+        ),
+        "window_days": args.window_days,
+        "terminal_rows_only": True,
+    }
+    observed_window_digest = _digest({
+        **query_identity,
+        "source": (
+            "local_statcast_terminal_pa_history"
+        ),
+    })
+    lineup_bullpen_window_digest = _digest({
+        **query_identity,
+        "source": (
+            "inferred_historical_starters"
+        ),
+    })
+
+    started = dt.datetime.now(
+        dt.timezone.utc
+    )
+    session_factory = _session_factory()
+    session = session_factory()
+
+    try:
+        rows = (
+            session.query(StatcastEvent)
+            .filter(
+                StatcastEvent.game_date
+                >= load_start,
+                StatcastEvent.game_date
+                < load_end,
+                StatcastEvent.events.isnot(None),
+            )
+            .order_by(
+                StatcastEvent.game_date,
+                StatcastEvent.game_pk,
+                StatcastEvent.at_bat_number,
+                StatcastEvent.pitch_number,
+                StatcastEvent.id,
+            )
+            .all()
+        )
+
+        selected_game_pks = _selected_games(
+            rows,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            max_games=args.max_games,
+        )
+
+        if not rows:
+            raise SystemExit(
+                "STOP: no terminal Statcast events "
+                "found in the requested load window."
+            )
+        if not selected_game_pks:
+            raise SystemExit(
+                "STOP: no evaluation games found "
+                "in the requested date range."
+            )
+
+        result = (
+            execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+                rows,
+                observed_window_digest=(
+                    observed_window_digest
+                ),
+                lineup_bullpen_window_digest=(
+                    lineup_bullpen_window_digest
+                ),
+                candidate_window_days=(
+                    args.window_days
+                ),
+                evaluation_game_pks=(
+                    selected_game_pks
+                ),
+                minimum_samples=(
+                    args.minimum_samples
+                ),
+                minimum_observed_pa=(
+                    args.minimum_observed_pa
+                ),
+                season_log_loss_regression_tolerance=(
+                    args.season_regression_tolerance
+                ),
+            )
+        )
+    finally:
+        session.close()
+
+    elapsed = (
+        dt.datetime.now(dt.timezone.utc)
+        - started
+    ).total_seconds()
+    summary = _summary(
+        args=args,
+        load_start=load_start,
+        rows=rows,
+        selected_game_pks=(
+            selected_game_pks
+        ),
+        result=result,
+        elapsed_seconds=elapsed,
+    )
+
+    print(
+        json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    if summary[
+        "production_authority_changed"
+    ] is not False:
+        raise SystemExit(
+            "STOP: production authority changed."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_canonical_pitcher_matchup_profile_shrinkage.py
+++ b/scripts/audit_canonical_pitcher_matchup_profile_shrinkage.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Audit canonical pitcher-profile shrinkage on historical holdouts.
+
+This executor is read-only. It materializes cutoff-safe historical evidence,
+evaluates candidate pseudo-counts, and writes a shadow-only audit artifact.
+It never writes to the database or changes production authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+from sqlalchemy import func
+
+from mlb_app.database import (
+    StatcastEvent,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_holdout import (
+    materialize_canonical_pitcher_matchup_profile_holdouts,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_shrinkage import (
+    calibrate_canonical_pitcher_matchup_profile_shrinkage,
+)
+from mlb_app.statcast_event_identity import (
+    load_canonical_statcast_events,
+)
+
+
+SCHEMA_VERSION = (
+    "canonical_pitcher_matchup_profile_shrinkage_audit_v1"
+)
+DEFAULT_OUTPUT = Path(
+    "tmp/"
+    "canonical_pitcher_matchup_profile_"
+    "shrinkage_expanded_audit.json"
+)
+DEFAULT_CANDIDATES = (
+    0,
+    25,
+    50,
+    100,
+    200,
+    400,
+    800,
+    1200,
+    1600,
+)
+TRAINING_WINDOW_DAYS = 90
+HOLDOUT_WINDOW_DAYS = 30
+CUTOFF_STEP_DAYS = 60
+MINIMUM_TRAINING_TRIALS = {
+    "discipline": 50,
+    "contact": 20,
+    "launch_angle": 20,
+}
+MINIMUM_HOLDOUT_TRIALS = {
+    "discipline": 10,
+    "contact": 5,
+    "launch_angle": 5,
+}
+
+
+def _candidate_values(text: str) -> tuple[float, ...]:
+    values = tuple(
+        float(part.strip())
+        for part in text.split(",")
+        if part.strip()
+    )
+    if not values:
+        raise ValueError(
+            "at least one candidate pseudo-count is required"
+        )
+    return values
+
+
+def _cutoffs(
+    minimum: dt.date,
+    maximum: dt.date,
+) -> tuple[dt.date, ...]:
+    first = minimum + dt.timedelta(
+        days=TRAINING_WINDOW_DAYS
+    )
+    latest = (
+        maximum
+        - dt.timedelta(days=HOLDOUT_WINDOW_DAYS)
+        + dt.timedelta(days=1)
+    )
+
+    values = []
+    current = first
+
+    while current <= latest:
+        values.append(current)
+        current += dt.timedelta(
+            days=CUTOFF_STEP_DAYS
+        )
+
+    return tuple(values)
+
+
+def _sample_summary(
+    samples: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    rows = list(samples)
+
+    return {
+        "sample_count": len(rows),
+        "by_season": dict(sorted(
+            collections.Counter(
+                str(row["season"])
+                for row in rows
+            ).items()
+        )),
+        "by_family": dict(sorted(
+            collections.Counter(
+                row["family"]
+                for row in rows
+            ).items()
+        )),
+        "by_metric": dict(sorted(
+            collections.Counter(
+                row["metric"]
+                for row in rows
+            ).items()
+        )),
+        "by_segment": dict(sorted(
+            collections.Counter(
+                row["segment"]
+                for row in rows
+            ).items()
+        )),
+    }
+
+
+def _selected_candidate(
+    result: dict[str, Any],
+) -> dict[str, Any]:
+    selected = result.get("pooled_candidate")
+    return selected if isinstance(selected, dict) else {}
+
+
+def _metric_summary(
+    calibration: dict[str, Any],
+) -> dict[str, Any]:
+    summary = {}
+
+    for metric, result in sorted(
+        calibration["metric_results"].items()
+    ):
+        selected = _selected_candidate(result)
+
+        segment_candidates = {
+            segment: (
+                diagnostic.get("best_candidate")
+                or {}
+            ).get("pseudo_count")
+            for segment, diagnostic in sorted(
+                result.get(
+                    "segment_diagnostics",
+                    {},
+                ).items()
+            )
+        }
+
+        summary[metric] = {
+            "status": result.get("status"),
+            "sample_count": result.get(
+                "sample_count"
+            ),
+            "holdout_trials": result.get(
+                "holdout_trials"
+            ),
+            "selected_candidate_for_review": (
+                selected.get("pseudo_count")
+            ),
+            "pooled_log_loss": selected.get(
+                "binomial_log_loss"
+            ),
+            "pooled_brier_score": selected.get(
+                "brier_score"
+            ),
+            "pooled_weighted_absolute_error": (
+                selected.get(
+                    "weighted_absolute_error"
+                )
+            ),
+            "mean_training_reliability": (
+                selected.get(
+                    "mean_training_reliability"
+                )
+            ),
+            "cross_season_candidate_range": (
+                result.get(
+                    "cross_season_candidate_range"
+                )
+            ),
+            "segment_candidates": (
+                segment_candidates
+            ),
+        }
+
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the shadow-only historical pitcher "
+            "profile shrinkage audit."
+        )
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get(
+            "DATABASE_URL",
+            "sqlite:///mlb.db",
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+    )
+    parser.add_argument(
+        "--candidates",
+        default=",".join(
+            str(value)
+            for value in DEFAULT_CANDIDATES
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    candidates = _candidate_values(
+        args.candidates
+    )
+
+    engine = get_engine(args.database_url)
+    Session = get_session(engine)
+
+    with Session() as session:
+        minimum, maximum = (
+            session.query(
+                func.min(StatcastEvent.game_date),
+                func.max(StatcastEvent.game_date),
+            ).one()
+        )
+
+        if minimum is None or maximum is None:
+            raise RuntimeError(
+                "Statcast history is unavailable"
+            )
+
+        cutoffs = _cutoffs(minimum, maximum)
+        if not cutoffs:
+            raise RuntimeError(
+                "historical range cannot support holdouts"
+            )
+
+        print(
+            "audit_date_range="
+            f"{minimum.isoformat()}.."
+            f"{maximum.isoformat()}",
+            flush=True,
+        )
+        print(
+            "candidate_cutoffs="
+            + ",".join(
+                cutoff.isoformat()
+                for cutoff in cutoffs
+            ),
+            flush=True,
+        )
+        print(
+            "candidate_pseudo_counts="
+            + ",".join(
+                str(value)
+                for value in candidates
+            ),
+            flush=True,
+        )
+
+        samples = []
+        cutoff_diagnostics = []
+        identity_diagnostics = []
+
+        for index, cutoff in enumerate(
+            cutoffs,
+            start=1,
+        ):
+            window_start = (
+                cutoff
+                - dt.timedelta(
+                    days=TRAINING_WINDOW_DAYS
+                )
+            )
+            window_end = (
+                cutoff
+                + dt.timedelta(
+                    days=HOLDOUT_WINDOW_DAYS
+                )
+            )
+
+            events, identity = (
+                load_canonical_statcast_events(
+                    session,
+                    StatcastEvent.game_date
+                    >= window_start,
+                    StatcastEvent.game_date
+                    < window_end,
+                    order_by=(
+                        StatcastEvent.game_date,
+                        StatcastEvent.game_pk,
+                        StatcastEvent.at_bat_number,
+                        StatcastEvent.pitch_number,
+                        StatcastEvent.id,
+                    ),
+                )
+            )
+
+            materialized = (
+                materialize_canonical_pitcher_matchup_profile_holdouts(
+                    events,
+                    cutoffs=(cutoff,),
+                    training_window_days=(
+                        TRAINING_WINDOW_DAYS
+                    ),
+                    holdout_window_days=(
+                        HOLDOUT_WINDOW_DAYS
+                    ),
+                    minimum_training_trials=(
+                        MINIMUM_TRAINING_TRIALS
+                    ),
+                    minimum_holdout_trials=(
+                        MINIMUM_HOLDOUT_TRIALS
+                    ),
+                )
+            )
+
+            window_samples = materialized[
+                "samples"
+            ]
+            samples.extend(window_samples)
+            cutoff_diagnostics.extend(
+                materialized.get(
+                    "cutoff_diagnostics",
+                    (),
+                )
+            )
+            identity_diagnostics.append({
+                "cutoff": cutoff.isoformat(),
+                **identity,
+            })
+
+            pitcher_count = len({
+                int(event.pitcher_id)
+                for event in events
+                if event.pitcher_id is not None
+            })
+
+            print(
+                "cutoff_progress="
+                f"{index}/{len(cutoffs)} "
+                f"cutoff={cutoff.isoformat()} "
+                f"events={len(events)} "
+                f"pitchers={pitcher_count} "
+                f"samples={len(window_samples)}",
+                flush=True,
+            )
+
+    calibration = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples,
+            candidate_pseudo_counts=candidates,
+        )
+    )
+
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "status": calibration["status"],
+        "shadow_only": True,
+        "production_authority_changed": False,
+        "parameter_selected": False,
+        "selection_role": (
+            "expanded_grid_candidate_evidence_only"
+        ),
+        "historical_range": {
+            "minimum": minimum.isoformat(),
+            "maximum": maximum.isoformat(),
+        },
+        "policy": {
+            "training_window_days": (
+                TRAINING_WINDOW_DAYS
+            ),
+            "holdout_window_days": (
+                HOLDOUT_WINDOW_DAYS
+            ),
+            "cutoff_step_days": (
+                CUTOFF_STEP_DAYS
+            ),
+            "overlapping_holdouts": False,
+            "minimum_training_trials": (
+                MINIMUM_TRAINING_TRIALS
+            ),
+            "minimum_holdout_trials": (
+                MINIMUM_HOLDOUT_TRIALS
+            ),
+            "candidate_pseudo_counts": (
+                list(candidates)
+            ),
+            "prior_scope": (
+                "same cutoff segment metric "
+                "excluding evaluated pitcher"
+            ),
+        },
+        "sample_summary": _sample_summary(
+            samples
+        ),
+        "cutoff_diagnostics": (
+            cutoff_diagnostics
+        ),
+        "identity_diagnostics": (
+            identity_diagnostics
+        ),
+        "metric_summary": _metric_summary(
+            calibration
+        ),
+        "calibration": calibration,
+        "recommendation": (
+            "Shadow evidence only. Apply explicit "
+            "stability gates before selecting or "
+            "activating any pseudo-count."
+        ),
+    }
+
+    if calibration["shadow_only"] is not True:
+        raise RuntimeError(
+            "calibration is not shadow-only"
+        )
+    if calibration["parameter_selected"] is not False:
+        raise RuntimeError(
+            "calibration selected a parameter"
+        )
+    if (
+        calibration[
+            "production_authority_changed"
+        ]
+        is not False
+    ):
+        raise RuntimeError(
+            "calibration changed production authority"
+        )
+
+    args.output.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    args.output.write_text(
+        json.dumps(
+            artifact,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    print(
+        json.dumps(
+            {
+                "status": artifact["status"],
+                "sample_summary": (
+                    artifact["sample_summary"]
+                ),
+                "metric_summary": (
+                    artifact["metric_summary"]
+                ),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    print(f"wrote={args.output}")
+
+    return (
+        0
+        if calibration["status"] == "ready"
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_canonical_pitcher_matchup_profile_activation_eligibility.py
+++ b/tests/test_canonical_pitcher_matchup_profile_activation_eligibility.py
@@ -1,0 +1,435 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_activation_eligibility import (
+    evaluate_canonical_pitcher_matchup_profile_activation_eligibility,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+
+
+def calibration(
+    *,
+    status="ready",
+    activation_status=(
+        "candidate_policy_ready"
+    ),
+    authority_changed=False,
+):
+    return {
+        "diagnostics": {
+            "status": status,
+            "activation_status": (
+                activation_status
+            ),
+            "calibration_policy_digest": (
+                DIGEST_A
+            ),
+            "production_authority": False,
+            "production_authority_changed": (
+                authority_changed
+            ),
+        },
+    }
+
+
+def historical(
+    *,
+    samples=446,
+    observed_pa=1093,
+    seasons=3,
+    log_loss_improvement=(
+        0.001702281887
+    ),
+    brier_improvement=(
+        0.000854666332
+    ),
+    gate_passed=True,
+    activation_status=(
+        "historical_pa_gate_passed"
+    ),
+    regressed_seasons=(),
+    production_authority=False,
+    production_authority_changed=False,
+):
+    by_season = {
+        str(2024 + index): {
+            "status": "ready",
+            "sample_count": 100,
+            "absolute_log_loss_improvement": (
+                0.001
+            ),
+        }
+        for index in range(seasons)
+    }
+
+    return {
+        "overall": {
+            "status": "ready",
+            "sample_count": samples,
+            "observed_pa": observed_pa,
+            "absolute_log_loss_improvement": (
+                log_loss_improvement
+            ),
+            "absolute_brier_improvement": (
+                brier_improvement
+            ),
+        },
+        "by_season": by_season,
+        "diagnostics": {
+            "status": "ready",
+            "selection_gate_passed": (
+                gate_passed
+            ),
+            "activation_status": (
+                activation_status
+            ),
+            "regressed_seasons": list(
+                regressed_seasons
+            ),
+            "evaluation_digest": DIGEST_B,
+            "production_authority": (
+                production_authority
+            ),
+            "production_authority_changed": (
+                production_authority_changed
+            ),
+        },
+    }
+
+
+def evaluate(
+    *,
+    calibration_value=None,
+    historical_value=None,
+    **kwargs,
+):
+    return (
+        evaluate_canonical_pitcher_matchup_profile_activation_eligibility(
+            calibration_policy=(
+                calibration_value
+                if calibration_value
+                is not None
+                else calibration()
+            ),
+            historical_evaluation=(
+                historical_value
+                if historical_value
+                is not None
+                else historical()
+            ),
+            **kwargs,
+        )
+    )
+
+
+def test_marks_audited_candidate_eligible():
+    result = evaluate()
+    diagnostics = result["diagnostics"]
+
+    assert result["eligible"] is True
+    assert diagnostics["status"] == "ready"
+    assert diagnostics[
+        "activation_status"
+    ] == "candidate_activation_eligible"
+    assert diagnostics[
+        "activation_eligible"
+    ] is True
+    assert diagnostics["blockers"] == []
+    assert diagnostics[
+        "calibration_policy_ready"
+    ] is True
+    assert diagnostics[
+        "historical_pa_gate_passed"
+    ] is True
+
+
+@pytest.mark.parametrize(
+    "calibration_value,blocker",
+    [
+        (
+            calibration(status="partial"),
+            "calibration_policy_not_ready",
+        ),
+        (
+            calibration(
+                activation_status=(
+                    "candidate_policy_blocked"
+                )
+            ),
+            "calibration_policy_not_ready",
+        ),
+        (
+            calibration(
+                authority_changed=True
+            ),
+            "calibration_authority_contract_invalid",
+        ),
+    ],
+)
+def test_calibration_failures_block(
+    calibration_value,
+    blocker,
+):
+    result = evaluate(
+        calibration_value=calibration_value
+    )
+
+    assert result["eligible"] is False
+    assert blocker in result[
+        "diagnostics"
+    ]["blockers"]
+
+
+def test_historical_gate_failure_blocks():
+    result = evaluate(
+        historical_value=historical(
+            gate_passed=False,
+            activation_status=(
+                "historical_pa_gate_blocked"
+            ),
+        )
+    )
+
+    assert result["eligible"] is False
+    assert (
+        "historical_pa_gate_not_passed"
+        in result["diagnostics"]["blockers"]
+    )
+
+
+@pytest.mark.parametrize(
+    "historical_value,blocker",
+    [
+        (
+            historical(samples=299),
+            "historical_sample_count_below_minimum",
+        ),
+        (
+            historical(observed_pa=899),
+            "historical_observed_pa_below_minimum",
+        ),
+        (
+            historical(seasons=2),
+            "historical_season_count_below_minimum",
+        ),
+        (
+            historical(
+                log_loss_improvement=0.0
+            ),
+            "absolute_log_loss_improvement_below_minimum",
+        ),
+        (
+            historical(
+                brier_improvement=0.0
+            ),
+            "absolute_brier_improvement_below_minimum",
+        ),
+        (
+            historical(
+                regressed_seasons=("2025",)
+            ),
+            "season_log_loss_instability",
+        ),
+    ],
+)
+def test_evidence_thresholds_block(
+    historical_value,
+    blocker,
+):
+    result = evaluate(
+        historical_value=historical_value
+    )
+
+    assert result["eligible"] is False
+    assert blocker in result[
+        "diagnostics"
+    ]["blockers"]
+
+
+@pytest.mark.parametrize(
+    "historical_value",
+    [
+        historical(
+            production_authority=True
+        ),
+        historical(
+            production_authority_changed=True
+        ),
+    ],
+)
+def test_historical_authority_violation_blocks(
+    historical_value,
+):
+    result = evaluate(
+        historical_value=historical_value
+    )
+
+    assert result["eligible"] is False
+    assert (
+        "historical_authority_contract_invalid"
+        in result["diagnostics"]["blockers"]
+    )
+
+
+def test_custom_improvement_thresholds_block():
+    result = evaluate(
+        minimum_absolute_log_loss_improvement=(
+            0.002
+        ),
+        minimum_absolute_brier_improvement=(
+            0.001
+        ),
+    )
+
+    assert result["eligible"] is False
+    assert result["diagnostics"][
+        "blockers"
+    ] == [
+        "absolute_log_loss_improvement_below_minimum",
+        "absolute_brier_improvement_below_minimum",
+    ]
+
+
+def test_eligibility_does_not_activate():
+    diagnostics = evaluate()["diagnostics"]
+
+    assert diagnostics[
+        "eligibility_only"
+    ] is True
+    assert diagnostics[
+        "activation_executed"
+    ] is False
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_evidence_digests_are_preserved():
+    diagnostics = evaluate()["diagnostics"]
+
+    assert diagnostics[
+        "calibration_policy_digest"
+    ] == DIGEST_A
+    assert diagnostics[
+        "historical_evaluation_digest"
+    ] == DIGEST_B
+    assert len(
+        diagnostics["eligibility_digest"]
+    ) == 64
+
+
+def test_decision_is_deterministic():
+    first = evaluate()
+    second = evaluate(
+        calibration_value={
+            "diagnostics": dict(
+                reversed(
+                    tuple(
+                        calibration()[
+                            "diagnostics"
+                        ].items()
+                    )
+                )
+            ),
+        },
+        historical_value=historical(),
+    )
+
+    assert first["diagnostics"][
+        "eligibility_digest"
+    ] == second["diagnostics"][
+        "eligibility_digest"
+    ]
+
+
+def test_inputs_are_not_mutated():
+    calibration_value = calibration()
+    historical_value = historical()
+    original_calibration = copy.deepcopy(
+        calibration_value
+    )
+    original_historical = copy.deepcopy(
+        historical_value
+    )
+
+    evaluate(
+        calibration_value=calibration_value,
+        historical_value=historical_value,
+    )
+
+    assert calibration_value == (
+        original_calibration
+    )
+    assert historical_value == (
+        original_historical
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs,reason",
+    [
+        (
+            {
+                "calibration_policy": None,
+                "historical_evaluation": (
+                    historical()
+                ),
+            },
+            "calibration_policy_must_be_mapping",
+        ),
+        (
+            {
+                "calibration_policy": (
+                    calibration()
+                ),
+                "historical_evaluation": None,
+            },
+            "historical_evaluation_must_be_mapping",
+        ),
+        (
+            {
+                "calibration_policy": (
+                    calibration()
+                ),
+                "historical_evaluation": (
+                    historical()
+                ),
+                "minimum_samples": 0,
+            },
+            "minimum_samples_must_be_positive_integer",
+        ),
+        (
+            {
+                "calibration_policy": (
+                    calibration()
+                ),
+                "historical_evaluation": (
+                    historical()
+                ),
+                "minimum_absolute_log_loss_improvement": -0.1,
+            },
+            "minimum_absolute_log_loss_improvement_must_be_nonnegative",
+        ),
+    ],
+)
+def test_invalid_contracts_raise(
+    kwargs,
+    reason,
+):
+    with pytest.raises(
+        ValueError,
+        match=reason,
+    ):
+        evaluate_canonical_pitcher_matchup_profile_activation_eligibility(
+            **kwargs,
+        )

--- a/tests/test_canonical_pitcher_matchup_profile_application.py
+++ b/tests/test_canonical_pitcher_matchup_profile_application.py
@@ -1,0 +1,274 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_application import (
+    apply_canonical_pitcher_matchup_profile_calibration,
+)
+
+
+def evidence():
+    return {
+        "overall": {
+            "discipline": {
+                "strikeouts": 20,
+                "unintentional_walks": 8,
+            },
+            "contact_quality": {
+                "hard_hits": 30,
+                "barrels_approx": 10,
+            },
+            "launch_angle_distribution": {
+                "sweet_spot_batted_balls": 25,
+                "ground_balls": 40,
+                "line_drives": 20,
+                "fly_balls": 30,
+                "popups": 10,
+            },
+            "metric_denominators": {
+                "k_rate": 100,
+                "bb_rate": 100,
+                "hard_hit_rate_allowed": 100,
+                "barrel_rate_allowed_approx": 100,
+                "sweet_spot_rate_allowed": 100,
+                "ground_ball_rate": 100,
+                "line_drive_rate": 100,
+                "fly_ball_rate": 100,
+                "popup_rate": 100,
+            },
+        },
+    }
+
+
+def policy():
+    return {
+        "status": "ready",
+        "selected_pseudo_counts": {
+            "k_rate": 100,
+            "hard_hit_rate_allowed": 200,
+            "ground_ball_rate": 50,
+        },
+        "blocked_metrics": {
+            "bb_rate": [
+                "cross_season_candidate_instability"
+            ],
+        },
+        "segment_parameters_selected": False,
+        "production_authority": False,
+        "production_authority_changed": False,
+    }
+
+
+def priors():
+    return {
+        "k_rate": 0.22,
+        "hard_hit_rate_allowed": 0.36,
+        "ground_ball_rate": 0.43,
+    }
+
+
+def test_applies_exact_binomial_shrinkage():
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=policy(),
+            league_priors=priors(),
+        )
+    )
+
+    assert result["profile_rates"]["k_rate"] == (
+        (20 + 100 * 0.22) / 200
+    )
+    assert result["profile_rates"][
+        "hard_hit_rate_allowed"
+    ] == (
+        (30 + 200 * 0.36) / 300
+    )
+    assert result["profile_rates"][
+        "ground_ball_rate"
+    ] == (
+        (40 + 50 * 0.43) / 150
+    )
+
+
+def test_exposes_reliability_and_provenance():
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=policy(),
+            league_priors=priors(),
+        )
+    )
+
+    row = result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]
+
+    assert row["successes"] == 20
+    assert row["trials"] == 100
+    assert row["observed_rate"] == 0.2
+    assert row["league_prior"] == 0.22
+    assert row["pseudo_count"] == 100
+    assert row["reliability"] == 0.5
+    assert row["production_authority"] is False
+
+
+def test_blocked_walk_rate_is_not_applied():
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=policy(),
+            league_priors=priors(),
+        )
+    )
+
+    assert "bb_rate" not in result["profile_rates"]
+    assert result["diagnostics"][
+        "blocked_metrics"
+    ] == {
+        "bb_rate": [
+            "cross_season_candidate_instability"
+        ],
+    }
+
+
+def test_missing_prior_fails_closed_per_metric():
+    values = priors()
+    del values["k_rate"]
+
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=policy(),
+            league_priors=values,
+        )
+    )
+
+    assert "k_rate" not in result["profile_rates"]
+    assert result["diagnostics"]["status"] == (
+        "partial"
+    )
+    assert result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]["reasons"] == [
+        "league_prior_unavailable"
+    ]
+
+
+def test_zero_trials_returns_league_prior():
+    values = evidence()
+    values["overall"]["discipline"][
+        "strikeouts"
+    ] = 0
+    values["overall"]["metric_denominators"][
+        "k_rate"
+    ] = 0
+
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            values,
+            calibration_policy=policy(),
+            league_priors=priors(),
+        )
+    )
+
+    row = result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]
+
+    assert result["profile_rates"]["k_rate"] == 0.22
+    assert row["observed_rate"] is None
+    assert row["reliability"] == 0.0
+
+
+def test_segment_parameters_remain_inactive():
+    result = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=policy(),
+            league_priors=priors(),
+        )
+    )
+
+    diagnostics = result["diagnostics"]
+
+    assert (
+        diagnostics["application_scope"]
+        == "overall_pooled_metrics_only"
+    )
+    assert (
+        diagnostics["segment_parameters_applied"]
+        is False
+    )
+    assert (
+        diagnostics["production_authority"]
+        is False
+    )
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+
+
+def test_rejects_policy_with_production_authority():
+    values = policy()
+    values["production_authority"] = True
+
+    with pytest.raises(
+        ValueError,
+        match="must not have production authority",
+    ):
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=values,
+            league_priors=priors(),
+        )
+
+
+def test_rejects_selected_segment_parameters():
+    values = policy()
+    values["segment_parameters_selected"] = True
+
+    with pytest.raises(
+        ValueError,
+        match="must remain deferred",
+    ):
+        apply_canonical_pitcher_matchup_profile_calibration(
+            evidence(),
+            calibration_policy=values,
+            league_priors=priors(),
+        )
+
+
+def test_application_is_deterministic_and_nonmutating():
+    source = evidence()
+    selected_policy = policy()
+    league_values = priors()
+
+    original_source = copy.deepcopy(source)
+    original_policy = copy.deepcopy(
+        selected_policy
+    )
+    original_priors = copy.deepcopy(
+        league_values
+    )
+
+    first = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            source,
+            calibration_policy=selected_policy,
+            league_priors=league_values,
+        )
+    )
+    second = (
+        apply_canonical_pitcher_matchup_profile_calibration(
+            source,
+            calibration_policy=selected_policy,
+            league_priors=league_values,
+        )
+    )
+
+    assert first == second
+    assert source == original_source
+    assert selected_policy == original_policy
+    assert league_values == original_priors

--- a/tests/test_canonical_pitcher_matchup_profile_calibration_policy.py
+++ b/tests/test_canonical_pitcher_matchup_profile_calibration_policy.py
@@ -1,0 +1,215 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_calibration_policy import (
+    finalize_canonical_pitcher_matchup_profile_calibration,
+)
+
+
+def metric(
+    selected,
+    losses,
+    *,
+    season_spread=0,
+):
+    grid = [
+        {
+            "pseudo_count": candidate,
+            "binomial_log_loss": loss,
+        }
+        for candidate, loss in losses
+    ]
+    selected_row = next(
+        row
+        for row in grid
+        if row["pseudo_count"] == selected
+    )
+
+    return {
+        "pooled_grid": grid,
+        "pooled_candidate": selected_row,
+        "cross_season_candidate_range": {
+            "minimum": selected - season_spread,
+            "maximum": selected,
+            "spread": season_spread,
+        },
+    }
+
+
+def artifact(results):
+    return {
+        "shadow_only": True,
+        "parameter_selected": False,
+        "production_authority_changed": False,
+        "calibration": {
+            "metric_results": results,
+        },
+    }
+
+
+def test_selects_stable_interior_candidate():
+    result = finalize_canonical_pitcher_matchup_profile_calibration(
+        artifact({
+            "k_rate": metric(
+                100,
+                [
+                    (0, 0.54),
+                    (50, 0.532),
+                    (100, 0.530),
+                    (200, 0.531),
+                ],
+            ),
+        })
+    )
+
+    assert result["selected_pseudo_counts"] == {
+        "k_rate": 100.0,
+    }
+    assert result["blocked_metrics"] == {}
+    assert result["parameter_selected"] is True
+    assert (
+        result["production_authority_changed"]
+        is False
+    )
+
+
+def test_accepts_stable_plateaued_boundary():
+    result = finalize_canonical_pitcher_matchup_profile_calibration(
+        artifact({
+            "line_drive_rate": metric(
+                1600,
+                [
+                    (0, 0.522),
+                    (800, 0.5100),
+                    (1200, 0.50991),
+                    (1600, 0.509908),
+                ],
+            ),
+        })
+    )
+
+    evaluation = result["metric_evaluations"][
+        "line_drive_rate"
+    ]
+
+    assert evaluation["status"] == "selected"
+    assert (
+        evaluation["plateaued_boundary"]
+        is True
+    )
+
+
+def test_blocks_unresolved_boundary():
+    result = finalize_canonical_pitcher_matchup_profile_calibration(
+        artifact({
+            "metric": metric(
+                400,
+                [
+                    (0, 0.60),
+                    (200, 0.58),
+                    (400, 0.575),
+                ],
+            ),
+        })
+    )
+
+    assert result["selected_pseudo_counts"] == {}
+    assert result["blocked_metrics"] == {
+        "metric": [
+            "unresolved_upper_grid_boundary"
+        ],
+    }
+
+
+def test_blocks_cross_season_instability():
+    result = finalize_canonical_pitcher_matchup_profile_calibration(
+        artifact({
+            "bb_rate": metric(
+                200,
+                [
+                    (0, 0.29),
+                    (100, 0.28),
+                    (200, 0.275),
+                    (400, 0.276),
+                ],
+                season_spread=100,
+            ),
+        })
+    )
+
+    assert result["blocked_metrics"] == {
+        "bb_rate": [
+            "cross_season_candidate_instability"
+        ],
+    }
+
+
+def test_segment_parameters_remain_deferred():
+    result = finalize_canonical_pitcher_matchup_profile_calibration(
+        artifact({
+            "k_rate": metric(
+                100,
+                [
+                    (0, 0.54),
+                    (100, 0.53),
+                    (200, 0.531),
+                ],
+            ),
+        })
+    )
+
+    assert (
+        result["segment_parameters_selected"]
+        is False
+    )
+    assert result["selection_scope"] == (
+        "pooled_metrics_only"
+    )
+    assert result["production_authority"] is False
+
+
+def test_rejects_non_shadow_artifact():
+    payload = artifact({})
+    payload["shadow_only"] = False
+
+    with pytest.raises(
+        ValueError,
+        match="shadow-only",
+    ):
+        finalize_canonical_pitcher_matchup_profile_calibration(
+            payload
+        )
+
+
+def test_rejects_artifact_with_prior_selection():
+    payload = artifact({})
+    payload["parameter_selected"] = True
+
+    with pytest.raises(
+        ValueError,
+        match="already selected",
+    ):
+        finalize_canonical_pitcher_matchup_profile_calibration(
+            payload
+        )
+
+
+def test_does_not_mutate_artifact():
+    payload = artifact({
+        "k_rate": metric(
+            100,
+            [
+                (0, 0.54),
+                (100, 0.53),
+                (200, 0.531),
+            ],
+        ),
+    })
+    original = copy.deepcopy(payload)
+
+    finalize_canonical_pitcher_matchup_profile_calibration(
+        payload
+    )
+
+    assert payload == original

--- a/tests/test_canonical_pitcher_matchup_profile_evidence.py
+++ b/tests/test_canonical_pitcher_matchup_profile_evidence.py
@@ -1,0 +1,490 @@
+import datetime as dt
+from types import SimpleNamespace
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_evidence import (
+    CANONICAL_PITCHER_MATCHUP_PROFILE_EVIDENCE_VERSION,
+    build_canonical_pitcher_matchup_profile_evidence,
+)
+
+
+def event(
+    *,
+    event_id,
+    game_date="2026-08-22",
+    game_pk=1,
+    at_bat_number=1,
+    pitch_number=1,
+    pitcher_id=101,
+    batter_id=201,
+    events=None,
+    description=None,
+    launch_speed=None,
+    launch_angle=None,
+    xwoba=None,
+    xba=None,
+    stand="R",
+):
+    return SimpleNamespace(
+        id=event_id,
+        game_date=dt.date.fromisoformat(game_date),
+        game_pk=game_pk,
+        at_bat_number=at_bat_number,
+        pitch_number=pitch_number,
+        pitcher_id=pitcher_id,
+        batter_id=batter_id,
+        events=events,
+        description=description,
+        launch_speed=launch_speed,
+        launch_angle=launch_angle,
+        estimated_woba_using_speedangle=xwoba,
+        estimated_ba_using_speedangle=xba,
+        stand=stand,
+        p_throws="R",
+    )
+
+
+def build(events):
+    return build_canonical_pitcher_matchup_profile_evidence(
+        events,
+        pitcher_id=101,
+        game_date="2026-08-23",
+    )
+
+
+def contact_sample():
+    return [
+        event(
+            event_id=1,
+            at_bat_number=1,
+            batter_id=201,
+            events="single",
+            description="hit_into_play",
+            launch_speed=100,
+            launch_angle=20,
+            xwoba=0.70,
+            xba=0.80,
+            stand="R",
+        ),
+        event(
+            event_id=2,
+            at_bat_number=2,
+            batter_id=202,
+            events="field_out",
+            description="hit_into_play",
+            launch_speed=90,
+            launch_angle=5,
+            xwoba=0.10,
+            xba=0.12,
+            stand="L",
+        ),
+        event(
+            event_id=3,
+            at_bat_number=3,
+            batter_id=203,
+            events="field_out",
+            description="hit_into_play",
+            launch_speed=96,
+            launch_angle=30,
+            xwoba=0.35,
+            xba=0.28,
+            stand="R",
+        ),
+        event(
+            event_id=4,
+            at_bat_number=4,
+            batter_id=204,
+            events="field_out",
+            description="hit_into_play",
+            launch_speed=85,
+            launch_angle=55,
+            xwoba=0.02,
+            xba=0.01,
+            stand="L",
+        ),
+    ]
+
+
+def test_builds_contact_quality_and_launch_distribution():
+    result = build(contact_sample())
+    overall = result["overall"]
+
+    assert result["status"] == "ready"
+    assert overall["sample_size"][
+        "plate_appearances"
+    ] == 4
+    assert overall["sample_size"]["batted_balls"] == 4
+    assert overall["contact_quality"][
+        "hard_hit_rate_allowed"
+    ] == 0.5
+    assert overall["contact_quality"][
+        "barrel_rate_allowed_approx"
+    ] == 0.25
+    assert overall["contact_quality"][
+        "median_exit_velocity_allowed"
+    ] == 93.0
+
+    distribution = overall[
+        "launch_angle_distribution"
+    ]
+    assert distribution["ground_ball_rate"] == 0.25
+    assert distribution["line_drive_rate"] == 0.25
+    assert distribution["fly_ball_rate"] == 0.25
+    assert distribution["popup_rate"] == 0.25
+    assert distribution["sweet_spot_rate_allowed"] == 0.5
+
+
+def test_builds_platoon_splits_with_exact_denominators():
+    result = build(contact_sample())
+
+    versus_left = result["platoon_splits"]["L"]
+    versus_right = result["platoon_splits"]["R"]
+
+    assert versus_left["sample_size"][
+        "plate_appearances"
+    ] == 2
+    assert versus_right["sample_size"][
+        "plate_appearances"
+    ] == 2
+    assert versus_left["contact_quality"][
+        "avg_exit_velocity_allowed"
+    ] == 87.5
+    assert versus_right["contact_quality"][
+        "avg_exit_velocity_allowed"
+    ] == 98.0
+
+
+def test_builds_times_through_order_splits():
+    rows = [
+        event(
+            event_id=1,
+            at_bat_number=1,
+            batter_id=201,
+            events="strikeout",
+        ),
+        event(
+            event_id=2,
+            at_bat_number=10,
+            batter_id=201,
+            events="walk",
+        ),
+        event(
+            event_id=3,
+            at_bat_number=19,
+            batter_id=201,
+            events="single",
+            launch_speed=100,
+            launch_angle=20,
+        ),
+        event(
+            event_id=4,
+            at_bat_number=28,
+            batter_id=201,
+            events="field_out",
+            launch_speed=90,
+            launch_angle=5,
+        ),
+    ]
+
+    result = build(rows)
+    splits = result["times_through_order_splits"]
+
+    assert splits["1"]["discipline"]["k_rate"] == 1.0
+    assert splits["2"]["discipline"]["bb_rate"] == 1.0
+    assert splits["3_plus"]["sample_size"][
+        "plate_appearances"
+    ] == 2
+    assert splits["3_plus"]["sample_size"][
+        "batted_balls"
+    ] == 2
+
+
+def test_excludes_same_day_future_and_old_evidence():
+    rows = [
+        event(
+            event_id=1,
+            game_date="2026-08-22",
+            events="strikeout",
+        ),
+        event(
+            event_id=2,
+            game_date="2026-08-23",
+            events="walk",
+        ),
+        event(
+            event_id=3,
+            game_date="2026-08-24",
+            events="walk",
+        ),
+        event(
+            event_id=4,
+            game_date="2026-05-01",
+            events="walk",
+        ),
+    ]
+
+    result = build(rows)
+
+    assert result["overall"]["sample_size"][
+        "plate_appearances"
+    ] == 1
+    assert result["overall"]["discipline"][
+        "k_rate"
+    ] == 1.0
+
+
+def test_deduplicates_pitch_identity():
+    row = event(
+        event_id=1,
+        events="strikeout",
+    )
+    duplicate = event(
+        event_id=2,
+        events="strikeout",
+    )
+
+    result = build([row, duplicate])
+
+    assert result["diagnostics"]["raw_event_count"] == 2
+    assert result["diagnostics"][
+        "deduped_pitch_count"
+    ] == 1
+    assert result["diagnostics"][
+        "duplicate_pitch_count"
+    ] == 1
+    assert result["overall"]["sample_size"][
+        "plate_appearances"
+    ] == 1
+
+
+def test_empty_evidence_fails_closed():
+    result = build([])
+
+    assert result["status"] == "unavailable"
+    assert result["overall"]["sample_size"][
+        "plate_appearances"
+    ] == 0
+    assert result["diagnostics"][
+        "production_authority"
+    ] is False
+    assert result["diagnostics"][
+        "activation_status"
+    ] == "evidence_only_pending_calibration"
+
+
+def test_result_is_deterministic():
+    rows = contact_sample()
+
+    first = build(rows)
+    second = build(list(reversed(rows)))
+
+    assert first == second
+    assert first["diagnostics"]["evidence_digest"] == (
+        second["diagnostics"]["evidence_digest"]
+    )
+
+
+def test_explicit_schema_and_classification_contract():
+    result = build(contact_sample())
+
+    assert (
+        CANONICAL_PITCHER_MATCHUP_PROFILE_EVIDENCE_VERSION
+        == "canonical_pitcher_matchup_profile_evidence_v1"
+    )
+    assert result["classification"][
+        "official_statcast_classification"
+    ] is False
+    assert result["classification"][
+        "source"
+    ] == "internal_launch_angle_classification_v1"
+    assert result["diagnostics"][
+        "shrinkage_applied"
+    ] is False
+
+
+def test_other_pitchers_are_excluded():
+    rows = [
+        event(
+            event_id=1,
+            pitcher_id=101,
+            events="strikeout",
+        ),
+        event(
+            event_id=2,
+            pitcher_id=999,
+            events="walk",
+        ),
+    ]
+
+    result = build(rows)
+
+    assert result["overall"]["sample_size"][
+        "plate_appearances"
+    ] == 1
+    assert result["overall"]["discipline"][
+        "k_rate"
+    ] == 1.0
+
+
+def test_missing_launch_angle_is_not_counted_as_non_barrel():
+    rows = [
+        event(
+            event_id=1,
+            at_bat_number=1,
+            batter_id=201,
+            events="single",
+            launch_speed=100,
+            launch_angle=20,
+        ),
+        event(
+            event_id=2,
+            at_bat_number=2,
+            batter_id=202,
+            events="field_out",
+            launch_speed=100,
+            launch_angle=None,
+        ),
+    ]
+
+    result = build(rows)
+    overall = result["overall"]
+
+    assert overall["sample_size"]["batted_balls"] == 2
+    assert overall["sample_size"][
+        "barrel_eligible_batted_balls"
+    ] == 1
+    assert overall["contact_quality"][
+        "barrel_rate_allowed_approx"
+    ] == 1.0
+
+
+def test_discipline_only_evidence_is_partial():
+    result = build([
+        event(
+            event_id=1,
+            events="strikeout",
+            launch_speed=None,
+            launch_angle=None,
+        ),
+    ])
+
+    assert result["status"] == "partial"
+    assert result["overall"]["sample_size"][
+        "plate_appearances"
+    ] == 1
+    assert result["overall"]["sample_size"][
+        "batted_balls"
+    ] == 0
+
+
+def test_legacy_tto_encounters_reset_by_date():
+    rows = [
+        event(
+            event_id=1,
+            game_date="2026-08-21",
+            game_pk=None,
+            at_bat_number=None,
+            batter_id=201,
+            events="strikeout",
+        ),
+        event(
+            event_id=2,
+            game_date="2026-08-22",
+            game_pk=None,
+            at_bat_number=None,
+            batter_id=201,
+            events="strikeout",
+        ),
+    ]
+
+    result = build(rows)
+    splits = result["times_through_order_splits"]
+
+    assert splits["1"]["sample_size"][
+        "plate_appearances"
+    ] == 2
+    assert splits["2"]["sample_size"][
+        "plate_appearances"
+    ] == 0
+    assert splits["3_plus"]["sample_size"][
+        "plate_appearances"
+    ] == 0
+
+
+def test_barrel_denominator_is_explicit():
+    result = build(contact_sample())
+
+    assert result["classification"][
+        "barrel_denominator"
+    ] == (
+        "batted balls with exit velocity and launch angle"
+    )
+
+
+def test_launch_distribution_exposes_exact_numerators():
+    result = build(contact_sample())
+    distribution = result["overall"][
+        "launch_angle_distribution"
+    ]
+
+    assert distribution[
+        "sweet_spot_batted_balls"
+    ] == 2
+    assert distribution["ground_balls"] == 1
+    assert distribution["line_drives"] == 1
+    assert distribution["fly_balls"] == 1
+    assert distribution["popups"] == 1
+
+    classified = result["overall"]["sample_size"][
+        "launch_angle_batted_balls"
+    ]
+    classified_sum = sum(
+        distribution[key]
+        for key in (
+            "ground_balls",
+            "line_drives",
+            "fly_balls",
+            "popups",
+        )
+    )
+
+    assert classified_sum == classified
+
+
+def test_metric_denominators_are_explicit():
+    result = build(contact_sample())
+    denominators = result["overall"][
+        "metric_denominators"
+    ]
+
+    assert denominators == {
+        "k_rate": 4,
+        "bb_rate": 4,
+        "hard_hit_rate_allowed": 4,
+        "barrel_rate_allowed_approx": 4,
+        "sweet_spot_rate_allowed": 4,
+        "ground_ball_rate": 4,
+        "line_drive_rate": 4,
+        "fly_ball_rate": 4,
+        "popup_rate": 4,
+        "avg_exit_velocity_allowed": 4,
+        "median_exit_velocity_allowed": 4,
+        "p90_exit_velocity_allowed": 4,
+        "max_exit_velocity_allowed": 4,
+        "avg_launch_angle_allowed": 4,
+        "xwoba_allowed": 4,
+        "xba_allowed": 4,
+    }
+
+
+def test_empty_segment_has_zero_denominators():
+    result = build(contact_sample())
+    empty = result["times_through_order_splits"][
+        "3_plus"
+    ]
+
+    assert all(
+        denominator == 0
+        for denominator in empty[
+            "metric_denominators"
+        ].values()
+    )

--- a/tests/test_canonical_pitcher_matchup_profile_historical_input_bridge.py
+++ b/tests/test_canonical_pitcher_matchup_profile_historical_input_bridge.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from mlb_app.simulation.pa_outcome_model import (
+    build_pa_outcome_probabilities,
+)
+from mlb_app.simulation.shadow.historical_probability_workspace_reconstruction import (
+    build_historical_probability_offense_profile,
+    build_historical_probability_pitcher_profile,
+)
+
+
+def offense_counts():
+    return {
+        "pa": 100,
+        "ab": 80,
+        "hits": 24,
+        "double": 6,
+        "triple": 2,
+        "hr": 4,
+        "bb": 10,
+        "k": 20,
+        "hbp": 2,
+    }
+
+
+def pitcher_counts():
+    return {
+        "batters_faced": 120,
+        "ab": 100,
+        "hits": 25,
+        "double": 5,
+        "triple": 1,
+        "hr": 3,
+        "bb": 12,
+        "k": 30,
+        "hbp": 2,
+    }
+
+
+def test_builds_exact_historical_profiles():
+    offense = (
+        build_historical_probability_offense_profile(
+            offense_counts()
+        )
+    )
+    pitcher = (
+        build_historical_probability_pitcher_profile(
+            pitcher_counts()
+        )
+    )
+
+    assert offense["contact_skill"] == {
+        "k_rate": 0.2,
+        "contact_rate": 0.8,
+        "batting_avg": 0.3,
+    }
+    assert offense["plate_discipline"] == {
+        "bb_rate": 0.1,
+    }
+    assert offense["power"] == {
+        "iso": 0.275,
+        "barrel_rate": None,
+        "hard_hit_rate": None,
+    }
+    assert pitcher["bat_missing"] == {
+        "k_rate": 0.25,
+    }
+    assert pitcher["command_control"] == {
+        "bb_rate": 0.1,
+    }
+    assert pitcher["contact_management"] == {
+        "xba_allowed": 0.25,
+        "barrel_rate_allowed": None,
+        "hard_hit_rate_allowed": None,
+    }
+
+
+def test_profiles_reproduce_canonical_historical_model():
+    result = build_pa_outcome_probabilities(
+        batter_profile=(
+            build_historical_probability_offense_profile(
+                offense_counts()
+            )
+        ),
+        pitcher_profile=(
+            build_historical_probability_pitcher_profile(
+                pitcher_counts()
+            )
+        ),
+        environment_profile=None,
+    )
+
+    assert result["model_version"] == "pa_outcome_v1"
+    assert round(
+        sum(result["probabilities"].values()),
+        12,
+    ) == 1.0
+    assert result["inputs_used"][
+        "batter_k_rate"
+    ] == 0.2
+    assert result["inputs_used"][
+        "pitcher_k_rate"
+    ] == 0.25
+
+
+def test_profile_builders_are_nonmutating():
+    offense = offense_counts()
+    pitcher = pitcher_counts()
+    original_offense = deepcopy(offense)
+    original_pitcher = deepcopy(pitcher)
+
+    build_historical_probability_offense_profile(
+        offense
+    )
+    build_historical_probability_pitcher_profile(
+        pitcher
+    )
+
+    assert offense == original_offense
+    assert pitcher == original_pitcher
+
+
+def test_zero_samples_use_model_fallbacks():
+    result = build_pa_outcome_probabilities(
+        batter_profile=(
+            build_historical_probability_offense_profile(
+                {}
+            )
+        ),
+        pitcher_profile=(
+            build_historical_probability_pitcher_profile(
+                {}
+            )
+        ),
+        environment_profile=None,
+    )
+
+    assert result["probabilities"]
+    assert round(
+        sum(result["probabilities"].values()),
+        12,
+    ) == 1.0

--- a/tests/test_canonical_pitcher_matchup_profile_holdout.py
+++ b/tests/test_canonical_pitcher_matchup_profile_holdout.py
@@ -1,0 +1,329 @@
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_holdout import (
+    CANONICAL_PITCHER_MATCHUP_PROFILE_HOLDOUT_VERSION,
+    materialize_canonical_pitcher_matchup_profile_holdouts,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_shrinkage import (
+    calibrate_canonical_pitcher_matchup_profile_shrinkage,
+)
+
+
+def event(
+    *,
+    event_id,
+    game_date,
+    pitcher_id,
+    batter_id,
+    at_bat_number,
+    events,
+    stand="R",
+    launch_speed=None,
+    launch_angle=None,
+):
+    return SimpleNamespace(
+        id=event_id,
+        game_date=dt.date.fromisoformat(game_date),
+        game_pk=(
+            pitcher_id * 1000
+            + int(game_date[-2:])
+        ),
+        at_bat_number=at_bat_number,
+        pitch_number=1,
+        pitcher_id=pitcher_id,
+        batter_id=batter_id,
+        events=events,
+        description=(
+            "hit_into_play"
+            if launch_speed is not None
+            else None
+        ),
+        launch_speed=launch_speed,
+        launch_angle=launch_angle,
+        estimated_woba_using_speedangle=None,
+        estimated_ba_using_speedangle=None,
+        stand=stand,
+        p_throws="R",
+    )
+
+
+def rows():
+    return [
+        event(
+            event_id=1,
+            game_date="2023-06-01",
+            pitcher_id=101,
+            batter_id=201,
+            at_bat_number=1,
+            events="strikeout",
+            stand="R",
+        ),
+        event(
+            event_id=2,
+            game_date="2023-06-02",
+            pitcher_id=101,
+            batter_id=202,
+            at_bat_number=2,
+            events="single",
+            stand="L",
+            launch_speed=100,
+            launch_angle=20,
+        ),
+        event(
+            event_id=3,
+            game_date="2023-06-01",
+            pitcher_id=102,
+            batter_id=203,
+            at_bat_number=1,
+            events="field_out",
+            stand="R",
+            launch_speed=85,
+            launch_angle=5,
+        ),
+        event(
+            event_id=4,
+            game_date="2023-06-02",
+            pitcher_id=102,
+            batter_id=204,
+            at_bat_number=2,
+            events="walk",
+            stand="L",
+        ),
+        event(
+            event_id=5,
+            game_date="2023-07-01",
+            pitcher_id=101,
+            batter_id=205,
+            at_bat_number=1,
+            events="strikeout",
+            stand="R",
+        ),
+        event(
+            event_id=6,
+            game_date="2023-07-02",
+            pitcher_id=101,
+            batter_id=206,
+            at_bat_number=2,
+            events="field_out",
+            stand="L",
+            launch_speed=90,
+            launch_angle=5,
+        ),
+        event(
+            event_id=7,
+            game_date="2023-07-01",
+            pitcher_id=102,
+            batter_id=207,
+            at_bat_number=1,
+            events="field_out",
+            stand="R",
+            launch_speed=99,
+            launch_angle=20,
+        ),
+        event(
+            event_id=8,
+            game_date="2023-07-02",
+            pitcher_id=102,
+            batter_id=208,
+            at_bat_number=2,
+            events="walk",
+            stand="L",
+        ),
+    ]
+
+
+def materialize(input_rows=None):
+    return materialize_canonical_pitcher_matchup_profile_holdouts(
+        rows() if input_rows is None else input_rows,
+        cutoffs=("2023-07-01",),
+        training_window_days=30,
+        holdout_window_days=30,
+    )
+
+
+def sample_for(result, *, pitcher_id, metric, segment):
+    return next(
+        row
+        for row in result["samples"]
+        if (
+            row["pitcher_id"] == pitcher_id
+            and row["metric"] == metric
+            and row["segment"] == segment
+        )
+    )
+
+
+def test_materializes_strict_training_and_forward_holdout():
+    result = materialize()
+    sample = sample_for(
+        result,
+        pitcher_id=101,
+        metric="k_rate",
+        segment="overall",
+    )
+
+    assert result["status"] == "ready"
+    assert sample["training_successes"] == 1
+    assert sample["training_trials"] == 2
+    assert sample["holdout_successes"] == 1
+    assert sample["holdout_trials"] == 2
+    assert sample["cutoff"] == "2023-07-01"
+    assert (
+        sample["holdout_end_exclusive"]
+        == "2023-07-31"
+    )
+
+
+def test_prior_excludes_evaluated_pitcher():
+    result = materialize()
+    pitcher_101 = sample_for(
+        result,
+        pitcher_id=101,
+        metric="k_rate",
+        segment="overall",
+    )
+    pitcher_102 = sample_for(
+        result,
+        pitcher_id=102,
+        metric="k_rate",
+        segment="overall",
+    )
+
+    assert pitcher_101[
+        "prior_successes_excluding_pitcher"
+    ] == 0
+    assert pitcher_101[
+        "prior_trials_excluding_pitcher"
+    ] == 2
+    assert pitcher_101["prior_probability"] == 0.0
+
+    assert pitcher_102[
+        "prior_successes_excluding_pitcher"
+    ] == 1
+    assert pitcher_102[
+        "prior_trials_excluding_pitcher"
+    ] == 2
+    assert pitcher_102["prior_probability"] == 0.5
+
+
+def test_materializes_platoon_and_tto_segments():
+    result = materialize()
+    segments = {
+        row["segment"]
+        for row in result["samples"]
+    }
+
+    assert {"overall", "vsL", "vsR", "tto1"} <= segments
+
+
+def test_thresholds_are_family_specific():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_holdouts(
+            rows(),
+            cutoffs=("2023-07-01",),
+            training_window_days=30,
+            holdout_window_days=30,
+            minimum_training_trials={
+                "discipline": 2,
+                "contact": 2,
+                "launch_angle": 2,
+            },
+            minimum_holdout_trials={
+                "discipline": 2,
+                "contact": 2,
+                "launch_angle": 2,
+            },
+        )
+    )
+
+    assert result["sample_count"] == 8
+    assert {
+        row["metric"]
+        for row in result["samples"]
+    } == {"k_rate", "bb_rate"}
+    assert {
+        row["segment"]
+        for row in result["samples"]
+    } == {"overall", "tto1"}
+    assert {
+        row["pitcher_id"]
+        for row in result["samples"]
+    } == {101, 102}
+
+
+def test_output_is_accepted_by_shrinkage_calibrator():
+    first_season = materialize()["samples"]
+    second_season = [
+        {
+            **sample,
+            "season": 2024,
+            "cutoff": "2024-07-01",
+        }
+        for sample in first_season
+    ]
+
+    calibration = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            first_season + second_season,
+            candidate_pseudo_counts=(0, 25),
+        )
+    )
+
+    assert calibration["eligible_sample_count"] == (
+        len(first_season) * 2
+    )
+    assert calibration["status"] == "ready"
+
+
+def test_materialization_is_deterministic():
+    first = materialize()
+    second = materialize(list(reversed(rows())))
+
+    assert first == second
+    assert first["sample_digest"] == (
+        second["sample_digest"]
+    )
+
+
+def test_empty_materialization_is_blocked():
+    result = materialize([])
+
+    assert result["status"] == "blocked"
+    assert result["sample_count"] == 0
+    assert result["production_authority_changed"] is False
+
+
+def test_invalid_windows_and_cutoffs_are_rejected():
+    with pytest.raises(
+        ValueError,
+        match="at least one cutoff",
+    ):
+        materialize_canonical_pitcher_matchup_profile_holdouts(
+            rows(),
+            cutoffs=(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="must be positive",
+    ):
+        materialize_canonical_pitcher_matchup_profile_holdouts(
+            rows(),
+            cutoffs=("2023-07-01",),
+            training_window_days=0,
+        )
+
+
+def test_explicit_shadow_only_contract():
+    result = materialize()
+
+    assert (
+        CANONICAL_PITCHER_MATCHUP_PROFILE_HOLDOUT_VERSION
+        == "canonical_pitcher_matchup_profile_holdout_v1"
+    )
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert result["parameter_selected"] is False

--- a/tests/test_canonical_pitcher_matchup_profile_league_prior.py
+++ b/tests/test_canonical_pitcher_matchup_profile_league_prior.py
@@ -1,0 +1,219 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_league_prior import (
+    build_canonical_pitcher_matchup_profile_league_priors,
+)
+
+
+def event(
+    *,
+    event_id,
+    pitcher_id,
+    game_date="2026-08-22",
+    events="field_out",
+    description="hit_into_play",
+    launch_speed=None,
+    launch_angle=None,
+):
+    return {
+        "id": event_id,
+        "game_pk": 500,
+        "at_bat_number": event_id,
+        "pitch_number": 1,
+        "pitcher_id": pitcher_id,
+        "batter_id": 1000 + event_id,
+        "game_date": game_date,
+        "events": events,
+        "description": description,
+        "launch_speed": launch_speed,
+        "launch_angle": launch_angle,
+        "stand": "R",
+    }
+
+
+def rows():
+    return [
+        event(
+            event_id=1,
+            pitcher_id=101,
+            events="strikeout",
+            description="swinging_strike",
+        ),
+        event(
+            event_id=2,
+            pitcher_id=102,
+            events="strikeout",
+            description="swinging_strike",
+        ),
+        event(
+            event_id=3,
+            pitcher_id=102,
+            launch_speed=100,
+            launch_angle=20,
+        ),
+        event(
+            event_id=4,
+            pitcher_id=103,
+            launch_speed=90,
+            launch_angle=5,
+        ),
+    ]
+
+
+def build(values=None, **kwargs):
+    return (
+        build_canonical_pitcher_matchup_profile_league_priors(
+            rows() if values is None else values,
+            game_date="2026-08-23",
+            excluded_pitcher_id=101,
+            metrics=(
+                "k_rate",
+                "hard_hit_rate_allowed",
+                "ground_ball_rate",
+            ),
+            **kwargs,
+        )
+    )
+
+
+def test_excludes_evaluated_pitcher_from_prior():
+    result = build()
+
+    k_row = result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]
+
+    assert k_row["successes"] == 1
+    assert k_row["trials"] == 3
+    assert result["league_priors"][
+        "k_rate"
+    ] == round(1 / 3, 12)
+    assert (
+        result["diagnostics"][
+            "excluded_event_count"
+        ]
+        == 1
+    )
+
+
+def test_uses_exact_metric_denominators():
+    result = build()
+
+    hard_hit = result["diagnostics"][
+        "metric_diagnostics"
+    ]["hard_hit_rate_allowed"]
+    ground_ball = result["diagnostics"][
+        "metric_diagnostics"
+    ]["ground_ball_rate"]
+
+    assert hard_hit["successes"] == 1
+    assert hard_hit["trials"] == 2
+    assert ground_ball["successes"] == 1
+    assert ground_ball["trials"] == 2
+
+
+def test_same_day_and_future_events_are_excluded():
+    values = rows() + [
+        event(
+            event_id=5,
+            pitcher_id=102,
+            game_date="2026-08-23",
+            events="strikeout",
+        ),
+        event(
+            event_id=6,
+            pitcher_id=102,
+            game_date="2026-08-24",
+            events="strikeout",
+        ),
+    ]
+
+    result = build(values)
+
+    assert result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]["trials"] == 3
+
+
+def test_old_events_are_excluded():
+    values = rows() + [
+        event(
+            event_id=7,
+            pitcher_id=102,
+            game_date="2026-04-01",
+            events="strikeout",
+        ),
+    ]
+
+    result = build(values)
+
+    assert result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]["trials"] == 3
+
+
+def test_missing_metric_evidence_fails_closed():
+    result = (
+        build_canonical_pitcher_matchup_profile_league_priors(
+            [],
+            game_date="2026-08-23",
+            excluded_pitcher_id=101,
+            metrics=("k_rate",),
+        )
+    )
+
+    assert result["league_priors"] == {}
+    assert result["diagnostics"]["status"] == (
+        "unavailable"
+    )
+    assert result["diagnostics"][
+        "metric_diagnostics"
+    ]["k_rate"]["reasons"] == [
+        "league_trials_unavailable"
+    ]
+
+
+def test_rejects_unknown_metric():
+    with pytest.raises(
+        ValueError,
+        match="unknown metrics",
+    ):
+        build_canonical_pitcher_matchup_profile_league_priors(
+            rows(),
+            game_date="2026-08-23",
+            excluded_pitcher_id=101,
+            metrics=("not_a_metric",),
+        )
+
+
+def test_rejects_invalid_excluded_pitcher():
+    with pytest.raises(
+        ValueError,
+        match="must be positive",
+    ):
+        build_canonical_pitcher_matchup_profile_league_priors(
+            rows(),
+            game_date="2026-08-23",
+            excluded_pitcher_id=0,
+        )
+
+
+def test_result_is_deterministic_and_nonmutating():
+    values = rows()
+    original = copy.deepcopy(values)
+
+    first = build(values)
+    second = build(
+        list(reversed(values))
+    )
+
+    assert first == second
+    assert values == original
+    assert (
+        first["diagnostics"][
+            "production_authority_changed"
+        ]
+        is False
+    )

--- a/tests/test_canonical_pitcher_matchup_profile_pa_activation.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_activation.py
@@ -1,0 +1,400 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_activation import (
+    APPROVED_CROSS_SEASON_AUDIT_DIGEST,
+    APPROVED_ELIGIBILITY_DIGEST,
+    APPROVED_HISTORICAL_EVALUATION_DIGEST,
+    select_canonical_pitcher_matchup_profile_pa_model,
+)
+
+
+def production():
+    return {
+        "model_version": "pa_outcome_v1",
+        "probabilities": {
+            "out": 0.65,
+            "single": 0.15,
+            "double": 0.05,
+            "triple": 0.01,
+            "home_run": 0.04,
+            "walk": 0.07,
+            "strikeout": 0.03,
+        },
+        "metadata": {
+            "source": "existing_production",
+        },
+    }
+
+
+def shadow_probabilities():
+    return {
+        "out": 0.64,
+        "single": 0.15,
+        "double": 0.05,
+        "triple": 0.01,
+        "home_run": 0.04,
+        "walk": 0.07,
+        "strikeout": 0.04,
+    }
+
+
+def comparison(
+    *,
+    status="ready",
+    executed=True,
+    probabilities=None,
+    inputs_unchanged=True,
+    authority_changed=False,
+):
+    return {
+        "status": status,
+        "executed": executed,
+        "shadow_model_version": (
+            "pa_outcome_v1"
+        ),
+        "production_probabilities": (
+            production()["probabilities"]
+        ),
+        "shadow_probabilities": (
+            shadow_probabilities()
+            if probabilities is None
+            else probabilities
+        ),
+        "production_inputs_unchanged": (
+            inputs_unchanged
+        ),
+        "production_authority": False,
+        "production_authority_changed": (
+            authority_changed
+        ),
+    }
+
+
+def select(
+    *,
+    production_value=None,
+    comparison_value=None,
+    requested=True,
+    eligibility_digest=(
+        APPROVED_ELIGIBILITY_DIGEST
+    ),
+    evaluation_digest=(
+        APPROVED_HISTORICAL_EVALUATION_DIGEST
+    ),
+    audit_digest=(
+        APPROVED_CROSS_SEASON_AUDIT_DIGEST
+    ),
+):
+    return (
+        select_canonical_pitcher_matchup_profile_pa_model(
+            production_model=(
+                production()
+                if production_value is None
+                else production_value
+            ),
+            comparison=(
+                comparison()
+                if comparison_value is None
+                else comparison_value
+            ),
+            activation_requested=requested,
+            eligibility_digest=(
+                eligibility_digest
+            ),
+            historical_evaluation_digest=(
+                evaluation_digest
+            ),
+            cross_season_audit_digest=(
+                audit_digest
+            ),
+        )
+    )
+
+
+def test_activation_selects_audited_candidate():
+    result = select()
+    diagnostics = result["diagnostics"]
+
+    assert result["activated"] is True
+    assert result["model"][
+        "probabilities"
+    ] == shadow_probabilities()
+    assert diagnostics["status"] == "activated"
+    assert diagnostics[
+        "activation_status"
+    ] == "production_candidate_activated"
+    assert diagnostics[
+        "selected_probability_source"
+    ] == (
+        "audited_canonical_pitcher_matchup_profile"
+    )
+    assert diagnostics["blockers"] == []
+
+
+def test_active_model_carries_evidence():
+    result = select()
+    evidence = result["model"][
+        "pitcher_matchup_profile_activation"
+    ]
+
+    assert evidence[
+        "eligibility_digest"
+    ] == APPROVED_ELIGIBILITY_DIGEST
+    assert evidence[
+        "historical_evaluation_digest"
+    ] == (
+        APPROVED_HISTORICAL_EVALUATION_DIGEST
+    )
+    assert evidence[
+        "cross_season_audit_digest"
+    ] == APPROVED_CROSS_SEASON_AUDIT_DIGEST
+
+
+def test_inactive_request_preserves_production():
+    original = production()
+    result = select(
+        production_value=original,
+        requested=False,
+    )
+    diagnostics = result["diagnostics"]
+
+    assert result["activated"] is False
+    assert result["model"] == original
+    assert diagnostics["status"] == "inactive"
+    assert diagnostics[
+        "activation_status"
+    ] == "production_activation_not_requested"
+    assert diagnostics[
+        "selected_probability_source"
+    ] == "existing_production_pa_model"
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is True
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+@pytest.mark.parametrize(
+    "kwargs,blocker",
+    [
+        (
+            {
+                "eligibility_digest": (
+                    "0" * 64
+                ),
+            },
+            "eligibility_digest_not_approved",
+        ),
+        (
+            {
+                "evaluation_digest": (
+                    "0" * 64
+                ),
+            },
+            "historical_evaluation_digest_not_approved",
+        ),
+        (
+            {
+                "audit_digest": "0" * 64,
+            },
+            "cross_season_audit_digest_not_approved",
+        ),
+    ],
+)
+def test_stale_evidence_fails_closed(
+    kwargs,
+    blocker,
+):
+    result = select(**kwargs)
+
+    assert result["activated"] is False
+    assert result["model"] == production()
+    assert blocker in result[
+        "diagnostics"
+    ]["blockers"]
+
+
+@pytest.mark.parametrize(
+    "comparison_value,blocker",
+    [
+        (
+            comparison(status="partial"),
+            "candidate_comparison_not_ready",
+        ),
+        (
+            comparison(executed=False),
+            "candidate_comparison_not_executed",
+        ),
+        (
+            comparison(
+                inputs_unchanged=False
+            ),
+            "comparison_authority_contract_invalid",
+        ),
+        (
+            comparison(
+                authority_changed=True
+            ),
+            "comparison_authority_contract_invalid",
+        ),
+        (
+            comparison(probabilities={}),
+            "candidate_probabilities_invalid",
+        ),
+        (
+            comparison(
+                probabilities={
+                    "out": 0.9,
+                    "single": 0.2,
+                }
+            ),
+            "candidate_probabilities_invalid",
+        ),
+    ],
+)
+def test_invalid_comparison_fails_closed(
+    comparison_value,
+    blocker,
+):
+    result = select(
+        comparison_value=comparison_value
+    )
+
+    assert result["activated"] is False
+    assert result["model"] == production()
+    assert blocker in result[
+        "diagnostics"
+    ]["blockers"]
+
+
+def test_candidate_keys_must_match_production():
+    values = shadow_probabilities()
+    values.pop("strikeout")
+    values["field_error"] = 0.04
+
+    result = select(
+        comparison_value=comparison(
+            probabilities=values
+        )
+    )
+
+    assert result["activated"] is False
+    assert (
+        "candidate_outcome_keys_mismatch"
+        in result["diagnostics"]["blockers"]
+    )
+
+
+@pytest.mark.parametrize(
+    "probabilities",
+    [
+        {},
+        {"out": 1.1},
+        {"out": float("nan")},
+        {"out": True},
+    ],
+)
+def test_invalid_production_fails_closed(
+    probabilities,
+):
+    value = production()
+    value["probabilities"] = probabilities
+
+    result = select(
+        production_value=value
+    )
+
+    assert result["activated"] is False
+    assert (
+        "production_probabilities_invalid"
+        in result["diagnostics"]["blockers"]
+    )
+
+
+def test_activation_authority_is_explicit():
+    diagnostics = select()["diagnostics"]
+
+    assert diagnostics["fail_closed"] is True
+    assert diagnostics[
+        "activation_requested"
+    ] is True
+    assert diagnostics[
+        "activation_executed"
+    ] is True
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is False
+    assert diagnostics[
+        "production_authority"
+    ] is True
+    assert diagnostics[
+        "production_authority_changed"
+    ] is True
+
+
+def test_selector_is_nonmutating():
+    production_value = production()
+    comparison_value = comparison()
+    original_production = copy.deepcopy(
+        production_value
+    )
+    original_comparison = copy.deepcopy(
+        comparison_value
+    )
+
+    select(
+        production_value=production_value,
+        comparison_value=comparison_value,
+    )
+
+    assert production_value == (
+        original_production
+    )
+    assert comparison_value == (
+        original_comparison
+    )
+
+
+def test_selector_is_deterministic():
+    first = select()
+    second = select(
+        production_value=dict(
+            reversed(
+                tuple(
+                    production().items()
+                )
+            )
+        ),
+    )
+
+    assert first["diagnostics"][
+        "activation_digest"
+    ] == second["diagnostics"][
+        "activation_digest"
+    ]
+
+
+def test_activation_request_must_be_boolean():
+    with pytest.raises(
+        ValueError,
+        match=(
+            "activation_requested_must_be_boolean"
+        ),
+    ):
+        select_canonical_pitcher_matchup_profile_pa_model(
+            production_model=production(),
+            comparison=comparison(),
+            activation_requested=1,
+            eligibility_digest=(
+                APPROVED_ELIGIBILITY_DIGEST
+            ),
+            historical_evaluation_digest=(
+                APPROVED_HISTORICAL_EVALUATION_DIGEST
+            ),
+            cross_season_audit_digest=(
+                APPROVED_CROSS_SEASON_AUDIT_DIGEST
+            ),
+        )

--- a/tests/test_canonical_pitcher_matchup_profile_pa_comparator.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_comparator.py
@@ -1,0 +1,244 @@
+from copy import deepcopy
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_comparator import (
+    compare_canonical_pitcher_matchup_profile_pa_outcomes,
+)
+
+
+def production_pitcher_profile():
+    return {
+        "bat_missing": {
+            "k_rate": 0.20,
+        },
+        "command_control": {
+            "bb_rate": 0.08,
+        },
+        "contact_management": {
+            "barrel_rate_allowed": 0.10,
+            "hard_hit_rate_allowed": 0.40,
+            "xba_allowed": 0.250,
+        },
+    }
+
+
+def batter_profile():
+    return {
+        "contact_skill": {
+            "k_rate": 0.22,
+            "contact_rate": 0.76,
+            "hit_skill": 0.290,
+        },
+        "plate_discipline": {
+            "bb_rate": 0.09,
+        },
+        "power": {
+            "iso": 0.180,
+            "barrel_rate": 0.09,
+            "hard_hit_rate": 0.41,
+        },
+    }
+
+
+def environment_profile():
+    return {
+        "run_environment": {
+            "hr_boost_index": 1.0,
+            "hit_boost_index": 1.0,
+            "run_scoring_index": 1.0,
+        },
+    }
+
+
+def ready_candidate():
+    return {
+        "profile_rates": {
+            "k_rate": 0.28,
+            "bb_rate": 0.05,
+            "barrel_rate_allowed_approx": 0.07,
+            "hard_hit_rate_allowed": 0.34,
+            "ground_ball_rate": 0.48,
+            "line_drive_rate": 0.19,
+            "fly_ball_rate": 0.25,
+            "popup_rate": 0.08,
+            "sweet_spot_rate_allowed": 0.29,
+        },
+        "diagnostics": {
+            "status": "ready",
+            "blocked_metrics": {
+                "bb_rate": [
+                    "cross_season_candidate_instability"
+                ],
+            },
+            "production_authority": False,
+            "production_authority_changed": False,
+        },
+    }
+
+
+def compare(candidate=None):
+    return (
+        compare_canonical_pitcher_matchup_profile_pa_outcomes(
+            candidate=(
+                candidate
+                if candidate is not None
+                else ready_candidate()
+            ),
+            production_pitcher_profile=(
+                production_pitcher_profile()
+            ),
+            batter_profile=batter_profile(),
+            environment_profile=environment_profile(),
+        )
+    )
+
+
+def test_runs_paired_shadow_comparison_without_mutation():
+    production = production_pitcher_profile()
+    original = deepcopy(production)
+
+    result = (
+        compare_canonical_pitcher_matchup_profile_pa_outcomes(
+            candidate=ready_candidate(),
+            production_pitcher_profile=production,
+            batter_profile=batter_profile(),
+            environment_profile=environment_profile(),
+        )
+    )
+
+    assert result["status"] == "ready"
+    assert result["executed"] is True
+    assert production == original
+    assert result["production_inputs_unchanged"] is True
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert (
+        result["maximum_absolute_probability_delta"]
+        > 0
+    )
+    assert set(result["probability_deltas"]) == set(
+        result["production_probabilities"]
+    )
+    assert abs(
+        result["production_probability_sum"] - 1.0
+    ) <= 0.0005
+    assert abs(
+        result["shadow_probability_sum"] - 1.0
+    ) <= 0.0005
+
+
+def test_maps_only_supported_calibrated_rates():
+    result = compare()
+    profile = result["candidate_pitcher_profile"]
+
+    assert profile["bat_missing"]["k_rate"] == 0.28
+    assert profile["contact_management"][
+        "barrel_rate_allowed"
+    ] == 0.07
+    assert profile["contact_management"][
+        "hard_hit_rate_allowed"
+    ] == 0.34
+    assert result["applied_rates"] == {
+        "k_rate": 0.28,
+        "barrel_rate_allowed_approx": 0.07,
+        "hard_hit_rate_allowed": 0.34,
+    }
+
+
+def test_blocked_walk_rate_remains_production_value():
+    result = compare()
+    profile = result["candidate_pitcher_profile"]
+
+    assert profile["command_control"]["bb_rate"] == 0.08
+    assert result["deferred_rates"]["bb_rate"] == (
+        "cross_season_candidate_instability"
+    )
+
+
+def test_unmapped_contact_distribution_is_deferred():
+    result = compare()
+
+    assert result["deferred_rates"][
+        "ground_ball_rate"
+    ] == "pa_outcome_v1_has_no_contact_type_input"
+    assert result["deferred_rates"][
+        "line_drive_rate"
+    ] == "pa_outcome_v1_has_no_contact_type_input"
+    assert result["deferred_rates"][
+        "sweet_spot_rate_allowed"
+    ] == "pa_outcome_v1_has_no_sweet_spot_input"
+
+
+def test_xba_remains_authoritative_production_input():
+    result = compare()
+
+    assert result["candidate_pitcher_profile"][
+        "contact_management"
+    ]["xba_allowed"] == 0.250
+
+
+def test_non_ready_candidate_fails_closed():
+    candidate = ready_candidate()
+    candidate["diagnostics"]["status"] = "blocked"
+
+    result = compare(candidate)
+
+    assert result["status"] == "blocked"
+    assert result["executed"] is False
+    assert result["production_authority_changed"] is False
+    assert "production_probabilities" not in result
+
+
+def test_invalid_authority_contract_fails_closed():
+    candidate = ready_candidate()
+    candidate["diagnostics"][
+        "production_authority_changed"
+    ] = True
+
+    result = compare(candidate)
+
+    assert result["status"] == "blocked"
+    assert result["executed"] is False
+    assert (
+        "candidate_authority_contract_invalid"
+        in result["blockers"]
+    )
+
+
+def test_missing_supported_rates_do_not_overwrite_profile():
+    candidate = ready_candidate()
+    candidate["profile_rates"] = {
+        "ground_ball_rate": 0.50,
+    }
+
+    result = compare(candidate)
+
+    assert result["status"] == "blocked"
+    assert result["executed"] is False
+    assert "no_supported_candidate_rates" in (
+        result["blockers"]
+    )
+
+
+
+def test_reconciles_ready_shadow_rounding_residual():
+    value = ready_candidate()
+    value["profile_rates"].update({
+        "k_rate": 0.25,
+        "barrel_rate_allowed_approx": 0.08,
+        "hard_hit_rate_allowed": 0.36,
+    })
+
+    result = compare(value)
+    probabilities = result[
+        "shadow_probabilities"
+    ]
+
+    assert result["status"] == "ready"
+    assert result[
+        "shadow_probability_sum"
+    ] == 1.0
+    assert round(
+        sum(probabilities.values()),
+        12,
+    ) == 1.0
+    assert probabilities["out"] == 0.4217

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_candidates.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_candidates.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+import mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_candidates as candidate_module
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_candidates import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_candidates,
+)
+
+
+def request(**overrides):
+    values = {
+        "game_pk": 700001,
+        "pitcher_id": 101,
+        "game_date": "2025-07-01",
+    }
+    values.update(overrides)
+    return values
+
+
+def candidate(
+    pitcher_id,
+    game_date,
+    *,
+    status="ready",
+    authority=False,
+    authority_changed=False,
+):
+    return {
+        "profile_rates": {
+            "k_rate": 0.30,
+        },
+        "diagnostics": {
+            "status": status,
+            "pitcher_id": pitcher_id,
+            "game_date": str(game_date),
+            "cutoff_rule": (
+                "events_strictly_before_game_date"
+            ),
+            "evidence_status": "ready",
+            "league_prior_status": "ready",
+            "application_status": status,
+            "runtime_candidate_digest": (
+                f"digest:{pitcher_id}:{game_date}"
+            ),
+            "production_authority": (
+                authority
+            ),
+            "production_authority_changed": (
+                authority_changed
+            ),
+        },
+    }
+
+
+@pytest.fixture
+def builder(monkeypatch):
+    calls = []
+
+    def fake(
+        events,
+        *,
+        pitcher_id,
+        game_date,
+        window_days,
+    ):
+        calls.append({
+            "events_id": id(events),
+            "event_count": len(events),
+            "pitcher_id": pitcher_id,
+            "game_date": game_date,
+            "window_days": window_days,
+        })
+        return candidate(
+            pitcher_id,
+            game_date,
+        )
+
+    monkeypatch.setattr(
+        candidate_module,
+        "build_canonical_pitcher_matchup_profile_runtime_candidate",
+        fake,
+    )
+
+    return calls
+
+
+def materialize(
+    requests=None,
+    events=None,
+    **overrides,
+):
+    values = {
+        "requests": (
+            [request()]
+            if requests is None
+            else requests
+        ),
+        "window_days": 90,
+    }
+    values.update(overrides)
+
+    return (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_candidates(
+            (
+                [{"event_id": 1}]
+                if events is None
+                else events
+            ),
+            **values,
+        )
+    )
+
+
+def test_builds_candidate_by_game_pitcher(
+    builder,
+):
+    result = materialize()
+
+    assert result["diagnostics"]["status"] == "ready"
+    assert result["diagnostics"][
+        "candidate_count"
+    ] == 1
+    assert result["diagnostics"][
+        "ready_candidate_count"
+    ] == 1
+    assert set(result["candidates"]) == {
+        (700001, 101)
+    }
+    assert result["candidates"][
+        (700001, 101)
+    ]["diagnostics"]["status"] == "ready"
+
+    assert builder[0]["pitcher_id"] == 101
+    assert builder[0]["window_days"] == 90
+    assert builder[0]["game_date"].isoformat() == (
+        "2025-07-01"
+    )
+
+
+def test_reuses_one_shared_event_collection(
+    builder,
+):
+    result = materialize(
+        requests=[
+            request(),
+            request(
+                game_pk=700002,
+                pitcher_id=102,
+                game_date="2025-07-02",
+            ),
+        ],
+        events=[
+            {"event_id": 1},
+            {"event_id": 2},
+        ],
+    )
+
+    assert result["diagnostics"][
+        "candidate_count"
+    ] == 2
+    assert len(builder) == 2
+    assert len({
+        call["events_id"]
+        for call in builder
+    }) == 1
+    assert {
+        call["event_count"]
+        for call in builder
+    } == {2}
+    assert result["diagnostics"][
+        "single_shared_event_collection"
+    ] is True
+    assert result["diagnostics"][
+        "event_collection_reused"
+    ] is True
+
+
+def test_deduplicates_identical_requests(
+    builder,
+):
+    result = materialize(
+        requests=[
+            request(),
+            request(),
+        ]
+    )
+
+    assert len(builder) == 1
+    assert result["diagnostics"][
+        "duplicate_request_count"
+    ] == 1
+    assert result["diagnostics"][
+        "candidate_count"
+    ] == 1
+
+
+def test_conflicting_dates_fail_closed(
+    builder,
+):
+    result = materialize(
+        requests=[
+            request(
+                game_date="2025-07-01"
+            ),
+            request(
+                game_date="2025-07-02"
+            ),
+            request(
+                game_date="2025-07-01"
+            ),
+        ]
+    )
+
+    assert builder == []
+    assert result["candidates"] == {}
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "rejected_requests"
+    ][0]["reason"] == (
+        "conflicting_game_pitcher_request"
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value,reason",
+    [
+        (
+            "game_pk",
+            0,
+            "game_pk_must_be_positive_integer",
+        ),
+        (
+            "pitcher_id",
+            False,
+            "pitcher_id_must_be_positive_integer",
+        ),
+        (
+            "game_date",
+            "bad-date",
+            "game_date_must_be_iso_date",
+        ),
+    ],
+)
+def test_rejects_invalid_requests(
+    builder,
+    field,
+    value,
+    reason,
+):
+    result = materialize(
+        requests=[
+            request(**{field: value}),
+        ]
+    )
+
+    assert builder == []
+    assert result["candidates"] == {}
+    assert result["diagnostics"][
+        "rejected_requests"
+    ][0]["reason"] == reason
+
+
+def test_valid_requests_survive_invalid_requests(
+    builder,
+):
+    result = materialize(
+        requests=[
+            request(),
+            request(
+                game_pk=None,
+                pitcher_id=102,
+            ),
+        ]
+    )
+
+    assert len(builder) == 1
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "candidate_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_request_count"
+    ] == 1
+
+
+def test_partial_candidate_reports_partial(
+    monkeypatch,
+):
+    def fake(
+        events,
+        *,
+        pitcher_id,
+        game_date,
+        window_days,
+    ):
+        return candidate(
+            pitcher_id,
+            game_date,
+            status="partial",
+        )
+
+    monkeypatch.setattr(
+        candidate_module,
+        "build_canonical_pitcher_matchup_profile_runtime_candidate",
+        fake,
+    )
+
+    result = materialize()
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "partial_candidate_count"
+    ] == 1
+    assert result["diagnostics"][
+        "ready_candidate_count"
+    ] == 0
+
+
+def test_invalid_authority_fails_closed(
+    monkeypatch,
+):
+    def fake(
+        events,
+        *,
+        pitcher_id,
+        game_date,
+        window_days,
+    ):
+        return candidate(
+            pitcher_id,
+            game_date,
+            authority=True,
+        )
+
+    monkeypatch.setattr(
+        candidate_module,
+        "build_canonical_pitcher_matchup_profile_runtime_candidate",
+        fake,
+    )
+
+    result = materialize()
+
+    assert result["candidates"] == {}
+    assert result["diagnostics"][
+        "rejected_requests"
+    ][0]["reason"] == (
+        "candidate_authority_contract_invalid"
+    )
+
+
+def test_builder_failure_is_reported(
+    monkeypatch,
+):
+    def fail(*args, **kwargs):
+        raise ValueError(
+            "synthetic failure"
+        )
+
+    monkeypatch.setattr(
+        candidate_module,
+        "build_canonical_pitcher_matchup_profile_runtime_candidate",
+        fail,
+    )
+
+    result = materialize()
+
+    assert result["candidates"] == {}
+    assert result["diagnostics"][
+        "rejected_requests"
+    ][0]["reason"] == (
+        "candidate_materialization_failed:"
+        "synthetic failure"
+    )
+
+
+def test_materialization_is_deterministic(
+    builder,
+):
+    requests = [
+        request(
+            game_pk=700001,
+            pitcher_id=101,
+            game_date="2025-07-01",
+        ),
+        request(
+            game_pk=700002,
+            pitcher_id=102,
+            game_date="2025-07-02",
+        ),
+    ]
+
+    first = materialize(
+        requests=requests
+    )
+    second = materialize(
+        requests=list(
+            reversed(requests)
+        )
+    )
+
+    assert first["candidates"] == (
+        second["candidates"]
+    )
+    assert first["diagnostics"][
+        "candidate_records"
+    ] == second["diagnostics"][
+        "candidate_records"
+    ]
+    assert first["diagnostics"][
+        "candidate_window_digest"
+    ] == second["diagnostics"][
+        "candidate_window_digest"
+    ]
+
+
+def test_inputs_are_not_mutated(
+    builder,
+):
+    event_rows = [
+        {"event_id": 1},
+    ]
+    request_rows = [
+        request(),
+    ]
+    original_events = deepcopy(
+        event_rows
+    )
+    original_requests = deepcopy(
+        request_rows
+    )
+
+    materialize(
+        events=event_rows,
+        requests=request_rows,
+    )
+
+    assert event_rows == original_events
+    assert request_rows == original_requests
+
+
+@pytest.mark.parametrize(
+    "window_days",
+    [
+        0,
+        -1,
+        True,
+        1.5,
+    ],
+)
+def test_window_days_must_be_positive_integer(
+    window_days,
+):
+    with pytest.raises(ValueError):
+        materialize(
+            window_days=window_days
+        )
+
+
+def test_authority_and_cutoff_contracts(
+    builder,
+):
+    diagnostics = materialize()[
+        "diagnostics"
+    ]
+
+    assert diagnostics["cutoff_rule"] == (
+        "events_strictly_before_each_game_date"
+    )
+    assert diagnostics[
+        "candidate_identity"
+    ] == "game_pk_pitcher_id"
+    assert diagnostics[
+        "calibrated_pooled_metrics_only"
+    ] is True
+    assert diagnostics[
+        "segment_parameters_applied"
+    ] is False
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_evaluation.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_evaluation.py
@@ -1,0 +1,302 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_evaluation import (
+    OUTCOME_KEYS,
+    evaluate_canonical_pitcher_matchup_profile_pa_history,
+)
+
+
+def probabilities(
+    *,
+    k,
+    bb,
+    single,
+    double,
+    triple,
+    hr,
+    hbp,
+    reached_on_error,
+):
+    out = 1.0 - sum((
+        k,
+        bb,
+        single,
+        double,
+        triple,
+        hr,
+        hbp,
+        reached_on_error,
+    ))
+
+    return {
+        "k": k,
+        "bb": bb,
+        "hbp": hbp,
+        "single": single,
+        "double": double,
+        "triple": triple,
+        "hr": hr,
+        "reached_on_error": (
+            reached_on_error
+        ),
+        "out": out,
+    }
+
+
+OBSERVED = {
+    "k": 22,
+    "bb": 8,
+    "hbp": 1,
+    "single": 14,
+    "double": 4,
+    "triple": 1,
+    "hr": 4,
+    "reached_on_error": 1,
+    "out": 45,
+}
+
+PRODUCTION = probabilities(
+    k=0.18,
+    bb=0.08,
+    hbp=0.01,
+    single=0.12,
+    double=0.035,
+    triple=0.005,
+    hr=0.025,
+    reached_on_error=0.01,
+)
+
+CANDIDATE = probabilities(
+    k=0.22,
+    bb=0.08,
+    hbp=0.01,
+    single=0.14,
+    double=0.04,
+    triple=0.01,
+    hr=0.04,
+    reached_on_error=0.01,
+)
+
+
+def sample(
+    index,
+    *,
+    season=2025,
+    candidate=None,
+):
+    return {
+        "season": season,
+        "game_pk": 1000 + index,
+        "comparison_id": f"sample-{index}",
+        "production_probabilities": (
+            dict(PRODUCTION)
+        ),
+        "candidate_probabilities": dict(
+            candidate
+            if candidate is not None
+            else CANDIDATE
+        ),
+        "observed_counts": dict(OBSERVED),
+    }
+
+
+def evaluate(values):
+    return (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            values,
+            minimum_samples=2,
+            minimum_observed_pa=100,
+        )
+    )
+
+
+def test_candidate_improvement_passes_paired_gate():
+    result = evaluate([
+        sample(1, season=2024),
+        sample(2, season=2025),
+    ])
+    diagnostics = result["diagnostics"]
+
+    assert result["overall"][
+        "absolute_log_loss_improvement"
+    ] > 0
+    assert result["overall"][
+        "absolute_brier_improvement"
+    ] > 0
+    assert diagnostics[
+        "selection_gate_passed"
+    ] is True
+    assert diagnostics[
+        "activation_status"
+    ] == "historical_pa_gate_passed"
+    assert diagnostics["blockers"] == []
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_reports_exact_outcome_contract():
+    assert OUTCOME_KEYS == (
+        "k",
+        "bb",
+        "hbp",
+        "single",
+        "double",
+        "triple",
+        "hr",
+        "reached_on_error",
+        "out",
+    )
+
+
+def test_season_regression_blocks_selection():
+    bad_candidate = probabilities(
+        k=0.40,
+        bb=0.03,
+        hbp=0.01,
+        single=0.06,
+        double=0.02,
+        triple=0.005,
+        hr=0.01,
+        reached_on_error=0.005,
+    )
+
+    result = evaluate([
+        sample(1, season=2024),
+        sample(
+            2,
+            season=2025,
+            candidate=bad_candidate,
+        ),
+    ])
+
+    assert result["diagnostics"][
+        "selection_gate_passed"
+    ] is False
+    assert (
+        "season_log_loss_instability"
+        in result["diagnostics"][
+            "blockers"
+        ]
+    )
+    assert "2025" in result[
+        "diagnostics"
+    ]["regressed_seasons"]
+
+
+def test_insufficient_sample_blocks_selection():
+    result = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            [sample(1)],
+            minimum_samples=2,
+            minimum_observed_pa=50,
+        )
+    )
+
+    assert result["diagnostics"][
+        "selection_gate_passed"
+    ] is False
+    assert (
+        "insufficient_sample_count"
+        in result["diagnostics"][
+            "blockers"
+        ]
+    )
+
+
+def test_invalid_distribution_is_rejected():
+    invalid = sample(1)
+    invalid[
+        "candidate_probabilities"
+    ]["k"] = 0.90
+
+    result = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            [invalid],
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+
+    assert result["diagnostics"][
+        "accepted_sample_count"
+    ] == 0
+    assert result["diagnostics"][
+        "rejected_sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "selection_gate_passed"
+    ] is False
+
+
+def test_duplicate_identity_is_rejected():
+    first = sample(1)
+    second = copy.deepcopy(first)
+
+    result = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            [first, second],
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+
+    assert result["diagnostics"][
+        "accepted_sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_sample_count"
+    ] == 1
+    assert (
+        "duplicate comparison identity"
+        in result["rejected_samples"][0][
+            "reason"
+        ]
+    )
+
+
+def test_evaluation_is_deterministic_and_nonmutating():
+    values = [
+        sample(1, season=2024),
+        sample(2, season=2025),
+    ]
+    original = copy.deepcopy(values)
+
+    first = evaluate(values)
+    second = evaluate(
+        list(reversed(values))
+    )
+
+    assert values == original
+    assert first["overall"] == second[
+        "overall"
+    ]
+    assert first["by_season"] == second[
+        "by_season"
+    ]
+    assert first["diagnostics"][
+        "evaluation_digest"
+    ] == second["diagnostics"][
+        "evaluation_digest"
+    ]
+
+
+@pytest.mark.parametrize(
+    "minimum_samples,minimum_pa",
+    [
+        (0, 1),
+        (1, 0),
+    ],
+)
+def test_thresholds_must_be_positive(
+    minimum_samples,
+    minimum_pa,
+):
+    with pytest.raises(ValueError):
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            [sample(1)],
+            minimum_samples=minimum_samples,
+            minimum_observed_pa=minimum_pa,
+        )

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_executor.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_executor.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_executor import (
+    execute_canonical_pitcher_matchup_profile_pa_historical_evaluation,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    HITTING_STAT_KEYS,
+    PITCHING_STAT_KEYS,
+    CanonicalHistoricalProbabilityGameStatistics,
+    CanonicalHistoricalProbabilityPlayerStatistics,
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+
+
+def counts(keys, values):
+    return tuple(
+        (
+            key,
+            int(values.get(key, 0)),
+        )
+        for key, _ in keys
+    )
+
+
+def statistics():
+    hitter = (
+        CanonicalHistoricalProbabilityPlayerStatistics(
+            player_id="201",
+            role="hitting",
+            counts=counts(
+                HITTING_STAT_KEYS,
+                {
+                    "pa": 100,
+                    "ab": 80,
+                    "hits": 24,
+                    "double": 6,
+                    "triple": 2,
+                    "hr": 4,
+                    "bb": 10,
+                    "k": 20,
+                    "hbp": 2,
+                },
+            ),
+            sample_available=True,
+        )
+    )
+    pitcher = (
+        CanonicalHistoricalProbabilityPlayerStatistics(
+            player_id="101",
+            role="pitching",
+            counts=counts(
+                PITCHING_STAT_KEYS,
+                {
+                    "batters_faced": 120,
+                    "ab": 100,
+                    "hits": 25,
+                    "double": 5,
+                    "triple": 1,
+                    "hr": 3,
+                    "bb": 12,
+                    "k": 30,
+                    "hbp": 2,
+                },
+            ),
+            sample_available=True,
+        )
+    )
+    game = (
+        CanonicalHistoricalProbabilityGameStatistics(
+            game_pk=700001,
+            game_date="2025-07-01",
+            statistics_through_date=(
+                "2025-06-30"
+            ),
+            players=(
+                hitter,
+                pitcher,
+            ),
+            snapshot_digest=DIGEST_D,
+        )
+    )
+
+    return (
+        CanonicalHistoricalProbabilityStatisticsWindow(
+            observed_window_digest=DIGEST_A,
+            lineup_bullpen_window_digest=(
+                DIGEST_B
+            ),
+            games=(game,),
+            digest=DIGEST_C,
+        )
+    )
+
+
+def candidate():
+    return {
+        "profile_rates": {
+            "k_rate": 0.35,
+            "barrel_rate_allowed_approx": 0.08,
+            "hard_hit_rate_allowed": 0.4,
+        },
+        "diagnostics": {
+            "status": "ready",
+            "production_authority": False,
+            "production_authority_changed": False,
+        },
+    }
+
+
+def events():
+    return [
+        {
+            "game_pk": 700001,
+            "game_date": "2025-07-01",
+            "at_bat_number": 1,
+            "pitcher_id": 101,
+            "batter_id": 201,
+            "events": "single",
+        },
+        {
+            "game_pk": 700001,
+            "game_date": "2025-07-01",
+            "at_bat_number": 2,
+            "pitcher_id": 101,
+            "batter_id": 201,
+            "events": "strikeout",
+        },
+    ]
+
+
+def execute(
+    source=None,
+    candidates=None,
+    **overrides,
+):
+    values = {
+        "statistics": statistics(),
+        "candidates_by_game_pitcher": (
+            {
+                (700001, 101): candidate(),
+            }
+            if candidates is None
+            else candidates
+        ),
+        "minimum_samples": 1,
+        "minimum_observed_pa": 1,
+    }
+    values.update(overrides)
+
+    return (
+        execute_canonical_pitcher_matchup_profile_pa_historical_evaluation(
+            events() if source is None else source,
+            **values,
+        )
+    )
+
+
+def test_executes_complete_historical_pipeline():
+    result = execute()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["status"] == "ready"
+    assert diagnostics["raw_event_count"] == 2
+    assert diagnostics["terminal_pa_count"] == 2
+    assert diagnostics["outcome_sample_count"] == 1
+    assert diagnostics["paired_sample_count"] == 1
+    assert diagnostics["accepted_sample_count"] == 1
+    assert diagnostics["observed_pa"] == 2
+
+    assert result["outcomes"][
+        "diagnostics"
+    ]["status"] == "ready"
+    assert result["paired_samples"][
+        "diagnostics"
+    ]["status"] == "ready"
+
+
+def test_executes_historical_evaluator():
+    result = execute()
+    evaluation = result["evaluation"]
+
+    assert evaluation["diagnostics"][
+        "accepted_sample_count"
+    ] == 1
+    assert evaluation["diagnostics"][
+        "rejected_sample_count"
+    ] == 0
+    assert evaluation["overall"][
+        "observed_pa"
+    ] == 2
+    assert evaluation["overall"][
+        "production_log_loss"
+    ] >= 0.0
+    assert evaluation["overall"][
+        "candidate_log_loss"
+    ] >= 0.0
+    assert evaluation["overall"][
+        "absolute_log_loss_improvement"
+    ] > 0.0
+    assert evaluation["diagnostics"][
+        "activation_status"
+    ] == "historical_pa_gate_passed"
+
+
+def test_partial_outcome_evidence_remains_partial():
+    source = events()
+    source.append({
+        "game_pk": 700001,
+        "game_date": "2025-07-01",
+        "at_bat_number": 3,
+        "pitcher_id": 101,
+        "batter_id": 201,
+        "events": "catcher_interf",
+    })
+
+    result = execute(source=source)
+
+    assert result["outcomes"][
+        "diagnostics"
+    ]["status"] == "partial"
+    assert result["diagnostics"][
+        "accepted_sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+
+
+def test_empty_evidence_is_unavailable():
+    result = execute(source=[])
+
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "accepted_sample_count"
+    ] == 0
+    assert result["diagnostics"][
+        "blockers"
+    ] == [
+        "no_evaluator_ready_historical_samples"
+    ]
+
+
+def test_missing_candidate_is_unavailable():
+    result = execute(
+        candidates={}
+    )
+
+    assert result["paired_samples"][
+        "diagnostics"
+    ]["status"] == "unavailable"
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "accepted_sample_count"
+    ] == 0
+
+
+def test_authority_contracts_all_pass():
+    result = execute()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics[
+        "authority_contracts"
+    ] == {
+        "outcomes": True,
+        "paired_samples": True,
+        "evaluation": True,
+    }
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics[
+        "database_accessed"
+    ] is False
+    assert diagnostics[
+        "calibration_parameters_selected"
+    ] is False
+
+
+def test_execution_is_deterministic():
+    first = execute()
+    second = execute(
+        source=list(
+            reversed(events())
+        )
+    )
+
+    assert first["outcomes"]["samples"] == (
+        second["outcomes"]["samples"]
+    )
+    assert first["paired_samples"][
+        "samples"
+    ] == second["paired_samples"]["samples"]
+    assert first["evaluation"]["overall"] == (
+        second["evaluation"]["overall"]
+    )
+    assert first["diagnostics"][
+        "execution_digest"
+    ] == second["diagnostics"][
+        "execution_digest"
+    ]
+
+
+def test_inputs_are_not_mutated():
+    source = events()
+    stats = statistics()
+    candidates = {
+        (700001, 101): candidate(),
+    }
+    original_source = deepcopy(source)
+    original_candidates = deepcopy(
+        candidates
+    )
+
+    execute_canonical_pitcher_matchup_profile_pa_historical_evaluation(
+        source,
+        statistics=stats,
+        candidates_by_game_pitcher=(
+            candidates
+        ),
+        minimum_samples=1,
+        minimum_observed_pa=1,
+    )
+
+    assert source == original_source
+    assert candidates == original_candidates
+
+
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("minimum_samples", 0),
+        ("minimum_observed_pa", 0),
+        (
+            "season_log_loss_regression_tolerance",
+            -0.1,
+        ),
+    ],
+)
+def test_evaluation_threshold_validation_is_preserved(
+    name,
+    value,
+):
+    with pytest.raises(ValueError):
+        execute(**{name: value})
+
+
+def test_pipeline_and_cutoff_contracts_are_explicit():
+    diagnostics = execute()["diagnostics"]
+
+    assert diagnostics["pipeline"] == (
+        "terminal_outcomes_to_paired_samples_to_evaluation"
+    )
+    assert diagnostics["cutoff_policy"] == (
+        "statistics_and_candidates_supplied_as_pregame_inputs"
+    )
+    assert diagnostics["outcome_digest"]
+    assert diagnostics["sample_digest"]
+    assert diagnostics["evaluation_digest"]

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_outcomes.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_outcomes.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_outcomes import (
+    OUTCOME_KEYS,
+    materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes,
+)
+
+
+def event(**overrides):
+    values = {
+        "game_pk": 700001,
+        "game_date": "2025-07-01",
+        "at_bat_number": 1,
+        "pitcher_id": 101,
+        "batter_id": 201,
+        "events": "single",
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.mark.parametrize(
+    "event_name,outcome",
+    [
+        ("strikeout", "k"),
+        ("strikeout_double_play", "k"),
+        ("walk", "bb"),
+        ("intent_walk", "bb"),
+        ("hit_by_pitch", "hbp"),
+        ("single", "single"),
+        ("double", "double"),
+        ("triple", "triple"),
+        ("home_run", "hr"),
+        ("field_error", "reached_on_error"),
+        ("field_out", "out"),
+        ("force_out", "out"),
+        ("grounded_into_double_play", "out"),
+        ("double_play", "out"),
+        ("triple_play", "out"),
+        ("fielders_choice", "out"),
+        ("fielders_choice_out", "out"),
+        ("sac_fly", "out"),
+        ("sac_bunt", "out"),
+    ],
+)
+def test_maps_supported_terminal_events(
+    event_name,
+    outcome,
+):
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(events=event_name),
+            ]
+        )
+    )
+
+    assert result["diagnostics"]["status"] == "ready"
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 1
+
+    sample = result["samples"][0]
+
+    assert tuple(
+        sample["observed_counts"]
+    ) == OUTCOME_KEYS
+    assert sample["observed_counts"][
+        outcome
+    ] == 1
+    assert sum(
+        sample["observed_counts"].values()
+    ) == 1
+
+
+def test_groups_by_game_pitcher_and_batter():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(
+                    at_bat_number=1,
+                    events="single",
+                ),
+                event(
+                    at_bat_number=2,
+                    events="strikeout",
+                ),
+                event(
+                    at_bat_number=3,
+                    batter_id=202,
+                    events="walk",
+                ),
+                event(
+                    game_pk=700002,
+                    at_bat_number=1,
+                    events="home_run",
+                ),
+            ]
+        )
+    )
+
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 4
+    assert result["diagnostics"][
+        "sample_count"
+    ] == 3
+
+    samples = {
+        sample["comparison_id"]: sample
+        for sample in result["samples"]
+    }
+
+    first = samples["700001:101:201"]
+    assert first["observed_counts"][
+        "single"
+    ] == 1
+    assert first["observed_counts"]["k"] == 1
+
+    second = samples["700001:101:202"]
+    assert second["observed_counts"]["bb"] == 1
+
+    third = samples["700002:101:201"]
+    assert third["observed_counts"]["hr"] == 1
+
+
+def test_deduplicates_identical_terminal_identity():
+    row = event(events="double")
+
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [row, dict(row)]
+        )
+    )
+
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 1
+    assert result["diagnostics"][
+        "duplicate_terminal_row_count"
+    ] == 1
+    assert result["samples"][0][
+        "observed_counts"
+    ]["double"] == 1
+
+
+def test_conflicting_terminal_identity_fails_closed():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(events="single"),
+                event(events="double"),
+            ]
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 0
+    assert result["diagnostics"][
+        "conflicting_terminal_pa_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "conflicting_terminal_pa_identity"
+    )
+
+
+def test_ignores_nonterminal_pitch_rows():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(events=None),
+                event(
+                    at_bat_number=2,
+                    events="single",
+                ),
+            ]
+        )
+    )
+
+    assert result["diagnostics"][
+        "nonterminal_pitch_row_count"
+    ] == 1
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 1
+
+
+def test_rejects_unsupported_terminal_event():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(events="catcher_interf"),
+            ]
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "unsupported_terminal_event"
+    )
+
+
+def test_valid_rows_survive_unsupported_rows():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(events="catcher_interf"),
+                event(
+                    at_bat_number=2,
+                    events="single",
+                ),
+            ]
+        )
+    )
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_row_count"
+    ] == 1
+
+
+@pytest.mark.parametrize(
+    "field,value,reason",
+    [
+        (
+            "game_pk",
+            None,
+            "game_pk_must_be_positive_integer",
+        ),
+        (
+            "at_bat_number",
+            0,
+            "at_bat_number_must_be_positive_integer",
+        ),
+        (
+            "pitcher_id",
+            None,
+            "pitcher_id_must_be_positive_integer",
+        ),
+        (
+            "batter_id",
+            False,
+            "batter_id_must_be_positive_integer",
+        ),
+        (
+            "game_date",
+            "not-a-date",
+            "game_date_must_be_iso_date",
+        ),
+    ],
+)
+def test_rejects_invalid_terminal_identity(
+    field,
+    value,
+    reason,
+):
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(**{field: value}),
+            ]
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == reason
+
+
+def test_accepts_date_objects_and_sets_season():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(
+                    game_date=dt.date(
+                        2024,
+                        8,
+                        15,
+                    )
+                ),
+            ]
+        )
+    )
+
+    sample = result["samples"][0]
+
+    assert sample["season"] == 2024
+    assert sample["game_date"] == "2024-08-15"
+
+
+def test_materialization_is_deterministic():
+    rows = [
+        event(
+            at_bat_number=1,
+            events="single",
+        ),
+        event(
+            at_bat_number=2,
+            events="strikeout",
+        ),
+        event(
+            at_bat_number=3,
+            batter_id=202,
+            events="walk",
+        ),
+    ]
+
+    first = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            rows
+        )
+    )
+    second = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            list(reversed(rows))
+        )
+    )
+
+    assert first["samples"] == second["samples"]
+    assert first["diagnostics"][
+        "outcome_digest"
+    ] == second["diagnostics"][
+        "outcome_digest"
+    ]
+
+
+def test_empty_input_fails_closed():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            []
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "raw_row_count"
+    ] == 0
+
+
+def test_authority_contract_remains_shadow_only():
+    result = (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                event(),
+            ]
+        )
+    )
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics[
+        "intentional_walk_policy"
+    ] == "mapped_to_canonical_bb"
+    assert diagnostics[
+        "unsupported_event_policy"
+    ] == "fail_closed"

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_samples.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_samples.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_evaluation import (
+    evaluate_canonical_pitcher_matchup_profile_pa_history,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_outcomes import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_samples import (
+    materialize_canonical_pitcher_matchup_profile_pa_historical_samples,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    HITTING_STAT_KEYS,
+    PITCHING_STAT_KEYS,
+    CanonicalHistoricalProbabilityGameStatistics,
+    CanonicalHistoricalProbabilityPlayerStatistics,
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+
+
+def counts(keys, values):
+    return tuple(
+        (
+            key,
+            int(values.get(key, 0)),
+        )
+        for key, _ in keys
+    )
+
+
+def hitter(
+    player_id="201",
+    *,
+    sample_available=True,
+):
+    values = {
+        "pa": 100,
+        "ab": 80,
+        "hits": 24,
+        "double": 6,
+        "triple": 2,
+        "hr": 4,
+        "bb": 10,
+        "k": 20,
+        "hbp": 2,
+    }
+
+    if not sample_available:
+        values = {}
+
+    return (
+        CanonicalHistoricalProbabilityPlayerStatistics(
+            player_id=player_id,
+            role="hitting",
+            counts=counts(
+                HITTING_STAT_KEYS,
+                values,
+            ),
+            sample_available=sample_available,
+        )
+    )
+
+
+def pitcher(
+    player_id="101",
+    *,
+    sample_available=True,
+):
+    values = {
+        "batters_faced": 120,
+        "ab": 100,
+        "hits": 25,
+        "double": 5,
+        "triple": 1,
+        "hr": 3,
+        "bb": 12,
+        "k": 30,
+        "hbp": 2,
+    }
+
+    if not sample_available:
+        values = {}
+
+    return (
+        CanonicalHistoricalProbabilityPlayerStatistics(
+            player_id=player_id,
+            role="pitching",
+            counts=counts(
+                PITCHING_STAT_KEYS,
+                values,
+            ),
+            sample_available=sample_available,
+        )
+    )
+
+
+def statistics(
+    *,
+    players=None,
+    game_date="2025-07-01",
+):
+    if players is None:
+        players = (
+            hitter(),
+            pitcher(),
+        )
+
+    game = (
+        CanonicalHistoricalProbabilityGameStatistics(
+            game_pk=700001,
+            game_date=game_date,
+            statistics_through_date=(
+                "2025-06-30"
+            ),
+            players=tuple(players),
+            snapshot_digest=DIGEST_D,
+        )
+    )
+
+    return (
+        CanonicalHistoricalProbabilityStatisticsWindow(
+            observed_window_digest=DIGEST_A,
+            lineup_bullpen_window_digest=(
+                DIGEST_B
+            ),
+            games=(game,),
+            digest=DIGEST_C,
+        )
+    )
+
+
+def candidate(
+    *,
+    status="ready",
+    production_authority=False,
+    production_authority_changed=False,
+):
+    return {
+        "profile_rates": {
+            "k_rate": 0.35,
+            "barrel_rate_allowed_approx": 0.08,
+            "hard_hit_rate_allowed": 0.40,
+        },
+        "diagnostics": {
+            "status": status,
+            "production_authority": (
+                production_authority
+            ),
+            "production_authority_changed": (
+                production_authority_changed
+            ),
+        },
+    }
+
+
+def outcomes(
+    *,
+    batter_id=201,
+    game_date="2025-07-01",
+):
+    return (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_outcomes(
+            [
+                {
+                    "game_pk": 700001,
+                    "game_date": game_date,
+                    "at_bat_number": 1,
+                    "pitcher_id": 101,
+                    "batter_id": batter_id,
+                    "events": "single",
+                },
+                {
+                    "game_pk": 700001,
+                    "game_date": game_date,
+                    "at_bat_number": 2,
+                    "pitcher_id": 101,
+                    "batter_id": batter_id,
+                    "events": "strikeout",
+                },
+            ]
+        )
+    )
+
+
+def materialize(**overrides):
+    values = {
+        "outcomes": outcomes(),
+        "statistics": statistics(),
+        "candidates_by_game_pitcher": {
+            (700001, 101): candidate(),
+        },
+    }
+    values.update(overrides)
+
+    return (
+        materialize_canonical_pitcher_matchup_profile_pa_historical_samples(
+            values.pop("outcomes"),
+            **values,
+        )
+    )
+
+
+def test_materializes_evaluator_ready_sample():
+    result = materialize()
+
+    assert result["diagnostics"]["status"] == "ready"
+    assert result["diagnostics"][
+        "materialized_sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_sample_count"
+    ] == 0
+
+    sample = result["samples"][0]
+
+    assert sample["season"] == 2025
+    assert sample["game_pk"] == "700001"
+    assert sample["comparison_id"] == (
+        "700001:101:201"
+    )
+    assert sample["pitcher_id"] == 101
+    assert sample["batter_id"] == 201
+    assert sample["observed_counts"]["single"] == 1
+    assert sample["observed_counts"]["k"] == 1
+    assert round(
+        sum(
+            sample[
+                "production_probabilities"
+            ].values()
+        ),
+        12,
+    ) == 1.0
+    assert round(
+        sum(
+            sample[
+                "candidate_probabilities"
+            ].values()
+        ),
+        12,
+    ) == 1.0
+
+
+def test_candidate_changes_supported_probabilities():
+    sample = materialize()["samples"][0]
+
+    assert sample[
+        "maximum_absolute_probability_delta"
+    ] > 0.0
+    assert sample["applied_rates"] == {
+        "k_rate": 0.35,
+        "barrel_rate_allowed_approx": 0.08,
+        "hard_hit_rate_allowed": 0.4,
+    }
+    assert sample[
+        "production_probabilities"
+    ] != sample["candidate_probabilities"]
+
+
+def test_output_is_accepted_by_historical_evaluator():
+    paired = materialize()
+
+    evaluation = (
+        evaluate_canonical_pitcher_matchup_profile_pa_history(
+            paired["samples"],
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+
+    assert evaluation["diagnostics"][
+        "accepted_sample_count"
+    ] == 1
+    assert evaluation["diagnostics"][
+        "rejected_sample_count"
+    ] == 0
+    assert evaluation["overall"][
+        "observed_pa"
+    ] == 2
+
+
+def test_missing_candidate_fails_closed():
+    result = materialize(
+        candidates_by_game_pitcher={}
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"] == (
+        "historical_pitcher_candidate_unavailable"
+    )
+
+
+def test_blocked_candidate_fails_closed():
+    result = materialize(
+        candidates_by_game_pitcher={
+            (700001, 101): candidate(
+                status="unavailable"
+            ),
+        }
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"].startswith(
+        "historical_pa_comparison_blocked:"
+    )
+
+
+def test_invalid_candidate_authority_fails_closed():
+    result = materialize(
+        candidates_by_game_pitcher={
+            (700001, 101): candidate(
+                production_authority=True
+            ),
+        }
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"] == (
+        "historical_pa_comparison_blocked:"
+        "candidate_authority_contract_invalid"
+    )
+
+
+def test_missing_batter_statistics_fails_closed():
+    result = materialize(
+        outcomes=outcomes(
+            batter_id=202
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"] == (
+        "historical_batter_statistics_unavailable"
+    )
+
+
+@pytest.mark.parametrize(
+    "players,reason",
+    [
+        (
+            (
+                hitter(
+                    sample_available=False
+                ),
+                pitcher(),
+            ),
+            "historical_batter_sample_unavailable",
+        ),
+        (
+            (
+                hitter(),
+                pitcher(
+                    sample_available=False
+                ),
+            ),
+            "historical_pitcher_sample_unavailable",
+        ),
+    ],
+)
+def test_zero_sample_statistics_fail_closed(
+    players,
+    reason,
+):
+    result = materialize(
+        statistics=statistics(
+            players=players
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"] == reason
+
+
+def test_game_date_mismatch_fails_closed():
+    result = materialize(
+        outcomes=outcomes(
+            game_date="2025-07-02"
+        )
+    )
+
+    assert result["samples"] == []
+    assert result["diagnostics"][
+        "rejected_samples"
+    ][0]["reason"] == (
+        "historical_statistics_game_date_mismatch"
+    )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "700001:101",
+        (700001,),
+        (0, 101),
+        (700001, False),
+    ],
+)
+def test_candidate_keys_must_be_exact_tuples(
+    key,
+):
+    with pytest.raises(ValueError):
+        materialize(
+            candidates_by_game_pitcher={
+                key: candidate(),
+            }
+        )
+
+
+def test_valid_samples_survive_rejected_samples():
+    source = outcomes()
+    source["samples"].append({
+        **deepcopy(source["samples"][0]),
+        "comparison_id": "700001:101:202",
+        "batter_id": 202,
+    })
+
+    result = materialize(
+        outcomes=source
+    )
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "materialized_sample_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_sample_count"
+    ] == 1
+
+
+def test_materialization_is_deterministic():
+    source = outcomes()
+    first = materialize(
+        outcomes=source
+    )
+    second = materialize(
+        outcomes={
+            **source,
+            "samples": list(
+                reversed(source["samples"])
+            ),
+        }
+    )
+
+    assert first["samples"] == second["samples"]
+    assert first["diagnostics"][
+        "sample_digest"
+    ] == second["diagnostics"][
+        "sample_digest"
+    ]
+
+
+def test_inputs_are_not_mutated():
+    source = outcomes()
+    stats = statistics()
+    candidates = {
+        (700001, 101): candidate(),
+    }
+    original_source = deepcopy(source)
+    original_candidates = deepcopy(
+        candidates
+    )
+
+    materialize(
+        outcomes=source,
+        statistics=stats,
+        candidates_by_game_pitcher=(
+            candidates
+        ),
+    )
+
+    assert source == original_source
+    assert candidates == original_candidates
+
+
+def test_authority_contract_remains_shadow_only():
+    diagnostics = materialize()[
+        "diagnostics"
+    ]
+
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["pairing_policy"] == (
+        "game_pitcher_batter_cutoff_safe"
+    )

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_starters.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_starters.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_starters import (
+    source_canonical_pitcher_matchup_profile_pa_historical_starters,
+)
+
+
+def event(**overrides):
+    values = {
+        "game_pk": 700001,
+        "game_date": "2025-07-01",
+        "at_bat_number": 1,
+        "pitch_number": 4,
+        "inning": 1,
+        "inning_topbot": "Top",
+        "pitcher_id": 900,
+        "batter_id": 201,
+        "events": "field_out",
+    }
+    values.update(overrides)
+    return values
+
+
+def game_rows(
+    *,
+    game_pk=700001,
+    game_date="2025-07-01",
+):
+    return [
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=1,
+            inning=1,
+            inning_topbot="Top",
+            pitcher_id=900,
+            batter_id=201,
+            events="field_out",
+        ),
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=2,
+            inning=1,
+            inning_topbot="Top",
+            pitcher_id=900,
+            batter_id=202,
+            events="single",
+        ),
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=3,
+            inning=7,
+            inning_topbot="Top",
+            pitcher_id=901,
+            batter_id=203,
+            events="strikeout",
+        ),
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=4,
+            inning=1,
+            inning_topbot="Bot",
+            pitcher_id=800,
+            batter_id=301,
+            events="walk",
+        ),
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=5,
+            inning=1,
+            inning_topbot="Bottom",
+            pitcher_id=800,
+            batter_id=302,
+            events="double",
+        ),
+        event(
+            game_pk=game_pk,
+            game_date=game_date,
+            at_bat_number=6,
+            inning=6,
+            inning_topbot="Bot",
+            pitcher_id=801,
+            batter_id=303,
+            events="home_run",
+        ),
+    ]
+
+
+def source(rows=None):
+    return (
+        source_canonical_pitcher_matchup_profile_pa_historical_starters(
+            game_rows()
+            if rows is None
+            else rows
+        )
+    )
+
+
+def test_identifies_away_and_home_starters():
+    result = source()
+
+    assert result["diagnostics"]["status"] == "ready"
+    assert result["diagnostics"][
+        "ready_game_count"
+    ] == 1
+
+    record = result["diagnostics"][
+        "starter_records"
+    ][0]
+
+    assert record == {
+        "game_pk": 700001,
+        "game_date": "2025-07-01",
+        "away_starter_id": 800,
+        "home_starter_id": 900,
+        "away_starter_pa_count": 2,
+        "home_starter_pa_count": 2,
+    }
+
+
+def test_builds_candidate_requests_for_both_starters():
+    result = source()
+
+    assert result["requests"] == [
+        {
+            "game_pk": 700001,
+            "pitcher_id": 800,
+            "game_date": result[
+                "requests"
+            ][0]["game_date"],
+            "side": "away",
+        },
+        {
+            "game_pk": 700001,
+            "pitcher_id": 900,
+            "game_date": result[
+                "requests"
+            ][1]["game_date"],
+            "side": "home",
+        },
+    ]
+
+    assert all(
+        request["game_date"].isoformat()
+        == "2025-07-01"
+        for request in result["requests"]
+    )
+
+
+def test_exposes_only_starter_plate_appearances():
+    result = source()
+
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 6
+    assert result["diagnostics"][
+        "starter_pa_count"
+    ] == 4
+
+    assert {
+        row["pitcher_id"]
+        for row in result["starter_events"]
+    } == {800, 900}
+    assert {
+        row["at_bat_number"]
+        for row in result["starter_events"]
+    } == {1, 2, 4, 5}
+
+
+def test_starter_identity_uses_game_order():
+    result = source(
+        list(reversed(game_rows()))
+    )
+
+    record = result["diagnostics"][
+        "starter_records"
+    ][0]
+
+    assert record["home_starter_id"] == 900
+    assert record["away_starter_id"] == 800
+
+
+def test_ignores_nonterminal_pitch_rows():
+    rows = game_rows()
+    rows.append(
+        event(
+            at_bat_number=7,
+            events=None,
+        )
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "raw_event_count"
+    ] == 7
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 6
+    assert result["diagnostics"][
+        "starter_pa_count"
+    ] == 4
+
+
+def test_deduplicates_identical_terminal_rows():
+    rows = game_rows()
+    rows.append(
+        deepcopy(rows[0])
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "duplicate_terminal_count"
+    ] == 1
+    assert result["diagnostics"][
+        "terminal_pa_count"
+    ] == 6
+    assert result["diagnostics"][
+        "starter_pa_count"
+    ] == 4
+
+
+def test_conflicting_terminal_identity_fails_closed():
+    rows = game_rows()
+    rows.append(
+        event(
+            at_bat_number=1,
+            pitcher_id=999,
+        )
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "conflicting_terminal_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "conflicting_terminal_pa_identity"
+    )
+    assert all(
+        row["at_bat_number"] != 1
+        for row in result["starter_events"]
+    )
+
+
+def test_requires_both_game_halves():
+    rows = [
+        row
+        for row in game_rows()
+        if str(
+            row["inning_topbot"]
+        ).lower() == "top"
+    ]
+
+    result = source(rows)
+
+    assert result["starter_events"] == []
+    assert result["requests"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "rejected_games"
+    ][0]["reason"] == (
+        "both_game_halves_required"
+    )
+
+
+def test_conflicting_game_dates_fail_closed():
+    rows = game_rows()
+    rows[3] = {
+        **rows[3],
+        "game_date": "2025-07-02",
+    }
+
+    result = source(rows)
+
+    assert result["starter_events"] == []
+    assert result["diagnostics"][
+        "rejected_games"
+    ][0]["reason"] == (
+        "conflicting_game_dates"
+    )
+
+
+def test_invalid_rows_do_not_block_valid_games():
+    rows = game_rows()
+    rows.append(
+        event(
+            game_pk=None,
+            at_bat_number=20,
+        )
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "ready_game_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_row_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "game_pk_must_be_positive_integer"
+    )
+
+
+def test_supports_object_rows():
+    rows = [
+        SimpleNamespace(**row)
+        for row in game_rows()
+    ]
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "status"
+    ] == "ready"
+    assert result["diagnostics"][
+        "starter_pa_count"
+    ] == 4
+    assert {
+        row.pitcher_id
+        for row in result["starter_events"]
+    } == {800, 900}
+
+
+def test_multiple_games_are_deterministic():
+    rows = (
+        game_rows()
+        + game_rows(
+            game_pk=700002,
+            game_date="2025-07-02",
+        )
+    )
+
+    first = source(rows)
+    second = source(
+        list(reversed(rows))
+    )
+
+    assert first["diagnostics"][
+        "ready_game_count"
+    ] == 2
+    assert first["diagnostics"][
+        "starter_request_count"
+    ] == 4
+    assert first["diagnostics"][
+        "starter_pa_count"
+    ] == 8
+    assert first["requests"] == second[
+        "requests"
+    ]
+    assert [
+        (
+            row["game_pk"],
+            row["at_bat_number"],
+        )
+        for row in first["starter_events"]
+    ] == [
+        (
+            row["game_pk"],
+            row["at_bat_number"],
+        )
+        for row in second[
+            "starter_events"
+        ]
+    ]
+    assert first["diagnostics"][
+        "starter_window_digest"
+    ] == second["diagnostics"][
+        "starter_window_digest"
+    ]
+
+
+def test_inputs_are_not_mutated():
+    rows = game_rows()
+    original = deepcopy(rows)
+
+    source(rows)
+
+    assert rows == original
+
+
+def test_inference_and_authority_contracts():
+    diagnostics = source()["diagnostics"]
+
+    assert diagnostics[
+        "starter_inference"
+    ] == {
+        "home": "first_pitcher_in_top_half",
+        "away": "first_pitcher_in_bottom_half",
+    }
+    assert diagnostics[
+        "scoring_scope"
+    ] == (
+        "terminal_pas_against_inferred_starters"
+    )
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+
+
+def test_empty_input_is_unavailable():
+    result = source([])
+
+    assert result["starter_events"] == []
+    assert result["requests"] == []
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_statcast_statistics import (
+    source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics,
+)
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+
+
+def event(**overrides):
+    values = {
+        "game_pk": 600001,
+        "game_date": "2025-06-01",
+        "at_bat_number": 1,
+        "pitcher_id": 101,
+        "batter_id": 201,
+        "events": "single",
+    }
+    values.update(overrides)
+    return values
+
+
+def history():
+    event_names = [
+        "single",
+        "double",
+        "triple",
+        "home_run",
+        "walk",
+        "intent_walk",
+        "strikeout",
+        "hit_by_pitch",
+        "sac_fly",
+        "field_out",
+    ]
+
+    return [
+        event(
+            at_bat_number=index,
+            events=event_name,
+        )
+        for index, event_name in enumerate(
+            event_names,
+            start=1,
+        )
+    ]
+
+
+def source(
+    rows=None,
+    **overrides,
+):
+    values = {
+        "game_pk": 700001,
+        "game_date": "2025-07-01",
+        "batter_ids": [201],
+        "pitcher_ids": [101],
+        "observed_window_digest": DIGEST_A,
+        "lineup_bullpen_window_digest": (
+            DIGEST_B
+        ),
+    }
+    values.update(overrides)
+
+    return (
+        source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics(
+            history() if rows is None else rows,
+            **values,
+        )
+    )
+
+
+def record_map(result):
+    game = result["statistics"].games[0]
+
+    return {
+        record.record_key: dict(
+            record.counts
+        )
+        for record in game.players
+    }
+
+
+def test_builds_exact_historical_counts():
+    result = source()
+    records = record_map(result)
+
+    assert result["diagnostics"]["status"] == "ready"
+
+    assert records[
+        ("hitting", "201")
+    ] == {
+        "pa": 10,
+        "ab": 6,
+        "hits": 4,
+        "double": 1,
+        "triple": 1,
+        "hr": 1,
+        "bb": 2,
+        "k": 1,
+        "hbp": 1,
+    }
+    assert records[
+        ("pitching", "101")
+    ] == {
+        "batters_faced": 10,
+        "ab": 6,
+        "hits": 4,
+        "double": 1,
+        "triple": 1,
+        "hr": 1,
+        "bb": 2,
+        "k": 1,
+        "hbp": 1,
+    }
+
+
+def test_emits_canonical_statistics_window():
+    result = source()
+    statistics = result["statistics"]
+
+    assert isinstance(
+        statistics,
+        CanonicalHistoricalProbabilityStatisticsWindow,
+    )
+    assert statistics.game_count == 1
+
+    game = statistics.games[0]
+
+    assert game.game_pk == 700001
+    assert game.game_date == "2025-07-01"
+    assert game.statistics_through_date == (
+        "2025-06-30"
+    )
+    assert game.observed_sample_count == 2
+    assert game.zero_sample_count == 0
+
+
+def test_excludes_same_day_and_future_rows():
+    rows = history()
+    rows.extend([
+        event(
+            game_pk=700001,
+            game_date="2025-07-01",
+            at_bat_number=1,
+            events="home_run",
+        ),
+        event(
+            game_pk=700002,
+            game_date="2025-07-02",
+            at_bat_number=1,
+            events="home_run",
+        ),
+    ])
+
+    result = source(rows)
+    records = record_map(result)
+
+    assert records[
+        ("hitting", "201")
+    ]["hr"] == 1
+    assert result["diagnostics"][
+        "excluded_future_or_same_day_count"
+    ] == 2
+
+
+def test_excludes_other_seasons():
+    rows = history()
+    rows.append(
+        event(
+            game_pk=500001,
+            game_date="2024-06-01",
+            at_bat_number=1,
+            events="home_run",
+        )
+    )
+
+    result = source(rows)
+
+    assert record_map(result)[
+        ("hitting", "201")
+    ]["hr"] == 1
+    assert result["diagnostics"][
+        "excluded_other_season_count"
+    ] == 1
+
+
+def test_ignores_nonterminal_pitch_rows():
+    rows = history()
+    rows.append(
+        event(
+            at_bat_number=20,
+            events=None,
+        )
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "nonterminal_pitch_count"
+    ] == 1
+    assert result["diagnostics"][
+        "eligible_terminal_pa_count"
+    ] == 10
+
+
+def test_deduplicates_terminal_identity():
+    rows = history()
+    rows.append(
+        deepcopy(rows[0])
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "duplicate_terminal_count"
+    ] == 1
+    assert record_map(result)[
+        ("hitting", "201")
+    ]["pa"] == 10
+
+
+def test_conflicting_terminal_identity_fails_closed():
+    rows = history()
+    rows.append({
+        **rows[0],
+        "events": "double",
+    })
+
+    result = source(rows)
+    records = record_map(result)
+
+    assert result["diagnostics"][
+        "conflicting_terminal_count"
+    ] == 1
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "conflicting_terminal_pa_identity"
+    )
+    assert records[
+        ("hitting", "201")
+    ]["pa"] == 9
+    assert records[
+        ("hitting", "201")
+    ]["hits"] == 3
+
+
+def test_unsupported_event_is_reported():
+    rows = history()
+    rows.append(
+        event(
+            at_bat_number=20,
+            events="synthetic_event",
+        )
+    )
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "rejected_rows"
+    ][0]["reason"] == (
+        "unsupported_terminal_event"
+    )
+
+
+def test_zero_sample_players_are_explicit():
+    result = source(
+        batter_ids=[
+            201,
+            202,
+        ],
+        pitcher_ids=[
+            101,
+            102,
+        ],
+    )
+    game = result["statistics"].games[0]
+    records = {
+        record.record_key: record
+        for record in game.players
+    }
+
+    assert result["diagnostics"][
+        "status"
+    ] == "partial"
+    assert result["diagnostics"][
+        "zero_sample_player_role_count"
+    ] == 2
+    assert records[
+        ("hitting", "202")
+    ].sample_available is False
+    assert records[
+        ("pitching", "102")
+    ].sample_available is False
+    assert all(
+        value == 0
+        for _, value in records[
+            ("hitting", "202")
+        ].counts
+    )
+
+
+def test_only_requested_players_are_exposed():
+    rows = history()
+    rows.append(
+        event(
+            at_bat_number=20,
+            pitcher_id=102,
+            batter_id=202,
+            events="home_run",
+        )
+    )
+
+    result = source(rows)
+    keys = {
+        record.record_key
+        for record in (
+            result["statistics"].games[0].players
+        )
+    }
+
+    assert keys == {
+        ("hitting", "201"),
+        ("pitching", "101"),
+    }
+
+
+def test_supports_object_rows():
+    rows = [
+        SimpleNamespace(**row)
+        for row in history()
+    ]
+
+    result = source(rows)
+
+    assert result["diagnostics"][
+        "status"
+    ] == "ready"
+    assert record_map(result)[
+        ("hitting", "201")
+    ]["pa"] == 10
+
+
+def test_materialization_is_deterministic():
+    rows = history()
+
+    first = source(rows)
+    second = source(
+        list(reversed(rows))
+    )
+
+    assert first["statistics"] == (
+        second["statistics"]
+    )
+    assert first["diagnostics"][
+        "snapshot_digest"
+    ] == second["diagnostics"][
+        "snapshot_digest"
+    ]
+    assert first["diagnostics"][
+        "statistics_window_digest"
+    ] == second["diagnostics"][
+        "statistics_window_digest"
+    ]
+
+
+def test_inputs_are_not_mutated():
+    rows = history()
+    original = deepcopy(rows)
+
+    source(rows)
+
+    assert rows == original
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("game_pk", 0),
+        ("game_date", "bad-date"),
+        ("batter_ids", []),
+        ("pitcher_ids", []),
+        (
+            "observed_window_digest",
+            "bad",
+        ),
+        (
+            "lineup_bullpen_window_digest",
+            "bad",
+        ),
+    ],
+)
+def test_rejects_invalid_source_contract(
+    field,
+    value,
+):
+    with pytest.raises(
+        (
+            TypeError,
+            ValueError,
+        )
+    ):
+        source(**{field: value})
+
+
+def test_cutoff_and_authority_contracts():
+    diagnostics = source()["diagnostics"]
+
+    assert diagnostics["cutoff_rule"] == (
+        "same_season_terminal_pas_strictly_before_game_date"
+    )
+    assert diagnostics[
+        "intentional_walk_policy"
+    ] == "included_in_historical_bb"
+    assert diagnostics["source"] == (
+        "local_statcast_terminal_pa_history"
+    )
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False

--- a/tests/test_canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_historical_statcast_window.py
@@ -1,0 +1,713 @@
+import copy
+import datetime as dt
+import hashlib
+
+import pytest
+
+import mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_pa_historical_statcast_window as window_module
+from mlb_app.simulation.shadow.historical_probability_statistics_source import (
+    HITTING_STAT_KEYS,
+    PITCHING_STAT_KEYS,
+    CanonicalHistoricalProbabilityGameStatistics,
+    CanonicalHistoricalProbabilityPlayerStatistics,
+    CanonicalHistoricalProbabilityStatisticsWindow,
+)
+
+
+def digest(value):
+    return hashlib.sha256(
+        str(value).encode("utf-8")
+    ).hexdigest()
+
+
+def event(
+    *,
+    game_pk=700001,
+    game_date=dt.date(2025, 7, 1),
+    pitcher_id=800,
+    batter_id=900,
+):
+    return {
+        "game_pk": game_pk,
+        "game_date": game_date,
+        "pitcher_id": pitcher_id,
+        "batter_id": batter_id,
+        "events": "single",
+        "at_bat_number": 1,
+        "pitch_number": 1,
+        "inning": 1,
+        "inning_topbot": "Top",
+    }
+
+
+def player(
+    player_id,
+    role,
+):
+    keys = (
+        HITTING_STAT_KEYS
+        if role == "hitting"
+        else PITCHING_STAT_KEYS
+    )
+    return (
+        CanonicalHistoricalProbabilityPlayerStatistics(
+            player_id=str(player_id),
+            role=role,
+            counts=tuple(
+                (key, 1)
+                for key, _ in keys
+            ),
+            sample_available=True,
+        )
+    )
+
+
+def install_components(
+    monkeypatch,
+    *,
+    no_requests=False,
+    conflicting_dates=False,
+    no_batters=False,
+    gate_passed=True,
+    statistics_status="ready",
+):
+    calls = {
+        "starter": 0,
+        "statistics": 0,
+        "candidate": 0,
+        "executor": 0,
+    }
+
+    def starters(rows):
+        calls["starter"] += 1
+
+        if no_requests:
+            requests = []
+            starter_events = []
+        else:
+            second_date = (
+                dt.date(2025, 7, 2)
+                if conflicting_dates
+                else dt.date(2025, 7, 1)
+            )
+            requests = [
+                {
+                    "game_pk": 700001,
+                    "pitcher_id": 800,
+                    "game_date": dt.date(
+                        2025,
+                        7,
+                        1,
+                    ),
+                    "side": "away",
+                },
+                {
+                    "game_pk": 700001,
+                    "pitcher_id": 801,
+                    "game_date": second_date,
+                    "side": "home",
+                },
+                {
+                    "game_pk": 700002,
+                    "pitcher_id": 802,
+                    "game_date": dt.date(
+                        2025,
+                        7,
+                        2,
+                    ),
+                    "side": "away",
+                },
+            ]
+            starter_events = (
+                []
+                if no_batters
+                else [
+                    event(),
+                    event(
+                        game_pk=700001,
+                        pitcher_id=801,
+                        batter_id=901,
+                    ),
+                    event(
+                        game_pk=700002,
+                        game_date=dt.date(
+                            2025,
+                            7,
+                            2,
+                        ),
+                        pitcher_id=802,
+                        batter_id=902,
+                    ),
+                ]
+            )
+
+        return {
+            "starter_events": starter_events,
+            "requests": requests,
+            "diagnostics": {
+                "status": (
+                    "unavailable"
+                    if no_requests
+                    else "ready"
+                ),
+                "starter_window_digest": (
+                    "starter-digest"
+                ),
+                "production_authority_changed": False,
+            },
+        }
+
+    def statistics(
+        rows,
+        *,
+        game_pk,
+        game_date,
+        batter_ids,
+        pitcher_ids,
+        observed_window_digest,
+        lineup_bullpen_window_digest,
+    ):
+        calls["statistics"] += 1
+        game_date = dt.date.fromisoformat(
+            game_date
+        ) if isinstance(
+            game_date,
+            str,
+        ) else game_date
+
+        players = tuple(
+            player(value, "hitting")
+            for value in batter_ids
+        ) + tuple(
+            player(value, "pitching")
+            for value in pitcher_ids
+        )
+        game = (
+            CanonicalHistoricalProbabilityGameStatistics(
+                game_pk=game_pk,
+                game_date=game_date.isoformat(),
+                statistics_through_date=(
+                    game_date
+                    - dt.timedelta(days=1)
+                ).isoformat(),
+                players=players,
+                snapshot_digest=digest(
+                    f"snapshot-{game_pk}"
+                ),
+            )
+        )
+        window = (
+            CanonicalHistoricalProbabilityStatisticsWindow(
+                observed_window_digest=(
+                    observed_window_digest
+                ),
+                lineup_bullpen_window_digest=(
+                    lineup_bullpen_window_digest
+                ),
+                games=(game,),
+                digest=digest(
+                    f"window-{game_pk}"
+                ),
+            )
+        )
+
+        return {
+            "statistics": window,
+            "diagnostics": {
+                "status": statistics_status,
+                "game_pk": game_pk,
+                "production_authority_changed": False,
+            },
+        }
+
+    def candidates(
+        rows,
+        *,
+        requests,
+        window_days,
+    ):
+        calls["candidate"] += 1
+        values = {
+            (
+                request["game_pk"],
+                request["pitcher_id"],
+            ): {
+                "diagnostics": {
+                    "status": "ready",
+                    "production_authority_changed": False,
+                },
+            }
+            for request in requests
+        }
+        return {
+            "candidates": values,
+            "diagnostics": {
+                "status": "ready",
+                "candidate_window_digest": (
+                    f"candidate-{window_days}"
+                ),
+                "production_authority_changed": False,
+            },
+        }
+
+    def executor(
+        rows,
+        *,
+        statistics,
+        candidates_by_game_pitcher,
+        minimum_samples,
+        minimum_observed_pa,
+        season_log_loss_regression_tolerance,
+    ):
+        calls["executor"] += 1
+        return {
+            "evaluation": {
+                "overall": {
+                    "status": "ready",
+                    "observed_pa": 3,
+                },
+                "diagnostics": {
+                    "status": "ready",
+                    "selection_gate_passed": (
+                        gate_passed
+                    ),
+                    "activation_status": (
+                        "historical_pa_gate_passed"
+                        if gate_passed
+                        else "historical_pa_gate_blocked"
+                    ),
+                    "production_authority_changed": False,
+                },
+            },
+            "diagnostics": {
+                "status": "ready",
+                "execution_digest": (
+                    "execution-digest"
+                ),
+                "production_authority_changed": False,
+            },
+        }
+
+    monkeypatch.setattr(
+        window_module,
+        "source_canonical_pitcher_matchup_profile_pa_historical_starters",
+        starters,
+    )
+    monkeypatch.setattr(
+        window_module,
+        "source_canonical_pitcher_matchup_profile_pa_historical_statcast_statistics",
+        statistics,
+    )
+    monkeypatch.setattr(
+        window_module,
+        "materialize_canonical_pitcher_matchup_profile_pa_historical_candidates",
+        candidates,
+    )
+    monkeypatch.setattr(
+        window_module,
+        "execute_canonical_pitcher_matchup_profile_pa_historical_evaluation",
+        executor,
+    )
+
+    return calls
+
+
+def execute():
+    return (
+        window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+            [
+                event(),
+                event(
+                    game_pk=700002,
+                    game_date=dt.date(
+                        2025,
+                        7,
+                        2,
+                    ),
+                    pitcher_id=802,
+                    batter_id=902,
+                ),
+            ],
+            observed_window_digest=digest(
+                "observed-window"
+            ),
+            lineup_bullpen_window_digest=digest(
+                "lineup-window"
+            ),
+            candidate_window_days=90,
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+
+
+def test_executes_multi_game_window(monkeypatch):
+    calls = install_components(monkeypatch)
+
+    result = execute()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["status"] == "ready"
+    assert diagnostics[
+        "activation_status"
+    ] == "historical_pa_gate_passed"
+    assert diagnostics["game_count"] == 2
+    assert diagnostics[
+        "statistics_game_count"
+    ] == 2
+    assert len(
+        result["statistics"].games
+    ) == 2
+    assert calls == {
+        "starter": 1,
+        "statistics": 2,
+        "candidate": 1,
+        "executor": 1,
+    }
+
+
+def test_reuses_single_event_collection(monkeypatch):
+    install_components(monkeypatch)
+
+    diagnostics = execute()["diagnostics"]
+
+    assert diagnostics[
+        "single_shared_event_collection"
+    ] is True
+    assert diagnostics[
+        "starter_inference_pass_count"
+    ] == 1
+    assert diagnostics[
+        "candidate_materialization_pass_count"
+    ] == 1
+    assert diagnostics[
+        "statistics_materialization_count"
+    ] == 2
+
+
+def test_statistics_games_are_canonical_order(
+    monkeypatch,
+):
+    install_components(monkeypatch)
+
+    games = execute()["statistics"].games
+
+    assert tuple(
+        game.game_pk
+        for game in games
+    ) == (700001, 700002)
+
+
+def test_gate_block_remains_partial(monkeypatch):
+    install_components(
+        monkeypatch,
+        gate_passed=False,
+    )
+
+    diagnostics = execute()["diagnostics"]
+
+    assert diagnostics["status"] == "partial"
+    assert diagnostics[
+        "activation_status"
+    ] == "historical_pa_gate_blocked"
+
+
+def test_partial_statistics_remain_executable(
+    monkeypatch,
+):
+    calls = install_components(
+        monkeypatch,
+        statistics_status="partial",
+    )
+
+    result = execute()
+
+    assert result["execution"] is not None
+    assert calls["executor"] == 1
+
+
+def test_no_starter_requests_fail_closed(
+    monkeypatch,
+):
+    calls = install_components(
+        monkeypatch,
+        no_requests=True,
+    )
+
+    result = execute()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["status"] == "unavailable"
+    assert diagnostics["blockers"] == [
+        "no_historical_starter_requests"
+    ]
+    assert result["statistics"] is None
+    assert result["candidates"] is None
+    assert result["execution"] is None
+    assert calls["candidate"] == 0
+    assert calls["executor"] == 0
+
+
+def test_conflicting_game_dates_are_rejected(
+    monkeypatch,
+):
+    install_components(
+        monkeypatch,
+        conflicting_dates=True,
+    )
+
+    result = execute()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics[
+        "rejected_game_count"
+    ] == 1
+    assert diagnostics[
+        "rejected_games"
+    ][0]["reason"] == (
+        "conflicting_game_dates"
+    )
+    assert tuple(
+        game.game_pk
+        for game in result[
+            "statistics"
+        ].games
+    ) == (700002,)
+
+
+def test_no_historical_batters_fail_closed(
+    monkeypatch,
+):
+    calls = install_components(
+        monkeypatch,
+        no_batters=True,
+    )
+
+    result = execute()
+
+    assert result["diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert result["diagnostics"][
+        "blockers"
+    ] == [
+        "no_historical_statistics_games"
+    ]
+    assert calls["statistics"] == 0
+    assert calls["candidate"] == 0
+    assert calls["executor"] == 0
+
+
+def test_evaluation_game_filter_preserves_lookback_events(
+    monkeypatch,
+):
+    calls = install_components(monkeypatch)
+
+    result = (
+        window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+            [
+                event(),
+                event(
+                    game_pk=700002,
+                    game_date=dt.date(2025, 7, 2),
+                    pitcher_id=802,
+                    batter_id=902,
+                ),
+            ],
+            observed_window_digest=digest(
+                "observed-filter"
+            ),
+            lineup_bullpen_window_digest=digest(
+                "lineup-filter"
+            ),
+            evaluation_game_pks=(700002,),
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics[
+        "evaluation_game_filter_applied"
+    ] is True
+    assert diagnostics[
+        "requested_evaluation_game_count"
+    ] == 1
+    assert diagnostics["raw_event_count"] == 2
+    assert diagnostics["game_count"] == 1
+    assert diagnostics[
+        "statistics_game_count"
+    ] == 1
+    assert tuple(
+        game.game_pk
+        for game in result["statistics"].games
+    ) == (700002,)
+    assert calls == {
+        "starter": 1,
+        "statistics": 1,
+        "candidate": 1,
+        "executor": 1,
+    }
+
+
+def test_unknown_evaluation_game_fails_closed(
+    monkeypatch,
+):
+    calls = install_components(monkeypatch)
+
+    result = (
+        window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+            [event()],
+            observed_window_digest=digest(
+                "observed-unknown"
+            ),
+            lineup_bullpen_window_digest=digest(
+                "lineup-unknown"
+            ),
+            evaluation_game_pks=(799999,),
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+    )
+
+    assert result["diagnostics"]["status"] == (
+        "unavailable"
+    )
+    assert result["diagnostics"]["blockers"] == [
+        "no_historical_starter_requests"
+    ]
+    assert calls["candidate"] == 0
+    assert calls["executor"] == 0
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        (),
+        (0,),
+        (True,),
+    ],
+)
+def test_evaluation_game_filter_must_be_valid(
+    monkeypatch,
+    values,
+):
+    install_components(monkeypatch)
+
+    with pytest.raises(ValueError):
+        window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+            [event()],
+            observed_window_digest=digest(
+                "observed-invalid-filter"
+            ),
+            lineup_bullpen_window_digest=digest(
+                "lineup-invalid-filter"
+            ),
+            evaluation_game_pks=values,
+            minimum_samples=1,
+            minimum_observed_pa=1,
+        )
+
+
+def test_execution_is_deterministic(monkeypatch):
+    install_components(monkeypatch)
+
+    first = execute()
+    second = execute()
+
+    assert first["diagnostics"][
+        "window_execution_digest"
+    ] == second["diagnostics"][
+        "window_execution_digest"
+    ]
+    assert first["statistics"].digest == (
+        second["statistics"].digest
+    )
+
+
+def test_input_events_are_not_mutated(monkeypatch):
+    install_components(monkeypatch)
+    values = [event()]
+    original = copy.deepcopy(values)
+
+    window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+        values,
+        observed_window_digest=digest(
+            "observed"
+        ),
+        lineup_bullpen_window_digest=digest(
+            "lineup"
+        ),
+        minimum_samples=1,
+        minimum_observed_pa=1,
+    )
+
+    assert values == original
+
+
+@pytest.mark.parametrize(
+    "kwargs,reason",
+    [
+        (
+            {
+                "observed_window_digest": "",
+                "lineup_bullpen_window_digest": "lineup",
+            },
+            "observed_window_digest_required",
+        ),
+        (
+            {
+                "observed_window_digest": "observed",
+                "lineup_bullpen_window_digest": "",
+            },
+            "lineup_bullpen_window_digest_required",
+        ),
+        (
+            {
+                "observed_window_digest": "observed",
+                "lineup_bullpen_window_digest": "lineup",
+                "candidate_window_days": 0,
+            },
+            "candidate_window_days_must_be_positive_integer",
+        ),
+    ],
+)
+def test_invalid_contracts_raise(
+    monkeypatch,
+    kwargs,
+    reason,
+):
+    install_components(monkeypatch)
+
+    with pytest.raises(
+        ValueError,
+        match=reason,
+    ):
+        window_module.execute_canonical_pitcher_matchup_profile_pa_historical_statcast_window(
+            [event()],
+            **kwargs,
+        )
+
+
+def test_shadow_authority_contract(monkeypatch):
+    install_components(monkeypatch)
+
+    diagnostics = execute()["diagnostics"]
+
+    assert diagnostics["database_accessed"] is False
+    assert diagnostics[
+        "calibration_parameters_selected"
+    ] is False
+    assert diagnostics["shadow_only"] is True
+    assert diagnostics[
+        "production_inputs_unchanged"
+    ] is True
+    assert diagnostics[
+        "production_authority"
+    ] is False
+    assert diagnostics[
+        "production_authority_changed"
+    ] is False
+    assert diagnostics["cutoff_policy"] == (
+        "per_game_same_season_strictly_before_game_date"
+    )

--- a/tests/test_canonical_pitcher_matchup_profile_pa_workspace_wiring.py
+++ b/tests/test_canonical_pitcher_matchup_profile_pa_workspace_wiring.py
@@ -1,0 +1,569 @@
+import copy
+
+from mlb_app import model_projections
+
+
+OUTCOMES = {
+    "out": 0.65,
+    "reached_on_error": 0.01,
+    "single": 0.13,
+    "double": 0.04,
+    "triple": 0.005,
+    "hr": 0.035,
+    "bb": 0.08,
+    "hbp": 0.01,
+    "k": 0.20,
+}
+
+
+def candidate(k_rate, barrel_rate, hard_hit_rate):
+    return {
+        "profile_rates": {
+            "k_rate": k_rate,
+            "barrel_rate_allowed_approx": (
+                barrel_rate
+            ),
+            "hard_hit_rate_allowed": (
+                hard_hit_rate
+            ),
+            "bb_rate": 0.04,
+        },
+        "diagnostics": {
+            "status": "ready",
+            "production_authority": False,
+            "production_authority_changed": False,
+        },
+    }
+
+
+def side(
+    team_id,
+    team_name,
+    pitcher_candidate,
+):
+    return {
+        "team_id": team_id,
+        "team_name": team_name,
+        "pitcher_id": team_id + 1000,
+        "pitcher_name": f"{team_name} Starter",
+        "pitcher_features": {},
+        "pitch_arsenal": {},
+        "offense_inputs": {},
+        "bullpen_inputs": {},
+        "pitcher_matchup_profile_candidate": (
+            pitcher_candidate
+        ),
+    }
+
+
+def test_workspace_exposes_paired_pitcher_pa_shadow(
+    monkeypatch,
+):
+    simulation_calls = []
+
+    monkeypatch.setattr(
+        model_projections,
+        "compute_environment_profile",
+        lambda value: {
+            "run_environment": {
+                "hr_boost_index": 1.0,
+                "hit_boost_index": 1.0,
+                "run_scoring_index": 1.0,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_team_offense_prior",
+        lambda **kwargs: {
+            "contact_skill": {
+                "k_rate": 0.22,
+                "contact_rate": 0.76,
+                "hit_skill": 0.29,
+            },
+            "plate_discipline": {
+                "bb_rate": 0.08,
+            },
+            "power": {
+                "iso": 0.17,
+                "barrel_rate": 0.08,
+                "hard_hit_rate": 0.39,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_bullpen_profile",
+        lambda **kwargs: {},
+    )
+
+    def fake_simulation(**kwargs):
+        simulation_calls.append(
+            copy.deepcopy(kwargs)
+        )
+        return {
+            "away_expected_runs": 4.1,
+            "home_expected_runs": 4.2,
+            "away_win_probability": 0.49,
+            "home_win_probability": 0.51,
+            "total_probabilities": {},
+            "team_total_probabilities": {},
+            "model_version": "fixture",
+            "simulations": 1,
+            "metadata": {
+                "simulation_count": 1,
+                "seed": 42,
+                "dynamic_starter_exit": True,
+            },
+        }
+
+    monkeypatch.setattr(
+        model_projections,
+        "simulate_game_with_bullpen",
+        fake_simulation,
+    )
+
+    away = side(
+        1,
+        "Away",
+        candidate(0.27, 0.07, 0.34),
+    )
+    home = side(
+        2,
+        "Home",
+        candidate(0.25, 0.08, 0.36),
+    )
+
+    result = (
+        model_projections
+        ._build_projection_simulation_cards(
+            {
+                "game_pk": 123,
+                "game_date": "2026-08-23",
+                "venue": "Fixture Park",
+                "weather": {},
+                "park_factor": 1.0,
+            },
+            away,
+            home,
+        )
+    )
+
+    workspace = result["workspace"]
+    comparisons = workspace[
+        "pitcherMatchupProfilePAShadowComparisons"
+    ]
+    away_comparison = comparisons[
+        "awayOffenseVsHomeStarter"
+    ]
+    home_comparison = comparisons[
+        "homeOffenseVsAwayStarter"
+    ]
+
+    assert away_comparison["status"] == "ready"
+    assert home_comparison["status"] == "ready"
+    assert (
+        away_comparison[
+            "maximum_absolute_probability_delta"
+        ]
+        > 0
+    )
+    assert (
+        home_comparison[
+            "maximum_absolute_probability_delta"
+        ]
+        > 0
+    )
+    assert comparisons[
+        "simulation_inputs_changed"
+    ] is False
+    assert comparisons[
+        "final_probabilities_changed"
+    ] is False
+    assert comparisons[
+        "production_authority_changed"
+    ] is False
+
+    assert len(simulation_calls) == 1
+    simulation_input = simulation_calls[0]
+
+    assert simulation_input[
+        "away_starter_probabilities"
+    ] == workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"]
+    assert simulation_input[
+        "home_starter_probabilities"
+    ] == workspace[
+        "homePAOutcomeModel"
+    ]["probabilities"]
+
+    assert simulation_input[
+        "away_starter_probabilities"
+    ] != home_comparison[
+        "shadow_probabilities"
+    ]
+    assert simulation_input[
+        "home_starter_probabilities"
+    ] != away_comparison[
+        "shadow_probabilities"
+    ]
+
+
+def test_workspace_fails_closed_when_candidates_missing(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        model_projections,
+        "compute_environment_profile",
+        lambda value: {},
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_team_offense_prior",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_bullpen_profile",
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "simulate_game_with_bullpen",
+        lambda **kwargs: {
+            "away_expected_runs": 4.0,
+            "home_expected_runs": 4.0,
+            "away_win_probability": 0.5,
+            "home_win_probability": 0.5,
+            "total_probabilities": {},
+            "team_total_probabilities": {},
+            "model_version": "fixture",
+            "simulations": 1,
+            "metadata": {},
+        },
+    )
+
+    result = (
+        model_projections
+        ._build_projection_simulation_cards(
+            {
+                "game_pk": 456,
+                "game_date": "2026-08-23",
+            },
+            side(1, "Away", {}),
+            side(2, "Home", {}),
+        )
+    )
+
+    comparisons = result["workspace"][
+        "pitcherMatchupProfilePAShadowComparisons"
+    ]
+
+    assert comparisons[
+        "awayOffenseVsHomeStarter"
+    ]["status"] == "blocked"
+    assert comparisons[
+        "homeOffenseVsAwayStarter"
+    ]["status"] == "blocked"
+    assert comparisons[
+        "simulation_inputs_changed"
+    ] is False
+    assert comparisons[
+        "production_authority_changed"
+    ] is False
+
+
+
+def _execute_activation_workspace(
+    monkeypatch,
+    *,
+    away_candidate,
+    home_candidate,
+):
+    simulation_calls = []
+
+    monkeypatch.setattr(
+        model_projections,
+        "compute_environment_profile",
+        lambda value: {
+            "run_environment": {
+                "hr_boost_index": 1.0,
+                "hit_boost_index": 1.0,
+                "run_scoring_index": 1.0,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_team_offense_prior",
+        lambda **kwargs: {
+            "contact_skill": {
+                "k_rate": 0.22,
+                "contact_rate": 0.76,
+                "hit_skill": 0.29,
+            },
+            "plate_discipline": {
+                "bb_rate": 0.08,
+            },
+            "power": {
+                "iso": 0.17,
+                "barrel_rate": 0.08,
+                "hard_hit_rate": 0.39,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "build_bullpen_profile",
+        lambda **kwargs: {},
+    )
+
+    def fake_simulation(**kwargs):
+        simulation_calls.append(
+            copy.deepcopy(kwargs)
+        )
+        return {
+            "away_expected_runs": 4.1,
+            "home_expected_runs": 4.2,
+            "away_win_probability": 0.49,
+            "home_win_probability": 0.51,
+            "total_probabilities": {},
+            "team_total_probabilities": {},
+            "model_version": "fixture",
+            "simulations": 1,
+            "metadata": {
+                "simulation_count": 1,
+                "seed": 42,
+                "dynamic_starter_exit": True,
+            },
+        }
+
+    monkeypatch.setattr(
+        model_projections,
+        "simulate_game_with_bullpen",
+        fake_simulation,
+    )
+
+    result = (
+        model_projections
+        ._build_projection_simulation_cards(
+            {
+                "game_pk": 789,
+                "game_date": "2026-08-23",
+                "venue": "Fixture Park",
+                "weather": {},
+                "park_factor": 1.0,
+            },
+            side(
+                1,
+                "Away",
+                away_candidate,
+            ),
+            side(
+                2,
+                "Home",
+                home_candidate,
+            ),
+        )
+    )
+
+    return result, simulation_calls
+
+
+def test_activation_flag_defaults_off(
+    monkeypatch,
+):
+    monkeypatch.delenv(
+        "MLB_ENABLE_CANONICAL_PITCHER_MATCHUP_PROFILE_PA",
+        raising=False,
+    )
+    result, simulation_calls = (
+        _execute_activation_workspace(
+            monkeypatch,
+            away_candidate=candidate(
+                0.27,
+                0.07,
+                0.34,
+            ),
+            home_candidate=candidate(
+                0.25,
+                0.08,
+                0.36,
+            ),
+        )
+    )
+
+    workspace = result["workspace"]
+    activation = workspace[
+        "pitcherMatchupProfilePAActivation"
+    ]
+    comparisons = workspace[
+        "pitcherMatchupProfilePAShadowComparisons"
+    ]
+
+    assert activation["requested"] is False
+    assert activation[
+        "simulation_inputs_changed"
+    ] is False
+    assert activation[
+        "final_side_probabilities_changed"
+    ] is False
+    assert activation[
+        "awayOffenseVsHomeStarter"
+    ]["activation_status"] == (
+        "production_activation_not_requested"
+    )
+    assert activation[
+        "homeOffenseVsAwayStarter"
+    ]["activation_status"] == (
+        "production_activation_not_requested"
+    )
+    assert comparisons[
+        "production_authority_changed"
+    ] is False
+
+    simulation_input = simulation_calls[0]
+    assert simulation_input[
+        "away_starter_probabilities"
+    ] == workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"]
+    assert simulation_input[
+        "home_starter_probabilities"
+    ] == workspace[
+        "homePAOutcomeModel"
+    ]["probabilities"]
+
+
+def test_activation_flag_uses_ready_candidates(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "MLB_ENABLE_CANONICAL_PITCHER_MATCHUP_PROFILE_PA",
+        "true",
+    )
+    result, simulation_calls = (
+        _execute_activation_workspace(
+            monkeypatch,
+            away_candidate=candidate(
+                0.27,
+                0.07,
+                0.34,
+            ),
+            home_candidate=candidate(
+                0.25,
+                0.08,
+                0.36,
+            ),
+        )
+    )
+
+    workspace = result["workspace"]
+    activation = workspace[
+        "pitcherMatchupProfilePAActivation"
+    ]
+    comparisons = workspace[
+        "pitcherMatchupProfilePAShadowComparisons"
+    ]
+    away_comparison = comparisons[
+        "awayOffenseVsHomeStarter"
+    ]
+    home_comparison = comparisons[
+        "homeOffenseVsAwayStarter"
+    ]
+
+    assert activation["requested"] is True
+    assert activation[
+        "simulation_inputs_changed"
+    ] is True
+    assert activation[
+        "final_side_probabilities_changed"
+    ] is False
+    assert activation[
+        "awayOffenseVsHomeStarter"
+    ]["activation_status"] == (
+        "production_candidate_activated"
+    )
+    assert activation[
+        "homeOffenseVsAwayStarter"
+    ]["activation_status"] == (
+        "production_candidate_activated"
+    )
+    assert comparisons[
+        "production_authority_changed"
+    ] is True
+
+    simulation_input = simulation_calls[0]
+    assert simulation_input[
+        "away_starter_probabilities"
+    ] == away_comparison[
+        "shadow_probabilities"
+    ]
+    assert simulation_input[
+        "home_starter_probabilities"
+    ] == home_comparison[
+        "shadow_probabilities"
+    ]
+
+
+def test_activation_fails_closed_per_invalid_candidate(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "MLB_ENABLE_CANONICAL_PITCHER_MATCHUP_PROFILE_PA",
+        "1",
+    )
+    result, simulation_calls = (
+        _execute_activation_workspace(
+            monkeypatch,
+            away_candidate=candidate(
+                0.27,
+                0.07,
+                0.34,
+            ),
+            home_candidate={},
+        )
+    )
+
+    workspace = result["workspace"]
+    activation = workspace[
+        "pitcherMatchupProfilePAActivation"
+    ]
+    comparisons = workspace[
+        "pitcherMatchupProfilePAShadowComparisons"
+    ]
+    away_comparison = comparisons[
+        "awayOffenseVsHomeStarter"
+    ]
+    home_comparison = comparisons[
+        "homeOffenseVsAwayStarter"
+    ]
+
+    assert away_comparison["status"] == "blocked"
+    assert home_comparison["status"] == "ready"
+    assert activation["requested"] is True
+    assert activation[
+        "awayOffenseVsHomeStarter"
+    ]["production_authority_changed"] is False
+    assert activation[
+        "homeOffenseVsAwayStarter"
+    ]["production_authority_changed"] is True
+    assert activation[
+        "simulation_inputs_changed"
+    ] is True
+    assert activation[
+        "final_side_probabilities_changed"
+    ] is False
+
+    simulation_input = simulation_calls[0]
+    assert simulation_input[
+        "away_starter_probabilities"
+    ] == workspace[
+        "awayPAOutcomeModel"
+    ]["probabilities"]
+    assert simulation_input[
+        "home_starter_probabilities"
+    ] == home_comparison[
+        "shadow_probabilities"
+    ]

--- a/tests/test_canonical_pitcher_matchup_profile_runtime_batch.py
+++ b/tests/test_canonical_pitcher_matchup_profile_runtime_batch.py
@@ -1,0 +1,275 @@
+import copy
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_runtime_batch import (
+    build_canonical_pitcher_matchup_profile_runtime_batch,
+)
+
+
+def event(
+    event_id,
+    pitcher_id,
+    *,
+    events="field_out",
+    description="hit_into_play",
+    launch_speed=90,
+    launch_angle=5,
+):
+    return {
+        "id": event_id,
+        "game_pk": 500,
+        "at_bat_number": event_id,
+        "pitch_number": 1,
+        "pitcher_id": pitcher_id,
+        "batter_id": 1000 + event_id,
+        "game_date": "2026-08-22",
+        "events": events,
+        "description": description,
+        "launch_speed": launch_speed,
+        "launch_angle": launch_angle,
+        "stand": "R",
+    }
+
+
+def rows():
+    return [
+        event(
+            1,
+            101,
+            events="strikeout",
+            description="swinging_strike",
+            launch_speed=None,
+            launch_angle=None,
+        ),
+        event(2, 101, launch_speed=100, launch_angle=20),
+        event(
+            3,
+            102,
+            events="strikeout",
+            description="swinging_strike",
+            launch_speed=None,
+            launch_angle=None,
+        ),
+        event(4, 102, launch_speed=90, launch_angle=5),
+        event(5, 103, launch_speed=99, launch_angle=28),
+    ]
+
+
+def build(values=None):
+    return (
+        build_canonical_pitcher_matchup_profile_runtime_batch(
+            rows() if values is None else values,
+            pitcher_ids=(101, 102),
+            game_date="2026-08-23",
+        )
+    )
+
+
+def test_builds_all_requested_candidates():
+    result = build()
+
+    assert set(result["candidates"]) == {
+        "101",
+        "102",
+    }
+    assert result["diagnostics"][
+        "candidate_count"
+    ] == 2
+
+
+def test_builds_each_pitcher_evidence_once():
+    result = build()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics[
+        "candidate_pitcher_count"
+    ] == 3
+    assert diagnostics[
+        "evidence_build_count"
+    ] == 3
+    assert diagnostics[
+        "single_shared_evidence_pass"
+    ] is True
+
+
+def test_priors_exclude_each_target_pitcher():
+    result = build()
+
+    first = result["candidates"]["101"][
+        "prior_diagnostics"
+    ]["k_rate"]
+    second = result["candidates"]["102"][
+        "prior_diagnostics"
+    ]["k_rate"]
+
+    assert first["excluded_pitcher_id"] == 101
+    assert second["excluded_pitcher_id"] == 102
+    assert first["trials"] == 3
+    assert second["trials"] == 3
+
+
+def test_candidates_remain_shadow_only():
+    result = build()
+
+    for candidate in result[
+        "candidates"
+    ].values():
+        diagnostics = candidate["diagnostics"]
+
+        assert (
+            diagnostics["production_authority"]
+            is False
+        )
+        assert (
+            diagnostics[
+                "production_authority_changed"
+            ]
+            is False
+        )
+        assert (
+            diagnostics[
+                "segment_parameters_applied"
+            ]
+            is False
+        )
+
+
+def test_missing_requested_pitcher_fails_closed():
+    result = (
+        build_canonical_pitcher_matchup_profile_runtime_batch(
+            rows(),
+            pitcher_ids=(999,),
+            game_date="2026-08-23",
+        )
+    )
+
+    candidate = result["candidates"]["999"]
+
+    assert candidate["profile_rates"] == {}
+    assert candidate["diagnostics"]["status"] == (
+        "unavailable"
+    )
+
+
+def test_batch_is_deterministic_and_nonmutating():
+    values = rows()
+    original = copy.deepcopy(values)
+
+    first = build(values)
+    second = build(
+        list(reversed(values))
+    )
+
+    assert first == second
+    assert values == original
+
+def test_missing_requested_pitcher_reports_explicit_unavailable_telemetry():
+    result = (
+        build_canonical_pitcher_matchup_profile_runtime_batch(
+            rows(),
+            pitcher_ids=(999,),
+            game_date="2026-08-23",
+        )
+    )
+    candidate = result["candidates"]["999"]
+    diagnostics = candidate["diagnostics"]
+    batch = result["diagnostics"]
+
+    assert diagnostics["status"] == (
+        "unavailable"
+    )
+    assert diagnostics["activation_status"] == (
+        "shadow_candidate_unavailable"
+    )
+    assert diagnostics["evidence_status"] == (
+        "unavailable"
+    )
+    assert diagnostics["league_prior_status"] == (
+        "ready"
+    )
+    assert diagnostics["application_status"] == (
+        "unavailable"
+    )
+    assert (
+        "pitcher_evidence_unavailable"
+        in diagnostics["blockers"]
+    )
+    assert (
+        "sufficient_statistics_unavailable"
+        in diagnostics["blockers"]
+    )
+    assert candidate["evidence_diagnostics"][
+        "status"
+    ] == "unavailable"
+    assert (
+        candidate["league_prior_diagnostics"]
+        == candidate["prior_diagnostics"]
+    )
+    assert candidate[
+        "application_diagnostics"
+    ]["status"] == "unavailable"
+
+    assert batch["candidate_count"] == 1
+    assert batch["ready_candidate_count"] == 0
+    assert batch["partial_candidate_count"] == 0
+    assert (
+        batch["unavailable_candidate_count"]
+        == 1
+    )
+    assert batch["candidate_status_counts"] == {
+        "ready": 0,
+        "partial": 0,
+        "unavailable": 1,
+    }
+    assert batch[
+        "ready_candidate_coverage"
+    ] == 0.0
+    assert batch[
+        "production_authority_changed"
+    ] is False
+
+
+def test_ready_candidates_report_materialized_telemetry():
+    result = build()
+    batch = result["diagnostics"]
+
+    assert batch["candidate_count"] == 2
+    assert batch["ready_candidate_count"] == 2
+    assert batch["partial_candidate_count"] == 0
+    assert (
+        batch["unavailable_candidate_count"]
+        == 0
+    )
+    assert batch[
+        "ready_candidate_coverage"
+    ] == 1.0
+
+    for candidate in result[
+        "candidates"
+    ].values():
+        diagnostics = candidate["diagnostics"]
+
+        assert diagnostics["status"] == "ready"
+        assert diagnostics[
+            "activation_status"
+        ] == "shadow_candidate_materialized"
+        assert diagnostics[
+            "evidence_status"
+        ] in {"ready", "partial"}
+        assert diagnostics[
+            "league_prior_status"
+        ] == "ready"
+        assert diagnostics[
+            "application_status"
+        ] == "ready"
+        assert diagnostics["blockers"] == []
+        assert candidate[
+            "evidence_diagnostics"
+        ]["status"] in {"ready", "partial"}
+        assert (
+            candidate[
+                "league_prior_diagnostics"
+            ]
+            == candidate[
+                "prior_diagnostics"
+            ]
+        )

--- a/tests/test_canonical_pitcher_matchup_profile_runtime_candidate.py
+++ b/tests/test_canonical_pitcher_matchup_profile_runtime_candidate.py
@@ -1,0 +1,177 @@
+import copy
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_runtime_candidate import (
+    CALIBRATED_POOLED_PSEUDO_COUNTS,
+    build_canonical_pitcher_matchup_profile_runtime_candidate,
+    calibrated_candidate_policy,
+)
+
+
+def event(
+    *,
+    event_id,
+    pitcher_id,
+    events="field_out",
+    description="hit_into_play",
+    launch_speed=90,
+    launch_angle=5,
+    game_date="2026-08-22",
+):
+    return {
+        "id": event_id,
+        "game_pk": 500,
+        "at_bat_number": event_id,
+        "pitch_number": 1,
+        "pitcher_id": pitcher_id,
+        "batter_id": 1000 + event_id,
+        "game_date": game_date,
+        "events": events,
+        "description": description,
+        "launch_speed": launch_speed,
+        "launch_angle": launch_angle,
+        "stand": "R",
+    }
+
+
+def rows():
+    return [
+        event(
+            event_id=1,
+            pitcher_id=101,
+            events="strikeout",
+            description="swinging_strike",
+            launch_speed=None,
+            launch_angle=None,
+        ),
+        event(
+            event_id=2,
+            pitcher_id=101,
+            launch_speed=100,
+            launch_angle=20,
+        ),
+        event(
+            event_id=3,
+            pitcher_id=102,
+            events="strikeout",
+            description="swinging_strike",
+            launch_speed=None,
+            launch_angle=None,
+        ),
+        event(
+            event_id=4,
+            pitcher_id=102,
+            launch_speed=90,
+            launch_angle=5,
+        ),
+        event(
+            event_id=5,
+            pitcher_id=103,
+            launch_speed=99,
+            launch_angle=28,
+        ),
+    ]
+
+
+def build(values=None):
+    return (
+        build_canonical_pitcher_matchup_profile_runtime_candidate(
+            rows() if values is None else values,
+            pitcher_id=101,
+            game_date="2026-08-23",
+        )
+    )
+
+
+def test_materializes_all_selected_pooled_metrics():
+    result = build()
+
+    assert set(result["profile_rates"]) == set(
+        CALIBRATED_POOLED_PSEUDO_COUNTS
+    )
+    assert result["diagnostics"]["status"] == (
+        "ready"
+    )
+
+
+def test_walk_rate_remains_blocked():
+    result = build()
+
+    assert "bb_rate" not in result[
+        "profile_rates"
+    ]
+    assert result["diagnostics"][
+        "blocked_metrics"
+    ] == {
+        "bb_rate": [
+            "cross_season_candidate_instability"
+        ],
+    }
+
+
+def test_candidate_has_no_production_authority():
+    result = build()
+    diagnostics = result["diagnostics"]
+
+    assert (
+        diagnostics["production_authority"]
+        is False
+    )
+    assert (
+        diagnostics["production_authority_changed"]
+        is False
+    )
+    assert (
+        diagnostics["activation_status"]
+        == "shadow_candidate_materialized"
+    )
+    assert (
+        diagnostics["segment_parameters_applied"]
+        is False
+    )
+
+
+def test_league_prior_excludes_target_pitcher():
+    result = build()
+
+    prior = result[
+        "league_prior_diagnostics"
+    ]
+
+    assert prior["excluded_pitcher_id"] == 101
+    assert prior["excluded_event_count"] == 2
+
+
+def test_same_event_window_drives_all_components():
+    result = build()
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["event_window_reused"] is True
+    assert diagnostics["evidence_digest"]
+    assert diagnostics["prior_digest"]
+    assert diagnostics["application_digest"]
+
+
+def test_candidate_policy_is_immutable_by_copy():
+    first = calibrated_candidate_policy()
+    first["selected_pseudo_counts"][
+        "k_rate"
+    ] = 999
+
+    second = calibrated_candidate_policy()
+
+    assert second["selected_pseudo_counts"][
+        "k_rate"
+    ] == 100.0
+
+
+def test_result_is_deterministic_and_nonmutating():
+    values = rows()
+    original = copy.deepcopy(values)
+
+    first = build(values)
+    second = build(
+        list(reversed(values))
+    )
+
+    assert first == second
+    assert values == original

--- a/tests/test_canonical_pitcher_matchup_profile_runtime_wiring.py
+++ b/tests/test_canonical_pitcher_matchup_profile_runtime_wiring.py
@@ -1,0 +1,210 @@
+import datetime as dt
+
+from mlb_app.model_projections import (
+    _materialize_pitcher_matchup_profile_runtime_batch,
+)
+
+
+MATCHUPS = [
+    {
+        "away_pitcher_id": 101,
+        "home_pitcher_id": 102,
+    },
+    {
+        "away_pitcher_id": 101,
+        "home_pitcher_id": 103,
+    },
+]
+
+
+def test_loads_one_terminal_window_for_all_pitchers():
+    calls = {
+        "loader": 0,
+        "builder": 0,
+    }
+
+    def loader(
+        session,
+        *filters,
+        order_by=None,
+    ):
+        calls["loader"] += 1
+        assert session == "session"
+        assert len(filters) == 3
+        assert order_by
+        return (
+            [{"pitcher_id": 101}],
+            {
+                "raw_rows": 1,
+                "canonical_pitch_rows": 1,
+            },
+        )
+
+    def builder(
+        events,
+        *,
+        pitcher_ids,
+        game_date,
+        window_days,
+    ):
+        calls["builder"] += 1
+        assert len(events) == 1
+        assert pitcher_ids == (
+            101,
+            102,
+            103,
+        )
+        assert game_date == dt.date(
+            2026,
+            8,
+            23,
+        )
+        assert window_days == 90
+
+        return {
+            "candidates": {
+                "101": {
+                    "profile_rates": {
+                        "k_rate": 0.22,
+                    },
+                },
+            },
+            "diagnostics": {
+                "status": "ready",
+                "single_shared_evidence_pass": True,
+            },
+        }
+
+    result = (
+        _materialize_pitcher_matchup_profile_runtime_batch(
+            session="session",
+            matchups=MATCHUPS,
+            game_date=dt.date(
+                2026,
+                8,
+                23,
+            ),
+            event_loader=loader,
+            batch_builder=builder,
+        )
+    )
+
+    assert calls == {
+        "loader": 1,
+        "builder": 1,
+    }
+    assert result["diagnostics"][
+        "single_terminal_event_load"
+    ] is True
+    assert result["diagnostics"][
+        "terminal_event_count"
+    ] == 1
+    assert result["diagnostics"][
+        "production_authority"
+    ] is False
+
+
+def test_deduplicates_probable_pitcher_ids():
+    captured = {}
+
+    def loader(*args, **kwargs):
+        return [], {}
+
+    def builder(
+        events,
+        *,
+        pitcher_ids,
+        **kwargs,
+    ):
+        captured["pitcher_ids"] = (
+            pitcher_ids
+        )
+        return {
+            "candidates": {},
+            "diagnostics": {
+                "status": "ready",
+            },
+        }
+
+    _materialize_pitcher_matchup_profile_runtime_batch(
+        session=None,
+        matchups=MATCHUPS,
+        game_date=dt.date(
+            2026,
+            8,
+            23,
+        ),
+        event_loader=loader,
+        batch_builder=builder,
+    )
+
+    assert captured["pitcher_ids"] == (
+        101,
+        102,
+        103,
+    )
+
+
+def test_database_failure_fails_open():
+    def loader(*args, **kwargs):
+        raise RuntimeError(
+            "database unavailable"
+        )
+
+    result = (
+        _materialize_pitcher_matchup_profile_runtime_batch(
+            session=None,
+            matchups=MATCHUPS,
+            game_date=dt.date(
+                2026,
+                8,
+                23,
+            ),
+            event_loader=loader,
+        )
+    )
+
+    assert result["candidates"] == {}
+    assert result["diagnostics"]["status"] == (
+        "error"
+    )
+    assert result["diagnostics"][
+        "blockers"
+    ] == [
+        "runtime_candidate_batch_failed"
+    ]
+    assert (
+        result["diagnostics"][
+            "production_authority_changed"
+        ]
+        is False
+    )
+
+
+def test_missing_pitchers_skips_database_load():
+    calls = []
+
+    def loader(*args, **kwargs):
+        calls.append(True)
+        return [], {}
+
+    result = (
+        _materialize_pitcher_matchup_profile_runtime_batch(
+            session=None,
+            matchups=[{}],
+            game_date=dt.date(
+                2026,
+                8,
+                23,
+            ),
+            event_loader=loader,
+        )
+    )
+
+    assert calls == []
+    assert result["diagnostics"]["status"] == (
+        "unavailable"
+    )
+    assert result["diagnostics"][
+        "single_terminal_event_load"
+    ] is False

--- a/tests/test_canonical_pitcher_matchup_profile_shrinkage.py
+++ b/tests/test_canonical_pitcher_matchup_profile_shrinkage.py
@@ -1,0 +1,241 @@
+import copy
+
+import pytest
+
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_shrinkage import (
+    CANONICAL_PITCHER_MATCHUP_PROFILE_SHRINKAGE_VERSION,
+    calibrate_canonical_pitcher_matchup_profile_shrinkage,
+)
+
+
+def sample(
+    *,
+    season,
+    training_successes,
+    training_trials=20,
+    holdout_successes=2,
+    holdout_trials=20,
+    prior_probability=0.10,
+    metric="barrel_rate_allowed_approx",
+    family="contact",
+    segment="overall",
+):
+    return {
+        "season": season,
+        "training_successes": training_successes,
+        "training_trials": training_trials,
+        "holdout_successes": holdout_successes,
+        "holdout_trials": holdout_trials,
+        "prior_probability": prior_probability,
+        "metric": metric,
+        "family": family,
+        "segment": segment,
+    }
+
+
+def test_strong_shrinkage_wins_for_noisy_small_samples():
+    samples = [
+        sample(
+            season=2023,
+            training_successes=18,
+        ),
+        sample(
+            season=2024,
+            training_successes=17,
+        ),
+        sample(
+            season=2025,
+            training_successes=19,
+        ),
+    ]
+
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples,
+            candidate_pseudo_counts=(0, 20, 100, 400),
+        )
+    )
+    metric = result["metric_results"][
+        "barrel_rate_allowed_approx"
+    ]
+
+    assert result["status"] == "ready"
+    assert metric["pooled_candidate"][
+        "pseudo_count"
+    ] == 400.0
+
+
+def test_no_shrinkage_wins_when_training_matches_holdout():
+    samples = [
+        sample(
+            season=2023,
+            training_successes=10,
+            holdout_successes=10,
+            prior_probability=0.05,
+        ),
+        sample(
+            season=2024,
+            training_successes=10,
+            holdout_successes=10,
+            prior_probability=0.05,
+        ),
+    ]
+
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples,
+            candidate_pseudo_counts=(0, 25, 100),
+        )
+    )
+
+    assert result["metric_results"][
+        "barrel_rate_allowed_approx"
+    ]["pooled_candidate"]["pseudo_count"] == 0.0
+
+
+def test_cross_season_folds_never_reselect_on_validation():
+    samples = [
+        sample(season=2023, training_successes=8),
+        sample(season=2024, training_successes=7),
+        sample(season=2025, training_successes=9),
+    ]
+
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples,
+            candidate_pseudo_counts=(0, 25, 100),
+        )
+    )
+    folds = result["metric_results"][
+        "barrel_rate_allowed_approx"
+    ]["cross_season_folds"]
+
+    assert {
+        fold["validation_season"]
+        for fold in folds
+    } == {2023, 2024, 2025}
+    assert all(
+        fold["candidate_reselected_on_validation"]
+        is False
+        for fold in folds
+    )
+
+
+def test_single_season_metric_is_blocked():
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage([
+            sample(
+                season=2025,
+                training_successes=2,
+            ),
+        ])
+    )
+
+    assert result["status"] == "blocked"
+    assert result["metric_results"][
+        "barrel_rate_allowed_approx"
+    ]["blockers"] == [
+        "insufficient_cross_season_coverage",
+    ]
+
+
+def test_rejects_invalid_samples_without_mutating_input():
+    samples = [
+        sample(
+            season=2023,
+            training_successes=2,
+        ),
+        sample(
+            season=2024,
+            training_successes=30,
+            training_trials=20,
+        ),
+    ]
+    original = copy.deepcopy(samples)
+
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples
+        )
+    )
+
+    assert samples == original
+    assert result["eligible_sample_count"] == 1
+    assert result["rejected_sample_count"] == 1
+    assert result["status"] == "blocked"
+
+
+def test_segment_diagnostics_remain_separate():
+    samples = [
+        sample(
+            season=2023,
+            training_successes=2,
+            segment="overall",
+        ),
+        sample(
+            season=2024,
+            training_successes=2,
+            segment="overall",
+        ),
+        sample(
+            season=2023,
+            training_successes=3,
+            segment="vsL",
+        ),
+        sample(
+            season=2024,
+            training_successes=3,
+            segment="vsL",
+        ),
+    ]
+
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            samples,
+            candidate_pseudo_counts=(0, 25),
+        )
+    )
+    segments = result["metric_results"][
+        "barrel_rate_allowed_approx"
+    ]["segment_diagnostics"]
+
+    assert set(segments) == {"overall", "vsL"}
+    assert segments["overall"]["sample_count"] == 2
+    assert segments["vsL"]["sample_count"] == 2
+
+
+def test_candidate_grid_validation():
+    with pytest.raises(
+        ValueError,
+        match="must be unique",
+    ):
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            [],
+            candidate_pseudo_counts=(25, 25),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="nonnegative",
+    ):
+        calibrate_canonical_pitcher_matchup_profile_shrinkage(
+            [],
+            candidate_pseudo_counts=(-1, 25),
+        )
+
+
+def test_explicit_shadow_only_contract():
+    result = (
+        calibrate_canonical_pitcher_matchup_profile_shrinkage([
+            sample(season=2023, training_successes=2),
+            sample(season=2024, training_successes=2),
+        ])
+    )
+
+    assert (
+        CANONICAL_PITCHER_MATCHUP_PROFILE_SHRINKAGE_VERSION
+        == "canonical_pitcher_matchup_profile_shrinkage_v1"
+    )
+    assert result["shadow_only"] is True
+    assert result["production_authority_changed"] is False
+    assert result["parameter_selected"] is False

--- a/tests/test_canonical_pitcher_matchup_profile_source.py
+++ b/tests/test_canonical_pitcher_matchup_profile_source.py
@@ -1,0 +1,315 @@
+import datetime as dt
+
+from mlb_app.database import (
+    PitcherAggregate,
+    create_tables,
+    get_engine,
+    get_session,
+)
+from mlb_app.simulation.shadow.canonical_pitcher_matchup_profile_source import (
+    CANONICAL_PITCHER_MATCHUP_PROFILE_SOURCE_VERSION,
+    source_canonical_pitcher_matchup_profile,
+)
+
+
+def session():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    return get_session(engine)()
+
+
+def aggregate(
+    *,
+    end_date,
+    pitcher_id=101,
+    k_pct=0.24,
+    bb_pct=0.08,
+    hard_hit_pct=0.31,
+    xwoba=0.315,
+    xba=0.245,
+):
+    return PitcherAggregate(
+        pitcher_id=pitcher_id,
+        window="90d",
+        end_date=dt.date.fromisoformat(end_date),
+        k_pct=k_pct,
+        bb_pct=bb_pct,
+        hard_hit_pct=hard_hit_pct,
+        xwoba=xwoba,
+        xba=xba,
+    )
+
+
+def test_selects_latest_strictly_prior_aggregate():
+    db = session()
+    db.add_all([
+        aggregate(
+            end_date="2026-08-20",
+            k_pct=0.20,
+        ),
+        aggregate(
+            end_date="2026-08-22",
+            k_pct=0.27,
+        ),
+        aggregate(
+            end_date="2026-08-23",
+            k_pct=0.40,
+        ),
+        aggregate(
+            end_date="2026-08-24",
+            k_pct=0.50,
+        ),
+    ])
+    db.commit()
+
+    result = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date="2026-08-23",
+    )
+
+    assert result["pitcher_features"]["k_pct"] == 0.27
+    assert (
+        result["diagnostics"]["selected_end_date"]
+        == "2026-08-22"
+    )
+    assert result["diagnostics"]["days_before_game"] == 1
+    assert result["diagnostics"]["status"] == "ready"
+
+
+def test_matchup_values_remain_authoritative():
+    db = session()
+    db.add(
+        aggregate(
+            end_date="2026-08-22",
+            k_pct=0.24,
+            bb_pct=0.08,
+        )
+    )
+    db.commit()
+
+    result = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date=dt.date(2026, 8, 23),
+        matchup_features={
+            "k_pct": 0.33,
+            "bb_pct": 0.0,
+            "custom_field": "preserved",
+        },
+    )
+
+    features = result["pitcher_features"]
+    provenance = result["diagnostics"][
+        "field_provenance"
+    ]
+
+    assert features["k_pct"] == 0.33
+    assert features["bb_pct"] == 0.0
+    assert features["hard_hit_pct"] == 0.31
+    assert features["custom_field"] == "preserved"
+    assert provenance["k_pct"]["source"] == "matchup_payload"
+    assert (
+        provenance["hard_hit_pct"]["source"]
+        == "pitcher_aggregate_90d"
+    )
+
+
+def test_partial_aggregate_reports_missing_fields():
+    db = session()
+    db.add(
+        aggregate(
+            end_date="2026-08-22",
+            xwoba=None,
+            xba=None,
+        )
+    )
+    db.commit()
+
+    result = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date="2026-08-23",
+    )
+
+    diagnostics = result["diagnostics"]
+
+    assert diagnostics["status"] == "partial"
+    assert diagnostics["missing_fields"] == [
+        "xwoba",
+        "xba",
+    ]
+
+
+def test_no_prior_evidence_fails_closed():
+    db = session()
+    db.add(
+        aggregate(
+            end_date="2026-08-23",
+        )
+    )
+    db.commit()
+
+    result = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date="2026-08-23",
+    )
+
+    assert result["pitcher_features"] == {}
+    assert (
+        result["diagnostics"]["status"]
+        == "unavailable"
+    )
+    assert (
+        result["diagnostics"]["selected_end_date"]
+        is None
+    )
+
+
+def test_source_is_deterministic_and_does_not_mutate_input():
+    db = session()
+    db.add(
+        aggregate(
+            end_date="2026-08-22",
+        )
+    )
+    db.commit()
+    supplied = {"k_pct": 0.30}
+
+    first = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date="2026-08-23",
+        matchup_features=supplied,
+    )
+    second = source_canonical_pitcher_matchup_profile(
+        db,
+        pitcher_id=101,
+        game_date="2026-08-23",
+        matchup_features=supplied,
+    )
+
+    assert first == second
+    assert supplied == {"k_pct": 0.30}
+    assert (
+        first["diagnostics"]["source_digest"]
+        == second["diagnostics"]["source_digest"]
+    )
+
+
+def test_version_is_explicit():
+    assert (
+        CANONICAL_PITCHER_MATCHUP_PROFILE_SOURCE_VERSION
+        == "canonical_pitcher_matchup_profile_source_v1"
+    )
+
+def test_side_context_uses_cutoff_safe_profile_source(
+    monkeypatch,
+):
+    from mlb_app import model_projections
+
+    db = session()
+    db.add_all([
+        aggregate(
+            end_date="2026-08-22",
+            k_pct=0.27,
+        ),
+        aggregate(
+            end_date="2026-08-23",
+            k_pct=0.49,
+        ),
+    ])
+    db.commit()
+
+    monkeypatch.setattr(
+        model_projections,
+        "_projection_offense_inputs",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "_bullpen_inputs",
+        lambda *_args: {},
+    )
+
+    context = model_projections._side_context(
+        {
+            "away_team_id": 10,
+            "away_team_name": "Away",
+            "away_pitcher_id": 101,
+            "away_pitcher_name": "Pitcher",
+            "away_pitcher_features": {
+                "bb_pct": 0.07,
+            },
+        },
+        "away",
+        db,
+        2026,
+        dt.date(2026, 8, 23),
+    )
+
+    assert (
+        context["pitcher_features"]["k_pct"]
+        == 0.27
+    )
+    assert (
+        context["pitcher_features"]["bb_pct"]
+        == 0.07
+    )
+    diagnostics = context[
+        "pitcher_matchup_profile_source"
+    ]
+    assert (
+        diagnostics["selected_end_date"]
+        == "2026-08-22"
+    )
+    assert (
+        diagnostics["field_provenance"]["bb_pct"][
+            "source"
+        ]
+        == "matchup_payload"
+    )
+
+
+def test_side_context_fails_closed_without_pitcher_id(
+    monkeypatch,
+):
+    from mlb_app import model_projections
+
+    db = session()
+
+    monkeypatch.setattr(
+        model_projections,
+        "_projection_offense_inputs",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        model_projections,
+        "_bullpen_inputs",
+        lambda *_args: {},
+    )
+
+    context = model_projections._side_context(
+        {
+            "away_team_id": 10,
+            "away_team_name": "Away",
+        },
+        "away",
+        db,
+        2026,
+        dt.date(2026, 8, 23),
+    )
+
+    assert (
+        context["pitcher_matchup_profile_source"][
+            "status"
+        ]
+        == "unavailable"
+    )
+    assert (
+        context["pitcher_matchup_profile_source"][
+            "blockers"
+        ]
+        == ["missing_pitcher_id"]
+    )


### PR DESCRIPTION
Builds cutoff-safe canonical pitcher matchup profiles and calibrated shrinkage policy.
Adds deterministic historical Statcast evaluation across three seasons.
Adds fail-closed activation eligibility and pinned evidence digests.
Wires production PA selection behind the default-off MLB_ENABLE_CANONICAL_PITCHER_MATCHUP_PROFILE_PA flag.
Preserves canonical final side probabilities and independently fails closed per matchup side.
Reconciles small probability-rounding residuals before activation.

Validation:

291 pitcher-profile tests passed.
66 model-projection tests passed.
Three-season audit: 446 samples and 1,093 observed PAs.
Positive log-loss and Brier improvements with no regressed season.
Compilation, whitespace, cached-diff, and isolation checks passed.
Production authority remains unchanged unless activation is explicitly requested and all pinned evidence matches.