### PR TITLE
Wire pitcher profile overlay into player projections

### DIFF
--- a/mlb_app/model_projections.py
+++ b/mlb_app/model_projections.py
@@ -559,7 +559,51 @@ def _matchup_workspace_analysis(offense_team: Dict[str, Any], opposing_pitcher: 
     }
 
 
-def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, Any], home: Dict[str, Any]) -> Dict[str, List[Dict[str, Any]]]:
+def _pitcher_profile_overlay_payloads_by_pitcher_id(
+    *,
+    away_pitcher_id: Any,
+    home_pitcher_id: Any,
+    away_vs_home_activation: Dict[str, Any],
+    away_vs_home_comparison: Dict[str, Any],
+    home_vs_away_activation: Dict[str, Any],
+    home_vs_away_comparison: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    """Map activated side comparisons to their opposing starter IDs."""
+
+    payloads: Dict[str, Dict[str, Any]] = {}
+
+    for pitcher_id, activation, comparison in (
+        (
+            home_pitcher_id,
+            away_vs_home_activation,
+            away_vs_home_comparison,
+        ),
+        (
+            away_pitcher_id,
+            home_vs_away_activation,
+            home_vs_away_comparison,
+        ),
+    ):
+        if (
+            pitcher_id in (None, "")
+            or isinstance(pitcher_id, bool)
+            or activation.get("activated") is not True
+        ):
+            continue
+
+        payloads[str(pitcher_id)] = {
+            "activation": activation,
+            "comparison": comparison,
+        }
+
+    return payloads
+
+
+def _build_projection_simulation_cards(
+    matchup: Dict[str, Any],
+    away: Dict[str, Any],
+    home: Dict[str, Any],
+) -> Dict[str, Any]:
     away_team_id = away.get("team_id")
     home_team_id = home.get("team_id")
     away_team_name = away.get("team_name")
@@ -688,6 +732,25 @@ def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
             ),
         )
     )
