### PR TITLE
Re-contract batter homepage to official MLB counting stats

### DIFF
--- a/frontend/src/pages/BatterPage.jsx
+++ b/frontend/src/pages/BatterPage.jsx
@@ -146,6 +146,7 @@ const LB_CONFIG = [
   { key: 'home_runs', title: 'Home Runs', fmt: v => `${Math.round(v)}`, color: C.blue, group: 'Counting' },
   { key: 'hits', title: 'Hits', fmt: v => `${Math.round(v)}`, color: C.green, group: 'Counting' },
   { key: 'doubles', title: 'Doubles (2B)', fmt: v => `${Math.round(v)}`, color: C.teal, group: 'Counting' },
+  { key: 'rbi', title: 'RBI', fmt: v => `${Math.round(v)}`, color: C.purple, group: 'Counting' },
   { key: 'avg_exit_velocity', title: 'Avg Exit Velocity', fmt: v => `${v.toFixed(1)} mph`, color: C.orange, group: 'Statcast' },
   { key: 'hard_hit_pct', title: 'Hard Hit %', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.orange, group: 'Statcast' },
   { key: 'barrel_pct', title: 'Barrel %', fmt: v => `${(v * 100).toFixed(1)}%`, color: C.red, group: 'Statcast' },
@@ -262,7 +263,7 @@ function LeaderboardDashboard({ data, loading }) {
         <div>
           <h1 style={{ fontSize: '24px', fontWeight: '700', color: C.text, margin: 0 }}>Batter Leaderboards</h1>
           <div style={{ fontSize: '13px', color: C.muted, marginTop: '6px' }}>
-            Daily Top 10 batter leaderboards built from canonical plate appearances, batted-ball events, and pitches.
+            Official MLB season totals joined to canonical Statcast pitch metrics by MLB player ID.
           </div>
         </div>
         <div style={{ fontSize: '13px', color: C.muted, textAlign: 'right' }}>
@@ -509,7 +510,7 @@ export default function BatterPage() {
     setLbLoading(true)
     setLbError(null)
 
-    fetch(`${API}/batters/leaderboards?contract=batter_leaderboards_v2`)
+    fetch(`${API}/batters/leaderboards?contract=batter_leaderboards_v3`)
       .then(r => r.ok ? r.json() : r.json().then(e => Promise.reject(e.detail || r.statusText)))
       .then(d => {
         if (cancelled) return

--- a/mlb_app/batter_routes.py
+++ b/mlb_app/batter_routes.py
@@ -33,11 +33,13 @@ from .db_utils import (
 )
 from .pitcher_intelligence import MLB_TIMEZONE, build_pitcher_intelligence_profile
 from .pitcher_leaderboards import build_pitcher_leaderboards
+from .official_player_stats import OfficialPlayerStatsUnavailable, fetch_official_hitting_season
 
 MLB_STATS_BASE = "https://statsapi.mlb.com/api/v1"
 router = APIRouter()
 
 _LEADERBOARD_TTL_SECONDS = 3600
+_BATTER_LEADERBOARD_TTL_SECONDS = 60
 _leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
 _pitcher_leaderboard_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
 _identity_cache: Dict[int, Tuple[float, Dict[str, Any]]] = {}
@@ -265,15 +267,35 @@ def player_identity(id: int) -> Dict[str, Any]:
 
 @router.get("/batters/leaderboards")
 def batters_leaderboards(season: Optional[int] = None, min_pa: int = Query(25, ge=1), min_bbe: int = Query(100, ge=1), limit: int = Query(10, ge=1, le=50)) -> Dict[str, Any]:
+    if season is None:
+        season = datetime.datetime.now(MLB_TIMEZONE).year
     cache_key = f"{season}:{min_pa}:{min_bbe}:{limit}"
     cached = _leaderboard_cache.get(cache_key)
     if cached is not None:
         cached_at, data = cached
-        if time.monotonic() - cached_at < _LEADERBOARD_TTL_SECONDS:
+        if time.monotonic() - cached_at < _BATTER_LEADERBOARD_TTL_SECONDS:
             return data
+    official_hitting: Dict[str, Any] = {}
+    official_warning: Optional[str] = None
+    try:
+        official_hitting = fetch_official_hitting_season(season)
+    except OfficialPlayerStatsUnavailable as exc:
+        official_warning = str(exc)
+
     Session = _get_session()
     with Session() as session:
-        result = get_batter_leaderboards(session, season=season, min_pa=min_pa, min_bbe=min_bbe, limit=limit)
+        result = get_batter_leaderboards(
+            session,
+            season=season,
+            min_pa=min_pa,
+            min_bbe=min_bbe,
+            limit=limit,
+            official_hitting=official_hitting,
+        )
+    if official_warning:
+        result.setdefault("warnings", []).append(
+            f"Official MLB counting stats unavailable: {official_warning}"
+        )
     _leaderboard_cache[cache_key] = (time.monotonic(), result)
     return result
 

--- a/mlb_app/db_utils.py
+++ b/mlb_app/db_utils.py
@@ -1384,87 +1384,83 @@ def get_batter_leaderboards(
     min_pa: int = 50,
     min_bbe: int = 100,
     limit: int = 10,
+    official_hitting: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     if season is None:
         season = datetime.date.today().year
 
-    # Find which season has data with a lightweight existence check
-    actual_season = season
-    s_start: Optional[datetime.date] = None
-    s_end: Optional[datetime.date] = None
-    for candidate_season in [season, season - 1]:
-        cs_start = datetime.date(candidate_season, 1, 1)
-        cs_end = datetime.date(candidate_season, 12, 31)
-        has_data = (
-            session.query(StatcastEvent.batter_id)
-            .filter(
-                StatcastEvent.game_date >= cs_start,
-                StatcastEvent.game_date <= cs_end,
-                StatcastEvent.batter_id.isnot(None),
-                StatcastEvent.events.in_(list(TERMINAL_EVENTS)),
-            )
-            .limit(1)
-            .first()
-        )
-        if has_data:
-            actual_season = candidate_season
-            s_start = cs_start
-            s_end = cs_end
-            break
+    actual_season = int(season)
+    s_start = datetime.date(actual_season, 1, 1)
+    s_end = datetime.date(actual_season, 12, 31)
 
     _all_metrics = [
-        "home_runs", "hits", "doubles", "iso",
+        "home_runs", "hits", "doubles", "rbi", "iso",
         "hard_hit_pct", "barrel_pct", "avg_exit_velocity", "max_exit_velocity",
         "bb_pct", "k_pct_avoidance", "contact_pct", "whiff_pct",
     ]
 
-    if s_start is None:
-        return {
-            "updated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
-            "source": "batter_aggregate_sql",
-            "season": season,
-            "leaderboards": {},
-            "available_metrics": [],
-            "unavailable_metrics": sorted(_all_metrics),
-            "notes": ["No StatcastEvent rows found for requested season or previous season."],
-        }
-
     name_map = _latest_batter_names(session)
     team_map = _latest_batter_teams(session, actual_season)
 
-    # Compute stats via SQL GROUP BY — no full-table-to-Python load
-    counting_rows = _compute_batter_counting_sql(session, s_start, s_end)
+    # Official counting totals and local pitch metrics intentionally have
+    # separate authorities. Never reconstruct an official season line here.
+    official_season = _safe_int((official_hitting or {}).get("season"))
+    official_rows = (
+        list((official_hitting or {}).get("rows") or [])
+        if official_season == actual_season
+        else []
+    )
     batted_ball_rows = _compute_batter_batted_ball_sql(session, s_start, s_end)
     swing_rows = _compute_batter_swing_sql(session, s_start, s_end)
 
     bb_by_batter: Dict[int, Any] = {int(row.batter_id): row for row in batted_ball_rows}
     swings_by_batter: Dict[int, Any] = {int(row.batter_id): row for row in swing_rows}
 
-    players: List[Dict[str, Any]] = []
-    for row in counting_rows:
-        batter_id = int(row.batter_id)
-        player_name = name_map.get(batter_id)
-        if not _is_real_player_name(player_name):
+    players_by_id: Dict[int, Dict[str, Any]] = {}
+    for row in official_rows:
+        batter_id = _safe_int(row.get("player_id"))
+        player_name = row.get("player_name")
+        if not batter_id or not _is_real_player_name(player_name):
             continue
+        players_by_id[batter_id] = {
+            "player_id": batter_id,
+            "player_name": player_name,
+            "team": row.get("team") or "",
+            "pa": _safe_int(row.get("pa")),
+            "ab": _safe_int(row.get("ab")),
+            "hits": _safe_int(row.get("hits")),
+            "home_runs": _safe_int(row.get("home_runs")),
+            "doubles": _safe_int(row.get("doubles")),
+            "rbi": _safe_int(row.get("rbi")),
+            "iso": row.get("iso"),
+            "k_pct": row.get("k_pct"),
+            "bb_pct": row.get("bb_pct"),
+            "counting_source": row.get("source") or "mlb_stats_api_season_hitting",
+        }
 
-        pa = int(row.pa or 0)
-        ab = int(row.ab or 0)
-        hits = int(row.hits or 0)
-        home_runs = int(row.home_runs or 0)
-        doubles = int(row.doubles or 0)
-        walks = int(row.walks or 0)
-        strikeouts = int(row.strikeouts or 0)
-        total_bases = int(row.total_bases or 0)
-
-        batting_avg = round(hits / ab, 3) if ab else None
-        slugging_pct = round(total_bases / ab, 3) if ab else None
-        iso = (
-            round(slugging_pct - batting_avg, 3)
-            if slugging_pct is not None and batting_avg is not None
-            else None
-        )
-        k_pct = round(strikeouts / pa, 3) if pa else None
-        bb_pct = round(walks / pa, 3) if pa else None
+    local_ids = set(bb_by_batter) | set(swings_by_batter)
+    for batter_id in local_ids:
+        player = players_by_id.get(batter_id)
+        if player is None:
+            player_name = name_map.get(batter_id)
+            if not _is_real_player_name(player_name):
+                continue
+            player = {
+                "player_id": batter_id,
+                "player_name": player_name,
+                "team": team_map.get(batter_id, ""),
+                "pa": None,
+                "ab": None,
+                "hits": None,
+                "home_runs": None,
+                "doubles": None,
+                "rbi": None,
+                "iso": None,
+                "k_pct": None,
+                "bb_pct": None,
+                "counting_source": None,
+            }
+            players_by_id[batter_id] = player
 
         bb = bb_by_batter.get(batter_id)
         if bb is not None:
@@ -1485,28 +1481,20 @@ def get_batter_leaderboards(
         whiff_pct = round(whiffs / swings, 3) if swings else None
         contact_pct = round(1.0 - (whiffs / swings), 3) if swings else None
 
-        players.append({
-            "player_id": batter_id,
-            "player_name": player_name,
-            "team": team_map.get(batter_id, ""),
-            "pa": pa,
-            "ab": ab,
+        player.update({
             "bbe": bbe,
-            "hits": hits,
-            "home_runs": home_runs,
-            "doubles": doubles,
-            "iso": iso,
             "hard_hit_pct": hard_hit_pct,
             "barrel_pct": barrel_pct,
             "avg_exit_velocity": avg_ev,
             "max_exit_velocity": max_ev,
-            "k_pct": k_pct,
-            "bb_pct": bb_pct,
             "swings": swings,
             "whiffs": whiffs,
             "whiff_pct": whiff_pct,
             "contact_pct": contact_pct,
+            "pitch_metrics_source": "postgres_statcast_events_canonical_pitch_identity",
         })
+
+    players = list(players_by_id.values())
 
     latest_event_date = (
         session.query(func.max(StatcastEvent.game_date))
@@ -1519,6 +1507,7 @@ def get_batter_leaderboards(
         ("home_runs", "home_runs", "pa", min_pa, True),
         ("hits", "hits", "pa", min_pa, True),
         ("doubles", "doubles", "pa", min_pa, True),
+        ("rbi", "rbi", "pa", min_pa, True),
         ("iso", "iso", "pa", max(min_pa, 100), True),
         ("hard_hit_pct", "hard_hit_pct", "bbe", min_bbe, True),
         ("barrel_pct", "barrel_pct", "bbe", min_bbe, True),
@@ -1539,21 +1528,27 @@ def get_batter_leaderboards(
     unavailable_metrics = sorted(set(_all_metrics) - set(available_metrics))
 
     notes: List[str] = [
-        "Counting stats computed via SQL GROUP BY on deduplicated terminal plate appearances.",
-        "Batted-ball stats computed via SQL GROUP BY on deduplicated pitch events.",
+        "Counting stats come from MLB's official regular-season player totals; they are never reconstructed from local pitch rows.",
+        "Batted-ball stats come from deduplicated terminal batted-ball events in the canonical pitch ledger.",
         "Swing metrics use duplicate-safe pitch identity; contact% is 1 - whiffs/swings.",
-        "RBI is intentionally unavailable because the local Statcast schema does not store runner scoring attribution.",
+        "Official and pitch-derived rows are joined only by MLB player ID.",
     ]
-    if actual_season != season:
-        notes.append(f"No rows found for {season}; leaderboards fell back to {actual_season}.")
+    if not official_rows:
+        notes.append("Official MLB season totals are unavailable; counting and rate boards are intentionally omitted rather than replaced with reconstructed values.")
     if not players:
         notes.append("No leaderboard rows had resolvable real player names.")
 
     return {
         "updated_at": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
-        "source": "batter_aggregate_sql",
+        "source": "official_mlb_counting_plus_canonical_statcast_pitch_metrics",
         "season": actual_season,
         "latest_event_date": latest_event_date.isoformat() if latest_event_date else None,
+        "official_stats_retrieved_at": (official_hitting or {}).get("retrieved_at"),
+        "sources": {
+            "counting": (official_hitting or {}).get("source"),
+            "pitch_metrics": "postgres_statcast_events_canonical_pitch_identity",
+        },
+        "contract_version": "batter_leaderboards_v3",
         "minimums": {"min_pa": min_pa, "min_bbe": min_bbe, "limit": limit},
         "leaderboards": leaderboards,
         "available_metrics": available_metrics,

--- a/mlb_app/official_player_stats.py
+++ b/mlb_app/official_player_stats.py
@@ -1,0 +1,111 @@
+"""Normalized MLB Stats API season lines for site-wide player contracts."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List
+
+import requests
+
+
+MLB_STATS_URL = "https://statsapi.mlb.com/api/v1/stats"
+OFFICIAL_HITTING_SOURCE = "mlb_stats_api_season_hitting"
+
+
+class OfficialPlayerStatsUnavailable(RuntimeError):
+    """Raised when an official season-stat population cannot be retrieved."""
+
+
+def _integer(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _decimal(value: Any) -> float | None:
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_official_hitting_splits(payload: Dict[str, Any], season: int) -> List[Dict[str, Any]]:
+    """Return one authoritative regular-season hitting line per MLB player ID."""
+
+    stats_groups = payload.get("stats") or []
+    splits = (stats_groups[0].get("splits") or []) if stats_groups else []
+    normalized: Dict[int, Dict[str, Any]] = {}
+
+    for split in splits:
+        player = split.get("player") or split.get("person") or {}
+        player_id = _integer(player.get("id"))
+        if not player_id:
+            continue
+
+        stat = split.get("stat") or {}
+        team = split.get("team") or player.get("currentTeam") or {}
+        avg = _decimal(stat.get("avg"))
+        slg = _decimal(stat.get("slg"))
+        pa = _integer(stat.get("plateAppearances"))
+        walks = _integer(stat.get("baseOnBalls"))
+        strikeouts = _integer(stat.get("strikeOuts"))
+
+        normalized[player_id] = {
+            "player_id": player_id,
+            "player_name": player.get("fullName") or player.get("name") or f"MLB ID {player_id}",
+            "team": team.get("abbreviation") or team.get("name") or "",
+            "season": int(season),
+            "pa": pa,
+            "ab": _integer(stat.get("atBats")),
+            "hits": _integer(stat.get("hits")),
+            "home_runs": _integer(stat.get("homeRuns")),
+            "doubles": _integer(stat.get("doubles")),
+            "rbi": _integer(stat.get("rbi")),
+            "walks": walks,
+            "strikeouts": strikeouts,
+            "batting_avg": avg,
+            "slugging_pct": slg,
+            "iso": round(slg - avg, 3) if slg is not None and avg is not None else None,
+            "bb_pct": round(walks / pa, 3) if pa else None,
+            "k_pct": round(strikeouts / pa, 3) if pa else None,
+            "source": OFFICIAL_HITTING_SOURCE,
+        }
+
+    return list(normalized.values())
+
+
+def fetch_official_hitting_season(season: int, *, timeout: int = 20) -> Dict[str, Any]:
+    """Fetch the complete official MLB regular-season hitter population."""
+
+    try:
+        response = requests.get(
+            MLB_STATS_URL,
+            params={
+                "stats": "season",
+                "group": "hitting",
+                "gameType": "R",
+                "sportIds": 1,
+                "playerPool": "ALL",
+                "season": int(season),
+                "limit": 5000,
+                "hydrate": "person(currentTeam),team",
+            },
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        rows = normalize_official_hitting_splits(response.json(), int(season))
+    except (requests.RequestException, ValueError, TypeError) as exc:
+        raise OfficialPlayerStatsUnavailable(str(exc)) from exc
+
+    if not rows:
+        raise OfficialPlayerStatsUnavailable(
+            f"MLB Stats API returned no regular-season hitting rows for {season}."
+        )
+
+    return {
+        "season": int(season),
+        "source": OFFICIAL_HITTING_SOURCE,
+        "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+        "rows": rows,
+    }

--- a/tests/test_official_batter_leaderboard_contract.py
+++ b/tests/test_official_batter_leaderboard_contract.py
@@ -1,0 +1,118 @@
+import datetime as dt
+
+from mlb_app.database import StatcastEvent, create_tables, get_engine, get_session
+from mlb_app.db_utils import get_batter_leaderboards
+from mlb_app.official_player_stats import (
+    OFFICIAL_HITTING_SOURCE,
+    normalize_official_hitting_splits,
+)
+
+
+def _session():
+    engine = get_engine("sqlite:///:memory:")
+    create_tables(engine)
+    return get_session(engine)()
+
+
+def _official_payload():
+    return {
+        "stats": [{
+            "splits": [{
+                "player": {"id": 202, "fullName": "Correct Batter"},
+                "team": {"abbreviation": "CHC"},
+                "stat": {
+                    "plateAppearances": 400,
+                    "atBats": 350,
+                    "hits": 100,
+                    "doubles": 21,
+                    "homeRuns": 27,
+                    "rbi": 77,
+                    "baseOnBalls": 42,
+                    "strikeOuts": 80,
+                    "avg": ".286",
+                    "slg": ".520",
+                },
+            }]
+        }]
+    }
+
+
+def test_normalizes_official_mlb_hitting_line():
+    row = normalize_official_hitting_splits(_official_payload(), 2026)[0]
+
+    assert row["player_id"] == 202
+    assert row["pa"] == 400
+    assert row["home_runs"] == 27
+    assert row["rbi"] == 77
+    assert row["iso"] == 0.234
+    assert row["source"] == OFFICIAL_HITTING_SOURCE
+
+
+def test_homepage_counting_boards_use_official_totals_not_local_reconstruction():
+    session = _session()
+    session.add(StatcastEvent(
+        game_date=dt.date(2026, 8, 25),
+        game_pk=9001,
+        at_bat_number=1,
+        pitch_number=1,
+        pitcher_id=101,
+        batter_id=202,
+        events="home_run",
+        description="hit_into_play",
+        launch_speed=101.0,
+        launch_angle=28.0,
+    ))
+    session.commit()
+
+    official_rows = normalize_official_hitting_splits(_official_payload(), 2026)
+    result = get_batter_leaderboards(
+        session,
+        season=2026,
+        min_pa=1,
+        min_bbe=1,
+        limit=10,
+        official_hitting={
+            "source": OFFICIAL_HITTING_SOURCE,
+            "season": 2026,
+            "retrieved_at": "2026-08-25T12:00:00+00:00",
+            "rows": official_rows,
+        },
+    )
+
+    assert result["contract_version"] == "batter_leaderboards_v3"
+    assert result["leaderboards"]["home_runs"][0]["value"] == 27
+    assert result["leaderboards"]["home_runs"][0]["pa"] == 400
+    assert result["leaderboards"]["rbi"][0]["value"] == 77
+    assert result["leaderboards"]["avg_exit_velocity"][0]["bbe"] == 1
+    assert result["sources"]["counting"] == OFFICIAL_HITTING_SOURCE
+
+
+def test_missing_official_feed_never_falls_back_to_local_counting_totals(monkeypatch):
+    session = _session()
+    monkeypatch.setattr("mlb_app.db_utils._latest_batter_names", lambda _session: {202: "Correct Batter"})
+    session.add(StatcastEvent(
+        game_date=dt.date(2026, 8, 25),
+        game_pk=9001,
+        at_bat_number=1,
+        pitch_number=1,
+        pitcher_id=101,
+        batter_id=202,
+        events="home_run",
+        description="hit_into_play",
+        launch_speed=101.0,
+        launch_angle=28.0,
+    ))
+    session.commit()
+
+    result = get_batter_leaderboards(
+        session,
+        season=2026,
+        min_pa=1,
+        min_bbe=1,
+        limit=10,
+        official_hitting=None,
+    )
+
+    assert "home_runs" not in result["leaderboards"]
+    assert result["leaderboards"]["avg_exit_velocity"][0]["value"] == 101.0
+    assert result["sources"]["counting"] is None


### PR DESCRIPTION
## Why

The batter homepage and batter profile used different authorities. Player profiles displayed MLB's official season line, while the homepage reconstructed HR, hits, doubles, PA, ISO, BB%, and K% from local pitch rows. That allowed ETL coverage and event-classification differences to produce totals that disagreed with the player page.

## Contract

- MLB Stats API regular-season player totals are authoritative for counting and official rate metrics.
- The canonical local pitch ledger remains authoritative for EV, hard-hit%, barrel%, contact%, and whiff%.
- The two populations join only by MLB player ID.
- If the official MLB feed is unavailable, counting/rate boards fail closed and are omitted. Local pitch rows never substitute for official totals.
- The requested season never silently falls back to the previous season.

## Changes

- add a normalized, complete MLB official hitting-season provider
- source HR, hits, doubles, RBI, PA, AB, ISO, BB%, and K% from that provider
- restore the RBI leaderboard now that runner attribution comes from official totals
- preserve canonical Statcast calculations for pitch-derived boards
- add explicit source, retrieval timestamp, and contract-version metadata
- reduce batter leaderboard cache TTL to 60 seconds without changing pitcher or identity cache TTLs
- update the homepage copy and request contract to `batter_leaderboards_v3`
- add regression coverage preventing local counting-stat fallback

## Verification

- 9 focused backend tests passed
- Python compile check passed
- `git diff --check` passed
- live MLB Stats API contract check returned 711 hitters
- observed official leaders included:
  - Kyle Schwarber: 39 HR / 564 PA
  - Yordan Alvarez: 36 HR / 566 PA
  - Matt Olson: 36 HR / 570 PA
- live response also returned MLB team abbreviations after team hydration