### PR TITLE
Fix incorrect batter homepage leaderboard data

### DIFF
--- a/frontend/src/pages/BatterPage.jsx
+++ b/frontend/src/pages/BatterPage.jsx
@@ -144,7 +144,6 @@ function cleanLeaderboardRows(board) {
 // ─── Leaderboard config ────────────────────────────────────────────────────
 const LB_CONFIG = [
   { key: 'home_runs', title: 'Home Runs', fmt: v => `${Math.round(v)}`, color: C.blue, group: 'Counting' },
-  { key: 'rbi', title: 'RBI', fmt: v => `${Math.round(v)}`, color: C.purple, group: 'Counting' },
   { key: 'hits', title: 'Hits', fmt: v => `${Math.round(v)}`, color: C.green, group: 'Counting' },
   { key: 'doubles', title: 'Doubles (2B)', fmt: v => `${Math.round(v)}`, color: C.teal, group: 'Counting' },
   { key: 'avg_exit_velocity', title: 'Avg Exit Velocity', fmt: v => `${v.toFixed(1)} mph`, color: C.orange, group: 'Statcast' },
@@ -263,7 +262,7 @@ function LeaderboardDashboard({ data, loading }) {
         <div>
           <h1 style={{ fontSize: '24px', fontWeight: '700', color: C.text, margin: 0 }}>Batter Leaderboards</h1>
           <div style={{ fontSize: '13px', color: C.muted, marginTop: '6px' }}>
-            Daily Top 10 batter leaderboards built from deduped Statcast data.
+            Daily Top 10 batter leaderboards built from canonical plate appearances, batted-ball events, and pitches.
           </div>
         </div>
         <div style={{ fontSize: '13px', color: C.muted, textAlign: 'right' }}>
@@ -510,7 +509,7 @@ export default function BatterPage() {
     setLbLoading(true)
     setLbError(null)
 
-    fetch(`${API}/batters/leaderboards`)
+    fetch(`${API}/batters/leaderboards?contract=batter_leaderboards_v2`)
       .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
       .then(d => {
         if (cancelled) return

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -46,10 +46,34 @@ TERMINAL_EVENTS = {
     "grounded_into_double_play",
     "fielders_choice",
     "fielders_choice_out",
+    "field_error",
+    "other_out",
+    "triple_play",
     "sac_fly",
+    "sac_fly_double_play",
     "sac_bunt",
+    "sac_bunt_double_play",
     "catcher_interf",
     "catcher_interference",
+}
+
+# A Statcast BBE is a batted ball that produces a result.  launch_speed can
+# also be populated on measured foul contact, so launch_speed alone must never
+# define the BBE population used by the batter homepage.
+BATTED_BALL_EVENTS = HIT_EVENTS | {
+    "field_out",
+    "force_out",
+    "double_play",
+    "grounded_into_double_play",
+    "fielders_choice",
+    "fielders_choice_out",
+    "field_error",
+    "other_out",
+    "triple_play",
+    "sac_fly",
+    "sac_fly_double_play",
+    "sac_bunt",
+    "sac_bunt_double_play",
 }
 TOTAL_BASES = {"single": 1, "double": 2, "triple": 3, "home_run": 4}
 
@@ -1226,10 +1250,11 @@ def _compute_batter_batted_ball_sql(
     s_start: datetime.date,
     s_end: datetime.date,
 ) -> List[Any]:
-    """Aggregate batted-ball EV/quality stats at the DB level.
+    """Aggregate true batted-ball events at the DB level.
 
-    Double GROUP BY deduplicates pitch events: first by
-    (batter_id, game_pk, at_bat_number, pitch_number), then aggregates per batter.
+    Statcast may provide launch_speed for foul contact.  A BBE must therefore
+    have both a measured exit velocity and a terminal batted-ball outcome.
+    The inner GROUP BY keeps the calculation duplicate-safe.
     """
     inner = (
         session.query(
@@ -1244,7 +1269,89 @@ def _compute_batter_batted_ball_sql(
             StatcastEvent.game_date >= s_start,
             StatcastEvent.game_date <= s_end,
             StatcastEvent.batter_id.isnot(None),
+            StatcastEvent.events.in_(list(BATTED_BALL_EVENTS)),
             StatcastEvent.launch_speed.isnot(None),
+            StatcastEvent.game_pk.isnot(None),
+            StatcastEvent.at_bat_number.isnot(None),
+            StatcastEvent.pitch_number.isnot(None),
+        )
+        .group_by(
+            StatcastEvent.batter_id,
+            StatcastEvent.game_pk,
+            StatcastEvent.at_bat_number,
+            StatcastEvent.pitch_number,
+        )
+        .subquery()
+    )
+
+    # MLB's barrel zone starts at 98 mph / 26-30 degrees and expands with
+    # exit velocity, reaching 8-50 degrees at 116 mph.  Cap both bounds at
+    # those documented limits.
+    barrel_lower_bound = case(
+        (inner.c.launch_speed >= 116.0, 8.0),
+        else_=124.0 - inner.c.launch_speed,
+    )
+    barrel_upper_bound = case(
+        (inner.c.launch_speed >= 108.0, 50.0),
+        else_=30.0 + ((inner.c.launch_speed - 98.0) * 2.0),
+    )
+
+    return (
+        session.query(
+            inner.c.batter_id,
+            func.count().label("bbe"),
+            func.avg(inner.c.launch_speed).label("avg_exit_velocity"),
+            func.max(inner.c.launch_speed).label("max_exit_velocity"),
+            func.sum(case((inner.c.launch_speed >= 95.0, 1), else_=0)).label("hard_hits"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            inner.c.launch_speed >= 98.0,
+                            inner.c.launch_angle.isnot(None),
+                            inner.c.launch_angle >= barrel_lower_bound,
+                            inner.c.launch_angle <= barrel_upper_bound,
+                        ),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ).label("barrels"),
+        )
+        .group_by(inner.c.batter_id)
+        .all()
+    )
+
+
+def _compute_batter_swing_sql(
+    session: Session,
+    s_start: datetime.date,
+    s_end: datetime.date,
+) -> List[Any]:
+    """Aggregate duplicate-safe swing, whiff, and contact counts per batter."""
+    inner = (
+        session.query(
+            StatcastEvent.batter_id.label("batter_id"),
+            StatcastEvent.game_pk.label("game_pk"),
+            StatcastEvent.at_bat_number.label("at_bat_number"),
+            StatcastEvent.pitch_number.label("pitch_number"),
+            func.max(
+                case(
+                    (StatcastEvent.description.in_(list(SWING_DESCRIPTIONS)), 1),
+                    else_=0,
+                )
+            ).label("is_swing"),
+            func.max(
+                case(
+                    (StatcastEvent.description.in_(list(WHIFF_DESCRIPTIONS)), 1),
+                    else_=0,
+                )
+            ).label("is_whiff"),
+        )
+        .filter(
+            StatcastEvent.game_date >= s_start,
+            StatcastEvent.game_date <= s_end,
+            StatcastEvent.batter_id.isnot(None),
             StatcastEvent.game_pk.isnot(None),
             StatcastEvent.at_bat_number.isnot(None),
             StatcastEvent.pitch_number.isnot(None),
@@ -1261,28 +1368,12 @@ def _compute_batter_batted_ball_sql(
     return (
         session.query(
             inner.c.batter_id,
-            func.count().label("bbe"),
-            func.avg(inner.c.launch_speed).label("avg_exit_velocity"),
-            func.max(inner.c.launch_speed).label("max_exit_velocity"),
-            func.sum(case((inner.c.launch_speed >= 95.0, 1), else_=0)).label("hard_hits"),
-            func.sum(
-                case(
-                    (
-                        and_(
-                            inner.c.launch_speed >= 98.0,
-                            inner.c.launch_angle >= 8.0,
-                            inner.c.launch_angle <= 50.0,
-                        ),
-                        1,
-                    ),
-                    else_=0,
-                )
-            ).label("barrels"),
+            func.sum(inner.c.is_swing).label("swings"),
+            func.sum(inner.c.is_whiff).label("whiffs"),
         )
         .group_by(inner.c.batter_id)
         .all()
     )
-
 
 def get_batter_leaderboards(
     session: Session,
@@ -1321,7 +1412,7 @@ def get_batter_leaderboards(
     _all_metrics = [
         "home_runs", "hits", "doubles", "iso",
         "hard_hit_pct", "barrel_pct", "avg_exit_velocity", "max_exit_velocity",
-        "bb_pct", "k_pct_avoidance",
+        "bb_pct", "k_pct_avoidance", "contact_pct", "whiff_pct",
     ]
 
     if s_start is None:
@@ -1341,8 +1432,10 @@ def get_batter_leaderboards(
     # Compute stats via SQL GROUP BY — no full-table-to-Python load
     counting_rows = _compute_batter_counting_sql(session, s_start, s_end)
     batted_ball_rows = _compute_batter_batted_ball_sql(session, s_start, s_end)
+    swing_rows = _compute_batter_swing_sql(session, s_start, s_end)
 
     bb_by_batter: Dict[int, Any] = {int(row.batter_id): row for row in batted_ball_rows}
+    swings_by_batter: Dict[int, Any] = {int(row.batter_id): row for row in swing_rows}
 
     players: List[Dict[str, Any]] = []
     for row in counting_rows:
@@ -1383,6 +1476,12 @@ def get_batter_leaderboards(
             bbe = 0
             avg_ev = max_ev = hard_hit_pct = barrel_pct = None
 
+        swing_row = swings_by_batter.get(batter_id)
+        swings = int(swing_row.swings or 0) if swing_row is not None else 0
+        whiffs = int(swing_row.whiffs or 0) if swing_row is not None else 0
+        whiff_pct = round(whiffs / swings, 3) if swings else None
+        contact_pct = round(1.0 - (whiffs / swings), 3) if swings else None
+
         players.append({
             "player_id": batter_id,
             "player_name": player_name,
@@ -1400,6 +1499,10 @@ def get_batter_leaderboards(
             "max_exit_velocity": max_ev,
             "k_pct": k_pct,
             "bb_pct": bb_pct,
+            "swings": swings,
+            "whiffs": whiffs,
+            "whiff_pct": whiff_pct,
+            "contact_pct": contact_pct,
         })
 
     latest_event_date = (
@@ -1420,6 +1523,8 @@ def get_batter_leaderboards(
         ("max_exit_velocity", "max_exit_velocity", "bbe", min_bbe, True),
         ("bb_pct", "bb_pct", "pa", max(min_pa, 100), True),
         ("k_pct_avoidance", "k_pct", "pa", max(min_pa, 100), False),
+        ("contact_pct", "contact_pct", "swings", 100, True),
+        ("whiff_pct", "whiff_pct", "swings", 100, False),
     ]
 
     for response_key, metric, min_key, min_count, reverse in board_specs:
@@ -1433,7 +1538,8 @@ def get_batter_leaderboards(
     notes: List[str] = [
         "Counting stats computed via SQL GROUP BY on deduplicated terminal plate appearances.",
         "Batted-ball stats computed via SQL GROUP BY on deduplicated pitch events.",
-        "Whiff/contact/RBI leaderboards require full pitch-level data and are not precomputed here.",
+        "Swing metrics use duplicate-safe pitch identity; contact% is 1 - whiffs/swings.",
+        "RBI is intentionally unavailable because the local Statcast schema does not store runner scoring attribution.",
     ]
     if actual_season != season:
         notes.append(f"No rows found for {season}; leaderboards fell back to {actual_season}.")

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -26,7 +26,9 @@ NON_AB_EVENTS = {
     "intent_walk",
     "hit_by_pitch",
     "sac_bunt",
+    "sac_bunt_double_play",
     "sac_fly",
+    "sac_fly_double_play",
     "catcher_interf",
     "catcher_interference",
 }
@@ -1374,6 +1376,7 @@ def _compute_batter_swing_sql(
         .group_by(inner.c.batter_id)
         .all()
     )
+
 
 def get_batter_leaderboards(
     session: Session,

--- a/tests/test_batter_homepage_leaderboards.py
+++ b/tests/test_batter_homepage_leaderboards.py
@@ -1,0 +1,114 @@
+import datetime as dt
+
+from sqlalchemy import text
+
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.db_utils import (
+    _compute_batter_batted_ball_sql,
+    _compute_batter_counting_sql,
+    _compute_batter_swing_sql,
+)
+
+
+def _session_with_legacy_duplicates():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    with engine.begin() as connection:
+        connection.execute(text("DROP INDEX ux_statcast_events_pitch_identity"))
+    return get_session(engine)()
+
+
+def _event(at_bat_number, pitch_number, **overrides):
+    values = {
+        "game_date": dt.date(2026, 8, 24),
+        "game_pk": 9001,
+        "at_bat_number": at_bat_number,
+        "pitch_number": pitch_number,
+        "pitcher_id": 101,
+        "batter_id": 202,
+        "pitch_type": "FF",
+        "description": "hit_into_play",
+        "events": "field_out",
+        "launch_speed": 90.0,
+        "launch_angle": 10.0,
+    }
+    values.update(overrides)
+    return StatcastEvent(**values)
+
+
+def test_batter_homepage_uses_terminal_batted_balls_not_measured_fouls():
+    session = _session_with_legacy_duplicates()
+    single = _event(
+        1,
+        3,
+        events="single",
+        launch_speed=100.0,
+        launch_angle=27.0,
+    )
+    measured_foul = _event(
+        1,
+        1,
+        events=None,
+        description="foul",
+        launch_speed=110.0,
+        launch_angle=20.0,
+    )
+    reached_on_error = _event(
+        2,
+        2,
+        events="field_error",
+        launch_speed=90.0,
+        launch_angle=5.0,
+    )
+    strikeout = _event(
+        3,
+        4,
+        events="strikeout",
+        description="swinging_strike",
+        launch_speed=None,
+        launch_angle=None,
+    )
+    session.add_all(
+        [
+            measured_foul,
+            single,
+            reached_on_error,
+            strikeout,
+            # Legacy duplicate source rows must not change homepage totals.
+            _event(
+                1,
+                1,
+                events=None,
+                description="foul",
+                launch_speed=110.0,
+                launch_angle=20.0,
+            ),
+            _event(
+                1,
+                3,
+                events="single",
+                launch_speed=100.0,
+                launch_angle=27.0,
+            ),
+        ]
+    )
+    session.commit()
+
+    start = end = dt.date(2026, 8, 24)
+    counting = _compute_batter_counting_sql(session, start, end)[0]
+    batted = _compute_batter_batted_ball_sql(session, start, end)[0]
+    swings = _compute_batter_swing_sql(session, start, end)[0]
+
+    assert counting.pa == 3
+    assert counting.ab == 3
+    assert counting.hits == 1
+
+    assert batted.bbe == 2
+    assert batted.bbe <= counting.pa
+    assert round(float(batted.avg_exit_velocity), 1) == 95.0
+    assert round(float(batted.max_exit_velocity), 1) == 100.0
+    assert batted.hard_hits == 1
+    assert batted.barrels == 1
+
+    assert swings.swings == 4
+    assert swings.whiffs == 1


### PR DESCRIPTION
## What was wrong

The batter homepage treated every pitch row with `launch_speed` as a batted-ball event. Statcast can record exit velocity for measured foul contact, so homepage BBE counts could exceed PA and the EV, hard-hit, and barrel leaderboards ranked contaminated populations.

The terminal-outcome contract also omitted legitimate PA results such as `field_error`, while contact and whiff cards were defined in the frontend but never supplied by the backend.

## Fix

- restrict BBE calculations to terminal batted-ball outcomes
- deduplicate BBE and swing metrics by canonical pitch identity
- expand terminal PA outcomes, including field errors and sacrifice double plays
- calculate contact% and whiff% from deduplicated swings
- use the documented expanding MLB barrel zone instead of the old fixed 98 mph / 8–50° shortcut
- remove the unsupported RBI homepage configuration
- version the frontend leaderboard request to bypass stale browser cache
- add regression coverage proving measured fouls do not inflate BBE and duplicate source rows do not inflate totals

## Expected result

BBE can no longer exceed PA because of measured foul contact, and each homepage section ranks its own correctly defined batter population.

## Verification

- `pytest -q tests/test_batter_homepage_leaderboards.py tests/test_batter_statcast_profile_integrity.py tests/test_batter_data_contract.py`
- 6 passed
- Python compile check passed
- `git diff --check` passed