+    pitcher_profile_overlay_payloads = (
+        _pitcher_profile_overlay_payloads_by_pitcher_id(
+            away_pitcher_id=away.get("pitcher_id"),
+            home_pitcher_id=home.get("pitcher_id"),
+            away_vs_home_activation=(
+                away_vs_home_pitcher_profile_activation
+            ),
+            away_vs_home_comparison=(
+                away_vs_home_pitcher_profile_shadow
+            ),
+            home_vs_away_activation=(
+                home_vs_away_pitcher_profile_activation
+            ),
+            home_vs_away_comparison=(
+                home_vs_away_pitcher_profile_shadow
+            ),
+        )
+    )
+
     away_vs_home_starter_pa = (
         away_vs_home_pitcher_profile_activation[
             "model"
@@ -929,7 +992,14 @@ def _build_projection_simulation_cards(matchup: Dict[str, Any], away: Dict[str, 
         },
     }
 
-    return {"away": [away_card, game_total_card], "home": [home_card], "workspace": workspace}
+    return {
+        "away": [away_card, game_total_card],
+        "home": [home_card],
+        "workspace": workspace,
+        "_pitcher_profile_overlay_payloads_by_pitcher_id": (
+            pitcher_profile_overlay_payloads
+        ),
+    }
 
 
 def _projection_offense_inputs(
@@ -2272,10 +2342,30 @@ def build_model_projection_payload(
                 pitcher_matchup_profile_candidates,
                 pitcher_matchup_profile_batch_diagnostics,
             )
-            simulation_cards = _build_projection_simulation_cards(matchup, away, home)
-            away["models"].extend(simulation_cards.get("away", []))
-            home["models"].extend(simulation_cards.get("home", []))
-            workspace = simulation_cards.get("workspace") or {}
+            simulation_cards = (
+                _build_projection_simulation_cards(
+                    matchup,
+                    away,
+                    home,
+                )
+            )
+            away["models"].extend(
+                simulation_cards.get("away", [])
+            )
+            home["models"].extend(
+                simulation_cards.get("home", [])
+            )
+            workspace = (
+                simulation_cards.get("workspace")
+                or {}
+            )
+            pitcher_profile_overlay_payloads = (
+                simulation_cards.get(
+                    "_pitcher_profile_overlay_"
+                    "payloads_by_pitcher_id"
+                )
+                or {}
+            )
 
             game_pk = (
                 matchup.get("game_pk")
@@ -2569,6 +2659,9 @@ def build_model_projection_payload(
                     bootstrap_ready=bool(
                         canonical_shadow_bootstrap_readiness
                         .get("ready")
+                    ),
+                    pitcher_matchup_profile_activation_payloads_by_pitcher_id=(
+                        pitcher_profile_overlay_payloads
                     ),
                     pitcher_usage_evidence_by_id=(
                         canonical_pitcher_usage_evidence

--- a/mlb_app/simulation/shadow/production_execution.py
+++ b/mlb_app/simulation/shadow/production_execution.py
@@ -51,6 +51,9 @@ from .probability_provider_discovery import (
 from .hitter_profile_simulation_shadow_overlay import (
     build_hitter_profile_simulation_shadow_overlay,
 )
+from .pitcher_matchup_profile_simulation_overlay import (
+    build_pitcher_matchup_profile_simulation_overlay,
+)
 
 
 CANONICAL_PRODUCTION_SHADOW_EXECUTION_VERSION = (
@@ -73,6 +76,9 @@ class CanonicalProductionShadowExecution:
     error_type: Optional[str] = None
     error_message: Optional[str] = None
     hitter_profile_overlay: Optional[
+        Mapping[str, Any]
+    ] = None
+    pitcher_matchup_profile_overlay: Optional[
         Mapping[str, Any]
     ] = None
     execution_version: str = (
@@ -122,6 +128,19 @@ class CanonicalProductionShadowExecution:
         ):
             raise TypeError(
                 "hitter_profile_overlay must be "
+                "a mapping or None"
+            )
+
+        if (
+            self.pitcher_matchup_profile_overlay
+            is not None
+            and not isinstance(
+                self.pitcher_matchup_profile_overlay,
+                Mapping,
+            )
+        ):
+            raise TypeError(
+                "pitcher_matchup_profile_overlay must be "
                 "a mapping or None"
             )
 
@@ -203,6 +222,16 @@ class CanonicalProductionShadowExecution:
                 "hitter_profile_simulation_shadow"
             ] = dict(
                 self.hitter_profile_overlay
+            )
+
+        if (
+            self.pitcher_matchup_profile_overlay
+            is not None
+        ):
+            diagnostics[
+                "pitcher_matchup_profile_simulation_overlay"
+            ] = dict(
+                self.pitcher_matchup_profile_overlay
             )
 
         return diagnostics
@@ -326,6 +355,12 @@ def run_canonical_production_shadow(
             Mapping[str, Any],
         ]
     ] = None,
+    pitcher_matchup_profile_activation_payloads_by_pitcher_id: Optional[
+        Mapping[
+            str,
+            Mapping[str, Any],
+        ]
+    ] = None,
     pitcher_usage_evidence_by_id: Optional[
         Mapping[Any, Any]
     ] = None,
@@ -372,6 +407,7 @@ def run_canonical_production_shadow(
         )
 
     hitter_profile_overlay_diagnostics = None
+    pitcher_matchup_profile_overlay_diagnostics = None
 
     try:
         normalized_simulation_count = int(
@@ -412,6 +448,41 @@ def run_canonical_production_shadow(
                 )
             )
             hitter_profile_overlay_diagnostics = {
+                key: value
+                for key, value in overlay.items()
+                if key
+                not in {
+                    "matchup_input",
+                    "exact_artifact",
+                    "fallback_catalog",
+                }
+            }
+
+            if overlay.get("overlay_applied") is True:
+                matchup_input = overlay[
+                    "matchup_input"
+                ]
+                exact_artifact = overlay[
+                    "exact_artifact"
+                ]
+                fallback_catalog = overlay[
+                    "fallback_catalog"
+                ]
+
+        if (
+            pitcher_matchup_profile_activation_payloads_by_pitcher_id
+        ):
+            overlay = (
+                build_pitcher_matchup_profile_simulation_overlay(
+                    matchup_input=matchup_input,
+                    exact_artifact=exact_artifact,
+                    fallback_catalog=fallback_catalog,
+                    activation_payloads_by_pitcher_id=(
+                        pitcher_matchup_profile_activation_payloads_by_pitcher_id
+                    ),
+                )
+            )
+            pitcher_matchup_profile_overlay_diagnostics = {
                 key: value
                 for key, value in overlay.items()
                 if key
@@ -515,6 +586,9 @@ def run_canonical_production_shadow(
             hitter_profile_overlay=(
                 hitter_profile_overlay_diagnostics
             ),
+            pitcher_matchup_profile_overlay=(
+                pitcher_matchup_profile_overlay_diagnostics
+            ),
         )
     except Exception as exc:
         return CanonicalProductionShadowExecution(
@@ -524,5 +598,8 @@ def run_canonical_production_shadow(
             error_message=str(exc),
             hitter_profile_overlay=(
                 hitter_profile_overlay_diagnostics
+            ),
+            pitcher_matchup_profile_overlay=(
+                pitcher_matchup_profile_overlay_diagnostics
             ),
         )

--- a/tests/test_canonical_production_shadow_execution.py
+++ b/tests/test_canonical_production_shadow_execution.py
@@ -1701,3 +1701,106 @@ def test_starter_exit_is_dynamic_with_performance_and_workload():
         audit["production_authority_changed"]
         is False
     )
+
+
+def pitcher_profile_activation_payload():
+    production = {
+        "out": 0.65,
+        "single": 0.15,
+        "double": 0.05,
+        "triple": 0.01,
+        "home_run": 0.04,
+        "walk": 0.07,
+        "strikeout": 0.03,
+    }
+    shadow = {
+        "out": 0.05,
+        "single": 0.05,
+        "double": 0.02,
+        "triple": 0.0,
+        "home_run": 0.02,
+        "walk": 0.01,
+        "strikeout": 0.85,
+    }
+
+    return {
+        "activation": {
+            "activated": True,
+            "model": {
+                "probabilities": shadow,
+            },
+            "diagnostics": {
+                "status": "activated",
+                "activation_executed": True,
+                "activation_status": (
+                    "production_candidate_activated"
+                ),
+                "production_authority_changed": True,
+            },
+        },
+        "comparison": {
+            "status": "ready",
+            "executed": True,
+            "production_inputs_unchanged": True,
+            "production_authority_changed": False,
+            "production_probabilities": production,
+            "shadow_probabilities": shadow,
+        },
+    }
+
+
+def test_pitcher_profile_overlay_reaches_execution_inputs():
+    baseline = run(simulation_count=25)
+    activated = run(
+        simulation_count=25,
+        pitcher_matchup_profile_activation_payloads_by_pitcher_id={
+            "200": pitcher_profile_activation_payload(),
+        },
+    )
+
+    assert activated.status == "executed"
+    assert (
+        activated.pitcher_matchup_profile_overlay[
+            "overlay_applied"
+        ]
+        is True
+    )
+    assert activated.execution_inputs.provider_identity != (
+        baseline.execution_inputs.provider_identity
+    )
+    assert activated.execution_inputs.exact_artifact_digest != (
+        baseline.execution_inputs.exact_artifact_digest
+    )
+    assert activated.pitcher_matchup_profile_overlay[
+        "overlaid_matchup_count"
+    ] == 9
+
+
+def test_pitcher_profile_overlay_reaches_player_projection_trials():
+    baseline = run(simulation_count=100)
+    activated = run(
+        simulation_count=100,
+        pitcher_matchup_profile_activation_payloads_by_pitcher_id={
+            "200": pitcher_profile_activation_payload(),
+        },
+    )
+
+    baseline_payload = (
+        baseline.material.canonical_payload
+    )
+    activated_payload = (
+        activated.material.canonical_payload
+    )
+
+    assert activated_payload["batters"] != (
+        baseline_payload["batters"]
+    )
+    assert activated_payload["pitchers"] != (
+        baseline_payload["pitchers"]
+    )
+
+    diagnostics = activated.to_diagnostics()[
+        "pitcher_matchup_profile_simulation_overlay"
+    ]
+    assert diagnostics["simulation_inputs_changed"] is True
+    assert diagnostics["production_authority_changed"] is False

--- a/tests/test_model_projection_pitcher_profile_overlay_transport.py
+++ b/tests/test_model_projection_pitcher_profile_overlay_transport.py
@@ -1,0 +1,118 @@
+from mlb_app import model_projections
+
+
+def activation(activated):
+    return {
+        "activated": activated,
+        "model": {
+            "probabilities": {},
+        },
+        "diagnostics": {
+            "status": (
+                "activated"
+                if activated
+                else "blocked"
+            ),
+        },
+    }
+
+
+def comparison(side):
+    return {
+        "status": "ready",
+        "side": side,
+    }
+
+
+def build(
+    *,
+    away_pitcher_id="100",
+    home_pitcher_id="200",
+    away_activated=True,
+    home_activated=True,
+):
+    away_activation = activation(
+        away_activated
+    )
+    home_activation = activation(
+        home_activated
+    )
+    away_comparison = comparison(
+        "away_offense_vs_home_starter"
+    )
+    home_comparison = comparison(
+        "home_offense_vs_away_starter"
+    )
+
+    result = (
+        model_projections
+        ._pitcher_profile_overlay_payloads_by_pitcher_id(
+            away_pitcher_id=away_pitcher_id,
+            home_pitcher_id=home_pitcher_id,
+            away_vs_home_activation=(
+                away_activation
+            ),
+            away_vs_home_comparison=(
+                away_comparison
+            ),
+            home_vs_away_activation=(
+                home_activation
+            ),
+            home_vs_away_comparison=(
+                home_comparison
+            ),
+        )
+    )
+
+    return (
+        result,
+        away_activation,
+        home_activation,
+        away_comparison,
+        home_comparison,
+    )
+
+
+def test_maps_each_activation_to_opposing_starter():
+    (
+        result,
+        away_activation,
+        home_activation,
+        away_comparison,
+        home_comparison,
+    ) = build()
+
+    assert result == {
+        "200": {
+            "activation": away_activation,
+            "comparison": away_comparison,
+        },
+        "100": {
+            "activation": home_activation,
+            "comparison": home_comparison,
+        },
+    }
+
+
+def test_omits_blocked_activation():
+    result, _, _, _, _ = build(
+        away_activated=False,
+    )
+
+    assert set(result) == {"100"}
+
+
+def test_omits_missing_or_boolean_pitcher_ids():
+    result, _, _, _, _ = build(
+        away_pitcher_id=True,
+        home_pitcher_id=None,
+    )
+
+    assert result == {}
+
+
+def test_transport_is_deterministic():
+    first, _, _, _, _ = build()
+    second, _, _, _, _ = build()
+
+    assert first == second


### PR DESCRIPTION
Routes activated starter matchup-profile deltas into canonical event trials and aggregated player projections. Includes fail-closed transport and execution coverage; 147 related tests pass.